### PR TITLE
Display History View in search suggestions

### DIFF
--- a/macOS/DuckDuckGo/Suggestions/Model/SuggestionContainer.swift
+++ b/macOS/DuckDuckGo/Suggestions/Model/SuggestionContainer.swift
@@ -164,20 +164,26 @@ extension SuggestionContainer: SuggestionLoadingDataSource {
         let openTabs = windowControllersManager.allTabViewModels(for: burnerMode, includingPinnedTabs: !burnerMode.isBurner)
         var isSettingsOpened = false
         var isBookmarksOpened = false
+        var isHistoryOpened = false
         // suggestions for Bookmarks&Settings if not Switch to Tab suggestions
         for tab in openTabs {
             if tab.tabContent == .bookmarks {
                 isBookmarksOpened = true
             } else if case .settings = tab.tabContent {
                 isSettingsOpened = true
+            } else if case .history = tab.tabContent {
+                isHistoryOpened = true
             }
-            if isBookmarksOpened && isSettingsOpened { break }
+            if isBookmarksOpened && isSettingsOpened && isHistoryOpened { break }
         }
         if !isBookmarksOpened {
             result.append(.init(title: UserText.bookmarks, url: .bookmarks))
         }
         if !isSettingsOpened {
             result.append(.init(title: UserText.settings, url: .settings))
+        }
+        if !isHistoryOpened {
+            result.append(.init(title: UserText.mainMenuHistory, url: .history))
         }
         result += PreferencePaneIdentifier.allCases.map {
             // preference panes URLs

--- a/macOS/DuckDuckGo/Suggestions/ViewModel/SuggestionViewModel.swift
+++ b/macOS/DuckDuckGo/Suggestions/ViewModel/SuggestionViewModel.swift
@@ -189,6 +189,9 @@ struct SuggestionViewModel: Equatable {
         case .internalPage(title: _, url: let url) where url.isSettingsURL,
              .openTab(title: _, url: let url, _) where url.isSettingsURL:
             return .settingsMulticolor16
+        case .internalPage(title: _, url: let url) where url.isHistory,
+             .openTab(title: _, url: let url, _) where url.isHistory:
+            return .historyFavicon
         case .internalPage(title: _, url: let url):
             guard url == URL(string: StartupPreferences.shared.formattedCustomHomePageURL) else { return nil }
             return .home16

--- a/macOS/UnitTests/Suggestions/ViewModel/SuggestionViewModelTests.swift
+++ b/macOS/UnitTests/Suggestions/ViewModel/SuggestionViewModelTests.swift
@@ -183,7 +183,7 @@ final class SuggestionViewModelTests: XCTestCase {
 
     func testWhenSuggestionIsOpenTabSettings_ThenSuggestionViewModelValuesAreCorrect() {
         let url = URL.settings
-        let title = "Settings"
+        let title = UserText.settings
         let suggestion = Suggestion.openTab(title: title, url: url, tabId: nil)
         let suggestionViewModel = SuggestionViewModel(suggestion: suggestion, userStringValue: "")
 
@@ -194,7 +194,7 @@ final class SuggestionViewModelTests: XCTestCase {
 
     func testWhenSuggestionIsOpenTabBookmarks_ThenSuggestionViewModelValuesAreCorrect() {
         let url = URL.bookmarks
-        let title = "Bookmarks"
+        let title = UserText.bookmarks
         let suggestion = Suggestion.openTab(title: title, url: url, tabId: nil)
         let suggestionViewModel = SuggestionViewModel(suggestion: suggestion, userStringValue: "")
 
@@ -203,6 +203,16 @@ final class SuggestionViewModelTests: XCTestCase {
         XCTAssertEqual(suggestionViewModel.suffix, UserText.duckDuckGo)
     }
 
+    func testWhenSuggestionIsOpenTabHistory_ThenSuggestionViewModelValuesAreCorrect() {
+        let url = URL.history
+        let title = UserText.mainMenuHistory
+        let suggestion = Suggestion.openTab(title: title, url: url, tabId: nil)
+        let suggestionViewModel = SuggestionViewModel(suggestion: suggestion, userStringValue: "")
+
+        XCTAssertEqual(suggestionViewModel.string, title)
+        XCTAssertEqual(suggestionViewModel.title, title)
+        XCTAssertEqual(suggestionViewModel.suffix, UserText.duckDuckGo)
+    }
 }
 
 extension SuggestionViewModel {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1209769319551329/f

### Description:
This change adds internal History page to search suggestions.

### Testing Steps
1. Launch the app
2. Type “history” in the address bar and verify that History View displays as the last suggestion. Verify that it opens History View.
3. Enable `autocompleteTabs` feature flag via _Main Menu -> Debug -> Feature Flag Overrides_
4. Keep History tab open and open a new tab. Type “history” and verify that it displays as “Switch to tab” suggestion. Verify that it correctly switches to History tab.

### Impact and Risks
Low/None: Minor visual changes, small bug fixes, improvement to existing features

### Quality Considerations
I’ve updated unit tests.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)