### PR TITLE
remove pixels for tab switcher open source

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -63,10 +63,6 @@ extension Pixel {
         case tabSwitchLongPressNewTab
         case tabSwitcherOpenedDaily
 
-        case tabSwitcherOpenedFromSerp
-        case tabSwitcherOpenedFromWebsite
-        case tabSwitcherOpenedFromNewTabPage
-
         case settingsDoNotSellShown
         case settingsDoNotSellOn
         case settingsDoNotSellOff
@@ -1029,10 +1025,6 @@ extension Pixel.Event {
         case .tabSwitcherSwipeCloseTab: return "m_tab_manager_close_tab_swipe"
         case .tabSwitchLongPressNewTab: return "m_tab_manager_long_press_new_tab"
         case .tabSwitcherOpenedDaily: return "m_tab_manager_opened_daily"
-
-        case .tabSwitcherOpenedFromSerp: return "m_tab_manager_open_from_serp"
-        case .tabSwitcherOpenedFromWebsite: return "m_tab_manager_open_from_website"
-        case .tabSwitcherOpenedFromNewTabPage: return "m_tab_manager_open_from_newtabpage"
 
         case .settingsDoNotSellShown: return "ms_dns"
         case .settingsDoNotSellOn: return "ms_dns_on"

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2715,13 +2715,6 @@ extension MainViewController: TabSwitcherButtonDelegate {
     func showTabSwitcher(_ button: TabSwitcherButton) {
         Pixel.fire(pixel: .tabBarTabSwitcherOpened)
         DailyPixel.fireDaily(.tabSwitcherOpenedDaily, withAdditionalParameters: TabSwitcherOpenDailyPixel().parameters(with: tabManager.model.tabs))
-        if currentTab?.url?.isDuckDuckGoSearch == true {
-            Pixel.fire(pixel: .tabSwitcherOpenedFromSerp)
-        } else if currentTab?.url != nil {
-            Pixel.fire(pixel: .tabSwitcherOpenedFromWebsite)
-        } else {
-            Pixel.fire(pixel: .tabSwitcherOpenedFromNewTabPage)
-        }
 
         performCancel()
         showTabSwitcher()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1208959606025764
Tech Design URL: 
CC:

### Description
Remove temporary pixels for tab switcher sources

### Testing Steps
1. Open the tab switcher from the new tab page
2. Open the tab switcher from the SERP
3. Open the tab switcher from a web page

### Impact and Risks
None - just removing pixels

#### What could go wrong?
n/a

### Quality Considerations
n/a

### Notes to Reviewer
Make sure tab switcher still opens / transitions
