### PR TITLE
tab switcher pixels

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -95,6 +95,7 @@ extension Pixel {
         case tabSwitcherLongPressSelectTabs
         case tabSwitcherLongPressCloseTab
         case tabSwitcherLongPressCloseOtherTabs
+        case tabSwitcherLongPressCloseOtherTabsDaily
 
         case settingsDoNotSellShown
         case settingsDoNotSellOn
@@ -2102,6 +2103,7 @@ extension Pixel.Event {
         case .tabSwitcherLongPressSelectTabs: return "m_tab_manager_long_press_select_tabs"
         case .tabSwitcherLongPressCloseTab: return "m_tab_manager_long_press_close_tab"
         case .tabSwitcherLongPressCloseOtherTabs: return "m_tab_manager_long_press_close_other_tabs"
+        case .tabSwitcherLongPressCloseOtherTabsDaily: return "m_tab_manager_long_press_close_other_tabs_daily"
         }
     }
 }

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -63,6 +63,39 @@ extension Pixel {
         case tabSwitchLongPressNewTab
         case tabSwitcherOpenedDaily
 
+        // MARK: Tabswitcher improvements
+        case tabSwitcherEditMenuClicked
+        case tabSwitcherEditMenuSelectTabs
+        case tabSwitcherEditMenuSelectTabsDaily
+        case tabSwitcherEditMenuCloseAllTabs
+        case tabSwitcherEditMenuCloseAllTabsDaily
+        case tabSwitcherTabSelected
+        case tabSwitcherTabDeselected
+        case tabSwitcherSelectAll
+        case tabSwitcherSelectAllDaily
+        case tabSwitcherDeselectAll
+        case tabSwitcherDeselectAllDaily
+        case tabSwitcherCloseAll
+        case tabSwitcherCloseAllDaily
+        case tabSwitcherConfirmCloseTabs
+        case tabSwitcherConfirmCloseTabsDaily
+        case tabSwitcherSelectModeMenuClicked
+        case tabSwitcherSelectModeMenuShareLinks
+        case tabSwitcherSelectModeMenuShareLinksDaily
+        case tabSwitcherSelectModeMenuBookmarkTabs
+        case tabSwitcherSelectModeMenuBookmarkTabsDaily
+        case tabSwitcherSelectModeMenuBookmarkAllTabs
+        case tabSwitcherSelectModeMenuBookmarkAllTabsDaily
+        case tabSwitcherSelectModeMenuCloseOtherTabs
+        case tabSwitcherSelectModeMenuCloseOtherTabsDaily
+        case tabSwitcherLongPress
+        case tabSwitcherLongPressDaily
+        case tabSwitcherLongPressShare
+        case tabSwitcherLongPressBookmarkThisTab
+        case tabSwitcherLongPressSelectTabs
+        case tabSwitcherLongPressCloseTab
+        case tabSwitcherLongPressCloseOtherTabs
+
         case settingsDoNotSellShown
         case settingsDoNotSellOn
         case settingsDoNotSellOff
@@ -2036,6 +2069,39 @@ extension Pixel.Event {
 
         // MARK: Malicious Site Protection
         case .maliciousSiteProtection(let event): return "m_\(event.name)"
+
+        // MARK: Tab switcher improvements
+        case .tabSwitcherEditMenuClicked: return "m_tab_manager_edit_menu_clicked"
+        case .tabSwitcherEditMenuSelectTabs: return "m_tab_manager_edit_menu_select_tabs"
+        case .tabSwitcherEditMenuSelectTabsDaily: return "m_tab_manager_edit_menu_select_tabs_daily"
+        case .tabSwitcherEditMenuCloseAllTabs: return "m_tab_manager_edit_menu_close_all_tabs"
+        case .tabSwitcherEditMenuCloseAllTabsDaily: return "m_tab_manager_edit_menu_close_all_tabs_daily"
+        case .tabSwitcherTabSelected: return "m_tab_manager_tab_selected"
+        case .tabSwitcherTabDeselected: return "m_tab_manager_tab_deselected"
+        case .tabSwitcherSelectAll: return "m_tab_manager_select_all"
+        case .tabSwitcherSelectAllDaily: return "m_tab_manager_select_all_daily"
+        case .tabSwitcherDeselectAll: return "m_tab_manager_deselect_all"
+        case .tabSwitcherDeselectAllDaily: return "m_tab_manager_deselect_all_daily"
+        case .tabSwitcherCloseAll: return "m_tab_manager_close_all"
+        case .tabSwitcherCloseAllDaily: return "m_tab_manager_close_all_daily"
+        case .tabSwitcherConfirmCloseTabs: return "m_tab_manager_confirm_close_tabs"
+        case .tabSwitcherConfirmCloseTabsDaily: return "m_tab_manager_confirm_close_tabs_daily"
+        case .tabSwitcherSelectModeMenuClicked: return "m_tab_manager_select_mode_menu_clicked"
+        case .tabSwitcherSelectModeMenuShareLinks: return "m_tab_manager_select_mode_menu_share_links"
+        case .tabSwitcherSelectModeMenuShareLinksDaily: return "m_tab_manager_select_mode_menu_share_links_daily"
+        case .tabSwitcherSelectModeMenuBookmarkTabs: return "m_tab_manager_select_mode_menu_bookmark_tabs"
+        case .tabSwitcherSelectModeMenuBookmarkTabsDaily: return "m_tab_manager_select_mode_menu_bookmark_tabs_daily"
+        case .tabSwitcherSelectModeMenuBookmarkAllTabs: return "m_tab_manager_select_mode_menu_bookmark_all_tabs"
+        case .tabSwitcherSelectModeMenuBookmarkAllTabsDaily: return "m_tab_manager_select_mode_menu_bookmark_all_tabs_daily"
+        case .tabSwitcherSelectModeMenuCloseOtherTabs: return "m_tab_manager_select_mode_menu_close_other_tabs"
+        case .tabSwitcherSelectModeMenuCloseOtherTabsDaily: return "m_tab_manager_select_mode_menu_close_other_tabs_daily"
+        case .tabSwitcherLongPress: return "m_tab_manager_long_press"
+        case .tabSwitcherLongPressDaily: return "m_tab_manager_long_press_daily"
+        case .tabSwitcherLongPressShare: return "m_tab_manager_long_press_share"
+        case .tabSwitcherLongPressBookmarkThisTab: return "m_tab_manager_long_press_bookmark_this_tab"
+        case .tabSwitcherLongPressSelectTabs: return "m_tab_manager_long_press_select_tabs"
+        case .tabSwitcherLongPressCloseTab: return "m_tab_manager_long_press_close_tab"
+        case .tabSwitcherLongPressCloseOtherTabs: return "m_tab_manager_long_press_close_other_tabs"
         }
     }
 }

--- a/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
+++ b/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
@@ -41,6 +41,7 @@ class TabSwitcherBarsStateHandler {
     var selectedTabsCount: Int = 0
     var totalTabsCount: Int = 0
     var containsWebPages = false
+    var canShowSelectionMenu = false
 
     func update(_ interfaceMode: TabSwitcherViewController.InterfaceMode,
                 selectedTabsCount: Int,
@@ -167,9 +168,5 @@ class TabSwitcherBarsStateHandler {
             ]
 
         }
-    }
-    
-    func menuButtonHasChildren() -> Bool {
-        return menuButton.menu?.children.contains { ($0 as? UIMenu)?.children.isEmpty == false } ?? false
-    }
+    }    
 }

--- a/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
@@ -26,7 +26,12 @@ import Bookmarks
 // TODO fire pixels from the source specific action implementations
 extension TabSwitcherViewController {
 
-    func bookmarkTabs(withIndexPaths indexPaths: [IndexPath], title: String, message: String) {
+    func bookmarkTabs(withIndexPaths indexPaths: [IndexPath], title: String, message: String,
+                      pixel: Pixel.Event, dailyPixel: Pixel.Event) {
+
+        Pixel.fire(pixel: pixel)
+        DailyPixel.fire(pixel: dailyPixel)
+
         func tabsToBookmarks(_ controller: TabSwitcherViewController) {
             let model = MenuBookmarksViewModel(bookmarksDatabase: controller.bookmarksDatabase, syncService: controller.syncService)
             model.favoritesDisplayMode = AppDependencyProvider.shared.appSettings.favoritesDisplayMode
@@ -137,6 +142,9 @@ extension TabSwitcherViewController {
     }
 
     func closeAllTabs() {
+        Pixel.fire(pixel: .tabSwitcherCloseAll)
+        DailyPixel.fire(pixel: .tabSwitcherCloseAllDaily)
+
         let alert = UIAlertController(
             title: UserText.alertTitleCloseAllTabs(withCount: tabsModel.count),
             message: UserText.alertMessageCloseAllTabs(withCount: tabsModel.count),
@@ -145,6 +153,8 @@ extension TabSwitcherViewController {
         alert.addAction(UIAlertAction(title: UserText.closeTabs(withCount: tabsModel.count),
                                       style: .destructive) { [weak self] _ in
             guard let self else { return }
+            Pixel.fire(pixel: .tabSwitcherConfirmCloseTabs)
+            DailyPixel.fire(pixel: .tabSwitcherConfirmCloseTabsDaily)
             self.delegate?.tabSwitcherDidRequestCloseAll(tabSwitcher: self)
         })
 
@@ -193,6 +203,9 @@ extension TabSwitcherViewController {
     }
 
     func shareTabs(_ tabs: [Tab]) {
+        Pixel.fire(pixel: .tabSwitcherSelectModeMenuShareLinks)
+        DailyPixel.fire(pixel: .tabSwitcherSelectModeMenuShareLinksDaily)
+
         let sharingItems = tabs.compactMap { $0.link?.url }
         let controller = UIActivityViewController(activityItems: sharingItems, applicationActivities: nil)
 
@@ -210,7 +223,10 @@ extension TabSwitcherViewController {
         present(controller, animated: true)
     }
 
-    func closeOtherTabs(retainingIndexPaths indexPaths: [IndexPath]) {
+    func closeOtherTabs(retainingIndexPaths indexPaths: [IndexPath], pixel: Pixel.Event, dailyPixel: Pixel.Event) {
+        Pixel.fire(pixel: pixel)
+        DailyPixel.fire(pixel: dailyPixel)
+
         let otherIndexPaths = Set<IndexPath>(tabsModel.tabs.indices.map {
             IndexPath(row: $0, section: 0)
         }).subtracting(indexPaths)
@@ -254,8 +270,9 @@ extension TabSwitcherViewController {
     }
     
     func createMultiSelectionMenu() -> UIMenu {
+
         let otherTabCount = max(0, tabsModel.count - selectedTabs.count)
-        let selectedTabs = selectedTabs.map { tabsModel.safeGetTabAt($0.row) }.compactMap { $0 }
+        let selectedTabs = selectedTabs.map { self.tabsModel.safeGetTabAt($0.row) }.compactMap { $0 }
         let selectedTabsContainsWebPages = selectedTabs.contains(where: { $0.link != nil })
         let canShare = selectedTabsContainsWebPages
         let canAddBookmarks = selectedTabsContainsWebPages
@@ -265,8 +282,8 @@ extension TabSwitcherViewController {
         let canShowSelectAll = interfaceMode.isLarge && selectedTabs.count < tabsModel.count
         let canClose = interfaceMode.isLarge && selectedTabs.count > 0
 
-        return UIMenu(title: "", children: [
-            
+        let items = [
+
             UIMenu(title: "", options: .displayInline, children: [
                 canShowDeselectAll ? action(UserText.deselectAllTabs, "Check-Circle-16", { [weak self] in
                     self?.deselectAllTabs()
@@ -275,7 +292,7 @@ extension TabSwitcherViewController {
                     self?.selectAllTabs()
                 }) : nil,
             ].compactMap { $0 }),
-            
+
             UIMenu(title: "", options: .displayInline, children: [
                 canShare ? action(UserText.shareLinks(withCount: selectedTabs.count), "Share-Apple-16", { [weak self] in
                     self?.selectModeShareLinks()
@@ -284,7 +301,7 @@ extension TabSwitcherViewController {
                     self?.selectModeBookmarkSelected()
                 }) : nil,
             ].compactMap { $0 }),
-                        
+
             UIMenu(title: "", options: .displayInline, children: [
                 // Always use plural here
                 canCloseOther ? destructive(UserText.tabSwitcherCloseOtherTabs(withCount: 2), "Tab-Close-16", { [weak self] in
@@ -303,14 +320,25 @@ extension TabSwitcherViewController {
                     self?.selectModeBookmarkAll()
                 }) : nil,
             ].compactMap { $0 })
+        ]
+
+        barsHandler.canShowSelectionMenu = !items.allSatisfy(\.children.isEmpty)
+
+        let deferredElement = UIDeferredMenuElement.uncached { completion in
+            Pixel.fire(pixel: .tabSwitcherSelectModeMenuClicked)
+            completion(items)
+        }
+
+        return UIMenu(title: "", children: [
+            deferredElement
         ])
     }
     
     func createEditMenu() -> UIMenu {
-        return UIMenu(children: [
+        let items = [
             // Force plural version for the menu - this really means "switch to select tabs mode"
             action(UserText.tabSwitcherSelectTabs(withCount: 2), "Check-Circle-16", { [weak self] in
-                self?.editMenuSelectAll()
+                self?.editMenuEnterSelectMode()
             }),
 
             UIMenu(title: "", options: [.displayInline], children: [
@@ -319,6 +347,15 @@ extension TabSwitcherViewController {
                     self?.editMenuCloseAllTabs()
                 })
             ]),
+        ]
+
+        let deferredElement = UIDeferredMenuElement.uncached { completion in
+            Pixel.fire(pixel: .tabSwitcherEditMenuClicked)
+            completion(items)
+        }
+
+        return UIMenu(children: [
+            deferredElement
         ])
     }
 
@@ -389,7 +426,9 @@ extension TabSwitcherViewController {
         barsHandler.addAllBookmarksButton.primaryAction = action(image: "Bookmark-New-24") { [weak self] in
             self?.bookmarkTabs(withIndexPaths: self!.tabsModel.tabs.indices.map { IndexPath(row: $0, section: 0) },
                                title: UserText.alertTitleBookmarkAll(withCount: self!.tabsModel.count),
-                               message: UserText.alertBookmarkAllMessage)
+                               message: UserText.alertBookmarkAllMessage,
+                               pixel: .tabSwitcherSelectModeMenuBookmarkAllTabs,
+                               dailyPixel: .tabSwitcherSelectModeMenuBookmarkAllTabsDaily)
         }
 
         barsHandler.plusButton.accessibilityLabel = UserText.keyCommandNewTab
@@ -419,7 +458,7 @@ extension TabSwitcherViewController {
         barsHandler.menuButton.image = UIImage(resource: .moreApple24)
         barsHandler.menuButton.tintColor = UIColor(designSystemColor: .icons)
         barsHandler.menuButton.menu = createMultiSelectionMenu()
-        barsHandler.menuButton.isEnabled = barsHandler.menuButtonHasChildren()
+        barsHandler.menuButton.isEnabled = barsHandler.canShowSelectionMenu
 
         barsHandler.closeTabsButton.isEnabled = selectedTabs.count > 0
         barsHandler.closeTabsButton.primaryAction = action(UserText.closeTabs(withCount: selectedTabs.count)) { [weak self] in
@@ -432,11 +471,15 @@ extension TabSwitcherViewController {
 // MARK: Edit menu actions
 extension TabSwitcherViewController {
 
-    func editMenuSelectAll() {
+    func editMenuEnterSelectMode() {
+        Pixel.fire(pixel: .tabSwitcherEditMenuSelectTabs)
+        DailyPixel.fire(pixel: .tabSwitcherEditMenuSelectTabsDaily)
         transitionToMultiSelect()
     }
 
     func editMenuCloseAllTabs() {
+        Pixel.fire(pixel: .tabSwitcherEditMenuCloseAllTabs)
+        DailyPixel.fire(pixel: .tabSwitcherEditMenuCloseAllTabsDaily)
         closeAllTabs()
     }
 
@@ -452,19 +495,25 @@ extension TabSwitcherViewController {
     }
 
     func selectModeCloseOtherTabs() {
-        closeOtherTabs(retainingIndexPaths: selectedTabs)
+        closeOtherTabs(retainingIndexPaths: selectedTabs,
+                       pixel: .tabSwitcherSelectModeMenuCloseOtherTabs,
+                       dailyPixel: .tabSwitcherSelectModeMenuCloseOtherTabsDaily)
     }
 
     func selectModeBookmarkAll() {
         bookmarkTabs(withIndexPaths: tabsModel.tabs.indices.map { IndexPath(row: $0, section: 0) },
                      title: UserText.alertTitleBookmarkAll(withCount: tabsModel.count),
-                     message: UserText.alertBookmarkAllMessage)
+                     message: UserText.alertBookmarkAllMessage,
+                     pixel: .tabSwitcherSelectModeMenuBookmarkAllTabs,
+                     dailyPixel: .tabSwitcherSelectModeMenuBookmarkAllTabsDaily)
     }
 
     func selectModeBookmarkSelected() {
         bookmarkTabs(withIndexPaths: selectedTabs,
                      title: UserText.alertTitleBookmarkSelectedTabs(withCount: selectedTabs.count),
-                     message: UserText.alertBookmarkAllMessage)
+                     message: UserText.alertBookmarkAllMessage,
+                     pixel: .tabSwitcherSelectModeMenuBookmarkTabs,
+                     dailyPixel: .tabSwitcherSelectModeMenuBookmarkTabsDaily)
     }
 
     func selectModeShareLinks() {
@@ -472,10 +521,14 @@ extension TabSwitcherViewController {
     }
 
     func selectModeDeselectAllTabs() {
+        Pixel.fire(pixel: .tabSwitcherDeselectAll)
+        DailyPixel.fire(pixel: .tabSwitcherDeselectAllDaily)
         deselectAllTabs()
     }
 
     func selectModeSelectAllTabs() {
+        Pixel.fire(pixel: .tabSwitcherSelectAll)
+        DailyPixel.fire(pixel: .tabSwitcherSelectAllDaily)
         selectAllTabs()
     }
 
@@ -495,22 +548,24 @@ extension TabSwitcherViewController {
     func longPressMenuBookmarkTabs(indexPaths: [IndexPath]) {
         bookmarkTabs(withIndexPaths: indexPaths,
                      title: UserText.bookmarkSelectedTabs(withCount: selectedTabs.count),
-                     message: UserText.alertBookmarkAllMessage)
-    }
-
-    func longPressMenuCloseUnselectedTabs() {
-        closeOtherTabs(retainingIndexPaths: selectedTabs)
+                     message: UserText.alertBookmarkAllMessage,
+                     pixel: .tabSwitcherSelectModeMenuBookmarkTabs,
+                     dailyPixel: .tabSwitcherSelectModeMenuBookmarkTabsDaily)
     }
 
     func longPressMenuShareLinks(tabs: [Tab]) {
+        Pixel.fire(pixel: .tabSwitcherLongPressShare)
         shareTabs(tabs)
     }
 
     func longPressMenuBookmarkThisPage(indexPath: IndexPath) {
+        Pixel.fire(pixel: .tabSwitcherLongPressBookmarkThisTab)
         bookmarkTabAt(indexPath)
     }
 
     func longPressMenuSelectTabs(indexPaths: [IndexPath]) {
+        Pixel.fire(pixel: .tabSwitcherLongPressSelectTabs)
+
         if !isEditing {
             transitionToMultiSelect()
         }
@@ -523,6 +578,8 @@ extension TabSwitcherViewController {
     }
 
     func longPressMenuCloseTabs(indexPaths: [IndexPath]) {
+        Pixel.fire(pixel: .tabSwitcherLongPressCloseTab)
+
         if indexPaths.count == 1 {
             // No confirmation for a single tab
             self.deleteTabsAtIndexPaths(indexPaths)
@@ -541,7 +598,9 @@ extension TabSwitcherViewController {
     }
 
     func longPressMenuCloseOtherTabs(retainingIndexPaths indexPaths: [IndexPath]) {
-        closeOtherTabs(retainingIndexPaths: indexPaths)
+        closeOtherTabs(retainingIndexPaths: indexPaths,
+                       pixel: .tabSwitcherLongPressCloseOtherTabs,
+                       dailyPixel: .tabSwitcherLongPressCloseOtherTabsDaily)
     }
 
 }

--- a/iOS/DuckDuckGo/TabSwitcherViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController.swift
@@ -392,6 +392,7 @@ extension TabSwitcherViewController: UICollectionViewDelegate {
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if isEditing {
+            Pixel.fire(pixel: .tabSwitcherTabSelected)
             (collectionView.cellForItem(at: indexPath) as? TabViewCell)?.refreshSelectionAppearance()
             updateUIForSelectionMode()
             refreshTitle()
@@ -406,6 +407,7 @@ extension TabSwitcherViewController: UICollectionViewDelegate {
         (collectionView.cellForItem(at: indexPath) as? TabViewCell)?.refreshSelectionAppearance()
         updateUIForSelectionMode()
         refreshTitle()
+        Pixel.fire(pixel: .tabSwitcherTabDeselected)
     }
 
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
@@ -429,6 +431,8 @@ extension TabSwitcherViewController: UICollectionViewDelegate {
         guard !indexPaths.isEmpty else { return nil }
         
         let configuration = UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { _ in
+            Pixel.fire(pixel: .tabSwitcherLongPress)
+            DailyPixel.fire(pixel: .tabSwitcherLongPressDaily)
             return self.createLongPressMenuForTabs(atIndexPaths: indexPaths)
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1209580566682860
Tech Design URL:
CC:

### Description
Adds pixels for the tab switcher. 

### Testing Steps
1. Go through each pixel in the iOS part of this list and trigger it using it the tab switcher UI (should be obvious how based on the name ;) ) https://app.asana.com/0/392891325557410/1209149615549471


### Impact and Risks
Low: Just adds pixels

#### What could go wrong?
Had to refactor the menus to use a deferred item so they might break.

### Quality Considerations
Just check each pixel gets fired and the edit menu and selection menus work.

### Notes to Reviewer
