### PR TITLE
Maestro Sync test fix: Assert visibility of 'Recover Synced Data’ Sync row before tapping

### DIFF
--- a/.maestro/shared/sync_recover_data.yaml
+++ b/.maestro/shared/sync_recover_data.yaml
@@ -4,8 +4,8 @@ appId: com.duckduckgo.mobile.ios
 - assertVisible: Sync & Backup
 - tapOn: Sync & Backup
 - assertVisible: Begin Syncing
-- tapOn: Recover Synced Data
 - assertVisible: Recover Synced Data
+- tapOn: Recover Synced Data
 - inputText: "0000"
 - pressKey: Enter
 - assertVisible: Get Started


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/414709148257752/1209708332006139/f
Tech Design URL:
CC:

### Description
Update order of actions so that `assertVisible` is called before `tapOn`, since tapping causing a blocking UI passcode prompt which causes the `assertVisible` to fail

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Confirm Sync UI tests complete successfully ->  https://github.com/duckduckgo/apple-browsers/actions/runs/13928524239

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)