### PR TITLE
Re-enable cron triggers

### DIFF
--- a/.github/workflows/ios_bump_internal_release.yml
+++ b/.github/workflows/ios_bump_internal_release.yml
@@ -5,8 +5,8 @@ defaults:
     working-directory: iOS
 
 on:
-  # schedule:
-  #   - cron: '0 5 * * 2-5' # Run at 05:00 UTC, Tuesday through Friday
+  schedule:
+    - cron: '0 5 * * 2-5' # Run at 05:00 UTC, Tuesday through Friday
   workflow_dispatch:
     inputs:
       asana-task-url:

--- a/.github/workflows/ios_end_to_end.yml
+++ b/.github/workflows/ios_end_to_end.yml
@@ -5,8 +5,8 @@ defaults:
     working-directory: iOS
 
 on:
-  # schedule:
-  #   - cron: '0 4 * * *' # run at 4 AM UTC
+  schedule:
+    - cron: '0 4 * * *' # run at 4 AM UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ios_nightly.yml
+++ b/.github/workflows/ios_nightly.yml
@@ -6,8 +6,8 @@ defaults:
 
 on:
   workflow_dispatch:
-  # schedule:
-  #   - cron: '0 2 * * *' # Run at 2 AM UTC
+  schedule:
+    - cron: '0 2 * * *' # Run at 2 AM UTC
 
 jobs:
   atb-ui-tests:

--- a/.github/workflows/ios_sync_end_to_end.yml
+++ b/.github/workflows/ios_sync_end_to_end.yml
@@ -1,8 +1,8 @@
 name: iOS - Sync-End-to-End tests
 
 on:
-  # schedule:
-  #   - cron: '0 1 * * *' # run at 1 AM UTC
+  schedule:
+    - cron: '0 1 * * *' # run at 1 AM UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/macos_bump_internal_release.yml
+++ b/.github/workflows/macos_bump_internal_release.yml
@@ -5,8 +5,8 @@ defaults:
     working-directory: macOS
 
 on:
-  # schedule:
-  #   - cron: '0 5 * * 2-5' # Run at 05:00 UTC, Tuesday through Friday
+  schedule:
+    - cron: '0 5 * * 2-5' # Run at 05:00 UTC, Tuesday through Friday
   workflow_dispatch:
     inputs:
       asana-task-url:

--- a/.github/workflows/macos_pir_end_to_end_tests.yml
+++ b/.github/workflows/macos_pir_end_to_end_tests.yml
@@ -6,8 +6,8 @@ defaults:
 
 on:
   workflow_dispatch:
-  # schedule:
-  #    - cron: '0 3 * * 1-5' # 3AM UTC offsetted to legacy to avoid action-junit-report@v4 bug
+  schedule:
+    - cron: '0 3 * * 1-5' # 3AM UTC offsetted to legacy to avoid action-junit-report@v4 bug
   pull_request:
 
 jobs:

--- a/.github/workflows/macos_sync_end_to_end.yml
+++ b/.github/workflows/macos_sync_end_to_end.yml
@@ -6,8 +6,8 @@ defaults:
 
 on:
   workflow_dispatch:
-  # schedule:
-  #   - cron: '0 5 * * *' # run at 5 AM UTC
+  schedule:
+    - cron: '0 5 * * *' # run at 5 AM UTC
 
 jobs:
   create-notarized-app:

--- a/.github/workflows/macos_sync_end_to_end_legacy_os.yml
+++ b/.github/workflows/macos_sync_end_to_end_legacy_os.yml
@@ -6,8 +6,8 @@ defaults:
 
 on:
   workflow_dispatch:
-  # schedule:
-  #   - cron: '0 4 * * *' # run at 4 AM UTC
+  schedule:
+    - cron: '0 4 * * *' # run at 4 AM UTC
 
 jobs:
   create-notarized-app:

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -6,8 +6,8 @@ defaults:
 
 on:
   workflow_dispatch:
-  # schedule:
-  #    - cron: '0 3 * * 1-5' # 3AM UTC offsetted to legacy to avoid action-junit-report@v4 bug
+  schedule:
+    - cron: '0 3 * * 1-5' # 3AM UTC offsetted to legacy to avoid action-junit-report@v4 bug
   pull_request:
     branches:
       - hotfix/*


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1209400939721274
Tech Design URL:
CC:

**Description**:

This PR re-enables cron workflow triggers for the monorepo, to be merged after we make the switch.

**Optional E2E tests**:
- [ ] Run macOS PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

**Steps to test this PR**:
1. Check that no `cron` entries are still commented out anywhere

<!--
Tagging instructions
If this PR isn't ready to be merged for whatever reason it should be marked with the `DO NOT MERGE` label (particularly if it's a draft)
If it's pending Product Review/PFR, please add the `Pending Product Review` label.

If at any point it isn't actively being worked on/ready for review/otherwise moving forward (besides the above PR/PFR exception) strongly consider closing it (or not opening it in the first place). If you decide not to close it, make sure it's labelled to make it clear the PRs state and comment with more information.
-->

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[Pull Request Documentation](https://app.asana.com/0/1202500774821704/1204012835277482/f)