### PR TITLE
Published VPN app exclusions, which were disabled by mistake

### DIFF
--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -101,7 +101,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .credentialsImportPromotionForExistingUsers:
             return .remoteReleasable(.subfeature(AutofillSubfeature.credentialsImportPromotionForExistingUsers))
         case .networkProtectionAppExclusions:
-            return .remoteDevelopment(.subfeature(NetworkProtectionSubfeature.appExclusions))
+            return .remoteReleasable(.subfeature(NetworkProtectionSubfeature.appExclusions))
         case .htmlNewTabPage:
             return .remoteReleasable(.subfeature(HTMLNewTabPageSubfeature.isLaunched))
         case .historyView:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207603085593419/1209598255904210

### Description

App exclusions is still internal and should have been published.

### Testing Steps

Just make sure that you see the App Exclusions UI in settings after removing your internal user state.

### Impact and Risks

None.

#### What could go wrong?

This feature has been available internally for a while and there haven't been issues.

### Quality Considerations

None.

### Notes to Reviewer

Ideally I'd like to push this today so it's included in tomorrow's internal build and released monday.

### Optional E2E tests**:
- [ ] Run macOS PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)