### PR TITLE
Fix paths used when attaching macOS failed CI run artifacts

### DIFF
--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -239,7 +239,7 @@ jobs:
       if: always() # always run even if the previous step fails
       with:
         check_name: "Test Report: ${{ matrix.flavor }}"
-        report_paths: '${{ matrix.flavor }}*.xml'
+        report_paths: 'macOS/${{ matrix.flavor }}*.xml'
         check_retries: true
 
     - name: Update Asana with failed unit tests
@@ -262,7 +262,7 @@ jobs:
       if: failure()
       with:
         name: ${{ matrix.flavor }}-unittests-xcodebuild.log
-        path: ${{ matrix.flavor }}-unittests-xcodebuild.log
+        path: macOS/${{ matrix.flavor }}-unittests-xcodebuild.log
         retention-days: 7
 
     - name: Upload failed unit tests xcresult
@@ -270,7 +270,7 @@ jobs:
       if: failure()
       with:
         name: ${{ matrix.flavor }}-unittests.xcresult
-        path: ${{ matrix.flavor }}-unittests.xcresult
+        path: macOS/${{ matrix.flavor }}-unittests.xcresult
         retention-days: 7
 
     - name: Upload failed integration tests log
@@ -278,7 +278,7 @@ jobs:
       if: failure()
       with:
         name: ${{ matrix.flavor }}-integrationtests-xcodebuild.log
-        path: ${{ matrix.flavor }}-integrationtests-xcodebuild.log
+        path: macOS/${{ matrix.flavor }}-integrationtests-xcodebuild.log
         retention-days: 7
 
     - name: Upload failed integration tests xcresult
@@ -286,7 +286,7 @@ jobs:
       if: failure()
       with:
         name: ${{ matrix.flavor }}-integrationtests.xcresult
-        path: ${{ matrix.flavor }}-integrationtests.xcresult
+        path: macOS/${{ matrix.flavor }}-integrationtests.xcresult
         retention-days: 7
 
     - name: Fetch latest commit author

--- a/macOS/IntegrationTests/Tab/AddressBarTests.swift
+++ b/macOS/IntegrationTests/Tab/AddressBarTests.swift
@@ -928,6 +928,8 @@ class AddressBarTests: XCTestCase {
 
     @MainActor
     func test_ZoomLevelNonDefault_ThenZoomButtonIsVisible() async throws {
+        XCTFail("forced test failure")
+
         // GIVEN
         let tab = Tab(content: .url(.duckDuckGo, credential: nil, source: .userEntered("")), webViewConfiguration: webViewConfiguration)
         let viewModel = TabCollectionViewModel(tabCollection: TabCollection(tabs: [tab]))

--- a/macOS/IntegrationTests/Tab/AddressBarTests.swift
+++ b/macOS/IntegrationTests/Tab/AddressBarTests.swift
@@ -928,8 +928,6 @@ class AddressBarTests: XCTestCase {
 
     @MainActor
     func test_ZoomLevelNonDefault_ThenZoomButtonIsVisible() async throws {
-        XCTFail("forced test failure")
-
         // GIVEN
         let tab = Tab(content: .url(.duckDuckGo, credential: nil, source: .userEntered("")), webViewConfiguration: webViewConfiguration)
         let viewModel = TabCollectionViewModel(tabCollection: TabCollection(tabs: [tab]))


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1199333091098016/1209505008661892
Tech Design URL:
CC:

### Description

This PR fixes the paths used by the macOS PR checks workflow when attaching failed test run artifacts.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that this workflow run contains a list of attached artifacts, like an xcresult file: https://github.com/duckduckgo/apple-browsers/actions/runs/13535222202?pr=105

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

### Optional E2E tests**:
- [ ] Run macOS PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)