### PR TITLE
finish onboarding animations by tapping anywhere on screen

### DIFF
--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewController.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewController.swift
@@ -46,4 +46,10 @@ final class OnboardingIntroViewController: UIHostingController<OnboardingView>, 
     override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
         return .portrait
     }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        viewModel.tapped()
+    }
+
 }

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
@@ -24,7 +24,29 @@ import class UIKit.UIApplication
 
 @MainActor
 final class OnboardingIntroViewModel: ObservableObject {
+
+    struct AppIconPickerContentState {
+        var animateTitle = true
+        var animateMessage = false
+        var showContent = false
+    }
+
+    struct AddressBarPositionContentState {
+        var animateTitle = true
+        var showContent = false
+    }
+
     @Published private(set) var state: OnboardingView.ViewState = .landing
+
+    @Published var showDaxDialogBox = false
+    @Published var showIntroViewContent = true
+    @Published var showIntroButton = false
+    @Published var animateIntroText = false
+    @Published var showComparisonButton = false
+    @Published var animateComparisonText = false
+
+    @Published var appIconPickerContentState = AppIconPickerContentState()
+    @Published var addressBarPositionContentState = AddressBarPositionContentState()
 
     let copy: Copy
     var onCompletingOnboardingIntro: (() -> Void)?
@@ -136,6 +158,26 @@ final class OnboardingIntroViewModel: ObservableObject {
             pixelReporter.measureChooseBottomAddressBarPosition()
         }
         onCompletingOnboardingIntro?()
+    }
+
+    func tapped() {
+        switch state.intro?.type {
+        case .startOnboardingDialog:
+            showIntroButton = true
+            animateIntroText = false
+        case .browsersComparisonDialog:
+            showComparisonButton = true
+            animateComparisonText = false
+        case .chooseAppIconDialog:
+            appIconPickerContentState.animateTitle = false
+            appIconPickerContentState.animateMessage = false
+            appIconPickerContentState.showContent = true
+        case .chooseAddressBarPositionDialog:
+            addressBarPositionContentState.animateTitle = false
+            addressBarPositionContentState.showContent = true
+        default: break
+        }
+
     }
 
 #if DEBUG || ALPHA

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView+AddressBarPositionContent.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView+AddressBarPositionContent.swift
@@ -27,11 +27,6 @@ private enum Metrics {
 
 extension OnboardingView {
 
-    struct AddressBarPositionContentState {
-        var animateTitle = true
-        var showContent = false
-    }
-
     struct AddressBarPositionContent: View {
 
         private var animateTitle: Binding<Bool>

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView+AppIconPickerContent.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView+AppIconPickerContent.swift
@@ -23,12 +23,6 @@ import Onboarding
 
 extension OnboardingView {
 
-    struct AppIconPickerContentState {
-        var animateTitle = true
-        var animateMessage = false
-        var showContent = false
-    }
-
     struct AppIconPickerContent: View {
 
         private var animateTitle: Binding<Bool>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1209263729854157/f
Tech Design URL:
CC:

### Description
Tap anywhere to skip animations in onboarding.

### Testing Steps
1. Run through onboarding (either clean install or from debug menu)
2. Check tapping on the screen outside of the switftui view ends the typing animation on each page

### Impact and Risks
Low: Minor visual changes, small bug fixes

#### What could go wrong?
Not much?

### Quality Considerations
Onboarding should work as before.

### Notes to Reviewer
n/a
