### PR TITLE
Stabilize LocalBookmarkManager unit tests

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "b5976277a68e18f93edb0d853889e461e06557fa",
-        "version" : "16.2.2"
+        "revision" : "2bc93bec9cbe6d916e84b42346b925c6c057bfa5",
+        "version" : "17.0.0"
       }
     },
     {
@@ -104,7 +104,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/privacy-dashboard",
       "state" : {
-        "revision" : "fd0a479bdc9db4a9d4ae3fb691e9057f7a67c578",
+        "revision" : "b370e1e1afa322a48a8a37c6c954a444c15489e4",
         "version" : "9.0.0"
       }
     },

--- a/macOS/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
@@ -33,7 +33,7 @@ protocol BookmarkManager: AnyObject {
     func getBookmark(forUrl url: String) -> Bookmark?
     func getBookmark(forVariantUrl variantURL: URL) -> Bookmark?
     func getBookmarkFolder(withId id: String) -> BookmarkFolder?
-    @discardableResult func makeBookmark(for url: URL, title: String, isFavorite: Bool, index: Int?, parent: BookmarkFolder?) -> Bookmark?
+    @discardableResult func makeBookmark(for url: URL, title: String, isFavorite: Bool, index: Int?, parent: BookmarkFolder?, completion: @escaping (Error?) -> Void) -> Bookmark?
     func makeBookmarks(for websitesInfo: [WebsiteInfo], inNewFolderNamed folderName: String?, withinParentFolder parent: ParentFolderType)
     func makeFolder(named title: String, parent: BookmarkFolder?, completion: @escaping (Result<BookmarkFolder, Error>) -> Void)
     func remove(bookmark: Bookmark, undoManager: UndoManager?)
@@ -71,11 +71,11 @@ protocol BookmarkManager: AnyObject {
     func requestSync()
 }
 extension BookmarkManager {
-    @discardableResult func makeBookmark(for url: URL, title: String, isFavorite: Bool) -> Bookmark? {
-        makeBookmark(for: url, title: title, isFavorite: isFavorite, index: nil, parent: nil)
+    @discardableResult func makeBookmark(for url: URL, title: String, isFavorite: Bool, completion: @escaping (Error?) -> Void = { _ in }) -> Bookmark? {
+        makeBookmark(for: url, title: title, isFavorite: isFavorite, index: nil, parent: nil, completion: completion)
     }
-    @discardableResult func makeBookmark(for url: URL, title: String, isFavorite: Bool, index: Int?, parent: BookmarkFolder?) -> Bookmark? {
-        makeBookmark(for: url, title: title, isFavorite: isFavorite, index: index, parent: parent)
+    @discardableResult func makeBookmark(for url: URL, title: String, isFavorite: Bool, index: Int?, parent: BookmarkFolder?, completion: @escaping (Error?) -> Void = { _ in }) -> Bookmark? {
+        makeBookmark(for: url, title: title, isFavorite: isFavorite, index: index, parent: parent, completion: completion)
     }
     func move(objectUUIDs: [String], toIndex index: Int?, withinParentFolder parent: ParentFolderType) {
         move(objectUUIDs: objectUUIDs, toIndex: index, withinParentFolder: parent) { _ in }
@@ -203,10 +203,10 @@ final class LocalBookmarkManager: BookmarkManager {
     }
 
     @discardableResult func makeBookmark(for url: URL, title: String, isFavorite: Bool) -> Bookmark? {
-        makeBookmark(for: url, title: title, isFavorite: isFavorite, index: nil, parent: nil)
+        makeBookmark(for: url, title: title, isFavorite: isFavorite, index: nil, parent: nil, completion: { _ in })
     }
 
-    @discardableResult func makeBookmark(for url: URL, title: String, isFavorite: Bool, index: Int? = nil, parent: BookmarkFolder? = nil) -> Bookmark? {
+    @discardableResult func makeBookmark(for url: URL, title: String, isFavorite: Bool, index: Int? = nil, parent: BookmarkFolder? = nil, completion: @escaping (Error?) -> Void) -> Bookmark? {
         guard list != nil else { return nil }
 
         guard !isUrlBookmarked(url: url) else {
@@ -227,6 +227,7 @@ final class LocalBookmarkManager: BookmarkManager {
             self?.foldersStore.lastBookmarkSingleTabFolderIdUsed = parent?.id
             self?.loadBookmarks()
             self?.requestSync()
+            completion(error)
         }
 
         return bookmark

--- a/macOS/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
@@ -221,6 +221,7 @@ final class LocalBookmarkManager: BookmarkManager {
         bookmarkStore.save(bookmark: bookmark, index: index) { [weak self] error in
             if error != nil {
                 self?.list?.remove(bookmark)
+                completion(error)
                 return
             }
 

--- a/macOS/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
@@ -203,7 +203,7 @@ final class LocalBookmarkManager: BookmarkManager {
     }
 
     @discardableResult func makeBookmark(for url: URL, title: String, isFavorite: Bool) -> Bookmark? {
-        makeBookmark(for: url, title: title, isFavorite: isFavorite, index: nil, parent: nil, completion: { _ in })
+        makeBookmark(for: url, title: title, isFavorite: isFavorite, index: nil, parent: nil)
     }
 
     @discardableResult func makeBookmark(for url: URL, title: String, isFavorite: Bool, index: Int? = nil, parent: BookmarkFolder? = nil, completion: @escaping (Error?) -> Void) -> Bookmark? {
@@ -218,7 +218,7 @@ final class LocalBookmarkManager: BookmarkManager {
         let bookmark = Bookmark(id: id, url: url.absoluteString, title: title, isFavorite: isFavorite, parentFolderUUID: parent?.id)
 
         list?.insert(bookmark)
-        bookmarkStore.save(bookmark: bookmark, index: index) { [weak self] error  in
+        bookmarkStore.save(bookmark: bookmark, index: index) { [weak self] error in
             if error != nil {
                 self?.list?.remove(bookmark)
                 return


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1205237866452338/1209660514434895/f

### Description:
This change adds completion handler to some of the BookmarkManager APIs in order to allow for more reliable unit testing.

### Testing Steps
Verify that CI is green.

### Impact and Risks
None (tests code + some API changes but made in a way that is transparent to the existing code).

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)