### PR TITLE
iOS: DuckPlayer: 44. Disable pill interaction when hidden

### DIFF
--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/DuckPlayerNativeUIPresenter.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/DuckPlayerNativeUIPresenter.swift
@@ -356,12 +356,14 @@ extension DuckPlayerNativeUIPresenter: DuckPlayerNativeUIPresenting {
     func hideBottomSheetForHiddenChrome() {
         containerViewModel?.dismiss()
         resetWebViewConstraint()
+        containerViewController?.view.isUserInteractionEnabled = false
     }
 
     /// Shows the bottom sheet when browser chrome is visible
     @MainActor
     func showBottomSheetForVisibleChrome() {
         containerViewModel?.show()
+        containerViewController?.view.isUserInteractionEnabled = true
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204099484721401/task/1209531197736712
Tech Design URL:
CC:

### Description
Bugfix: Disable interactions when DuckPlayer Pill is hidden

### Testing Steps
1. Make youself internal
2. Go to DuckPlayer > Settings > Enable Native UI
3. Tab Fire button
4. Go to a youtube.com and open a video
5. DuckPlayer Pill should appear at the bottom
6. Scroll the page until pill hides
7. Confirm webview receives touch events where the pill was showing.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)