### PR TITLE
[iOS] Set As Default Browser Manager

### DIFF
--- a/iOS/Core/UserDefaultsPropertyWrapper.swift
+++ b/iOS/Core/UserDefaultsPropertyWrapper.swift
@@ -186,6 +186,9 @@ public struct UserDefaultsWrapper<T> {
         case maliciousSiteProtectionEnabled = "com.duckduckgo.ios.maliciousSiteProtection.enabled"
         case voiceSearchTargetPreferences = "voiceSearchTargetPreferences"
 
+        // Check Default Browser
+        case defaultBrowserInfo = "com.duckduckgo.ios.defaultBrowserInfo"
+
         // Debug screen
         case debugPinnedScreens = "debugPinnedScreens"
     }

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -869,6 +869,7 @@
 		9F254B052CF9FB890063B308 /* SpecialErrorPageContextHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254B042CF9FB890063B308 /* SpecialErrorPageContextHandling.swift */; };
 		9F254B082CF9FC270063B308 /* SpecialErrorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254B072CF9FC270063B308 /* SpecialErrorModel.swift */; };
 		9F38A28C2D09BDE500EB100E /* SpecialErrorPageThreatProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F38A28B2D09BDE500EB100E /* SpecialErrorPageThreatProvider.swift */; };
+		9F3DF7902D7EACAD00857D06 /* CheckDefaultBrowserServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3DF78F2D7EACAD00857D06 /* CheckDefaultBrowserServiceTests.swift */; };
 		9F465E1E2D3F5C2E00490109 /* Logger+MaliciousSiteProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F465E1D2D3F5C2700490109 /* Logger+MaliciousSiteProtection.swift */; };
 		9F465E2A2D41B61900490109 /* MaliciousSiteProtectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F465E292D41B61300490109 /* MaliciousSiteProtectionService.swift */; };
 		9F46BEF82CD8D7490092E0EF /* OnboardingView+AddToDockContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F46BEF72CD8D7490092E0EF /* OnboardingView+AddToDockContent.swift */; };
@@ -895,6 +896,7 @@
 		9F69331D2C5A191400CD6A5D /* MockTutorialSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F69331C2C5A191400CD6A5D /* MockTutorialSettings.swift */; };
 		9F69331F2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F69331E2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift */; };
 		9F6933212C5B9A5B00CD6A5D /* OnboardingHostingControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6933202C5B9A5B00CD6A5D /* OnboardingHostingControllerMock.swift */; };
+		9F70B8562D6D942800199D4B /* CheckDefaultBrowserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F70B8552D6D942200199D4B /* CheckDefaultBrowserService.swift */; };
 		9F72FE272CD223A000BA35F5 /* add-to-dock-promo.json in Resources */ = {isa = PBXBuildFile; fileRef = 9F72FE262CD223A000BA35F5 /* add-to-dock-promo.json */; };
 		9F74B7922D49E43A00A7F174 /* MaliciousSiteProtection+Pixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F74B7912D49E42D00A7F174 /* MaliciousSiteProtection+Pixel.swift */; };
 		9F74B7982D518FFF00A7F174 /* MaliciousSiteProtectionEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F74B7972D518FFF00A7F174 /* MaliciousSiteProtectionEventMapper.swift */; };
@@ -2866,6 +2868,7 @@
 		9F254B042CF9FB890063B308 /* SpecialErrorPageContextHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialErrorPageContextHandling.swift; sourceTree = "<group>"; };
 		9F254B072CF9FC270063B308 /* SpecialErrorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialErrorModel.swift; sourceTree = "<group>"; };
 		9F38A28B2D09BDE500EB100E /* SpecialErrorPageThreatProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialErrorPageThreatProvider.swift; sourceTree = "<group>"; };
+		9F3DF78F2D7EACAD00857D06 /* CheckDefaultBrowserServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckDefaultBrowserServiceTests.swift; sourceTree = "<group>"; };
 		9F465E1D2D3F5C2700490109 /* Logger+MaliciousSiteProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+MaliciousSiteProtection.swift"; sourceTree = "<group>"; };
 		9F465E292D41B61300490109 /* MaliciousSiteProtectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionService.swift; sourceTree = "<group>"; };
 		9F46BEF72CD8D7490092E0EF /* OnboardingView+AddToDockContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+AddToDockContent.swift"; sourceTree = "<group>"; };
@@ -2892,6 +2895,7 @@
 		9F69331C2C5A191400CD6A5D /* MockTutorialSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTutorialSettings.swift; sourceTree = "<group>"; };
 		9F69331E2C5B1D0C00CD6A5D /* OnFirstAppearViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnFirstAppearViewModifier.swift; sourceTree = "<group>"; };
 		9F6933202C5B9A5B00CD6A5D /* OnboardingHostingControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingHostingControllerMock.swift; sourceTree = "<group>"; };
+		9F70B8552D6D942200199D4B /* CheckDefaultBrowserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckDefaultBrowserService.swift; sourceTree = "<group>"; };
 		9F72FE262CD223A000BA35F5 /* add-to-dock-promo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "add-to-dock-promo.json"; sourceTree = "<group>"; };
 		9F74B7912D49E42D00A7F174 /* MaliciousSiteProtection+Pixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MaliciousSiteProtection+Pixel.swift"; sourceTree = "<group>"; };
 		9F74B7972D518FFF00A7F174 /* MaliciousSiteProtectionEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionEventMapper.swift; sourceTree = "<group>"; };
@@ -5563,6 +5567,7 @@
 		9F23B8042C2BE20500950875 /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
+				9F3DF78E2D7EAC8F00857D06 /* CheckDefaultBrowser */,
 				9F23B8052C2BE22700950875 /* OnboardingIntroViewModelTests.swift */,
 				56D0602C2C383FD2003BAEB5 /* OnboardingSuggestedSearchesProviderTests.swift */,
 				564DE4542C3EDEF200D23241 /* ContextualOnboardingNewTabDialogFactoryTests.swift */,
@@ -5653,6 +5658,14 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		9F3DF78E2D7EAC8F00857D06 /* CheckDefaultBrowser */ = {
+			isa = PBXGroup;
+			children = (
+				9F3DF78F2D7EACAD00857D06 /* CheckDefaultBrowserServiceTests.swift */,
+			);
+			path = CheckDefaultBrowser;
+			sourceTree = "<group>";
+		};
 		9F4CC5252C4E22F9006A96EB /* ContextualOnboarding */ = {
 			isa = PBXGroup;
 			children = (
@@ -5690,6 +5703,14 @@
 				9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */,
 			);
 			path = ContextualOnboarding;
+			sourceTree = "<group>";
+		};
+		9F70B8542D6D941300199D4B /* CheckDefaultBrowser */ = {
+			isa = PBXGroup;
+			children = (
+				9F70B8552D6D942200199D4B /* CheckDefaultBrowserService.swift */,
+			);
+			path = CheckDefaultBrowser;
 			sourceTree = "<group>";
 		};
 		9F74B7902D49E42100A7F174 /* Events */ = {
@@ -7294,6 +7315,7 @@
 			isa = PBXGroup;
 			children = (
 				C1D2C3612D6F310B00213E3B /* PrivacyProPromotionExperiment */,
+				9F70B8542D6D941300199D4B /* CheckDefaultBrowser */,
 				56D060292C381AD1003BAEB5 /* OnboardingHelpers */,
 				9FF7E9802C22A19800902BE5 /* OnboardingExperiment */,
 				984147AA24F0259000362052 /* Onboarding.storyboard */,
@@ -8837,6 +8859,7 @@
 				981FED6E22025151008488D7 /* BlankSnapshotViewController.swift in Sources */,
 				D66F683D2BB333C100AE93E2 /* SubscriptionContainerView.swift in Sources */,
 				851B128822200575004781BC /* Onboarding.swift in Sources */,
+				9F70B8562D6D942800199D4B /* CheckDefaultBrowserService.swift in Sources */,
 				9FB027192C26BC29009EA190 /* BrowsersComparisonModel.swift in Sources */,
 				859DB8142CE6263C001F7210 /* TextZoomController.swift in Sources */,
 				F1EFB0062C5B8B8E009AB44B /* StatusIndicatorView.swift in Sources */,
@@ -9252,6 +9275,7 @@
 				8528AE84212FF9A100D0BD74 /* AppRatingPromptStorageTests.swift in Sources */,
 				569437312BE3F64400C0881B /* SyncErrorHandlerSyncPausedAlertsTests.swift in Sources */,
 				563A3D012D37BF83001966FD /* ConfigurationManagerTests.swift in Sources */,
+				9F3DF7902D7EACAD00857D06 /* CheckDefaultBrowserServiceTests.swift in Sources */,
 				9F16230B2CA0F0190093C4FC /* DebouncerTests.swift in Sources */,
 				9F254ADC2CF6120E0063B308 /* MockSpecialErrorPageNavigationDelegate.swift in Sources */,
 				1CB7B82323CEA28300AA24EA /* DateExtensionTests.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -869,6 +869,7 @@
 		9F254B052CF9FB890063B308 /* SpecialErrorPageContextHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254B042CF9FB890063B308 /* SpecialErrorPageContextHandling.swift */; };
 		9F254B082CF9FC270063B308 /* SpecialErrorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254B072CF9FC270063B308 /* SpecialErrorModel.swift */; };
 		9F38A28C2D09BDE500EB100E /* SpecialErrorPageThreatProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F38A28B2D09BDE500EB100E /* SpecialErrorPageThreatProvider.swift */; };
+		9F3C7FE02D7990740061FA72 /* DefaultBrowserInfoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3C7FDF2D7990710061FA72 /* DefaultBrowserInfoStore.swift */; };
 		9F3DF7902D7EACAD00857D06 /* CheckDefaultBrowserServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3DF78F2D7EACAD00857D06 /* CheckDefaultBrowserServiceTests.swift */; };
 		9F465E1E2D3F5C2E00490109 /* Logger+MaliciousSiteProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F465E1D2D3F5C2700490109 /* Logger+MaliciousSiteProtection.swift */; };
 		9F465E2A2D41B61900490109 /* MaliciousSiteProtectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F465E292D41B61300490109 /* MaliciousSiteProtectionService.swift */; };
@@ -890,6 +891,7 @@
 		9F5E5AAC2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */; };
 		9F5E5AB02C3E4C6000165F54 /* ContextualOnboardingPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */; };
 		9F5E5AB22C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */; };
+		9F63BABB2D7EC0EF00BD31F4 /* DefaultBrowserInfoStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F63BABA2D7EC0EF00BD31F4 /* DefaultBrowserInfoStoreTests.swift */; };
 		9F678B892C9BAA4800CA0E19 /* Debouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F678B882C9BAA4800CA0E19 /* Debouncer.swift */; };
 		9F6933192C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6933182C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift */; };
 		9F69331B2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F69331A2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift */; };
@@ -2868,6 +2870,7 @@
 		9F254B042CF9FB890063B308 /* SpecialErrorPageContextHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialErrorPageContextHandling.swift; sourceTree = "<group>"; };
 		9F254B072CF9FC270063B308 /* SpecialErrorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialErrorModel.swift; sourceTree = "<group>"; };
 		9F38A28B2D09BDE500EB100E /* SpecialErrorPageThreatProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialErrorPageThreatProvider.swift; sourceTree = "<group>"; };
+		9F3C7FDF2D7990710061FA72 /* DefaultBrowserInfoStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserInfoStore.swift; sourceTree = "<group>"; };
 		9F3DF78F2D7EACAD00857D06 /* CheckDefaultBrowserServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckDefaultBrowserServiceTests.swift; sourceTree = "<group>"; };
 		9F465E1D2D3F5C2700490109 /* Logger+MaliciousSiteProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+MaliciousSiteProtection.swift"; sourceTree = "<group>"; };
 		9F465E292D41B61300490109 /* MaliciousSiteProtectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionService.swift; sourceTree = "<group>"; };
@@ -2889,6 +2892,7 @@
 		9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualDaxDialogsFactory.swift; sourceTree = "<group>"; };
 		9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenter.swift; sourceTree = "<group>"; };
 		9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenterTests.swift; sourceTree = "<group>"; };
+		9F63BABA2D7EC0EF00BD31F4 /* DefaultBrowserInfoStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserInfoStoreTests.swift; sourceTree = "<group>"; };
 		9F678B882C9BAA4800CA0E19 /* Debouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debouncer.swift; sourceTree = "<group>"; };
 		9F6933182C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPixelReporterMock.swift; sourceTree = "<group>"; };
 		9F69331A2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingDaxFavouritesTests.swift; sourceTree = "<group>"; };
@@ -5662,6 +5666,7 @@
 			isa = PBXGroup;
 			children = (
 				9F3DF78F2D7EACAD00857D06 /* CheckDefaultBrowserServiceTests.swift */,
+				9F63BABA2D7EC0EF00BD31F4 /* DefaultBrowserInfoStoreTests.swift */,
 			);
 			path = CheckDefaultBrowser;
 			sourceTree = "<group>";
@@ -5708,6 +5713,7 @@
 		9F70B8542D6D941300199D4B /* CheckDefaultBrowser */ = {
 			isa = PBXGroup;
 			children = (
+				9F3C7FDF2D7990710061FA72 /* DefaultBrowserInfoStore.swift */,
 				9F70B8552D6D942200199D4B /* CheckDefaultBrowserService.swift */,
 			);
 			path = CheckDefaultBrowser;
@@ -8902,6 +8908,7 @@
 				9F0949A02D372AE60079291B /* MaliciousSiteProtectionDatasetsFetcher.swift in Sources */,
 				C1836CE12C359EC90016D057 /* AutofillBreakageReportCellContentView.swift in Sources */,
 				9FDEC7C12C9127F100C7A692 /* OnboardingAddressBarPositionPickerViewModel.swift in Sources */,
+				9F3C7FE02D7990740061FA72 /* DefaultBrowserInfoStore.swift in Sources */,
 				CBF259902D47BEC700AC63E4 /* AuthenticationService.swift in Sources */,
 				6F9FFE282C579DEA00A238BE /* NewTabPageSectionsSettingsStorage.swift in Sources */,
 				85374D3C21AC41E700FF5A1E /* FavoritesHomeViewSectionRenderer.swift in Sources */,
@@ -9277,6 +9284,7 @@
 				563A3D012D37BF83001966FD /* ConfigurationManagerTests.swift in Sources */,
 				9F3DF7902D7EACAD00857D06 /* CheckDefaultBrowserServiceTests.swift in Sources */,
 				9F16230B2CA0F0190093C4FC /* DebouncerTests.swift in Sources */,
+				9F63BABB2D7EC0EF00BD31F4 /* DefaultBrowserInfoStoreTests.swift in Sources */,
 				9F254ADC2CF6120E0063B308 /* MockSpecialErrorPageNavigationDelegate.swift in Sources */,
 				1CB7B82323CEA28300AA24EA /* DateExtensionTests.swift in Sources */,
 				31C138A427A3352600FFD4B2 /* DownloadTests.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -870,6 +870,7 @@
 		9F254B082CF9FC270063B308 /* SpecialErrorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254B072CF9FC270063B308 /* SpecialErrorModel.swift */; };
 		9F38A28C2D09BDE500EB100E /* SpecialErrorPageThreatProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F38A28B2D09BDE500EB100E /* SpecialErrorPageThreatProvider.swift */; };
 		9F3C7FE02D7990740061FA72 /* DefaultBrowserInfoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3C7FDF2D7990710061FA72 /* DefaultBrowserInfoStore.swift */; };
+		9F3C7FE22D7990E50061FA72 /* DefaultBrowserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3C7FE12D7990DE0061FA72 /* DefaultBrowserManager.swift */; };
 		9F3DF7902D7EACAD00857D06 /* CheckDefaultBrowserServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3DF78F2D7EACAD00857D06 /* CheckDefaultBrowserServiceTests.swift */; };
 		9F465E1E2D3F5C2E00490109 /* Logger+MaliciousSiteProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F465E1D2D3F5C2700490109 /* Logger+MaliciousSiteProtection.swift */; };
 		9F465E2A2D41B61900490109 /* MaliciousSiteProtectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F465E292D41B61300490109 /* MaliciousSiteProtectionService.swift */; };
@@ -892,6 +893,7 @@
 		9F5E5AB02C3E4C6000165F54 /* ContextualOnboardingPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */; };
 		9F5E5AB22C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */; };
 		9F63BABB2D7EC0EF00BD31F4 /* DefaultBrowserInfoStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F63BABA2D7EC0EF00BD31F4 /* DefaultBrowserInfoStoreTests.swift */; };
+		9F63BABD2D7ECFD800BD31F4 /* DefaultBrowserManagerTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F63BABC2D7ECFD800BD31F4 /* DefaultBrowserManagerTesting.swift */; };
 		9F678B892C9BAA4800CA0E19 /* Debouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F678B882C9BAA4800CA0E19 /* Debouncer.swift */; };
 		9F6933192C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6933182C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift */; };
 		9F69331B2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F69331A2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift */; };
@@ -2871,6 +2873,7 @@
 		9F254B072CF9FC270063B308 /* SpecialErrorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialErrorModel.swift; sourceTree = "<group>"; };
 		9F38A28B2D09BDE500EB100E /* SpecialErrorPageThreatProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialErrorPageThreatProvider.swift; sourceTree = "<group>"; };
 		9F3C7FDF2D7990710061FA72 /* DefaultBrowserInfoStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserInfoStore.swift; sourceTree = "<group>"; };
+		9F3C7FE12D7990DE0061FA72 /* DefaultBrowserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserManager.swift; sourceTree = "<group>"; };
 		9F3DF78F2D7EACAD00857D06 /* CheckDefaultBrowserServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckDefaultBrowserServiceTests.swift; sourceTree = "<group>"; };
 		9F465E1D2D3F5C2700490109 /* Logger+MaliciousSiteProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+MaliciousSiteProtection.swift"; sourceTree = "<group>"; };
 		9F465E292D41B61300490109 /* MaliciousSiteProtectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionService.swift; sourceTree = "<group>"; };
@@ -2893,6 +2896,7 @@
 		9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenter.swift; sourceTree = "<group>"; };
 		9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenterTests.swift; sourceTree = "<group>"; };
 		9F63BABA2D7EC0EF00BD31F4 /* DefaultBrowserInfoStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserInfoStoreTests.swift; sourceTree = "<group>"; };
+		9F63BABC2D7ECFD800BD31F4 /* DefaultBrowserManagerTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserManagerTesting.swift; sourceTree = "<group>"; };
 		9F678B882C9BAA4800CA0E19 /* Debouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debouncer.swift; sourceTree = "<group>"; };
 		9F6933182C59BB0300CD6A5D /* OnboardingPixelReporterMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPixelReporterMock.swift; sourceTree = "<group>"; };
 		9F69331A2C5A16E200CD6A5D /* OnboardingDaxFavouritesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingDaxFavouritesTests.swift; sourceTree = "<group>"; };
@@ -5667,6 +5671,7 @@
 			children = (
 				9F3DF78F2D7EACAD00857D06 /* CheckDefaultBrowserServiceTests.swift */,
 				9F63BABA2D7EC0EF00BD31F4 /* DefaultBrowserInfoStoreTests.swift */,
+				9F63BABC2D7ECFD800BD31F4 /* DefaultBrowserManagerTesting.swift */,
 			);
 			path = CheckDefaultBrowser;
 			sourceTree = "<group>";
@@ -5715,6 +5720,7 @@
 			children = (
 				9F3C7FDF2D7990710061FA72 /* DefaultBrowserInfoStore.swift */,
 				9F70B8552D6D942200199D4B /* CheckDefaultBrowserService.swift */,
+				9F3C7FE12D7990DE0061FA72 /* DefaultBrowserManager.swift */,
 			);
 			path = CheckDefaultBrowser;
 			sourceTree = "<group>";
@@ -8942,6 +8948,7 @@
 				CBFCB30E2B2CD47800253E9E /* ConfigurationURLDebugViewController.swift in Sources */,
 				6FDC64052C98515E00DB71B3 /* FavoriteAddItemView.swift in Sources */,
 				7BBE25A52D71EEEB003131FA /* TabViewController+Automation.swift in Sources */,
+				9F3C7FE22D7990E50061FA72 /* DefaultBrowserManager.swift in Sources */,
 				982686AD2600C0850011A8D6 /* ActionMessageView.swift in Sources */,
 				D6E0C1852B7A2B9400D5E1E9 /* DesktopDownloadPlatformConstants.swift in Sources */,
 				6F72353D2D3EBCB800710C07 /* WebViewStateRestorationDebugView.swift in Sources */,
@@ -9423,6 +9430,7 @@
 				85C503FF2CF0F4DC0075DF6F /* MockWebsiteDataManager.swift in Sources */,
 				9F23B8092C2BE9B700950875 /* MockURLOpener.swift in Sources */,
 				9F8007262C5261AF003EDAF4 /* MockPrivacyDataReporter.swift in Sources */,
+				9F63BABD2D7ECFD800BD31F4 /* DefaultBrowserManagerTesting.swift in Sources */,
 				F40F843728C939760081AE75 /* AutofillLoginListViewModelTests.swift in Sources */,
 				C14882E827F20DAB00D59F0C /* TestDataLoader.swift in Sources */,
 				C14882EA27F20DD000D59F0C /* MockBookmarksCoreDataStorage.swift in Sources */,

--- a/iOS/DuckDuckGo/CheckDefaultBrowser/CheckDefaultBrowserService.swift
+++ b/iOS/DuckDuckGo/CheckDefaultBrowser/CheckDefaultBrowserService.swift
@@ -1,0 +1,87 @@
+//
+//  CheckDefaultBrowserService.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+
+// MARK: - DefaultBrowserChecker
+
+enum CheckDefaultBrowserServiceError: Error, Equatable {
+    case notSupportedOnThisOSVersion
+    case maxNumberOfAttemptsExceeded(nextRetryDate: Date?)
+    case unknownError(NSError)
+}
+
+protocol CheckDefaultBrowserService: AnyObject {
+    func isDefaultWebBrowser() -> Result<Bool, CheckDefaultBrowserServiceError>
+}
+
+// Wrapper on UIApplication.
+// `isDefault(_ category: UIApplication.Category) throws -> Bool` is supported only on iOS 18.2+.
+// Usually we would make an interface with the same method and have UIApplication conform to it.
+// The issue with the above approach is that it requires marking the protocol `@available(iOS 18.2, *)`.
+// That will cause issues with injecting the parameter as it is available only for iOS 18.2.
+enum CheckDefaultBrowserServiceFactory {
+
+    static func makeCheckDefaultBrowserService() -> CheckDefaultBrowserService {
+        if #available(iOS 18.2, *) {
+            IOS18CheckDefaultBrowserService()
+        } else {
+            LegacyCheckDefaultBrowserService()
+        }
+    }
+
+}
+
+// MARK: - iOS 18.2
+
+@available(iOS 18.2, *)
+protocol ApplicationDefaultCategoryChecking: AnyObject {
+    func isDefault(_ category: UIApplication.Category) throws -> Bool
+}
+
+extension UIApplication: ApplicationDefaultCategoryChecking {}
+
+@available(iOS 18.2, *)
+final class IOS18CheckDefaultBrowserService: CheckDefaultBrowserService {
+    private let application: ApplicationDefaultCategoryChecking
+
+    init(application: ApplicationDefaultCategoryChecking = UIApplication.shared) {
+        self.application = application
+    }
+
+    func isDefaultWebBrowser() -> Result<Bool, CheckDefaultBrowserServiceError> {
+        do {
+            let isDefaultBrowser = try application.isDefault(.webBrowser)
+            return .success(isDefaultBrowser)
+        } catch let error as NSError where error.domain == UIApplication.CategoryDefaultError.errorDomain && error.code == UIApplication.CategoryDefaultError.Code.rateLimited.rawValue {
+            let nextRetryDate = error.userInfo[UIApplication.CategoryDefaultError.retryAvailableDateErrorKey] as? Date
+            return .failure(CheckDefaultBrowserServiceError.maxNumberOfAttemptsExceeded(nextRetryDate: nextRetryDate))
+        } catch {
+            return .failure(CheckDefaultBrowserServiceError.unknownError(error as NSError))
+        }
+    }
+}
+
+// MARK: - Legacy
+
+final class LegacyCheckDefaultBrowserService: CheckDefaultBrowserService {
+    func isDefaultWebBrowser() -> Result<Bool, CheckDefaultBrowserServiceError> {
+        return .failure(CheckDefaultBrowserServiceError.notSupportedOnThisOSVersion)
+    }
+}

--- a/iOS/DuckDuckGo/CheckDefaultBrowser/CheckDefaultBrowserService.swift
+++ b/iOS/DuckDuckGo/CheckDefaultBrowser/CheckDefaultBrowserService.swift
@@ -36,10 +36,6 @@ protocol CheckDefaultBrowserService: AnyObject {
 // Usually we would make an interface with the same method and have UIApplication conform to it.
 // The issue with the above approach is that it requires marking the protocol `@available(iOS 18.2, *)`.
 // That will cause issues with injecting the parameter as it is available only for iOS 18.2.
-//enum CheckDefaultBrowserServiceFactory {
-
-// MARK: - iOS 18.2
-
 protocol ApplicationDefaultCategoryChecking: AnyObject {
     @available(iOS 18.2, *)
     func isDefault(_ category: UIApplication.Category) throws -> Bool

--- a/iOS/DuckDuckGo/CheckDefaultBrowser/CheckDefaultBrowserService.swift
+++ b/iOS/DuckDuckGo/CheckDefaultBrowser/CheckDefaultBrowserService.swift
@@ -36,29 +36,18 @@ protocol CheckDefaultBrowserService: AnyObject {
 // Usually we would make an interface with the same method and have UIApplication conform to it.
 // The issue with the above approach is that it requires marking the protocol `@available(iOS 18.2, *)`.
 // That will cause issues with injecting the parameter as it is available only for iOS 18.2.
-enum CheckDefaultBrowserServiceFactory {
-
-    static func makeCheckDefaultBrowserService() -> CheckDefaultBrowserService {
-        if #available(iOS 18.2, *) {
-            IOS18CheckDefaultBrowserService()
-        } else {
-            LegacyCheckDefaultBrowserService()
-        }
-    }
-
-}
+//enum CheckDefaultBrowserServiceFactory {
 
 // MARK: - iOS 18.2
 
-@available(iOS 18.2, *)
 protocol ApplicationDefaultCategoryChecking: AnyObject {
+    @available(iOS 18.2, *)
     func isDefault(_ category: UIApplication.Category) throws -> Bool
 }
 
 extension UIApplication: ApplicationDefaultCategoryChecking {}
 
-@available(iOS 18.2, *)
-final class IOS18CheckDefaultBrowserService: CheckDefaultBrowserService {
+final class SystemCheckDefaultBrowserService: CheckDefaultBrowserService {
     private let application: ApplicationDefaultCategoryChecking
 
     init(application: ApplicationDefaultCategoryChecking = UIApplication.shared) {
@@ -66,22 +55,18 @@ final class IOS18CheckDefaultBrowserService: CheckDefaultBrowserService {
     }
 
     func isDefaultWebBrowser() -> Result<Bool, CheckDefaultBrowserServiceError> {
+        guard #available(iOS 18.2, *) else { return .failure(.notSupportedOnThisOSVersion) }
+
         do {
             let isDefaultBrowser = try application.isDefault(.webBrowser)
             return .success(isDefaultBrowser)
         } catch let error as NSError where error.domain == UIApplication.CategoryDefaultError.errorDomain && error.code == UIApplication.CategoryDefaultError.Code.rateLimited.rawValue {
+            // Max attempts of getting a result in a year reached.
+            // See: https://developer.apple.com/documentation/UIKit/UIApplication/isDefault(_:) 
             let nextRetryDate = error.userInfo[UIApplication.CategoryDefaultError.retryAvailableDateErrorKey] as? Date
             return .failure(CheckDefaultBrowserServiceError.maxNumberOfAttemptsExceeded(nextRetryDate: nextRetryDate))
         } catch {
             return .failure(CheckDefaultBrowserServiceError.unknownError(error as NSError))
         }
-    }
-}
-
-// MARK: - Legacy
-
-final class LegacyCheckDefaultBrowserService: CheckDefaultBrowserService {
-    func isDefaultWebBrowser() -> Result<Bool, CheckDefaultBrowserServiceError> {
-        return .failure(CheckDefaultBrowserServiceError.notSupportedOnThisOSVersion)
     }
 }

--- a/iOS/DuckDuckGo/CheckDefaultBrowser/DefaultBrowserInfoStore.swift
+++ b/iOS/DuckDuckGo/CheckDefaultBrowser/DefaultBrowserInfoStore.swift
@@ -1,0 +1,41 @@
+//
+//  DefaultBrowserInfoStore.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Core
+
+protocol DefaultBrowserInfoStorage: AnyObject {
+    var defaultBrowserInfo: DefaultBrowserInfo? { get set }
+}
+
+final class DefaultBrowserInfoStore: DefaultBrowserInfoStorage {
+
+    @UserDefaultsWrapper(key: .defaultBrowserInfo, defaultValue: nil)
+    private var defaultBrowserInfoData: Data?
+
+    var defaultBrowserInfo: DefaultBrowserInfo? {
+        get {
+            guard let data = defaultBrowserInfoData else { return nil }
+            return try? JSONDecoder().decode(DefaultBrowserInfo.self, from: data)
+        }
+        set {
+            defaultBrowserInfoData = try? newValue.flatMap(JSONEncoder().encode)
+        }
+    }
+    
+}

--- a/iOS/DuckDuckGo/CheckDefaultBrowser/DefaultBrowserManager.swift
+++ b/iOS/DuckDuckGo/CheckDefaultBrowser/DefaultBrowserManager.swift
@@ -35,6 +35,7 @@ struct DefaultBrowserInfo: Codable, Equatable {
     let nextRetryAvailableDate: TimeInterval?
 }
 
+@MainActor
 protocol DefaultBrowserManaging: AnyObject {
     func defaultBrowserInfo() -> DefaultBrowserInfoResult
 }
@@ -71,6 +72,7 @@ extension DefaultBrowserInfoResult {
 
 // MARK: - DefaultBrowserManager
 
+@MainActor
 final class DefaultBrowserManager: DefaultBrowserManaging {
     private let defaultBrowserChecker: CheckDefaultBrowserService
     private let defaultBrowserInfoStore: DefaultBrowserInfoStorage

--- a/iOS/DuckDuckGo/CheckDefaultBrowser/DefaultBrowserManager.swift
+++ b/iOS/DuckDuckGo/CheckDefaultBrowser/DefaultBrowserManager.swift
@@ -79,7 +79,7 @@ final class DefaultBrowserManager: DefaultBrowserManaging {
     private let dateProvider: () -> Date
 
     init(
-        defaultBrowserChecker: CheckDefaultBrowserService = CheckDefaultBrowserServiceFactory.makeCheckDefaultBrowserService(),
+        defaultBrowserChecker: CheckDefaultBrowserService = SystemCheckDefaultBrowserService(),
         defaultBrowserInfoStore: DefaultBrowserInfoStorage = DefaultBrowserInfoStore(),
         dateProvider: @escaping () -> Date = Date.init
     ) {

--- a/iOS/DuckDuckGo/CheckDefaultBrowser/DefaultBrowserManager.swift
+++ b/iOS/DuckDuckGo/CheckDefaultBrowser/DefaultBrowserManager.swift
@@ -1,0 +1,135 @@
+//
+//  DefaultBrowserManager.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import class UIKit.UIApplication
+
+// MARK: - Model
+
+struct DefaultBrowserInfo: Codable, Equatable {
+    /// True if DDG browser is set as default, false otherwise.
+    let isDefaultBrowser: Bool
+    /// The time interval when we last got a valid result.
+    let lastSuccessfulCheckDate: TimeInterval
+    /// The time interval when we last attempted to check an updated result.
+    let lastAttemptedCheckDate: TimeInterval
+    /// Total number of times that the app requested an updated result.
+    let numberOfTimesChecked: Int
+    /// The time interval at which the app can next request an updated response.
+    let nextRetryAvailableDate: TimeInterval?
+}
+
+protocol DefaultBrowserManaging: AnyObject {
+    func defaultBrowserInfo() -> DefaultBrowserInfoResult
+}
+
+enum DefaultBrowserInfoResult: Equatable {
+    enum Failure: Equatable {
+        case notSupportedOnCurrentOSVersion
+        case unknownError(NSError)
+        case rateLimitReached(updatedStoredInfo: DefaultBrowserInfo?)
+    }
+
+    case failure(DefaultBrowserInfoResult.Failure)
+    case success(newInfo: DefaultBrowserInfo)
+}
+
+extension DefaultBrowserInfoResult {
+
+    @discardableResult
+    func onNewValue(_ f: (DefaultBrowserInfo) -> Void) -> Self {
+        if case let .success(newInfo) = self {
+            f(newInfo)
+        }
+        return self
+    }
+
+    @discardableResult
+    func onFailure(_ f: (Failure) -> Void) -> Self {
+        if case let .failure(failure) = self {
+            f(failure)
+        }
+        return self
+    }
+}
+
+// MARK: - DefaultBrowserManager
+
+final class DefaultBrowserManager: DefaultBrowserManaging {
+    private let defaultBrowserChecker: CheckDefaultBrowserService
+    private let defaultBrowserInfoStore: DefaultBrowserInfoStorage
+    private let dateProvider: () -> Date
+
+    init(
+        defaultBrowserChecker: CheckDefaultBrowserService = CheckDefaultBrowserServiceFactory.makeCheckDefaultBrowserService(),
+        defaultBrowserInfoStore: DefaultBrowserInfoStorage = DefaultBrowserInfoStore(),
+        dateProvider: @escaping () -> Date = Date.init
+    ) {
+        self.defaultBrowserChecker = defaultBrowserChecker
+        self.defaultBrowserInfoStore = defaultBrowserInfoStore
+        self.dateProvider = dateProvider
+    }
+
+    func defaultBrowserInfo() -> DefaultBrowserInfoResult {
+        let defaultBrowserResult = defaultBrowserChecker.isDefaultWebBrowser()
+
+        switch defaultBrowserResult {
+        case let .success(value):
+            let defaultBrowserInfo = makeDefaultBrowserInfo(isDefaultBrowser: value)
+            saveDefaultBrowserInfo(defaultBrowserInfo)
+            return .success(newInfo: defaultBrowserInfo)
+        case let .failure(.maxNumberOfAttemptsExceeded(nextRetryDate)):
+            // If there's no previous information saved exit early. This should not happen.
+            guard let storedDefaultBrowserInfo = defaultBrowserInfoStore.defaultBrowserInfo else {
+                return .failure(.rateLimitReached(updatedStoredInfo: nil))
+            }
+            // Update the current info and save them
+            let defaultBrowserInfo = makeDefaultBrowserInfo(
+                isDefaultBrowser: storedDefaultBrowserInfo.isDefaultBrowser,
+                lastSuccessfulCheckDate: storedDefaultBrowserInfo.lastSuccessfulCheckDate,
+                nextRetryAvailableDate: nextRetryDate
+            )
+            saveDefaultBrowserInfo(defaultBrowserInfo)
+            return .failure(.rateLimitReached(updatedStoredInfo: defaultBrowserInfo))
+        case let .failure(.unknownError(error)):
+            return .failure(.unknownError(error))
+        case .failure(.notSupportedOnThisOSVersion):
+            return .failure(.notSupportedOnCurrentOSVersion)
+        }
+    }
+
+    private func makeDefaultBrowserInfo(isDefaultBrowser: Bool, lastSuccessfulCheckDate: TimeInterval? = nil, nextRetryAvailableDate: Date? = nil) -> DefaultBrowserInfo {
+        let lastSuccessfulCheckDate = lastSuccessfulCheckDate ?? dateProvider().timeIntervalSince1970
+        let lastAttemptedCheckDate = dateProvider().timeIntervalSince1970
+        let currentNumberOfTimesChecked = defaultBrowserInfoStore.defaultBrowserInfo.flatMap(\.numberOfTimesChecked) ?? 0
+        let nextRetryAvailableDate = nextRetryAvailableDate?.timeIntervalSince1970
+
+        return DefaultBrowserInfo(
+            isDefaultBrowser: isDefaultBrowser,
+            lastSuccessfulCheckDate: lastSuccessfulCheckDate,
+            lastAttemptedCheckDate: lastAttemptedCheckDate,
+            numberOfTimesChecked: currentNumberOfTimesChecked + 1,
+            nextRetryAvailableDate: nextRetryAvailableDate
+        )
+    }
+
+    private func saveDefaultBrowserInfo(_ defaultBrowserInfo: DefaultBrowserInfo) {
+        defaultBrowserInfoStore.defaultBrowserInfo = defaultBrowserInfo
+    }
+}

--- a/iOS/DuckDuckGoTests/CheckDefaultBrowser/CheckDefaultBrowserServiceTests.swift
+++ b/iOS/DuckDuckGoTests/CheckDefaultBrowser/CheckDefaultBrowserServiceTests.swift
@@ -23,106 +23,103 @@ import class UIKit.UIApplication
 import Foundation
 
 struct CheckDefaultBrowserServiceTests {
-
-    @Suite("Check Default Browser iOS > 18.2+ Tests")
-    struct IOS18CheckDefaultServiceTests {
-
-        @MainActor
-        @Test(
-            "Check Is Default Browser returns success when there are no errors",
-            arguments: [
-                true,
-                false
-            ]
-        )
-        @available(iOS 18.2, *)
-        func checkDefaultBrowserReturnsSuccess(_ expectedDefaultBrowserValue: Bool) throws {
-            // GIVEN
-            let application = MockApplication()
-            application.resultToReturn = .success(expectedDefaultBrowserValue)
-            let sut = IOS18CheckDefaultBrowserService(application: application)
-
-            // WHEN
-            let result = sut.isDefaultWebBrowser()
-
-            // THEN
-            #expect(try result.get() == expectedDefaultBrowserValue)
+    private static let isLowerThanIOS18PointTwo: Bool = {
+        if #available(iOS 18.2, *) {
+            true
+        } else {
+            false
         }
+    }()
 
-        @MainActor
-        @Test("Check is Default Browser returns maxNumberOfAttemptsExceeded when rateLimited error")
-        @available(iOS 18.2, *)
-        func checkDefaultBrowserReturnsMaxNumberOfAttemptsExceededFailure() throws {
-            // GIVEN
-            let timestamp: TimeInterval = 1773122108000 // 10th of March 2026
-            let expectedRetryDate = Date(timeIntervalSince1970: timestamp)
-            let systemError = NSError(
-                domain: UIApplication.CategoryDefaultError.errorDomain,
-                code: UIApplication.CategoryDefaultError.rateLimited.rawValue,
-                userInfo: [
-                    UIApplication.CategoryDefaultError.retryAvailableDateErrorKey: expectedRetryDate,
-                ]
-            )
-            let application = MockApplication()
-            application.resultToReturn = .failure(systemError)
-            let sut = IOS18CheckDefaultBrowserService(application: application)
+    @MainActor
+    @Test(
+        "Check Is Default Browser returns success when there are no errors",
+        arguments: [
+            true,
+            false
+        ]
+    )
+    @available(iOS 18.2, *)
+    func checkDefaultBrowserReturnsSuccess(_ expectedDefaultBrowserValue: Bool) throws {
+        // GIVEN
+        let application = MockApplication()
+        application.resultToReturn = .success(expectedDefaultBrowserValue)
+        let sut = SystemCheckDefaultBrowserService(application: application)
 
-            // WHEN
-            let result = sut.isDefaultWebBrowser()
+        // WHEN
+        let result = sut.isDefaultWebBrowser()
 
-            // THEN
-            let error = try #require(try result.getError())
-            guard case let CheckDefaultBrowserServiceError.maxNumberOfAttemptsExceeded(nextRetryDate) = error else {
-                Issue.record("Should be maxNumberOfAttemptsExceeded error")
-                return
-            }
-            #expect(nextRetryDate == expectedRetryDate)
-        }
-
-        @MainActor
-        @Test("Check is Default Browser returns unknown failure when generic error")
-        @available(iOS 18.2, *)
-        func checkDefaultBrowserReturnsUnknownFailure() throws {
-            // GIVEN
-            let systemError = NSError(
-                domain: UIApplication.CategoryDefaultError.errorDomain,
-                code: 123456,
-                userInfo: nil
-            )
-            let application = MockApplication()
-            application.resultToReturn = .failure(systemError)
-            let sut = IOS18CheckDefaultBrowserService(application: application)
-
-            // WHEN
-            let result = sut.isDefaultWebBrowser()
-
-            // THEN
-            let error = try #require(try result.getError())
-            guard case let CheckDefaultBrowserServiceError.unknownError(error) = error else {
-                Issue.record("Should be maxNumberOfAttemptsExceeded error")
-                return
-            }
-            #expect(error == systemError)
-        }
-
+        // THEN
+        #expect(try result.get() == expectedDefaultBrowserValue)
     }
 
-    @Suite("Check Default Browser iOS < 18.2 Tests")
-    struct LegacyCheckDefaultServiceTests {
+    @MainActor
+    @Test("Check is Default Browser returns maxNumberOfAttemptsExceeded when rateLimited error")
+    @available(iOS 18.2, *)
+    func checkDefaultBrowserReturnsMaxNumberOfAttemptsExceededFailure() throws {
+        // GIVEN
+        let timestamp: TimeInterval = 1773122108000 // 10th of March 2026
+        let expectedRetryDate = Date(timeIntervalSince1970: timestamp)
+        let systemError = NSError(
+            domain: UIApplication.CategoryDefaultError.errorDomain,
+            code: UIApplication.CategoryDefaultError.rateLimited.rawValue,
+            userInfo: [
+                UIApplication.CategoryDefaultError.retryAvailableDateErrorKey: expectedRetryDate,
+            ]
+        )
+        let application = MockApplication()
+        application.resultToReturn = .failure(systemError)
+        let sut = SystemCheckDefaultBrowserService(application: application)
 
-        @Test
-        func legacyCheckDefaultBrowserReturnsNotSupportedFailure() throws {
-            // GIVEN
-            let sut = LegacyCheckDefaultBrowserService()
+        // WHEN
+        let result = sut.isDefaultWebBrowser()
 
-            // WHEN
-            let result = sut.isDefaultWebBrowser()
-
-            // THEN
-            let error = try #require(try result.getError())
-            #expect(error == .notSupportedOnThisOSVersion)
+        // THEN
+        let error = try #require(try result.getError())
+        guard case let CheckDefaultBrowserServiceError.maxNumberOfAttemptsExceeded(nextRetryDate) = error else {
+            Issue.record("Should be maxNumberOfAttemptsExceeded error")
+            return
         }
+        #expect(nextRetryDate == expectedRetryDate)
+    }
 
+    @MainActor
+    @Test("Check is Default Browser returns unknown failure when generic error")
+    @available(iOS 18.2, *)
+    func checkDefaultBrowserReturnsUnknownFailure() throws {
+        // GIVEN
+        let systemError = NSError(
+            domain: UIApplication.CategoryDefaultError.errorDomain,
+            code: 123456,
+            userInfo: nil
+        )
+        let application = MockApplication()
+        application.resultToReturn = .failure(systemError)
+        let sut = SystemCheckDefaultBrowserService(application: application)
+
+        // WHEN
+        let result = sut.isDefaultWebBrowser()
+
+        // THEN
+        let error = try #require(try result.getError())
+        guard case let CheckDefaultBrowserServiceError.unknownError(error) = error else {
+            Issue.record("Should be maxNumberOfAttemptsExceeded error")
+            return
+        }
+        #expect(error == systemError)
+    }
+
+    @Test(.disabled(if: CheckDefaultBrowserServiceTests.isLowerThanIOS18PointTwo))
+    func legacyCheckDefaultBrowserReturnsNotSupportedFailure() throws {
+        // GIVEN
+        let sut = SystemCheckDefaultBrowserService()
+
+        // WHEN
+        let result = sut.isDefaultWebBrowser()
+
+        // THEN
+        let error = try #require(try result.getError())
+        #expect(error == .notSupportedOnThisOSVersion)
     }
 
 }

--- a/iOS/DuckDuckGoTests/CheckDefaultBrowser/CheckDefaultBrowserServiceTests.swift
+++ b/iOS/DuckDuckGoTests/CheckDefaultBrowser/CheckDefaultBrowserServiceTests.swift
@@ -1,0 +1,155 @@
+//
+//  CheckDefaultBrowserServiceTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Testing
+import class UIKit.UIApplication
+@testable import DuckDuckGo
+import Foundation
+
+struct CheckDefaultBrowserServiceTests {
+
+    @Suite("Check Default Browser iOS > 18.2+ Tests")
+    struct IOS18CheckDefaultServiceTests {
+
+        @MainActor
+        @Test(
+            "Check Is Default Browser returns success when there are no errors",
+            arguments: [
+                true,
+                false
+            ]
+        )
+        @available(iOS 18.2, *)
+        func checkDefaultBrowserReturnsSuccess(_ expectedDefaultBrowserValue: Bool) throws {
+            // GIVEN
+            let application = MockApplication()
+            application.resultToReturn = .success(expectedDefaultBrowserValue)
+            let sut = IOS18CheckDefaultBrowserService(application: application)
+
+            // WHEN
+            let result = sut.isDefaultWebBrowser()
+
+            // THEN
+            #expect(try result.get() == expectedDefaultBrowserValue)
+        }
+
+        @MainActor
+        @Test("Check is Default Browser returns maxNumberOfAttemptsExceeded when rateLimited error")
+        @available(iOS 18.2, *)
+        func checkDefaultBrowserReturnsMaxNumberOfAttemptsExceededFailure() throws {
+            // GIVEN
+            let timestamp: TimeInterval = 1773122108000 // 10th of March 2026
+            let expectedRetryDate = Date(timeIntervalSince1970: timestamp)
+            let systemError = NSError(
+                domain: UIApplication.CategoryDefaultError.errorDomain,
+                code: UIApplication.CategoryDefaultError.rateLimited.rawValue,
+                userInfo: [
+                    UIApplication.CategoryDefaultError.retryAvailableDateErrorKey: expectedRetryDate,
+                ]
+            )
+            let application = MockApplication()
+            application.resultToReturn = .failure(systemError)
+            let sut = IOS18CheckDefaultBrowserService(application: application)
+
+            // WHEN
+            let result = sut.isDefaultWebBrowser()
+
+            // THEN
+            let error = try #require(try result.getError())
+            guard case let CheckDefaultBrowserServiceError.maxNumberOfAttemptsExceeded(nextRetryDate) = error else {
+                Issue.record("Should be maxNumberOfAttemptsExceeded error")
+                return
+            }
+            #expect(nextRetryDate == expectedRetryDate)
+        }
+
+        @MainActor
+        @Test("Check is Default Browser returns unknown failure when generic error")
+        @available(iOS 18.2, *)
+        func checkDefaultBrowserReturnsUnknownFailure() throws {
+            // GIVEN
+            let systemError = NSError(
+                domain: UIApplication.CategoryDefaultError.errorDomain,
+                code: 123456,
+                userInfo: nil
+            )
+            let application = MockApplication()
+            application.resultToReturn = .failure(systemError)
+            let sut = IOS18CheckDefaultBrowserService(application: application)
+
+            // WHEN
+            let result = sut.isDefaultWebBrowser()
+
+            // THEN
+            let error = try #require(try result.getError())
+            guard case let CheckDefaultBrowserServiceError.unknownError(error) = error else {
+                Issue.record("Should be maxNumberOfAttemptsExceeded error")
+                return
+            }
+            #expect(error == systemError)
+        }
+
+    }
+
+    @Suite("Check Default Browser iOS < 18.2 Tests")
+    struct LegacyCheckDefaultServiceTests {
+
+        @Test
+        func legacyCheckDefaultBrowserReturnsNotSupportedFailure() throws {
+            // GIVEN
+            let sut = LegacyCheckDefaultBrowserService()
+
+            // WHEN
+            let result = sut.isDefaultWebBrowser()
+
+            // THEN
+            let error = try #require(try result.getError())
+            #expect(error == .notSupportedOnThisOSVersion)
+        }
+
+    }
+
+}
+
+@available(iOS 18.2, *)
+private class MockApplication: ApplicationDefaultCategoryChecking {
+    var resultToReturn: Result<Bool, Error> = .success(false)
+
+    func isDefault(_ category: UIApplication.Category) throws -> Bool {
+        switch resultToReturn {
+        case .success(let value):
+            return value
+        case .failure(let error):
+            throw error
+        }
+    }
+}
+
+private extension Result {
+
+    func getError() throws -> Failure {
+        switch self {
+        case .success:
+            throw NSError(domain: "testing expecting failure", code: 0, userInfo: nil)
+        case let .failure(error):
+            return error
+        }
+    }
+
+}

--- a/iOS/DuckDuckGoTests/CheckDefaultBrowser/DefaultBrowserInfoStoreTests.swift
+++ b/iOS/DuckDuckGoTests/CheckDefaultBrowser/DefaultBrowserInfoStoreTests.swift
@@ -1,0 +1,54 @@
+//
+//  DefaultBrowserInfoStoreTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Core
+import Testing
+@testable import DuckDuckGo
+
+class DefaultBrowserInfoStoreTests {
+    private static let userDefaultsKey = "com.duckduckgo.ios.defaultBrowserInfo"
+
+    init() {
+        UserDefaults.app.removeObject(forKey: Self.userDefaultsKey)
+    }
+
+    @Test
+    func testDefaultInfoIsPersisted() throws {
+        // GIVEN
+        let timeInterval: TimeInterval = 1773122108000 // March 10, 2026
+        let defaultBrowserInfo = DefaultBrowserInfo(
+            isDefaultBrowser: true,
+            lastSuccessfulCheckDate: timeInterval,
+            lastAttemptedCheckDate: timeInterval,
+            numberOfTimesChecked: 10,
+            nextRetryAvailableDate: timeInterval
+        )
+        let sut = DefaultBrowserInfoStore()
+
+        // WHEN
+        sut.defaultBrowserInfo = defaultBrowserInfo
+
+        // THEN
+        let data = try #require(UserDefaults.app.data(forKey: Self.userDefaultsKey))
+        let retrievedBrowserInfo = try JSONDecoder().decode(DefaultBrowserInfo.self, from: data)
+        #expect(retrievedBrowserInfo == defaultBrowserInfo)
+    }
+
+}

--- a/iOS/DuckDuckGoTests/CheckDefaultBrowser/DefaultBrowserManagerTesting.swift
+++ b/iOS/DuckDuckGoTests/CheckDefaultBrowser/DefaultBrowserManagerTesting.swift
@@ -1,5 +1,5 @@
 //
-//  CheckDefaultBrowserManagerTesting.swift
+//  DefaultBrowserManagerTesting.swift
 //  DuckDuckGo
 //
 //  Copyright © 2025 DuckDuckGo. All rights reserved.
@@ -161,7 +161,7 @@ final class DefaultBrowserManagerTesting {
 
         // THEN
         result
-            .onNewValue { info in
+            .onNewValue { _ in
                 Issue.record("Failure expected")
             }
             .onFailure { failure in
@@ -183,7 +183,7 @@ final class DefaultBrowserManagerTesting {
 
         // THEN
         result
-            .onNewValue { info in
+            .onNewValue { _ in
                 Issue.record("Failure expected")
             }
             .onFailure { failure in
@@ -204,7 +204,7 @@ final class DefaultBrowserManagerTesting {
 
         // THEN
         result
-            .onNewValue { info in
+            .onNewValue { _ in
                 Issue.record("Failure expected")
             }
             .onFailure { failure in
@@ -224,7 +224,7 @@ final class DefaultBrowserManagerTesting {
 
         // THEN
         result
-            .onNewValue { info in
+            .onNewValue { _ in
                 Issue.record("Failure expected")
             }
             .onFailure { failure in
@@ -248,7 +248,7 @@ final class MockCheckDefaultBrowserService: CheckDefaultBrowserService {
 final class MockDefaultBrowserInfoStore: DefaultBrowserInfoStorage {
     private(set) var didSetDefaultBrowserInfo = false
 
-    var defaultBrowserInfo: DuckDuckGo.DefaultBrowserInfo? = nil {
+    var defaultBrowserInfo: DuckDuckGo.DefaultBrowserInfo? {
         didSet {
             didSetDefaultBrowserInfo = true
         }

--- a/iOS/DuckDuckGoTests/CheckDefaultBrowser/DefaultBrowserManagerTesting.swift
+++ b/iOS/DuckDuckGoTests/CheckDefaultBrowser/DefaultBrowserManagerTesting.swift
@@ -21,6 +21,7 @@ import Foundation
 import Testing
 @testable import DuckDuckGo
 
+@MainActor
 final class DefaultBrowserManagerTesting {
     let defaultBrowserService: MockCheckDefaultBrowserService!
     let timeTraveller: TimeTraveller!

--- a/iOS/DuckDuckGoTests/CheckDefaultBrowser/DefaultBrowserManagerTesting.swift
+++ b/iOS/DuckDuckGoTests/CheckDefaultBrowser/DefaultBrowserManagerTesting.swift
@@ -1,0 +1,255 @@
+//
+//  CheckDefaultBrowserManagerTesting.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Testing
+@testable import DuckDuckGo
+
+final class DefaultBrowserManagerTesting {
+    let defaultBrowserService: MockCheckDefaultBrowserService!
+    let timeTraveller: TimeTraveller!
+    let store: MockDefaultBrowserInfoStore
+    var sut: DefaultBrowserManager!
+
+    init() {
+        defaultBrowserService = MockCheckDefaultBrowserService()
+        store = MockDefaultBrowserInfoStore()
+        timeTraveller = TimeTraveller()
+        sut = DefaultBrowserManager(
+            defaultBrowserChecker: defaultBrowserService,
+            defaultBrowserInfoStore: store,
+            dateProvider: timeTraveller.getDate
+        )
+    }
+
+    @Test("Check Browser Succeeds store and returns expected info",
+        arguments: [
+            true,
+            false
+        ]
+    )
+    func checkDefaultBrowserReturnsSuccess(_ value: Bool) throws {
+        // GIVEN
+        let timestamp: TimeInterval = 1741586108000 // March 10, 2025
+        let date = Date(timeIntervalSince1970: timestamp)
+        let timeTraveller = TimeTraveller(date: date)
+        defaultBrowserService.resultToReturn = .success(value)
+        sut = DefaultBrowserManager(
+            defaultBrowserChecker: defaultBrowserService,
+            defaultBrowserInfoStore: store,
+            dateProvider: timeTraveller.getDate
+        )
+
+        // WHEN
+        let result = sut.defaultBrowserInfo()
+
+        // THEN
+        result
+            .onNewValue { info in
+                #expect(info.isDefaultBrowser == value)
+                #expect(info.lastSuccessfulCheckDate == timestamp)
+                #expect(info.lastAttemptedCheckDate == timestamp)
+                #expect(info.numberOfTimesChecked  == 1)
+                #expect(info.nextRetryAvailableDate == nil)
+            }
+            .onFailure { _ in
+                Issue.record("Success expected")
+            }
+        #expect(store.didSetDefaultBrowserInfo)
+    }
+
+    @Test("Check Successful attempts update Browser Info data")
+    func checkSuccessfulAttemptsUpdateBrowserInfoData() {
+        // GIVEN 1st Check
+        let timestamp: TimeInterval = 1741586108000 // March 10, 2025
+        let date = Date(timeIntervalSince1970: timestamp)
+        let timeTraveller = TimeTraveller(date: date)
+        defaultBrowserService.resultToReturn = .success(false)
+        sut = DefaultBrowserManager(
+            defaultBrowserChecker: defaultBrowserService,
+            defaultBrowserInfoStore: store,
+            dateProvider: timeTraveller.getDate
+        )
+
+        // WHEN
+        var result = sut.defaultBrowserInfo()
+
+        // THEN
+        result
+            .onNewValue { info in
+                #expect(!info.isDefaultBrowser)
+                #expect(info.lastSuccessfulCheckDate == timestamp)
+                #expect(info.lastAttemptedCheckDate == timestamp)
+                #expect(info.numberOfTimesChecked  == 1)
+                #expect(info.nextRetryAvailableDate == nil)
+            }
+            .onFailure { _ in
+                Issue.record("Success expected")
+            }
+
+        // GIVEN 2nd Check
+        defaultBrowserService.resultToReturn = .success(true)
+        timeTraveller.advanceBy(TimeInterval.days(5))
+        let lastSuccessfulTimestamp: TimeInterval = timeTraveller.getDate().timeIntervalSince1970
+
+        // WHEN
+        result = sut.defaultBrowserInfo()
+
+        // THEN
+        result
+            .onNewValue { info in
+                #expect(info.isDefaultBrowser)
+                #expect(info.lastSuccessfulCheckDate == lastSuccessfulTimestamp)
+                #expect(info.lastAttemptedCheckDate == lastSuccessfulTimestamp)
+                #expect(info.numberOfTimesChecked == 2)
+                #expect(info.nextRetryAvailableDate == nil)
+            }
+            .onFailure { _ in
+                Issue.record("Success expected")
+            }
+    }
+
+    @Test("Check Max Attempts Exceeded Failure and no Browser Info stored does not update info and return nil object")
+    func checkDefaultBrowserReturnsMaxNumberOfAttemptsExceededFailure() {
+        // GIVEN
+        let lastSuccessfulTimestamp: TimeInterval = 1741586108 // March 10, 2025
+        let nextRetryTimestamp: TimeInterval = 1773122108000 // March 10, 2026
+        let savedDefaultBrowserInfo = DefaultBrowserInfo(
+            isDefaultBrowser: true,
+            lastSuccessfulCheckDate: lastSuccessfulTimestamp,
+            lastAttemptedCheckDate: lastSuccessfulTimestamp,
+            numberOfTimesChecked: 5,
+            nextRetryAvailableDate: nextRetryTimestamp
+        )
+        defaultBrowserService.resultToReturn = .failure(.maxNumberOfAttemptsExceeded(nextRetryDate: Date(timeIntervalSince1970: nextRetryTimestamp)))
+        store.defaultBrowserInfo = savedDefaultBrowserInfo
+        let timeTraveller = TimeTraveller(date: Date(timeIntervalSince1970: lastSuccessfulTimestamp))
+        timeTraveller.advanceBy(TimeInterval.day)
+        let lastAttemptedCheckTimestamp = timeTraveller.getDate().timeIntervalSince1970
+        let expectedDefaultBrowserInfo = DefaultBrowserInfo(
+            isDefaultBrowser: savedDefaultBrowserInfo.isDefaultBrowser,
+            lastSuccessfulCheckDate: lastSuccessfulTimestamp,
+            lastAttemptedCheckDate: lastAttemptedCheckTimestamp,
+            numberOfTimesChecked: 6,
+            nextRetryAvailableDate: nextRetryTimestamp
+        )
+        sut = DefaultBrowserManager(
+            defaultBrowserChecker: defaultBrowserService,
+            defaultBrowserInfoStore: store,
+            dateProvider: timeTraveller.getDate
+        )
+
+        // WHEN
+        let result = sut.defaultBrowserInfo()
+
+        // THEN
+        result
+            .onNewValue { info in
+                Issue.record("Failure expected")
+            }
+            .onFailure { failure in
+                #expect(failure == .rateLimitReached(updatedStoredInfo: expectedDefaultBrowserInfo))
+            }
+
+        #expect(store.didSetDefaultBrowserInfo)
+    }
+
+    @Test("Check When Max Attempts Exceeded Failure and no Browser Info stored do not update info and return nil object")
+    func checkDefaultBrowserReturnsMaxNumberOfAttemptsExceededFailureAndNoInfoStored() {
+        // GIVEN
+        let timestamp: TimeInterval = 1773122108000 // March 8, 2026
+        let date = Date(timeIntervalSince1970: timestamp)
+        defaultBrowserService.resultToReturn = .failure(.maxNumberOfAttemptsExceeded(nextRetryDate: date))
+
+        // WHEN
+        let result = sut.defaultBrowserInfo()
+
+        // THEN
+        result
+            .onNewValue { info in
+                Issue.record("Failure expected")
+            }
+            .onFailure { failure in
+                #expect(failure == .rateLimitReached(updatedStoredInfo: nil))
+            }
+
+        #expect(!store.didSetDefaultBrowserInfo)
+    }
+
+    @Test("Check Default Browser Info is not stored when unknown error")
+    func checkDefaultBrowserReturnsUnknownError() {
+        // GIVEN
+        let error = NSError(domain: #function, code: 0)
+        defaultBrowserService.resultToReturn = .failure(.unknownError(error))
+
+        // WHEN
+        let result = sut.defaultBrowserInfo()
+
+        // THEN
+        result
+            .onNewValue { info in
+                Issue.record("Failure expected")
+            }
+            .onFailure { failure in
+                #expect(failure == .unknownError(error))
+            }
+
+        #expect(!store.didSetDefaultBrowserInfo)
+    }
+
+    @Test("Check Default Browser Info is not stored when notSupportedOnCurrentOSVersion error")
+    func checkDefaultBrowserReturnsUnsupportedOS() {
+        // GIVEN
+        defaultBrowserService.resultToReturn = .failure(.notSupportedOnThisOSVersion)
+
+        // WHEN
+        let result = sut.defaultBrowserInfo()
+
+        // THEN
+        result
+            .onNewValue { info in
+                Issue.record("Failure expected")
+            }
+            .onFailure { failure in
+                #expect(failure == .notSupportedOnCurrentOSVersion)
+            }
+
+        #expect(!store.didSetDefaultBrowserInfo)
+    }
+
+}
+
+final class MockCheckDefaultBrowserService: CheckDefaultBrowserService {
+    var resultToReturn: Result<Bool, CheckDefaultBrowserServiceError> = .success(true)
+
+    func isDefaultWebBrowser() -> Result<Bool, DuckDuckGo.CheckDefaultBrowserServiceError> {
+        resultToReturn
+    }
+
+}
+
+final class MockDefaultBrowserInfoStore: DefaultBrowserInfoStorage {
+    private(set) var didSetDefaultBrowserInfo = false
+
+    var defaultBrowserInfo: DuckDuckGo.DefaultBrowserInfo? = nil {
+        didSet {
+            didSetDefaultBrowserInfo = true
+        }
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1209503813353609

### Description

Add manager to check if web browser is default and persist result

### Testing Steps
Ensure unit tests pass.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

### Optional E2E tests**:
- [ ] Run macOS PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)