### PR TITLE
[HackDays] Add duck.ai app icon shortcut

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -973,6 +973,7 @@ extension Pixel {
         case openAIChatFromWidgetQuickAction
         case openAIChatFromWidgetControlCenter
         case openAIChatFromWidgetLockScreenComplication
+        case openAIChatFromIconShortcut
 
         // MARK: Lifecycle
         case appDidTransitionToUnexpectedState
@@ -1963,6 +1964,8 @@ extension Pixel.Event {
         case .openAIChatFromWidgetLockScreenComplication: return "m_aichat-widget-lock-screen-complication"
         case .browsingMenuAIChat: return "m_aichat_menu_tab_icon"
         case .browsingMenuListAIChat: return "m_browsing_menu_list_aichat"
+        case .openAIChatFromIconShortcut: return "m_aichat-icon-shortcut"
+
 
         // MARK: Lifecycle
         case .appDidTransitionToUnexpectedState: return "m_debug_app-did-transition-to-unexpected-state-4"

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
@@ -191,6 +191,8 @@ extension Foreground {
             mainCoordinator.handleSearchPassword()
         } else if shortcutItem.type == ShortcutKey.openVPNSettings {
             mainCoordinator.presentNetworkProtectionStatusSettingsModal()
+        } else if shortcutItem.type == ShortcutKey.aiChat {
+            mainCoordinator.handleAIChatAppIconShortuct()
         }
     }
 

--- a/iOS/DuckDuckGo/Info.plist
+++ b/iOS/DuckDuckGo/Info.plist
@@ -84,13 +84,6 @@
 			<dict>
 				<key>CFBundleIconFiles</key>
 				<array>
-					<string>AppIcon-blue</string>
-				</array>
-			</dict>
-			<key>AppIcon-green</key>
-			<dict>
-				<key>CFBundleIconFiles</key>
-				<array>
 					<string>AppIcon-green</string>
 				</array>
 			</dict>
@@ -199,6 +192,14 @@
 			<string>Search Passwords</string>
 			<key>UIApplicationShortcutItemType</key>
 			<string>com.duckduckgo.mobile.ios.passwords</string>
+		</dict>
+		<dict>
+			<key>UIApplicationShortcutItemIconFile</key>
+			<string>AIChat-24</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>Duck.ai</string>
+			<key>UIApplicationShortcutItemType</key>
+			<string>com.duckduckgo.mobile.ios.aichat</string>
 		</dict>
 	</array>
 	<key>UIBackgroundModes</key>

--- a/iOS/DuckDuckGo/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/MainCoordinator.swift
@@ -249,6 +249,15 @@ final class MainCoordinator {
         Pixel.fire(pixel: .autofillLoginsLaunchAppShortcut)
     }
 
+    func handleAIChatAppIconShortuct() {
+        controller.clearNavigationStack()
+        // Give the `clearNavigationStack` call time to complete.
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.5) {
+            self.controller.openAIChat()
+        }
+        Pixel.fire(pixel: .openAIChatFromIconShortcut)
+    }
+
     func handleURL(_ url: URL) {
         guard !handleAppDeepLink(url: url) else { return }
         controller.loadUrlInNewTab(url, reuseExisting: true, inheritedAttribution: nil, fromExternalLink: true)

--- a/iOS/DuckDuckGo/ShortcutKey.swift
+++ b/iOS/DuckDuckGo/ShortcutKey.swift
@@ -23,6 +23,7 @@ enum ShortcutKey {
 
     static let clipboard = "com.duckduckgo.mobile.ios.clipboard"
     static let passwords = "com.duckduckgo.mobile.ios.passwords"
+    static let aiChat = "com.duckduckgo.mobile.ios.aichat"
     static let openVPNSettings = "com.duckduckgo.mobile.ios.vpn.open-settings"
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205782359654716/1209372297178954/f

### Description
Add a new UIApplicationShortcutItemType for duck.ai 

### Testing Steps
1. Long press the app icon to bring the shortcuts
2. Check that duck.ai is there and when pressed, opens duck.ai in the app
