### PR TITLE
Update History View onboarding popover copy and positioning

### DIFF
--- a/macOS/DuckDuckGo/Common/Extensions/NSPopoverExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/NSPopoverExtension.swift
@@ -73,15 +73,10 @@ extension NSPopover {
 
     @objc func adjustFrame(_ frame: NSRect) -> NSRect {
         var frame = frame
+        frame.size.width -= 12
         let boundingFrame = self.boundingFrame
         if !boundingFrame.isInfinite, boundingFrame.width > frame.width {
-            var rightEdge = boundingFrame.maxX
-            if positioningView?.window?.isFullScreen == true {
-                // Move the popover to the left in full screen to ensure it's fully shown on screen.
-                // This fixes presenting from "More Options" menu.
-                rightEdge -= 48
-            }
-            frame.origin.x = min(max(frame.minX, boundingFrame.minX), rightEdge - frame.width)
+            frame.origin.x = min(max(frame.minX, boundingFrame.minX), boundingFrame.maxX - frame.width)
         }
         return frame
     }

--- a/macOS/DuckDuckGo/Common/Extensions/NSPopoverExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/NSPopoverExtension.swift
@@ -73,7 +73,6 @@ extension NSPopover {
 
     @objc func adjustFrame(_ frame: NSRect) -> NSRect {
         var frame = frame
-        frame.size.width -= 12
         let boundingFrame = self.boundingFrame
         if !boundingFrame.isInfinite, boundingFrame.width > frame.width {
             frame.origin.x = min(max(frame.minX, boundingFrame.minX), boundingFrame.maxX - frame.width)

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -210,8 +210,9 @@ struct UserText {
     static let mainMenuHelpDuckDuckGoHelp = NSLocalizedString("DuckDuckGo Help", comment: "Main Menu Help item")
 
     // MARK: - History
-    static let historyViewOnboardingTitle = NSLocalizedString("history.view.onboarding.title", value: "Manage Your History", comment: "Title for the history view onboarding popover")
-    static let historyViewOnboardingMessage = NSLocalizedString("history.view.onboarding.message", value: "We’ve added a dedicated History page, making it easier for you to see, revisit, and clear the sites you’ve previously visited.", comment: "Message for the history view onboarding popover")
+    static let historyViewOnboardingTitle = NSLocalizedString("history.view.onboarding.title", value: "Manage Your History Easier", comment: "Title for the history view onboarding popover")
+    static let historyViewOnboardingMessage = NSLocalizedString("history.view.onboarding.message", value: "We've added a dedicated History page in this ••• menu for easier history management, also accessible via the History menu and ⌘Y keyboard shortcut.", comment: "Message for the history view onboarding popover. Please make sure to keep ••• and ⌘Y intact.")
+    static let historyViewOnboardingLocalStorageExplanation = NSLocalizedString("history.view.onboarding.local.storage.explanation", value: "History is stored locally and not on any DuckDuckGo or other remote server, and can also be cleared using the Fire Button.", comment: "Message for the history view onboarding popover explaining that history is kept locally.")
     static let historyViewOnboardingAccept = NSLocalizedString("history.view.onboarding.accept", value: "View History Page", comment: "Accept button label on the history view onboarding popover")
 
     static let today = NSLocalizedString("today", value: "today", comment: "Date section in history view indicating current day")

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -210,10 +210,16 @@ struct UserText {
     static let mainMenuHelpDuckDuckGoHelp = NSLocalizedString("DuckDuckGo Help", comment: "Main Menu Help item")
 
     // MARK: - History
-    static let historyViewOnboardingTitle = NSLocalizedString("history.view.onboarding.title", value: "Manage Your History Easier", comment: "Title for the history view onboarding popover")
-    static let historyViewOnboardingMessage = NSLocalizedString("history.view.onboarding.message", value: "We've added a dedicated History page in this ••• menu for easier history management, also accessible via the History menu and ⌘Y keyboard shortcut.", comment: "Message for the history view onboarding popover. Please make sure to keep ••• and ⌘Y intact.")
-    static let historyViewOnboardingLocalStorageExplanation = NSLocalizedString("history.view.onboarding.local.storage.explanation", value: "History is stored locally and not on any DuckDuckGo or other remote server, and can also be cleared using the Fire Button.", comment: "Message for the history view onboarding popover explaining that history is kept locally.")
-    static let historyViewOnboardingAccept = NSLocalizedString("history.view.onboarding.accept", value: "View History Page", comment: "Accept button label on the history view onboarding popover")
+    static let historyViewOnboardingTitle = NSLocalizedString("history.view.onboarding.title", value: "Easier History Management", comment: "Title for the history view onboarding popover")
+
+    static func historyViewOnboardingMessage(shortcut: String) -> String {
+        let localized = NSLocalizedString("history.view.onboarding.message",
+                                          value: "We added a new History page for easier history searching and management. Access it at any time from the ••• or History menu, or by pressing %@.",
+                                          comment: "Message for the history view onboarding popover. Please make sure to keep ••• intact. %@ will be replaced with a keyboard shortcut for accessing history (e.g. '⌘Y').")
+        return String(format: localized, shortcut)
+    }
+    static let historyViewOnboardingLocalStorageExplanation = NSLocalizedString("history.view.onboarding.local.storage.explanation", value: "History is only stored on your device and can be deleted at any time using the Fire Button.", comment: "Message for the history view onboarding popover explaining that history is kept locally.")
+    static let historyViewOnboardingAccept = NSLocalizedString("history.view.onboarding.accept", value: "View History", comment: "Accept button label on the history view onboarding popover")
 
     static let today = NSLocalizedString("today", value: "today", comment: "Date section in history view indicating current day")
     static let yesterday = NSLocalizedString("yesterday", value: "yesterday", comment: "Date section in history view indicating previous day")

--- a/macOS/DuckDuckGo/History/View/Onboarding/HistoryViewOnboardingPopover.swift
+++ b/macOS/DuckDuckGo/History/View/Onboarding/HistoryViewOnboardingPopover.swift
@@ -27,6 +27,7 @@ final class HistoryViewOnboardingPopover: NSPopover {
         self.ctaCallback = ctaCallback
         super.init()
         self.behavior = .semitransient
+        contentSize = .init(width: HistoryViewOnboardingView.Const.width, height: 200)
         setupContentController()
     }
 

--- a/macOS/DuckDuckGo/History/View/Onboarding/HistoryViewOnboardingPopover.swift
+++ b/macOS/DuckDuckGo/History/View/Onboarding/HistoryViewOnboardingPopover.swift
@@ -27,7 +27,13 @@ final class HistoryViewOnboardingPopover: NSPopover {
         self.ctaCallback = ctaCallback
         super.init()
         self.behavior = .semitransient
-        contentSize = .init(width: HistoryViewOnboardingView.Const.width, height: 200)
+        /// popover frame used for positioning is 26px wider than `contentSize.width`
+        /// and makes the popover appear partially outside of the window.
+        /// Subtract 12px to ensure that the popover is fully contained within the window.
+        ///
+        /// Height is an arbitrary value and it doesn't influence positioning. It will be
+        /// updated with the actual height of the popover's SwiftUI view.
+        contentSize = .init(width: HistoryViewOnboardingView.Const.width - 12, height: 200)
         setupContentController()
     }
 

--- a/macOS/DuckDuckGo/History/View/Onboarding/HistoryViewOnboardingView.swift
+++ b/macOS/DuckDuckGo/History/View/Onboarding/HistoryViewOnboardingView.swift
@@ -35,6 +35,10 @@ struct HistoryViewOnboardingView: View {
             Text(.init(UserText.historyViewOnboardingMessage))
                 .fixMultilineScrollableText()
                 .font(.system(size: 13))
+                .padding(.bottom, 8)
+            Text(.init(UserText.historyViewOnboardingLocalStorageExplanation))
+                .fixMultilineScrollableText()
+                .font(.system(size: 12))
                 .padding(.bottom, 20)
 
             HStack {

--- a/macOS/DuckDuckGo/History/View/Onboarding/HistoryViewOnboardingView.swift
+++ b/macOS/DuckDuckGo/History/View/Onboarding/HistoryViewOnboardingView.swift
@@ -20,6 +20,10 @@ import SwiftUIExtensions
 
 struct HistoryViewOnboardingView: View {
 
+    enum Const {
+        static let width: CGFloat = 384
+    }
+
     @ObservedObject var model: HistoryViewOnboardingViewModel
 
     var body: some View {
@@ -66,11 +70,11 @@ struct HistoryViewOnboardingView: View {
         .padding(.horizontal, 16)
         .padding(.top, 20)
         .padding(.bottom, 16)
-        .frame(width: 384)
+        .frame(width: Const.width)
     }
 }
 
 #Preview {
     HistoryViewOnboardingView(model: .init(ctaCallback: { _ in }))
-        .frame(width: 384)
+        .frame(width: HistoryViewOnboardingView.Const.width)
 }

--- a/macOS/DuckDuckGo/History/View/Onboarding/HistoryViewOnboardingView.swift
+++ b/macOS/DuckDuckGo/History/View/Onboarding/HistoryViewOnboardingView.swift
@@ -32,20 +32,21 @@ struct HistoryViewOnboardingView: View {
                 .font(.system(size: 15).weight(.semibold))
                 .padding(.bottom, 12)
 
-            Text(.init(UserText.historyViewOnboardingMessage))
+            Text(.init(UserText.historyViewOnboardingMessage(shortcut: "⌘Y")))
                 .fixMultilineScrollableText()
                 .font(.system(size: 13))
                 .padding(.bottom, 8)
+
             Text(.init(UserText.historyViewOnboardingLocalStorageExplanation))
                 .fixMultilineScrollableText()
-                .font(.system(size: 12))
+                .font(.system(size: 13))
                 .padding(.bottom, 20)
 
             HStack {
                 Button {
                     model.notNow()
                 } label: {
-                    Text(UserText.notNow)
+                    Text(UserText.close)
                         .frame(maxWidth: .infinity)
                         .frame(height: 28)
                 }

--- a/macOS/DuckDuckGo/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localizable.xcstrings
@@ -29123,61 +29123,73 @@
         }
       }
     },
+    "history.view.onboarding.local.storage.explanation" : {
+      "comment" : "Message for the history view onboarding popover explaining that history is kept locally.",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History is stored locally and not on any DuckDuckGo or other remote server, and can also be cleared using the Fire Button."
+          }
+        }
+      }
+    },
     "history.view.onboarding.message" : {
-      "comment" : "Message for the history view onboarding popover",
+      "comment" : "Message for the history view onboarding popover. Please make sure to keep ••• and ⌘Y intact.",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Wir haben eine spezielle Verlaufsseite hinzugefügt, die es dir erleichtert, die von dir besuchten Seiten anzuzeigen, erneut zu besuchen und zu löschen."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "We’ve added a dedicated History page, making it easier for you to see, revisit, and clear the sites you’ve previously visited."
+            "value" : "We've added a dedicated History page in this ••• menu for easier history management, also accessible via the History menu and ⌘Y keyboard shortcut."
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Hemos añadido una página de historial exclusiva, para que puedas ver, volver a abrir y borrar los sitios que has visitado anteriormente de forma más sencilla."
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Nous avons ajouté une page d’historique dédiée, ce qui vous permet de voir, de revisiter et d’effacer plus facilement les sites que vous avez déjà consultés."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Abbiamo aggiunto una pagina dedicata alla cronologia che ti consente di visualizzare, rivisitare e cancellare i siti che hai visitato in precedenza."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "We hebben een speciale geschiedenispagina toegevoegd. Zo kun je makkelijker de sites die je eerder hebt bezocht bekijken, opnieuw bezoeken en wissen."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Dodaliśmy specjalną stronę historii, dzięki której możesz łatwiej przeglądać wcześniej odwiedzone strony, przeglądać je i usuwać."
           }
         },
         "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Adicionámos uma página de histórico dedicada para ser mais fácil ver, revisitar e limpar os sites que visitaste anteriormente."
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Мы добавили отдельную страницу «История», где можно легко просмотреть, заново открыть и удалить ранее посещенные сайты."
           }
         }
@@ -29189,55 +29201,55 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Verwalte deinen Verlauf"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Manage Your History"
+            "value" : "Manage Your History Easier"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Gestiona tu historial"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Gérer votre historique"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Gestisci la cronologia"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Beheer je geschiedenis"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Zarządzanie historią"
           }
         },
         "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Gere o teu histórico"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Управление историей"
           }
         }

--- a/macOS/DuckDuckGo/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localizable.xcstrings
@@ -27963,10 +27963,58 @@
       "comment" : "Explanation of what deleting site data means.",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dadurch wirst du von diesen Websites abgemeldet, die Website-Einstellungen werden zurückgesetzt und gespeicherte Sitzungen werden entfernt. Cookies und Daten einer „Fireproof“-Website werden nicht gelöscht."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This will log you out of these sites, reset site preferences, and remove saved sessions. Fireproof site cookies and data won’t be deleted."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto cerrará tu sesión en estos sitios, restablecerá las preferencias del sitio y eliminará las sesiones guardadas. Las cookies y los datos del sitio Fireproof no se eliminarán."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ceci vous déconnectera de ces sites, réinitialisera les préférences des sites et supprimera les sessions enregistrées. Les cookies et les données Fireproof des sites ne seront pas supprimés."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In questo modo potrai uscire da questi siti, reimpostare le preferenze del sito e rimuovere le sessioni salvate. I cookie e i dati del sito Fireproof non saranno eliminati."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Je wordt nu afgemeld bij deze sites, je sitevoorkeuren worden opnieuw ingesteld en opgeslagen sessies worden verwijderd. Fireproof site-cookies en -gegevens worden niet verwijderd."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spowoduje to wylogowanie z tych witryn, zresetowanie preferencji dotyczących witryn i usunięcie zapisanych sesji. Pliki cookie i dane witryn oznaczonych jako Fireproof nie zostaną usunięte."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta ação termina a tua sessão nestes sites, repõe as preferências dos sites e remove as sessões guardadas. Os cookies e dados dos sites Fireproof não serão eliminados."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вы выйдете из учетных записей на этих сайтах, настройки сайтов будут сброшены, а сохраненные сеансы — удалены. Куки-файлы и данные «огнеупорных» сайтов не удаляются."
           }
         }
       }
@@ -28215,10 +28263,58 @@
       "comment" : "Title of a dialog asking the user to confirm deleting history",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verlauf löschen?"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Delete history?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Borrar historial?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer l'historique ?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancellare la cronologia?"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geschiedenis verwijderen?"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usunąć historię?"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apagar histórico?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить историю?"
           }
         }
       }
@@ -29069,8 +29165,8 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Verlaufsseite anzeigen"
+            "state" : "translated",
+            "value" : "Verlauf anzeigen"
           }
         },
         "en" : {
@@ -29081,44 +29177,44 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Ver tu página de historial"
+            "state" : "translated",
+            "value" : "Ver historial"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Voir la page d'historique"
+            "state" : "translated",
+            "value" : "Voir l'historique"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Visualizza la pagina Cronologia"
+            "state" : "translated",
+            "value" : "Visualizza cronologia"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Bekijk de geschiedenispagina"
+            "state" : "translated",
+            "value" : "Geschiedenis weergeven"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Wyświetl stronę historii"
+            "state" : "translated",
+            "value" : "Wyświetl historię"
           }
         },
         "pt" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Ver página de histórico"
+            "state" : "translated",
+            "value" : "Ver histórico"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Просмотреть страницу истории"
+            "state" : "translated",
+            "value" : "Просмотреть историю"
           }
         }
       }
@@ -29127,10 +29223,58 @@
       "comment" : "Message for the history view onboarding popover explaining that history is kept locally.",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Verlauf wird nur auf deinem Gerät gespeichert und kann jederzeit mit dem Fire Button gelöscht werden."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "History is only stored on your device and can be deleted at any time using the Fire Button."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El historial solo se almacena en tu dispositivo y se puede eliminar en cualquier momento usando el Fire Button."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'historique est uniquement stocké sur votre appareil et peut être supprimé à tout moment à l'aide du Fire Button."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La cronologia è memorizzata solo sul tuo dispositivo e può essere cancellata in qualsiasi momento usando il Fire Button."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Je geschiedenis wordt alleen op je apparaat opgeslagen en kan op elk moment worden gewist met de Fire Button."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Historia jest przechowywana tylko na Twoim urządzeniu i można ją usunąć w dowolnym momencie za pomocą przycisku Fire Button."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O histórico é guardado apenas no teu dispositivo e pode ser apagado em qualquer altura com o Fire Button."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "История хранится только на вашем устройстве, и ее можно в любой момент стереть с помощью кнопки Fire Button."
           }
         }
       }
@@ -29141,8 +29285,8 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Wir haben eine spezielle Verlaufsseite hinzugefügt, die es dir erleichtert, die von dir besuchten Seiten anzuzeigen, erneut zu besuchen und zu löschen."
+            "state" : "translated",
+            "value" : "Wir haben eine neue Verlaufsseite hinzugefügt, um die Suche im Verlauf und seine Verwaltung zu vereinfachen. Greife jederzeit über das Menü ••• oder das „Verlauf“-Menü oder durch Drücken von %@ darauf zu."
           }
         },
         "en" : {
@@ -29153,44 +29297,44 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Hemos añadido una página de historial exclusiva, para que puedas ver, volver a abrir y borrar los sitios que has visitado anteriormente de forma más sencilla."
+            "state" : "translated",
+            "value" : "Hemos añadido una nueva página de historial para facilitar la búsqueda y gestión del historial. Accede a él en cualquier momento desde el menú ••• o el menú Historial, o pulsando %@."
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Nous avons ajouté une page d’historique dédiée, ce qui vous permet de voir, de revisiter et d’effacer plus facilement les sites que vous avez déjà consultés."
+            "state" : "translated",
+            "value" : "Nous avons ajouté une nouvelle page Historique pour faciliter la recherche et la gestion de l'historique. Vous pouvez y accéder à tout moment à partir du menu ••• ou Historique, ou en appuyant sur %@."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Abbiamo aggiunto una pagina dedicata alla cronologia che ti consente di visualizzare, rivisitare e cancellare i siti che hai visitato in precedenza."
+            "state" : "translated",
+            "value" : "Abbiamo aggiunto una nuova pagina Cronologia per facilitare la ricerca e la gestione della cronologia. Accedi in qualsiasi momento dal menu ••• o Cronologia, oppure premendo %@."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "We hebben een speciale geschiedenispagina toegevoegd. Zo kun je makkelijker de sites die je eerder hebt bezocht bekijken, opnieuw bezoeken en wissen."
+            "state" : "translated",
+            "value" : "We hebben een nieuwe pagina Geschiedenis toegevoegd om je geschiedenis gemakkelijker te doorzoeken en beheren. Open hem via het menu ••• of het menu Geschiedenis, of door op %@ te drukken."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Dodaliśmy specjalną stronę historii, dzięki której możesz łatwiej przeglądać wcześniej odwiedzone strony, przeglądać je i usuwać."
+            "state" : "translated",
+            "value" : "Dodaliśmy nową stronę Historia, aby ułatwić jej przeszukiwanie i zarządzanie historią. Możesz uzyskać do niej dostęp w dowolnym momencie z menu ••• lub Historia, albo naciskając %@."
           }
         },
         "pt" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Adicionámos uma página de histórico dedicada para ser mais fácil ver, revisitar e limpar os sites que visitaste anteriormente."
+            "state" : "translated",
+            "value" : "Adicionámos uma nova página de Histórico para facilitar a pesquisa e gestão do histórico. Acede a qualquer momento a partir do atalho ••• ou do menu Histórico, ou prime %@."
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Мы добавили отдельную страницу «История», где можно легко просмотреть, заново открыть и удалить ранее посещенные сайты."
+            "state" : "translated",
+            "value" : "Для удобства поиска и управления журналом посещений мы добавили новую страницу \"История\". Ее всегда можно открыть из меню \"История\" (•••) или с помощью сочетания клавиш %@."
           }
         }
       }
@@ -29201,8 +29345,8 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Verwalte deinen Verlauf"
+            "state" : "translated",
+            "value" : "Einfacheres Verlaufsmanagement"
           }
         },
         "en" : {
@@ -29213,44 +29357,44 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Gestiona tu historial"
+            "state" : "translated",
+            "value" : "Gestión de historial más sencilla"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Gérer votre historique"
+            "state" : "translated",
+            "value" : "Gestion simplifiée de l'historique"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Gestisci la cronologia"
+            "state" : "translated",
+            "value" : "Gestione più semplice della cronologia"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Beheer je geschiedenis"
+            "state" : "translated",
+            "value" : "Eenvoudiger beheer van Geschiedenis"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Zarządzanie historią"
+            "state" : "translated",
+            "value" : "Łatwiejsze zarządzanie historią"
           }
         },
         "pt" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Gere o teu histórico"
+            "state" : "translated",
+            "value" : "Gestão mais fácil do histórico"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Управление историей"
+            "state" : "translated",
+            "value" : "Упрощенное управление историей"
           }
         }
       }
@@ -44026,10 +44170,58 @@
       "comment" : "Menu item that opens all the bookmarks in a folder in new tabs in the current window",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle im aktuellen Fenster öffnen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Open All in Current Window"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir todo en la ventana actual"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tout ouvrir dans la fenêtre actuelle"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apri tutto nella finestra corrente"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alles openen in het huidige venster"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otwórz wszystko w bieżącym oknie"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir tudo na janela atual"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открыть все в текущем окне"
           }
         }
       }
@@ -44038,10 +44230,58 @@
       "comment" : "Menu item that opens all URLs in a new Fire Window",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle in neuem Fire Window öffnen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Open All in New Fire Window"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir todo en una nueva Fire Window"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tout ouvrir dans une nouvelle Fire Window"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apri tutto in una nuova Fire Window"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alles openen in nieuw Fire Window"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otwórz wszystko w nowym oknie Fire Window"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir tudo numa nova Fire Window"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открыть все в новом окне Fire Window"
           }
         }
       }
@@ -63218,7 +63458,7 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ustaw jako domyślne"
+            "value" : "Ustaw jako domyślną"
           }
         },
         "pt" : {

--- a/macOS/DuckDuckGo/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localizable.xcstrings
@@ -29069,55 +29069,55 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Verlaufsseite anzeigen"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "View History Page"
+            "value" : "View History"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Ver tu página de historial"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Voir la page d'historique"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Visualizza la pagina Cronologia"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Bekijk de geschiedenispagina"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Wyświetl stronę historii"
           }
         },
         "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Ver página de histórico"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Просмотреть страницу истории"
           }
         }
@@ -29130,13 +29130,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "History is stored locally and not on any DuckDuckGo or other remote server, and can also be cleared using the Fire Button."
+            "value" : "History is only stored on your device and can be deleted at any time using the Fire Button."
           }
         }
       }
     },
     "history.view.onboarding.message" : {
-      "comment" : "Message for the history view onboarding popover. Please make sure to keep ••• and ⌘Y intact.",
+      "comment" : "Message for the history view onboarding popover. Please make sure to keep ••• intact. %@ will be replaced with a keyboard shortcut for accessing history (e.g. '⌘Y').",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "de" : {
@@ -29148,7 +29148,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "We've added a dedicated History page in this ••• menu for easier history management, also accessible via the History menu and ⌘Y keyboard shortcut."
+            "value" : "We added a new History page for easier history searching and management. Access it at any time from the ••• or History menu, or by pressing %@."
           }
         },
         "es" : {
@@ -29208,7 +29208,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Manage Your History Easier"
+            "value" : "Easier History Management"
           }
         },
         "es" : {

--- a/macOS/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/Resources/Localizable.xcstrings
+++ b/macOS/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/Resources/Localizable.xcstrings
@@ -4342,7 +4342,7 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aggiorna o o annulla il piano"
+            "value" : "Aggiorna o annulla il piano"
           }
         },
         "nl" : {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1142021229838617/1209662271514050

### Description:
This change updates the message in History View onboarding popover and fixes positioning so that
the popover is always contained in the parent window.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Launch the app and select Main Menu -> Debug -> History -> Show History View Onboarding.
2. Verify that it uses the new copy as linked in the Asana task, and that it’s fully visible in the containing window.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)