### PR TITLE
Update autofill to 17.0.0

### DIFF
--- a/BrowserServicesKit/Package.resolved
+++ b/BrowserServicesKit/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "b5976277a68e18f93edb0d853889e461e06557fa",
-        "version" : "16.2.2"
+        "revision" : "2bc93bec9cbe6d916e84b42346b925c6c057bfa5",
+        "version" : "17.0.0"
       }
     },
     {

--- a/BrowserServicesKit/Package.swift
+++ b/BrowserServicesKit/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
         .library(name: "PrivacyStats", targets: ["PrivacyStats"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "16.2.2"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "17.0.0"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.4.2"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit.git", exact: "3.0.0"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.5.0"),

--- a/BrowserServicesKit/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SourceProvider.swift
+++ b/BrowserServicesKit/Sources/BrowserServicesKit/Autofill/AutofillUserScript+SourceProvider.swift
@@ -17,7 +17,7 @@
 //
 
 import Foundation
-import Autofill
+import AutofillResources
 import Common
 import os.log
 
@@ -51,8 +51,8 @@ public class DefaultAutofillSourceProvider: AutofillUserScriptSourceProvider {
             sourceStr = ""
             return
         }
-        sourceStr = AutofillUserScript.loadJS(isDebug ? "assets/autofill-debug" : "assets/autofill",
-                                              from: Autofill.bundle,
+        sourceStr = AutofillUserScript.loadJS(isDebug ? "autofill-debug" : "autofill",
+                                              from: AutofillResources.bundle,
                                               withReplacements: replacements)
     }
 

--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "b5976277a68e18f93edb0d853889e461e06557fa",
-        "version" : "16.2.2"
+        "revision" : "2bc93bec9cbe6d916e84b42346b925c6c057bfa5",
+        "version" : "17.0.0"
       }
     },
     {

--- a/macOS/DuckDuckGo/Autofill/ContentOverlayViewController.swift
+++ b/macOS/DuckDuckGo/Autofill/ContentOverlayViewController.swift
@@ -21,7 +21,7 @@ import WebKit
 import Combine
 import BrowserServicesKit
 import SecureStorage
-import Autofill
+import AutofillResources
 import PixelKit
 
 @MainActor
@@ -106,7 +106,7 @@ public final class ContentOverlayViewController: NSViewController, EmailManagerR
 
         webView.appearance = NSApp.effectiveAppearance
 
-        let url = Autofill.bundle.url(forResource: "assets/TopAutofill", withExtension: "html")
+        let url = AutofillResources.bundle.url(forResource: "TopAutofill", withExtension: "html")
         if let url = url {
             webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
             return


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1209632498809625/1209632498809625
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/17.0.0
Apple PR: 

## Description
Updates Autofill to version [17.0.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/17.0.0).

### Autofill 17.0.0 release notes
## What's Changed
* [Workflow] Upgrade ubunutu in workflows by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/767
* Update password-related json files (2025-03-05) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/768
* Update password-related json files (2025-03-07) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/771
* build: drop apple-specific assets by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/772
* build: migrate to esbuild by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/327


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/16.2.2...17.0.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).