### PR TITLE
Do not show AI Chat in popup window

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -1068,7 +1068,10 @@ final class NavigationBarViewController: NSViewController {
         aiChatButton.menu = menu
         aiChatButton.toolTip = UserText.aiChat
 
-        aiChatButton.isHidden = !(LocalPinningManager.shared.isPinned(.aiChat) && aiChatMenuConfig.isFeatureEnabledForToolbarShortcut)
+        let isFeatureEnabled = LocalPinningManager.shared.isPinned(.aiChat) && aiChatMenuConfig.isFeatureEnabledForToolbarShortcut
+        let isPopUpWindow = view.window?.isPopUpWindow ?? false
+
+        aiChatButton.isHidden = !isFeatureEnabled || isPopUpWindow
     }
 }
 
@@ -1099,7 +1102,7 @@ extension NavigationBarViewController: NSMenuDelegate {
             menu.addItem(withTitle: networkProtectionTitle, action: #selector(toggleNetworkProtectionPanelPinning), keyEquivalent: "")
         }
 
-        if aiChatMenuConfig.isFeatureEnabledForToolbarShortcut {
+        if !isPopUpWindow && aiChatMenuConfig.isFeatureEnabledForToolbarShortcut {
             let aiChatTitle = LocalPinningManager.shared.shortcutTitle(for: .aiChat)
             menu.addItem(withTitle: aiChatTitle, action: #selector(toggleAIChatPanelPinning), keyEquivalent: "L")
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204167627774280/1209550650690084

### Description
Do not show AI Chat menu bar icon in popup window

### Testing Steps
1. Enable AI Chat in the browser navigation bar (Right click, show duck.ai)
2. Open a pop-up window on Debug -> UI Trigger Show popup window
3. Make sure AI Chat icon is not visible

### Impact and Risks
Low: Minor visual changes

#### What could go wrong?
Hide the icon on the main window when it shouldn't
