### PR TITLE
Youtube background video Management

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -321,6 +321,9 @@
 		56D7793C2CFFC7E800B619EF /* PixelKit in Frameworks */ = {isa = PBXBuildFile; productRef = 56D7793B2CFFC7E800B619EF /* PixelKit */; };
 		56D8556A2BEA9169009F9698 /* CurrentDateProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D855692BEA9169009F9698 /* CurrentDateProviding.swift */; };
 		56D8556C2BEA91C4009F9698 /* SyncAlertsPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D8556B2BEA91C4009F9698 /* SyncAlertsPresenting.swift */; };
+		6505529C2D6741BA0067D4F2 /* addMediaControl.js in Resources */ = {isa = PBXBuildFile; fileRef = 650552952D673E440067D4F2 /* addMediaControl.js */; };
+		6505529D2D6741BD0067D4F2 /* muteAudio.js in Resources */ = {isa = PBXBuildFile; fileRef = 650552962D673E440067D4F2 /* muteAudio.js */; };
+		6505529E2D6741C00067D4F2 /* removeMediaControl.js in Resources */ = {isa = PBXBuildFile; fileRef = 650552972D673E440067D4F2 /* removeMediaControl.js */; };
 		653561022D4D2C6D0064F258 /* Logger+DuckPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653561012D4D2C680064F258 /* Logger+DuckPlayer.swift */; };
 		655A9C6A2D4D2812000A7841 /* DuckPlayerWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655A9C692D4D280D000A7841 /* DuckPlayerWebView.swift */; };
 		6594CCEA2D4A3E1200188B1A /* DuckPlayerSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6594CCE92D4A3E1200188B1A /* DuckPlayerSettingsTests.swift */; };
@@ -1795,6 +1798,9 @@
 		56D0602C2C383FD2003BAEB5 /* OnboardingSuggestedSearchesProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSuggestedSearchesProviderTests.swift; sourceTree = "<group>"; };
 		56D855692BEA9169009F9698 /* CurrentDateProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentDateProviding.swift; sourceTree = "<group>"; };
 		56D8556B2BEA91C4009F9698 /* SyncAlertsPresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncAlertsPresenting.swift; sourceTree = "<group>"; };
+		650552952D673E440067D4F2 /* addMediaControl.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = addMediaControl.js; sourceTree = "<group>"; };
+		650552962D673E440067D4F2 /* muteAudio.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = muteAudio.js; sourceTree = "<group>"; };
+		650552972D673E440067D4F2 /* removeMediaControl.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = removeMediaControl.js; sourceTree = "<group>"; };
 		653561012D4D2C680064F258 /* Logger+DuckPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+DuckPlayer.swift"; sourceTree = "<group>"; };
 		655A9C692D4D280D000A7841 /* DuckPlayerWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckPlayerWebView.swift; sourceTree = "<group>"; };
 		6594CCE92D4A3E1200188B1A /* DuckPlayerSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckPlayerSettingsTests.swift; sourceTree = "<group>"; };
@@ -4311,6 +4317,16 @@
 			path = OnboardingHelpers;
 			sourceTree = "<group>";
 		};
+		650552982D673E440067D4F2 /* Scripts */ = {
+			isa = PBXGroup;
+			children = (
+				650552952D673E440067D4F2 /* addMediaControl.js */,
+				650552962D673E440067D4F2 /* muteAudio.js */,
+				650552972D673E440067D4F2 /* removeMediaControl.js */,
+			);
+			path = Scripts;
+			sourceTree = "<group>";
+		};
 		6F03CAF82C32C3AA004179A8 /* Messages */ = {
 			isa = PBXGroup;
 			children = (
@@ -6168,6 +6184,7 @@
 		D63FF8922C1B67D1006DE24D /* DuckPlayer */ = {
 			isa = PBXGroup;
 			children = (
+				650552982D673E440067D4F2 /* Scripts */,
 				31DE43C82C2DAA8F00F8C51F /* Modal */,
 				31DE43C72C2DAA7F00F8C51F /* Resources */,
 				653561012D4D2C680064F258 /* Logger+DuckPlayer.swift */,
@@ -7871,6 +7888,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6505529C2D6741BA0067D4F2 /* addMediaControl.js in Resources */,
+				6505529D2D6741BD0067D4F2 /* muteAudio.js in Resources */,
+				6505529E2D6741C00067D4F2 /* removeMediaControl.js in Resources */,
 				F47E53DB250A9A1C0037C686 /* Onboarding.xcassets in Resources */,
 				1E242960293F585300584836 /* cookie-icon-animated-40-light.json in Resources */,
 				984147C024F026A300362052 /* Tab.storyboard in Resources */,

--- a/iOS/DuckDuckGo/DuckPlayer/Scripts/addMediaControl.js
+++ b/iOS/DuckDuckGo/DuckPlayer/Scripts/addMediaControl.js
@@ -1,0 +1,71 @@
+function addMediaControl() {
+    let userInitiated = false;
+
+    // Listen for user interactions that may lead to playback
+    ['touchstart'].forEach(eventType => {
+        document.addEventListener(eventType, () => {
+            userInitiated = true;
+
+            // Unmute all media elements when user interacts
+            document.querySelectorAll('audio, video').forEach(media => {
+                media.muted = false;
+            });
+
+            // Reset after a short delay to prevent indefinite allowance
+            setTimeout(() => {
+                userInitiated = false;
+            }, 500);
+        }, true);  // Capture phase to detect early
+    });
+
+    // Override play to detect and conditionally allow playback
+    const originalPlay = HTMLMediaElement.prototype.play;
+    HTMLMediaElement.prototype.play = function() {
+        if (userInitiated) {
+            // User-triggered playback is allowed, so disconnect the observer and unmute
+            observer.disconnect();
+            this.muted = false;  // Unmute the specific media element being played
+            return originalPlay.apply(this, arguments);
+        } else {
+            // Block programmatic playback
+            this.pause();
+            return Promise.reject(new Error("Playback blocked: Not user-initiated"));
+        }
+    };
+
+    // Initial pause of all media
+    function pauseAndMuteAllMedia() {
+        document.querySelectorAll('audio, video').forEach(media => {
+            media.pause();
+            media.muted = true;
+        });
+    }
+
+    pauseAndMuteAllMedia();
+
+    // Monitor DOM for newly added media elements
+    const observer = new MutationObserver(mutations => {
+        mutations.forEach(mutation => {
+            mutation.addedNodes.forEach(node => {
+                if (node.tagName === 'AUDIO' || node.tagName === 'VIDEO') {
+                    if (!userInitiated) {  // Only mute if not user-initiated
+                        node.pause();
+                        node.muted = true;
+                    }
+                } else if (node.querySelectorAll) {
+                    node.querySelectorAll('audio, video').forEach(media => {
+                        if (!userInitiated) {  // Only mute if not user-initiated
+                            media.pause();
+                            media.muted = true;
+                        }
+                    });
+                }
+            });
+        });
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+}
+
+// Call the function
+addMediaControl();

--- a/iOS/DuckDuckGo/DuckPlayer/Scripts/muteAudio.js
+++ b/iOS/DuckDuckGo/DuckPlayer/Scripts/muteAudio.js
@@ -1,0 +1,5 @@
+function muteAudio(mute) {
+    document.querySelectorAll('audio, video').forEach(media => {
+        media.muted = mute;
+    });
+}

--- a/iOS/DuckDuckGo/DuckPlayer/Scripts/removeMediaControl.js
+++ b/iOS/DuckDuckGo/DuckPlayer/Scripts/removeMediaControl.js
@@ -1,0 +1,14 @@
+function removeMediaControl() {
+    // Restore original play method
+    if (HTMLMediaElement.prototype._originalPlay) {
+        HTMLMediaElement.prototype.play = HTMLMediaElement.prototype._originalPlay;
+        delete HTMLMediaElement.prototype._originalPlay;
+    }
+    
+    // Remove event listeners (if we stored references to them)
+    // Clean up any observers
+    if (window._mediaObserver) {
+        window._mediaObserver.disconnect();
+        delete window._mediaObserver;
+    }
+}

--- a/iOS/DuckDuckGo/UserScripts.swift
+++ b/iOS/DuckDuckGo/UserScripts.swift
@@ -106,10 +106,14 @@ final class UserScripts: UserScriptsProvider {
     // Initialize DuckPlayer scripts
     private func initializeDuckPlayer() {
         if let duckPlayer {
-            youtubeOverlayScript = YoutubeOverlayUserScript(duckPlayer: duckPlayer)
-            youtubePlayerUserScript = YoutubePlayerUserScript(duckPlayer: duckPlayer)
-            youtubeOverlayScript.map { contentScopeUserScriptIsolated.registerSubfeature(delegate: $0) }
-            youtubePlayerUserScript.map { specialPages?.registerSubfeature(delegate: $0) }
+            
+            // Initialize scripts if nativeUI is disabled
+            if !duckPlayer.settings.nativeUI {
+                youtubeOverlayScript = YoutubeOverlayUserScript(duckPlayer: duckPlayer)
+                youtubePlayerUserScript = YoutubePlayerUserScript(duckPlayer: duckPlayer)
+                youtubeOverlayScript.map { contentScopeUserScriptIsolated.registerSubfeature(delegate: $0) }
+                youtubePlayerUserScript.map { specialPages?.registerSubfeature(delegate: $0) }
+            }
         }
     }
     


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1204099484721401/1209372536181328/f
Tech Design URL:
CC:

### Description
Removes all JS, overlays and injected JS from CSS into Youtube pages when Native player is enabled.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1.  Enable DuckPlayer Native UI Experiment
2. Set DuckPlayer to ‘Always'
3. Go to Youtube.com, find a video an watch it
4. Confirm that after dismissing DuckPlayer, the video you watched is loaded and paused
5. Tap the video to play it and confirm it plays and has sound
6. Go to SERP and search for videos
7. Watch a few videos
8. COnfirm that Closing DuckPlayer will take you back to SERP


### Impact and Risks
<!— 
What's the impact on users if something goes wrong?
Low: No impact in production DuckPlayer

—>

#### What could go wrong?
- Youtube page issues (videos not playing or no audio

### Quality Considerations
It’s still under discussions if the added JS should be part of the native app or moved to CSS.  For now it’s only used in iOS, so it makes sense to have it here, but discussion with FE folk is needed. It’s also important that FE folks revise that code.

### Notes to Reviewer
- ⚠️ DuckPlayer in ‘ASK’ mode will NOT Worl