### PR TITLE
Update widget name

### DIFF
--- a/iOS/Widgets/QuickActionsSmallWidget.swift
+++ b/iOS/Widgets/QuickActionsSmallWidget.swift
@@ -108,7 +108,7 @@ enum ShortcutOption: String, CaseIterable, Identifiable, AppEnum {
 
 @available(iOS 17.0, *)
 struct QuickActionsSmallWidget: Widget {
-    let kind: String = "QuickActionsSmallWidget"
+    let kind: String = "QuickActionsWidget"
 
     var body: some WidgetConfiguration {
         AppIntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: QuickActionsProvider()) { entry in


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209568442838954/f

### Description
Update the widget name to avoid iOS issue updating widgets

### Testing Steps
1. Install the 7.159.0 release on your device (or install it from the app store)
2. Add the Quick Shortcuts widget to your homescreen
3. Install the app using this PR, check if the widget is still working

### Impact and Risks

Medium: Change of breaking the widget and the user having to re-add it
