### PR TITLE
Fix autocomplete UI tests

### DIFF
--- a/macOS/DuckDuckGo/History/View/Dialogs/HistoryViewDeleteDialog.swift
+++ b/macOS/DuckDuckGo/History/View/Dialogs/HistoryViewDeleteDialog.swift
@@ -66,6 +66,7 @@ struct HistoryViewDeleteDialog: ModalView {
                         .frame(height: 28)
                 }
                 .buttonStyle(StandardButtonStyle(topPadding: 0, bottomPadding: 0))
+                .accessibilityIdentifier("ClearAllHistoryAndDataAlert.cancelButton")
 
                 Button {
                     model.delete()
@@ -77,6 +78,7 @@ struct HistoryViewDeleteDialog: ModalView {
                         .frame(height: 28)
                 }
                 .buttonStyle(DestructiveActionButtonStyle(enabled: true, topPadding: 0, bottomPadding: 0))
+                .accessibilityIdentifier("ClearAllHistoryAndDataAlert.clearButton")
 
             }
         }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1201037661562251/1209649886640549

### Description:
This change adds missing accessibility identifiers to HistoryViewDeleteDialog.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
Fix that Autocomplete Tests pass in [this UI tests workflow](https://github.com/duckduckgo/apple-browsers/actions/runs/13805829542).

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)