### PR TITLE
Fix E2E test memory usage for PIR

### DIFF
--- a/macOS/DBPE2ETests/DBPEndToEndTests.swift
+++ b/macOS/DBPE2ETests/DBPEndToEndTests.swift
@@ -125,12 +125,16 @@ final class DBPEndToEndTests: XCTestCase {
         await awaitFulfillment(of: profileSavedExpectation,
                                withTimeout: 3,
                                whenCondition: {
-            try! database.fetchProfile() != nil
+            autoreleasepool {
+                try! database.fetchProfile() != nil
+            }
         })
         await awaitFulfillment(of: profileQueriesCreatedExpectation,
                                withTimeout: 3,
                                whenCondition: {
-            try! database.fetchAllBrokerProfileQueryData().count > 0
+            autoreleasepool {
+                try! database.fetchAllBrokerProfileQueryData().count > 0
+            }
         })
 
         // Also check that we made the broker profile queries correctly
@@ -183,10 +187,12 @@ final class DBPEndToEndTests: XCTestCase {
         await awaitFulfillment(of: extractedProfilesFoundExpectation,
                                withTimeout: 60,
                                whenCondition: {
-            let queries = try! database.fetchAllBrokerProfileQueryData()
-            let brokerIDs = queries.compactMap { $0.dataBroker.id }
-            let extractedProfiles = brokerIDs.flatMap { try! database.fetchExtractedProfiles(for: $0) }
-            return extractedProfiles.count > 0
+            autoreleasepool {
+                let queries = try! database.fetchAllBrokerProfileQueryData()
+                let brokerIDs = queries.compactMap { $0.dataBroker.id }
+                let extractedProfiles = brokerIDs.flatMap { try! database.fetchExtractedProfiles(for: $0) }
+                return extractedProfiles.count > 0
+            }
         })
 
         print("Stage 3 passed: We find and save extracted profiles")
@@ -199,9 +205,11 @@ final class DBPEndToEndTests: XCTestCase {
         await awaitFulfillment(of: optOutJobsCreatedExpectation,
                                withTimeout: 10,
                                whenCondition: {
-            let queries = try! database.fetchAllBrokerProfileQueryData()
-            let optOutJobs = queries.flatMap { $0.optOutJobData }
-            return optOutJobs.count > 0
+            autoreleasepool {
+                let queries = try! database.fetchAllBrokerProfileQueryData()
+                let optOutJobs = queries.flatMap { $0.optOutJobData }
+                return optOutJobs.count > 0
+            }
         })
 
         print("Stage 4 passed: We create opt out jobs")
@@ -215,9 +223,11 @@ final class DBPEndToEndTests: XCTestCase {
         await awaitFulfillment(of: optOutJobsRunExpectation,
                                withTimeout: 300,
                                whenCondition: {
-            let queries = try! database.fetchAllBrokerProfileQueryData()
-            let optOutJobs = queries.flatMap { $0.optOutJobData }
-            return optOutJobs.first?.lastRunDate != nil
+            autoreleasepool {
+                let queries = try! database.fetchAllBrokerProfileQueryData()
+                let optOutJobs = queries.flatMap { $0.optOutJobData }
+                return optOutJobs.first?.lastRunDate != nil
+            }
         })
         print("Stage 5.1 passed: We start running the opt out jobs")
 
@@ -279,11 +289,13 @@ final class DBPEndToEndTests: XCTestCase {
         await awaitFulfillment(of: optOutConfirmedExpectation,
                                withTimeout: 600,
                                whenCondition: {
-            let queries = try! database.fetchAllBrokerProfileQueryData()
-            let optOutJobs = queries.flatMap { $0.optOutJobData }
-            let events = optOutJobs.flatMap { $0.historyEvents }
-            let optOutsConfirmed = events.filter{ $0.type == .optOutConfirmed }
-            return optOutsConfirmed.count > 0
+            autoreleasepool {
+                let queries = try! database.fetchAllBrokerProfileQueryData()
+                let optOutJobs = queries.flatMap { $0.optOutJobData }
+                let events = optOutJobs.flatMap { $0.historyEvents }
+                let optOutsConfirmed = events.filter{ $0.type == .optOutConfirmed }
+                return optOutsConfirmed.count > 0
+            }
         })
         print("Stage 9 passed: We confirm the opt out through a scan")
     }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1199333091098016/1209661386167901
Tech Design URL:
CC:

### Description

This PR reduces PIR E2E test memory usage, as it's likely causing issues with the runner images. The issue is related to the `awaitFulfillment` blocks in the suite, which run their block repeatedly until they either get a success or time out.

The fix is to wrap these checks in an `autoreleasepool` to force the memory to be released. After this change, the suite never consumes more than 60MB for me at its peak, down from multiple gigabytes.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI is green - note that I'm not sure that we don't also have other issues here with Auth v2 so green might not be possible yet, but this change should at least help overall

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)