### PR TITLE
Add keyboard shortcuts to History Delete dialog

### DIFF
--- a/macOS/DuckDuckGo/History/View/Dialogs/HistoryViewDeleteDialog.swift
+++ b/macOS/DuckDuckGo/History/View/Dialogs/HistoryViewDeleteDialog.swift
@@ -66,6 +66,7 @@ struct HistoryViewDeleteDialog: ModalView {
                         .frame(height: 28)
                 }
                 .buttonStyle(StandardButtonStyle(topPadding: 0, bottomPadding: 0))
+                .keyboardShortcut(.cancelAction)
                 .accessibilityIdentifier("ClearAllHistoryAndDataAlert.cancelButton")
 
                 Button {
@@ -78,6 +79,7 @@ struct HistoryViewDeleteDialog: ModalView {
                         .frame(height: 28)
                 }
                 .buttonStyle(DestructiveActionButtonStyle(enabled: true, topPadding: 0, bottomPadding: 0))
+                .keyboardShortcut(.defaultAction)
                 .accessibilityIdentifier("ClearAllHistoryAndDataAlert.clearButton")
 
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199178362774117/1209701864754233/f

### Description
This change brings back the return and escape key functionality to control History Delete Dialog.

### Testing Steps
1. Launch the app from Xcode
2. Press cmd+shift+delete
3. Verify that the dialog to delete all history is presented.
4. Press Escape and verify that the dialog is dismissed.
5. Press cmd+shift+delete again. Press Enter and verify that the dialog is accepted and history is deleted/burned.

### Impact and Risks
Low: just adding keyboard shortcuts.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)