### PR TITLE
Close all child windows before playing fire animation

### DIFF
--- a/macOS/DuckDuckGo/Fire/View/FireViewController.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireViewController.swift
@@ -187,6 +187,8 @@ final class FireViewController: NSViewController {
         }
 
         if playFireAnimation {
+            view.window?.childWindows?.forEach { $0.close() }
+
             await waitForFireAnimationViewIfNeeded()
 
             progressIndicatorWrapper.isHidden = true

--- a/macOS/DuckDuckGo/Fire/View/FireViewController.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireViewController.swift
@@ -153,7 +153,10 @@ final class FireViewController: NSViewController {
     private let fireAnimationBeginning = 0.1
     private let fireAnimationEnd = 0.63
 
+    @MainActor
     func animateFireWhenClosing() async {
+        closeAllChildWindows()
+
         await waitForFireAnimationViewIfNeeded()
         await withUnsafeContinuation { (continuation: UnsafeContinuation<Void, Never>) in
             progressIndicatorWrapper.isHidden = true
@@ -187,7 +190,7 @@ final class FireViewController: NSViewController {
         }
 
         if playFireAnimation {
-            view.window?.childWindows?.forEach { $0.close() }
+            closeAllChildWindows()
 
             await waitForFireAnimationViewIfNeeded()
 
@@ -219,6 +222,11 @@ final class FireViewController: NSViewController {
         if fireAnimationView == nil {
             await fireAnimationViewLoadingTask?.value
         }
+    }
+
+    @MainActor
+    private func closeAllChildWindows() {
+        view.window?.childWindows?.forEach { $0.close() }
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1209535721897918/f

### Description
This change attempts closing all windows before fire animation is played. Otherwise, if there
was a popover open (e.g. location permission or search suggestions), the animation would be
played “below” the popover and only after that the popover would be closed.

### Testing Steps
1. Run the app and visit maps.google.com
2. Request current location to trigger the location permission popover.
3. Burn all data using Fire button.
4. Verify that the location permission popover is closed before playing fire animation.
5. Type a search phrase in the address bar (so that the suggestions window is open) but don’t trigger the search.
6. Burn all data using Fire button and verify that the suggestions window is closed before playing fire animation.

### Impact and Risks
None - just moving child windows closing a bit earlier, to before fire animation.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)