### PR TITLE
Update autofill to 16.2.2

### DIFF
--- a/BrowserServicesKit/Package.resolved
+++ b/BrowserServicesKit/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "3a9606fd26e9a54bf369cc241e6fa3b2571eb13a",
-        "version" : "16.2.1"
+        "revision" : "b5976277a68e18f93edb0d853889e461e06557fa",
+        "version" : "16.2.2"
       }
     },
     {

--- a/BrowserServicesKit/Package.swift
+++ b/BrowserServicesKit/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
         .library(name: "PrivacyStats", targets: ["PrivacyStats"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "16.2.1"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "16.2.2"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.4.2"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit.git", exact: "3.0.0"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.4.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1209465117664031/1209465117664031
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/16.2.2
Apple PR: 

## Description
Updates Autofill to version [16.2.2](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/16.2.2).

### Autofill 16.2.2 release notes
## What's Changed
* chore: update actions cache to v3 by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/759
* Update Apple project file references in the release workflow by @samsymons in https://github.com/duckduckgo/duckduckgo-autofill/pull/758
* Update release workflow to support Apple monorepo by @samsymons in https://github.com/duckduckgo/duckduckgo-autofill/pull/756
* [Formatters] Make fixes for credentials less restrictive by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/763

## New Contributors
* @samsymons made their first contribution in https://github.com/duckduckgo/duckduckgo-autofill/pull/758

**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/16.2.1...16.2.2

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).