### PR TITLE
iOS: Privacy Pro Onboarding Promotion - Ensure Correct Keyboard Behavior

### DIFF
--- a/iOS/DuckDuckGo/DaxDialogs.swift
+++ b/iOS/DuckDuckGo/DaxDialogs.swift
@@ -55,6 +55,10 @@ protocol ContextualOnboardingLogic {
 }
 
 protocol PrivacyProPromotionCoordinating {
+    /// Indicates whether the Privacy Pro promotion dialog is currently being displayed
+    var isShowingPrivacyProPromotion: Bool { get }
+    
+    /// Indicates whether the user has seen the Privacy Pro promotion dialog
     var privacyProPromotionDialogSeen: Bool { get set }
 }
 
@@ -665,6 +669,11 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
 }
 
 extension DaxDialogs: PrivacyProPromotionCoordinating {
+    
+    var isShowingPrivacyProPromotion: Bool {
+        currentHomeSpec == .privacyProPromotion
+    }
+
     var privacyProPromotionDialogSeen: Bool {
         get {
             settings.privacyProPromotionDialogShown

--- a/iOS/DuckDuckGo/NewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewController.swift
@@ -44,6 +44,8 @@ final class NewTabPageViewController: UIHostingController<AnyView>, NewTabPage {
 
     private let pixelFiring: PixelFiring.Type
 
+    private var privacyProPromotionCoordinating: PrivacyProPromotionCoordinating
+
     var isDaxDialogVisible: Bool {
         daxDialogViewController?.view.isHidden == false
     }
@@ -56,6 +58,7 @@ final class NewTabPageViewController: UIHostingController<AnyView>, NewTabPage {
          variantManager: VariantManager,
          newTabDialogFactory: any NewTabDaxDialogProvider,
          newTabDialogTypeProvider: NewTabDialogSpecProvider,
+         privacyProPromotionCoordinating: PrivacyProPromotionCoordinating = DaxDialogs.shared,
          faviconLoader: FavoritesFaviconLoading,
          pixelFiring: PixelFiring.Type = Pixel.self) {
 
@@ -63,6 +66,7 @@ final class NewTabPageViewController: UIHostingController<AnyView>, NewTabPage {
         self.variantManager = variantManager
         self.newTabDialogFactory = newTabDialogFactory
         self.newTabDialogTypeProvider = newTabDialogTypeProvider
+        self.privacyProPromotionCoordinating = privacyProPromotionCoordinating
         self.pixelFiring = pixelFiring
 
         newTabPageViewModel = NewTabPageViewModel()
@@ -210,6 +214,8 @@ final class NewTabPageViewController: UIHostingController<AnyView>, NewTabPage {
     weak var shortcutsDelegate: NewTabPageControllerShortcutsDelegate?
 
     func launchNewSearch() {
+        // If we are displaying a Privacy Pro promotion on a new tab, do not activate search
+        guard !privacyProPromotionCoordinating.isShowingPrivacyProPromotion else { return }
         chromeDelegate?.omniBar.becomeFirstResponder()
     }
 
@@ -288,19 +294,22 @@ extension NewTabPageViewController {
 
         guard let spec = dialogProvider.nextHomeScreenMessageNew() else { return }
 
-        let onDismiss = { [weak self] in
+        let onDismiss: (_ activateSearch: Bool) -> Void = { [weak self] activateSearch in
             guard let self else { return }
 
             let nextSpec = dialogProvider.nextHomeScreenMessageNew()
             guard nextSpec != .privacyProPromotion else {
+                chromeDelegate?.omniBar.resignFirstResponder()
                 showNextDaxDialog()
                 return
             }
 
             dialogProvider.dismiss()
             self.dismissHostingController(didFinishNTPOnboarding: true)
-            // Make the address bar first responder after closing the new tab page final dialog.
-            self.launchNewSearch()
+            if activateSearch {
+                // Make the address bar first responder after closing the new tab page final dialog.
+                self.launchNewSearch()
+            }
         }
         let daxDialogView = AnyView(factory.createDaxDialog(for: spec, onDismiss: onDismiss))
         let hostingController = UIHostingController(rootView: daxDialogView)

--- a/iOS/DuckDuckGoTests/ContextualOnboardingNewTabDialogFactoryTests.swift
+++ b/iOS/DuckDuckGoTests/ContextualOnboardingNewTabDialogFactoryTests.swift
@@ -68,7 +68,7 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
         let homeDialog = DaxDialogs.HomeScreenSpec.initial
 
         // When
-        let view = factory.createDaxDialog(for: homeDialog, onDismiss: {})
+        let view = factory.createDaxDialog(for: homeDialog, onDismiss: { _ in })
         let host = UIHostingController(rootView: view)
         XCTAssertNotNil(host.view)
 
@@ -83,7 +83,7 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
         let homeDialog = DaxDialogs.HomeScreenSpec.subsequent
 
         // When
-        let view = factory.createDaxDialog(for: homeDialog, onDismiss: {})
+        let view = factory.createDaxDialog(for: homeDialog, onDismiss: { _ in })
         let host = UIHostingController(rootView: view)
         XCTAssertNotNil(host.view)
 
@@ -99,7 +99,7 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
         contextualOnboardingLogicMock.expectation = expectation
         var onDismissedRun = false
         let homeDialog = DaxDialogs.HomeScreenSpec.final
-        let onDimsiss = { onDismissedRun = true }
+        let onDimsiss: (Bool) -> Void = {  _ in onDismissedRun = true }
 
         // When
         let view = factory.createDaxDialog(for: homeDialog, onDismiss: onDimsiss)
@@ -121,7 +121,7 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
         let homeDialog = DaxDialogs.HomeScreenSpec.addFavorite
 
         // When
-        let view = factory.createDaxDialog(for: homeDialog, onDismiss: {})
+        let view = factory.createDaxDialog(for: homeDialog, onDismiss: { _ in })
         let host = UIHostingController(rootView: view)
         XCTAssertNotNil(host.view)
 
@@ -159,7 +159,7 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
 
     func testWhenOnboardingFinalDialogCTAIsTapped_ThenFireExpectedPixel() throws {
         // GIVEN
-        let view = factory.createDaxDialog(for: DaxDialogs.HomeScreenSpec.final, onDismiss: {})
+        let view = factory.createDaxDialog(for: DaxDialogs.HomeScreenSpec.final, onDismiss: { _ in })
         let host = UIHostingController(rootView: view)
         window.rootViewController = host
         let finalDialog = try XCTUnwrap(find(OnboardingFinalDialog.self, in: host))
@@ -178,7 +178,7 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
         // GIVEN
         let spec = DaxDialogs.HomeScreenSpec.final
         onboardingManagerMock.addToDockEnabledState = .contextual
-        let dialog = factory.createDaxDialog(for: spec, onDismiss: {})
+        let dialog = factory.createDaxDialog(for: spec, onDismiss: { _ in })
 
         // WHEN
         let result = try XCTUnwrap(find(OnboardingFinalDialog.self, in: dialog))
@@ -192,7 +192,7 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
         // GIVEN
         let spec = DaxDialogs.HomeScreenSpec.final
         onboardingManagerMock.addToDockEnabledState = .contextual
-        let dialog = factory.createDaxDialog(for: spec, onDismiss: {})
+        let dialog = factory.createDaxDialog(for: spec, onDismiss: { _ in })
         let view = try XCTUnwrap(find(OnboardingFinalDialog.self, in: dialog))
 
         // WHEN
@@ -218,7 +218,7 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
         // GIVEN
         let spec = DaxDialogs.HomeScreenSpec.final
         onboardingManagerMock.addToDockEnabledState = .contextual
-        let dialog = factory.createDaxDialog(for: spec, onDismiss: {})
+        let dialog = factory.createDaxDialog(for: spec, onDismiss: { _ in })
         let view = try XCTUnwrap(find(OnboardingFinalDialog.self, in: dialog))
         XCTAssertFalse(pixelReporterMock.didCallMeasureAddToDockPromoShowTutorialCTAAction)
 
@@ -233,7 +233,7 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
         // GIVEN
         let spec = DaxDialogs.HomeScreenSpec.final
         onboardingManagerMock.addToDockEnabledState = .contextual
-        let dialog = factory.createDaxDialog(for: spec, onDismiss: {})
+        let dialog = factory.createDaxDialog(for: spec, onDismiss: { _ in })
         let view = try XCTUnwrap(find(OnboardingFinalDialog.self, in: dialog))
         XCTAssertFalse(pixelReporterMock.didCallMeasureAddToDockPromoDismissCTAAction)
 
@@ -248,7 +248,7 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
         // GIVEN
         let spec = DaxDialogs.HomeScreenSpec.final
         onboardingManagerMock.addToDockEnabledState = .contextual
-        let dialog = factory.createDaxDialog(for: spec, onDismiss: {})
+        let dialog = factory.createDaxDialog(for: spec, onDismiss: { _ in })
         let view = try XCTUnwrap(find(OnboardingFinalDialog.self, in: dialog))
         XCTAssertFalse(pixelReporterMock.didCallMeasureAddToDockTutorialDismissCTAAction)
 
@@ -278,7 +278,7 @@ private extension ContextualOnboardingNewTabDialogFactoryTests {
         XCTAssertNil(pixelReporterMock.capturedScreenImpression)
 
         // WHEN
-        let view = factory.createDaxDialog(for: spec, onDismiss: {})
+        let view = factory.createDaxDialog(for: spec, onDismiss: { _ in })
         let host = OnboardingHostingControllerMock(rootView: AnyView(view))
         host.onAppearExpectation = expectation
         window.rootViewController = host

--- a/iOS/DuckDuckGoTests/ContextualOnboardingNewTabDialogFactoryTests.swift
+++ b/iOS/DuckDuckGoTests/ContextualOnboardingNewTabDialogFactoryTests.swift
@@ -99,7 +99,7 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
         contextualOnboardingLogicMock.expectation = expectation
         var onDismissedRun = false
         let homeDialog = DaxDialogs.HomeScreenSpec.final
-        let onDimsiss: (Bool) -> Void = {  _ in onDismissedRun = true }
+        let onDimsiss: (Bool) -> Void = { _ in onDismissedRun = true }
 
         // When
         let view = factory.createDaxDialog(for: homeDialog, onDismiss: onDimsiss)

--- a/iOS/DuckDuckGoTests/DaxDialogTests.swift
+++ b/iOS/DuckDuckGoTests/DaxDialogTests.swift
@@ -1030,6 +1030,47 @@ final class DaxDialog: XCTestCase {
         XCTAssertTrue(result)
     }
 
+    func testWhenCurrentHomeSpecIsPrivacyProPromotion_ThenIsShowingPrivacyProPromotionIsTrue() {
+        // GIVEN
+        let settings = MockDaxDialogsSettings()
+        settings.browsingFinalDialogShown = true
+        settings.privacyProPromotionDialogShown = false
+        let mockExperiment = MockOnboardingPrivacyProPromoExperimenting(cohort: .treatment)
+        let sut = makeSUT(settings: settings, onboardingPrivacyProPromoExperiment: mockExperiment)
+
+        // WHEN
+        _ = sut.nextHomeScreenMessageNew()
+        let result = sut.isShowingPrivacyProPromotion
+
+        // THEN
+        XCTAssertTrue(result)
+    }
+
+    func testWhenCurrentHomeSpecIsNotPrivacyProPromotion_ThenIsShowingPrivacyProPromotionIsFalse() {
+        // GIVEN
+        let settings = MockDaxDialogsSettings()
+        let sut = makeSUT(settings: settings)
+
+        // WHEN
+        let result = sut.isShowingPrivacyProPromotion
+
+        // THEN
+        XCTAssertFalse(result)
+    }
+
+    func testWhenCurrentHomeSpecIsFinal_ThenIsShowingPrivacyProPromotionIsFalse() {
+        // GIVEN
+        let settings = MockDaxDialogsSettings()
+        let sut = makeSUT(settings: settings)
+
+        // WHEN
+        _ = sut.nextHomeScreenMessageNew()
+        let result = sut.isShowingPrivacyProPromotion
+
+        // THEN
+        XCTAssertFalse(result)
+    }
+
     private func detectedTrackerFrom(_ url: URL, pageUrl: String) -> DetectedRequest {
         let entity = entityProvider.entity(forHost: url.host!)
         return DetectedRequest(url: url.absoluteString,

--- a/iOS/DuckDuckGoTests/NewTabPageControllerDaxDialogTests.swift
+++ b/iOS/DuckDuckGoTests/NewTabPageControllerDaxDialogTests.swift
@@ -156,8 +156,8 @@ class MockFavoritesListInteracting: FavoritesListInteracting {
 
 class CapturingNewTabDaxDialogProvider: NewTabDaxDialogProvider {
     var homeDialog: DaxDialogs.HomeScreenSpec?
-    var onDismiss: (() -> Void)?
-    func createDaxDialog(for homeDialog: DaxDialogs.HomeScreenSpec, onDismiss: @escaping () -> Void) -> some View {
+    var onDismiss: ((_ activateSearch: Bool) -> Void)?
+    func createDaxDialog(for homeDialog: DaxDialogs.HomeScreenSpec, onDismiss: @escaping (_ activateSearch: Bool) -> Void) -> some View {
         self.homeDialog = homeDialog
         self.onDismiss = onDismiss
         return EmptyView()

--- a/iOS/DuckDuckGoTests/NewTabPageControllerPixelTests.swift
+++ b/iOS/DuckDuckGoTests/NewTabPageControllerPixelTests.swift
@@ -87,7 +87,7 @@ final class NewTabPageControllerPixelTests: XCTestCase {
 }
 
 private class MockDaxDialogFactory: NewTabDaxDialogProvider {
-    func createDaxDialog(for homeDialog: DaxDialogs.HomeScreenSpec, onDismiss: @escaping () -> Void) -> EmptyView {
+    func createDaxDialog(for homeDialog: DaxDialogs.HomeScreenSpec, onDismiss: @escaping (_ activateSearch: Bool) -> Void) -> EmptyView {
         EmptyView()
     }
 }

--- a/iOS/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
+++ b/iOS/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
@@ -246,6 +246,7 @@ final class ContextualOnboardingLogicMock: ContextualOnboardingLogic, PrivacyPro
     var isShowingSearchSuggestions: Bool = false
     var isShowingSitesSuggestions: Bool = false
     var isShowingAddToDockDialog: Bool = false
+    var isShowingPrivacyProPromotion: Bool = false
 
     func setTryAnonymousSearchMessageSeen() {
         didCallSetTryAnonymousSearchMessageSeen = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209738106994913

### Description
This PR makes changes to ensure we display/dismiss the keyboard as expected when displaying/dismissing the Privacy Pro Onboarding Promotion. See test cases below.

### Test Prerequisites
1. Force a treatment cohort by adding `return .treatment` as the first line of the `getCohortIfEnabled` method in `OnboardingPrivacyProPromoExperiment`

### Testing Steps
#### Test Case 1 ####
1. Fresh install the app on a physical device
2. Launch and proceed to the ‘High Five’ last onboarding step
3. Tap ‘High Five’ to display the PP promotion
4. Ensure the Keyboard is dismissed
5. Tap ‘Learn More'
6. Ensure the keyboard remains dismissed the the PP paywall is opened

#### Test Case 2 ####
1. Fresh install the app on a physical device
2. Launch and proceed to the ‘High Five’ last onboarding step
3. Tap ‘High Five’ to display the PP promotion
4. Ensure the Keyboard is dismissed
5. Tap ’Skip'
6. Ensure the omnibar becomes focused and the keyboard is displayed

#### Test Case 3 ####
1. Fresh install the app on a physical device
2. Launch and proceed to the ‘High Five’ last onboarding step
3. Dismiss the keyboard by tapping the back arrow in the omnibar
4. Ensure the Keyboard is dismissed
5. Open a new tab
6. Ensure the PP promotion is displayed and the keyboard remains dismissed

### Impact and Risks
Medium: If this did not work as expected, existing omnibar and keyboard behavior could be impacted.

#### What could go wrong?
The omnibar and keyboard might not behave as expected (i.e not be focused on a new tab opening)

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)