### PR TITLE
Revert "Fix scrolling when moving to a not visible tab (#311)"

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -724,12 +724,9 @@ extension TabBarViewController: TabCollectionViewModelDelegate {
 
         self.updateTabMode(for: collectionView.numberOfItems(inSection: 0) - 1, updateLayout: false)
 
-        let visibleIndexPaths = collectionView.indexPathsForVisibleItems
-        let selectedIndexPathIsVisible = visibleIndexPaths().contains(where: { $0.item == selectionIndex })
-
         // don't scroll when mouse over and removing non-last Tab
         let shouldScroll = collectionView.isAtEndScrollPosition
-        && (!self.view.isMouseLocationInsideBounds() || removedIndex == self.collectionView.numberOfItems(inSection: 0) - 1) || !selectedIndexPathIsVisible
+            && (!self.view.isMouseLocationInsideBounds() || removedIndex == self.collectionView.numberOfItems(inSection: 0) - 1)
         let visiRect = collectionView.enclosingScrollView!.contentView.documentVisibleRect
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0.15

--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
@@ -497,8 +497,8 @@ final class TabCollectionViewModel: NSObject {
             newSelectionIndex = selectionIndex.sanitized(for: self)
         }
 
-        select(at: newSelectionIndex, forceChange: forced)
         notifyDelegate()
+        select(at: newSelectionIndex, forceChange: forced)
     }
 
     func getLastSelectedTab() -> TabIndex? {

--- a/macOS/UITests/TabBarTests.swift
+++ b/macOS/UITests/TabBarTests.swift
@@ -124,24 +124,6 @@ class TabBarTests: UITestCase {
         XCTAssertTrue(app.staticTexts["Privacy Test Pages"].waitForExistence(timeout: UITests.Timeouts.elementExistence))
     }
 
-    func testCorrectTabIsSelected_whenTabBarIsInOverflowMode() {
-        /// Opens 20 sites
-        for i in 1..<21 {
-            openSite(pageTitle: "Page #\(i)")
-
-            if i != 20 {
-                app.openNewTab()
-            }
-        }
-
-        /// Selects the first tab and closes it
-        app.typeKey("1", modifierFlags: [.command])
-        app.menuItems["Close Tab"].tap()
-
-        /// Asserts that the recently used tab is shown
-        XCTAssertTrue(app.staticTexts["Sample text for Page #20"].waitForExistence(timeout: UITests.Timeouts.elementExistence))
-    }
-
     // MARK: - Utilities
 
     private func resetPinnedTabs() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1209751086393041/f
Tech Design URL:
CC:

### Description
This reverts commit 7e15ec6e4f6f83c084e71cd052fcef41249109de.

I was testing the new internal release, and I realized that if you have a pinned tab and try to close the only unpinned tab, the application would be in a weird state where the unpinned tab would not disappear, and new tabs would not appear.


### Testing Steps
1. Open a tab and pin it
2. Open an unpinned tab
4. Close the unpinned tab
5. The unpinned tab should disappear and adding new tabs should work as normal

### Impact and Risks
Low: we are removing a change that introduced a bug.

#### What could go wrong?
Nothing