### PR TITLE
(iOS) Prevent swipe coordinator crash

### DIFF
--- a/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -133,6 +133,10 @@ class SwipeTabsCoordinator: NSObject {
         }
         
         let indexPath = IndexPath(row: self.tabsModel.currentIndex, section: 0)
+        guard indexPath.row < collectionView.numberOfItems(inSection: 0) else {
+            assertionFailure("target row is equal to or greater than the number of items in the collection view")
+            return
+        }
         self.collectionView.scrollToItem(at: indexPath,
                                          at: .centeredHorizontally,
                                          animated: false)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1209397835075918
Tech Design URL:
CC:

**Description**:
Ensure that the target row is less than the number of items in the collection at this point and assert if not.

**Steps to test this PR**:
Smoke testing of opening, swiping between and managing tabs:

1. Add a bunch of tabs, swipe between them. 
2. Close tabs, swipe between remaining tabs
3. Repeat with different combinations of single tab, multiple tabs.

**Definition of Done**:

* [x] Does this PR satisfy our [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f)?

