### PR TITLE
macOS: Freemium PIR - Add Follow-up Pixel Measurement of Cohort Subscriptions

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -581,9 +581,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         DataBrokerProtectionAppEvents(featureGatekeeper: pirGatekeeper).applicationDidBecomeActive()
 
-        subscriptionManagerV1?.refreshCachedSubscriptionAndEntitlements { isSubscriptionActive in
+        subscriptionManagerV1?.refreshCachedSubscriptionAndEntitlements { [weak self] isSubscriptionActive in
             if isSubscriptionActive {
                 PixelKit.fire(PrivacyProPixel.privacyProSubscriptionActive, frequency: .daily)
+
+                // Temporary experiment pixel - https://app.asana.com/0/1206488453854252/1209643339074944
+                guard let self else { return }
+                let experimentManager = FreemiumDBPPixelExperimentManager(subscriptionManager: self.subscriptionAuthV1toV2Bridge)
+                experimentManager.sendOneTimeCohortSubscriptionStatusPixel()
+                // ----
             }
         }
 

--- a/macOS/DuckDuckGo/Freemium/DBP/Experiment/FreemiumDBPPixelExperimentManaging.swift
+++ b/macOS/DuckDuckGo/Freemium/DBP/Experiment/FreemiumDBPPixelExperimentManaging.swift
@@ -20,6 +20,8 @@ import Foundation
 import Subscription
 import OSLog
 import PixelKit
+import Common
+import DataBrokerProtection
 
 /// Protocol defining the interface for managing Freemium DBP pixel experiments.
 protocol FreemiumDBPPixelExperimentManaging {
@@ -32,6 +34,8 @@ protocol FreemiumDBPPixelExperimentManaging {
 
     /// Assigns the user to an experimental cohort if eligible.
     func assignUserToCohort()
+
+    func sendOneTimeCohortSubscriptionStatusPixel()
 }
 
 /// Manager responsible for handling user assignments to experimental cohorts and providing pixel parameters for analytics.
@@ -45,6 +49,7 @@ final class FreemiumDBPPixelExperimentManager: FreemiumDBPPixelExperimentManagin
 
     private enum PixelKeys {
         static let daysEnrolled = "daysEnrolled"
+        static let experimentCohort = "experimentCohort"
     }
 
     // MARK: - Dependencies
@@ -52,6 +57,9 @@ final class FreemiumDBPPixelExperimentManager: FreemiumDBPPixelExperimentManagin
     private let subscriptionManager: any SubscriptionAuthV1toV2Bridge
     private let userDefaults: UserDefaults
     private let locale: Locale
+
+    /// The `FreemiumDBPExperimentPixelHandler` instance used to fire pixels
+    private let freemiumDBPExperimentPixelHandler: EventMapping<FreemiumDBPExperimentPixel>
 
     // MARK: - Initialization
 
@@ -63,10 +71,12 @@ final class FreemiumDBPPixelExperimentManager: FreemiumDBPPixelExperimentManagin
     ///   - locale: Determines user eligibility based on region. Defaults to `Locale.current`.
     init(subscriptionManager: any SubscriptionAuthV1toV2Bridge,
          userDefaults: UserDefaults = .dbp,
-         locale: Locale = Locale.current) {
+         locale: Locale = Locale.current,
+         freemiumDBPExperimentPixelHandler: EventMapping<FreemiumDBPExperimentPixel> = FreemiumDBPExperimentPixelHandler()) {
         self.subscriptionManager = subscriptionManager
         self.userDefaults = userDefaults
         self.locale = locale
+        self.freemiumDBPExperimentPixelHandler = freemiumDBPExperimentPixelHandler
     }
 
     // MARK: - FreemiumDBPPixelExperimentManaging
@@ -99,6 +109,22 @@ final class FreemiumDBPPixelExperimentManager: FreemiumDBPPixelExperimentManagin
         userDefaults.enrollmentDate = Date()
 
         Logger.freemiumDBP.debug("[Freemium DBP] User enrolled to cohort: \(cohort.rawValue)")
+    }
+
+    func sendOneTimeCohortSubscriptionStatusPixel() {
+        if userIsNotEnrolled { return }
+
+        var parameters: [String: String] = [:]
+
+        if let daysEnrolled = daysEnrolled {
+            parameters[PixelKeys.daysEnrolled] = daysEnrolled
+        }
+
+        if let experimentCohort = experimentCohort?.rawValue {
+            parameters[PixelKeys.experimentCohort] = experimentCohort
+        }
+
+        freemiumDBPExperimentPixelHandler.fire(.oneTimeCohortSubscriptionStatusPixel, parameters: parameters)
     }
 }
 

--- a/macOS/DuckDuckGo/Freemium/DBP/Experiment/FreemiumDBPPixelExperimentManaging.swift
+++ b/macOS/DuckDuckGo/Freemium/DBP/Experiment/FreemiumDBPPixelExperimentManaging.swift
@@ -112,7 +112,7 @@ final class FreemiumDBPPixelExperimentManager: FreemiumDBPPixelExperimentManagin
     }
 
     func sendOneTimeCohortSubscriptionStatusPixel() {
-        if userIsNotEnrolled { return }
+        if userIsNotEnrolled || !subscriptionManager.isUserAuthenticated { return }
 
         var parameters: [String: String] = [:]
 

--- a/macOS/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Pixels/FreemiumDBPExperimentPixel.swift
+++ b/macOS/LocalPackages/DataBrokerProtection/Sources/DataBrokerProtection/Pixels/FreemiumDBPExperimentPixel.swift
@@ -24,7 +24,7 @@ public class FreemiumDBPExperimentPixelHandler: EventMapping<FreemiumDBPExperime
     public init() {
         super.init { event, _, params, _ in
             switch event {
-            case .subscription:
+            case .subscription, .oneTimeCohortSubscriptionStatusPixel:
                 PixelKit.fire(event, frequency: .uniqueByName, withAdditionalParameters: params)
             default:
                 PixelKit.fire(event, frequency: .uniqueByName)
@@ -60,6 +60,8 @@ public enum FreemiumDBPExperimentPixel: PixelKitEventV2 {
     case firstScanCompleteNotificationClicked
     // Subscription
     case subscription
+    // Follow-up Analysis
+    case oneTimeCohortSubscriptionStatusPixel
 
     public var name: String {
         switch self {
@@ -91,6 +93,8 @@ public enum FreemiumDBPExperimentPixel: PixelKitEventV2 {
             return "dbp-free_notification_opened_first_scan_complete_u"
         case .subscription:
             return "dbp-free_subscription_u"
+        case .oneTimeCohortSubscriptionStatusPixel:
+            return "dbp-free_subscription_status_u"
         }
     }
 

--- a/macOS/UnitTests/Freemium/DBP/Experiment/FreemiumDBPPixelExperimentManagingTests.swift
+++ b/macOS/UnitTests/Freemium/DBP/Experiment/FreemiumDBPPixelExperimentManagingTests.swift
@@ -27,6 +27,7 @@ final class FreemiumDBPPixelExperimentManagingTests: XCTestCase {
     private var mockAccountManager: MockAccountManager!
     private var mockSubscriptionManager: SubscriptionManagerMock!
     private var mockUserDefaults: MockUserDefaults!
+    private var mockPixelHandler: MockFreemiumDBPExperimentPixelHandler!
 
     override func setUp() {
        super.setUp()
@@ -47,8 +48,9 @@ final class FreemiumDBPPixelExperimentManagingTests: XCTestCase {
                                                           canPurchase: false,
                                                           subscriptionFeatureMappingCache: mockSubscriptionFeatureMappingCache)
         mockUserDefaults = MockUserDefaults()
+        mockPixelHandler = MockFreemiumDBPExperimentPixelHandler()
         let testLocale = Locale(identifier: "en_US")
-        sut = FreemiumDBPPixelExperimentManager(subscriptionManager: mockSubscriptionManager, userDefaults: mockUserDefaults, locale: testLocale)
+        sut = FreemiumDBPPixelExperimentManager(subscriptionManager: mockSubscriptionManager, userDefaults: mockUserDefaults, locale: testLocale, freemiumDBPExperimentPixelHandler: mockPixelHandler)
    }
 
    override func tearDown() {
@@ -187,6 +189,52 @@ final class FreemiumDBPPixelExperimentManagingTests: XCTestCase {
 
         // Then
         XCTAssertEqual("2", parameters?["daysEnrolled"])
+    }
+
+    // MARK: - Send One-time Subscription status pixel tests
+
+    func testSendOneTimeCohortSubscriptionStatusPixel_whenUserNotEnrolled_doesNotFirePixel() {
+        // Given
+        mockUserDefaults.removeObject(forKey: MockUserDefaults.Keys.enrollmentDate)
+        mockUserDefaults.removeObject(forKey: MockUserDefaults.Keys.experimentCohort)
+        mockAccountManager.accessToken = "some_token"
+
+        // When
+        sut.sendOneTimeCohortSubscriptionStatusPixel()
+
+        // Then
+        XCTAssertNil(mockPixelHandler.lastFiredEvent)
+    }
+
+    func testSendOneTimeCohortSubscriptionStatusPixel_whenUserNotAuthenticated_doesNotFirePixel() {
+        // Given
+        let enrollmentDate = Date()
+        mockUserDefaults.set(enrollmentDate, forKey: MockUserDefaults.Keys.enrollmentDate)
+        mockUserDefaults.set("treatment", forKey: MockUserDefaults.Keys.experimentCohort)
+        mockAccountManager.accessToken = nil
+
+        // When
+        sut.sendOneTimeCohortSubscriptionStatusPixel()
+
+        // Then
+        XCTAssertNil(mockPixelHandler.lastFiredEvent)
+    }
+
+    func testSendOneTimeCohortSubscriptionStatusPixel_whenUserEnrolledAndAuthenticated_firesPixelWithCorrectParameters() {
+        // Given
+        let calendar = Calendar.current
+        let twoDaysAgo = calendar.date(byAdding: .day, value: -2, to: Date())!
+        mockUserDefaults.set(twoDaysAgo, forKey: MockUserDefaults.Keys.enrollmentDate)
+        mockUserDefaults.set("treatment", forKey: MockUserDefaults.Keys.experimentCohort)
+        mockAccountManager.accessToken = "some_token"
+
+        // When
+        sut.sendOneTimeCohortSubscriptionStatusPixel()
+
+        // Then
+        XCTAssertEqual(mockPixelHandler.lastFiredEvent, .oneTimeCohortSubscriptionStatusPixel)
+        XCTAssertEqual(mockPixelHandler.lastPassedParameters?["daysEnrolled"], "2")
+        XCTAssertEqual(mockPixelHandler.lastPassedParameters?["experimentCohort"], "treatment")
     }
 }
 

--- a/macOS/UnitTests/Freemium/DBP/FreemiumDBPFeatureTests.swift
+++ b/macOS/UnitTests/Freemium/DBP/FreemiumDBPFeatureTests.swift
@@ -443,4 +443,6 @@ final class MockFreemiumDBPExperimentManager: FreemiumDBPPixelExperimentManaging
     var pixelParameters: [String: String]?
 
     func assignUserToCohort() {}
+
+    func sendOneTimeCohortSubscriptionStatusPixel() {}
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206488453854252/1209643339074944

### Description
This PR implements a follow-up retroactive measurement to enable us to compare subscriptions between the control and treatment cohorts. Our metric works as follows:
* Adds a new pixel which is fired under the following conditions:
** User is in the control or treatment cohort
** User has an active PP subscription (wouldn't include users who have since cancelled)
* The pixel includes the following parameters:
** Cohort
** Days enrolled (the number of days the user has been enrolled in the experiment)
* The pixel is unique (fired once per user)

### Testing Steps
1. Launch the browser. 
2. Via the debug `Freemium` menu, select `Enroll into Experiment`
3. Filter the Xcode console by “pixel"
4. Re-launch the browser
5. Ensure the `m_mac_dbp-free_subscription_status_u` pixel **is not fired** (check the console)
6. Sign into your Privacy Pro subscription
7. Re-launch the browser
8. Ensure the `m_mac_dbp-free_subscription_status_u` pixel **is fired** (check the console), and looks like:

```
👾[Unique-Skipped] m_mac_dbp-free_subscription_status_u ["appVersion": "1.130.0", "daysEnrolled": "0", "pixelSource": "browser-dmg", "experimentCohort": "treatment”]
```

#### What could go wrong?
Incorrect data if pixel is fired incorrectly.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)