### PR TITLE
Improve logic for newly selected tabs after closing one

### DIFF
--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
@@ -106,8 +106,6 @@ final class TabCollectionViewModel: NSObject {
     }
     private weak var previouslySelectedTabViewModel: TabViewModel?
 
-    // In a special occasion, we want to select the "parent" tab after closing the currently selected tab
-    private var selectParentOnRemoval = false
     private var tabLazyLoader: TabLazyLoader<TabCollectionViewModel>?
     private var isTabLazyLoadingRequested: Bool = false
 
@@ -304,7 +302,6 @@ final class TabCollectionViewModel: NSObject {
         }
 
         selectionIndex = .unpinned(index)
-        selectParentOnRemoval = selectedTabViewModel === previouslySelectedTabViewModel && selectParentOnRemoval
         return true
     }
 
@@ -319,7 +316,6 @@ final class TabCollectionViewModel: NSObject {
         }
 
         selectionIndex = .pinned(index)
-        selectParentOnRemoval = selectedTabViewModel === previouslySelectedTabViewModel && selectParentOnRemoval
         return true
     }
 
@@ -345,10 +341,6 @@ final class TabCollectionViewModel: NSObject {
             delegate?.tabCollectionViewModelDidAppend(self, selected: true)
         } else {
             delegate?.tabCollectionViewModelDidAppend(self, selected: false)
-        }
-
-        if selected {
-            self.selectParentOnRemoval = true
         }
     }
 
@@ -381,10 +373,6 @@ final class TabCollectionViewModel: NSObject {
         }
         if index.isUnpinnedTab {
             delegate?.tabCollectionViewModelDidInsert(self, at: index.item, selected: selected)
-        }
-
-        if selected {
-            self.selectParentOnRemoval = true
         }
     }
 
@@ -545,7 +533,6 @@ final class TabCollectionViewModel: NSObject {
 
         otherViewModel.selectUnpinnedTab(at: toIndex)
         otherViewModel.delegate?.tabCollectionViewModelDidInsert(otherViewModel, at: toIndex, selected: true)
-        otherViewModel.selectParentOnRemoval = true
     }
 
     func removeAllTabs(except exceptionIndex: Int? = nil, forceChange: Bool = false) {

--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
@@ -459,10 +459,12 @@ final class TabCollectionViewModel: NSObject {
     private func removeUnpinnedTab(at index: Int, published: Bool = true, forceChange: Bool = false) {
         guard changesEnabled || forceChange else { return }
 
-        let parentTab = tabCollection.tabs[safe: index]?.parentTab
+        let removedTab = tabCollection.tabs[safe: index]
+        let parentTab = removedTab?.parentTab
         guard tabCollection.removeTab(at: index, published: published, forced: forceChange) else { return }
 
-        didRemoveTab(at: .unpinned(index),
+        didRemoveTab(tab: removedTab!,
+                     at: .unpinned(index),
                      withParent: parentTab,
                      forced: forceChange)
     }
@@ -473,12 +475,12 @@ final class TabCollectionViewModel: NSObject {
         defer {
             shouldBlockPinnedTabsManagerUpdates = false
         }
-        guard pinnedTabsManager?.unpinTab(at: index, published: published) != nil else { return }
+        guard let removedTab = pinnedTabsManager?.unpinTab(at: index, published: published) else { return }
 
-        didRemoveTab(at: .pinned(index), withParent: nil)
+        didRemoveTab(tab: removedTab, at: .pinned(index), withParent: nil)
     }
 
-    private func didRemoveTab(at index: TabIndex, withParent parentTab: Tab?, forced: Bool = false) {
+    private func didRemoveTab(tab: Tab, at index: TabIndex, withParent parentTab: Tab?, forced: Bool = false) {
 
         func notifyDelegate() {
             if index.isUnpinnedTab {
@@ -500,21 +502,9 @@ final class TabCollectionViewModel: NSObject {
         }
 
         let newSelectionIndex: TabIndex
-        if selectionIndex == index,
-           selectParentOnRemoval,
-           let parentTab = parentTab,
-           let parentTabIndex = indexInAllTabs(of: parentTab) {
-            // Select parent tab
-            newSelectionIndex = parentTabIndex
-        } else if selectionIndex == index,
-                  let parentTab = parentTab,
-                  let leftTab = tab(at: index.previous(in: self)),
-                  let rightTab = tab(at: index),
-                  rightTab.parentTab !== parentTab && (leftTab.parentTab === parentTab || leftTab === parentTab) {
-            // Select parent tab on left or another child tab on left instead of the tab on right
-            newSelectionIndex = .unpinned(max(0, selectionIndex.item - 1))
-        } else if selectionIndex > index, selectionIndex.isInSameSection(as: index) {
-            newSelectionIndex = selectionIndex.previous(in: self)
+
+        if let calculatedIndex = selectionIndex.calculateSelectedTabIndexAfterClosing(for: self, removedTab: tab, withParent: parentTab) {
+            newSelectionIndex = calculatedIndex
         } else {
             newSelectionIndex = selectionIndex.sanitized(for: self)
         }
@@ -523,15 +513,35 @@ final class TabCollectionViewModel: NSObject {
         select(at: newSelectionIndex, forceChange: forced)
     }
 
+    func getLastSelectedTab() -> TabIndex? {
+        let recentlyOpenedPinnedTab = pinnedTabs.max(by: { $0.lastSelectedAt ?? Date.distantPast < $1.lastSelectedAt ?? Date.distantPast })
+        let recentlyOpenedNormalTab = tabs.max(by: { $0.lastSelectedAt ?? Date.distantPast < $1.lastSelectedAt ?? Date.distantPast })
+
+        if let pinnedTab = recentlyOpenedPinnedTab, let normalTab = recentlyOpenedNormalTab {
+            if pinnedTab.lastSelectedAt ?? Date.distantPast > normalTab.lastSelectedAt ?? Date.distantPast {
+                return indexInAllTabs(of: pinnedTab)
+            } else {
+                return indexInAllTabs(of: normalTab)
+            }
+        } else if let pinnedTab = recentlyOpenedPinnedTab {
+            return indexInAllTabs(of: pinnedTab)
+        } else if let normalTab = recentlyOpenedNormalTab {
+            return indexInAllTabs(of: normalTab)
+        } else {
+            return nil
+        }
+    }
+
     func moveTab(at fromIndex: Int, to otherViewModel: TabCollectionViewModel, at toIndex: Int) {
         assert(self !== otherViewModel)
         guard changesEnabled else { return }
 
-        let parentTab = tabCollection.tabs[safe: fromIndex]?.parentTab
+        let movedTab = tabCollection.tabs[safe: fromIndex]
+        let parentTab = movedTab?.parentTab
 
         guard tabCollection.moveTab(at: fromIndex, to: otherViewModel.tabCollection, at: toIndex) else { return }
 
-        didRemoveTab(at: .unpinned(fromIndex), withParent: parentTab)
+        didRemoveTab(tab: movedTab!, at: .unpinned(fromIndex), withParent: parentTab)
 
         otherViewModel.selectUnpinnedTab(at: toIndex)
         otherViewModel.delegate?.tabCollectionViewModelDidInsert(otherViewModel, at: toIndex, selected: true)
@@ -686,7 +696,7 @@ final class TabCollectionViewModel: NSObject {
 
     private func handleTabUnpinnedInAnotherTabCollectionViewModel(at index: Int) {
         if selectionIndex == .pinned(index) {
-            didRemoveTab(at: .pinned(index), withParent: nil)
+            didRemoveTab(tab: tabCollection.tabs[safe: index]!, at: .pinned(index), withParent: nil)
         }
     }
 

--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabIndex.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabIndex.swift
@@ -207,16 +207,31 @@ extension TabIndex {
         case next, previous
     }
 
+    /// - Parameters:
+    ///   - viewModel: The `TabCollectionViewModel` to search within
+    ///   - parentTab: The parent tab to find the next tab for
+    /// - Returns: The `TabIndex` of the next tab with the same parent, if found
     @MainActor
     private func findNextTabWithSameParent(for viewModel: TabCollectionViewModel, parentTab: Tab) -> TabIndex? {
         return findTabWithParent(for: viewModel, parentTab: parentTab, direction: .next)
     }
 
+    /// - Parameters:
+    ///   - viewModel: The `TabCollectionViewModel` to search within
+    ///   - parentTab: The parent tab to find the previous tab for
+    /// - Returns: The `TabIndex` of the previous tab with the same parent, if found
     @MainActor
     private func findPreviousTabWithSameParent(for viewModel: TabCollectionViewModel, parentTab: Tab) -> TabIndex? {
         return findTabWithParent(for: viewModel, parentTab: parentTab, direction: .previous)
     }
 
+    /// Finds the next or previous tab that has the given parent tab
+    ///
+    /// - Parameters:
+    ///   - viewModel: The `TabCollectionViewModel` to search within
+    ///   - parentTab: The parent tab to find the tab for
+    ///   - direction: The direction to search in (.next or .previous)
+    /// - Returns: The `TabIndex` of the first tab found with the given parent, if any
     @MainActor
     private func findTabWithParent(for viewModel: TabCollectionViewModel, parentTab: Tab, direction: SearchDirection) -> TabIndex? {
         var currentIndex = self
@@ -233,6 +248,15 @@ extension TabIndex {
         return nil
     }
 
+    /// Finds the new tab index to select after closing a tab that doesn't have a parent
+    ///
+    /// The rules are:
+    /// 1. Try to find the next tab that has the closed tab as its parent
+    /// 2. Try to find the previous tab that has the closed tab as its parent
+    /// 3. Try to find the recently closed tab
+    /// 4. Try to find the current tab index (if it still exists)
+    /// 5. Try to find the next tab
+    /// 6. Try to find the previous tab
     @MainActor
     private func findNewSelectionIndexWithoutParent(for viewModel: TabCollectionViewModel, removedTab: Tab) -> TabIndex? {
         if let nextTabWithRemovedTabAsParent = findNextTabWithRemovedTabAsParent(for: viewModel, removedTab: removedTab) {
@@ -243,12 +267,12 @@ extension TabIndex {
             return previousTabWithRemovedTabAsParent
         }
 
-        /// Rule 4: Try to find the recently closed tab
         if let recentlyClosedTabIndex = viewModel.getLastSelectedTab() {
             return recentlyClosedTabIndex
         }
 
-        /// The tab index being manipulate was the tab index of the removed/closed tab. The problem is that this new
+        /// Given of the nature of when this method is called, the tab index being manipulated (self) could be the tab to the right.
+        /// So we need to check for self to see if it exists, if it exists, we return it.
         if viewModel.tabViewModel(at: self) != nil {
             return self
         }
@@ -264,6 +288,12 @@ extension TabIndex {
         return nil
     }
 
+    /// Finds the next tab that has the given removed tab as its parent
+    ///
+    /// - Parameters:
+    ///   - viewModel: The `TabCollectionViewModel` to search within
+    ///   - removedTab: The tab that was removed
+    /// - Returns: The `TabIndex` of the next tab with the given removed tab as its parent, if found
     @MainActor
     private func findNextTabWithRemovedTabAsParent(for viewModel: TabCollectionViewModel, removedTab: Tab) -> TabIndex? {
         var currentIndex = self
@@ -281,6 +311,12 @@ extension TabIndex {
         return nil
     }
 
+    /// Finds the previous tab that has the given removed tab as its parent
+    ///
+    /// - Parameters:
+    ///   - viewModel: The `TabCollectionViewModel` to search within
+    ///   - removedTab: The tab that was removed
+    /// - Returns: The `TabIndex` of the previous tab with the given removed tab as its parent, if found
     @MainActor
     private func findPreviousTabWithRemovedTabAsParent(for viewModel: TabCollectionViewModel, removedTab: Tab) -> TabIndex? {
         var currentIndex = self
@@ -293,7 +329,9 @@ extension TabIndex {
         return nil
     }
 
-    /// Gets the tab to the right, if it is the last one, returns nil.
+    /// Gets the tab to the right of the current tab index
+    ///
+    /// If the current tab index is the last one, returns `nil`
     @MainActor
     private func getRighteousTab(for viewModel: TabCollectionViewModel) -> TabIndex? {
         switch self {
@@ -310,7 +348,9 @@ extension TabIndex {
         }
     }
 
-    /// Gets the tab to the left, if it is the last one, returns nil.
+    /// Gets the tab to the left of the current tab index
+    ///
+    /// If the current tab index is the first one, returns `nil`
     @MainActor
     private func getLeftTab(for viewModel: TabCollectionViewModel) -> TabIndex? {
         switch self {

--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabIndex.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabIndex.swift
@@ -171,6 +171,161 @@ extension TabIndex {
             return .unpinned(max(0, min(index, viewModel.tabsCount - 1)))
         }
     }
+
+    // MARK: - Logic when closing a tab
+
+    /// When closing a tab, the following rules will be used to find the appropriate tab to activate. Rules will be evaluated top to bottom and evaluation stops once a tab has been found:
+    /// 1. If this tab has a parent (i.e. has been opened via "Open In New Tab"):
+    ///     a. Try to find the next tab with the same parent tab
+    ///     b. Try to find the previous tab with the same parent tab
+    ///     c. Try to find the parent tab
+    /// 2. Try to find the next tab that has the closing tab as it's parent
+    /// 3. Try to find the previous tab that has the closing tab as it's parent
+    /// 4. Try to find the previously closed tab.
+    /// 5. Try to find the next tab
+    /// 6. Try to find the previous tab
+    @MainActor
+    func calculateSelectedTabIndexAfterClosing(for viewModel: TabCollectionViewModel, removedTab: Tab, withParent parentTab: Tab?) -> TabIndex? {
+        if let parentTab = parentTab {
+            if let nextTabWithSameParent = findNextTabWithSameParent(for: viewModel, parentTab: parentTab) {
+                return nextTabWithSameParent
+            }
+
+            if let previousTabWithSameParent = findPreviousTabWithSameParent(for: viewModel, parentTab: parentTab) {
+                return previousTabWithSameParent
+            }
+
+            if let parentTabIndex = viewModel.indexInAllTabs(of: parentTab) {
+                return parentTabIndex
+            }
+        }
+
+        return findNewSelectionIndexWithoutParent(for: viewModel, removedTab: removedTab)
+    }
+
+    private enum SearchDirection {
+        case next, previous
+    }
+
+    @MainActor
+    private func findNextTabWithSameParent(for viewModel: TabCollectionViewModel, parentTab: Tab) -> TabIndex? {
+        return findTabWithParent(for: viewModel, parentTab: parentTab, direction: .next)
+    }
+
+    @MainActor
+    private func findPreviousTabWithSameParent(for viewModel: TabCollectionViewModel, parentTab: Tab) -> TabIndex? {
+        return findTabWithParent(for: viewModel, parentTab: parentTab, direction: .previous)
+    }
+
+    @MainActor
+    private func findTabWithParent(for viewModel: TabCollectionViewModel, parentTab: Tab, direction: SearchDirection) -> TabIndex? {
+        var currentIndex = self
+        if let viewModelTab = viewModel.tabViewModel(at: currentIndex), viewModelTab.tab.parentTab == parentTab {
+            return currentIndex
+        }
+
+        while let nextIndex = direction == .next ? currentIndex.getRighteousTab(for: viewModel) : currentIndex.getLeftTab(for: viewModel) {
+            if let viewModelTab = viewModel.tabViewModel(at: nextIndex), viewModelTab.tab.parentTab == parentTab {
+                return nextIndex
+            }
+            currentIndex = nextIndex
+        }
+        return nil
+    }
+
+    @MainActor
+    private func findNewSelectionIndexWithoutParent(for viewModel: TabCollectionViewModel, removedTab: Tab) -> TabIndex? {
+        if let nextTabWithRemovedTabAsParent = findNextTabWithRemovedTabAsParent(for: viewModel, removedTab: removedTab) {
+            return nextTabWithRemovedTabAsParent
+        }
+
+        if let previousTabWithRemovedTabAsParent = findPreviousTabWithRemovedTabAsParent(for: viewModel, removedTab: removedTab) {
+            return previousTabWithRemovedTabAsParent
+        }
+
+        /// Rule 4: Try to find the recently closed tab
+        if let recentlyClosedTabIndex = viewModel.getLastSelectedTab() {
+            return recentlyClosedTabIndex
+        }
+
+        /// The tab index being manipulate was the tab index of the removed/closed tab. The problem is that this new
+        if viewModel.tabViewModel(at: self) != nil {
+            return self
+        }
+
+        if let nextIndex = getRighteousTab(for: viewModel) {
+            return nextIndex
+        }
+
+        if let previousIndex = getLeftTab(for: viewModel) {
+            return previousIndex
+        }
+
+        return nil
+    }
+
+    @MainActor
+    private func findNextTabWithRemovedTabAsParent(for viewModel: TabCollectionViewModel, removedTab: Tab) -> TabIndex? {
+        var currentIndex = self
+
+        if let viewModelTab = viewModel.tabViewModel(at: currentIndex), viewModelTab.tab.parentTab == removedTab {
+            return currentIndex
+        }
+
+        while let nextIndex = currentIndex.getRighteousTab(for: viewModel) {
+            if let viewModelTab = viewModel.tabViewModel(at: nextIndex), viewModelTab.tab.parentTab == removedTab {
+                return nextIndex
+            }
+            currentIndex = nextIndex
+        }
+        return nil
+    }
+
+    @MainActor
+    private func findPreviousTabWithRemovedTabAsParent(for viewModel: TabCollectionViewModel, removedTab: Tab) -> TabIndex? {
+        var currentIndex = self
+        while let previousIndex = currentIndex.getLeftTab(for: viewModel) {
+            if let viewModelTab = viewModel.tabViewModel(at: previousIndex), viewModelTab.tab.parentTab == removedTab {
+                return previousIndex
+            }
+            currentIndex = previousIndex
+        }
+        return nil
+    }
+
+    /// Gets the tab to the right, if it is the last one, returns nil.
+    @MainActor
+    private func getRighteousTab(for viewModel: TabCollectionViewModel) -> TabIndex? {
+        switch self {
+        case .pinned(let index):
+            if index >= viewModel.pinnedTabsCount - 1 {
+                return viewModel.tabsCount > 0 ? .unpinned(0) : nil
+            }
+            return .pinned(index + 1)
+        case .unpinned(let index):
+            if index >= viewModel.tabCollection.tabs.count - 1 {
+                return nil
+            }
+            return .unpinned(index + 1)
+        }
+    }
+
+    /// Gets the tab to the left, if it is the last one, returns nil.
+    @MainActor
+    private func getLeftTab(for viewModel: TabCollectionViewModel) -> TabIndex? {
+        switch self {
+        case .pinned(let index):
+            if index == 0 {
+                return nil
+            }
+            return .pinned(index - 1)
+        case .unpinned(let index):
+            if index == 0 {
+                return viewModel.pinnedTabsCount > 0 ? .pinned(viewModel.pinnedTabsCount - 1) : nil
+            }
+            return .unpinned(index - 1)
+        }
+    }
 }
 
 private extension TabCollectionViewModel {

--- a/macOS/UITests/TabBarTests.swift
+++ b/macOS/UITests/TabBarTests.swift
@@ -33,18 +33,56 @@ class TabBarTests: UITestCase {
         UITests.firstRun()
     }
 
-    func testWhenClickingAddTab_ThenTabsOpen() throws {
-//        let app = XCUIApplication()
-//
-//        let tabbarviewitemElementsQuery = app.windows.collectionViews.otherElements.containing(.group, identifier: "TabBarViewItem")
-//        // click on add tab button twice
-//        tabbarviewitemElementsQuery.children(matching: .group).element(boundBy: 1).children(matching: .button).element.click()
-//        tabbarviewitemElementsQuery.children(matching: .group).element(boundBy: 2).children(matching: .button).element.click()
-//
-//        let tabs = app.windows.collectionViews.otherElements.containing(.group, identifier: "TabBarViewItem").children(matching: .group)
-//            .matching(identifier: "TabBarViewItem")
-//
-//        XCTAssertEqual(tabs.count, 3)
-        _ = XCTSkip("Test needs accessibility identifier debugging before usage")
+    func testTabGetsToRecentlyClosedTabWhenCurrentTabIsClosed() {
+        openThreeSitesOnSameWindow()
+        pinsPageOne()
+        moveToRightEndTab()
+        /// Closes last tab
+        app.typeKey("W", modifierFlags: [.command])
+
+        /// Asserts that the pinned tab
+        XCTAssertTrue(app.staticTexts["Sample text for Page #1"].waitForExistence(timeout: UITests.Timeouts.elementExistence))
+    }
+
+    // MARK: - Utilities
+
+    private func moveToRightEndTab() {
+        let toolbar = app.toolbars.firstMatch
+        let toolbarCoordinate = toolbar.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
+        let startPoint = toolbarCoordinate.withOffset(CGVector(dx: 160, dy: 0))
+        startPoint.press(forDuration: 0.1)
+
+        sleep(1)
+    }
+
+    private func openThreeSitesOnSameWindow() {
+        openSite(pageTitle: "Page #1")
+        app.openNewTab()
+        openSite(pageTitle: "Page #2")
+        app.openNewTab()
+        openSite(pageTitle: "Page #3")
+        app.openNewTab()
+        openSite(pageTitle: "Page #4")
+    }
+
+    private func pinsPageOne() {
+        app.typeKey("[", modifierFlags: [.command, .shift])
+        app.typeKey("[", modifierFlags: [.command, .shift])
+        app.typeKey("[", modifierFlags: [.command, .shift])
+        app.menuItems["Pin Tab"].tap()
+    }
+
+    private func openSite(pageTitle: String) {
+        let url = UITests.simpleServedPage(titled: pageTitle)
+        let addressBarTextField = app.windows.firstMatch.textFields["AddressBarViewController.addressBarTextField"]
+        XCTAssertTrue(
+            addressBarTextField.waitForExistence(timeout: UITests.Timeouts.elementExistence),
+            "The address bar text field didn't become available in a reasonable timeframe."
+        )
+        addressBarTextField.typeURL(url)
+        XCTAssertTrue(
+            app.windows.firstMatch.webViews[pageTitle].waitForExistence(timeout: UITests.Timeouts.elementExistence),
+            "Visited site didn't load with the expected title in a reasonable timeframe."
+        )
     }
 }

--- a/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests+CloseTabLogic.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests+CloseTabLogic.swift
@@ -1,0 +1,139 @@
+//
+//  TabCollectionViewModelTests+CloseTabLogic.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo_Privacy_Browser
+
+// MARK: - Tests for TabCollectionViewModel selected tab after closing logic
+
+extension TabCollectionViewModelTests {
+
+    @MainActor
+    func testFindNextTabWithSameParent() {
+        let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
+        let parentTab = tabCollectionViewModel.tabCollection.tabs[0]
+        let childTab1 = Tab(parentTab: parentTab)
+        tabCollectionViewModel.append(tab: childTab1, selected: false)
+        let childTab2 = Tab(parentTab: parentTab)
+        tabCollectionViewModel.append(tab: childTab2, selected: true)
+        let childTab3 = Tab(parentTab: parentTab)
+        tabCollectionViewModel.append(tab: childTab3, selected: false)
+
+        tabCollectionViewModel.remove(at: .unpinned(2))
+
+        /// We have Parent + Child1 + Child 2 (selected) + Child 3. Then, we remove Child 2.
+        /// So the next tab should be selected, not the parent nor the previous tab.
+        XCTAssertEqual(tabCollectionViewModel.selectedTabViewModel?.tab, childTab3)
+    }
+
+    @MainActor
+    func testFindPreviousTabWithSameParent() {
+        let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
+        let parentTab = tabCollectionViewModel.tabCollection.tabs[0]
+        let childTab1 = Tab(parentTab: parentTab)
+        tabCollectionViewModel.append(tab: childTab1, selected: false)
+        let childTab2 = Tab(parentTab: parentTab)
+        tabCollectionViewModel.append(tab: childTab2, selected: true)
+        let normalTab = Tab()
+        tabCollectionViewModel.append(tab: normalTab, selected: false)
+
+        tabCollectionViewModel.remove(at: .unpinned(2))
+
+        /// We have Parent + Child1 + Child 2 (selected) + Non Child. Then, we remove Child 2.
+        /// So the previous tab should be selected, not the parent nor the non child tab.
+        XCTAssertEqual(tabCollectionViewModel.selectedTabViewModel?.tab, childTab1)
+    }
+
+    @MainActor
+    func testFindParentTab_whenNoChildParentIsClose() {
+        let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
+        let parentTab = tabCollectionViewModel.tabCollection.tabs[0]
+        let normalTab = Tab()
+        tabCollectionViewModel.append(tab: normalTab, selected: false)
+        let childTab1 = Tab(parentTab: parentTab)
+        tabCollectionViewModel.append(tab: childTab1, selected: true)
+
+        tabCollectionViewModel.remove(at: .unpinned(2))
+
+        /// We have Parent + Non Child + Child 1. Then, we remove Child1.
+        /// So the parent tab should be selected.
+        XCTAssertEqual(tabCollectionViewModel.selectedTabViewModel?.tab, parentTab)
+    }
+
+    @MainActor
+    func testFindNextTabWithRemovedTabAsParent() {
+        let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
+        let parentTab = tabCollectionViewModel.tabCollection.tabs[0]
+        let normalTab = Tab()
+        tabCollectionViewModel.append(tab: normalTab, selected: false)
+        let childTab1 = Tab(parentTab: parentTab)
+        tabCollectionViewModel.append(tab: childTab1, selected: true)
+
+        tabCollectionViewModel.remove(at: .unpinned(0))
+
+        /// We have Parent + Non Child + Child 1. Then, we remove Parent.
+        /// So the next child tab should be selected.
+        XCTAssertEqual(tabCollectionViewModel.selectedTabViewModel?.tab, childTab1)
+    }
+
+    @MainActor
+    func testFindPreviousTabWithRemovedTabAsParent() {
+        let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
+        let parentTab = tabCollectionViewModel.tabCollection.tabs[0]
+        let childTab1 = Tab(parentTab: parentTab)
+        tabCollectionViewModel.append(tab: childTab1, selected: true)
+        let normalTab = Tab()
+        tabCollectionViewModel.append(tab: normalTab, selected: false)
+
+        /// We move the parent to the last position
+        tabCollectionViewModel.moveTab(at: 0, to: 2)
+
+        tabCollectionViewModel.remove(at: .unpinned(2))
+
+        /// We have Child 1 + Non Child + Parent . Then, we remove Parent.
+        /// So the previous child tab should be selected.
+        XCTAssertEqual(tabCollectionViewModel.selectedTabViewModel?.tab, childTab1)
+    }
+
+    @MainActor
+    func testFindNextTabWhenNoParentOrChildIsInvoled_shouldReturnToPreviouslyClosedTab() {
+        let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
+        let firstTab = tabCollectionViewModel.tabCollection.tabs[0]
+
+        for _ in 1..<100 {
+            tabCollectionViewModel.append(tab: Tab(), selected: false)
+        }
+
+        let lastTab = Tab()
+        tabCollectionViewModel.append(tab: lastTab, selected: true)
+
+        tabCollectionViewModel.remove(at: .unpinned(100))
+
+        /// We have a tab and we open 99 tabs more without selecting them.
+        /// So the previous child tab should be selected.
+        XCTAssertEqual(tabCollectionViewModel.selectedTabViewModel?.tab, firstTab)
+    }
+}
+
+fileprivate extension TabCollectionViewModel {
+
+    static func aTabCollectionViewModel() -> TabCollectionViewModel {
+        let tabCollection = TabCollection()
+        return TabCollectionViewModel(tabCollection: tabCollection, pinnedTabsManager: nil)
+    }
+}

--- a/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests+PinnedTabs.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests+PinnedTabs.swift
@@ -216,12 +216,13 @@ extension TabCollectionViewModelTests {
     }
 
     @MainActor
-    func test_WithPinnedTabs_WhenSelectedPinnedTabIsRemovedThenNextPinnedTabWithHigherIndexIsSelected() {
+    func test_WithPinnedTabs_WhenSelectedPinnedTabIsRemovedThenLastSelectedPinnedTabIsSelected() {
         let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModelWithPinnedTab()
         tabCollectionViewModel.appendPinnedTab()
         tabCollectionViewModel.appendPinnedTab()
         let lastPinnedTab = tabCollectionViewModel.pinnedTabsCollection?.tabs[2]
 
+        tabCollectionViewModel.select(at: .pinned(2))
         tabCollectionViewModel.select(at: .pinned(1))
         tabCollectionViewModel.remove(at: .pinned(1))
 
@@ -248,6 +249,7 @@ extension TabCollectionViewModelTests {
         tabCollectionViewModel.appendPinnedTab()
         let lastPinnedTab = tabCollectionViewModel.pinnedTabsCollection?.tabs[1]
 
+        tabCollectionViewModel.select(at: .pinned(1))
         tabCollectionViewModel.remove(at: .unpinned(0))
 
         XCTAssertIdentical(lastPinnedTab, tabCollectionViewModel.selectedTabViewModel?.tab)
@@ -269,7 +271,7 @@ extension TabCollectionViewModelTests {
     }
 
     @MainActor
-    func test_WithPinnedTabs_WhenChildTabIsInsertedAndRemoved_ThenPinnedParentIsSelectedBack() {
+    func test_WithPinnedTabs_WhenChildTabIsInsertedAndRemoved_ThenChildTabIsSelectedBackIfPresent() {
         let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModelWithPinnedTab()
         tabCollectionViewModel.appendPinnedTab()
         let parentTab = tabCollectionViewModel.pinnedTabsCollection!.tabs[0]
@@ -278,6 +280,23 @@ extension TabCollectionViewModelTests {
         tabCollectionViewModel.append(tab: childTab1, selected: false)
         let childTab2 = Tab(parentTab: parentTab)
         tabCollectionViewModel.append(tab: childTab2, selected: true)
+
+        tabCollectionViewModel.remove(at: .unpinned(2))
+
+        XCTAssertIdentical(tabCollectionViewModel.selectedTabViewModel?.tab, childTab1)
+        XCTAssertEqual(tabCollectionViewModel.selectionIndex, .unpinned(1))
+    }
+
+    @MainActor
+    func test_WithPinnedTabs_WhenChildTabIsInsertedAndRemovedAndNoChildIsNear_ThenParentIsSelectedBack() {
+        let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModelWithPinnedTab()
+        let parentTab = tabCollectionViewModel.pinnedTabsCollection!.tabs[0]
+
+        // Append two tabs that are not parent related
+        tabCollectionViewModel.append(tab: Tab(), selected: true)
+
+        let childTab1 = Tab(parentTab: parentTab)
+        tabCollectionViewModel.append(tab: childTab1, selected: false)
 
         tabCollectionViewModel.remove(at: .unpinned(2))
 

--- a/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests+WithoutPinnedTabsManager.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests+WithoutPinnedTabsManager.swift
@@ -415,7 +415,7 @@ extension TabCollectionViewModelTests {
     }
 
     @MainActor
-    func test_WithoutPinnedTabsManager_WhenChildTabIsInsertedAndRemoved_ThenParentIsSelectedBack() {
+    func test_WithoutPinnedTabsManager_WhenChildTabIsInsertedAndRemoved_ThenOtherChildIsSelectedBackIfPresent() {
         let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
         let parentTab = tabCollectionViewModel.tabCollection.tabs[0]
         let childTab1 = Tab(parentTab: parentTab)
@@ -425,7 +425,7 @@ extension TabCollectionViewModelTests {
 
         tabCollectionViewModel.remove(at: .unpinned(2))
 
-        XCTAssertEqual(tabCollectionViewModel.selectedTabViewModel?.tab, parentTab)
+        XCTAssertEqual(tabCollectionViewModel.selectedTabViewModel?.tab, childTab1)
     }
 
     @MainActor

--- a/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests.swift
@@ -475,7 +475,7 @@ final class TabCollectionViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testWhenChildTabIsInsertedAndRemoved_ThenParentIsSelectedBack() {
+    func testWhenChildTabIsInsertedAndRemovedAndThereIsAChildTabClose_ThenChildTabIsSelected() {
         let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
         let parentTab = tabCollectionViewModel.tabCollection.tabs[0]
         let childTab1 = Tab(parentTab: parentTab)
@@ -485,7 +485,7 @@ final class TabCollectionViewModelTests: XCTestCase {
 
         tabCollectionViewModel.remove(at: .unpinned(2))
 
-        XCTAssertEqual(tabCollectionViewModel.selectedTabViewModel?.tab, parentTab)
+        XCTAssertEqual(tabCollectionViewModel.selectedTabViewModel?.tab, childTab1)
     }
 
     @MainActor


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1209684411145358/f
Tech Design URL:
CC:

### Description
Improves the logic of how we return to a tab after closing one.

When closing a tab, the following rules will be used to find the appropriate tab to activate. Rules will be evaluated top to bottom and evaluation stops once a tab has been found:
1. If this tab has a parent (i.e. has been opened via "Open In New Tab"):
a. Try to find the next tab with the same parent tab
b. Try to find the previous tab with the same parent tab
c. Try to find the parent tab
2. Try to find the next tab that has the closing tab as it's parent
3. Try to find the previous tab that has the closing tab as it's parent
4. Try to find the previously closed tab.
5. Try to find the next tab
6. Try to find the previous tab

### Testing Steps
1. Open a site on a tab
2. To create a child tab, right tap on a link and tap ‘Open Link In New tab'
3. To create a regular/normal tab, jsut tap CMD + T or the + button in the TabBar

### Impact and Risks
Medium to low.

#### What could go wrong?
Users could be used to the old way causing confusion.

### Quality Considerations
I’ve considered different edge cases that I covered with unit tests.

### Notes to Reviewer
Nothing specific.