### PR TITLE
make tab switcher remote switchable

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -179,7 +179,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .aiChatDeepLink:
             return .remoteReleasable(.subfeature(AIChatSubfeature.deepLink))
         case .tabManagerMultiSelection:
-            return .internalOnly()
+            return .remoteReleasable(.subfeature(TabManagerSubfeature.multiSelection))
         case .webViewStateRestoration:
             return .remoteReleasable(.feature(.webViewStateRestoration))
         case .syncSeamlessAccountSwitching:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1209568168593153
Tech Design URL:
CC:

### Description
Makes the feature flag for tab switcher changes remote confurable.

### Testing Steps
1. Open a few tabs
1. Check tabManager -> multiSelection feature is set to minimum supported 7.160.0 in https://jsonblob.com/1348616393872039936 (if not, change it)
2. Then using debug screen, update the privacy config to use the json: https://jsonblob.com/api/jsonBlob/1348616393872039936
3. Open tab switcher - it should be enabled (edit button present)
4. Update the above JSON Blob and set the the minimum supported to 7.161.0 
5. Reload the config via the debug screen
6. Open tab switcher - it should be disabled (edit button not visible)

### Impact and Risks
Medium

#### What could go wrong?
Could accidentally enable this feature before the main release where it is completed.

### Quality Considerations
Ensure screen respects privacy config

### Notes to Reviewer

