### PR TITLE
Add Privacy Pro Onboarding CTA feature flag

### DIFF
--- a/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -182,6 +182,7 @@ public enum PrivacyProSubfeature: String, Equatable, PrivacySubfeature {
     case useUnifiedFeedback
     case setAccessTokenCookieForSubscriptionDomains
     case privacyProFreeTrialJan25
+    case privacyProOnboardingCTAMarch25
 }
 
 public enum SslCertificatesSubfeature: String, PrivacySubfeature {

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -82,6 +82,9 @@ public enum FeatureFlag: String {
     case experimentalBrowserTheming
 
     case alternativeColorScheme
+
+    /// https://app.asana.com/0/1206488453854252/1208706841336530
+    case privacyProOnboardingCTAMarch25
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -89,6 +92,8 @@ extension FeatureFlag: FeatureFlagDescribing {
         switch self {
         case .privacyProFreeTrialJan25:
             PrivacyProFreeTrialExperimentCohort.self
+        case .privacyProOnboardingCTAMarch25:
+            PrivacyProOnboardingCTAMarch25Cohort.self
         default:
             nil
         }
@@ -98,7 +103,7 @@ extension FeatureFlag: FeatureFlagDescribing {
 
     public var supportsLocalOverriding: Bool {
         switch self {
-        case .textZoom, .alternativeColorScheme, .experimentalBrowserTheming:
+        case .textZoom, .alternativeColorScheme, .experimentalBrowserTheming, .privacyProOnboardingCTAMarch25:
             return true
         default:
             return false
@@ -187,6 +192,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteDevelopment(.feature(.experimentalBrowserTheming))
         case .alternativeColorScheme:
             return .internalOnly()
+        case .privacyProOnboardingCTAMarch25:
+            return .remoteReleasable(.subfeature(PrivacyProSubfeature.privacyProOnboardingCTAMarch25))
         }
     }
 }
@@ -199,6 +206,13 @@ extension FeatureFlagger {
 }
 
 public enum PrivacyProFreeTrialExperimentCohort: String, FeatureFlagCohortDescribing {
+    /// Control cohort with no changes applied.
+    case control
+    /// Treatment cohort where the experiment modifications are applied.
+    case treatment
+}
+
+public enum PrivacyProOnboardingCTAMarch25Cohort: String, FeatureFlagCohortDescribing {
     /// Control cohort with no changes applied.
     case control
     /// Treatment cohort where the experiment modifications are applied.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208706841336532

### Description
Add Privacy Pro Onboarding CTA Experiment Feature Flag, which will be used on iOS

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Green CI

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?
Low: Minor visual changes, small bug fixes, improvement to existing features
-->

#### What could go wrong?
Experimental feature availability

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)