### PR TITLE
Pre-populate current tab after closing other tab

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1124,7 +1124,8 @@ class MainViewController: UIViewController {
     }
 
     fileprivate func updateCurrentTab() {
-        if let currentTab = currentTab {
+        // prepopulate VC for current tab if needed
+        if let currentTab = tabManager.current(createIfNeeded: true) {
             select(tab: currentTab)
             viewCoordinator.omniBar.resignFirstResponder()
         } else {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1209463640725362
Tech Design URL:
CC:

### Description

Makes sure automatically selected tab is populated before transitioning back to the TabViewController.

### Testing Steps
1. Open a bunch of tabs, close an restart the app
2. Go to tab switcher and close currently selected tab, note newly selected tab
3. Press done
4. Check newly selected tab is now visible.

### Optional E2E tests**:
- [ ] Run macOS PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)