### PR TITLE
update metrics windows

### DIFF
--- a/BrowserServicesKit/Sources/PixelExperimentKit/TDSOverrideExperimentMetrics.swift
+++ b/BrowserServicesKit/Sources/PixelExperimentKit/TDSOverrideExperimentMetrics.swift
@@ -57,7 +57,6 @@ public struct TDSOverrideExperimentMetrics {
     public static func fireTDSExperimentMetric( metricType: TDSExperimentMetricType,
                                                 etag: String,
                                                 fireDebugExperiment: @escaping FireDebugExperiment) {
-        
         for experiment in TDSExperimentType.allCases {
             for day in 0...5 {
                 ExperimentConfig.firePixelExperiment(experiment.subfeature.rawValue,

--- a/BrowserServicesKit/Sources/PixelExperimentKit/TDSOverrideExperimentMetrics.swift
+++ b/BrowserServicesKit/Sources/PixelExperimentKit/TDSOverrideExperimentMetrics.swift
@@ -57,11 +57,12 @@ public struct TDSOverrideExperimentMetrics {
     public static func fireTDSExperimentMetric( metricType: TDSExperimentMetricType,
                                                 etag: String,
                                                 fireDebugExperiment: @escaping FireDebugExperiment) {
+        
         for experiment in TDSExperimentType.allCases {
             for day in 0...5 {
                 ExperimentConfig.firePixelExperiment(experiment.subfeature.rawValue,
                                                      metricType.rawValue,
-                                                     day...day,
+                                                     0...day,
                                                      "1"
                 )
                 fireDebugBreakageExperiment(experimentType: experiment,

--- a/iOS/DuckDuckGo/AppPageRefreshMonitor.swift
+++ b/iOS/DuckDuckGo/AppPageRefreshMonitor.swift
@@ -33,30 +33,14 @@ extension PageRefreshMonitor {
             TDSOverrideExperimentMetrics.fireTDSExperimentMetric(metricType: .refresh2X, etag: tdsEtag, fireDebugExperiment: { parameters in
                 UniquePixel.fire(pixel: .debugBreakageExperiment, withAdditionalParameters: parameters)
             })
-            TDSOverrideExperimentMetrics.fireTDSExperimentMetricUpdated(metricType: .refresh2X)
         case 3:
             Pixel.fire(pixel: .pageRefreshThreeTimesWithin20Seconds)
             TDSOverrideExperimentMetrics.fireTDSExperimentMetric(metricType: .refresh3X, etag: tdsEtag, fireDebugExperiment: { parameters in
                 UniquePixel.fire(pixel: .debugBreakageExperiment, withAdditionalParameters: parameters)
             })
-            TDSOverrideExperimentMetrics.fireTDSExperimentMetricUpdated(metricType: .refresh3X)
         default:
             return
         }
     }
 
-}
-
-public extension TDSOverrideExperimentMetrics {
-    static func fireTDSExperimentMetricUpdated( metricType: TDSExperimentMetricType) {
-        for experiment in TDSExperimentType.allCases {
-            PixelKit.fireExperimentPixel(for: experiment.subfeature.rawValue, metric: metricType.rawValue, conversionWindowDays: 0...0, value: "1")
-            PixelKit.fireExperimentPixel(for: experiment.subfeature.rawValue, metric: metricType.rawValue, conversionWindowDays: 0...1, value: "1")
-            PixelKit.fireExperimentPixel(for: experiment.subfeature.rawValue, metric: metricType.rawValue, conversionWindowDays: 0...2, value: "1")
-            PixelKit.fireExperimentPixel(for: experiment.subfeature.rawValue, metric: metricType.rawValue, conversionWindowDays: 0...3, value: "1")
-            PixelKit.fireExperimentPixel(for: experiment.subfeature.rawValue, metric: metricType.rawValue, conversionWindowDays: 0...4, value: "1")
-            PixelKit.fireExperimentPixel(for: experiment.subfeature.rawValue, metric: metricType.rawValue, conversionWindowDays: 0...5, value: "1")
-
-        }
-    }
 }

--- a/iOS/DuckDuckGo/PrivacyDashboard/PrivacyDashboardViewController.swift
+++ b/iOS/DuckDuckGo/PrivacyDashboard/PrivacyDashboardViewController.swift
@@ -141,7 +141,6 @@ final class PrivacyDashboardViewController: UIViewController {
             TDSOverrideExperimentMetrics.fireTDSExperimentMetric(metricType: .privacyToggleUsed, etag: tdsEtag) { parameters in
                 UniquePixel.fire(pixel: .debugBreakageExperiment, withAdditionalParameters: parameters)
             }
-            TDSOverrideExperimentMetrics.fireTDSExperimentMetricUpdated(metricType: .privacyToggleUsed)
         }
         
         contentBlockingManager.scheduleCompilation()

--- a/iOS/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
@@ -535,7 +535,6 @@ extension TabViewController {
         TDSOverrideExperimentMetrics.fireTDSExperimentMetric(metricType: .privacyToggleUsed, etag: tdsEtag) { parameters in
             UniquePixel.fire(pixel: .debugBreakageExperiment, withAdditionalParameters: parameters)
         }
-        TDSOverrideExperimentMetrics.fireTDSExperimentMetricUpdated(metricType: .privacyToggleUsed)
     }
 
     private func togglePrivacyProtection(domain: String, didSendReport: Bool = false) {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1204186595873227/1209454650312256

### Description: Update experiment metrics for TDS experiment (it was updated for iOS just on iOS for celerity and now ported to BSK to be applied to macOS as well)

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app —>
On both platforms
1. Start with a fresh app (check you are enrolled for a tdsNextExperiment either baseline or Feb25 otherwise remove and relaunch the app) on macOS clear the data
2. refresh a page 3 times and check you see pixels like 👾[Unique By Name And Parameters-Fired] experiment_metrics_tdsNextExperimentBaseline_treatment_ios_phone ["conversionWindowDays": "0-4", "pixelSource": "phone", "metric": "3XRefresh", "value": "1", "enrollmentDate": "2025-02-14”] with metric": “3XRefresh” and “2XRefresh” with conversion windows (0, 0-1, 0-2, 0-3, 0-4, 0-5)
3. Same if you toggle protection off

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

### Optional E2E tests**:
- [ ] Run macOS PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)