### PR TITLE
Update Condition for Creating a New Window from a Dragged Tab

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -1056,10 +1056,10 @@ extension TabBarViewController: NSCollectionViewDelegate {
               let frameRelativeToScreen = view.window?.convertToScreen(frameRelativeToWindow) else {
             return
         }
-        
+
         // Check if the drop point is above the tab bar by more than 10 points
         let isDroppedAboveTabBar = screenPoint.y > (frameRelativeToScreen.maxY + 10)
-        
+
         // Create new window if dropped above tab bar or too far away
         if isDroppedAboveTabBar || !screenPoint.isNearRect(frameRelativeToScreen, allowedDistance: Self.dropToOpenDistance) {
             moveToNewWindow(from: sourceIndex,

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -1049,19 +1049,23 @@ extension TabBarViewController: NSCollectionViewDelegate {
         // dropping not on a tab bar
         guard case .none = operation else { return }
 
-        // Create a new window if the drop is too distant
+        // Create a new window if dragged upward or too distant
         let frameRelativeToWindow = view.convert(view.bounds, to: nil)
         guard TabDragAndDropManager.shared.sourceUnit?.tabCollectionViewModel === tabCollectionViewModel,
               let sourceIndex = TabDragAndDropManager.shared.sourceUnit?.index,
-              let frameRelativeToScreen = view.window?.convertToScreen(frameRelativeToWindow),
-              !screenPoint.isNearRect(frameRelativeToScreen, allowedDistance: Self.dropToOpenDistance) else {
-            // dropped near the tab bar, do nothing
+              let frameRelativeToScreen = view.window?.convertToScreen(frameRelativeToWindow) else {
             return
         }
-
-        moveToNewWindow(from: sourceIndex,
-                        droppingPoint: screenPoint,
-                        burner: tabCollectionViewModel.isBurner)
+        
+        // Check if the drop point is above the tab bar by more than 10 points
+        let isDroppedAboveTabBar = screenPoint.y > (frameRelativeToScreen.maxY + 10)
+        
+        // Create new window if dropped above tab bar or too far away
+        if isDroppedAboveTabBar || !screenPoint.isNearRect(frameRelativeToScreen, allowedDistance: Self.dropToOpenDistance) {
+            moveToNewWindow(from: sourceIndex,
+                           droppingPoint: screenPoint,
+                           burner: tabCollectionViewModel.isBurner)
+        }
     }
 
     func collectionView(_ collectionView: NSCollectionView,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209434873980812

### Description
We received the following feedback:

> Just now I was trying to drag a tab out of the window and even if I brought it to the very tippy top of my screen (see screenshot) it would just bounce back into the existing window. I had to make the window smaller. It just seems unnecessary. Do we have control over this? 
> I notice on Chrome it’s waaaaaaay more responsive — as soon as I pulled a tab several pixels upward it created a new window.

To address this I’ve implemented the following:
* Added a check for `isDroppedAboveTabBar` that triggers when the drop point is more than 10 points above the tab bar
* Now we will create a new window if either:
** The tab is dropped above the tab bar (new condition)
** The tab is dropped far away from the tab bar (existing condition)

### Testing Steps
1. Launch browser
2. Create multiple tabs and drag them left and right to rearrange them. Ensure this functions as expected, and new windows are not created
3. Now drag a tab slightly up above the window. Ensure a new window is created from the dragged tab

### Impact and Risks
* Impacts tab functionality

#### What could go wrong?
* Dragged tabs don’t function as expected

### Optional E2E tests**:
- [ ] Run macOS PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)