### PR TITLE
Fix Find in Page UI tests

### DIFF
--- a/macOS/UITests/Common/UITests.swift
+++ b/macOS/UITests/Common/UITests.swift
@@ -141,4 +141,11 @@ extension XCTestCase {
         screenshot.lifetime = .keepAlways
         add(screenshot)
     }
+
+    func assertElement(_ element: XCUIElement, hasValue value: CVarArg, file: StaticString = #file, line: UInt = #line) {
+        let predicate = NSPredicate(format: "%K == %@", #keyPath(XCUIElement.value), value)
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
+        let result = XCTWaiter().wait(for: [expectation], timeout: UITests.Timeouts.elementExistence)
+        XCTAssertEqual(result, .completed, "Unexpected status field text content after a \"Find Next\" operation.")
+    }
 }

--- a/macOS/UITests/FindInPageTests.swift
+++ b/macOS/UITests/FindInPageTests.swift
@@ -217,8 +217,7 @@ class FindInPageTests: UITestCase {
             statusField.waitForExistence(timeout: UITests.Timeouts.elementExistence),
             "Couldn't find \"Find in Page\" statusField in a reasonable timeframe."
         )
-        let statusFieldTextContent = try XCTUnwrap(statusField.value as? String)
-        XCTAssertEqual(statusFieldTextContent, "1 of 4") // Note: this is not a localized test element, and it should have a localization strategy.
+        assertElement(statusField, hasValue: "1 of 4")
     }
 
     func test_findInPage_showsFocusAndOccurrenceHighlighting() throws {
@@ -243,9 +242,7 @@ class FindInPageTests: UITestCase {
             statusField.waitForExistence(timeout: UITests.Timeouts.elementExistence),
             "Couldn't find \"Find in Page\" statusField in a reasonable timeframe."
         )
-        let statusFieldTextContent = try XCTUnwrap(statusField.value as? String)
-        // Note: the following is not a localized test element, but it should have a localization strategy.
-        XCTAssertEqual(statusFieldTextContent, "1 of 4", "Unexpected status field text content after a \"Find in Page\" operation.")
+        assertElement(statusField, hasValue: "1 of 4")
 
         let webViewWithSelectedWordsScreenshot = loremIpsumWebView.screenshot()
         let highlightedPixelsInScreenshot = try XCTUnwrap(webViewWithSelectedWordsScreenshot.image.matchingPixels(of: .findHighlightColor))
@@ -277,9 +274,8 @@ class FindInPageTests: UITestCase {
             statusField.waitForExistence(timeout: UITests.Timeouts.elementExistence),
             "Couldn't find \"Find in Page\" statusField in a reasonable timeframe."
         )
-        let statusFieldTextContent = try XCTUnwrap(statusField.value as? String)
         // Note: the following is not a localized test element, but it should have a localization strategy.
-        XCTAssertEqual(statusFieldTextContent, "1 of 4", "Unexpected status field text content after a \"Find in Page\" operation.")
+        assertElement(statusField, hasValue: "1 of 4")
         let findInPageScreenshot = loremIpsumWebView.screenshot()
         let highlightedPixelsInFindScreenshot = try XCTUnwrap(findInPageScreenshot.image.matchingPixels(of: .findHighlightColor))
         let findHighlightPoints = Set(highlightedPixelsInFindScreenshot.map { $0.point }) // Coordinates of highlighted pixels in the find screenshot
@@ -290,13 +286,8 @@ class FindInPageTests: UITestCase {
             "Couldn't find \"Find Next\" main menu bar item in a reasonable timeframe."
         )
         findNextMenuBarItem.click()
-        let updatedStatusField = app.textFields["FindInPageController.statusField"]
-        let updatedStatusFieldTextContent = updatedStatusField.value as! String
-        XCTAssertTrue(
-            updatedStatusField.waitForExistence(timeout: UITests.Timeouts.elementExistence),
-            "Couldn't find the updated \"Find in Page\" statusField in a reasonable timeframe."
-        )
-        XCTAssertEqual(updatedStatusFieldTextContent, "2 of 4", "Unexpected status field text content after a \"Find Next\" operation.")
+        assertElement(statusField, hasValue: "2 of 4")
+
         let findNextScreenshot = loremIpsumWebView.screenshot()
         let highlightedPixelsInFindNextScreenshot =
             try XCTUnwrap(Set(findNextScreenshot.image
@@ -337,9 +328,8 @@ class FindInPageTests: UITestCase {
             statusField.waitForExistence(timeout: UITests.Timeouts.elementExistence),
             "Couldn't find \"Find in Page\" statusField in a reasonable timeframe."
         )
-        let statusFieldTextContent = try XCTUnwrap(statusField.value as? String)
-        // Note: the following is not a localized test element, but it should have a localization strategy.
-        XCTAssertEqual(statusFieldTextContent, "1 of 4", "Unexpected status field text content after a \"Find in Page\" operation.")
+        assertElement(statusField, hasValue: "1 of 4")
+
         let findInPageScreenshot = loremIpsumWebView.screenshot()
         let highlightedPixelsInFindScreenshot = try XCTUnwrap(findInPageScreenshot.image.matchingPixels(of: .findHighlightColor))
         let findHighlightPoints = Set(highlightedPixelsInFindScreenshot.map { $0.point }) // Coordinates of highlighted pixels in the find screenshot
@@ -350,13 +340,8 @@ class FindInPageTests: UITestCase {
         )
 
         findInPageNextButton.click()
-        let updatedStatusField = app.textFields["FindInPageController.statusField"]
-        let updatedStatusFieldTextContent = updatedStatusField.value as! String
-        XCTAssertTrue(
-            updatedStatusField.waitForExistence(timeout: UITests.Timeouts.elementExistence),
-            "Couldn't find the updated \"Find in Page\" statusField in a reasonable timeframe."
-        )
-        XCTAssertEqual(updatedStatusFieldTextContent, "2 of 4", "Unexpected status field text content after a \"Find Next\" operation.")
+        assertElement(statusField, hasValue: "2 of 4")
+
         let findNextScreenshot = loremIpsumWebView.screenshot()
         let highlightedPixelsInFindNextScreenshot = try XCTUnwrap(findNextScreenshot.image.matchingPixels(of: .findHighlightColor))
         let findNextHighlightPoints = highlightedPixelsInFindNextScreenshot.map { $0.point }
@@ -395,22 +380,14 @@ class FindInPageTests: UITestCase {
             statusField.waitForExistence(timeout: UITests.Timeouts.elementExistence),
             "Couldn't find \"Find in Page\" statusField in a reasonable timeframe."
         )
-        let statusFieldTextContent = try XCTUnwrap(statusField.value as? String)
+        assertElement(statusField, hasValue: "1 of 4")
 
-        // Note: the following is not a localized test element, but it should have a localization strategy.
-        XCTAssertEqual(statusFieldTextContent, "1 of 4", "Unexpected status field text content after a \"Find in Page\" operation.")
         let findInPageScreenshot = loremIpsumWebView.screenshot()
         let highlightedPixelsInFindScreenshot = try XCTUnwrap(findInPageScreenshot.image.matchingPixels(of: .findHighlightColor))
         let findHighlightPoints = Set(highlightedPixelsInFindScreenshot.map { $0.point }) // Coordinates of highlighted pixels in the find screenshot
         app.typeKey("g", modifierFlags: [.command])
-        let updatedStatusField = app.textFields["FindInPageController.statusField"]
-        let updatedStatusFieldTextContent = updatedStatusField.value as! String
-        XCTAssertTrue(
-            updatedStatusField.waitForExistence(timeout: UITests.Timeouts.elementExistence),
-            "Couldn't find the updated \"Find in Page\" statusField in a reasonable timeframe."
-        )
+        assertElement(statusField, hasValue: "2 of 4")
 
-        XCTAssertEqual(updatedStatusFieldTextContent, "2 of 4", "Unexpected status field text content after a \"Find Next\" operation.")
         let findNextScreenshot = loremIpsumWebView.screenshot()
         let highlightedPixelsInFindNextScreenshot = try XCTUnwrap(findNextScreenshot.image.matchingPixels(of: .findHighlightColor))
         let findNextHighlightPoints = highlightedPixelsInFindNextScreenshot.map { $0.point }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1201037661562251/1209624775880991

### Description
This change improves checking for search status field value by awaiting the actual value, not the field visibility.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
Verify that Find in Page tests pass in [this UI tests](https://github.com/duckduckgo/apple-browsers/actions/runs/13760652904) run.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

### Optional E2E tests**:
- [ ] Run macOS PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)