### PR TITLE
Update autofill to 16.1.0

### DIFF
--- a/BrowserServicesKit/Package.resolved
+++ b/BrowserServicesKit/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "3a9606fd26e9a54bf369cc241e6fa3b2571eb13a",
-        "version" : "16.2.1"
+        "revision" : "dd1624a4fa57b36efd74a40099fd4c66876c84bb",
+        "version" : "16.1.0"
       }
     },
     {

--- a/BrowserServicesKit/Package.swift
+++ b/BrowserServicesKit/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
         .library(name: "PrivacyStats", targets: ["PrivacyStats"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "16.2.1"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "16.1.0"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.4.2"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit.git", exact: "3.0.0"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.4.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1209420381982087/1209420381982087
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/16.1.0
Apple PR: 

## Description
Updates Autofill to version [16.1.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/16.1.0).

### Autofill 16.1.0 release notes
Test release for the Apple monorepo

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).