### PR TITLE
Append error parameter when interaction state write fails

### DIFF
--- a/iOS/DuckDuckGo/TabInteractionStateDiskSource.swift
+++ b/iOS/DuckDuckGo/TabInteractionStateDiskSource.swift
@@ -87,7 +87,7 @@ final class TabInteractionStateDiskSource: TabInteractionStateSource, TabInterac
             pixelFiring.fire(pixel: .tabInteractionStateSourceFailedToWrite,
                              error: error,
                              includedParameters: [.appVersion],
-                             withAdditionalParameters: ["dataSizeBytes": String(stateData.count)],
+                             withAdditionalParameters: ["dataSizeBytes": TabInteractionStateDataSizeBucket(dataSize: stateData.count).value],
                              onComplete: { _ in })
         }
     }
@@ -144,3 +144,27 @@ final class TabInteractionStateDiskSource: TabInteractionStateSource, TabInterac
 private extension Logger {
     static var tabInteractionStateSource: Logger = { Logger(subsystem: "TabInteractionStateSource", category: "") }()
 }
+
+private struct TabInteractionStateDataSizeBucket {
+
+    let value: String
+
+    init(dataSize: Int) {
+
+        switch dataSize {
+        case 0:
+            value = "0"
+        case ...256:
+            value = "<256"
+        case ...16000:
+            value = "<16000"
+        case ...1000000:
+            value = "<1000000"
+        case ...100000000:
+            value = "<100000000"
+        default:
+            value = "more"
+        }
+    }
+}
+

--- a/iOS/DuckDuckGo/TabInteractionStateDiskSource.swift
+++ b/iOS/DuckDuckGo/TabInteractionStateDiskSource.swift
@@ -87,7 +87,7 @@ final class TabInteractionStateDiskSource: TabInteractionStateSource, TabInterac
             pixelFiring.fire(pixel: .tabInteractionStateSourceFailedToWrite,
                              error: error,
                              includedParameters: [.appVersion],
-                             withAdditionalParameters: [:],
+                             withAdditionalParameters: ["dataSizeBytes": String(stateData.count)],
                              onComplete: { _ in })
         }
     }

--- a/iOS/DuckDuckGo/TabInteractionStateDiskSource.swift
+++ b/iOS/DuckDuckGo/TabInteractionStateDiskSource.swift
@@ -167,4 +167,3 @@ private struct TabInteractionStateDataSizeBucket {
         }
     }
 }
-


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1206226850447395/1209362951077123
Tech Design URL:
CC:

### Description

We've been getting a decent amount of web view interaction state write errors with error code 83 (Value too large to be stored in data type). Adding the size of to-be-written data as a parameter to check for unexpectedly large Data instances.

### Testing Steps
1. Change `tabCacheLocation` in `TabInteractionStateDiskSource` line 74 to unwritable path, e.g. `let tabCacheLocation = URL("///failingPath.json")!`
2. Run the app and browse to any site.
3. Check if data size attribute is added to error pixel.

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Optional E2E tests**:
- [ ] Run macOS PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)