### PR TITLE
(7.160.0) VPN Entitlement check fix

### DIFF
--- a/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionAuthV1toV2Bridge.swift
+++ b/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionAuthV1toV2Bridge.swift
@@ -67,7 +67,7 @@ extension DefaultSubscriptionManager: SubscriptionAuthV1toV2Bridge {
 extension DefaultSubscriptionManagerV2: SubscriptionAuthV1toV2Bridge {
 
     public func isEnabled(feature: Entitlement.ProductName) async throws -> Bool {
-        switch feature { // TODO Check what happens if fails to fetch current features
+        switch feature { // todo Check what happens if fails to fetch current features
         case .networkProtection:
             return await isFeatureAvailableForUser(.networkProtection)
         case .dataBrokerProtection:

--- a/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionAuthV1toV2Bridge.swift
+++ b/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionAuthV1toV2Bridge.swift
@@ -31,7 +31,7 @@ public protocol SubscriptionAuthV1toV2Bridge: SubscriptionTokenProvider, Subscri
 
 extension SubscriptionAuthV1toV2Bridge {
     public func isEnabled(feature: Entitlement.ProductName) async throws -> Bool {
-        try await isEnabled(feature: feature, cachePolicy: .reloadIgnoringLocalCacheData)
+        try await isEnabled(feature: feature, cachePolicy: .returnCacheDataElseLoad)
     }
 }
 

--- a/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionAuthV1toV2Bridge.swift
+++ b/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionAuthV1toV2Bridge.swift
@@ -20,7 +20,7 @@ import Foundation
 
 /// Temporary bridge between auth v1 and v2, this is implemented by SubscriptionManager V1 and V2
 public protocol SubscriptionAuthV1toV2Bridge: SubscriptionTokenProvider, SubscriptionAuthenticationStateProvider {
-    func isEnabled(feature: Entitlement.ProductName) async -> Bool
+    func isEnabled(feature: Entitlement.ProductName) async throws -> Bool
     func currentSubscriptionFeatures() async -> [Entitlement.ProductName]
     func signOut(notifyUI: Bool) async
     var canPurchase: Bool { get }
@@ -31,12 +31,14 @@ public protocol SubscriptionAuthV1toV2Bridge: SubscriptionTokenProvider, Subscri
 
 extension DefaultSubscriptionManager: SubscriptionAuthV1toV2Bridge {
 
-    public func isEnabled(feature: Entitlement.ProductName) async -> Bool {
-        if case .success(let hasEntitlements) = await accountManager.hasEntitlement(forProductName: .networkProtection,
-                                                                                    cachePolicy: .reloadIgnoringLocalCacheData), hasEntitlements {
+    public func isEnabled(feature: Entitlement.ProductName) async throws -> Bool {
+
+        let result = await accountManager.hasEntitlement(forProductName: .networkProtection, cachePolicy: .reloadIgnoringLocalCacheData)
+        switch result {
+        case .success(let hasEntitlements):
             return hasEntitlements
-        } else {
-            return false
+        case .failure(let error):
+            throw error
         }
     }
 
@@ -64,8 +66,8 @@ extension DefaultSubscriptionManager: SubscriptionAuthV1toV2Bridge {
 
 extension DefaultSubscriptionManagerV2: SubscriptionAuthV1toV2Bridge {
 
-    public func isEnabled(feature: Entitlement.ProductName) async -> Bool {
-        switch feature {
+    public func isEnabled(feature: Entitlement.ProductName) async throws -> Bool {
+        switch feature { // TODO Check what happens if fails to fetch current features
         case .networkProtection:
             return await isFeatureAvailableForUser(.networkProtection)
         case .dataBrokerProtection:

--- a/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionAuthV1toV2Bridge.swift
+++ b/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionAuthV1toV2Bridge.swift
@@ -20,7 +20,7 @@ import Foundation
 
 /// Temporary bridge between auth v1 and v2, this is implemented by SubscriptionManager V1 and V2
 public protocol SubscriptionAuthV1toV2Bridge: SubscriptionTokenProvider, SubscriptionAuthenticationStateProvider {
-    func isEnabled(feature: Entitlement.ProductName) async throws -> Bool
+    func isEnabled(feature: Entitlement.ProductName, cachePolicy: APICachePolicy) async throws -> Bool
     func currentSubscriptionFeatures() async -> [Entitlement.ProductName]
     func signOut(notifyUI: Bool) async
     var canPurchase: Bool { get }
@@ -29,11 +29,17 @@ public protocol SubscriptionAuthV1toV2Bridge: SubscriptionTokenProvider, Subscri
     var email: String? { get }
 }
 
+extension SubscriptionAuthV1toV2Bridge {
+    public func isEnabled(feature: Entitlement.ProductName) async throws -> Bool {
+        try await isEnabled(feature: feature, cachePolicy: .reloadIgnoringLocalCacheData)
+    }
+}
+
 extension DefaultSubscriptionManager: SubscriptionAuthV1toV2Bridge {
 
-    public func isEnabled(feature: Entitlement.ProductName) async throws -> Bool {
+    public func isEnabled(feature: Entitlement.ProductName, cachePolicy: APICachePolicy) async throws -> Bool {
 
-        let result = await accountManager.hasEntitlement(forProductName: .networkProtection, cachePolicy: .reloadIgnoringLocalCacheData)
+        let result = await accountManager.hasEntitlement(forProductName: .networkProtection, cachePolicy: cachePolicy)
         switch result {
         case .success(let hasEntitlements):
             return hasEntitlements
@@ -66,7 +72,7 @@ extension DefaultSubscriptionManager: SubscriptionAuthV1toV2Bridge {
 
 extension DefaultSubscriptionManagerV2: SubscriptionAuthV1toV2Bridge {
 
-    public func isEnabled(feature: Entitlement.ProductName) async throws -> Bool {
+    public func isEnabled(feature: Entitlement.ProductName, cachePolicy: APICachePolicy) async throws -> Bool {
         switch feature { // todo Check what happens if fails to fetch current features
         case .networkProtection:
             return await isFeatureAvailableForUser(.networkProtection)

--- a/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionManagerMock.swift
+++ b/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionManagerMock.swift
@@ -117,11 +117,14 @@ public final class SubscriptionManagerMock: SubscriptionManager {
         accountManager.isUserAuthenticated
     }
 
-    public func isEnabled(feature: Entitlement.ProductName) async -> Bool {
-        if case .success(let hasEntitlements) = await accountManager.hasEntitlement(forProductName: .networkProtection), hasEntitlements {
-            return true
-        } else {
-            return false
+    public func isEnabled(feature: Entitlement.ProductName, cachePolicy: APICachePolicy) async throws -> Bool {
+
+        let result = await accountManager.hasEntitlement(forProductName: .networkProtection, cachePolicy: cachePolicy)
+        switch result {
+        case .success(let hasEntitlements):
+            return hasEntitlements
+        case .failure(let error):
+            throw error
         }
     }
 

--- a/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionManagerMockV2.swift
+++ b/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionManagerMockV2.swift
@@ -184,7 +184,7 @@ public final class SubscriptionManagerMockV2: SubscriptionManagerV2 {
         resultTokenContainer = nil
     }
 
-    public func isEnabled(feature: Entitlement.ProductName) async -> Bool {
+    public func isEnabled(feature: Subscription.Entitlement.ProductName, cachePolicy: Subscription.APICachePolicy) async throws -> Bool {
         switch feature {
         case .networkProtection:
             return await isFeatureAvailableForUser(.networkProtection)

--- a/iOS/DuckDuckGo/AppServices/VPNService.swift
+++ b/iOS/DuckDuckGo/AppServices/VPNService.swift
@@ -114,7 +114,8 @@ final class VPNService: NSObject {
     @MainActor
     private func refreshVPNShortcuts() async {
         guard await vpnFeatureVisibility.shouldShowVPNShortcut(),
-              let hasEntitlement = try? await subscriptionManager.isEnabled(feature: .networkProtection),
+              let hasEntitlement = try? await subscriptionManager.isEnabled(feature: .networkProtection,
+                                                                            cachePolicy: .returnCacheDataDontLoad),
               hasEntitlement
         else {
             application.shortcutItems = nil

--- a/iOS/DuckDuckGo/AppServices/VPNService.swift
+++ b/iOS/DuckDuckGo/AppServices/VPNService.swift
@@ -114,7 +114,8 @@ final class VPNService: NSObject {
     @MainActor
     private func refreshVPNShortcuts() async {
         guard await vpnFeatureVisibility.shouldShowVPNShortcut(),
-              await subscriptionManager.isEnabled(feature: .networkProtection)
+              let hasEntitlement = try? await subscriptionManager.isEnabled(feature: .networkProtection),
+              hasEntitlement
         else {
             application.shortcutItems = nil
             return

--- a/iOS/DuckDuckGo/Feedback/VPNMetadataCollector.swift
+++ b/iOS/DuckDuckGo/Feedback/VPNMetadataCollector.swift
@@ -242,9 +242,10 @@ final class DefaultVPNMetadataCollector: VPNMetadataCollector {
     }
 
     func collectPrivacyProInfo() async -> VPNMetadata.PrivacyProInfo {
+        let hasVPNEntitlement = (try? await subscriptionManager.isEnabled(feature: .networkProtection)) ?? false
         return .init(
             hasPrivacyProAccount: subscriptionManager.isUserAuthenticated,
-            hasVPNEntitlement: await subscriptionManager.isEnabled(feature: .networkProtection)
+            hasVPNEntitlement: hasVPNEntitlement
         )
     }
 }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -529,7 +529,7 @@ class MainViewController: UIViewController {
     func presentNetworkProtectionStatusSettingsModal() {
         Task {
             let subscriptionManager = AppDependencyProvider.shared.subscriptionAuthV1toV2Bridge
-            if await subscriptionManager.isEnabled(feature: .networkProtection) {
+            if let hasEntitlement = try? await subscriptionManager.isEnabled(feature: .networkProtection), hasEntitlement {
                 segueToVPN()
             } else {
                 segueToPrivacyPro()
@@ -1691,7 +1691,9 @@ class MainViewController: UIViewController {
     private func onEntitlementsChange(_ notification: Notification) {
         Task {
             let subscriptionManager = AppDependencyProvider.shared.subscriptionAuthV1toV2Bridge
-            guard await subscriptionManager.isEnabled(feature: .networkProtection) else { return }
+            guard let hasEntitlement = try? await subscriptionManager.isEnabled(feature: .networkProtection),
+                      hasEntitlement == false
+            else { return }
 
             if await networkProtectionTunnelController.isInstalled {
                 tunnelDefaults.enableEntitlementMessaging()

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -841,8 +841,11 @@ extension SettingsViewModel {
             var currentEntitlements: [Entitlement.ProductName] = []
             let entitlementsToCheck: [Entitlement.ProductName] = [.networkProtection, .dataBrokerProtection, .identityTheftRestoration, .identityTheftRestorationGlobal]
 
-            for entitlement in entitlementsToCheck where await subscriptionAuthV1toV2Bridge.isEnabled(feature: entitlement) {
-                currentEntitlements.append(entitlement)
+            for entitlement in entitlementsToCheck {
+                if let hasEntitlement = try? await subscriptionAuthV1toV2Bridge.isEnabled(feature: entitlement),
+                    hasEntitlement {
+                    currentEntitlements.append(entitlement)
+                }
             }
 
             self.state.subscription.entitlements = currentEntitlements

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -160,7 +160,8 @@ final class MainCoordinator {
 
     func presentNetworkProtectionStatusSettingsModal() {
         Task {
-            if await subscriptionManager.isEnabled(feature: .networkProtection) {
+            if let hasEntitlement = try? await subscriptionManager.isEnabled(feature: .networkProtection),
+               hasEntitlement {
                 controller.segueToVPN()
             } else {
                 controller.segueToPrivacyPro()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201011656765697/1208864390316201
CC: @Bunn @samsymons @miasma13 

### Description

Fix for a bug introduced in https://app.asana.com/0/1205842942115003/1209170372758738 where a failure to fetch the subscription entitlements was treated as the user not having the entitlements at all.

### Testing Steps
1. Install 7.160.0
2. Subscribe to Privacy pro and enable VPN
3. Install this fix on top
4. Check that subscription is still available and the VPN is still enabled

1. Enable VPN
2. Click on the vpn widget for disabling the VPN
3. All should work as expected

1. Disable VPN
2. Click on the vpn widget for enabling the VPN
3. All should work as expected

### Impact and Risks

High, we could log out the Subscription Pro users

#### What could go wrong?

- User can be logged out from Subscription Pro
- The VPN could be disconnected
- We could present the wrong VPN related settings

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)