### PR TITLE
Privacy Pro Onboarding Experiment - Remove Redundant Code & Update Test

### DIFF
--- a/iOS/DuckDuckGo/PrivacyProPromotionExperiment/OnboardingPrivacyProPromoExperiment.swift
+++ b/iOS/DuckDuckGo/PrivacyProPromotionExperiment/OnboardingPrivacyProPromoExperiment.swift
@@ -75,19 +75,14 @@ struct OnboardingPrivacyProPromoExperiment: OnboardingPrivacyProPromoExperimenti
     /// A type responsible for firing experiment-related analytics pixels.
     private let experimentPixelFirer: ExperimentPixelFiring.Type
 
-    /// A manager for handling subscriptions.
-    private let subscriptionManager: SubscriptionManager?
-
     /// A manager for handling variant assignments.
     private let variantManager: VariantManager
 
     init(featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
          experimentPixelFirer: ExperimentPixelFiring.Type = PixelKit.self,
-         subscriptionManager: SubscriptionManager? = AppDependencyProvider.shared.subscriptionManager,
          variantManager: VariantManager = DefaultVariantManager()) {
         self.featureFlagger = featureFlagger
         self.experimentPixelFirer = experimentPixelFirer
-        self.subscriptionManager = subscriptionManager
         self.variantManager = variantManager
     }
 
@@ -96,9 +91,6 @@ struct OnboardingPrivacyProPromoExperiment: OnboardingPrivacyProPromoExperimenti
 
         // Exclude returning users from experiment enrollment
         guard variantManager.isNewUser else { return nil }
-
-        // Exclude Privacy Pro ineligible users from experiment enrollment
-        guard subscriptionManager?.canPurchase ?? false else { return nil }
 
         return featureFlagger.resolveCohort(for: FeatureFlag.privacyProOnboardingCTAMarch25)
                 as? PrivacyProOnboardingCTAMarch25Cohort

--- a/iOS/DuckDuckGoTests/Onboarding/PrivacyProPromotionExperiment/OnboardingPrivacyProPromoExperimentTests.swift
+++ b/iOS/DuckDuckGoTests/Onboarding/PrivacyProPromotionExperiment/OnboardingPrivacyProPromoExperimentTests.swift
@@ -29,34 +29,23 @@ final class OnboardingPrivacyProPromoExperimentTests: XCTestCase {
 
     private var sut: OnboardingPrivacyProPromoExperiment!
     private var mockFeatureFlagger: MockFeatureFlagger!
-    private var mockSubscriptionManager: SubscriptionManagerMock!
     private var mockVariantManager: MockVariantManager!
 
     override func setUpWithError() throws {
         mockFeatureFlagger = MockFeatureFlagger()
-        mockSubscriptionManager = SubscriptionManagerMock(accountManager: AccountManagerMock(),
-                                                      subscriptionEndpointService: SubscriptionEndpointServiceMock(),
-                                                      authEndpointService: AuthEndpointServiceMock(),
-                                                          storePurchaseManager: StorePurchaseManagerMock(),
-                                                      currentEnvironment: SubscriptionEnvironment(serviceEnvironment: .production, purchasePlatform: .appStore),
-                                                      canPurchase: true,
-                                                      subscriptionFeatureMappingCache: SubscriptionFeatureMappingCacheMock())
         mockVariantManager = MockVariantManager()
         sut = OnboardingPrivacyProPromoExperiment(featureFlagger: mockFeatureFlagger,
                                                   experimentPixelFirer: MockExperimentPixelFirer.self,
-                                                  subscriptionManager: mockSubscriptionManager,
                                                   variantManager: mockVariantManager)
         MockExperimentPixelFirer.reset()
     }
 
-    func testGetCohortIfEnabled_WhenNewUserAndCanPurchase_ReturnsTreatment() {
+    func testGetCohortIfEnabled_WhenNewUser_ReturnsTreatment() {
         // Given
         mockVariantManager.currentVariant = nil
-        mockSubscriptionManager.canPurchase = true
         mockFeatureFlagger.cohortToReturn = PrivacyProOnboardingCTAMarch25Cohort.treatment
         sut = OnboardingPrivacyProPromoExperiment(featureFlagger: mockFeatureFlagger,
                                                   experimentPixelFirer: MockExperimentPixelFirer.self,
-                                                  subscriptionManager: mockSubscriptionManager,
                                                   variantManager: mockVariantManager)
 
 
@@ -70,27 +59,9 @@ final class OnboardingPrivacyProPromoExperimentTests: XCTestCase {
     func testGetCohortIfEnabled_WhenReturningUser_ReturnsNil() {
         // Given
         mockVariantManager.currentVariant = VariantIOS.returningUser
-        mockSubscriptionManager.canPurchase = true
         mockFeatureFlagger.cohortToReturn = PrivacyProOnboardingCTAMarch25Cohort.treatment
         sut = OnboardingPrivacyProPromoExperiment(featureFlagger: mockFeatureFlagger,
                                                   experimentPixelFirer: MockExperimentPixelFirer.self,
-                                                  subscriptionManager: mockSubscriptionManager,
-                                                  variantManager: mockVariantManager)
-
-        // When
-        let cohort = sut.getCohortIfEnabled()
-
-        // Then
-        XCTAssertNil(cohort)
-    }
-
-    func testGetCohortIfEnabled_WhenCannotPurchase_ReturnsNil() {
-        // Given
-        mockVariantManager.currentVariant = nil
-        mockSubscriptionManager.canPurchase = false
-        sut = OnboardingPrivacyProPromoExperiment(featureFlagger: mockFeatureFlagger,
-                                                  experimentPixelFirer: MockExperimentPixelFirer.self,
-                                                  subscriptionManager: mockSubscriptionManager,
                                                   variantManager: mockVariantManager)
 
         // When


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209678164669763

### Description
This PR contains a minor change to remove unnecessary code relating to the Privacy Pro Onboarding experiment. This code checked privacy pro eligibility to ensure a user is eligible before enrolling them to the experiment. However, we have decided to only target the US, and so this check is redundant. See the related Privacy Config [here](https://github.com/duckduckgo/privacy-configuration/pull/2876).

### Testing Steps
1. Green CI is adequate here, as this is removing redundant code and updating tests.

### Impact and Risks
Low: If the privacy config was incorrectly configured, non-US users might be incorrectly enrolled.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)