### PR TITLE
Add inspectable to Duck.ai WebView

### DIFF
--- a/iOS/DuckDuckGo/AIChat/AIChatViewControllerManager.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatViewControllerManager.swift
@@ -43,6 +43,13 @@ final class AIChatViewControllerManager {
     func openAIChat(_ query: String? = nil, payload: Any? = nil, autoSend: Bool = false, on viewController: UIViewController) {
         let settings = AIChatSettings(privacyConfigurationManager: privacyConfigurationManager)
 
+        let inspectableWebView: Bool
+#if DEBUG
+        inspectableWebView = true
+#else
+        inspectableWebView = AppUserDefaults().inspectableWebViewEnabled
+#endif
+
         // Check if the viewController is already presenting a RoundedPageSheetContainerViewController with AIChatViewController inside
         if let presentedVC = viewController.presentedViewController as? RoundedPageSheetContainerViewController,
            presentedVC.contentViewController is AIChatViewController {
@@ -59,7 +66,8 @@ final class AIChatViewControllerManager {
         self.userContentController = userContentController
         let aiChatViewController = AIChatViewController(settings: settings,
                                                         webViewConfiguration: webviewConfiguration,
-                                                        requestAuthHandler: AIChatRequestAuthorizationHandler(debugSettings: AIChatDebugSettings()))
+                                                        requestAuthHandler: AIChatRequestAuthorizationHandler(debugSettings: AIChatDebugSettings()),
+                                                        inspectableWebView: inspectableWebView)
         aiChatViewController.delegate = self
 
         let roundedPageSheet = RoundedPageSheetContainerViewController(

--- a/iOS/LocalPackages/AIChat/Sources/AIChat/AIChatViewModel.swift
+++ b/iOS/LocalPackages/AIChat/Sources/AIChat/AIChatViewModel.swift
@@ -35,19 +35,25 @@ protocol AIChatViewModeling {
     /// Forward function from AIChatRequestAuthorizationHandling
     @MainActor
     func shouldAllowRequestWithNavigationAction(_ navigationAction: WKNavigationAction) -> Bool
+
+    /// Sets inspectable property in the webView
+    var inspectableWebView: Bool { get }
 }
 
 final class AIChatViewModel: AIChatViewModeling {
     private let settings: AIChatSettingsProvider
     let webViewConfiguration: WKWebViewConfiguration
     let requestAuthHandler: AIChatRequestAuthorizationHandling
+    let inspectableWebView: Bool
 
     init(webViewConfiguration: WKWebViewConfiguration,
          settings: AIChatSettingsProvider,
-         requestAuthHandler: AIChatRequestAuthorizationHandling) {
+         requestAuthHandler: AIChatRequestAuthorizationHandling,
+         inspectableWebView: Bool) {
         self.webViewConfiguration = webViewConfiguration
         self.settings = settings
         self.requestAuthHandler = requestAuthHandler
+        self.inspectableWebView = inspectableWebView
     }
 
     var aiChatURL: URL {

--- a/iOS/LocalPackages/AIChat/Sources/AIChat/AIChatWebViewController.swift
+++ b/iOS/LocalPackages/AIChat/Sources/AIChat/AIChatWebViewController.swift
@@ -66,6 +66,10 @@ final class AIChatWebViewController: UIViewController {
     private func setupWebView() {
         view.addSubview(webView)
 
+        if #available(iOS 16.4, *) {
+            webView.isInspectable = chatModel.inspectableWebView
+        }
+
         NSLayoutConstraint.activate([
             webView.topAnchor.constraint(equalTo: view.topAnchor),
             webView.bottomAnchor.constraint(equalTo: view.bottomAnchor),

--- a/iOS/LocalPackages/AIChat/Sources/AIChat/Public API/AIChatViewController.swift
+++ b/iOS/LocalPackages/AIChat/Sources/AIChat/Public API/AIChatViewController.swift
@@ -58,12 +58,15 @@ public final class AIChatViewController: UIViewController {
     ///   - remoteSettings: An object conforming to `AIChatSettingsProvider` that provides remote settings.
     ///   - webViewConfiguration: A `WKWebViewConfiguration` object used to configure the web view.
     ///   - requestAuthHandler: A `AIChatRequestAuthorizationHandling` object to handle decide policy callbacks
+    ///   - inspectableWebView: Boolean indicating if the webView should be inspectable
     public convenience init(settings: AIChatSettingsProvider,
                             webViewConfiguration: WKWebViewConfiguration,
-                            requestAuthHandler: AIChatRequestAuthorizationHandling) {
+                            requestAuthHandler: AIChatRequestAuthorizationHandling,
+                            inspectableWebView: Bool) {
         let chatModel = AIChatViewModel(webViewConfiguration: webViewConfiguration,
                                         settings: settings,
-                                        requestAuthHandler: requestAuthHandler)
+                                        requestAuthHandler: requestAuthHandler,
+                                        inspectableWebView: inspectableWebView)
         self.init(chatModel: chatModel)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204167627774280/1209536893026327

### Description
Add inspectable to Duck.ai WebView

### Testing Steps
1. Add a breakpoint here https://github.com/duckduckgo/apple-browsers/blob/896ddef0af15ba61aa8d1057e32b23863a9c5437/iOS/LocalPackages/AIChat/Sources/AIChat/AIChatWebViewController.swift#L70
2. Run the app as DEBUG, open duck.ai, chatModel.inspectableWebView should be true
3. Run the app as release, open duck.ai, chatModel.inspectableWebView should be false
4. Go to debug settings, turn on Inspectable WebViews
5. Close Duck.ai, open it again, chatModel.inspectableWebView should be true

### Impact and Risks
Low: Allowing users that have access to the Debug UI to inspect the URL

#### What could go wrong?
Allowing users that don’t have access to the Debug UI to inspect the URL
