### PR TITLE
Fixes some VPN issues

### DIFF
--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionNavBarPopoverManager.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionNavBarPopoverManager.swift
@@ -116,22 +116,27 @@ final class NetworkProtectionNavBarPopoverManager: NetPPopoverManager {
                 }))
         }
 
+        if proxySettings.proxyAvailable {
+            menuItems.append(contentsOf: [
+                .textWithDetail(
+                    icon: Image(.window16),
+                    title: UserText.vpnStatusViewExcludedAppsMenuItemTitle,
+                    detail: "(\(proxySettings.excludedAppsMinusDBPAgent.count))",
+                    action: { [weak self] in
+                        self?.manageExcludedApps()
+                    }),
+                .textWithDetail(
+                    icon: Image(.globe16),
+                    title: UserText.vpnStatusViewExcludedDomainsMenuItemTitle,
+                    detail: "(\(proxySettings.excludedDomains.count))",
+                    action: { [weak self] in
+                        self?.manageExcludedSites()
+                    }),
+                .divider()
+            ])
+        }
+
         menuItems.append(contentsOf: [
-            .textWithDetail(
-                icon: Image(.window16),
-                title: UserText.vpnStatusViewExcludedAppsMenuItemTitle,
-                detail: "(\(proxySettings.excludedAppsMinusDBPAgent.count))",
-                action: { [weak self] in
-                    self?.manageExcludedApps()
-            }),
-            .textWithDetail(
-                icon: Image(.globe16),
-                title: UserText.vpnStatusViewExcludedDomainsMenuItemTitle,
-                detail: "(\(proxySettings.excludedDomains.count))",
-                action: { [weak self] in
-                    self?.manageExcludedSites()
-            }),
-            .divider(),
             .text(icon: Image(.help16), title: UserText.vpnStatusViewFAQMenuItemTitle, action: {
                 try? await appLauncher.launchApp(withCommand: VPNAppLaunchCommand.showFAQ)
             }),

--- a/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
+++ b/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
@@ -359,24 +359,29 @@ final class DuckDuckGoVPNAppDelegate: NSObject, NSApplicationDelegate {
                 }))
         }
 
+        if proxySettings.proxyAvailable {
+            menuItems.append(contentsOf: [
+                .textWithDetail(
+                    icon: Image(.window16),
+                    title: UserText.vpnStatusViewExcludedAppsMenuItemTitle,
+                    detail: "(\(excludedAppsMinusDBPAgent.count))",
+                    action: { [weak self] in
+
+                        try? await self?.appLauncher.launchApp(withCommand: VPNAppLaunchCommand.manageExcludedApps)
+                    }),
+                .textWithDetail(
+                    icon: Image(.globe16),
+                    title: UserText.vpnStatusViewExcludedDomainsMenuItemTitle,
+                    detail: "(\(proxySettings.excludedDomains.count))",
+                    action: { [weak self] in
+
+                        try? await self?.appLauncher.launchApp(withCommand: VPNAppLaunchCommand.manageExcludedDomains)
+                    }),
+                .divider()
+            ])
+        }
+
         menuItems.append(contentsOf: [
-            .textWithDetail(
-                icon: Image(.window16),
-                title: UserText.vpnStatusViewExcludedAppsMenuItemTitle,
-                detail: "(\(excludedAppsMinusDBPAgent.count))",
-                action: { [weak self] in
-
-                    try? await self?.appLauncher.launchApp(withCommand: VPNAppLaunchCommand.manageExcludedApps)
-            }),
-            .textWithDetail(
-                icon: Image(.globe16),
-                title: UserText.vpnStatusViewExcludedDomainsMenuItemTitle,
-                detail: "(\(proxySettings.excludedDomains.count))",
-                action: { [weak self] in
-
-                    try? await self?.appLauncher.launchApp(withCommand: VPNAppLaunchCommand.manageExcludedDomains)
-            }),
-            .divider(),
             .text(icon: Image(.help16), title: UserText.vpnStatusViewFAQMenuItemTitle, action: { [weak self] in
                 try? await self?.appLauncher.launchApp(withCommand: VPNAppLaunchCommand.showFAQ)
             }),

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Controller/TransparentProxyController.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Controller/TransparentProxyController.swift
@@ -216,6 +216,16 @@ public final class TransparentProxyController {
 
     // MARK: - Connection & Session
 
+    /// Checks whether a connection is the one being used by this proxy, with the option of not loading the configuration from settings.
+    ///
+    /// Not loading the connection from settings can be good in some circumstances, as it triggers a status updates.  This is particularly
+    /// useful when we're comparing the connection from an event triggered by a status update, so the proxy won't enter an infinite
+    /// loop of updating status > loading config > updating status > etc.
+    ///
+    public func isUsingConnection(_ connection: NEVPNConnection, loadFromSettings: Bool = false) -> Bool {
+        internalManager?.connection === connection
+    }
+
     public var connection: NEVPNConnection? {
         get async {
             await manager?.connection

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Controller/TransparentProxyController.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Controller/TransparentProxyController.swift
@@ -222,7 +222,7 @@ public final class TransparentProxyController {
     /// useful when we're comparing the connection from an event triggered by a status update, so the proxy won't enter an infinite
     /// loop of updating status > loading config > updating status > etc.
     ///
-    public func isUsingConnection(_ connection: NEVPNConnection, loadFromSettings: Bool = false) -> Bool {
+    public func isUsingConnection(_ connection: NEVPNConnection) -> Bool {
         internalManager?.connection === connection
     }
 

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Controller/TransparentProxyController.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Controller/TransparentProxyController.swift
@@ -216,7 +216,7 @@ public final class TransparentProxyController {
 
     // MARK: - Connection & Session
 
-    /// Checks whether a connection is the one being used by this proxy, with the option of not loading the configuration from settings.
+    /// Checks whether a connection is the one being used by this proxy, not loading our configuration from settings.
     ///
     /// Not loading the connection from settings can be good in some circumstances, as it triggers a status updates.  This is particularly
     /// useful when we're comparing the connection from an event triggered by a status update, so the proxy won't enter an infinite


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/0/task/1209699791105436

### Description

The VPN menu app can become unresponsive in our App Store builds due to a never ending loop where status updates cause our proxy configuration to be loaded, which in turns trigger another status update.

Also pushing some changes to make sure the exclusions menu is not visible in App Store builds.

### Testing Steps

1. Run the App Store build.
2. Ensure the VPN menu app stays responsive.

### Impact and Risks

NA

#### What could go wrong?

If the logic isn't right we introduce a regression, but I believe it's pretty much self-explanatory.

### Quality Considerations

NA

### Notes to Reviewer

Focus on making sure the changes are logical, and testing shows no issues.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)