### PR TITLE
Add skip onboarding button for Debug and Alpha builds

### DIFF
--- a/iOS/DuckDuckGo/LaunchOptionsHandler.swift
+++ b/iOS/DuckDuckGo/LaunchOptionsHandler.swift
@@ -46,6 +46,12 @@ public final class LaunchOptionsHandler {
         return .notOverridden
     }
 
+#if DEBUG || ALPHA
+    public func overrideOnboardingCompleted() {
+        userDefaults.set("true", forKey: Self.isOnboardingCompleted)
+    }
+#endif
+
     public var appVariantName: String? {
         sanitisedEnvParameter(string: userDefaults.string(forKey: Self.appVariantName))
     }

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
@@ -117,6 +117,12 @@ final class OnboardingIntroViewModel: ObservableObject {
         onCompletingOnboardingIntro?()
     }
 
+#if DEBUG || ALPHA
+    public func overrideOnboardingCompleted() {
+        LaunchOptionsHandler().overrideOnboardingCompleted()
+        onCompletingOnboardingIntro?()
+    }
+#endif
 }
 
 // MARK: - Private

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
@@ -19,6 +19,7 @@
 
 import SwiftUI
 import Onboarding
+import DuckUI
 
 // MARK: - OnboardingView
 
@@ -54,6 +55,16 @@ struct OnboardingView: View {
                 landingView
             case let .onboarding(viewState):
                 onboardingDialogView(state: viewState)
+#if DEBUG || ALPHA
+                    .safeAreaInset(edge: .bottom) {
+                        Button {
+                            model.overrideOnboardingCompleted()
+                        } label: {
+                            Text(verbatim: "Skip")
+                        }
+                        .buttonStyle(SecondaryFillButtonStyle(compact: true, fullWidth: false))
+                    }
+#endif
             }
         }
     }

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
@@ -60,7 +60,7 @@ struct OnboardingView: View {
                         Button {
                             model.overrideOnboardingCompleted()
                         } label: {
-                            Text(verbatim: "Skip")
+                            Text(UserText.Onboarding.Intro.skip)
                         }
                         .buttonStyle(SecondaryFillButtonStyle(compact: true, fullWidth: false))
                     }

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -1552,6 +1552,7 @@ Duck.ai is an optional feature that lets you chat anonymously with popular 3rd-p
         public enum Intro {
             public static let title = NSLocalizedString("onboarding.highlights.intro.title", value: "Hi there.\n\nReady for a faster browser that keeps you protected?", comment: "The title of the onboarding dialog popup")
             public static let cta = NSLocalizedString("onboarding.intro.cta", value: "Let’s do it!", comment: "Button to continue the onboarding process")
+            public static let skip = NotLocalizedString("onboarding.intro.skip", value: "Skip", comment: "Button to skip the onboarding process")
         }
 
         public enum BrowsersComparison {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1206226850447395/1209483939027886
Tech Design URL:
CC: @alessandroboron 

### Description

### Testing Steps
1. Check button does not show up on production build
2. Check onboarding can be skipped using the button on a clean install.

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Button becomes visible on production build, allowing users to skip onboarding.

### Optional E2E tests**:
- [ ] Run macOS PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)