### PR TITLE
Skip checking for update in DEBUG

### DIFF
--- a/macOS/DuckDuckGo/Updates/ReleaseNotesTabExtension.swift
+++ b/macOS/DuckDuckGo/Updates/ReleaseNotesTabExtension.swift
@@ -195,11 +195,11 @@ private extension Update {
 private extension UpdateCycleProgress {
     var toStatus: ReleaseNotesValues.Status {
         switch self {
-        case .updateCycleNotStarted, .updateCycleDidStart: return .loading
+        case .updateCycleDidStart: return .loading
         case .downloadDidStart, .downloading: return .updateDownloading
         case .extractionDidStart, .extracting, .readyToInstallAndRelaunch, .installationDidStart, .installing: return .updatePreparing
         case .updaterError: return .updateError
-        case .updateCycleDone: return .loaded
+        case .updateCycleNotStarted, .updateCycleDone: return .loaded
         }
     }
 

--- a/macOS/DuckDuckGo/Updates/UpdateController.swift
+++ b/macOS/DuckDuckGo/Updates/UpdateController.swift
@@ -138,7 +138,10 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
         super.init()
 
         try? configureUpdater()
+
+#if !DEBUG
         checkForUpdateRespectingRollout()
+#endif
     }
 
     func checkNewApplicationVersion() {
@@ -182,10 +185,17 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
 
         updater = SPUUpdater(hostBundle: Bundle.main, applicationBundle: Bundle.main, userDriver: userDriver, delegate: self)
 
+#if DEBUG
+        // Skip checking for updates for DEBUG builds
+        updater?.updateCheckInterval = 0
+        updater?.automaticallyChecksForUpdates = false
+        updater?.automaticallyDownloadsUpdates = false
+#else
         // We don't want SUAutomaticallyUpdate enabled because it interferes with our custom updater UI
         if updater?.automaticallyDownloadsUpdates == true {
             updater?.automaticallyDownloadsUpdates = false
         }
+#endif
 
         updateProcessCancellable = userDriver.updateProgressPublisher
             .assign(to: \.updateProgress, onWeaklyHeld: self)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1201037661562251/1209428046557004
Tech Design URL:
CC:

### Description

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Change CURRENT_PROJECT_VERSION to a smaller number (e.g. 300)
2. Build and run the app
3. Expect: The app won't automatically check for updates
4. Expect: Opening Preferences > About page won't trigger any auto update
5. Expect: Opening Release Notes will show status as Up to date. Caveat: The release note will be empty, as its content is populated from the appcast (which we aren't checking)

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low: Release Notes status may be wrong when the update cycle hasn't started.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
Changes are made behind the DEBUG check so this should not affect any non-developers.
Change to Release notes status may affect external users.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

### Optional E2E tests**:
- [ ] Run macOS PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)