### PR TITLE
Set UA on duck.ai webview

### DIFF
--- a/iOS/LocalPackages/AIChat/Sources/AIChat/AIChatViewModel.swift
+++ b/iOS/LocalPackages/AIChat/Sources/AIChat/AIChatViewModel.swift
@@ -41,10 +41,14 @@ protocol AIChatViewModeling {
 
     /// Path for AI Chat downloads, like exported chat
     var downloadsPath: URL { get }
+
+    /// User Agent to be used on AI Chat
+    var userAgent: String { get }
 }
 
 final class AIChatViewModel: AIChatViewModeling {
     private let settings: AIChatSettingsProvider
+    private let userAgentManager: AIChatUserAgentProviding
     let webViewConfiguration: WKWebViewConfiguration
     let requestAuthHandler: AIChatRequestAuthorizationHandling
     let inspectableWebView: Bool
@@ -54,12 +58,14 @@ final class AIChatViewModel: AIChatViewModeling {
          settings: AIChatSettingsProvider,
          requestAuthHandler: AIChatRequestAuthorizationHandling,
          inspectableWebView: Bool,
-         downloadsPath: URL) {
+         downloadsPath: URL,
+         userAgentManager: AIChatUserAgentProviding) {
         self.webViewConfiguration = webViewConfiguration
         self.settings = settings
         self.requestAuthHandler = requestAuthHandler
         self.inspectableWebView = inspectableWebView
         self.downloadsPath = downloadsPath
+        self.userAgentManager = userAgentManager
     }
 
     var aiChatURL: URL {
@@ -69,5 +75,9 @@ final class AIChatViewModel: AIChatViewModeling {
     @MainActor
     func shouldAllowRequestWithNavigationAction(_ navigationAction: WKNavigationAction) -> Bool {
         requestAuthHandler.shouldAllowRequestWithNavigationAction(navigationAction)
+    }
+
+    var userAgent: String {
+        userAgentManager.userAgent(url: aiChatURL)
     }
 }

--- a/iOS/LocalPackages/AIChat/Sources/AIChat/AIChatWebViewController.swift
+++ b/iOS/LocalPackages/AIChat/Sources/AIChat/AIChatWebViewController.swift
@@ -84,6 +84,7 @@ final class AIChatWebViewController: UIViewController {
 
     private func setupWebView() {
         view.addSubview(webView)
+        webView.customUserAgent = chatModel.userAgent
 
         if #available(iOS 16.4, *) {
             webView.isInspectable = chatModel.inspectableWebView

--- a/iOS/LocalPackages/AIChat/Sources/AIChat/Public API/AIChatUserAgentProviding.swift
+++ b/iOS/LocalPackages/AIChat/Sources/AIChat/Public API/AIChatUserAgentProviding.swift
@@ -1,0 +1,31 @@
+//
+//  AIChatUserAgentProviding.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// A protocol for generating a user agent string based on a given URL.
+public protocol AIChatUserAgentProviding {
+
+    /// Returns a user agent string for the specified URL.
+    ///
+    /// - Parameter url: An optional URL to customize the user agent. If `nil`, a default
+    ///                  user agent should be returned.
+    /// - Returns: A `String` representing the user agent for the given URL.
+    func userAgent(url: URL?) -> String
+}

--- a/iOS/LocalPackages/AIChat/Sources/AIChat/Public API/AIChatViewController.swift
+++ b/iOS/LocalPackages/AIChat/Sources/AIChat/Public API/AIChatViewController.swift
@@ -71,12 +71,14 @@ public final class AIChatViewController: UIViewController {
                             webViewConfiguration: WKWebViewConfiguration,
                             requestAuthHandler: AIChatRequestAuthorizationHandling,
                             inspectableWebView: Bool,
-                            downloadsPath: URL) {
+                            downloadsPath: URL,
+                            userAgentManager: AIChatUserAgentProviding) {
         let chatModel = AIChatViewModel(webViewConfiguration: webViewConfiguration,
                                         settings: settings,
                                         requestAuthHandler: requestAuthHandler,
                                         inspectableWebView: inspectableWebView,
-                                        downloadsPath: downloadsPath)
+                                        downloadsPath: downloadsPath,
+                                        userAgentManager: userAgentManager)
         self.init(chatModel: chatModel)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204167627774280/1209701767587116/f
Tech Design URL:
CC:

### Description
Set UA on duck.ai webview

### Testing Steps
1. Go to the debug settings, and enable inspectable webview
2. Open a tab on the SERP, inspect the webview and check the UA with `navigator.userAgent`
3. Open duck.ai, inspect the webview and check the UA with `navigator.userAgent`
4. Both UA should match 

### Impact and Risks
Low: small bug fixes

#### What could go wrong?
Wrong UA is set