### PR TITLE
[iOS] DuckPlayer: Fix issue with landscape mode + new tab

### DIFF
--- a/iOS/DuckDuckGo/DuckPlayer/DuckPlayer.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/DuckPlayer.swift
@@ -412,9 +412,16 @@ final class DuckPlayer: NSObject, DuckPlayerControlling {
     /// Called when the Orientation notification is changed
     @objc private func orientationDidChange() {
         let orientation = UIDevice.current.orientation
-        if let url = hostView?.url, url.isDuckPlayer {
-            handleOrientationChange(orientation)
+        
+        // Only proceed with orientation change if DuckPlayer is visible
+        guard let hostView = hostView,
+              let hostViewDelegate = hostView.delegate,
+              hostViewDelegate.tabCheckIfItsBeingCurrentlyPresented(hostView),
+              let url = hostView.url,
+              url.isDuckPlayer else {
+            return
         }
+        handleOrientationChange(orientation)
     }
     
     /// Handles UI Updates based on orientation.  When switching to landscape, we hide


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1207252092703676/1209403718901685/f
Tech Design URL:
CC:

### Description
The URL and tab bar were dissapearing when switching to landscape mode in the new tab page after watching a video in DuckPlayer.

Since the “New Tab” page is not actually a “tab”, DuckPlayer orientation handler was still active, causing the issue.

### Testing Steps (iOS)
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Search 'metallica' on SERP and select 'Videos' from navigation
2. Select any video to play in DuckPlayer and rotate phone to landscape
3. Check if URL and tab bar hide automatically
4. Return to Portrait mode
5. Add a new tab
6. Rotate to landscape while on new tab
7. Verify URL and tab bar are visible (do not hide)

### Impact and Risks
Low: Fixes minor issue

#### What could go wrong?
N/A

### Quality Considerations
N/A


—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)