### PR TITLE
iOS - Fix app switches to wrong tab when pressing back

### DIFF
--- a/.maestro/release_tests/backbutton-close-tab.yaml
+++ b/.maestro/release_tests/backbutton-close-tab.yaml
@@ -1,0 +1,54 @@
+# tabs.yaml
+appId: com.duckduckgo.mobile.ios
+tags:
+    - release
+
+---
+
+# Set up 
+- runFlow: 
+    file: ../shared/setup.yaml
+
+# Load Site
+- assertVisible:
+    id: "searchEntry"
+- tapOn: 
+    id: "searchEntry"
+- inputText: "https://privacy-test-pages.site"
+- pressKey: Enter
+    
+- assertVisible: ".*Privacy Test Pages.*"
+
+# Add tab
+- assertVisible: Tab Switcher
+- tapOn: Tab Switcher
+- assertVisible: ".*Privacy Test Pages.*"
+- assertVisible: "New Tab"
+- tapOn: "New Tab"
+- assertVisible:
+    id: "searchEntry"
+- tapOn: 
+    id: "searchEntry"
+- inputText: "https://www.search-company.site"
+- pressKey: Enter
+- assertVisible: "Search engine"
+
+# Switch Tab
+- assertVisible: Tab Switcher
+- tapOn: Tab Switcher
+- assertVisible: ".*Privacy Test Pages.*"
+- assertVisible: ".*Ad Click Flow.*"
+- assertVisible: "2 Private Tabs"
+- tapOn: "Open \"Privacy Test Pages - Home\" at privacy-test-pages.site"
+- assertNotVisible: ".*Ad Click Flow.*"
+- assertVisible: ".*Privacy Test Pages.*"
+- tapOn: "Refresh Page"
+
+# Long press an item and open in new tab
+- longPressOn: "• 1 major tracker loaded via script"
+- tapOn: "Open In New Tab"
+
+# Back button should return to privacy page
+- tapOn: "Browse Back"
+- assertVisible: ".*Privacy Test Pages.*"
+

--- a/iOS/DuckDuckGo/TabsModel.swift
+++ b/iOS/DuckDuckGo/TabsModel.swift
@@ -140,10 +140,12 @@ public class TabsModel: NSObject, NSCoding {
             currentIndex = index
         } else if currentIndex >= tabs.count {
             currentIndex = tabs.count - 1
+        } else if currentIndex > 0 {
+            currentIndex -= 1
         }
         // Else: don't adjust the index as it'll be the 'next' tab
     }
-
+ 
     func remove(tab: Tab) {
         if let index = indexOf(tab: tab) {
             remove(at: index)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/392891325557410/1209761300722413/f
Tech Design URL:
CC:

### Description
When the back button is used on a tab that was open from another page it should go back to that page.

### Testing Steps
1. Visit https://privacy-test-pages.site
2. Open a new tab and visit https://www.search-company.site
3. Go back to the first tab and long press on a link, then select open in new tab
4. Tap the back button - should return to the privacy test pages
5. Open a few tabs and try closing with the tab switcher

### Impact and Risks
Medium

#### What could go wrong?
Could disrupt back button flow

### Quality Considerations
* UI and unit tests were added, especially around the tab manager.

### Notes to Reviewer
Focus on opening and closing tabs in various ways.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)