### PR TITLE
When creating HostnameMatchingRule also include port number

### DIFF
--- a/BrowserServicesKit/Sources/UserScript/UserScriptMessaging.swift
+++ b/BrowserServicesKit/Sources/UserScript/UserScriptMessaging.swift
@@ -289,6 +289,16 @@ extension BrokerError: LocalizedError {
 public enum HostnameMatchingRule {
     case etldPlus1(hostname: String)
     case exact(hostname: String)
+
+    public static func makeExactRule(for url: URL) -> HostnameMatchingRule? {
+        guard let host = url.host else { return nil }
+
+        if let port = url.port, port != 0 {
+            return .exact(hostname: host + ":\(port)")
+        } else {
+            return .exact(hostname: host)
+        }
+    }
 }
 
 /// Force consumers to be explicit about the difference between accepting messages

--- a/BrowserServicesKit/Sources/UserScript/UserScriptMessaging.swift
+++ b/BrowserServicesKit/Sources/UserScript/UserScriptMessaging.swift
@@ -293,7 +293,7 @@ public enum HostnameMatchingRule {
     public static func makeExactRule(for url: URL) -> HostnameMatchingRule? {
         guard let host = url.host else { return nil }
 
-        if let port = url.port, port != 0 {
+        if let port = url.port, port > 0 {
             return .exact(hostname: host + ":\(port)")
         } else {
             return .exact(hostname: host)

--- a/BrowserServicesKit/Tests/UserScriptTests/UserScriptMessagingTests.swift
+++ b/BrowserServicesKit/Tests/UserScriptTests/UserScriptMessagingTests.swift
@@ -187,6 +187,51 @@ class UserScriptMessagingTests: XCTestCase {
     }
 }
 
+class HostnameMatchingRuleTests: XCTestCase {
+
+    func testMakingExactRuleBasedOnURL() throws {
+        // Given
+        let url = try XCTUnwrap(URL(string: "https://duckduckgo.com/subscriptions"))
+
+        // When
+        let result = HostnameMatchingRule.makeExactRule(for: url)
+
+        // Then
+        if case let .exact(hostname) = result {
+            XCTAssertEqual(hostname, "duckduckgo.com")
+        } else {
+            XCTFail("Result rule incorrect")
+        }
+    }
+
+    func testMakingExactRuleBasedOnURLWithPort() throws {
+        // Given
+        let url = try XCTUnwrap(URL(string: "http://localhost:1234/subscriptions"))
+
+        // When
+        let result = HostnameMatchingRule.makeExactRule(for: url)
+
+        // Then
+        if case let .exact(hostname) = result {
+            XCTAssertEqual(hostname, "localhost:1234")
+        } else {
+            XCTFail("Result rule incorrect")
+        }
+    }
+
+    func testMakingExactRuleWhenURLHasNoHostname() throws {
+        // Given
+        let url = try XCTUnwrap(URL(string: "zzz"))
+        XCTAssertNil(url.host)
+
+        // When
+        let result = HostnameMatchingRule.makeExactRule(for: url)
+
+        // Then
+        XCTAssertNil(result)
+    }
+}
+
 /// A helper for registering a test delegate and creating a MockMsg based on the
 /// incoming dictionary (which represents a message coming from a webview)
 ///

--- a/iOS/DuckDuckGo/Subscription/UserScripts/IdentityTheftRestorationPagesFeature.swift
+++ b/iOS/DuckDuckGo/Subscription/UserScripts/IdentityTheftRestorationPagesFeature.swift
@@ -51,7 +51,7 @@ final class IdentityTheftRestorationPagesFeature: Subfeature, ObservableObject {
 
     let featureName: String = Constants.featureName
     lazy var messageOriginPolicy: MessageOriginPolicy = .only(rules: [
-        .exact(hostname: subscriptionManager.url(for: .baseURL).host ?? OriginDomains.duckduckgo)
+        HostnameMatchingRule.makeExactRule(for: subscriptionManager.url(for: .baseURL)) ?? .exact(hostname: OriginDomains.duckduckgo)
     ])
 
     var originalMessage: WKScriptMessage?

--- a/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
@@ -123,7 +123,7 @@ final class SubscriptionPagesUseSubscriptionFeature: Subfeature, ObservableObjec
 
     let featureName = Constants.featureName
     lazy var messageOriginPolicy: MessageOriginPolicy = .only(rules: [
-        .exact(hostname: subscriptionManager.url(for: .baseURL).host ?? OriginDomains.duckduckgo)
+        HostnameMatchingRule.makeExactRule(for: subscriptionManager.url(for: .baseURL)) ?? .exact(hostname: OriginDomains.duckduckgo)
     ])
 
     var originalMessage: WKScriptMessage?

--- a/macOS/DuckDuckGo/Tab/UserScripts/Subscription/IdentityTheftRestorationPagesUserScript.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/Subscription/IdentityTheftRestorationPagesUserScript.swift
@@ -81,7 +81,7 @@ final class IdentityTheftRestorationPagesFeature: Subfeature {
 
     let featureName = "useIdentityTheftRestoration"
     lazy var messageOriginPolicy: MessageOriginPolicy = .only(rules: [
-        .exact(hostname: subscriptionManager.url(for: .baseURL).host ?? OriginDomains.duckduckgo)
+        HostnameMatchingRule.makeExactRule(for: subscriptionManager.url(for: .baseURL)) ?? .exact(hostname: OriginDomains.duckduckgo)
     ])
 
     init(subscriptionManager: SubscriptionManager, subscriptionFeatureAvailability: SubscriptionFeatureAvailability = DefaultSubscriptionFeatureAvailability()) {

--- a/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeature.swift
@@ -39,7 +39,7 @@ final class SubscriptionPagesUseSubscriptionFeature: Subfeature {
 
     let featureName = "useSubscription"
     lazy var messageOriginPolicy: MessageOriginPolicy = .only(rules: [
-        .exact(hostname: subscriptionManager.url(for: .baseURL).host ?? OriginDomains.duckduckgo)
+        HostnameMatchingRule.makeExactRule(for: subscriptionManager.url(for: .baseURL)) ?? .exact(hostname: OriginDomains.duckduckgo)
     ])
 
     let subscriptionManager: SubscriptionManager


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1207974891378353

### Description
When creating HostnameMatchingRule also include port number along with the hostname.

### Testing Steps
1. Following testing steps in https://app.asana.com/0/0/1209495545684681 define a custom URL with a port number e.g. "http://localhost:1234/subs" 
2. Restart the app
3. Set a breakpoint in the init of SubscriptionPagesUseSubscriptionFeature
4. Open purchase page
5. When execution stops at the breakpoint print out "messageOriginPolicy" and confirm that the port number is included in the rule

### Impact and Risks
High: Could affect user privacy, lose user data, break core functionality

#### What could go wrong?
Mistake in generating proper "messageOriginPolicy" matching the page URL can result in subscription pages now working (redirect to SERP), including the paywall.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)