### PR TITLE
[iOS] Onboarding Experiment - Set as default browser pixels implementation

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -818,6 +818,22 @@ extension Pixel {
         case siteNotWorkingShown
         case siteNotWorkingWebsiteIsBroken
 
+        // Set As Default Browser Debug Pixels
+        // Privacy Triage: https://app.asana.com/0/1206329551987282/1209505775591500
+
+        /// Fired when a successful result (either true or false) is returned from [isDefault(.webBrowser)](https://developer.apple.com/documentation/UIKit/UIApplication/isDefault(_:)) method.
+        case debugSetAsDefaultBrowserSuccessfulResult
+
+        /// Fired when an error with domain `UIApplicationCategoryDefaultErrorDomain` and code `rateLimited` is thrown from [isDefault(.webBrowser)](https://developer.apple.com/documentation/UIKit/UIApplication/isDefault(_:)) method.
+        case debugSetAsDefaultBrowserMaxNumberOfAttemptsFailure
+
+        /// Fired when an error with domain `UIApplicationCategoryDefaultErrorDomain` and code `rateLimited` is thrown from [isDefault(.webBrowser)](https://developer.apple.com/documentation/UIKit/UIApplication/isDefault(_:)) method
+        /// and we don’t have a persisted version of the previous result.
+        case debugSetAsDefaultBrowserMaxNumberOfAttemptsNoExistingResultPersistedFailure
+
+        /// Fired when a generic error is thrown from [isDefault(.webBrowser)](https://developer.apple.com/documentation/UIKit/UIApplication/isDefault(_:)) method.
+        case debugSetAsDefaultBrowserUnknownFailure
+
         // MARK: History
         case historyStoreLoadFailed
         case historyRemoveFailed
@@ -1680,6 +1696,11 @@ extension Pixel.Event {
             return "m_d_tab-interaction-state_failed-to-restore"
         case .tabInteractionStateRestorationTime(let aggregation):
             return "m_d_tab-interaction-state_restoration-time-\(aggregation)"
+
+        case .debugSetAsDefaultBrowserSuccessfulResult: return "m_debug_set-default-browser_successful-result"
+        case .debugSetAsDefaultBrowserMaxNumberOfAttemptsFailure: return "m_debug_set-default-browser_failure-max-number-of-attempts-reached"
+        case .debugSetAsDefaultBrowserMaxNumberOfAttemptsNoExistingResultPersistedFailure: return "m_debug_set-default-browser_failure-max-number-of-attempts-reached-no-persisted-result"
+        case .debugSetAsDefaultBrowserUnknownFailure: return "m_debug_set-default-browser_failure-unknown-error"
 
             // MARK: Ad Attribution
 

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -919,6 +919,7 @@
 		9F8E0F332CCA642D001EA7C5 /* VideoPlayerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8E0F322CCA642D001EA7C5 /* VideoPlayerViewModelTests.swift */; };
 		9F8E0F382CCFAA8A001EA7C5 /* AddToDockPromoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8E0F372CCFAA8A001EA7C5 /* AddToDockPromoView.swift */; };
 		9F8E0F3D2CCFD072001EA7C5 /* AddToDockPromoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8E0F3C2CCFD071001EA7C5 /* AddToDockPromoViewModel.swift */; };
+		9F8F6DD42D8278CE00E253F6 /* DefaultBrowserManagerEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8F6DD32D8278C800E253F6 /* DefaultBrowserManagerEventMapper.swift */; };
 		9F8FE9492BAE50E50071E372 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 9F8FE9482BAE50E50071E372 /* Lottie */; };
 		9F96F73F2C914C57009E45D5 /* OnboardingGradient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F96F73E2C914C57009E45D5 /* OnboardingGradient.swift */; };
 		9F9A922E2C86A56B001D036D /* OnboardingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9A922D2C86A56B001D036D /* OnboardingManager.swift */; };
@@ -2924,6 +2925,7 @@
 		9F8E0F322CCA642D001EA7C5 /* VideoPlayerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerViewModelTests.swift; sourceTree = "<group>"; };
 		9F8E0F372CCFAA8A001EA7C5 /* AddToDockPromoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddToDockPromoView.swift; sourceTree = "<group>"; };
 		9F8E0F3C2CCFD071001EA7C5 /* AddToDockPromoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddToDockPromoViewModel.swift; sourceTree = "<group>"; };
+		9F8F6DD32D8278C800E253F6 /* DefaultBrowserManagerEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserManagerEventMapper.swift; sourceTree = "<group>"; };
 		9F96F73E2C914C57009E45D5 /* OnboardingGradient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingGradient.swift; sourceTree = "<group>"; };
 		9F9A922D2C86A56B001D036D /* OnboardingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingManager.swift; sourceTree = "<group>"; };
 		9F9A92302C86AAE9001D036D /* OnboardingDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingDebugView.swift; sourceTree = "<group>"; };
@@ -5726,6 +5728,7 @@
 				9F3C7FDF2D7990710061FA72 /* DefaultBrowserInfoStore.swift */,
 				9F70B8552D6D942200199D4B /* CheckDefaultBrowserService.swift */,
 				9F3C7FE12D7990DE0061FA72 /* DefaultBrowserManager.swift */,
+				9F8F6DD32D8278C800E253F6 /* DefaultBrowserManagerEventMapper.swift */,
 			);
 			path = CheckDefaultBrowser;
 			sourceTree = "<group>";
@@ -8780,6 +8783,7 @@
 				982E5630222C3D5B008D861B /* FeedbackPickerViewController.swift in Sources */,
 				6FD8E5202C5BA23200345670 /* NewTabPageViewModel.swift in Sources */,
 				37FCAABC2992F592000E420A /* MultilineScrollableTextFix.swift in Sources */,
+				9F8F6DD42D8278CE00E253F6 /* DefaultBrowserManagerEventMapper.swift in Sources */,
 				85DFEDED24C7CCA500973FE7 /* AppWidthObserver.swift in Sources */,
 				4B6484F327FD1E350050A7A1 /* MenuControllerView.swift in Sources */,
 				7B059F0F2D0387E900371ED0 /* NumberedParagraphView.swift in Sources */,

--- a/iOS/DuckDuckGo/CheckDefaultBrowser/DefaultBrowserManagerEventMapper.swift
+++ b/iOS/DuckDuckGo/CheckDefaultBrowser/DefaultBrowserManagerEventMapper.swift
@@ -1,0 +1,39 @@
+//
+//  DefaultBrowserManagerEventMapper.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import class Common.EventMapping
+import class Core.DailyPixel
+
+enum DefaultBrowserManagerEventMapper {
+
+    static let debugEvents = EventMapping<DefaultBrowserManager.DebugEvent> { event, _, _, _ in
+        switch event {
+        case .successfulResult:
+            DailyPixel.fireDailyAndCount(pixel: .debugSetAsDefaultBrowserSuccessfulResult)
+        case .rateLimitReached:
+            DailyPixel.fireDailyAndCount(pixel: .debugSetAsDefaultBrowserMaxNumberOfAttemptsFailure)
+        case .rateLimitReachedNoExistingResultPersisted:
+            DailyPixel.fireDailyAndCount(pixel: .debugSetAsDefaultBrowserMaxNumberOfAttemptsNoExistingResultPersistedFailure)
+        case .unknownError:
+            DailyPixel.fireDailyAndCount(pixel: .debugSetAsDefaultBrowserUnknownFailure)
+        }
+    }
+
+}

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
@@ -31,14 +31,14 @@ final class OnboardingIntroViewModel: ObservableObject {
     private var introSteps: [OnboardingIntroStep]
 
     private let defaultBrowserManager: DefaultBrowserManaging
-    private let pixelReporter: OnboardingIntroPixelReporting & OnboardingAddToDockReporting
+    private let pixelReporter: LinearOnboardingPixelReporting
     private let onboardingManager: OnboardingManaging
     private let isIpad: Bool
     private let urlOpener: URLOpener
     private let appIconProvider: () -> AppIcon
     private let addressBarPositionProvider: () -> AddressBarPosition
 
-    convenience init(pixelReporter: OnboardingIntroPixelReporting & OnboardingAddToDockReporting) {
+    convenience init(pixelReporter: LinearOnboardingPixelReporting) {
         self.init(
             defaultBrowserManager: DefaultBrowserManager(),
             pixelReporter: pixelReporter,
@@ -52,7 +52,7 @@ final class OnboardingIntroViewModel: ObservableObject {
 
     init(
         defaultBrowserManager: DefaultBrowserManaging,
-        pixelReporter: OnboardingIntroPixelReporting & OnboardingAddToDockReporting,
+        pixelReporter: LinearOnboardingPixelReporting,
         onboardingManager: OnboardingManaging,
         isIpad: Bool,
         urlOpener: URLOpener,
@@ -190,11 +190,11 @@ private extension OnboardingIntroViewModel {
 
         defaultBrowserManager.defaultBrowserInfo()
             .onNewValue { newInfo in
-                // Send experimental pixel
-                Logger.onboarding.debug("Succesfully received default browser result: \(newInfo.isDefaultBrowser)")
-            }
-            .onFailure { _ in
-                // Send Debug pixel
+                if newInfo.isDefaultBrowser {
+                    pixelReporter.measureDidSetDDGAsDefaultBrowser()
+                } else {
+                    pixelReporter.measureDidNotSetDDGAsDefaultBrowser()
+                }
             }
     }
 

--- a/iOS/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
@@ -292,7 +292,7 @@ extension OnboardingPixelReporter: OnboardingSetAsDefaultBrowserExperimentReport
             for: SetAsDefaultExperimentMetrics.subfeatureIdentifier,
             metric: SetAsDefaultExperimentMetrics.metricDefaultBrowserSet,
             conversionWindowDays: SetAsDefaultExperimentMetrics.conversionWindowDays,
-            value: ""
+            value: "true"
         )
     }
 
@@ -301,7 +301,7 @@ extension OnboardingPixelReporter: OnboardingSetAsDefaultBrowserExperimentReport
             for: SetAsDefaultExperimentMetrics.subfeatureIdentifier,
             metric: SetAsDefaultExperimentMetrics.metricDefaultBrowserNotSet,
             conversionWindowDays: SetAsDefaultExperimentMetrics.conversionWindowDays,
-            value: ""
+            value: "true"
         )
     }
     

--- a/iOS/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
@@ -21,6 +21,7 @@ import Foundation
 import Core
 import BrowserServicesKit
 import Onboarding
+import PixelKit
 
 // MARK: - Pixel Fire Interface
 
@@ -74,7 +75,13 @@ protocol OnboardingAddToDockReporting {
     func measureAddToDockTutorialDismissCTAAction()
 }
 
-typealias OnboardingPixelReporting = OnboardingIntroImpressionReporting & OnboardingIntroPixelReporting & OnboardingSearchSuggestionsPixelReporting & OnboardingSiteSuggestionsPixelReporting & OnboardingCustomInteractionPixelReporting & OnboardingDaxDialogsReporting & OnboardingAddToDockReporting
+protocol OnboardingSetAsDefaultBrowserExperimentReporting {
+    func measureDidSetDDGAsDefaultBrowser()
+    func measureDidNotSetDDGAsDefaultBrowser()
+}
+
+typealias LinearOnboardingPixelReporting = OnboardingIntroPixelReporting & OnboardingAddToDockReporting & OnboardingSetAsDefaultBrowserExperimentReporting
+typealias OnboardingPixelReporting = LinearOnboardingPixelReporting & OnboardingSearchSuggestionsPixelReporting & OnboardingSiteSuggestionsPixelReporting & OnboardingCustomInteractionPixelReporting & OnboardingDaxDialogsReporting
 
 // MARK: - Implementation
 
@@ -82,6 +89,7 @@ final class OnboardingPixelReporter {
     private let pixel: OnboardingPixelFiring.Type
     private let uniquePixel: OnboardingPixelFiring.Type
     private let statisticsStore: StatisticsStore
+    private let experimentPixel: ExperimentPixelFiring.Type
     private let calendar: Calendar
     private let dateProvider: () -> Date
     private let userDefaults: UserDefaults
@@ -92,6 +100,7 @@ final class OnboardingPixelReporter {
     init(
         pixel: OnboardingPixelFiring.Type = Pixel.self,
         uniquePixel: OnboardingPixelFiring.Type = UniquePixel.self,
+        experimentPixel: ExperimentPixelFiring.Type = PixelKit.self,
         statisticsStore: StatisticsStore = StatisticsUserDefaults(),
         calendar: Calendar = .current,
         dateProvider: @escaping () -> Date = Date.init,
@@ -99,6 +108,7 @@ final class OnboardingPixelReporter {
     ) {
         self.pixel = pixel
         self.uniquePixel = uniquePixel
+        self.experimentPixel = experimentPixel
         self.statisticsStore = statisticsStore
         self.calendar = calendar
         self.dateProvider = dateProvider
@@ -259,6 +269,42 @@ extension OnboardingPixelReporter: OnboardingAddToDockReporting {
         fire(event: .onboardingAddToDockTutorialDismissCTATapped, unique: false)
     }
 
+}
+
+// MARK: - OnboardingPixelReporter + Set As Default Experiment
+
+extension OnboardingPixelReporter: OnboardingSetAsDefaultBrowserExperimentReporting {
+
+    enum SetAsDefaultExperimentMetrics {
+        /// Unique identifier for the subfeature being tested.
+        static let subfeatureIdentifier = FeatureFlag.onboardingSetAsDefaultBrowser.rawValue
+
+        /// Metric identifiers for various user actions during the experiment.
+        static let metricDefaultBrowserSet = "setAsDefaultBrowser"
+        static let metricDefaultBrowserNotSet = "rejectSetAsDefaultBrowser"
+
+        /// Conversion window in days for tracking user actions.
+        static let conversionWindowDays = 0...0
+    }
+
+    func measureDidSetDDGAsDefaultBrowser() {
+        experimentPixel.fireExperimentPixel(
+            for: SetAsDefaultExperimentMetrics.subfeatureIdentifier,
+            metric: SetAsDefaultExperimentMetrics.metricDefaultBrowserSet,
+            conversionWindowDays: SetAsDefaultExperimentMetrics.conversionWindowDays,
+            value: ""
+        )
+    }
+
+    func measureDidNotSetDDGAsDefaultBrowser() {
+        experimentPixel.fireExperimentPixel(
+            for: SetAsDefaultExperimentMetrics.subfeatureIdentifier,
+            metric: SetAsDefaultExperimentMetrics.metricDefaultBrowserNotSet,
+            conversionWindowDays: SetAsDefaultExperimentMetrics.conversionWindowDays,
+            value: ""
+        )
+    }
+    
 }
 
 struct EnqueuedPixel {

--- a/iOS/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
@@ -277,7 +277,7 @@ extension OnboardingPixelReporter: OnboardingSetAsDefaultBrowserExperimentReport
 
     enum SetAsDefaultExperimentMetrics {
         /// Unique identifier for the subfeature being tested.
-        static let subfeatureIdentifier = FeatureFlag.onboardingSetAsDefaultBrowser.rawValue
+        static let subfeatureIdentifier = OnboardingSubfeature.setAsDefaultBrowserExperiment.rawValue
 
         /// Metric identifiers for various user actions during the experiment.
         static let metricDefaultBrowserSet = "setAsDefaultBrowser"
@@ -292,7 +292,7 @@ extension OnboardingPixelReporter: OnboardingSetAsDefaultBrowserExperimentReport
             for: SetAsDefaultExperimentMetrics.subfeatureIdentifier,
             metric: SetAsDefaultExperimentMetrics.metricDefaultBrowserSet,
             conversionWindowDays: SetAsDefaultExperimentMetrics.conversionWindowDays,
-            value: "true"
+            value: "1"
         )
     }
 
@@ -301,7 +301,7 @@ extension OnboardingPixelReporter: OnboardingSetAsDefaultBrowserExperimentReport
             for: SetAsDefaultExperimentMetrics.subfeatureIdentifier,
             metric: SetAsDefaultExperimentMetrics.metricDefaultBrowserNotSet,
             conversionWindowDays: SetAsDefaultExperimentMetrics.conversionWindowDays,
-            value: "true"
+            value: "1"
         )
     }
     

--- a/iOS/DuckDuckGoTests/DefaultBrowserManagerMock.swift
+++ b/iOS/DuckDuckGoTests/DefaultBrowserManagerMock.swift
@@ -23,7 +23,7 @@ import Foundation
 final class DefaultBrowserManagerMock: DefaultBrowserManaging {
     private(set) var didCallDefaultBrowserInfo: Bool = false
 
-    var resultToReturn: DefaultBrowserInfoResult = .success(newInfo: .stub)
+    var resultToReturn: DefaultBrowserInfoResult = .successful(isDefaultBrowser: true)
 
     func defaultBrowserInfo() -> DefaultBrowserInfoResult {
         didCallDefaultBrowserInfo = true
@@ -31,12 +31,22 @@ final class DefaultBrowserManagerMock: DefaultBrowserManaging {
     }
 }
 
-extension DefaultBrowserInfo {
-    static let stub = DefaultBrowserInfo(
-        isDefaultBrowser: true,
-        lastSuccessfulCheckDate: 1741586108000,
-        lastAttemptedCheckDate: 1741586108000,
-        numberOfTimesChecked: 1,
-        nextRetryAvailableDate: nil
-    )
+extension DefaultBrowserInfoResult {
+
+    static func successful(isDefaultBrowser: Bool) -> DefaultBrowserInfoResult {
+        .success(
+            newInfo:
+                DefaultBrowserInfo(
+                    isDefaultBrowser: isDefaultBrowser,
+                    lastSuccessfulCheckDate: 1741586108000,
+                    lastAttemptedCheckDate: 1741586108000,
+                    numberOfTimesChecked: 1,
+                    nextRetryAvailableDate: nil
+                )
+        )
+    }
+
+    static func failed(reason: Failure) -> DefaultBrowserInfoResult {
+        .failure(reason)
+    }
 }

--- a/iOS/DuckDuckGoTests/OnboardingFirePixelMock.swift
+++ b/iOS/DuckDuckGoTests/OnboardingFirePixelMock.swift
@@ -19,6 +19,8 @@
 
 import Foundation
 import Core
+import BrowserServicesKit
+import PixelExperimentKit
 @testable import DuckDuckGo
 
 final class OnboardingPixelFireMock: OnboardingPixelFiring {
@@ -64,5 +66,31 @@ final class OnboardingUniquePixelFireMock: OnboardingPixelFiring {
         capturedParams = [:]
         capturedIncludeParameters = []
         capturedPixelEventHistory = []
+    }
+}
+
+final class OnboardingExperimentPixelFireMock: ExperimentPixelFiring {
+    struct FiredPixel {
+        let subfeatureID: SubfeatureID
+        let metric: String
+        let conversionWindow: ConversionWindow
+        let value: String
+    }
+
+    static private(set) var firedMetrics: [FiredPixel] = []
+
+    static func fireExperimentPixel(for subfeatureID: SubfeatureID, metric: String, conversionWindowDays: ConversionWindow, value: String) {
+
+        let firedPixel = FiredPixel(
+            subfeatureID: subfeatureID,
+            metric: metric,
+            conversionWindow: conversionWindowDays,
+            value: value
+        )
+        firedMetrics.append(firedPixel)
+    }
+
+    static func tearDown() {
+        firedMetrics.removeAll()
     }
 }

--- a/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -512,6 +512,86 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         XCTAssertFalse(defaultBrowserManagerMock.didCallDefaultBrowserInfo)
     }
 
+    func testWhenDefaultBrowserInfoIsSuccessfulResult_AndIsDefaultBrowserIsTrue_ThenFireDidSetDefaultBrowserPixel() {
+        // GIVEN
+        onboardingManagerMock.isEnrolledInSetAsDefaultBrowserExperiment = true
+        defaultBrowserManagerMock.resultToReturn = .successful(isDefaultBrowser: true)
+        let sut = makeSUT()
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDidSetDDGAsDefaultBrowser)
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDidNotSetDDGAsDefaultBrowser)
+
+        // WHEN
+        sut.appIconPickerContinueAction()
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallMeasureDidSetDDGAsDefaultBrowser)
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDidNotSetDDGAsDefaultBrowser)
+    }
+
+    func testWhenDefaultBrowserInfoIsSuccessfulResult_AndIsDefaultBrowserIsFalse_ThenFireDidNotSetDefaultBrowserPixel() {
+        // GIVEN
+        onboardingManagerMock.isEnrolledInSetAsDefaultBrowserExperiment = true
+        defaultBrowserManagerMock.resultToReturn = .successful(isDefaultBrowser: false)
+        let sut = makeSUT()
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDidSetDDGAsDefaultBrowser)
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDidNotSetDDGAsDefaultBrowser)
+
+        // WHEN
+        sut.appIconPickerContinueAction()
+
+        // THEN
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDidSetDDGAsDefaultBrowser)
+        XCTAssertTrue(pixelReporterMock.didCallMeasureDidNotSetDDGAsDefaultBrowser)
+    }
+
+    func testWhenDefaultBrowserInfoIsFailureResult_AndFailureIsRateLimited_ThenDoNotFireSetDefaultBrowserPixels() {
+        // GIVEN
+        onboardingManagerMock.isEnrolledInSetAsDefaultBrowserExperiment = true
+        defaultBrowserManagerMock.resultToReturn = .failed(reason: .rateLimitReached(updatedStoredInfo: nil))
+        let sut = makeSUT()
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDidSetDDGAsDefaultBrowser)
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDidNotSetDDGAsDefaultBrowser)
+
+        // WHEN
+        sut.appIconPickerContinueAction()
+
+        // THEN
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDidSetDDGAsDefaultBrowser)
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDidNotSetDDGAsDefaultBrowser)
+    }
+
+    func testWhenDefaultBrowserInfoIsFailureResult_AndFailureIsUnkownError_ThenDoNotFireSetDefaultBrowserPixels() {
+        // GIVEN
+        onboardingManagerMock.isEnrolledInSetAsDefaultBrowserExperiment = true
+        defaultBrowserManagerMock.resultToReturn = .failed(reason: .unknownError(NSError(domain: #function, code: 0)))
+        let sut = makeSUT()
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDidSetDDGAsDefaultBrowser)
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDidNotSetDDGAsDefaultBrowser)
+
+        // WHEN
+        sut.appIconPickerContinueAction()
+
+        // THEN
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDidSetDDGAsDefaultBrowser)
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDidNotSetDDGAsDefaultBrowser)
+    }
+
+    func testWhenDefaultBrowserInfoIsFailureResult_AndFailureIsNotSupportedOnCurrentOSVersion_ThenDoNotFireSetDefaultBrowserPixels() {
+        // GIVEN
+        onboardingManagerMock.isEnrolledInSetAsDefaultBrowserExperiment = true
+        defaultBrowserManagerMock.resultToReturn = .failed(reason: .notSupportedOnCurrentOSVersion)
+        let sut = makeSUT()
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDidSetDDGAsDefaultBrowser)
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDidNotSetDDGAsDefaultBrowser)
+
+        // WHEN
+        sut.appIconPickerContinueAction()
+
+        // THEN
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDidSetDDGAsDefaultBrowser)
+        XCTAssertFalse(pixelReporterMock.didCallMeasureDidNotSetDDGAsDefaultBrowser)
+    }
+
 }
 
 extension OnboardingIntroViewModelTests {

--- a/iOS/DuckDuckGoTests/OnboardingPixelReporterMock.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPixelReporterMock.swift
@@ -22,7 +22,7 @@ import Core
 import Onboarding
 @testable import DuckDuckGo
 
-final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, OnboardingSiteSuggestionsPixelReporting, OnboardingSearchSuggestionsPixelReporting, OnboardingCustomInteractionPixelReporting, OnboardingDaxDialogsReporting, OnboardingAddToDockReporting {
+final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, OnboardingSiteSuggestionsPixelReporting, OnboardingSearchSuggestionsPixelReporting, OnboardingCustomInteractionPixelReporting, OnboardingDaxDialogsReporting, OnboardingAddToDockReporting, OnboardingSetAsDefaultBrowserExperimentReporting {
     private(set) var didCallMeasureOnboardingIntroImpression = false
     private(set) var didCallMeasureBrowserComparisonImpression = false
     private(set) var didCallMeasureChooseBrowserCTAAction = false
@@ -49,6 +49,9 @@ final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, Onboardi
     private(set) var didCallMeasureAddToDockPromoShowTutorialCTAAction = false
     private(set) var didCallMeasureAddToDockPromoDismissCTAAction = false
     private(set) var didCallMeasureAddToDockTutorialDismissCTAAction = false
+
+    private(set) var didCallMeasureDidSetDDGAsDefaultBrowser = false
+    private(set) var didCallMeasureDidNotSetDDGAsDefaultBrowser = false
 
     func measureOnboardingIntroImpression() {
         didCallMeasureOnboardingIntroImpression = true
@@ -125,5 +128,13 @@ final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, Onboardi
 
     func measureAddToDockTutorialDismissCTAAction() {
         didCallMeasureAddToDockTutorialDismissCTAAction = true
+    }
+
+    func measureDidSetDDGAsDefaultBrowser() {
+        didCallMeasureDidSetDDGAsDefaultBrowser = true
+    }
+
+    func measureDidNotSetDDGAsDefaultBrowser() {
+        didCallMeasureDidNotSetDDGAsDefaultBrowser = true
     }
 }

--- a/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
@@ -487,7 +487,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(firedPixel.subfeatureID, OnboardingPixelReporter.SetAsDefaultExperimentMetrics.subfeatureIdentifier)
         XCTAssertEqual(firedPixel.metric, "setAsDefaultBrowser")
         XCTAssertEqual(firedPixel.conversionWindow, 0...0)
-        XCTAssertEqual(firedPixel.value, "")
+        XCTAssertEqual(firedPixel.value, "1")
     }
 
     func testWhenMeasureDidNotSetDDGAsDefaultBrowserThenOnboardingDidNotSetDDGAsDefaultBrowserPixelFires() throws {
@@ -503,7 +503,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(firedPixel.subfeatureID, OnboardingPixelReporter.SetAsDefaultExperimentMetrics.subfeatureIdentifier)
         XCTAssertEqual(firedPixel.metric, "rejectSetAsDefaultBrowser")
         XCTAssertEqual(firedPixel.conversionWindow, 0...0)
-        XCTAssertEqual(firedPixel.value, "")
+        XCTAssertEqual(firedPixel.value, "1")
     }
 
 }

--- a/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
@@ -35,13 +35,14 @@ final class OnboardingPixelReporterTests: XCTestCase {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = try XCTUnwrap(TimeZone(secondsFromGMT: 0))
         userDefaultsMock = UserDefaults(suiteName: Self.suiteName)
-        sut = OnboardingPixelReporter(pixel: OnboardingPixelFireMock.self, uniquePixel: OnboardingUniquePixelFireMock.self, statisticsStore: statisticsStoreMock, calendar: calendar, dateProvider: { self.now }, userDefaults: userDefaultsMock)
+        sut = OnboardingPixelReporter(pixel: OnboardingPixelFireMock.self, uniquePixel: OnboardingUniquePixelFireMock.self, experimentPixel: OnboardingExperimentPixelFireMock.self, statisticsStore: statisticsStoreMock, calendar: calendar, dateProvider: { self.now }, userDefaults: userDefaultsMock)
         try super.setUpWithError()
     }
 
     override func tearDownWithError() throws {
         OnboardingPixelFireMock.tearDown()
         OnboardingUniquePixelFireMock.tearDown()
+        OnboardingExperimentPixelFireMock.tearDown()
         statisticsStoreMock = nil
         now = nil
         userDefaultsMock.removePersistentDomain(forName: Self.suiteName)
@@ -469,6 +470,40 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(OnboardingPixelFireMock.capturedPixelEvent, expectedPixel)
         XCTAssertEqual(expectedPixel.name, expectedPixel.name)
         XCTAssertEqual(OnboardingPixelFireMock.capturedIncludeParameters, [.appVersion, .atb])
+    }
+
+    // MARK: - Set as Default Experiment
+
+    func testWhenMeasureDidSetDDGAsDefaultBrowserThenOnboardingDidSetDDGAsDefaultBrowserPixelFires() throws {
+        // GIVEN
+        XCTAssertTrue(OnboardingExperimentPixelFireMock.firedMetrics.isEmpty)
+
+        // WHEN
+        sut.measureDidSetDDGAsDefaultBrowser()
+
+        // THEN
+        XCTAssertEqual(OnboardingExperimentPixelFireMock.firedMetrics.count, 1)
+        let firedPixel = try XCTUnwrap(OnboardingExperimentPixelFireMock.firedMetrics.first)
+        XCTAssertEqual(firedPixel.subfeatureID, OnboardingPixelReporter.SetAsDefaultExperimentMetrics.subfeatureIdentifier)
+        XCTAssertEqual(firedPixel.metric, "setAsDefaultBrowser")
+        XCTAssertEqual(firedPixel.conversionWindow, 0...0)
+        XCTAssertEqual(firedPixel.value, "")
+    }
+
+    func testWhenMeasureDidNotSetDDGAsDefaultBrowserThenOnboardingDidNotSetDDGAsDefaultBrowserPixelFires() throws {
+        // GIVEN
+        XCTAssertTrue(OnboardingExperimentPixelFireMock.firedMetrics.isEmpty)
+
+        // WHEN
+        sut.measureDidNotSetDDGAsDefaultBrowser()
+
+        // THEN
+        XCTAssertEqual(OnboardingExperimentPixelFireMock.firedMetrics.count, 1)
+        let firedPixel = try XCTUnwrap(OnboardingExperimentPixelFireMock.firedMetrics.first)
+        XCTAssertEqual(firedPixel.subfeatureID, OnboardingPixelReporter.SetAsDefaultExperimentMetrics.subfeatureIdentifier)
+        XCTAssertEqual(firedPixel.metric, "rejectSetAsDefaultBrowser")
+        XCTAssertEqual(firedPixel.conversionWindow, 0...0)
+        XCTAssertEqual(firedPixel.value, "")
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1209505775591510

### Description

This PR add experiment pixels for Set as Default Browser experiment. 

### Testing Steps
Prerequisites: Run the build on a device with iOS 13.3 installed.
Override Privacy Config URL with: https://www.jsonblob.com/api/1344905087407022080

Scenario 1: Control Group

1. Open the Debug menu.
2. Ensure the Internal User State toggle is on.
3. Tap the Feature Flags item.
4. Tap “onboardingSetAsDefaultBrowser”.
5. Choose the control cohort.
6. Go back to the main debug menu.
7. Tap Onboarding.
8. Tap “Preview Onboarding Intro”.
9. Wait for the onboarding to appear and tap the Let’s do it! button.
10. Wait for the Protections activated! screen to appear.
11. Tap the 'Choose Your Browser' button.
12. Ensure pixel experiment enrollment is fired.
13. Ensure that the DuckDuckGo settings in the System settings open.
14. Select DDG as default browser
15. Go back to the App.
16. Tap Chose App Icon color Continue CTA.
17. Ensure that Experiment pixel  `experiment_metrics_setAsDefaultBrowserExperiment_control_ios_phone ["conversionWindowDays": "0", "metric": “setAsDefaultBrowser", "enrollmentDate": "2025-03-13", "value": “1", "pixelSource": "phone”]` is fired

Repeat experiment without setting DDG as default browser and ensure “metric” value in `experiment_metrics_setAsDefaultBrowserExperiment_control_ios_phone ` is `rejectedsetAsDefaultBrowser`.

Scenario 2 Treatment Group

1. Open the Debug menu.
2. Ensure the Internal User State toggle is on.
3. Tap the Feature Flags item.
4. Tap “onboardingSetAsDefaultBrowser”.
5. Choose the treatment cohort.
6. Go back to the main debug menu.
7. Tap Onboarding.
8. Tap “Preview Onboarding Intro”.
9. Wait for the onboarding to appear and tap the Let’s do it! button.
10. Wait for the Protections activated! screen to appear.
11. Tap the 'Choose Your Browser' button.
12. Ensure pixel experiment enrollment is fired.
13. Ensure that the DuckDuckGo settings in the System settings open.
14. Select DDG as default browser
15. Go back to the App.
16. Tap Chose App Icon color Continue CTA.
17. Ensure that Experiment pixel  `experiment_metrics_setAsDefaultBrowserExperiment_treatment_ios_phone ["conversionWindowDays": "0", "metric": “setAsDefaultBrowser", "enrollmentDate": "2025-03-13", "value": “1", "pixelSource": "phone”]` is fired

Repeat experiment without setting DDG as default browser and ensure “metric” value in `experiment_metrics_setAsDefaultBrowserExperiment_treatment_ios_phone ` is `rejectedsetAsDefaultBrowser`.

### Impact and Risks
<!— 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
—>

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)