### PR TITLE
Disable bookmarking Bookmarks and Settings pages

### DIFF
--- a/macOS/DuckDuckGo/Tab/Model/TabContent.swift
+++ b/macOS/DuckDuckGo/Tab/Model/TabContent.swift
@@ -344,9 +344,9 @@ extension TabContent {
 
     var canBeBookmarked: Bool {
         switch self {
-        case .newtab, .onboardingDeprecated, .onboarding, .none:
+        case .newtab, .onboardingDeprecated, .onboarding, .bookmarks, .settings, .none:
             return false
-        case .url, .settings, .bookmarks, .history, .subscription, .identityTheftRestoration, .dataBrokerProtection, .releaseNotes, .webExtensionUrl:
+        case .url, .history, .subscription, .identityTheftRestoration, .dataBrokerProtection, .releaseNotes, .webExtensionUrl:
             return true
         }
     }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1201048563534612/1209628040657468

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Launch the app
2. Open Bookmarks Manager
3. Open Settings
4. Verify that you can’t bookmark either of the two tabs via tab context menu or Main Menu -> Bookmarks -> Bookmark This Page.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Not much, it’s a straightforward change.

### Quality Considerations
This doesn’t affect `canBookmarkAllOpenTabs` logic as it checks canBeBookmarked so will return proper result for the “Bookmark All Open Tabs” action.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

### Optional E2E tests**:
- [ ] Run macOS PIR E2E tests
	Check this to run the Personal Information Removal end to end tests. If updating CCF, or any PIR related code, tick this.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)