### PR TITLE
Initialize dock customizer after first launch date is set

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -147,7 +147,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 #if SPARKLE
     var updateController: UpdateController!
-    var dockCustomization: DockCustomization!
+    var dockCustomization: DockCustomization?
 #endif
 
     @UserDefaultsWrapper(key: .firstLaunchDate, defaultValue: Date.monthAgo)
@@ -337,7 +337,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 #if SPARKLE
         if NSApp.runType != .uiTests {
             updateController = UpdateController(internalUserDecider: internalUserDecider)
-            dockCustomization = DockCustomizer()
             stateRestorationManager.subscribeToAutomaticAppRelaunching(using: updateController.willRelaunchAppPublisher)
         }
 #endif
@@ -393,6 +392,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         DefaultVariantManager().assignVariantIfNeeded { _ in
             // MARK: perform first time launch logic here
         }
+
+        #if SPARKLE
+        dockCustomization = DockCustomizer()
+        #endif
 
         let statisticsLoader = NSApp.runType.requiresEnvironment ? StatisticsLoader.shared : nil
         statisticsLoader?.load()


### PR DESCRIPTION
Task/Issue URL:https://app.asana.com/0/1204006570077678/1209486069724547
Tech Design URL:
CC:

### Description
The blue notification dot in the more options menu was shown in a fresh install. The problem was that the blue dot was checking if two days had passed since the `firstLaunchDate`, but for new users, the `DockCustomizer` was being created before its initialization, and the default value of it was a month ago, causing the check to return true.

![Screenshot 2025-03-04 at 4 25 56 PM](https://github.com/user-attachments/assets/fff2cf06-fce5-4b2e-bf6a-f14c422b6e67)

The fix moves the initialization of the `DockCustomizer` just after the `firstLaunchDate` is initialized.


### Testing Steps

1. Run `./clean-app.sh debug` to set the state as fresh
2. Run the application
3. The blue dot shouldn’t be present
4. Go to the `DockCustomizer` class and in the `startTimer` function, reduce the timer from `12 * 60 * 60`, to just one. This is just to make the check every one second
5. Run the app again
6. Run `defaults delete com.duckduckgo.macos.browser.debug first.app.launch.date` This will set the first launch date a month from here.
7. Check if the notification appears
8. Open multiple windows, it will appear there too
9. Open and close the more options menu, it should disappear from all windows.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
I do not foresee problems.

### Quality Considerations
This is pretty straightforward.