### PR TITLE
Fixes the color of VPN exclusion details in the VPN Status View menus

### DIFF
--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/SwiftUI/MenuItemButton.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/SwiftUI/MenuItemButton.swift
@@ -20,11 +20,18 @@ import Foundation
 import SwiftUI
 
 struct MenuItemButton: View {
+
+    struct Detail {
+        let text: String
+        let color: Color
+    }
+
     @Environment(\.colorScheme) private var colorScheme
     private let icon: Image?
     private let title: String
-    private let detail: String?
-    private let textColor: Color
+    private let titleColor: Color
+    private let detail: Detail?
+    private let highlightColor: Color
     private let action: () async -> Void
 
     private let highlightAnimationStepSpeed = AnimationConstants.highlightAnimationStepSpeed
@@ -32,11 +39,22 @@ struct MenuItemButton: View {
     @State private var isHovered = false
     @State private var animatingTap = false
 
-    init(icon: Image? = nil, title: String, detail: String? = nil, textColor: Color, action: @escaping () async -> Void) {
+    init(icon: Image? = nil, title: String, titleColor: Color, highlightColor: Color, action: @escaping () async -> Void) {
+
         self.icon = icon
         self.title = title
-        self.detail = detail
-        self.textColor = textColor
+        self.titleColor = titleColor
+        self.detail = nil
+        self.highlightColor = highlightColor
+        self.action = action
+    }
+
+    init(icon: Image? = nil, title: String, titleColor: Color, detail: String, detailColor: Color, highlightColor: Color, action: @escaping () async -> Void) {
+        self.icon = icon
+        self.title = title
+        self.titleColor = titleColor
+        self.detail = Detail(text: detail, color: detailColor)
+        self.highlightColor = highlightColor
         self.action = action
     }
 
@@ -47,14 +65,14 @@ struct MenuItemButton: View {
             HStack(spacing: 4) {
                 if let icon {
                     icon
-                        .foregroundColor(isHovered ? .white : textColor)
+                        .foregroundColor(isHovered ? highlightColor : titleColor)
                 }
                 Text(title)
-                    .foregroundColor(isHovered ? .white : textColor)
+                    .foregroundColor(isHovered ? highlightColor : titleColor)
 
                 if let detail {
-                    Text(detail)
-                        .foregroundColor(.secondary)
+                    Text(detail.text)
+                        .foregroundColor(isHovered ? highlightColor : detail.color)
                 }
 
                 Spacer()

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/SwiftUI/MenuItemButton.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/SwiftUI/MenuItemButton.swift
@@ -21,7 +21,7 @@ import SwiftUI
 
 struct MenuItemButton: View {
 
-    struct Detail {
+    private struct Detail {
         let text: String
         let color: Color
     }

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Views/StatusView/NetworkProtectionStatusView.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionUI/Views/StatusView/NetworkProtectionStatusView.swift
@@ -88,12 +88,20 @@ public struct NetworkProtectionStatusView: View {
                     Divider()
                         .padding(EdgeInsets(top: 5, leading: 9, bottom: 5, trailing: 9))
                 case .text(_, let icon, let title, let action):
-                    MenuItemButton(icon: icon, title: title, textColor: Color(.defaultText)) {
+                    MenuItemButton(icon: icon,
+                                   title: title,
+                                   titleColor: Color(.defaultText),
+                                   highlightColor: .white) {
                         await action()
                         dismiss()
                     }.applyMenuAttributes()
                 case .textWithDetail(_, let icon, let title, let detail, let action):
-                    MenuItemButton(icon: icon, title: title, detail: detail, textColor: Color(.defaultText)) {
+                    MenuItemButton(icon: icon,
+                                   title: title,
+                                   titleColor: Color(.defaultText),
+                                   detail: detail,
+                                   detailColor: .secondary,
+                                   highlightColor: .white) {
                         await action()
                         dismiss()
                     }.applyMenuAttributes()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203108348835387/1209463463956054

### Description

Fixes the coloring for the VPN Status View's exclusion menu item.  The detail color was off when hovered.

Also cleans up the code a bit.

The following screenshot shows the coloring issue:

<img width=400 src="https://github.com/user-attachments/assets/1c67a41d-01c4-4246-b63a-70e3f580e9e6"/>

### Testing Steps

1. Run target "macOS VPN Agent"
2. Make sure the detail (ie: the count) in the exclusion menu items becomes white when hovered in both light and dark mode.

### Impact and Risks

Low impact and the only identified risk is coloring issues - which we already have.

#### What could go wrong?

Nothing I can think of.

### Quality Considerations

Nothing I can think of.

### Notes to Reviewer

Just make sure the code changes make sense since there's a small refactoring here.

### Optional E2E tests**:
- [ ] Run macOS PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)