### PR TITLE
Copy context menu item added to new tab page favorites

### DIFF
--- a/macOS/DuckDuckGo/Bookmarks/Services/BookmarksContextMenu.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Services/BookmarksContextMenu.swift
@@ -200,7 +200,7 @@ extension BookmarksContextMenu {
     }
 
     static func copyBookmarkMenuItem(bookmark: Bookmark?, target: AnyObject?) -> NSMenuItem {
-        NSMenuItem(title: UserText.copy, action: #selector(BookmarkMenuItemSelectors.copyBookmark(_:)), target: target, representedObject: bookmark)
+        NSMenuItem(title: UserText.copyLink, action: #selector(BookmarkMenuItemSelectors.copyBookmark(_:)), target: target, representedObject: bookmark)
     }
 
     static func deleteBookmarkMenuItem(bookmark: Bookmark?, target: AnyObject?) -> NSMenuItem {

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -1031,7 +1031,6 @@ struct UserText {
     static let showBookmarksBarAlways = NSLocalizedString("bookmarks.bar.show.always", value: "Always show", comment: "Preference for always showing the bookmarks bar")
     static let showBookmarksBarNewTabOnly = NSLocalizedString("bookmarks.bar.show.new-tab-only", value: "Only show on New Tab", comment: "Preference for only showing the bookmarks bar on new tab")
     static let bookmarksBarFolderEmpty = NSLocalizedString("bookmarks.bar.folder.empty", value: "Empty", comment: "Empty state for a bookmarks bar folder")
-    static let bookmarksBarContextMenuCopy = NSLocalizedString("bookmarks.bar.context-menu.copy", value: "Copy", comment: "Copy menu item for the bookmarks bar context menu")
     static let bookmarksBarContextMenuDelete = NSLocalizedString("bookmarks.bar.context-menu.delete", value: "Delete", comment: "Delete menu item for the bookmarks bar context menu")
     static let bookmarksBarContextMenuMoveToEnd = NSLocalizedString("bookmarks.bar.context-menu.move-to-end", value: "Move to End", comment: "Move to End menu item for the bookmarks bar context menu")
 

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -41,6 +41,7 @@ struct UserText {
     static let update = NSLocalizedString("update", value: "Update", comment: "Update button")
     static let dontUpdate = NSLocalizedString("dont.update", value: "Don't Update", comment: "Don't Update button")
     static let copy = NSLocalizedString("copy", value: "Copy", comment: "Copy button")
+    static let copyLink = NSLocalizedString("copy.link", value: "Copy Link", comment: "Copy Link button")
     static let details = NSLocalizedString("details", value: "Details", comment: "details button")
     static let submit = NSLocalizedString("submit", value: "Submit", comment: "Submit button")
     static let submitReport = NSLocalizedString("submit.report", value: "Submit Report", comment: "Submit Report button")

--- a/macOS/DuckDuckGo/History/View/HistoryViewActionsHandler.swift
+++ b/macOS/DuckDuckGo/History/View/HistoryViewActionsHandler.swift
@@ -176,8 +176,8 @@ final class HistoryViewActionsHandler: HistoryView.ActionsHandling {
                 NSMenuItem(title: UserText.showAllHistoryFromThisSite, action: #selector(showAllHistoryFromThisSite(_:)), target: self)
                     .withAccessibilityIdentifier("HistoryView.showAllHistoryFromThisSite")
                 NSMenuItem.separator()
-                NSMenuItem(title: UserText.copy, action: #selector(copy(_:)), target: self, representedObject: url)
-                    .withAccessibilityIdentifier("HistoryView.copy")
+                NSMenuItem(title: UserText.copyLink, action: #selector(copy(_:)), target: self, representedObject: url)
+                    .withAccessibilityIdentifier("HistoryView.copyLink")
                 if !bookmarksHandler.isUrlBookmarked(url: url) {
                     NSMenuItem(title: UserText.addToBookmarks, action: #selector(addBookmarks(_:)), target: self, representedObject: [url])
                         .withAccessibilityIdentifier("HistoryView.addBookmark")

--- a/macOS/DuckDuckGo/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localizable.xcstrings
@@ -9799,7 +9799,7 @@
     },
     "bookmarks.bar.context-menu.copy" : {
       "comment" : "Copy menu item for the bookmarks bar context menu",
-      "extractionState" : "extracted_with_value",
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/macOS/DuckDuckGo/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localizable.xcstrings
@@ -16062,6 +16062,18 @@
         }
       }
     },
+    "copy.link" : {
+      "comment" : "Copy Link button",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Copy Link"
+          }
+        }
+      }
+    },
     "Country" : {
       "comment" : "Title of the section of the Identities manager where the user can add/modify a country (US,UK, Italy etc...)",
       "localizations" : {

--- a/macOS/DuckDuckGo/NewTabPage/Features/DefaultsFavoritesActionHandler.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/DefaultsFavoritesActionHandler.swift
@@ -47,7 +47,7 @@ final class DefaultFavoritesActionsHandler: FavoritesActionsHandling {
         }
     }
 
-    func copyToPasteboard(_ favorite: Bookmark) {
+    func copyLink(_ favorite: Bookmark) {
         favorite.copyUrlToPasteboard()
     }
 

--- a/macOS/DuckDuckGo/NewTabPage/Features/DefaultsFavoritesActionHandler.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/DefaultsFavoritesActionHandler.swift
@@ -47,6 +47,10 @@ final class DefaultFavoritesActionsHandler: FavoritesActionsHandling {
         }
     }
 
+    func copyToPasteboard(_ favorite: Bookmark) {
+        favorite.copyUrlToPasteboard()
+    }
+
     func removeFavorite(_ favorite: Bookmark) {
         favorite.isFavorite = false
         bookmarkManager.update(bookmark: favorite)

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Favorites/NewTabPageFavoritesActionsHandler.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Favorites/NewTabPageFavoritesActionsHandler.swift
@@ -33,7 +33,7 @@ public protocol FavoritesActionsHandling {
     @MainActor func addNewFavorite()
     @MainActor func edit(_ favorite: FavoriteType)
 
-    func copyToPasteboard(_ favorite: FavoriteType)
+    func copyLink(_ favorite: FavoriteType)
 
     func removeFavorite(_ favorite: FavoriteType)
     func deleteBookmark(for favorite: FavoriteType)

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Favorites/NewTabPageFavoritesActionsHandler.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Favorites/NewTabPageFavoritesActionsHandler.swift
@@ -33,6 +33,8 @@ public protocol FavoritesActionsHandling {
     @MainActor func addNewFavorite()
     @MainActor func edit(_ favorite: FavoriteType)
 
+    func copyToPasteboard(_ favorite: FavoriteType)
+
     func removeFavorite(_ favorite: FavoriteType)
     func deleteBookmark(for favorite: FavoriteType)
     func move(_ favoriteID: String, toIndex: Int)

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Favorites/NewTabPageFavoritesModel.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Favorites/NewTabPageFavoritesModel.swift
@@ -147,6 +147,8 @@ public final class NewTabPageFavoritesModel<FavoriteType, ActionHandler>: NSObje
 
             NSMenuItem(title: UserText.edit, action: #selector(editBookmark(_:)), target: self, representedObject: favorite)
                 .withAccessibilityIdentifier("HomePage.Views.editBookmark")
+            NSMenuItem(title: UserText.copy, action: #selector(copyToPasteboard(_:)), target: self, representedObject: favorite)
+                .withAccessibilityIdentifier("HomePage.Views.copyBookmarkLink")
             NSMenuItem(title: UserText.removeFavorite, action: #selector(removeFavorite(_:)), target: self, representedObject: favorite)
                 .withAccessibilityIdentifier("HomePage.Views.removeFavorite")
             NSMenuItem(title: UserText.deleteBookmark, action: #selector(deleteBookmark(_:)), target: self, representedObject: favorite)
@@ -172,6 +174,12 @@ public final class NewTabPageFavoritesModel<FavoriteType, ActionHandler>: NSObje
     @objc public func editBookmark(_ sender: NSMenuItem) {
         guard let bookmark = sender.representedObject as? FavoriteType else { return }
         actionsHandler.edit(bookmark)
+    }
+
+    @MainActor
+    @objc public func copyToPasteboard(_ sender: NSMenuItem) {
+        guard let bookmark = sender.representedObject as? FavoriteType else { return }
+        actionsHandler.copyToPasteboard(bookmark)
     }
 
     @MainActor

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Favorites/NewTabPageFavoritesModel.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Favorites/NewTabPageFavoritesModel.swift
@@ -147,7 +147,7 @@ public final class NewTabPageFavoritesModel<FavoriteType, ActionHandler>: NSObje
 
             NSMenuItem(title: UserText.edit, action: #selector(editBookmark(_:)), target: self, representedObject: favorite)
                 .withAccessibilityIdentifier("HomePage.Views.editBookmark")
-            NSMenuItem(title: UserText.copy, action: #selector(copyToPasteboard(_:)), target: self, representedObject: favorite)
+            NSMenuItem(title: UserText.copyLink, action: #selector(copyLink(_:)), target: self, representedObject: favorite)
                 .withAccessibilityIdentifier("HomePage.Views.copyBookmarkLink")
             NSMenuItem(title: UserText.removeFavorite, action: #selector(removeFavorite(_:)), target: self, representedObject: favorite)
                 .withAccessibilityIdentifier("HomePage.Views.removeFavorite")
@@ -177,9 +177,9 @@ public final class NewTabPageFavoritesModel<FavoriteType, ActionHandler>: NSObje
     }
 
     @MainActor
-    @objc public func copyToPasteboard(_ sender: NSMenuItem) {
+    @objc public func copyLink(_ sender: NSMenuItem) {
         guard let bookmark = sender.representedObject as? FavoriteType else { return }
-        actionsHandler.copyToPasteboard(bookmark)
+        actionsHandler.copyLink(bookmark)
     }
 
     @MainActor

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/internal/UserText.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/internal/UserText.swift
@@ -22,7 +22,7 @@ enum UserText {
     static let openInNewTab = NSLocalizedString("open.in.new.tab", value: "Open in New Tab", comment: "Menu item that opens the link in a new tab")
     static let openInNewWindow = NSLocalizedString("open.in.new.window", value: "Open in New Window", comment: "Menu item that opens the link in a new window")
     static let edit = NSLocalizedString("edit", value: "Edit", comment: "Edit button")
-    static let copy = NSLocalizedString("copy", value: "Copy", comment: "Copy button")
+    static let copyLink = NSLocalizedString("copy.link", value: "Copy Link", comment: "Menu item that copies the link from bookmark")
     static let deleteBookmark = NSLocalizedString("delete-bookmark", value: "Delete Bookmark", comment: "Delete Bookmark button")
     static let removeFavorite = NSLocalizedString("remove-favorite", value: "Remove Favorite", comment: "Remove Favorite button")
 }

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/internal/UserText.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/internal/UserText.swift
@@ -22,6 +22,7 @@ enum UserText {
     static let openInNewTab = NSLocalizedString("open.in.new.tab", value: "Open in New Tab", comment: "Menu item that opens the link in a new tab")
     static let openInNewWindow = NSLocalizedString("open.in.new.window", value: "Open in New Window", comment: "Menu item that opens the link in a new window")
     static let edit = NSLocalizedString("edit", value: "Edit", comment: "Edit button")
+    static let copy = NSLocalizedString("copy", value: "Copy", comment: "Copy button")
     static let deleteBookmark = NSLocalizedString("delete-bookmark", value: "Delete Bookmark", comment: "Delete Bookmark button")
     static let removeFavorite = NSLocalizedString("remove-favorite", value: "Remove Favorite", comment: "Remove Favorite button")
 }

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/CapturingNewTabPageFavoritesActionsHandler.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/CapturingNewTabPageFavoritesActionsHandler.swift
@@ -20,6 +20,7 @@ import Foundation
 import NewTabPage
 
 final class CapturingNewTabPageFavoritesActionsHandler: FavoritesActionsHandling {
+
     typealias FavoriteType = MockNewTabPageFavorite
 
     struct OpenCall: Equatable {
@@ -45,6 +46,7 @@ final class CapturingNewTabPageFavoritesActionsHandler: FavoritesActionsHandling
     var openCalls: [OpenCall] = []
     var addNewFavoriteCallCount: Int = 0
     var editCalls: [MockNewTabPageFavorite] = []
+    var copyToPasteboardCalls: [MockNewTabPageFavorite] = []
     var onFaviconMissingCallCount: Int = 0
     var removeFavoriteCalls: [MockNewTabPageFavorite] = []
     var deleteBookmarkCalls: [MockNewTabPageFavorite] = []
@@ -60,6 +62,10 @@ final class CapturingNewTabPageFavoritesActionsHandler: FavoritesActionsHandling
 
     func edit(_ favorite: MockNewTabPageFavorite) {
         editCalls.append(favorite)
+    }
+
+    func copyToPasteboard(_ favorite: MockNewTabPageFavorite) {
+        copyToPasteboardCalls.append(favorite)
     }
 
     func removeFavorite(_ favorite: MockNewTabPageFavorite) {

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/CapturingNewTabPageFavoritesActionsHandler.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/CapturingNewTabPageFavoritesActionsHandler.swift
@@ -46,7 +46,7 @@ final class CapturingNewTabPageFavoritesActionsHandler: FavoritesActionsHandling
     var openCalls: [OpenCall] = []
     var addNewFavoriteCallCount: Int = 0
     var editCalls: [MockNewTabPageFavorite] = []
-    var copyToPasteboardCalls: [MockNewTabPageFavorite] = []
+    var copyLinkCalls: [MockNewTabPageFavorite] = []
     var onFaviconMissingCallCount: Int = 0
     var removeFavoriteCalls: [MockNewTabPageFavorite] = []
     var deleteBookmarkCalls: [MockNewTabPageFavorite] = []
@@ -64,8 +64,8 @@ final class CapturingNewTabPageFavoritesActionsHandler: FavoritesActionsHandling
         editCalls.append(favorite)
     }
 
-    func copyToPasteboard(_ favorite: MockNewTabPageFavorite) {
-        copyToPasteboardCalls.append(favorite)
+    func copyLink(_ favorite: MockNewTabPageFavorite) {
+        copyLinkCalls.append(favorite)
     }
 
     func removeFavorite(_ favorite: MockNewTabPageFavorite) {

--- a/macOS/UnitTests/Bookmarks/Model/ContextualMenuTests.swift
+++ b/macOS/UnitTests/Bookmarks/Model/ContextualMenuTests.swift
@@ -44,7 +44,7 @@ final class ContextualMenuTests: XCTestCase {
         assertMenuItem(items[3], withTitle: UserText.addToFavorites, selector: #selector(BookmarkMenuItemSelectors.toggleBookmarkAsFavorite(_:)), representedObject: bookmark)
         XCTAssertTrue(items[4].isSeparatorItem) // Separator
         assertMenuItem(items[5], withTitle: UserText.editBookmark, selector: #selector(BookmarkMenuItemSelectors.editBookmark(_:)), representedObject: bookmark)
-        assertMenuItem(items[6], withTitle: UserText.bookmarksBarContextMenuCopy, selector: #selector(BookmarkMenuItemSelectors.copyBookmark(_:)), representedObject: bookmark)
+        assertMenuItem(items[6], withTitle: UserText.copyLink, selector: #selector(BookmarkMenuItemSelectors.copyBookmark(_:)), representedObject: bookmark)
         assertMenuItem(items[7], withTitle: UserText.bookmarksBarContextMenuDelete, selector: #selector(BookmarkMenuItemSelectors.deleteBookmark(_:)), representedObject: bookmark)
         assertMenuItem(items[8], withTitle: UserText.bookmarksBarContextMenuMoveToEnd, selector: #selector(BookmarkMenuItemSelectors.moveToEnd(_:)), representedObject: bookmark)
         XCTAssertTrue(items[9].isSeparatorItem) // Separator
@@ -68,7 +68,7 @@ final class ContextualMenuTests: XCTestCase {
         assertMenuItem(items[3], withTitle: UserText.removeFromFavorites, selector: #selector(BookmarkMenuItemSelectors.toggleBookmarkAsFavorite(_:)), representedObject: bookmark)
         XCTAssertTrue(items[4].isSeparatorItem) // Separator
         assertMenuItem(items[5], withTitle: UserText.editBookmark, selector: #selector(BookmarkMenuItemSelectors.editBookmark(_:)), representedObject: bookmark)
-        assertMenuItem(items[6], withTitle: UserText.bookmarksBarContextMenuCopy, selector: #selector(BookmarkMenuItemSelectors.copyBookmark(_:)), representedObject: bookmark)
+        assertMenuItem(items[6], withTitle: UserText.copyLink, selector: #selector(BookmarkMenuItemSelectors.copyBookmark(_:)), representedObject: bookmark)
         assertMenuItem(items[7], withTitle: UserText.bookmarksBarContextMenuDelete, selector: #selector(BookmarkMenuItemSelectors.deleteBookmark(_:)), representedObject: bookmark)
         assertMenuItem(items[8], withTitle: UserText.bookmarksBarContextMenuMoveToEnd, selector: #selector(BookmarkMenuItemSelectors.moveToEnd(_:)), representedObject: bookmark)
         XCTAssertTrue(items[9].isSeparatorItem) // Separator
@@ -92,7 +92,7 @@ final class ContextualMenuTests: XCTestCase {
         assertMenuItem(items[3], withTitle: UserText.removeFromFavorites, selector: #selector(BookmarkMenuItemSelectors.toggleBookmarkAsFavorite(_:)), representedObject: bookmark)
         XCTAssertTrue(items[4].isSeparatorItem) // Separator
         assertMenuItem(items[5], withTitle: UserText.editBookmark, selector: #selector(BookmarkMenuItemSelectors.editBookmark(_:)), representedObject: bookmark)
-        assertMenuItem(items[6], withTitle: UserText.bookmarksBarContextMenuCopy, selector: #selector(BookmarkMenuItemSelectors.copyBookmark(_:)), representedObject: bookmark)
+        assertMenuItem(items[6], withTitle: UserText.copyLink, selector: #selector(BookmarkMenuItemSelectors.copyBookmark(_:)), representedObject: bookmark)
         assertMenuItem(items[7], withTitle: UserText.bookmarksBarContextMenuDelete, selector: #selector(BookmarkMenuItemSelectors.deleteBookmark(_:)), representedObject: bookmark)
         assertMenuItem(items[8], withTitle: UserText.bookmarksBarContextMenuMoveToEnd, selector: #selector(BookmarkMenuItemSelectors.moveToEnd(_:)), representedObject: bookmark)
         XCTAssertTrue(items[9].isSeparatorItem) // Separator
@@ -166,7 +166,7 @@ final class ContextualMenuTests: XCTestCase {
         assertMenuItem(items[3], withTitle: UserText.addToFavorites, selector: #selector(BookmarkMenuItemSelectors.toggleBookmarkAsFavorite(_:)), representedObject: bookmark)
         XCTAssertTrue(items[4].isSeparatorItem) // Separator
         assertMenuItem(items[5], withTitle: UserText.editBookmark, selector: #selector(BookmarkMenuItemSelectors.editBookmark(_:)), representedObject: bookmark)
-        assertMenuItem(items[6], withTitle: UserText.bookmarksBarContextMenuCopy, selector: #selector(BookmarkMenuItemSelectors.copyBookmark(_:)), representedObject: bookmark)
+        assertMenuItem(items[6], withTitle: UserText.copyLink, selector: #selector(BookmarkMenuItemSelectors.copyBookmark(_:)), representedObject: bookmark)
         assertMenuItem(items[7], withTitle: UserText.bookmarksBarContextMenuDelete, selector: #selector(BookmarkMenuItemSelectors.deleteBookmark(_:)), representedObject: bookmark)
         assertMenuItem(items[8], withTitle: UserText.bookmarksBarContextMenuMoveToEnd, selector: #selector(BookmarkMenuItemSelectors.moveToEnd(_:)), representedObject: bookmark)
         XCTAssertTrue(items[9].isSeparatorItem) // Separator
@@ -194,7 +194,7 @@ final class ContextualMenuTests: XCTestCase {
         assertMenuItem(items[3], withTitle: UserText.addToFavorites, selector: #selector(BookmarkMenuItemSelectors.toggleBookmarkAsFavorite(_:)), representedObject: bookmark)
         XCTAssertTrue(items[4].isSeparatorItem) // Separator
         assertMenuItem(items[5], withTitle: UserText.editBookmark, selector: #selector(BookmarkMenuItemSelectors.editBookmark(_:)), representedObject: bookmark)
-        assertMenuItem(items[6], withTitle: UserText.bookmarksBarContextMenuCopy, selector: #selector(BookmarkMenuItemSelectors.copyBookmark(_:)), representedObject: bookmark)
+        assertMenuItem(items[6], withTitle: UserText.copyLink, selector: #selector(BookmarkMenuItemSelectors.copyBookmark(_:)), representedObject: bookmark)
         assertMenuItem(items[7], withTitle: UserText.bookmarksBarContextMenuDelete, selector: #selector(BookmarkMenuItemSelectors.deleteBookmark(_:)), representedObject: bookmark)
         assertMenuItem(items[8], withTitle: UserText.bookmarksBarContextMenuMoveToEnd, selector: #selector(BookmarkMenuItemSelectors.moveToEnd(_:)), representedObject: bookmark)
         XCTAssertTrue(items[9].isSeparatorItem) // Separator
@@ -520,7 +520,7 @@ final class ContextualMenuTests: XCTestCase {
         // GIVEN
         let bookmark = Bookmark(id: "n", url: URL.duckDuckGo.absoluteString, title: "DuckDuckGo", isFavorite: true, parentFolderUUID: "1")
         let menu = BookmarksContextMenu.bookmarkMenu(with: bookmark)
-        guard let menuItem = menu.items.first(where: { $0.title == UserText.copy }) else {
+        guard let menuItem = menu.items.first(where: { $0.title == UserText.copyLink }) else {
             XCTFail("No item")
             return
         }

--- a/macOS/UnitTests/History/View/HistoryViewActionsHandlerTests.swift
+++ b/macOS/UnitTests/History/View/HistoryViewActionsHandlerTests.swift
@@ -307,7 +307,7 @@ final class HistoryViewActionsHandlerTests: XCTestCase {
         XCTAssertTrue(menu.items[3].isSeparatorItem)
         XCTAssertEqual(menu.items[4].title, UserText.showAllHistoryFromThisSite)
         XCTAssertTrue(menu.items[5].isSeparatorItem)
-        XCTAssertEqual(menu.items[6].title, UserText.copy)
+        XCTAssertEqual(menu.items[6].title, UserText.copyLink)
         XCTAssertEqual(menu.items[7].title, UserText.addToBookmarks)
         XCTAssertEqual(menu.items[8].title, UserText.addToFavorites)
         XCTAssertTrue(menu.items[9].isSeparatorItem)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1148564399326804/1209296794793953/f

### Description
Adding a new "Copy" context menu item to new tab page favorites

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Make a couple of favorites
2. Open a new tab page
3. Open a context menu on a random favorite and select "Copy"
4. Paste the content of a clipboard to the address bar and verify it contains the URL of favorite
5. Open a context menu on a different favorite and select "Copy" again
4. Paste the content of a clipboard to a third party app (Notes) and verify it contains the URL of the last copied favorite

### Impact and Risks
Low


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)