### PR TITLE
Fixes an issue where the proxy can cause high CPU usage

### DIFF
--- a/macOS/DuckDuckGoVPN/VPNProxyLauncher.swift
+++ b/macOS/DuckDuckGoVPN/VPNProxyLauncher.swift
@@ -47,24 +47,35 @@ final class VPNProxyLauncher {
 
     // MARK: - Status Changes
 
+    private struct ProxyStatusUpdate: Equatable {
+        let newStatus: NEVPNStatus
+        let isProxyStatusChange: Bool
+    }
+
     private func subscribeToStatusChanges() {
         notificationCenter.publisher(for: .NEVPNStatusDidChange)
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] notification in
-                self?.statusChanged(notification: notification)
+            .compactMap { [proxyController] notification in
+                guard let connection = notification.object as? NEVPNConnection else {
+                    return nil
+                }
+
+                return ProxyStatusUpdate(
+                    newStatus: connection.status,
+                    isProxyStatusChange: proxyController.isUsingConnection(connection))
+            }
+            .removeDuplicates()
+            .sink { [weak self] (proxyStatusUpdate: ProxyStatusUpdate) in
+                self?.statusChanged(
+                    newStatus: proxyStatusUpdate.newStatus,
+                    isProxyStatusChange: proxyStatusUpdate.isProxyStatusChange)
             }
             .store(in: &cancellables)
     }
 
-    private func statusChanged(notification: Notification) {
+    private func statusChanged(newStatus: NEVPNStatus, isProxyStatusChange: Bool) {
         Task { @MainActor in
-            guard let connection = notification.object as? NEVPNConnection else {
-                return
-            }
-
-            let isProxyConnectionStatusChange = proxyController.isUsingConnection(connection)
-
-            try await startOrStopProxyIfNeeded(isProxyConnectionStatusChange: isProxyConnectionStatusChange)
+            try await startOrStopProxyIfNeeded(isProxyConnectionStatusChange: isProxyStatusChange)
         }
     }
 

--- a/macOS/DuckDuckGoVPN/VPNProxyLauncher.swift
+++ b/macOS/DuckDuckGoVPN/VPNProxyLauncher.swift
@@ -75,7 +75,7 @@ final class VPNProxyLauncher {
 
     private func statusChanged(newStatus: NEVPNStatus, isProxyStatusChange: Bool) {
         Task { @MainActor in
-            try await startOrStopProxyIfNeeded(isProxyConnectionStatusChange: isProxyStatusChange)
+            try await startOrStopProxyIfNeeded(isProxyStatusChange: isProxyStatusChange)
         }
     }
 
@@ -99,7 +99,7 @@ final class VPNProxyLauncher {
 
     private var isControllingProxy = false
 
-    private func startOrStopProxyIfNeeded(isProxyConnectionStatusChange: Bool = false) async throws {
+    private func startOrStopProxyIfNeeded(isProxyStatusChange: Bool = false) async throws {
         if await shouldStartProxy {
             guard !isControllingProxy else {
                 return
@@ -114,7 +114,7 @@ final class VPNProxyLauncher {
             // When we're auto-starting the proxy because its own status changed to
             // disconnected, we want to give it a pause because if it fails to connect again
             // we risk the proxy entering a frenetic connect / disconnect loop
-            if isProxyConnectionStatusChange {
+            if isProxyStatusChange {
                 // If the proxy connection was stopped, let's wait a bit before trying to enable it again
                 try await Task.sleep(interval: .seconds(1))
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1199230911884351/1209699791105436/f

### Description

This is a follow up to [a previous attempt at fixing this issue](https://github.com/duckduckgo/apple-browsers/pull/252).  While my previous attempt did mitigate the issue, the issue was not fully resolved.

### Testing Steps

1. Start the VPN.  Ensure CPU usage is normal.
2. If testing on the Sparkle build make sure the proxy is launched when exclusions are added, and stopped when there are no app or website exclusions

### Impact and Risks

Low

#### What could go wrong?

Not much really.  This would only affect the VPN proxy, which is mostly not noticeable.

### Quality Considerations

Ensure the logical changes make sense.

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)