### PR TITLE
Add single/multiple parameter to history item opened pixel

### DIFF
--- a/.github/workflows/create_asana_pr_subtask.yml
+++ b/.github/workflows/create_asana_pr_subtask.yml
@@ -19,8 +19,10 @@ jobs:
             BODY: ${{ github.event.pull_request.body }}
           run: |
             task_id=$(grep -i "task/issue url.*https://app.asana.com/" <<< "$BODY" \
-            | sed -E 's|.*https://(.*)|\1|' \
-            | cut -d '/' -f 4)
+              | perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?|\1|; \
+                s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?|\1|; \
+                s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)|\1|'
+            )
             echo "task_id=${task_id//[^0-9]/}" >> $GITHUB_OUTPUT
 
         - name: Create or Update PR Subtask

--- a/.github/workflows/ios_pr_task_url.yml
+++ b/.github/workflows/ios_pr_task_url.yml
@@ -30,8 +30,10 @@ jobs:
         BODY: ${{ github.event.pull_request.body }}
       run: |
         task_id=$(grep -i "task/issue url.*https://app.asana.com/" <<< "$BODY" \
-          | sed -E 's|.*https://(.*)|\1|' \
-          | cut -d '/' -f 4)
+          | perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?|\1|; \
+            s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?|\1|; \
+            s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)|\1|'
+        )
         echo "task_id=${task_id//[^0-9]/}" >> $GITHUB_OUTPUT
 
     - name: Check App Board Project Membership

--- a/.github/workflows/macos_pr_task_url.yml
+++ b/.github/workflows/macos_pr_task_url.yml
@@ -30,8 +30,10 @@ jobs:
         BODY: ${{ github.event.pull_request.body }}
       run: |
         task_id=$(grep -i "task/issue url.*https://app.asana.com/" <<< "$BODY" \
-          | sed -E 's|.*https://(.*)|\1|' \
-          | cut -d '/' -f 4)
+          | perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?|\1|; \
+            s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?|\1|; \
+            s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)|\1|'
+        )
         echo "task_id=${task_id//[^0-9]/}" >> $GITHUB_OUTPUT
 
     - name: Check App Board Project Membership

--- a/iOS/Gemfile.lock
+++ b/iOS/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: 96984c87bc71f14edb1d3a5ec39681149a2df94a
-  tag: 2.0.2
+  revision: 7e3719ebb7348294febe0b1ce76302f368d495eb
+  tag: 2.1.1
   specs:
-    fastlane-plugin-ddg_apple_automation (2.0.2)
+    fastlane-plugin-ddg_apple_automation (2.1.1)
       asana
       climate_control
       httpparty

--- a/iOS/fastlane/Pluginfile
+++ b/iOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '2.0.2'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '2.1.1'

--- a/macOS/DuckDuckGo/History/View/HistoryViewActionsHandler.swift
+++ b/macOS/DuckDuckGo/History/View/HistoryViewActionsHandler.swift
@@ -207,7 +207,7 @@ final class HistoryViewActionsHandler: HistoryView.ActionsHandling {
     }
 
     func open(_ url: URL) async {
-        firePixel(.itemOpened, .dailyAndStandard)
+        firePixel(.itemOpened(.single), .dailyAndStandard)
         await tabOpener.open(url)
     }
 
@@ -242,9 +242,10 @@ final class HistoryViewActionsHandler: HistoryView.ActionsHandling {
     }
 
     private func fireItemOpenedPixel(_ urls: [URL]) {
-        if urls.count == 1 {
-            firePixel(.itemOpened, .dailyAndStandard)
+        guard !urls.isEmpty else {
+            return
         }
+        firePixel(.itemOpened(urls.count == 1 ? .single : .multiple), .dailyAndStandard)
     }
 
     @MainActor

--- a/macOS/DuckDuckGo/Statistics/HistoryViewPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/HistoryViewPixel.swift
@@ -55,7 +55,7 @@ enum HistoryViewPixel: PixelKitEventV2 {
     /**
      * Event Trigger: History item is opened.
      */
-    case itemOpened
+    case itemOpened(OpenItemType)
 
     /**
      * Event Trigger: History item was deleted. This pixel indicates any type of deletion.
@@ -128,6 +128,10 @@ enum HistoryViewPixel: PixelKitEventV2 {
         }
     }
 
+    enum OpenItemType: String {
+        case single, multiple
+    }
+
     // MARK: - Debug
 
     /**
@@ -164,14 +168,14 @@ enum HistoryViewPixel: PixelKitEventV2 {
             return [Parameters.filter: filter.rawValue]
         case .filterCleared:
             return nil
-        case .itemOpened:
-            return nil
+        case .itemOpened(let type):
+            return [Parameters.type: type.rawValue]
         case .delete:
             return nil
         case .singleItemDeleted:
             return nil
         case .multipleItemsDeleted(let batchKind, let burn):
-            return [Parameters.filter: batchKind.rawValue, Parameters.deleteType: burn ? "burn" : "delete"]
+            return [Parameters.filter: batchKind.rawValue, Parameters.type: burn ? "burn" : "delete"]
         case .onboardingDialogShown:
             return nil
         case .onboardingDialogDismissed:
@@ -187,7 +191,7 @@ enum HistoryViewPixel: PixelKitEventV2 {
 
     enum Parameters {
         static let filter = "filter"
-        static let deleteType = "type"
+        static let type = "type"
         static let message = "message"
         static let source = "source"
     }

--- a/macOS/Gemfile.lock
+++ b/macOS/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: 5f4f38ab2c9b8b043d4d542cd23bbd7fb3cced1e
-  tag: 2.1.0
+  revision: 7e3719ebb7348294febe0b1ce76302f368d495eb
+  tag: 2.1.1
   specs:
-    fastlane-plugin-ddg_apple_automation (2.1.0)
+    fastlane-plugin-ddg_apple_automation (2.1.1)
       asana
       climate_control
       httpparty

--- a/macOS/UnitTests/History/View/HistoryViewActionsHandlerTests.swift
+++ b/macOS/UnitTests/History/View/HistoryViewActionsHandlerTests.swift
@@ -401,7 +401,7 @@ final class HistoryViewActionsHandlerTests: XCTestCase {
         let url = try XCTUnwrap("https://example.com".url)
         await actionsHandler.open(url)
         XCTAssertEqual(tabOpener.openCalls, [url])
-        XCTAssertEqual(firePixelCalls, [.init(.itemOpened, .dailyAndStandard)])
+        XCTAssertEqual(firePixelCalls, [.init(.itemOpened(.single), .dailyAndStandard)])
     }
 
     @MainActor
@@ -418,7 +418,7 @@ final class HistoryViewActionsHandlerTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 100_000_000)
 
         XCTAssertEqual(tabOpener.openInNewTabCalls, [[url]])
-        XCTAssertEqual(firePixelCalls, [.init(.itemOpened, .dailyAndStandard)])
+        XCTAssertEqual(firePixelCalls, [.init(.itemOpened(.single), .dailyAndStandard)])
     }
 
     @MainActor
@@ -435,7 +435,7 @@ final class HistoryViewActionsHandlerTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 100_000_000)
 
         XCTAssertEqual(tabOpener.openInNewWindowCalls, [[url]])
-        XCTAssertEqual(firePixelCalls, [.init(.itemOpened, .dailyAndStandard)])
+        XCTAssertEqual(firePixelCalls, [.init(.itemOpened(.single), .dailyAndStandard)])
     }
 
     @MainActor
@@ -452,11 +452,11 @@ final class HistoryViewActionsHandlerTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 100_000_000)
 
         XCTAssertEqual(tabOpener.openInNewFireWindowCalls, [[url]])
-        XCTAssertEqual(firePixelCalls, [.init(.itemOpened, .dailyAndStandard)])
+        XCTAssertEqual(firePixelCalls, [.init(.itemOpened(.single), .dailyAndStandard)])
     }
 
     @MainActor
-    func testThatOpenActionsForMultipleItemsDoNotFirePixel() async throws {
+    func testThatOpenActionsForMultipleItemsFirePixelForMultipleItems() async throws {
         let identifiers: [VisitIdentifier] = [
             .init(uuid: "abcd", url: try XCTUnwrap("https://example1.com".url), date: Date()),
             .init(uuid: "efgh", url: try XCTUnwrap("https://example2.com".url), date: Date())
@@ -475,7 +475,11 @@ final class HistoryViewActionsHandlerTests: XCTestCase {
         // Wait for a short time to allow the async task to complete
         try? await Task.sleep(nanoseconds: 100_000_000)
 
-        XCTAssertEqual(firePixelCalls, [])
+        XCTAssertEqual(firePixelCalls, [
+            .init(.itemOpened(.multiple), .dailyAndStandard),
+            .init(.itemOpened(.multiple), .dailyAndStandard),
+            .init(.itemOpened(.multiple), .dailyAndStandard)
+        ])
     }
 
     // MARK: - addBookmarks

--- a/macOS/fastlane/Pluginfile
+++ b/macOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: "2.1.0"
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: "2.1.1"


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1209676887976296?focus=true

### Testing Steps  
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Launch the app and filter logs by PixelKit subsystem
2. Open history view (cmd+y)
3. Double click a single item on the list. Verify that it opens the URL and sends _m_mac_history-page_item-opened_ pixel with _"type": "single”_
4. Select multiple history items, show context menu and trigger any of the open actions. Verify that it opens URLs and sends _m_mac_history-page_item-opened_ pixel with _"type": “multiple”_

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)