### PR TITLE
fire pixel on de/select all tabs

### DIFF
--- a/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
@@ -195,11 +195,15 @@ extension TabSwitcherViewController {
     }
 
     func deselectAllTabs() {
+        Pixel.fire(pixel: .tabSwitcherDeselectAll)
+        DailyPixel.fire(pixel: .tabSwitcherDeselectAllDaily)
         collectionView.reloadData()
         updateUIForSelectionMode()
     }
 
     func selectAllTabs() {
+        Pixel.fire(pixel: .tabSwitcherSelectAll)
+        DailyPixel.fire(pixel: .tabSwitcherSelectAllDaily)
         collectionView.reloadData()
         tabsModel.tabs.indices.forEach {
             collectionView.selectItem(at: IndexPath(row: $0, section: 0), animated: true, scrollPosition: [])
@@ -526,18 +530,6 @@ extension TabSwitcherViewController {
 
     func selectModeShareLinks() {
         shareTabs(selectedTabs.compactMap { tabsModel.safeGetTabAt($0.row) })
-    }
-
-    func selectModeDeselectAllTabs() {
-        Pixel.fire(pixel: .tabSwitcherDeselectAll)
-        DailyPixel.fire(pixel: .tabSwitcherDeselectAllDaily)
-        deselectAllTabs()
-    }
-
-    func selectModeSelectAllTabs() {
-        Pixel.fire(pixel: .tabSwitcherSelectAll)
-        DailyPixel.fire(pixel: .tabSwitcherSelectAllDaily)
-        selectAllTabs()
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1209499866654340/1209755087595724/f
Tech Design URL:
CC:

### Description
Fire a pixel when de/select all tabs is tapped.

### Testing Steps
1. Open tab switcher. 
2. Tap edit
3. Tap select tabs
4. Tap Select all button - check select all tabs and select all tabs daily button fired
5. Tap Deselect all button - check deselect all tabs and deselect all tabs daily button fired
6. Repeat and check the daily not sent again


### Impact and Risks
Low: minor fix for pixels

#### What could go wrong?
Not much

### Quality Considerations
Only affects the de/select all tabs functionality.

### Notes to Reviewer
Just the tab switcher and firing pixels.
