### PR TITLE
Fix displaying Dax logo in new window

### DIFF
--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -199,8 +199,7 @@ final class MainViewController: NSViewController {
             mainView.navigationBarContainerView.wantsLayer = true
             mainView.navigationBarContainerView.layer?.masksToBounds = false
 
-            if tabCollectionViewModel.selectedTabViewModel?.tab.content == .newtab,
-               browserTabViewController.homePageViewController?.addressBarModel.shouldShowAddressBar == false {
+            if tabCollectionViewModel.selectedTabViewModel?.tab.content == .newtab {
                 resizeNavigationBar(isHomePage: true, animated: lastTabContent != .newtab)
             } else {
                 resizeNavigationBar(isHomePage: false, animated: false)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1201899738287924/1209532040383733

### Description:
This change simplifies the logic of displaying Dax logo next to the address bar
by removing dead code of the Big Search Box experiment.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Launch the app and verify that Dax logo is shown next to the address bar while on NTP.
2. Open new tab and verify that it shows Dax logo
3. Open new window and verify that it shows Dax logo
4. Open new Fire Window and verify that it shows Dax logo

### Impact and Risks
Low

#### What could go wrong?
Big Search Box was part of native NTP which is no more displayed, so we can safely remove it (the full native NTP code removal is still due).

### Quality Considerations
N/A

### Notes to Reviewer
N/A

### Optional E2E tests**:
- [ ] Run macOS PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)