### PR TITLE
Run macOS UI Tests on all macOS-related pull requests

### DIFF
--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -15,9 +15,10 @@ on:
   schedule:
     - cron: '0 3 * * 1-5' # 3AM UTC offsetted to legacy to avoid action-junit-report@v4 bug
   pull_request:
-    branches:
-      - hotfix/macos/**
-      - release/macos/**
+    paths:
+      - '.github/**'
+      - 'BrowserServicesKit/**'
+      - 'macOS/**'
 
 jobs:
   create-notarized-app:
@@ -55,7 +56,8 @@ jobs:
       - name: Define runners
         id: define-runners
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" || "${{ inputs.all_os_versions }}" == "false" ]]; then
+          all_os_versions="${{ inputs.all_os_versions || 'true' }}"
+          if [[ "${{ github.event_name }}" == "pull_request" || "$all_os_versions" == "false" ]]; then
             runner='["macos-15-xlarge"]'
             include='[{"runner": "macos-15-xlarge", "os-version": "15", "xcode-version": "16.2"}]'
           else

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -189,10 +189,11 @@ jobs:
       id: prepare-test-report
       if: always()
       run: |
-        file="${{ matrix.test }} (macOS ${{ matrix.os-version }}).xml"
+        test_id="${{ matrix.test }} (macOS ${{ matrix.os-version }})"
+        file="${test_id}.xml"
         echo "file=$file" >> $GITHUB_OUTPUT
         xcbeautify --report junit --report-path . --junit-report-filename "$file" < ui-tests.log
-        sed -i '' 's/Selected tests/${{ matrix.test }}/' "$file"
+        sed -i '' 's/Selected tests/${test_id}/' "$file"
 
     - name: Upload test report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -227,12 +227,14 @@ jobs:
         merge-multiple: true
 
     - name: Publish tests report
-      uses: mikepenz/action-junit-report@v4
+      uses: mikepenz/action-junit-report@v5
       if: always()
       with:
-        check_title_template: "{{FILE_NAME}}"
+        check_name: UI Tests Report
         report_paths: "*.xml"
         check_retries: true
+        detailed_summary: true
+        group_suite: true
 
   notify-failure:
     name: Notify on failure

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -197,7 +197,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: "Test Report: ${{ matrix.test }} (macOS ${{ matrix.os-version }})"
+        name: "testreport-${{ matrix.test }}-macos${{ matrix.os-version }}"
         path: "macOS/${{ steps.prepare-test-report.outputs.file }}"
         retention-days: 1
 
@@ -223,7 +223,7 @@ jobs:
       uses: actions/download-artifact@v4
       if: always()
       with:
-        pattern: "Test Report:*"
+        pattern: "testreport-*"
         merge-multiple: true
 
     - name: Publish tests report

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -193,7 +193,7 @@ jobs:
         file="${test_id}.xml"
         echo "file=$file" >> $GITHUB_OUTPUT
         xcbeautify --report junit --report-path . --junit-report-filename "$file" < ui-tests.log
-        sed -i '' 's/Selected tests/${test_id}/' "$file"
+        sed -i '' "s/Selected tests/${test_id}/" "$file"
 
     - name: Upload test report
       uses: actions/upload-artifact@v4
@@ -236,7 +236,7 @@ jobs:
         report_paths: "*.xml"
         check_retries: true
         group_reports: false
-        include_empty_in_summary: false
+        skip_annotations: true
 
   notify-failure:
     name: Notify on failure

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -238,7 +238,9 @@ jobs:
         report_paths: "*.xml"
         check_retries: true
         group_reports: false
-        skip_annotations: true
+        flaky_summary: true
+        verbose_summary: false
+        include_time_in_summary: true
 
   notify-failure:
     name: Notify on failure

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -60,11 +60,11 @@ jobs:
             include='[{"runner": "macos-15-xlarge", "os-version": "15", "xcode-version": "16.2"}]'
           else
             runner='["macos-13-xlarge", "macos-14-xlarge", "macos-15-xlarge"]'
-            include='[
+            include=$(jq -c <<< '[
               {"runner": "macos-13-xlarge", "os-version": "13", "xcode-version": "15.2"},
               {"runner": "macos-14-xlarge", "os-version": "14", "xcode-version": "15.4"},
               {"runner": "macos-15-xlarge", "os-version": "15", "xcode-version": "16.2"}
-            ]'
+            ]')
           fi
           echo "runner=${runner}" >> $GITHUB_OUTPUT
           echo "include=${include}" >> $GITHUB_OUTPUT

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -77,7 +77,7 @@ jobs:
         id: list-tests
         run: |
           # Find all test files in the UITests directory
-          # This assumes that all test test files are named *Tests.swift and are put directly in the UITests directory
+          # This assumes that all test files are named *Tests.swift and are put directly in the UITests directory
           test_names="$(find UITests -type f -maxdepth 1 -name *Tests.swift | xargs basename | sed 's/\.swift//')"
           test=$(echo $test_names | jq -cR 'split(" ")')
           echo "test=${test}" >> $GITHUB_OUTPUT
@@ -199,6 +199,7 @@ jobs:
         file="${test_id}.xml"
         echo "file=$file" >> $GITHUB_OUTPUT
         xcbeautify --report junit --report-path . --junit-report-filename "$file" < ui-tests.log
+        # Replace the default test suite name with the test id for better grouping in the test report
         sed -i '' "s/Selected tests/${test_id}/" "$file"
 
     # Upload test report as artifact for the test-report job

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -14,6 +14,11 @@ on:
         required: true
   schedule:
     - cron: '0 3 * * 1-5' # 3AM UTC offsetted to legacy to avoid action-junit-report@v4 bug
+  push:
+    branches: [ main, "release/macos/**", "hotfix/macos/**" ]
+    paths:
+      - 'BrowserServicesKit/**'
+      - 'macOS/**'
   pull_request:
     paths:
       - '.github/**'
@@ -59,7 +64,7 @@ jobs:
         run: |
           # scheduled runs don't have inputs so let's default to true for all_os_versions
           all_os_versions="${{ inputs.all_os_versions || 'true' }}"
-          if [[ "${{ github.event_name }}" == "pull_request" || "$all_os_versions" == "false" ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "push" || "$all_os_versions" == "false" ]]; then
             runner='["macos-15-xlarge"]'
             include='[{"runner": "macos-15-xlarge", "os-version": "15", "xcode-version": "16.2"}]'
           else

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -6,6 +6,12 @@ defaults:
 
 on:
   workflow_dispatch:
+    inputs:
+      all_os_versions:
+        description: "Whether to test all OS versions or only the latest"
+        type: boolean
+        default: true
+        required: true
   schedule:
     - cron: '0 3 * * 1-5' # 3AM UTC offsetted to legacy to avoid action-junit-report@v4 bug
   pull_request:
@@ -35,14 +41,33 @@ jobs:
       MM_WEBHOOK_URL: ${{ secrets.MM_WEBHOOK_URL }}
       SSH_PRIVATE_KEY_FASTLANE_MATCH: ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
 
-  create-tests-list:
-    name: Create tests list
+  setup-tests:
+    name: Set up tests list
     runs-on: macos-15
     outputs:
+      runner: ${{ steps.define-runners.outputs.runner }}
+      include: ${{ steps.define-runners.outputs.include }}
       test: ${{ steps.list-tests.outputs.test }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Define runners
+        id: define-runners
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" || "${{ inputs.all_os_versions }}" == "false" ]]; then
+            runner='["macos-15-xlarge"]'
+            include='[{"runner": "macos-15-xlarge", "os-version": "15", "xcode-version": "16.2"}]'
+          else
+            runner='["macos-13-xlarge", "macos-14-xlarge", "macos-15-xlarge"]'
+            include='[
+              {"runner": "macos-13-xlarge", "os-version": "13", "xcode-version": "15.2"},
+              {"runner": "macos-14-xlarge", "os-version": "14", "xcode-version": "15.4"},
+              {"runner": "macos-15-xlarge", "os-version": "15", "xcode-version": "16.2"}
+            ]'
+          fi
+          echo "runner=${runner}" >> $GITHUB_OUTPUT
+          echo "include=${include}" >> $GITHUB_OUTPUT
 
       - name: List tests
         id: list-tests
@@ -53,23 +78,14 @@ jobs:
 
   ui-tests:
     name: ${{ matrix.test }} (macOS ${{ matrix.os-version }})
-    needs: [create-notarized-app, create-tests-list]
+    needs: [create-notarized-app, setup-tests]
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        runner: ["macos-13-xlarge", "macos-14-xlarge", "macos-15-xlarge"]
-        test: ${{ fromJSON(needs.create-tests-list.outputs.test) }}
-        include:
-          - runner: macos-13-xlarge
-            os-version: "13"
-            xcode-version: "15.2"
-          - runner: macos-14-xlarge
-            os-version: "14"
-            xcode-version: "15.4"
-          - runner: macos-15-xlarge
-            os-version: "15"
-            xcode-version: "16.2"
+        runner: ${{ fromJSON(needs.setup-tests.outputs.runner) }}
+        test: ${{ fromJSON(needs.setup-tests.outputs.test) }}
+        include: ${{ fromJSON(needs.setup-tests.outputs.include) }}
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.runner }}-${{ matrix.test }}

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -35,36 +35,41 @@ jobs:
       MM_WEBHOOK_URL: ${{ secrets.MM_WEBHOOK_URL }}
       SSH_PRIVATE_KEY_FASTLANE_MATCH: ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
 
-  create-test-matrix:
-    name: Create test matrix
+  create-tests-list:
+    name: Create tests list
     runs-on: macos-15
     outputs:
-      include: ${{ steps.get-tests-matrix.outputs.include }}
+      test: ${{ steps.list-tests.outputs.test }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Calculate matrix
-        id: get-tests-matrix
+      - name: List tests
+        id: list-tests
         run: |
           test_names="$(find UITests -type f -maxdepth 1 -name *Tests.swift | xargs basename | sed 's/\.swift//')"
-          include="$(for i in $test_names; do
-            echo "{\"xcode-version\": \"15.2\", \"runner\": \"macos-13-xlarge\", \"test\": \"$i\"} \
-                {\"xcode-version\": \"15.4\", \"runner\": \"macos-14-xlarge\", \"test\": \"$i\"} \
-                {\"xcode-version\": \"16.2\", \"runner\": \"macos-15-xlarge\", \"test\": \"$i\"}"
-          done | jq -sc '{include: .}')"
-          echo "include=${include}" >> $GITHUB_OUTPUT
+          test=$(echo $test_names | jq -cR 'split(" ")')
+          echo "test=${test}" >> $GITHUB_OUTPUT
 
   ui-tests:
     name: UI tests
-    needs: [create-notarized-app, create-test-matrix]
+    needs: [create-notarized-app, create-tests-list]
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.create-test-matrix.outputs.include) }}
+      matrix:
+        runner: ["macos-13-xlarge", "macos-14-xlarge", "macos-15-xlarge"]
+        test: ${{ fromJSON(needs.create-tests-list.outputs.test) }}
+        include:
+          - runner: macos-13-xlarge
+            xcode-version: "15.2"
+          - runner: macos-14-xlarge
+            xcode-version: "15.4"
+          - runner: macos-15-xlarge
+            xcode-version: "16.2"
 
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.runner }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.runner }}-${{ matrix.test }}
       cancel-in-progress: true
 
     timeout-minutes: 120

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -35,21 +35,33 @@ jobs:
       MM_WEBHOOK_URL: ${{ secrets.MM_WEBHOOK_URL }}
       SSH_PRIVATE_KEY_FASTLANE_MATCH: ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
 
+  create-test-matrix:
+    name: Create test matrix
+    runs-on: macos-15
+    outputs:
+      include: ${{ steps.get-tests-matrix.outputs.include }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Calculate matrix
+        id: get-tests-matrix
+        run: |
+          test_names="$(find UITests -type f -maxdepth 1 -name *Tests.swift | xargs basename | sed 's/\.swift//')"
+          include="$(for i in $test_names; do
+            echo "{\"xcode-version\": \"15.2\", \"runner\": \"macos-13-xlarge\", \"test\": \"$i\"} \
+                {\"xcode-version\": \"15.4\", \"runner\": \"macos-14-xlarge\", \"test\": \"$i\"} \
+                {\"xcode-version\": \"16.2\", \"runner\": \"macos-15-xlarge\", \"test\": \"$i\"}"
+          done | jq -sc '{include: .}')"
+          echo "include=${include}" >> $GITHUB_OUTPUT
+
   ui-tests:
     name: UI tests
-    needs: create-notarized-app
+    needs: [create-notarized-app, create-test-matrix]
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
-      matrix:
-        runner: [macos-13-xlarge, macos-14-xlarge, macos-15-xlarge]
-        include:
-          - xcode-version: "15.2"
-            runner: macos-13-xlarge
-          - xcode-version: "15.4"
-            runner: macos-14-xlarge
-          - xcode-version: "16.2"
-            runner: macos-15-xlarge
+      matrix: ${{ fromJSON(needs.create-test-matrix.outputs.include) }}
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.runner }}
@@ -145,6 +157,7 @@ jobs:
           -skipMacroValidation \
           -test-iterations 2 \
           -retry-tests-on-failure \
+          '-only-testing:UI Tests/${{ matrix.test }}' \
         | tee -a xcodebuild.log \
         | tee ui-tests.log
 
@@ -157,7 +170,7 @@ jobs:
       uses: mikepenz/action-junit-report@v4
       if: always()
       with:
-        check_name: "Test Report ${{ matrix.runner }}"
+        check_name: "Test Report ${{ matrix.runner }} ${{ matrix.test }}"
         report_paths: macOS/ui-tests.xml
         check_retries: true
 
@@ -165,7 +178,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: failure() || cancelled()
       with:
-        name: "BuildLogs ${{ matrix.runner }}"
+        name: "BuildLogs ${{ matrix.runner }} ${{ matrix.test }}"
         path: |
           macOS/xcodebuild.log
           macOS/DerivedData/Logs/Test/*.xcresult

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -233,8 +233,7 @@ jobs:
         check_name: UI Tests Report
         report_paths: "*.xml"
         check_retries: true
-        detailed_summary: true
-        group_suite: true
+        group_reports: false
 
   notify-failure:
     name: Notify on failure

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -247,6 +247,7 @@ jobs:
         flaky_summary: true
         verbose_summary: false
         include_time_in_summary: true
+        skip_annotations: true
 
   notify-failure:
     name: Notify on failure

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -170,28 +170,53 @@ jobs:
         | tee ui-tests.log
 
     - name: Prepare test report
+      id: prepare-test-report
       if: always()
       run: |
-        xcbeautify --report junit --report-path . --junit-report-filename ui-tests.xml < ui-tests.log
+        file="${{ matrix.test }} (macOS ${{ matrix.os-version }}).xml"
+        echo "file=$file" >> $GITHUB_OUTPUT
+        xcbeautify --report junit --report-path . --junit-report-filename "$file" < ui-tests.log
 
-    - name: Publish tests report
-      uses: mikepenz/action-junit-report@v4
+    - name: Upload test report
+      uses: actions/upload-artifact@v4
       if: always()
       with:
-        check_name: "Test Report ${{ matrix.runner }} ${{ matrix.test }}"
-        report_paths: macOS/ui-tests.xml
-        check_retries: true
+        name: "Test Report: ${{ matrix.test }} (macOS ${{ matrix.os-version }})"
+        path: "macOS/${{ steps.prepare-test-report.outputs.file }}"
+        retention-days: 1
 
     - name: Upload logs when workflow failed
       uses: actions/upload-artifact@v4
       if: failure() || cancelled()
       with:
-        name: "BuildLogs ${{ matrix.runner }} ${{ matrix.test }}"
+        name: "BuildLogs ${{ matrix.test }} (macOS ${{ matrix.os-version }})"
         path: |
           macOS/xcodebuild.log
           macOS/DerivedData/Logs/Test/*.xcresult
           ~/Library/Logs/DiagnosticReports/*
         retention-days: 7
+
+  test-report:
+    name: Report test results
+    if: always()
+    needs: [ui-tests]
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download test reports
+      uses: actions/download-artifact@v4
+      if: always()
+      with:
+        pattern: "Test Report:*"
+        merge-multiple: true
+
+    - name: Publish tests report
+      uses: mikepenz/action-junit-report@v4
+      if: always()
+      with:
+        check_title_template: "{{FILE_NAME}}"
+        report_paths: "*.xml"
+        check_retries: true
 
   notify-failure:
     name: Notify on failure

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -192,6 +192,7 @@ jobs:
         file="${{ matrix.test }} (macOS ${{ matrix.os-version }}).xml"
         echo "file=$file" >> $GITHUB_OUTPUT
         xcbeautify --report junit --report-path . --junit-report-filename "$file" < ui-tests.log
+        sed -i '' 's/Selected tests/${{ matrix.test }}/' "$file"
 
     - name: Upload test report
       uses: actions/upload-artifact@v4
@@ -230,10 +231,11 @@ jobs:
       uses: mikepenz/action-junit-report@v5
       if: always()
       with:
-        check_name: UI Tests Report
+        check_name: Tests Report
         report_paths: "*.xml"
         check_retries: true
         group_reports: false
+        include_empty_in_summary: false
 
   notify-failure:
     name: Notify on failure

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -52,7 +52,7 @@ jobs:
           echo "test=${test}" >> $GITHUB_OUTPUT
 
   ui-tests:
-    name: UI tests
+    name: ${{ matrix.test }} (macOS ${{ matrix.os-version }})
     needs: [create-notarized-app, create-tests-list]
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -62,10 +62,13 @@ jobs:
         test: ${{ fromJSON(needs.create-tests-list.outputs.test) }}
         include:
           - runner: macos-13-xlarge
+            os-version: "13"
             xcode-version: "15.2"
           - runner: macos-14-xlarge
+            os-version: "14"
             xcode-version: "15.4"
           - runner: macos-15-xlarge
+            os-version: "15"
             xcode-version: "16.2"
 
     concurrency:

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -42,6 +42,7 @@ jobs:
       MM_WEBHOOK_URL: ${{ secrets.MM_WEBHOOK_URL }}
       SSH_PRIVATE_KEY_FASTLANE_MATCH: ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
 
+  # This job sets up the matrix strategy arguments for the ui-tests job
   setup-tests:
     name: Set up tests list
     runs-on: macos-15
@@ -56,6 +57,7 @@ jobs:
       - name: Define runners
         id: define-runners
         run: |
+          # scheduled runs don't have inputs so let's default to true for all_os_versions
           all_os_versions="${{ inputs.all_os_versions || 'true' }}"
           if [[ "${{ github.event_name }}" == "pull_request" || "$all_os_versions" == "false" ]]; then
             runner='["macos-15-xlarge"]'
@@ -74,6 +76,8 @@ jobs:
       - name: List tests
         id: list-tests
         run: |
+          # Find all test files in the UITests directory
+          # This assumes that all test test files are named *Tests.swift and are put directly in the UITests directory
           test_names="$(find UITests -type f -maxdepth 1 -name *Tests.swift | xargs basename | sed 's/\.swift//')"
           test=$(echo $test_names | jq -cR 'split(" ")')
           echo "test=${test}" >> $GITHUB_OUTPUT
@@ -197,6 +201,8 @@ jobs:
         xcbeautify --report junit --report-path . --junit-report-filename "$file" < ui-tests.log
         sed -i '' "s/Selected tests/${test_id}/" "$file"
 
+    # Upload test report as artifact for the test-report job
+    # that publishes a combined report for all test cases
     - name: Upload test report
       uses: actions/upload-artifact@v4
       if: always()


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1203301625297703/1209765123515594/f

### Description:
This change updates macOS UI Tests workflow so that it runs single workflow per test case per OS version,
reducing total run time to <30 minutes. UI Tests will now run on macOS-related pull requests (only testing
macOS 15 to reduce costs).

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Verify [this workflow](https://github.com/duckduckgo/apple-browsers/actions/runs/14022842581) output for testing all OS versions.
2. Verify that this pull request runs UI tests for macOS 15.

### Impact and Risks
None

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)