### PR TITLE
Fix issue with jumping dax logo

### DIFF
--- a/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -229,9 +229,10 @@ extension SwipeTabsCoordinator: UICollectionViewDelegate {
         var height = targetSize.height
 
         let tab = tabsModel.safeGetTabAt(nextIndex)
-        if let tab, tab.link != nil, let image = tabPreviewsSource.preview(for: tab) {
+        if let tab, let image = tabPreviewsSource.preview(for: tab) {
             createPreviewFromImage(image)
             if appSettings.currentAddressBarPosition.isBottom,
+               tab.link != nil,
                let collectionView = coordinator.navigationBarContainer.subviews.first as? UICollectionView {
                 // Adjust the preview height to account for the omnibar at the bottom
                 // When the omnibar is at the bottom, the webview content extends underneath it
@@ -240,11 +241,13 @@ extension SwipeTabsCoordinator: UICollectionViewDelegate {
                 // because the container height can change when the keyboard appears
                 height = targetSize.height - collectionView.frame.size.height
             }
+            preview?.frame = CGRect(x: 0, y: 0, width: targetSize.width, height: height)
         } else if tab?.link == nil {
-            createPreviewFromLogoContainerWithSize(targetSize)
+            let targetFrame = CGRect(origin: .zero, size: coordinator.contentContainer.frame.size)
+            createPreviewFromLogoContainerWithSize(targetFrame.size)
+            preview?.frame = targetFrame
         }
 
-        preview?.frame = CGRect(x: 0, y: 0, width: targetSize.width, height: height)
         preview?.frame.origin.x = coordinator.contentContainer.frame.width * CGFloat(modifier)
         if ExperimentalThemingManager().isExperimentalThemingEnabled {
             preview?.clipsToBounds = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201392122292466/task/1209485028986793
CC: @dus7 

### Description
Fixes the issue with dax logo jumping on swipe.
This code needs to be refactored to create snapshot based on the new NewTabPageViewController and not logoContainer which no longer displays.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Make sure tab swiping works as on main, and doesn't glitch for regular pages.

### Impact and Risks
What's the impact on users if something goes wrong?
Low: Minor visual changes

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)