### PR TITLE
Reopen window in the same position after burning

### DIFF
--- a/macOS/DuckDuckGo/Windows/View/WindowsManager.swift
+++ b/macOS/DuckDuckGo/Windows/View/WindowsManager.swift
@@ -131,8 +131,8 @@ final class WindowsManager {
     }
 
     @discardableResult
-    class func openNewWindow(with initialUrl: URL, source: Tab.TabContent.URLSource, isBurner: Bool, parentTab: Tab? = nil) -> MainWindow? {
-        openNewWindow(with: Tab(content: .contentFromURL(initialUrl, source: source), parentTab: parentTab, shouldLoadInBackground: true, burnerMode: BurnerMode(isBurner: isBurner)))
+    class func openNewWindow(with initialUrl: URL, source: Tab.TabContent.URLSource, isBurner: Bool, parentTab: Tab? = nil, droppingPoint: NSPoint? = nil) -> MainWindow? {
+        openNewWindow(with: Tab(content: .contentFromURL(initialUrl, source: source), parentTab: parentTab, shouldLoadInBackground: true, burnerMode: BurnerMode(isBurner: isBurner)), droppingPoint: droppingPoint)
     }
 
     @discardableResult


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199178362774117/1209703704629721/f

### Description:
This change remembers burned window frame in order to reopen a new window with the same exact frame
(instead of cascading from that frame that resulted in shifting the window to the right and down).

### Testing Steps
1. Launch the app and, to simplify testing, put the window in the upper-left corner of the screen.
2. Burn all data. Verify that the new window is placed in the exact same frame in the upper-left corner of the screen.
3. Repeat the same with burning “current window”.
4. Repeat the same with burning “current tab” when you only have 1 tab.
5. Open multiple windows and burn all data. Verify that the new window is placed in the exact same frame as the window you’ve initiated burning from.

### Impact and Risks
Low

#### What could go wrong?
Nothing really – we’re assigning an optional dropping point to new window function. If non-nil, it represents previous window frame, if nil it does nothing (like currently).

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)