### PR TITLE
Fixes VPN StartError 2

### DIFF
--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
@@ -204,6 +204,8 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
             switch session.status {
             case .connected:
                 try await enableOnDemand(tunnelManager: manager)
+            case .invalid:
+                clearInternalManager()
             default:
                 break
             }
@@ -539,6 +541,8 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
 
     /// Starts the VPN connection
     ///
+    /// Handles all the top level error management logic.
+    ///
     func start() async {
         Logger.networkProtection.log("Start VPN")
         VPNOperationErrorRecorder().beginRecordingControllerStart()
@@ -547,49 +551,18 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
         controllerErrorStore.lastErrorMessage = nil
 
         do {
-#if NETP_SYSTEM_EXTENSION
-            try await activateSystemExtension { [weak self] in
-                // If we're waiting for user approval we wanna make sure the
-                // onboarding step is set correctly.  This can be useful to
-                // help prevent the value from being de-synchronized.
-                self?.onboardingStatusRawValue = OnboardingStatus.isOnboarding(step: .userNeedsToAllowExtension).rawValue
-            }
-#endif
-
-            let tunnelManager: NETunnelProviderManager
-
-            do {
-                tunnelManager = try await loadOrMakeTunnelManager()
-            } catch {
-                if case NEVPNError.configurationReadWriteFailed = error {
-                    onboardingStatusRawValue = OnboardingStatus.isOnboarding(step: .userNeedsToAllowVPNConfiguration).rawValue
-
-                    throw StartError.cancelled
-                }
-
-                throw error
-            }
-            onboardingStatusRawValue = OnboardingStatus.completed.rawValue
-
-            switch tunnelManager.connection.status {
-            case .invalid:
-                throw StartError.connectionStatusInvalid
-            case .connected:
-                throw StartError.connectionAlreadyStarted
-            default:
-                try await start(tunnelManager)
-
-                // It's important to note that we've seen instances where the above call to start()
-                // doesn't throw any errors, yet the tunnel fails to start.  In any case this pixel
-                // should be interpreted as "the controller successfully requested the tunnel to be
-                // started".  Meaning there's no error caught in this start attempt.  There are pixels
-                // in the packet tunnel provider side that can be used to debug additional logic.
-                //
-                PixelKit.fire(NetworkProtectionPixelEvent.networkProtectionControllerStartSuccess,
-                              frequency: .legacyDailyAndCount)
-            }
+            try await start(isFirstAttempt: true)
+            // It's important to note that we've seen instances where the call to start() the VPN
+            // doesn't throw any errors, yet the tunnel fails to start.  In any case this pixel
+            // should be interpreted as "the controller successfully requested the tunnel to be
+            // started".  Meaning there's no error caught in this start attempt.  There are pixels
+            // in the packet tunnel provider side that can be used to debug additional logic.
+            //
+            PixelKit.fire(NetworkProtectionPixelEvent.networkProtectionControllerStartSuccess,
+                          frequency: .legacyDailyAndCount)
+            Logger.networkProtection.error("Controller start tunnel success")
         } catch {
-            Logger.networkProtection.error("Starting tunnel error: \(error, privacy: .public)")
+            Logger.networkProtection.error("Controller start tunnel failure: \(error, privacy: .public)")
 
             VPNOperationErrorRecorder().recordControllerStartFailure(error)
             knownFailureStore.lastKnownFailure = KnownFailure(error)
@@ -608,6 +581,62 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
             if controllerErrorStore.lastErrorMessage == nil {
                 controllerErrorStore.lastErrorMessage = error.localizedDescription
             }
+        }
+    }
+
+    private func start(isFirstAttempt: Bool) async throws {
+#if NETP_SYSTEM_EXTENSION
+        try await activateSystemExtension { [weak self] in
+            // If we're waiting for user approval we wanna make sure the
+            // onboarding step is set correctly.  This can be useful to
+            // help prevent the value from being de-synchronized.
+            self?.onboardingStatusRawValue = OnboardingStatus.isOnboarding(step: .userNeedsToAllowExtension).rawValue
+        }
+
+        self.controllerErrorStore.lastErrorMessage = nil
+
+        // We'll only update to completed if we were showing the onboarding step to
+        // allow the system extension.  Otherwise we may override the allow-VPN
+        // onboarding step.
+        //
+        // Additionally if the onboarding step was allowing the system extension, we won't
+        // start the tunnel at once, and instead require that the user enables the toggle.
+        //
+        if onboardingStatusRawValue == OnboardingStatus.isOnboarding(step: .userNeedsToAllowExtension).rawValue {
+            onboardingStatusRawValue = OnboardingStatus.isOnboarding(step: .userNeedsToAllowVPNConfiguration).rawValue
+            return
+        }
+#endif
+
+        let tunnelManager: NETunnelProviderManager
+
+        do {
+            tunnelManager = try await loadOrMakeTunnelManager()
+        } catch {
+            if case NEVPNError.configurationReadWriteFailed = error {
+                onboardingStatusRawValue = OnboardingStatus.isOnboarding(step: .userNeedsToAllowVPNConfiguration).rawValue
+
+                throw StartError.cancelled
+            }
+
+            throw error
+        }
+        onboardingStatusRawValue = OnboardingStatus.completed.rawValue
+
+        switch tunnelManager.connection.status {
+        case .invalid:
+            guard isFirstAttempt else {
+                // This means the VPN isn't configured, so let's drop our cached
+                // manager and try again
+                throw StartError.connectionStatusInvalid
+            }
+
+            await clearInternalManager()
+            try await start(isFirstAttempt: false)
+        case .connected:
+            throw StartError.connectionAlreadyStarted
+        default:
+            try await start(tunnelManager)
         }
     }
 

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
@@ -625,9 +625,10 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
 
         switch tunnelManager.connection.status {
         case .invalid:
+            // This means the VPN isn't configured, so let's drop our cached
+            // manager and try again
+
             guard isFirstAttempt else {
-                // This means the VPN isn't configured, so let's drop our cached
-                // manager and try again
                 throw StartError.connectionStatusInvalid
             }
 

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Provider/TransparentProxyProvider.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Provider/TransparentProxyProvider.swift
@@ -198,10 +198,6 @@ open class TransparentProxyProvider: NETransparentProxyProvider {
                 NENetworkRule(destinationHost: NWHostEndpoint(hostname: "duckduckgo.com", port: "443"), protocol: .any))
         }
 
-        networkSettings.excludedNetworkRules = [
-            NENetworkRule(destinationHost: NWHostEndpoint(hostname: "push.apple.com", port: ""), protocol: .any),
-        ]
-
         return networkSettings
     }
 

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Provider/TransparentProxyProvider.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Provider/TransparentProxyProvider.swift
@@ -198,6 +198,10 @@ open class TransparentProxyProvider: NETransparentProxyProvider {
                 NENetworkRule(destinationHost: NWHostEndpoint(hostname: "duckduckgo.com", port: "443"), protocol: .any))
         }
 
+        networkSettings.excludedNetworkRules = [
+            NENetworkRule(destinationHost: NWHostEndpoint(hostname: "push.apple.com", port: ""), protocol: .any),
+        ]
+
         return networkSettings
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207603085593419/1207633069844317/f

### Description

Resolve the VPN's `StartError` code `2`.

### Known Limitations

This won't fix all VPN start issues.  Only a specific one.

### Testing Steps

Start the VPN, delete the configuration from settings, start the VPN again.

Make sure you never see a "[DEBUG] Connection status invalid" message or "An unexpected error occurred, please try again".

### Impact and Risks

Medium

#### What could go wrong?

A mistake in my changes could cause trouble for users starting the VPN, but our testing is aimed to handle that.

### Quality Considerations

None

### Notes to Reviewer

Focus on making sure the changes make sense, and testing that the VPN doesn't become completely broken.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)