### PR TITLE
Modal changes for tab switcher

### DIFF
--- a/iOS/DuckDuckGo/AIChat/AIChatDeepLinkHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatDeepLinkHandler.swift
@@ -19,13 +19,30 @@
 
 import Foundation
 import Core
+import AIChat
 
 struct AIChatDeepLinkHandler {
 
     /// Utility function to handle AI Chat deeplink since it needs to be called from 2 different entry points
     func handleDeepLink(_ url: URL, on mainViewController: MainViewController) {
         firePixel(url)
-        mainViewController.openAIChat()
+
+        guard !isAIChatAlreadyPresented(on: mainViewController) else {
+            return
+        }
+
+        mainViewController.dismiss(animated: true) {
+            mainViewController.openAIChat()
+        }
+    }
+
+    /// Checks if the AIChatViewController is already presented
+    private func isAIChatAlreadyPresented(on mainViewController: MainViewController) -> Bool {
+        if let presentedVC = mainViewController.presentedViewController as? RoundedPageSheetContainerViewController,
+           presentedVC.contentViewController is AIChatViewController {
+            return true
+        }
+        return false
     }
 
     func firePixel(_ url: URL) {

--- a/iOS/DuckDuckGo/AIChat/AIChatViewControllerManager.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatViewControllerManager.swift
@@ -54,14 +54,6 @@ final class AIChatViewControllerManager {
         inspectableWebView = AppUserDefaults().inspectableWebViewEnabled
 #endif
 
-        // Check if the viewController is already presenting a RoundedPageSheetContainerViewController with AIChatViewController inside
-        if let presentedVC = viewController.presentedViewController as? RoundedPageSheetContainerViewController,
-           presentedVC.contentViewController is AIChatViewController {
-            return
-        } else {
-            viewController.dismiss(animated: true)
-        }
-
         let webviewConfiguration = WKWebViewConfiguration.persistent()
         let userContentController = UserContentController()
         userContentController.delegate = self

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2757,9 +2757,7 @@ extension MainViewController: TabSwitcherDelegate {
     }
 
     func tabSwitcherDidRequestAIChat(tabSwitcher: TabSwitcherViewController) {
-        tabSwitcher.dismiss(animated: true) {
-            self.openAIChat()
-        }
+        self.aiChatViewControllerManager.openAIChat(on: tabSwitcher)
     }
 
 }


### PR DESCRIPTION
Task/Issue URL:
Tech Design URL:
CC:

### Description
Allow duck.ai to be opened from already presented modals

### Testing Steps
1. Open tab switcher, tap on duck.ai, check if it works
2. Open random modals like passwords, bookmarks, etc. Then open duck.ai from widgets. Validate that it first dismisses whatever was presented and then opens duck.ai
