### PR TITLE
[iOS] Onbording - Show "Try a Search” and “Visit Site" only once

### DIFF
--- a/iOS/Core/UserDefaultsPropertyWrapper.swift
+++ b/iOS/Core/UserDefaultsPropertyWrapper.swift
@@ -43,6 +43,8 @@ public struct UserDefaultsWrapper<T> {
 
         case daxIsDismissed = "com.duckduckgo.ios.daxOnboardingIsDismissed"
         case daxHomeScreenMessagesSeen = "com.duckduckgo.ios.daxOnboardingHomeScreenMessagesSeen"
+        case daxTryAnonymousSearchShown = "com.duckduckgo.ios.daxOnboardingTryAnonymousSearchShown"
+        case daxTryVisitSiteShown = "com.duckduckgo.ios.daxOnboardingTryVisitSiteShown"
         case daxBrowsingAfterSearchShown = "com.duckduckgo.ios.daxOnboardingBrowsingAfterSearchShown"
         case daxBrowsingWithTrackersShown = "com.duckduckgo.ios.daxOnboardingBrowsingWithTrackersShown"
         case daxBrowsingWithoutTrackersShown = "com.duckduckgo.ios.daxOnboardingBrowsingWithoutTrackersShown"

--- a/iOS/DuckDuckGo/DaxDialogs.swift
+++ b/iOS/DuckDuckGo/DaxDialogs.swift
@@ -416,7 +416,6 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
     }
 
     func setTryAnonymousSearchMessageSeen() {
-        // Show "Try a search" dialog only once.
         settings.tryAnonymousSearchShown = true
     }
 

--- a/iOS/DuckDuckGo/DaxDialogs.swift
+++ b/iOS/DuckDuckGo/DaxDialogs.swift
@@ -541,8 +541,6 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
             return .initial
         }
 
-        // Return Visit site suggestion if:
-        // 1. Anonymous search skipped by opening a new tab
         if !settings.tryVisitASiteShown {
             return .subsequent
         }

--- a/iOS/DuckDuckGo/DaxDialogs.swift
+++ b/iOS/DuckDuckGo/DaxDialogs.swift
@@ -42,6 +42,8 @@ protocol ContextualOnboardingLogic {
     var isShowingSitesSuggestions: Bool { get }
     var isShowingAddToDockDialog: Bool { get }
 
+    func setTryAnonymousSearchMessageSeen()
+    func setTryVisitSiteMessageSeen()
     func setSearchMessageSeen()
     func setFireEducationMessageSeen()
     func clearedBrowserData()
@@ -372,7 +374,7 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
         case BrowsingSpec.SpecType.afterSearch.rawValue:
             return BrowsingSpec.afterSearch
         case BrowsingSpec.SpecType.visitWebsite.rawValue:
-            return .visitWebsite
+            return nil
         case BrowsingSpec.SpecType.withoutTrackers.rawValue:
             return BrowsingSpec.withoutTrackers
         case BrowsingSpec.SpecType.siteIsMajorTracker.rawValue:
@@ -411,6 +413,15 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
     func fireButtonPulseCancelled() {
         fireButtonPulseTimer?.invalidate()
         settings.fireButtonEducationShownOrExpired = true
+    }
+
+    func setTryAnonymousSearchMessageSeen() {
+        // Show "Try a search" dialog only once.
+        settings.tryAnonymousSearchShown = true
+    }
+
+    func setTryVisitSiteMessageSeen() {
+        settings.tryVisitASiteShown = true
     }
 
     func setSearchMessageSeen() {
@@ -525,11 +536,14 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
             return .final
         }
 
-        if !settings.browsingAfterSearchShown {
+        // If try a visit hasn't been show return initial
+        if !settings.tryAnonymousSearchShown {
             return .initial
         }
 
-        if firstSearchSeenButNoSiteVisited {
+        // Return Visit site suggestion if:
+        // 1. Anonymous search skipped by opening a new tab
+        if !settings.tryVisitASiteShown {
             return .subsequent
         }
         

--- a/iOS/DuckDuckGo/DaxDialogsSettings.swift
+++ b/iOS/DuckDuckGo/DaxDialogsSettings.swift
@@ -26,6 +26,10 @@ protocol DaxDialogsSettings: AnyObject {
     // Used to understand if users completed the old onboarding flow and should not be prompted in-context dax dialogs.
     var homeScreenMessagesSeen: Int { get }
 
+    var tryAnonymousSearchShown: Bool { get set }
+
+    var tryVisitASiteShown: Bool { get set }
+
     var browsingAfterSearchShown: Bool { get set }
     
     var browsingWithTrackersShown: Bool { get set }
@@ -57,7 +61,13 @@ class DefaultDaxDialogsSettings: DaxDialogsSettings {
     
     @UserDefaultsWrapper(key: .daxHomeScreenMessagesSeen, defaultValue: 0)
     var homeScreenMessagesSeen: Int
-    
+
+    @UserDefaultsWrapper(key: .daxTryAnonymousSearchShown, defaultValue: false)
+    var tryAnonymousSearchShown: Bool
+
+    @UserDefaultsWrapper(key: .daxTryVisitSiteShown, defaultValue: false)
+    var tryVisitASiteShown: Bool
+
     @UserDefaultsWrapper(key: .daxBrowsingAfterSearchShown, defaultValue: false)
     var browsingAfterSearchShown: Bool
     

--- a/iOS/DuckDuckGo/OnboardingDebugView.swift
+++ b/iOS/DuckDuckGo/OnboardingDebugView.swift
@@ -59,7 +59,7 @@ struct OnboardingDebugView: View {
                     Text(verbatim: "Reset Dax Dialogs State")
                 })
                 .alert(isPresented: $isShowingResetDaxDialogsAlert, content: {
-                    Alert(title: Text(verbatim: "Dax Dialogs reset"), dismissButton: .cancel())
+                    Alert(title: Text(verbatim: "Dax Dialogs reset"), dismissButton: .cancel(Text(verbatim: "Done")))
                 })
             }
 
@@ -97,10 +97,13 @@ final class OnboardingDebugViewModel: ObservableObject {
 
     func resetDaxDialogs() {
         settings.isDismissed = false
+        settings.tryAnonymousSearchShown = false
+        settings.tryVisitASiteShown = false
         settings.browsingAfterSearchShown = false
         settings.browsingWithTrackersShown = false
         settings.browsingWithoutTrackersShown = false
         settings.browsingMajorTrackingSiteShown = false
+        settings.fireButtonEducationShownOrExpired = false
         settings.fireMessageExperimentShown = false
         settings.fireButtonPulseDateShown = nil
         settings.privacyButtonPulseShown = false

--- a/iOS/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/NewTabDaxDialogFactory.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/NewTabDaxDialogFactory.swift
@@ -69,6 +69,7 @@ final class NewTabDaxDialogFactory: NewTabDaxDialogProvider {
         }
         .onboardingContextualBackgroundStyle(background: .illustratedGradient)
         .onFirstAppear { [weak self] in
+            self?.contextualOnboardingLogic.setTryAnonymousSearchMessageSeen()
             self?.onboardingPixelReporter.trackScreenImpression(event: .onboardingContextualTrySearchUnique)
         }
     }
@@ -81,6 +82,7 @@ final class NewTabDaxDialogFactory: NewTabDaxDialogProvider {
         }
         .onboardingContextualBackgroundStyle(background: .illustratedGradient)
         .onFirstAppear { [weak self] in
+            self?.contextualOnboardingLogic.setTryVisitSiteMessageSeen()
             self?.onboardingPixelReporter.trackScreenImpression(event: .onboardingContextualTryVisitSiteUnique)
         }
     }

--- a/iOS/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
@@ -124,6 +124,7 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
             { [weak delegate, weak self] in
                 onSizeUpdate()
                 delegate?.didAcknowledgeContextualOnboardingSearch()
+                self?.contextualOnboardingLogic.setTryVisitSiteMessageSeen()
                 self?.contextualOnboardingPixelReporter.trackScreenImpression(event: .onboardingContextualTryVisitSiteUnique)
             }
         } else {
@@ -142,6 +143,7 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
         let viewModel = OnboardingSiteSuggestionsViewModel(title: UserText.Onboarding.ContextualOnboarding.onboardingTryASiteTitle, suggestedSitesProvider: contextualOnboardingSiteSuggestionsProvider, delegate: delegate, pixelReporter: contextualOnboardingPixelReporter)
         return OnboardingTryVisitingSiteDialog(logoPosition: .left, viewModel: viewModel)
             .onFirstAppear { [weak self] in
+                self?.contextualOnboardingLogic.setTryVisitSiteMessageSeen()
                 self?.contextualOnboardingPixelReporter.trackScreenImpression(event: .onboardingContextualTryVisitSiteUnique)
             }
     }

--- a/iOS/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/ContextualOnboarding/ContextualDaxDialogsFactory.swift
@@ -70,7 +70,7 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
         case .afterSearch:
             rootView = AnyView(
                 afterSearchDialog(
-                    shouldFollowUpToWebsiteSearch: !contextualOnboardingSettings.userHasSeenTrackersDialog,
+                    shouldFollowUpToWebsiteSearch: !contextualOnboardingSettings.userHasSeenTrackersDialog && !contextualOnboardingSettings.userHasSeenTryVisitSiteDialog,
                     delegate: delegate,
                     afterSearchPixelEvent: spec.pixelName,
                     onSizeUpdate: onSizeUpdate
@@ -225,6 +225,7 @@ final class ExperimentContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
 protocol ContextualOnboardingSettings {
     var userHasSeenTrackersDialog: Bool { get }
     var userHasSeenFireDialog: Bool { get }
+    var userHasSeenTryVisitSiteDialog: Bool { get }
 }
 
 extension DefaultDaxDialogsSettings: ContextualOnboardingSettings {
@@ -237,6 +238,10 @@ extension DefaultDaxDialogsSettings: ContextualOnboardingSettings {
     
     var userHasSeenFireDialog: Bool {
         fireMessageExperimentShown
+    }
+
+    var userHasSeenTryVisitSiteDialog: Bool {
+        tryVisitASiteShown
     }
 
 }

--- a/iOS/DuckDuckGoTests/ContextualDaxDialogsFactoryTests.swift
+++ b/iOS/DuckDuckGoTests/ContextualDaxDialogsFactoryTests.swift
@@ -462,6 +462,7 @@ extension ContextualDaxDialogsFactoryTests {
 final class ContextualOnboardingSettingsMock: ContextualOnboardingSettings {
     var userHasSeenTrackersDialog: Bool = false
     var userHasSeenFireDialog: Bool = false
+    var userHasSeenTryVisitSiteDialog: Bool = false
 }
 
 

--- a/iOS/DuckDuckGoTests/ContextualOnboardingNewTabDialogFactoryTests.swift
+++ b/iOS/DuckDuckGoTests/ContextualOnboardingNewTabDialogFactoryTests.swift
@@ -113,7 +113,7 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
         finalDialog?.dismissAction(false)
         XCTAssertTrue(onDismissedRun)
         wait(for: [expectation], timeout: 5.0)
-        XCTAssertTrue(contextualOnboardingLogicMock.didCallsetFinalOnboardingDialogSeen)
+        XCTAssertTrue(contextualOnboardingLogicMock.didCallSetFinalOnboardingDialogSeen)
     }
 
     func testCreateAddFavoriteDialogCreatesAContextualDaxDialog() {

--- a/iOS/DuckDuckGoTests/DaxDialogTests.swift
+++ b/iOS/DuckDuckGoTests/DaxDialogTests.swift
@@ -528,7 +528,7 @@ final class DaxDialog: XCTestCase {
         XCTAssertNil(result2)
     }
 
-    func testWhenVisitWebsiteSeen_OnReload_VisitWebsiteReturned() {
+    func testWhenVisitWebsiteSeen_OnReload_VisitWebsiteNotReturned() {
         // GIVEN
         let settings = MockDaxDialogsSettings()
         let sut = makeSUT(settings: settings)
@@ -542,11 +542,11 @@ final class DaxDialog: XCTestCase {
 
         // THEN
         XCTAssertEqual(result1?.type, .afterSearch)
-        XCTAssertEqual(result2?.type, .visitWebsite)
-        XCTAssertEqual(result2, result3)
+        XCTAssertNil(result2)
+        XCTAssertNil(result3)
     }
 
-    func testWhenVisitWebsiteSeen_OnLoadingAnotherSearch_NilIseturned() {
+    func testWhenVisitWebsiteSeen_OnLoadingAnotherSearch_NilIsReturned() {
         // GIVEN
         let settings = MockDaxDialogsSettings()
         let sut = makeSUT(settings: settings)
@@ -560,7 +560,7 @@ final class DaxDialog: XCTestCase {
 
         // THEN
         XCTAssertEqual(result1?.type, .afterSearch)
-        XCTAssertEqual(result2?.type, .visitWebsite)
+        XCTAssertNil(result2)
         XCTAssertNil(result3)
     }
 

--- a/iOS/DuckDuckGoTests/DaxDialogsNewTabTests.swift
+++ b/iOS/DuckDuckGoTests/DaxDialogsNewTabTests.swift
@@ -48,7 +48,10 @@ final class DaxDialogsNewTabTests: XCTestCase {
         XCTAssertEqual(homeScreenMessage, .addFavorite)
     }
 
-    func testIfBrowsingAfterSearchNotShown_OnNextHomeScreenMessageNew_ReturnsInitial() {
+    func testIfTryAnonymousSearchNotShown_OnNextHomeScreenMessageNew_ReturnsInitial() {
+        // GIVEN
+        settings.tryAnonymousSearchShown = false
+
         // WHEN
         let homeScreenMessage = daxDialogs.nextHomeScreenMessageNew()
 
@@ -56,9 +59,10 @@ final class DaxDialogsNewTabTests: XCTestCase {
         XCTAssertEqual(homeScreenMessage, .initial)
     }
 
-    func testIfBrowsingAfterSearchShown_OnNextHomeScreenMessageNew_ReturnsSubsequent() {
+    func testIfTryAnonymousSearchShown_AndTryVisitASiteNotShown_OnNextHomeScreenMessageNew_ReturnsSubsequent() {
         // GIVEN
-        settings.browsingAfterSearchShown = true
+        settings.tryAnonymousSearchShown = true
+        settings.tryVisitASiteShown = false
 
         // WHEN
         let homeScreenMessage = daxDialogs.nextHomeScreenMessageNew()
@@ -67,10 +71,42 @@ final class DaxDialogsNewTabTests: XCTestCase {
         XCTAssertEqual(homeScreenMessage, .subsequent)
     }
 
-    func testIfBrowsingAfterSearchShown_andBrowsingMajorTrackingSiteShown_OnNextHomeScreenMessageNew_ReturnsFinal() {
+    func testIfTryAnonymousSearchShown_AndTryVisitASiteShown_AndFireDialogNotShown_OnNextHomeScreenMessageNew_ReturnsNil() {
         // GIVEN
-        settings.browsingAfterSearchShown = true
-        settings.browsingMajorTrackingSiteShown = true
+        settings.tryAnonymousSearchShown = true
+        settings.tryVisitASiteShown = true
+
+        // WHEN
+        let homeScreenMessage = daxDialogs.nextHomeScreenMessageNew()
+
+        // THEN
+        XCTAssertNil(homeScreenMessage)
+    }
+
+    func testIfFinalDialogSeen_OnNextHomeScreenMessageNew_ReturnsNil() {
+        // GIVEN
+        settings.browsingFinalDialogShown = true
+
+        // WHEN
+        let homeScreenMessage = daxDialogs.nextHomeScreenMessageNew()
+
+        //
+        XCTAssertNil(homeScreenMessage)
+    }
+
+    func testIfIsNotEnabled_OnNextHomeScreenMessageNew_ReturnsNil() {
+        // GIVEN
+        settings.isDismissed = true
+
+        // WHEN
+        let homeScreenMessage = daxDialogs.nextHomeScreenMessageNew()
+
+        //
+        XCTAssertNil(homeScreenMessage)
+    }
+
+    func testIfFireDialogShow_OnNextHomeScreenMessageNew_ReturnsFinal() {
+        // GIVEN
         settings.fireMessageExperimentShown = true
 
         // WHEN
@@ -79,100 +115,6 @@ final class DaxDialogsNewTabTests: XCTestCase {
         // THEN
         XCTAssertEqual(homeScreenMessage, .final)
     }
-
-    func testIfBrowsingAfterSearchShown_andBrowsingWithTrackersShown_andFireAnimationShown_OnNextHomeScreenMessageNew_ReturnsFinal() {
-        // GIVEN
-        settings.browsingAfterSearchShown = true
-        settings.browsingWithTrackersShown = true
-        settings.fireMessageExperimentShown = true
-
-        // WHEN
-        let homeScreenMessage = daxDialogs.nextHomeScreenMessageNew()
-
-        // THEN
-        XCTAssertEqual(homeScreenMessage, .final)
-    }
-
-    func testIfBrowsingAfterSearchShown_andBrowsingWithoutTrackersShown_andFireAnimationShown_OnNextHomeScreenMessageNew_ReturnsFinal() {
-        // GIVEN
-        settings.browsingAfterSearchShown = true
-        settings.browsingWithoutTrackersShown = true
-        settings.fireMessageExperimentShown = true
-
-        // WHEN
-        let homeScreenMessage = daxDialogs.nextHomeScreenMessageNew()
-
-        // THEN
-        XCTAssertEqual(homeScreenMessage, .final)
-    }
-
-    func testIfBrowsingAfterSearchShown_andTrackersDialogsShown_andFirreButtonFialogNotShown_OnNextHomeScreenMessageNew_ReturnsNil() {
-        // GIVEN
-        settings.browsingAfterSearchShown = true
-        settings.browsingWithoutTrackersShown = true
-        settings.browsingMajorTrackingSiteShown = true
-        settings.browsingWithTrackersShown = true
-
-        // WHEN
-        let homeScreenMessage = daxDialogs.nextHomeScreenMessageNew()
-
-        // THEN
-        XCTAssertNil(homeScreenMessage)
-        XCTAssertFalse(settings.browsingFinalDialogShown)
-    }
-
-
-    func testIfBrowsingAfterSearchShown_andBrowsingMajorTrackingSiteShown_andFinalDialogAlreadyShown_OnNextHomeScreenMessageNew_ReturnsNil() {
-        // GIVEN
-        settings.browsingAfterSearchShown = true
-        settings.browsingMajorTrackingSiteShown = true
-        settings.browsingFinalDialogShown = true
-
-        // WHEN
-        let homeScreenMessage = daxDialogs.nextHomeScreenMessageNew()
-
-        // THEN
-        XCTAssertNil(homeScreenMessage)
-    }
-
-    func testIfBrowsingAfterSearchShown_andBrowsingWithTrackersShown_andFinalDialogAlreadyShown_OnNextHomeScreenMessageNew_ReturnsNil() {
-        // GIVEN
-        settings.browsingAfterSearchShown = true
-        settings.browsingWithTrackersShown = true
-        settings.browsingFinalDialogShown = true
-
-        // WHEN
-        let homeScreenMessage = daxDialogs.nextHomeScreenMessageNew()
-
-        // THEN
-        XCTAssertNil(homeScreenMessage)
-    }
-
-    func testIfBrowsingAfterSearchShown_andBrowsingWithoutTrackersShown_andFinalDialogAlreadyShown_OnNextHomeScreenMessageNew_ReturnsNil() {
-        // GIVEN
-        settings.browsingAfterSearchShown = true
-        settings.browsingWithoutTrackersShown = true
-        settings.browsingFinalDialogShown = true
-
-        // WHEN
-        let homeScreenMessage = daxDialogs.nextHomeScreenMessageNew()
-
-        // THEN
-        XCTAssertNil(homeScreenMessage)
-    }
-
-    func testIfFinalDialogShown_andBrowsingAfterSearchNotShown_OnNextHomeScreenMessageNew_ReturnsNil() {
-        // GIVEN
-        settings.browsingAfterSearchShown = false
-        settings.browsingFinalDialogShown = true
-
-        // WHEN
-        let homeScreenMessage = daxDialogs.nextHomeScreenMessageNew()
-
-        // THEN
-        XCTAssertNil(homeScreenMessage)
-    }
-
 }
 
 class MockDaxDialogsSettings: DaxDialogsSettings {
@@ -184,6 +126,10 @@ class MockDaxDialogsSettings: DaxDialogsSettings {
     var isDismissed: Bool = false
 
     var homeScreenMessagesSeen: Int = 0
+
+    var tryAnonymousSearchShown: Bool = false
+
+    var tryVisitASiteShown: Bool = false
 
     var browsingAfterSearchShown: Bool = false
 

--- a/iOS/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
+++ b/iOS/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
@@ -147,13 +147,13 @@ final class TabViewControllerDaxDialogTests: XCTestCase {
 
     func testWhenDidAcknowledgeContextualOnboardingSearchIsCalledThenSetSearchMessageSeenOnLogic() {
         // GIVEN
-        XCTAssertFalse(onboardingLogicMock.didCallsetsetSearchMessageSeen)
+        XCTAssertFalse(onboardingLogicMock.didCallSetSearchMessageSeen)
 
         // WHEN
         sut.didAcknowledgeContextualOnboardingSearch()
 
         // THEN
-        XCTAssertTrue(onboardingLogicMock.didCallsetsetSearchMessageSeen)
+        XCTAssertTrue(onboardingLogicMock.didCallSetSearchMessageSeen)
     }
 
     func testWhenDidShowContextualOnboardingTrackersDialog_AndShouldShowPrivacyAnimation_ShieldIconAnimationActivated() {
@@ -230,9 +230,11 @@ final class TabViewControllerDaxDialogTests: XCTestCase {
 
 final class ContextualOnboardingLogicMock: ContextualOnboardingLogic {
     var expectation: XCTestExpectation?
+    private(set) var didCallSetTryAnonymousSearchMessageSeen = false
+    private(set) var didCallSetTryVisitSiteMessageSeen = false
     private(set) var didCallSetFireEducationMessageSeen = false
-    private(set) var didCallsetFinalOnboardingDialogSeen = false
-    private(set) var didCallsetsetSearchMessageSeen = false
+    private(set) var didCallSetFinalOnboardingDialogSeen = false
+    private(set) var didCallSetSearchMessageSeen = false
     private(set) var didCallEnableAddFavoriteFlow = false
     private(set) var didCallSetDaxDialogDismiss = false
     private(set) var didCallClearedBrowserData = false
@@ -245,17 +247,25 @@ final class ContextualOnboardingLogicMock: ContextualOnboardingLogic {
     var isShowingSitesSuggestions: Bool = false
     var isShowingAddToDockDialog: Bool = false
 
+    func setTryAnonymousSearchMessageSeen() {
+        didCallSetTryAnonymousSearchMessageSeen = true
+    }
+
+    func setTryVisitSiteMessageSeen() {
+        didCallSetTryVisitSiteMessageSeen = true
+    }
+
     func setFireEducationMessageSeen() {
         didCallSetFireEducationMessageSeen = true
     }
 
     func setFinalOnboardingDialogSeen() {
-        didCallsetFinalOnboardingDialogSeen = true
+        didCallSetFinalOnboardingDialogSeen = true
         expectation?.fulfill()
     }
 
     func setSearchMessageSeen() {
-        didCallsetsetSearchMessageSeen = true
+        didCallSetSearchMessageSeen = true
     }
 
     func setPrivacyButtonPulseSeen() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1142021229838617/1209605043831313

### Description

Show "Try a Search” & “Visit Site” Dax dialogs only once during the onboarding flow. 

### Testing Steps

To show the Dax dialogs again after they have been prompted:
1. Ensure you’re logged in as internal user.
2. Then open Settings → All debug options → Onboarding → Reset Dax Dialog State
3. Open a new tab, to see “Try a Search Dialog”.

**Scenario 1: Showing “Try a Search” & “Visit a Site" only once when opening new tabs.**
1. Wait for “Try a search” dialog is shown on new tab page.
2. Open a new tab.
3. “Visit a site” dialog should be shown.
4. Opean a new tab.
5. No dialog should be displayed on new tab page.

**Scenario 2: Showing “Try a Search” & “Visit a Site" only once when restarting the app.**
1. Wait for “Try a search” dialog is shown on new tab page.
2. Close and reopen the app.
3. “Visit a site” dialog should be shown.
4. Close and reopen the app.
5. No dialog should be displayed on new tab page.

**Scenario 3: Hide “Visit a site” on page reload.**
1. Wait for “Try a search” dialog is shown on new tab page.
2. Tap Surprise Me.
3. Wait for dialog to appear and tap the “Got It” button.
4. "Try visit a site" contextual dialog should appear.
5. Reload the page.
6. The dialog should dismiss.

**Scenario 4: Hide “Visit a site” on re-launch.**
1. Wait for “Try a search” dialog is shown on new tab page.
2. Tap Surprise Me.
3. Wait for dialog to appear and tap the “Got It” button.
4. "Try visit a site" contextual dialog should appear.
5. Close and re-open the app.
6. The website should reload and no dialog should appear.

**Scenario 5: Do not show “Visit site” contextually if users already seen the “Visit Site” on new tab page.**
1. Wait for “Try a search” dialog is shown on new tab page.
2. Open a new tab.
3. “Visit a site” dialog should be shown.
4. Search for “baby ducklings”.
5. Wait for performed search dialog to appear and tap the “Got It” button.
6. The dialog should hide since the user already was prompted with visit site in new tab page. 
7. Navigate to another website and continue the onboarding process.
8. Ensure onboarding can be completed per usual flow.

**Smoke Test onboarding flow.**
Smoke test onboarding to see if there any issues.

### Impact and Risks
<!— 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
—>

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

### Optional E2E tests**:
- [ ] Run macOS PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)