### PR TITLE
[iOS] Add alerts playground to debug screen

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "695df496504a9a98ee15a32ad1be25c94a5bb532",
-        "version" : "7.20.0"
+        "revision" : "c8428aec4646126b7aa4903f85caf6315d565995",
+        "version" : "7.22.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "3a9606fd26e9a54bf369cc241e6fa3b2571eb13a",
-        "version" : "16.2.1"
+        "revision" : "b5976277a68e18f93edb0d853889e461e06557fa",
+        "version" : "16.2.2"
       }
     },
     {

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -546,6 +546,7 @@
 		85371D242121B9D500920548 /* new_tab.json in Resources */ = {isa = PBXBuildFile; fileRef = 85371D232121B9D400920548 /* new_tab.json */; };
 		85372447220DD103009D09CD /* UIKeyCommandExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85372446220DD103009D09CD /* UIKeyCommandExtension.swift */; };
 		85374D3C21AC41E700FF5A1E /* FavoritesHomeViewSectionRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85374D3B21AC41E700FF5A1E /* FavoritesHomeViewSectionRenderer.swift */; };
+		853807922D6E638000CE1455 /* AlertPlaygroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853807912D6E638000CE1455 /* AlertPlaygroundView.swift */; };
 		853A717620F62FE800FE60BC /* Pixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853A717520F62FE800FE60BC /* Pixel.swift */; };
 		853A717820F645FB00FE60BC /* PixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853A717720F645FB00FE60BC /* PixelTests.swift */; };
 		853C5F6121C277C7001F7A05 /* global.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853C5F6021C277C7001F7A05 /* global.swift */; };
@@ -2035,6 +2036,7 @@
 		85371D232121B9D400920548 /* new_tab.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = new_tab.json; sourceTree = "<group>"; };
 		85372446220DD103009D09CD /* UIKeyCommandExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKeyCommandExtension.swift; sourceTree = "<group>"; };
 		85374D3B21AC41E700FF5A1E /* FavoritesHomeViewSectionRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesHomeViewSectionRenderer.swift; sourceTree = "<group>"; };
+		853807912D6E638000CE1455 /* AlertPlaygroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPlaygroundView.swift; sourceTree = "<group>"; };
 		853A717520F62FE800FE60BC /* Pixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pixel.swift; sourceTree = "<group>"; };
 		853A717720F645FB00FE60BC /* PixelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelTests.swift; sourceTree = "<group>"; };
 		853C5F6021C277C7001F7A05 /* global.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = global.swift; sourceTree = "<group>"; };
@@ -4998,6 +5000,7 @@
 				6FB1FE9C2C24D4060075B68B /* NewTabPageSectionsDebugView */,
 				9F9A922F2C86AACB001D036D /* OnboardingDebugView */,
 				31206F6F2D3804E800A95D76 /* AIChatDebugView.swift */,
+				853807912D6E638000CE1455 /* AlertPlaygroundView.swift */,
 				98A860EE2C4682E00077FE4D /* BookmarksDebugViewController.swift */,
 				4B0295182537BC6700E00CEF /* ConfigurationDebugViewController.swift */,
 				CBFCB30D2B2CD47800253E9E /* ConfigurationURLDebugViewController.swift */,
@@ -8413,6 +8416,7 @@
 				8569E1702D52C9A4004A3CB7 /* TabSwitcherBarsStateHandler.swift in Sources */,
 				9FE08BDC2C2A88FA001D5EBC /* OnboardingIntroViewController.swift in Sources */,
 				3157B43527F497F50042D3D7 /* SaveLoginViewController.swift in Sources */,
+				853807922D6E638000CE1455 /* AlertPlaygroundView.swift in Sources */,
 				C14D43012B45D6CD00ACA4DC /* AutofillDebugViewController.swift in Sources */,
 				856F28D72D3EC5FA00A88211 /* TabSwitcherViewController+MultiSelect.swift in Sources */,
 				853C5F6121C277C7001F7A05 /* global.swift in Sources */,

--- a/iOS/DuckDuckGo/AlertPlaygroundView.swift
+++ b/iOS/DuckDuckGo/AlertPlaygroundView.swift
@@ -1,0 +1,146 @@
+//
+//  AlertPlaygroundView.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+
+struct AlertPlaygroundView: View {
+    
+    enum ActionStyle: String, CaseIterable {
+        case `default`
+        case cancel
+        case destructive
+        
+        var uikitStyle: UIAlertAction.Style {
+            switch self {
+            case .default:
+                return .default
+            case .cancel:
+                return .cancel
+            case .destructive:
+                return .destructive
+            }
+        }
+        
+    }
+    
+    @State var title: String = "Example title"
+    @State var message: String = "An example of a message"
+    @State var primary: String = "Primary"
+    @State var secondary: String = "Secondary"
+
+    @State var primaryStyle: ActionStyle = .default
+    @State var secondaryStyle: ActionStyle = .default
+    
+    @State var alertPresented = false
+    
+    func showUIAlert() {
+        guard let controller = UIApplication.shared.window?.rootViewController?.presentedViewController else { return }
+        
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(title: primary, style: primaryStyle.uikitStyle)
+        alert.addAction(title: secondary, style: primaryStyle.uikitStyle)
+        controller.present(alert, animated: true)
+        
+    }
+
+    var body: some View {
+        
+        VStack(alignment: .leading, spacing: 0) {
+            
+            Text("Title")
+                .font(.caption)
+            TextField("Title", text: $title)
+                .padding(.bottom, 8)
+
+            Text("Message")
+                .font(.caption)
+            TextField("Message", text: $message)
+                .padding(.bottom, 8)
+            
+            Text("Primary / First Action")
+                .font(.caption)
+            TextField("Primary / First Action", text: $primary)
+            Picker("Style", selection: $primaryStyle, content: {
+                ForEach(ActionStyle.allCases, id: \.rawValue) { style in
+                    Text(style.rawValue).tag(style)
+                }
+            })
+                .padding(.bottom, 8)
+
+            Text("Secondary / Second Action")
+                .font(.caption)
+            TextField("Secondary / Second Action", text: $secondary)
+            Picker("Style", selection: $secondaryStyle, content: {
+                ForEach(ActionStyle.allCases, id: \.rawValue) { style in
+                    Text(style.rawValue).tag(style)
+                }
+            })
+                .padding(.bottom, 8)
+
+            
+            HStack {
+                
+                Button {
+                    alertPresented = true
+                } label: {
+                    Text("SwiftUI Alert")
+                }
+                .buttonStyle(.bordered)
+                .alert(title, isPresented: $alertPresented, actions: {
+                    
+                    switch primaryStyle {
+                    case .default:
+                        Button(primary) { }
+                    case .cancel:
+                        Button(primary, role: .cancel) { }
+                    case .destructive:
+                        Button(primary, role: .destructive) { }
+                    }
+
+                    switch secondaryStyle {
+                    case .default:
+                        Button(secondary) { }
+                    case .cancel:
+                        Button(secondary, role: .cancel) { }
+                    case .destructive:
+                        Button(secondary, role: .destructive) { }
+                    }
+                            
+                }, message: {
+                    Text(message)
+                })
+
+                Button {
+                    showUIAlert()
+                } label: {
+                    Text("UIAlert")
+                }
+                .buttonStyle(.bordered)
+
+            }
+            
+            Spacer()
+
+        }
+        .padding(.horizontal)
+        .navigationTitle("Alert Playground")
+        
+    }
+    
+}

--- a/iOS/DuckDuckGo/AlertPlaygroundView.swift
+++ b/iOS/DuckDuckGo/AlertPlaygroundView.swift
@@ -54,93 +54,99 @@ struct AlertPlaygroundView: View {
         
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(title: primary, style: primaryStyle.uikitStyle)
-        alert.addAction(title: secondary, style: primaryStyle.uikitStyle)
+        alert.addAction(title: secondary, style: secondaryStyle.uikitStyle)
         controller.present(alert, animated: true)
         
     }
 
     var body: some View {
-        
-        VStack(alignment: .leading, spacing: 0) {
-            
-            Text("Title")
-                .font(.caption)
-            TextField("Title", text: $title)
-                .padding(.bottom, 8)
-
-            Text("Message")
-                .font(.caption)
-            TextField("Message", text: $message)
-                .padding(.bottom, 8)
-            
-            Text("Primary / First Action")
-                .font(.caption)
-            TextField("Primary / First Action", text: $primary)
-            Picker("Style", selection: $primaryStyle, content: {
-                ForEach(ActionStyle.allCases, id: \.rawValue) { style in
-                    Text(style.rawValue).tag(style)
-                }
-            })
-                .padding(.bottom, 8)
-
-            Text("Secondary / Second Action")
-                .font(.caption)
-            TextField("Secondary / Second Action", text: $secondary)
-            Picker("Style", selection: $secondaryStyle, content: {
-                ForEach(ActionStyle.allCases, id: \.rawValue) { style in
-                    Text(style.rawValue).tag(style)
-                }
-            })
-                .padding(.bottom, 8)
-
-            
-            HStack {
+        List {
+            Section {
                 
-                Button {
-                    alertPresented = true
-                } label: {
-                    Text("SwiftUI Alert")
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("Title")
+                        .font(.caption)
+                    TextField("Title", text: $title)
                 }
-                .buttonStyle(.bordered)
-                .alert(title, isPresented: $alertPresented, actions: {
+                
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("Message")
+                        .font(.caption)
+                    TextField("Message", text: $message)
+                }
+                
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("Primary / First Action")
+                        .font(.caption)
+                    HStack {
+                        TextField("Primary / First Action", text: $primary)
+                        Spacer()
+                        Picker("", selection: $primaryStyle, content: {
+                            ForEach(ActionStyle.allCases, id: \.rawValue) { style in
+                                Text(style.rawValue).tag(style)
+                            }
+                        })
+                    }
+                }
+                
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("Secondary / Second Action")
+                        .font(.caption)
+                    HStack {
+                        TextField("Secondary / Second Action", text: $secondary)
+                        Spacer()
+                        Picker("", selection: $secondaryStyle, content: {
+                            ForEach(ActionStyle.allCases, id: \.rawValue) { style in
+                                Text(style.rawValue).tag(style)
+                            }
+                        })
+                    }
+                }
+            } footer: {
+                HStack {
                     
-                    switch primaryStyle {
-                    case .default:
-                        Button(primary) { }
-                    case .cancel:
-                        Button(primary, role: .cancel) { }
-                    case .destructive:
-                        Button(primary, role: .destructive) { }
+                    Button {
+                        alertPresented = true
+                    } label: {
+                        Text("SwiftUI Alert")
                     }
-
-                    switch secondaryStyle {
-                    case .default:
-                        Button(secondary) { }
-                    case .cancel:
-                        Button(secondary, role: .cancel) { }
-                    case .destructive:
-                        Button(secondary, role: .destructive) { }
+                    .buttonStyle(.bordered)
+                    .alert(title, isPresented: $alertPresented, actions: {
+                        
+                        switch primaryStyle {
+                        case .default:
+                            Button(primary) { }
+                        case .cancel:
+                            Button(primary, role: .cancel) { }
+                        case .destructive:
+                            Button(primary, role: .destructive) { }
+                        }
+                        
+                        switch secondaryStyle {
+                        case .default:
+                            Button(secondary) { }
+                        case .cancel:
+                            Button(secondary, role: .cancel) { }
+                        case .destructive:
+                            Button(secondary, role: .destructive) { }
+                        }
+                        
+                    }, message: {
+                        Text(message)
+                    })
+                    
+                    Button {
+                        showUIAlert()
+                    } label: {
+                        Text("UIAlert")
                     }
-                            
-                }, message: {
-                    Text(message)
-                })
-
-                Button {
-                    showUIAlert()
-                } label: {
-                    Text("UIAlert")
+                    .buttonStyle(.bordered)
+                    
                 }
-                .buttonStyle(.bordered)
-
             }
-            
-            Spacer()
-
         }
-        .padding(.horizontal)
         .navigationTitle("Alert Playground")
-        
+
     }
     
 }

--- a/iOS/DuckDuckGo/AlertPlaygroundView.swift
+++ b/iOS/DuckDuckGo/AlertPlaygroundView.swift
@@ -49,6 +49,10 @@ struct AlertPlaygroundView: View {
     
     @State var alertPresented = false
     
+    var isDoubleCancel: Bool {
+        primaryStyle == .cancel && secondaryStyle == .cancel
+    }
+    
     func showUIAlert() {
         guard let controller = UIApplication.shared.window?.rootViewController?.presentedViewController else { return }
         
@@ -103,45 +107,54 @@ struct AlertPlaygroundView: View {
                     }
                 }
             } footer: {
-                HStack {
-                    
-                    Button {
-                        alertPresented = true
-                    } label: {
-                        Text("SwiftUI Alert")
-                    }
-                    .buttonStyle(.bordered)
-                    .alert(title, isPresented: $alertPresented, actions: {
+                VStack {
+                    HStack {
                         
-                        switch primaryStyle {
-                        case .default:
-                            Button(primary) { }
-                        case .cancel:
-                            Button(primary, role: .cancel) { }
-                        case .destructive:
-                            Button(primary, role: .destructive) { }
+                        Button {
+                            alertPresented = true
+                        } label: {
+                            Text("SwiftUI Alert")
                         }
+                        .buttonStyle(.bordered)
+                        .alert(title, isPresented: $alertPresented, actions: {
+                            
+                            switch primaryStyle {
+                            case .default:
+                                Button(primary) { }
+                            case .cancel:
+                                Button(primary, role: .cancel) { }
+                            case .destructive:
+                                Button(primary, role: .destructive) { }
+                            }
+                            
+                            switch secondaryStyle {
+                            case .default:
+                                Button(secondary) { }
+                            case .cancel:
+                                Button(secondary, role: .cancel) { }
+                            case .destructive:
+                                Button(secondary, role: .destructive) { }
+                            }
+                            
+                        }, message: {
+                            Text(message)
+                        })
+                        .disabled(isDoubleCancel)
                         
-                        switch secondaryStyle {
-                        case .default:
-                            Button(secondary) { }
-                        case .cancel:
-                            Button(secondary, role: .cancel) { }
-                        case .destructive:
-                            Button(secondary, role: .destructive) { }
+                        Button {
+                            showUIAlert()
+                        } label: {
+                            Text("UIAlert")
                         }
-                        
-                    }, message: {
-                        Text(message)
-                    })
-                    
-                    Button {
-                        showUIAlert()
-                    } label: {
-                        Text("UIAlert")
+                        .buttonStyle(.bordered)
+                        .disabled(isDoubleCancel)
                     }
-                    .buttonStyle(.bordered)
                     
+                    if isDoubleCancel {
+                        Text("Cancel is not allowed more than once")
+                            .bold()
+                            .foregroundStyle(.red)
+                    }
                 }
             }
         }

--- a/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
@@ -97,6 +97,9 @@ extension DebugScreensViewModel {
                                             userAgent: DefaultUserAgentManager.duckDuckGoUserAgent)
 
             }),
+            .view(title: "Alert Playground", { _ in
+                AlertPlaygroundView()
+            }),
 
             // MARK: Controllers
             .controller(title: "Image Cache", { d in


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1209499866654334
Tech Design URL:
CC:

### Description
Adds alert playground to the debug screen.

### Testing Steps
1. Go to the debug screen
2. Tap on Alerts Playground
3. Have a play!

### Impact and Risks
None

#### What could go wrong?
Not much

### Quality Considerations
N/A

### Notes to Reviewer
N/A

