### PR TITLE
Malicious Site Protection - Attempt to prevent crashes

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers.git",
+      "state" : {
+        "revision" : "5928286acce13def418ec36d05a001a9641086f2",
+        "version" : "1.0.3"
+      }
+    },
+    {
       "identity" : "content-scope-scripts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",

--- a/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/Services/DataManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/Services/DataManager.swift
@@ -21,7 +21,7 @@ import os
 
 protocol DataManaging {
     func dataSet<DataKey: MaliciousSiteDataKey>(for key: DataKey) async -> DataKey.DataSet
-    func store<DataKey: MaliciousSiteDataKey>(_ dataSet: DataKey.DataSet, for key: DataKey) async throws
+    func updateDataSet<DataKey: MaliciousSiteDataKey>(with key: DataKey, changeSet: APIClient.ChangeSetResponse<DataKey.DataSet.Element>) async throws
     func preloadData(for threatKinds: [ThreatKind]) async
 }
 
@@ -98,7 +98,10 @@ public actor DataManager: DataManaging {
         return storedDataSet
     }
 
-    func store<DataKey: MaliciousSiteDataKey>(_ dataSet: DataKey.DataSet, for key: DataKey) throws {
+    func updateDataSet<DataKey: MaliciousSiteDataKey>(with key: DataKey, changeSet: APIClient.ChangeSetResponse<DataKey.DataSet.Element>) async throws {
+        var dataSet = self.dataSet(for: key)
+        dataSet.apply(changeSet)
+
         let dataType = key.dataType
         let fileName = fileNameProvider(dataType)
         self.store[dataType] = dataSet

--- a/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/Services/DataManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/Services/DataManager.swift
@@ -98,7 +98,7 @@ public actor DataManager: DataManaging {
         return storedDataSet
     }
 
-    func updateDataSet<DataKey: MaliciousSiteDataKey>(with key: DataKey, changeSet: APIClient.ChangeSetResponse<DataKey.DataSet.Element>) async throws {
+    func updateDataSet<DataKey: MaliciousSiteDataKey>(with key: DataKey, changeSet: APIClient.ChangeSetResponse<DataKey.DataSet.Element>) throws {
         var dataSet = self.dataSet(for: key)
         dataSet.apply(changeSet)
 

--- a/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/Services/UpdateManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/Services/UpdateManager.swift
@@ -167,9 +167,7 @@ public struct UpdateManager: InternalUpdateManaging {
             }
 
             // Check that at least one of the dataset type have updated
-            let shouldSaveLastUpdateDate = results.reduce(false) { partial, newValue in
-                partial || newValue
-            }
+            let shouldSaveLastUpdateDate = results.contains(true)
 
             if shouldSaveLastUpdateDate {
                 await saveLastUpdateDate(for: datasetType)

--- a/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/Services/UpdateManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/Services/UpdateManager.swift
@@ -79,8 +79,7 @@ public struct UpdateManager: InternalUpdateManaging {
         }
 
         // load currently stored data set
-        var dataSet = await dataManager.dataSet(for: key)
-        let oldRevision = dataSet.revision
+        let oldRevision = await dataManager.dataSet(for: key).revision
 
         // get change set from current revision from API
         let changeSet: APIClient.ChangeSetResponse<DataKey.DataSet.Element>
@@ -91,25 +90,22 @@ public struct UpdateManager: InternalUpdateManaging {
             Logger.updateManager.error("error fetching \(type(of: key)).\(key.threatKind): \(error)")
 
             // Fire a Pixel if it fails to load initial datasets
-            if case APIRequestV2.Error.urlSession(URLError.notConnectedToInternet) = error, dataSet.revision == 0 {
+            if case APIRequestV2.Error.urlSession(URLError.notConnectedToInternet) = error, oldRevision == 0 {
                 eventMapping.fire(MaliciousSiteProtection.Event.failedToDownloadInitialDataSets(category: key.threatKind, type: key.dataType.kind))
             }
 
             throw error
         }
 
-        guard !changeSet.isEmpty || changeSet.revision != dataSet.revision else {
+        guard !changeSet.isEmpty || changeSet.revision != oldRevision else {
             Logger.updateManager.debug("no changes to \(type(of: key)).\(key.threatKind)")
             return
         }
 
-        // apply changes
-        dataSet.apply(changeSet)
-
-        // store back
+        // apply and save changes
         do {
-            try await self.dataManager.store(dataSet, for: key)
-            Logger.updateManager.debug("\(type(of: key)).\(key.threatKind) updated from rev.\(oldRevision) to rev.\(dataSet.revision)")
+            try await dataManager.updateDataSet(with: key, changeSet: changeSet)
+            Logger.updateManager.debug("\(type(of: key)).\(key.threatKind) updated from rev.\(oldRevision) to rev.\(oldRevision)")
         } catch {
             Logger.updateManager.error("\(type(of: key)).\(key.threatKind) failed to be saved")
             throw error

--- a/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/Services/UpdateManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/Services/UpdateManager.swift
@@ -105,7 +105,7 @@ public struct UpdateManager: InternalUpdateManaging {
         // apply and save changes
         do {
             try await dataManager.updateDataSet(with: key, changeSet: changeSet)
-            Logger.updateManager.debug("\(type(of: key)).\(key.threatKind) updated from rev.\(oldRevision) to rev.\(oldRevision)")
+            Logger.updateManager.debug("\(type(of: key)).\(key.threatKind) updated from rev.\(oldRevision) to rev.\(changeSet.revision)")
         } catch {
             Logger.updateManager.error("\(type(of: key)).\(key.threatKind) failed to be saved")
             throw error

--- a/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/MaliciousSiteProtectionUpdateManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/MaliciousSiteProtectionUpdateManagerTests.swift
@@ -24,6 +24,7 @@ import XCTest
 
 @testable import MaliciousSiteProtection
 
+@available(iOS 16, macOS 13, *)
 class MaliciousSiteProtectionUpdateManagerTests: XCTestCase {
 
     var updateManager: MaliciousSiteProtection.UpdateManager!
@@ -525,7 +526,7 @@ class MaliciousSiteProtectionUpdateManagerTests: XCTestCase {
         XCTAssertEqual(updateManagerInfoStore.lastHashPrefixSetsUpdateDate, .distantPast)
 
         // WHEN
-        try await updateManager.updateData(datasetType: .hashPrefixSet).value
+        await updateManager.updateData(datasetType: .hashPrefixSet).value
 
         // THEN
         XCTAssertNotEqual(updateManagerInfoStore.lastHashPrefixSetsUpdateDate, .distantPast)
@@ -536,7 +537,7 @@ class MaliciousSiteProtectionUpdateManagerTests: XCTestCase {
         XCTAssertEqual(updateManagerInfoStore.lastFilterSetsUpdateDate, .distantPast)
 
         // WHEN
-        try await updateManager.updateData(datasetType: .filterSet).value
+        await updateManager.updateData(datasetType: .filterSet).value
 
         // THEN
         XCTAssertNotEqual(updateManagerInfoStore.lastFilterSetsUpdateDate, .distantPast)
@@ -545,11 +546,11 @@ class MaliciousSiteProtectionUpdateManagerTests: XCTestCase {
     func testWhenUpdateDataForDatasetTypeIsCalled_AndTypeIsHashPrefix_AndDatasetIsNotUpdated_ThenDoNotSaveUpdateDate() async throws {
         // GIVEN
         dataManager = MockMaliciousSiteProtectionDataManager(storeDatasetSuccess: false)
-        updateManager = MaliciousSiteProtection.UpdateManager(apiClient: apiClient, dataManager: dataManager, updateInfoStorage: updateManagerInfoStore, updateIntervalProvider: { self.updateIntervalProvider($0) })
+        updateManager = MaliciousSiteProtection.UpdateManager(apiClient: apiClient, dataManager: dataManager, eventMapping: mockEventMapping, updateInfoStorage: updateManagerInfoStore, updateIntervalProvider: { self.updateIntervalProvider($0) }, supportedThreatsProvider: { return self.isScamProtectionSupported ? ThreatKind.allCases : ThreatKind.allCases.filter { $0 != .scam } })
         XCTAssertEqual(updateManagerInfoStore.lastHashPrefixSetsUpdateDate, .distantPast)
 
         // WHEN
-        try await updateManager.updateData(datasetType: .hashPrefixSet).value
+        await updateManager.updateData(datasetType: .hashPrefixSet).value
 
         // THEN
         XCTAssertEqual(updateManagerInfoStore.lastHashPrefixSetsUpdateDate, .distantPast)
@@ -558,11 +559,11 @@ class MaliciousSiteProtectionUpdateManagerTests: XCTestCase {
     func testWhenUpdateDataForDatasetTypeIsCalled_AndTypeIsFilterSet_AndDatasetIsNotUpdated_ThenDoNotSaveUpdateDate() async throws {
         // GIVEN
         dataManager = MockMaliciousSiteProtectionDataManager(storeDatasetSuccess: false)
-        updateManager = MaliciousSiteProtection.UpdateManager(apiClient: apiClient, dataManager: dataManager, updateInfoStorage: updateManagerInfoStore, updateIntervalProvider: { self.updateIntervalProvider($0) })
+        updateManager = MaliciousSiteProtection.UpdateManager(apiClient: apiClient, dataManager: dataManager, eventMapping: mockEventMapping, updateInfoStorage: updateManagerInfoStore, updateIntervalProvider: { self.updateIntervalProvider($0) }, supportedThreatsProvider: { return self.isScamProtectionSupported ? ThreatKind.allCases : ThreatKind.allCases.filter{ $0 != .scam } })
         XCTAssertEqual(updateManagerInfoStore.lastFilterSetsUpdateDate, .distantPast)
 
         // WHEN
-        try await updateManager.updateData(datasetType: .hashPrefixSet).value
+        await updateManager.updateData(datasetType: .hashPrefixSet).value
 
         // THEN
         XCTAssertEqual(updateManagerInfoStore.lastFilterSetsUpdateDate, .distantPast)

--- a/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/Mocks/MockMaliciousSiteProtectionDataManager.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/Mocks/MockMaliciousSiteProtectionDataManager.swift
@@ -40,6 +40,12 @@ actor MockMaliciousSiteProtectionDataManager: MaliciousSiteProtection.DataManagi
         return store[key.dataType] as? DataKey.DataSet ?? .init(revision: 0, items: [])
     }
 
+    public func updateDataSet<DataKey>(with key: DataKey, changeSet: APIClient.ChangeSetResponse<DataKey.DataSet.Element>) async throws where DataKey : MaliciousSiteDataKey {
+        var dataSet = self.dataSet(for: key)
+        dataSet.apply(changeSet)
+        try await store(dataSet, for: key)
+    }
+
     func store<DataKey>(_ dataSet: DataKey.DataSet, for key: DataKey) async throws where DataKey: MaliciousSiteProtection.MaliciousSiteDataKey {
         if storeDatasetSuccess {
             store[key.dataType] = dataSet

--- a/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/Mocks/MockMaliciousSiteProtectionDataManager.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/Mocks/MockMaliciousSiteProtectionDataManager.swift
@@ -40,7 +40,7 @@ actor MockMaliciousSiteProtectionDataManager: MaliciousSiteProtection.DataManagi
         return store[key.dataType] as? DataKey.DataSet ?? .init(revision: 0, items: [])
     }
 
-    public func updateDataSet<DataKey>(with key: DataKey, changeSet: APIClient.ChangeSetResponse<DataKey.DataSet.Element>) async throws where DataKey : MaliciousSiteDataKey {
+    public func updateDataSet<DataKey>(with key: DataKey, changeSet: APIClient.ChangeSetResponse<DataKey.DataSet.Element>) async throws where DataKey: MaliciousSiteDataKey {
         var dataSet = self.dataSet(for: key)
         dataSet.apply(changeSet)
         try await store(dataSet, for: key)

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -988,6 +988,7 @@
 		9FCFCD852C75C91A006EB7A0 /* ProgressBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCFCD842C75C91A006EB7A0 /* ProgressBarView.swift */; };
 		9FD1BDEC2D8C183C002F4EFE /* OnboardingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD1BDEB2D8C183C002F4EFE /* OnboardingManagerTests.swift */; };
 		9FD1BDED2D8C183C002F4EFE /* OnboardingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD1BDEB2D8C183C002F4EFE /* OnboardingManagerTests.swift */; };
+		9FDD72052D895D8C0016246B /* CombineSchedulers in Frameworks */ = {isa = PBXBuildFile; productRef = 9FDD72042D895D8C0016246B /* CombineSchedulers */; };
 		9FDEC7B42C8FD62F00C7A692 /* OnboardingAddressBarPositionPickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FDEC7B32C8FD62F00C7A692 /* OnboardingAddressBarPositionPickerViewModelTests.swift */; };
 		9FDEC7B62C8FDFD600C7A692 /* OnboardingManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FDEC7B52C8FDFD600C7A692 /* OnboardingManagerMock.swift */; };
 		9FDEC7B82C9004D600C7A692 /* OnboardingIntroViewModel+Copy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FDEC7B72C9004D600C7A692 /* OnboardingIntroViewModel+Copy.swift */; };
@@ -3649,6 +3650,7 @@
 				4BC95E7F2D7416C1002FAB32 /* PrivacyDashboard in Frameworks */,
 				31E69A63280F4CB600478327 /* DuckUI in Frameworks */,
 				F42D541D29DCA40B004C4FF1 /* DesignResourcesKit in Frameworks */,
+				9FDD72052D895D8C0016246B /* CombineSchedulers in Frameworks */,
 				9F254AF12CF8D5250063B308 /* MaliciousSiteProtection in Frameworks */,
 				F4D7F634298C00C3006C3AE9 /* FindInPageIOSJSSupport in Frameworks */,
 				4B94B79E2D4831D90014AAB8 /* SyncUI-iOS in Frameworks */,
@@ -7953,6 +7955,7 @@
 				4BC95E7C2D7416B2002FAB32 /* Onboarding */,
 				4BC95E7E2D7416C1002FAB32 /* PrivacyDashboard */,
 				4BC95EC42D7418B2002FAB32 /* NetworkProtection */,
+				9FDD72042D895D8C0016246B /* CombineSchedulers */,
 			);
 			productName = DuckDuckGo;
 			productReference = 84E341921E2F7EFB00BDBA6F /* DuckDuckGo.app */;
@@ -8345,6 +8348,7 @@
 				9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */,
 				4BC8948A2C7902E6009AA141 /* XCRemoteSwiftPackageReference "wireguard-apple" */,
 				84EFBCCA2D817CB500706739 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
+				9FDD72032D895D8C0016246B /* XCRemoteSwiftPackageReference "combine-schedulers" */,
 			);
 			productRefGroup = 84E341931E2F7EFB00BDBA6F /* Products */;
 			projectDirPath = "";
@@ -13018,6 +13022,14 @@
 				version = 4.5.1;
 			};
 		};
+		9FDD72032D895D8C0016246B /* XCRemoteSwiftPackageReference "combine-schedulers" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pointfreeco/combine-schedulers.git";
+			requirement = {
+				kind = exactVersion;
+				version = 1.0.3;
+			};
+		};
 		B6F997C22B8F374300476735 /* XCRemoteSwiftPackageReference "apple-toolbox" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/apple-toolbox.git";
@@ -13343,6 +13355,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */;
 			productName = Lottie;
+		};
+		9FDD72042D895D8C0016246B /* CombineSchedulers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9FDD72032D895D8C0016246B /* XCRemoteSwiftPackageReference "combine-schedulers" */;
+			productName = CombineSchedulers;
 		};
 		B6DFE6D52BC7E47F00A9CE59 /* SwiftLintTool */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/iOS/DuckDuckGo/AppServices/MaliciousSiteProtectionService.swift
+++ b/iOS/DuckDuckGo/AppServices/MaliciousSiteProtectionService.swift
@@ -31,13 +31,14 @@ final class MaliciousSiteProtectionService {
     init(featureFlagger: FeatureFlagger) {
         let maliciousSiteProtectionAPI = MaliciousSiteProtectionAPI()
 
+        // If Application Support directory is not available leave a trail in crash logs.
+        guard let applicationSupportDirectory = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            fatalError("Could not found Application Support directory for Malicious Site Protection")
+        }
+
         let maliciousSiteProtectionDataManager = MaliciousSiteProtection.DataManager(
             fileStore: MaliciousSiteProtection.FileStore(
-                dataStoreURL: FileManager.default.urls(
-                    for: .applicationSupportDirectory,
-                    in: .userDomainMask
-                )
-                .first!
+                dataStoreURL: applicationSupportDirectory
             ),
             embeddedDataProvider: nil,
             fileNameProvider: MaliciousSiteProtectionManager.fileName(for:)

--- a/iOS/DuckDuckGo/AppServices/MaliciousSiteProtectionService.swift
+++ b/iOS/DuckDuckGo/AppServices/MaliciousSiteProtectionService.swift
@@ -81,11 +81,14 @@ final class MaliciousSiteProtectionService {
             supportedThreatsProvider: supportedThreatsProvider
         )
 
-        maliciousSiteProtectionDatasetsFetcher.registerBackgroundRefreshTaskHandler()
+        Task { @MainActor in
+            maliciousSiteProtectionDatasetsFetcher.registerBackgroundRefreshTaskHandler()
+        }
     }
 
     // MARK: - Resume
 
+    @MainActor
     func resume() {
         manager.startFetching()
     }

--- a/iOS/DuckDuckGo/AppServices/MaliciousSiteProtectionService.swift
+++ b/iOS/DuckDuckGo/AppServices/MaliciousSiteProtectionService.swift
@@ -81,8 +81,7 @@ final class MaliciousSiteProtectionService {
             supportedThreatsProvider: supportedThreatsProvider
         )
 
-        // Register Malicious Site Protection background tasks to fetch datasets
-        manager.registerBackgroundRefreshTaskHandler()
+        maliciousSiteProtectionDatasetsFetcher.registerBackgroundRefreshTaskHandler()
     }
 
     // MARK: - Resume

--- a/iOS/DuckDuckGo/MaliciousSiteProtection/MaliciousSiteProtectionManager.swift
+++ b/iOS/DuckDuckGo/MaliciousSiteProtection/MaliciousSiteProtectionManager.swift
@@ -60,10 +60,6 @@ extension MaliciousSiteProtectionManager: MaliciousSiteProtectionDatasetsFetchin
         dataFetcher.startFetching()
     }
     
-    func registerBackgroundRefreshTaskHandler() {
-        dataFetcher.registerBackgroundRefreshTaskHandler()
-    }
-    
 }
 
 // MARK: - MaliciousSiteDetecting

--- a/iOS/DuckDuckGo/MaliciousSiteProtection/MaliciousSiteProtectionManager.swift
+++ b/iOS/DuckDuckGo/MaliciousSiteProtection/MaliciousSiteProtectionManager.swift
@@ -56,7 +56,9 @@ final class MaliciousSiteProtectionManager {
 
 extension MaliciousSiteProtectionManager: MaliciousSiteProtectionDatasetsFetching {
 
-    func startFetching() {
+    @MainActor
+    @discardableResult
+    func startFetching() -> Task<Void, Error> {
         dataFetcher.startFetching()
     }
     

--- a/iOS/DuckDuckGo/MaliciousSiteProtection/Services/Logger+MaliciousSiteProtection.swift
+++ b/iOS/DuckDuckGo/MaliciousSiteProtection/Services/Logger+MaliciousSiteProtection.swift
@@ -22,7 +22,7 @@ import os.log
 
 extension Logger {
     enum MaliciousSiteProtection {
-        static let datasetsFetcher = Logger(subsystem: "MalSite", category: "DatasetsFetcher")
-        static let manager = Logger(subsystem: "MalSite", category: "Manager")
+        static let datasetsFetcher = Logger(subsystem: "MSP", category: "DatasetsFetcher")
+        static let manager = Logger(subsystem: "MSP", category: "Manager")
     }
 }

--- a/iOS/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionDatasetsFetcher.swift
+++ b/iOS/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionDatasetsFetcher.swift
@@ -44,7 +44,7 @@ final class MaliciousSiteProtectionDatasetsFetcher {
     private static var registeredTaskIdentifiers: Set<String> = []
 
     @MainActor
-    private(set) var inFlyUpdateTasks: [DataManager.StoredDataType.Kind: Task<Void, any Error>] = [:]
+    private(set) var inFlyUpdateTasks: [DataManager.StoredDataType.Kind: Task<Void, Never>] = [:]
 
     private var preferencesManagerCancellable: AnyCancellable?
     private var featureFlagOverrideCancellable: AnyCancellable?
@@ -95,7 +95,7 @@ extension MaliciousSiteProtectionDatasetsFetcher: MaliciousSiteProtectionDataset
     func startFetching() -> Task<Void, Error> {
         guard canFetchDatasets else { return Task {} }
 
-        var updateTasksToReturn: [Task<Void, Error>] = []
+        var updateTasksToReturn: [Task<Void, Never>] = []
 
         Logger.MaliciousSiteProtection.datasetsFetcher.debug("Feature is On and Enabled in App Settings")
 
@@ -105,7 +105,7 @@ extension MaliciousSiteProtectionDatasetsFetcher: MaliciousSiteProtectionDataset
             let task = updateManager.updateData(datasetType: .hashPrefixSet)
             inFlyUpdateTasks[.hashPrefixSet] = task
             Task {
-                try? await task.value
+                await task.value
                 inFlyUpdateTasks[.hashPrefixSet] = nil
             }
             updateTasksToReturn.append(task)
@@ -117,7 +117,7 @@ extension MaliciousSiteProtectionDatasetsFetcher: MaliciousSiteProtectionDataset
             let task = updateManager.updateData(datasetType: .filterSet)
             inFlyUpdateTasks[.filterSet] = task
             Task {
-                try? await task.value
+                await task.value
                 inFlyUpdateTasks[.filterSet] = nil
             }
             updateTasksToReturn.append(task)
@@ -125,7 +125,7 @@ extension MaliciousSiteProtectionDatasetsFetcher: MaliciousSiteProtectionDataset
 
         return Task {
             for task in updateTasksToReturn {
-                try await task.value
+                await task.value
             }
         }
     }

--- a/iOS/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionDatasetsFetcher.swift
+++ b/iOS/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionDatasetsFetcher.swift
@@ -44,7 +44,7 @@ final class MaliciousSiteProtectionDatasetsFetcher {
     private static var registeredTaskIdentifiers: Set<String> = []
 
     @MainActor
-    private(set) var inFlyUpdateTasks: [DataManager.StoredDataType.Kind: Task<Void, Never>] = [:]
+    private(set) var isDatasetsFetchInProgress: Bool = false
 
     private var preferencesManagerCancellable: AnyCancellable?
     private var featureFlagOverrideCancellable: AnyCancellable?
@@ -52,14 +52,12 @@ final class MaliciousSiteProtectionDatasetsFetcher {
     @MainActor
     private var shouldUpdateHashPrefixSets: Bool {
         // Absolute interval to avoid never updating the dataset if the `lastHashPrefixSetUpdateDate` is mistakenly set in the far future
-        inFlyUpdateTasks[.hashPrefixSet] == nil &&
         abs(dateProvider().timeIntervalSince(updateManager.lastHashPrefixSetUpdateDate)) > .minutes(featureFlagger.hashPrefixUpdateFrequency)
     }
 
     @MainActor
     private var shouldUpdateFilterSets: Bool {
         // Absolute interval to avoid never updating the dataset if the `lastFilterSetUpdateDate` is mistakenly set in the far future
-        inFlyUpdateTasks[.filterSet] == nil &&
         abs(dateProvider().timeIntervalSince(updateManager.lastFilterSetUpdateDate)) > .minutes(featureFlagger.filterSetUpdateFrequency)
     }
 
@@ -93,39 +91,30 @@ extension MaliciousSiteProtectionDatasetsFetcher: MaliciousSiteProtectionDataset
     @MainActor
     @discardableResult
     func startFetching() -> Task<Void, Error> {
-        guard canFetchDatasets else { return Task {} }
-
-        var updateTasksToReturn: [Task<Void, Never>] = []
-
-        Logger.MaliciousSiteProtection.datasetsFetcher.debug("Feature is On and Enabled in App Settings")
-
-        // If hashPrefix Sets need to be updated fetch them
-        if shouldUpdateHashPrefixSets {
-            Logger.MaliciousSiteProtection.datasetsFetcher.debug("Downloading HashPrefixSets")
-            let task = updateManager.updateData(datasetType: .hashPrefixSet)
-            inFlyUpdateTasks[.hashPrefixSet] = task
-            Task {
-                await task.value
-                inFlyUpdateTasks[.hashPrefixSet] = nil
-            }
-            updateTasksToReturn.append(task)
+        guard
+            canFetchDatasets,
+            !isDatasetsFetchInProgress
+        else {
+            return Task {}
         }
 
-        // If hashPrefix Sets need to be updated fetch them
-        if shouldUpdateFilterSets {
-            Logger.MaliciousSiteProtection.datasetsFetcher.debug("Downloading FilterSets")
-            let task = updateManager.updateData(datasetType: .filterSet)
-            inFlyUpdateTasks[.filterSet] = task
-            Task {
-                await task.value
-                inFlyUpdateTasks[.filterSet] = nil
-            }
-            updateTasksToReturn.append(task)
-        }
+        isDatasetsFetchInProgress = shouldUpdateHashPrefixSets || shouldUpdateFilterSets
+        Logger.MaliciousSiteProtection.datasetsFetcher.debug("Start Updating Datasets...")
 
         return Task {
-            for task in updateTasksToReturn {
-                await task.value
+            // If hashPrefix Sets need to be updated fetch them
+            if shouldUpdateHashPrefixSets {
+                Logger.MaliciousSiteProtection.datasetsFetcher.debug("Downloading HashPrefixSets")
+                await updateManager.updateData(datasetType: .hashPrefixSet).value
+                // Reset the flag to false only if FilterSets don't have to be fetched.
+                isDatasetsFetchInProgress = shouldUpdateFilterSets
+            }
+
+            // If hashPrefix Sets need to be updated fetch them
+            if shouldUpdateFilterSets {
+                Logger.MaliciousSiteProtection.datasetsFetcher.debug("Downloading FilterSets")
+                await updateManager.updateData(datasetType: .filterSet).value
+                isDatasetsFetchInProgress = false
             }
         }
     }

--- a/iOS/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionDatasetsFetcher.swift
+++ b/iOS/DuckDuckGo/MaliciousSiteProtection/Services/MaliciousSiteProtectionDatasetsFetcher.swift
@@ -102,19 +102,18 @@ extension MaliciousSiteProtectionDatasetsFetcher: MaliciousSiteProtectionDataset
         Logger.MaliciousSiteProtection.datasetsFetcher.debug("Start Updating Datasets...")
 
         return Task {
+            defer { isDatasetsFetchInProgress = false }
+
             // If hashPrefix Sets need to be updated fetch them
             if shouldUpdateHashPrefixSets {
                 Logger.MaliciousSiteProtection.datasetsFetcher.debug("Downloading HashPrefixSets")
                 await updateManager.updateData(datasetType: .hashPrefixSet).value
-                // Reset the flag to false only if FilterSets don't have to be fetched.
-                isDatasetsFetchInProgress = shouldUpdateFilterSets
             }
 
             // If hashPrefix Sets need to be updated fetch them
             if shouldUpdateFilterSets {
                 Logger.MaliciousSiteProtection.datasetsFetcher.debug("Downloading FilterSets")
                 await updateManager.updateData(datasetType: .filterSet).value
-                isDatasetsFetchInProgress = false
             }
         }
     }

--- a/iOS/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionDatasetsFetcherTests.swift
+++ b/iOS/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionDatasetsFetcherTests.swift
@@ -24,7 +24,7 @@ import enum UIKit.UIBackgroundRefreshStatus
 import CombineSchedulers
 @testable import DuckDuckGo
 
-@Suite("Malicious Site Protection - Feature Flags")
+@Suite("Malicious Site Protection - Datasets Fetcher")
 final class MaliciousSiteProtectionDatasetsFetcherTests {
     private var sut: MaliciousSiteProtectionDatasetsFetcher!
     private var updateManagerMock: MockMaliciousSiteProtectionUpdateManager!

--- a/iOS/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionDatasetsFetcherTests.swift
+++ b/iOS/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionDatasetsFetcherTests.swift
@@ -35,6 +35,7 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
 
     init() {
         setupSUT()
+        MaliciousSiteProtectionDatasetsFetcher.resetRegisteredTaskIdentifiers()
     }
 
     func setupSUT(
@@ -271,7 +272,28 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         sut.registerBackgroundRefreshTaskHandler()
 
         // THEN
-        #expect(backgroundSchedulerMock.capturedRegisteredTaskIdentifiers == expectedBackgroundTasksIdentifiers)
+        #expect(backgroundSchedulerMock.capturedRegisteredTaskIdentifiers[expectedBackgroundTasksIdentifiers[0]] != nil)
+        #expect(backgroundSchedulerMock.capturedRegisteredTaskIdentifiers[expectedBackgroundTasksIdentifiers[1]] != nil)
+    }
+
+    @Test("Prevent register Background Tasks multiple times When RegisterBackgroundTasksIsCalled")
+    func whenRegisterBackgroundTasksIsCalledThenItAsksDataFetcherToRegisterBackgroundTasks() {
+        // GIVEN
+        #expect(backgroundSchedulerMock.capturedRegisteredTaskIdentifiers.isEmpty)
+
+        // WHEN registering the first time
+        sut.registerBackgroundRefreshTaskHandler()
+
+        // THEN
+        #expect(backgroundSchedulerMock.capturedRegisteredTaskIdentifiers["com.duckduckgo.app.maliciousSiteProtectionHashPrefixSetRefresh"] == 1)
+        #expect(backgroundSchedulerMock.capturedRegisteredTaskIdentifiers["com.duckduckgo.app.maliciousSiteProtectionFilterSetRefresh"] == 1)
+
+        // WHEN registering a second time
+        sut.registerBackgroundRefreshTaskHandler()
+
+        // THEN there are no more registration happening
+        #expect(backgroundSchedulerMock.capturedRegisteredTaskIdentifiers["com.duckduckgo.app.maliciousSiteProtectionHashPrefixSetRefresh"] == 1)
+        #expect(backgroundSchedulerMock.capturedRegisteredTaskIdentifiers["com.duckduckgo.app.maliciousSiteProtectionFilterSetRefresh"] == 1)
     }
 
     @Test(

--- a/iOS/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionDatasetsFetcherTests.swift
+++ b/iOS/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionDatasetsFetcherTests.swift
@@ -72,7 +72,7 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
 
     @MainActor
     @Test("Fetch Datasets When Feature Is Enabled and User Turned On the Feature")
-    func whenStartFetchingCalled_AndFeatureEnabled_AndPreferencesEnabled_ThenStartUpdateTask() {
+    func whenStartFetchingCalled_AndFeatureEnabled_AndPreferencesEnabled_ThenStartUpdateTask() async throws {
         // GIVEN
         featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
@@ -81,7 +81,7 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         #expect(updateManagerMock.updateDatasets[.filterSet] == false)
 
         // WHEN
-        sut.startFetching()
+        try await sut.startFetching().value
 
         // THEN
         #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == true)
@@ -124,7 +124,7 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
 
     @MainActor
     @Test("Fetch Hash Prefix Dataset When Start Fetching Is Called And Last Update Date Is Greater Than Update Interval")
-    func whenStartFetchingCalled_AndLastHashPrefixSetUpdateDateIsGreaterThanUpdateInterval_ThenFetchHashPrefixSet() {
+    func whenStartFetchingCalled_AndLastHashPrefixSetUpdateDateIsGreaterThanUpdateInterval_ThenFetchHashPrefixSet() async throws {
         // GIVEN
         let timeTraveller = TimeTraveller()
         timeTraveller.advanceBy(-.minutes(6))
@@ -138,7 +138,7 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         #expect(updateManagerMock.updateDatasets[.filterSet] == false)
 
         // WHEN
-        sut.startFetching()
+        try await sut.startFetching().value
 
         // THEN
         #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == true)
@@ -147,7 +147,7 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
 
     @MainActor
     @Test("Fetch Filter Dataset When Start Fetching Is Called And Last Update Date Is Greater Than Update Interval")
-    func whenStartFetchingCalled_AndLastFilterSetUpdateDateIsGreaterThanUpdateInterval_ThenFetchHashPrefixSet() {
+    func whenStartFetchingCalled_AndLastFilterSetUpdateDateIsGreaterThanUpdateInterval_ThenFetchHashPrefixSet() async throws {
         // GIVEN
         let timeTraveller = TimeTraveller()
         timeTraveller.advanceBy(-.minutes(11))
@@ -161,7 +161,7 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         #expect(updateManagerMock.updateDatasets[.filterSet] == false)
 
         // WHEN
-        sut.startFetching()
+        try await sut.startFetching().value
 
         // THEN
         #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
@@ -179,27 +179,80 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
         featureFlaggerMock.hashPrefixUpdateFrequency = 1 // Value expressed in minutes
         featureFlaggerMock.filterSetUpdateFrequency = 1 // Value expressed in minutes
-        #expect(sut.inFlyUpdateTasks.isEmpty)
+        #expect(!sut.isDatasetsFetchInProgress)
 
         // WHEN
         let firstCallTask = sut.startFetching()
 
         // THEN
-        #expect(sut.inFlyUpdateTasks.count == 2)
+        #expect(sut.isDatasetsFetchInProgress)
 
         // WHEN
         let secondCallTask = sut.startFetching()
 
+        // THEN
         try await firstCallTask.value
         try await secondCallTask.value
 
         #expect(updateManagerMock.updateCallCount == 2)
-        #expect(sut.inFlyUpdateTasks.isEmpty)
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == true)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == true)
+        #expect(!sut.isDatasetsFetchInProgress)
+    }
+
+    @MainActor
+    @Test("Check Fetching Only HashPrefix Reset InProgress Flag to False When Finishing Update")
+    func whenStartFetchingCalled_AndOnlyHashPrefixNeedsUpdate_ThenResetInProgressFlagWhenUpdateFinishes() async throws {
+        // GIVEN
+        updateManagerMock.lastHashPrefixSetUpdateDate = .distantPast
+        updateManagerMock.lastFilterSetUpdateDate = .now
+        updateManagerMock.updateDataTaskExecutionTime = 0.5
+        featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+        featureFlaggerMock.hashPrefixUpdateFrequency = 1 // Value expressed in minutes
+        featureFlaggerMock.filterSetUpdateFrequency = 1 // Value expressed in minutes
+        #expect(!sut.isDatasetsFetchInProgress)
+
+        // WHEN
+        let task = sut.startFetching()
+        #expect(sut.isDatasetsFetchInProgress)
+
+        // THEN
+        try await task.value
+        #expect(updateManagerMock.updateCallCount == 1)
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == true)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == false)
+        #expect(!sut.isDatasetsFetchInProgress)
+    }
+
+    @MainActor
+    @Test("Check Fetching Only FilterSet Reset InProgress Flag to False When Finishing Update")
+    func whenStartFetchingCalled_AndOnlyFilterSetNeedsUpdate_ThenResetInProgressFlagWhenUpdateFinishes() async throws {
+        // GIVEN
+        updateManagerMock.lastHashPrefixSetUpdateDate = .now
+        updateManagerMock.lastFilterSetUpdateDate = .distantPast
+        updateManagerMock.updateDataTaskExecutionTime = 0.5
+        featureFlaggerMock.isMaliciousSiteProtectionEnabled = true
+        userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
+        featureFlaggerMock.hashPrefixUpdateFrequency = 1 // Value expressed in minutes
+        featureFlaggerMock.filterSetUpdateFrequency = 1 // Value expressed in minutes
+        #expect(!sut.isDatasetsFetchInProgress)
+
+        // WHEN
+        let task = sut.startFetching()
+        #expect(sut.isDatasetsFetchInProgress)
+
+        // THEN
+        try await task.value
+        #expect(updateManagerMock.updateCallCount == 1)
+        #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
+        #expect(updateManagerMock.updateDatasets[.filterSet] == true)
+        #expect(!sut.isDatasetsFetchInProgress)
     }
 
     @MainActor
     @Test("Fetch Datasets When Update Interval Becomes Greater Than Last Update Interval")
-    func whenStartFetchingCalled_AndUpdateIntervalBecomesGraterThanLastUpdateDate_ThenFetchDatasets() {
+    func whenStartFetchingCalled_AndUpdateIntervalBecomesGraterThanLastUpdateDate_ThenFetchDatasets() async throws {
         // GIVEN
         updateManagerMock.lastHashPrefixSetUpdateDate = timeTraveller.getDate()
         updateManagerMock.lastFilterSetUpdateDate = timeTraveller.getDate()
@@ -213,7 +266,7 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
 
         // WHEN
         timeTraveller.advanceBy(.minutes(16))
-        sut.startFetching()
+        try await sut.startFetching().value
 
         // THEN
         #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == true)
@@ -238,7 +291,7 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
 
     @MainActor
     @Test("Start Fetching Datasets When User Turns On the Feature And Last Update Is Greater Than Update Interval")
-    func whenPreferencesEnabled_AndLastUpdateDateIsGreaterThanUpdateInterval_ThenStartUpdateTask() {
+    func whenPreferencesEnabled_AndLastUpdateDateIsGreaterThanUpdateInterval_ThenStartUpdateTask() async {
         // GIVEN
         updateManagerMock.lastHashPrefixSetUpdateDate = .distantPast
         updateManagerMock.lastFilterSetUpdateDate = .distantPast
@@ -248,19 +301,24 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         sut.registerBackgroundRefreshTaskHandler()
         #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
         #expect(updateManagerMock.updateDatasets[.filterSet] == false)
+        let expectation = Expectation()
+        updateManagerMock.onUpdateDatasets = {
+            expectation.fulfill()
+        }
 
         // WHEN
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
 
         // TRUE
-        preferencesScheduler.advance(by: .seconds(1))
+        await preferencesScheduler.advance(by: .seconds(1))
+        #expect(await expectation.wait(timeout: 0.1))
         #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == true)
         #expect(updateManagerMock.updateDatasets[.filterSet] == true)
     }
 
     @MainActor
     @Test("Check Multiple Preferences Settings Toggles And Final Preference is On Starts Fetching Tasks Only Once")
-    func whenPreferencesEnabledAndDisabledMultipleTimes_AndFinalPreferencesOn_ThenDoNotStartUpdateTask() {
+    func whenPreferencesEnabledAndDisabledMultipleTimes_AndFinalPreferencesOn_ThenDoNotStartUpdateTask() async {
         // GIVEN
         updateManagerMock.lastHashPrefixSetUpdateDate = .distantPast
         updateManagerMock.lastFilterSetUpdateDate = .distantPast
@@ -270,6 +328,10 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         sut.registerBackgroundRefreshTaskHandler()
         #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
         #expect(updateManagerMock.updateDatasets[.filterSet] == false)
+        let expectation = Expectation()
+        updateManagerMock.onUpdateDatasets = {
+            expectation.fulfill()
+        }
 
         // WHEN
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
@@ -279,14 +341,16 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
 
         // TRUE
-        preferencesScheduler.advance(by: .seconds(1))
+        await preferencesScheduler.advance(by: .seconds(1))
+        #expect(await expectation.wait(timeout: 0.1))
+        #expect(updateManagerMock.updateCallCount == 2)
         #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == true)
         #expect(updateManagerMock.updateDatasets[.filterSet] == true)
     }
 
     @MainActor
     @Test("Check Multiple Preferences Settings Toggles And Final Preference is Off Does Not Start Fetching Tasks")
-    func whenPreferencesEnabledAndDisabledMultipleTimes_AndFinalPreferencesOff_ThenDoNotStartUpdateTask() {
+    func whenPreferencesEnabledAndDisabledMultipleTimes_AndFinalPreferencesOff_ThenDoNotStartUpdateTask() async {
         // GIVEN
         updateManagerMock.lastHashPrefixSetUpdateDate = .distantPast
         updateManagerMock.lastFilterSetUpdateDate = .distantPast
@@ -296,6 +360,10 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         sut.registerBackgroundRefreshTaskHandler()
         #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
         #expect(updateManagerMock.updateDatasets[.filterSet] == false)
+        let expectation = Expectation(isInverted: true)
+        updateManagerMock.onUpdateDatasets = {
+            expectation.fulfill()
+        }
 
         // WHEN
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = true
@@ -306,7 +374,9 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         userPreferencesManagerMock.isMaliciousSiteProtectionOn = false
 
         // TRUE
-        preferencesScheduler.advance(by: .seconds(1))
+        await preferencesScheduler.advance(by: .seconds(1))
+        #expect(await expectation.wait(timeout: 0.1))
+        #expect(updateManagerMock.updateCallCount == 0)
         #expect(updateManagerMock.updateDatasets[.hashPrefixSet] == false)
         #expect(updateManagerMock.updateDatasets[.filterSet] == false)
     }
@@ -556,4 +626,51 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         #expect(backgroundSchedulerMock.didCallCancelTaskRequestWithIdentifier)
     }
 
+}
+
+// Workaround to wait on unstructured task in tests
+private final class Expectation {
+    private var isFulfilled = false
+    private var isFulfilledCalled: Bool = false
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isInverted: Bool
+
+    init(isInverted: Bool = false) {
+        self.isInverted = isInverted
+    }
+
+    func fulfill() {
+        isFulfilledCalled = true
+
+        if isInverted {
+            isFulfilled = false
+        } else {
+            isFulfilled = true
+        }
+
+        continuation?.resume()
+    }
+
+    func wait(timeout: TimeInterval) async -> Bool {
+        if !isInverted && isFulfilled {
+            return true
+        }
+
+        if isInverted && isFulfilledCalled {
+            return false
+        }
+
+        let task = Task {
+            try? await Task.sleep(interval: timeout)
+            continuation?.resume()
+        }
+
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+
+        task.cancel()
+
+        return isInverted ? !isFulfilledCalled : isFulfilled
+    }
 }

--- a/iOS/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionManagerTests.swift
+++ b/iOS/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionManagerTests.swift
@@ -67,18 +67,6 @@ final class MaliciousSiteProtectionManagerTests {
         #expect(dataFetcherMock.didCallStartFetching)
     }
 
-    @Test("Register Background Tasks Asks DatasetsFetcher to Register Background Tasks")
-    func whenRegisterBackgroundTasksIsCalledThenItAsksDataFetcherToRegisterBackgroundTasks() {
-        // GIVEN
-        #expect(!dataFetcherMock.didCallRegisterBackgroundRefreshTaskHandler)
-
-        // WHEN
-        sut.registerBackgroundRefreshTaskHandler()
-
-        // THEN
-        #expect(dataFetcherMock.didCallRegisterBackgroundRefreshTaskHandler)
-    }
-
     @Test(
         "No Threat Detected when Feature is disabled",
         arguments: [

--- a/iOS/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionManagerTests.swift
+++ b/iOS/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionManagerTests.swift
@@ -22,7 +22,7 @@ import Foundation
 import MaliciousSiteProtection
 @testable import DuckDuckGo
 
-@Suite("Malicious Site Protection - Manager", .serialized)
+@Suite("Malicious Site Protection - Manager")
 final class MaliciousSiteProtectionManagerTests {
     private var sut: MaliciousSiteProtectionManager!
     private var mockDetector: MockMaliciousSiteDetector!
@@ -55,6 +55,7 @@ final class MaliciousSiteProtectionManagerTests {
         )
     }
 
+    @MainActor
     @Test("Start Fetching Datasets Asks DatasetsFetcher To Fetch Data")
     func whenStartFetchingDatasetsIsCalledThenItAsksDataFetcherToFetchData() {
         // GIVEN

--- a/iOS/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
+++ b/iOS/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
@@ -30,17 +30,26 @@ final class MockMaliciousSiteProtectionUpdateManager: MaliciousSiteUpdateManagin
         .hashPrefixSet: false,
         .filterSet: false
     ]
+    private(set) var updateCallCount = 0
 
     var lastHashPrefixSetUpdateDate: Date = .distantPast
     var lastFilterSetUpdateDate: Date = .distantPast
+
+    var updateDataTaskExecutionTime: TimeInterval = 0
 
     func startPeriodicUpdates() -> Task<Void, any Error> {
         Task { }
     }
     
     func updateData(datasetType: MaliciousSiteProtection.DataManager.StoredDataType.Kind) -> Task<Void, any Error> {
+        updateCallCount += 1
         updateDatasets[datasetType] = true
-        return Task { }
+
+        return Task {
+            if updateDataTaskExecutionTime > 0 {
+                try await Task.sleep(interval: updateDataTaskExecutionTime)
+            }
+        }
     }
 }
 
@@ -139,8 +148,11 @@ final class MockMaliciousSiteProtectionDataFetcher: MaliciousSiteProtectionDatas
     private(set) var didCallStartFetching = false
     private(set) var didCallRegisterBackgroundRefreshTaskHandler = false
 
-    func startFetching() {
+    @MainActor
+    @discardableResult
+    func startFetching() -> Task<Void, Error> {
         didCallStartFetching = true
+        return Task {}
     }
     
     func registerBackgroundRefreshTaskHandler() {

--- a/iOS/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
+++ b/iOS/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
@@ -41,13 +41,13 @@ final class MockMaliciousSiteProtectionUpdateManager: MaliciousSiteUpdateManagin
         Task { }
     }
     
-    func updateData(datasetType: MaliciousSiteProtection.DataManager.StoredDataType.Kind) -> Task<Void, any Error> {
+    func updateData(datasetType: MaliciousSiteProtection.DataManager.StoredDataType.Kind) -> Task<Void, Never> {
         updateCallCount += 1
         updateDatasets[datasetType] = true
 
         return Task {
             if updateDataTaskExecutionTime > 0 {
-                try await Task.sleep(interval: updateDataTaskExecutionTime)
+                try? await Task.sleep(interval: updateDataTaskExecutionTime)
             }
         }
     }

--- a/iOS/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
+++ b/iOS/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
@@ -76,7 +76,7 @@ final class MockMaliciousSiteProtectionFeatureFlags: MaliciousSiteProtectionFeat
 }
 
 final class MockBackgroundScheduler: BGTaskScheduling {
-    private(set) var capturedRegisteredTaskIdentifiers: [String] = []
+    private(set) var capturedRegisteredTaskIdentifiers: [String: Int] = [:]
 
     private(set) var didCallSubmitTaskRequest = false
     private(set) var capturedSubmittedTaskRequest: BGTaskRequest?
@@ -90,7 +90,9 @@ final class MockBackgroundScheduler: BGTaskScheduling {
     var launchHandlers: [String: ((BGTaskInterface) -> Void)?] = [:]
 
     func register(forTaskWithIdentifier identifier: String, launchHandler: @escaping (BGTaskInterface) -> Void) -> Bool {
-        capturedRegisteredTaskIdentifiers.append(identifier)
+        var counterForTaskIdentifier = capturedRegisteredTaskIdentifiers[identifier] ?? 0
+        counterForTaskIdentifier += 1
+        capturedRegisteredTaskIdentifiers[identifier] = counterForTaskIdentifier
         self.launchHandlers[identifier] = launchHandler
         return true
     }

--- a/iOS/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
+++ b/iOS/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MaliciousSiteProtectionMocks.swift
@@ -35,6 +35,10 @@ final class MockMaliciousSiteProtectionUpdateManager: MaliciousSiteUpdateManagin
     var lastHashPrefixSetUpdateDate: Date = .distantPast
     var lastFilterSetUpdateDate: Date = .distantPast
 
+    var onUpdateDatasets: (() -> Void)?
+    var onHashPrefixUpdate: (() -> Void)?
+    var onFilterSetUpdate: (() -> Void)?
+
     var updateDataTaskExecutionTime: TimeInterval = 0
 
     func startPeriodicUpdates() -> Task<Void, any Error> {
@@ -44,7 +48,12 @@ final class MockMaliciousSiteProtectionUpdateManager: MaliciousSiteUpdateManagin
     func updateData(datasetType: MaliciousSiteProtection.DataManager.StoredDataType.Kind) -> Task<Void, Never> {
         updateCallCount += 1
         updateDatasets[datasetType] = true
-
+        if datasetType == .hashPrefixSet {
+            onHashPrefixUpdate?()
+        } else if datasetType == .filterSet {
+            onFilterSetUpdate?()
+        }
+        onUpdateDatasets?()
         return Task {
             if updateDataTaskExecutionTime > 0 {
                 try? await Task.sleep(interval: updateDataTaskExecutionTime)

--- a/iOS/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MockMaliciousSiteProtectionManager.swift
+++ b/iOS/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MockMaliciousSiteProtectionManager.swift
@@ -31,10 +31,6 @@ final class MockMaliciousSiteProtectionManager: MaliciousSiteDetecting, Maliciou
         didCallStartFetching = true
     }
 
-    func registerBackgroundRefreshTaskHandler() {
-        didCallRegisterBackgroundRefreshTaskHandler = true
-    }
-
     func evaluate(_ url: URL) async -> MaliciousSiteProtection.ThreatKind? {
         threatKind
     }

--- a/iOS/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MockMaliciousSiteProtectionManager.swift
+++ b/iOS/DuckDuckGoTests/MaliciousSiteProtection/Mocks/MockMaliciousSiteProtectionManager.swift
@@ -27,8 +27,11 @@ final class MockMaliciousSiteProtectionManager: MaliciousSiteDetecting, Maliciou
 
     var threatKind: ThreatKind?
 
-    func startFetching() {
+    @MainActor
+    @discardableResult
+    func startFetching() -> Task<Void, Error> {
         didCallStartFetching = true
+        return Task {}
     }
 
     func evaluate(_ url: URL) async -> MaliciousSiteProtection.ThreatKind? {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206329551987282/1209638992004951/f

### Description

This PR attempts to mitigate crashes happening for Malicious Site Protection by:

1. Use `fatalError` if ApplicationSupportDirectory is unavailable when the DataManager is initialised. This is a slight improvement as the `fatalError` message should be available in the crash logs. [fc3b11f](https://github.com/duckduckgo/apple-browsers/commit/fc3b11ff388d280c2c656a58f70c4abd5744c3c9)

2. Ensure Background Tasks identifiers are registered only once. [9914e8a](https://github.com/duckduckgo/apple-browsers/commit/9914e8a23ce2c8dfbbd8e8206833223e357619ad)

3. Prevent starting new dataset updates if there are already requests in flight. [603ec57](https://github.com/duckduckgo/apple-browsers/commit/603ec576f3f6a7dc0589ba0b70df0826928e8c64)

4. Prevent starting/stopping update tasks multiple times if the user continuously switches the toggle flag in the settings by adding a debounce. [74a20d3](https://github.com/duckduckgo/apple-browsers/commit/74a20d3391064122f658e1569cd3d041d9d36027)

5. Serialise the update of datasets when `updateData` is called [514b260](https://github.com/duckduckgo/apple-browsers/pull/258/commits/514b260b2ce82ff338101483b16664238651fd35) 

### Testing Steps
1. Ensure CI is green
2. Smoke test Malicious Site Protection feature:
2.1 Delete the App.
2.2 Ensure datasets are fetched when the app launches
2.3 Ensure [phishing](http://privacy-test-pages.site/security/badware/phishing.html), [malware](http://privacy-test-pages.site/security/badware/malware.html), and [scam](http://privacy-test-pages.site/security/badware/scam.html) (if the feature is enabled)websites are intercepted and blocked

### Impact and Risks
High:  Cold affect or break a core flow

### Quality Considerations
While the new approach reduces the risk of data races by keeping dataset modifications within the actor's isolation, it introduces a small performance tradeoff. Indeed, the actor remains locked during dataset changes, potentially reducing concurrent access in scenarios where large number of objects need to be inserted, updated, or deleted.

### Notes to Reviewer
I was unable to reproduce the crashes. These changes attempt to address potential root causes, such asaces in dataset operations and system-triggered terminations, such as when possible data or background tasks with the same identifiers are registered more than once.

The crashes appear in Sentry with a SIGKILL 0 signature, indicating that the OS terminated the process. Example crash report:

```
Application Specific Information:
SIGKILL 0
```
These reports lack the termination reason that would typically help identify the underlying cause, as described in [Apple's documentation](https://developer.apple.com/documentation/xcode/sigkill). I’m unsure if this is an issue with Apple's reporting or with how we're integrating with Sentry.
 
@mallexxx I’ve implemented the changes we discussed to make the dataset changes as single operation.
@bwaresiak If you could please take a look at the PR that would be great.
@SabrinaTardio could you just quickly check I didn’t affect your scam work since I had some merge conflicts?  

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)