### PR TITLE
iOS: Fix pixel values for subscription related errors

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1792,14 +1792,14 @@ extension Pixel.Event {
         case .historyInsertVisitFailed: return "m_debug_history-insert-visit-failed"
         case .historyRemoveVisitsFailed: return "m_debug_history-remove-visits-failed"
 
-        // MARK: Privacy pro
+        // MARK: Privacy Pro
         case .privacyProSubscriptionActive: return "m_privacy-pro_app_subscription_active"
         case .privacyProOfferScreenImpression: return "m_privacy-pro_offer_screen_impression"
         case .privacyProPurchaseAttempt: return "m_privacy-pro_terms-conditions_subscribe_click"
         case .privacyProPurchaseFailure: return "m_privacy-pro_app_subscription-purchase_failure_other"
         case .privacyProPurchaseFailureStoreError: return "m_privacy-pro_app_subscription-purchase_failure_store"
-        case .privacyProPurchaseFailureAccountNotCreated: return "m_privacy-pro_app_subscription-purchase_failure_backend"
-        case .privacyProPurchaseFailureBackendError: return "m_privacy-pro_app_subscription-purchase_failure_account-creation"
+        case .privacyProPurchaseFailureAccountNotCreated: return "m_privacy-pro_app_subscription-purchase_failure_account-creation"
+        case .privacyProPurchaseFailureBackendError: return "m_privacy-pro_app_subscription-purchase_failure_backend"
         case .privacyProPurchaseSuccess: return "m_privacy-pro_app_subscription-purchase_success"
         case .privacyProRestorePurchaseOfferPageEntry: return "m_privacy-pro_offer_restore-purchase_click"
         case .privacyProRestorePurchaseClick: return "m_privacy-pro_app-settings_restore-purchase_click"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203936086921904/1209499063210750
CC:

### Description
We noticed that the 2 Privacy Pro pixels are badly reported due to having their values switched.

### Testing Steps
[iOS only]
Since it may be hard to reproduce real error cases to test the pixels, in `SubscriptionPagesUseSubscriptionFeature` you can add to one of the methods a forced `setTransactionError(...)` call that should trigger the pixel being sent.

1. Ensure that for `setTransactionError(.accountCreationFailed)` error a `.privacyProPurchaseFailureAccountNotCreated` pixel is being fired with a value of `m_privacy-pro_app_subscription-purchase_failure_account-creation`

3. Ensure that for `setTransactionError(.missingEntitlements)` error a `.privacyProPurchaseFailureBackendError` pixel is being fired with a value of `m_privacy-pro_app_subscription-purchase_failure_backend`


### Impact and Risks
Low: Wrong pixel values

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)