### PR TITLE
Set alpha build as internal by default

### DIFF
--- a/iOS/Core/InternalUserStore.swift
+++ b/iOS/Core/InternalUserStore.swift
@@ -23,7 +23,10 @@ import BrowserServicesKit
 public class InternalUserStore: InternalUserStoring {
     public init() {
     }
-
+#if ALPHA
+    @UserDefaultsWrapper(key: .featureFlaggingDidVerifyInternalUser, defaultValue: true)
+#else
     @UserDefaultsWrapper(key: .featureFlaggingDidVerifyInternalUser, defaultValue: false)
+#endif
     public var isInternalUser: Bool
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204167627774280/1209432030981303

### Description
Set alpha builds internal by default

### Testing Steps
1. Run both alpha and release configurations on a clean install
2. Make sure alpha builds are set as internal by default and release builds aren't
3. You can also check [these builds](https://app.asana.com/0/0/1209432035885355/f) to validate

### Impact and Risks
Low: Release builds should not be set as internal by default.
