### PR TITLE
fix tab switcher layout so that the title isn't too short

### DIFF
--- a/iOS/DuckDuckGo/Base.lproj/TabSwitcher.storyboard
+++ b/iOS/DuckDuckGo/Base.lproj/TabSwitcher.storyboard
@@ -47,25 +47,12 @@
                                                         <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Og-aa-efh">
                                                             <rect key="frame" x="273" y="0.0" width="48" height="38"/>
                                                             <subviews>
-                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OHa-Ni-Kxf">
+                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="q09-Zc-YX5">
                                                                     <rect key="frame" x="0.0" y="0.0" width="24" height="38"/>
-                                                                    <subviews>
-                                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="q09-Zc-YX5">
-                                                                            <rect key="frame" x="0.0" y="7" width="24" height="24"/>
-                                                                            <constraints>
-                                                                                <constraint firstAttribute="width" constant="24" id="34q-Ja-o2s"/>
-                                                                                <constraint firstAttribute="height" constant="24" id="B1W-gV-eii"/>
-                                                                            </constraints>
-                                                                        </imageView>
-                                                                    </subviews>
-                                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="height" constant="38" id="DdB-UJ-g59"/>
-                                                                        <constraint firstAttribute="width" constant="24" id="XSt-ib-cpJ"/>
-                                                                        <constraint firstItem="q09-Zc-YX5" firstAttribute="centerY" secondItem="OHa-Ni-Kxf" secondAttribute="centerY" id="cwR-sC-B5n"/>
-                                                                        <constraint firstItem="q09-Zc-YX5" firstAttribute="centerX" secondItem="OHa-Ni-Kxf" secondAttribute="centerX" id="l8W-dv-n8f"/>
+                                                                        <constraint firstAttribute="width" constant="24" id="34q-Ja-o2s"/>
                                                                     </constraints>
-                                                                </view>
+                                                                </imageView>
                                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G2C-qh-g3T">
                                                                     <rect key="frame" x="24" y="0.0" width="24" height="38"/>
                                                                     <accessibility key="accessibilityConfiguration" label="Close Tab"/>
@@ -189,28 +176,16 @@
                                                     <rect key="frame" x="0.0" y="0.0" width="327" height="70"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lk6-g3-EJO">
-                                                            <rect key="frame" x="247" y="13" width="76" height="44"/>
+                                                            <rect key="frame" x="255" y="13" width="68" height="44"/>
                                                             <subviews>
-                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yIj-t5-PIn">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="32" height="44"/>
-                                                                    <subviews>
-                                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="dZD-kS-WDA">
-                                                                            <rect key="frame" x="4" y="10" width="24" height="24"/>
-                                                                            <constraints>
-                                                                                <constraint firstAttribute="height" constant="24" id="Qod-ZJ-b6o"/>
-                                                                                <constraint firstAttribute="width" constant="24" id="adc-cz-ySa"/>
-                                                                            </constraints>
-                                                                        </imageView>
-                                                                    </subviews>
-                                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="dZD-kS-WDA">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="24" height="44"/>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="width" constant="32" id="RwG-Fh-1uo"/>
-                                                                        <constraint firstItem="dZD-kS-WDA" firstAttribute="centerX" secondItem="yIj-t5-PIn" secondAttribute="centerX" id="bWH-CF-3CF"/>
-                                                                        <constraint firstItem="dZD-kS-WDA" firstAttribute="centerY" secondItem="yIj-t5-PIn" secondAttribute="centerY" id="gAe-LT-Ih7"/>
+                                                                        <constraint firstAttribute="width" constant="24" id="adc-cz-ySa"/>
                                                                     </constraints>
-                                                                </view>
+                                                                </imageView>
                                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2en-CB-bYH">
-                                                                    <rect key="frame" x="32" y="0.0" width="44" height="44"/>
+                                                                    <rect key="frame" x="24" y="0.0" width="44" height="44"/>
                                                                     <accessibility key="accessibilityConfiguration" label="Close Tab"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="44" id="BSv-9y-qF3"/>
@@ -241,7 +216,7 @@
                                                             </constraints>
                                                         </imageView>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2GU-MM-UwX">
-                                                            <rect key="frame" x="45" y="18" width="198" height="19.5"/>
+                                                            <rect key="frame" x="45" y="18" width="206" height="19.5"/>
                                                             <accessibility key="accessibilityConfiguration">
                                                                 <accessibilityTraits key="traits" button="YES" staticText="YES"/>
                                                                 <bool key="isElement" value="YES"/>
@@ -251,7 +226,7 @@
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Link" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LbT-NO-T0G">
-                                                            <rect key="frame" x="45" y="38" width="198" height="17"/>
+                                                            <rect key="frame" x="45" y="38" width="206" height="17"/>
                                                             <accessibility key="accessibilityConfiguration">
                                                                 <bool key="isElement" value="NO"/>
                                                             </accessibility>
@@ -568,10 +543,10 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemOrangeColor">
-            <color red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.58431372549019611" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemTealColor">
-            <color red="0.18823529410000001" green="0.69019607839999997" blue="0.78039215689999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.18823529411764706" green="0.69019607843137254" blue="0.7803921568627451" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemYellowColor">
             <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1209484209211269
Tech Design URL: 
CC: @amddg44 

### Description

### Testing Steps
1. Open a few web pages (imdb is good)
2. Open the tab switcher
3. Check the title extends to the close button (with some padding)

### Impact and Risks
Low: minor visual change.

#### What could go wrong?
Not much

### Quality Considerations
This is a fix for the title length

### Notes to Reviewer
Just the tab switcher.
