### PR TITLE
Fix Swift package missing resource warnings

### DIFF
--- a/BrowserServicesKit/Package.swift
+++ b/BrowserServicesKit/Package.swift
@@ -455,9 +455,6 @@ let package = Package(
                 "BrowserServicesKit",
                 "Configuration"
             ],
-            resources: [
-                .process("Resources")
-            ],
             swiftSettings: [
                 .define("DEBUG", .when(configuration: .debug))
             ]

--- a/macOS/LocalPackages/DataBrokerProtectionShared/Package.swift
+++ b/macOS/LocalPackages/DataBrokerProtectionShared/Package.swift
@@ -48,7 +48,8 @@ let package = Package(
                 .product(name: "Persistence", package: "BrowserServicesKit"),
                 .product(name: "Freemium", package: "Freemium"),
             ],
-            resources: [.copy("Resources")],
+            // Commented out until this package needs to bundle resources, as it causes SwiftPM warnings:
+            // resources: [.copy("Resources")],
             swiftSettings: [
                 .define("DEBUG", .when(configuration: .debug))
             ]
@@ -61,10 +62,9 @@ let package = Package(
                 "Freemium",
                 .product(name: "PersistenceTestingUtils", package: "BrowserServicesKit"),
                 .product(name: "SubscriptionTestingUtilities", package: "BrowserServicesKit"),
-            ],
-            resources: [
-                .copy("Resources")
             ]
+            // Commented out until this package needs to bundle resources, as it causes SwiftPM warnings:
+            // resources: [.copy("Resources")]
         )
     ]
 )


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1193060753475688/1209428043078885
Tech Design URL:
CC:

### Description

This PR fixes some Swift package warnings with PixelExperimentKit and DataBrokerProtectionShared.

In both cases, the packages were trying to include a Resources directory that doesn't exist - it looks like a copy-paste error with the package configuration, so I've removed those includes.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Clean DerivedData
2. Build the macOS and iOS targets locally
3. Check that there is no ⚠️ icon beside any Swift packages in the Xcode sidebar

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

None

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

The main risk is that these includes were actually needed, but Xcode is giving us these warnings because it has no files found at the given paths. Also, I checked each of the affected packages and they have no `Resources` directories, so we're safe to remove these.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

### Optional E2E tests**:
- [x] Run macOS PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)