### PR TITLE
Fix sharing preferences on macOS 15

### DIFF
--- a/macOS/DuckDuckGo/Sharing/SharingMenu.swift
+++ b/macOS/DuckDuckGo/Sharing/SharingMenu.swift
@@ -57,14 +57,18 @@ final class SharingMenu: NSMenu {
     }
 
     @objc func openSharingPreferences(_ sender: NSMenuItem) {
-        if #available(macOS 13.0, *),
-           let preferencesLink = URL(string: "x-apple.systempreferences:com.apple.preferences.extensions?Sharing") {
-
-            NSWorkspace.shared.open(preferencesLink)
+        guard let url = if #available(macOS 15.0, *) {
+            URL(string: "x-apple.systempreferences:com.apple.ExtensionsPreferences?extensionPointIdentifier=com.apple.share-services")
+        } else if #available(macOS 13.0, *) {
+            URL(string: "x-apple.systempreferences:com.apple.preferences.extensions?Sharing")
+        } else {
+            URL(fileURLWithPath: "/System/Library/PreferencePanes/Extensions.prefPane")
+        } else { return }
+        if #available(macOS 13.0, *) {
+            NSWorkspace.shared.open(url)
             return
         }
 
-        let url = URL(fileURLWithPath: "/System/Library/PreferencePanes/Extensions.prefPane")
         let plist = [
             "action": "revealExtensionPoint",
             "protocol": "com.apple.share-services"


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1201048563534612/1209580911916105

### Description
- Fix opening System Sharing preferences on macOS 15

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Open a tab, navigate somewhere
2. Click “⋮” menu -> Share -> More… item
3. Validate System Sharing Settings is opened

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

### Optional E2E tests**:
- [ ] Run macOS PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)