### PR TITLE
macOS: Fix translation issues in App Store builds

### DIFF
--- a/macOS/Configuration/App/DuckDuckGoAppStore.xcconfig
+++ b/macOS/Configuration/App/DuckDuckGoAppStore.xcconfig
@@ -33,8 +33,15 @@ ENABLE_APP_SANDBOX = YES
 MACOSX_DEPLOYMENT_TARGET = 12.3
 
 PRODUCT_MODULE_NAME = $(APP_STORE_PRODUCT_MODULE_NAME_OVERRIDE:default=$(DEFAULT_PRODUCT_MODULE_NAME))
-PRODUCT_NAME_PREFIX = DuckDuckGo App Store
-PRODUCT_NAME[config=Release][arch=*][sdk=*] = $(RELEASE_PRODUCT_NAME_OVERRIDE:default=$(PRODUCT_NAME_PREFIX))
+PRODUCT_NAME_PREFIX[config=Debug][arch=*][sdk=*] = DuckDuckGo App Store
+PRODUCT_NAME_PREFIX[config=CI][arch=*][sdk=*] = DuckDuckGo
+PRODUCT_NAME_PREFIX[config=Review][arch=*][sdk=*] = DuckDuckGo App Store
+PRODUCT_NAME_PREFIX[config=Release][arch=*][sdk=*] = DuckDuckGo
+
+PRODUCT_NAME[config=Debug][arch=*][sdk=*] = $(PRODUCT_NAME_PREFIX)
+PRODUCT_NAME[config=CI][arch=*][sdk=*] = $(PRODUCT_NAME_PREFIX)
+PRODUCT_NAME[config=Review][arch=*][sdk=*] = $(PRODUCT_NAME_PREFIX)
+PRODUCT_NAME[config=Release][arch=*][sdk=*] = $(PRODUCT_NAME_PREFIX)
 
 PROVISIONING_PROFILE_SPECIFIER[config=Debug][sdk=macosx*] =
 PROVISIONING_PROFILE_SPECIFIER[config=CI][sdk=macosx*] = match Direct com.duckduckgo.mobile.ios.debug macos

--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS Browser App Store.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS Browser App Store.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "3706FA6A293F65D500E42796"
-               BuildableName = "DuckDuckGo App Store.app"
+               BuildableName = "DuckDuckGo.app"
                BlueprintName = "DuckDuckGo Privacy Browser App Store"
                ReferencedContainer = "container:DuckDuckGo-macOS.xcodeproj">
             </BuildableReference>
@@ -66,7 +66,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "3706FA6A293F65D500E42796"
-                     BuildableName = "DuckDuckGo App Store.app"
+                     BuildableName = "DuckDuckGo.app"
                      BlueprintName = "DuckDuckGo Privacy Browser App Store"
                      ReferencedContainer = "container:DuckDuckGo-macOS.xcodeproj">
                   </BuildableReference>
@@ -282,7 +282,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "3706FA6A293F65D500E42796"
-            BuildableName = "DuckDuckGo App Store.app"
+            BuildableName = "DuckDuckGo.app"
             BlueprintName = "DuckDuckGo Privacy Browser App Store"
             ReferencedContainer = "container:DuckDuckGo-macOS.xcodeproj">
          </BuildableReference>
@@ -308,7 +308,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "3706FA6A293F65D500E42796"
-            BuildableName = "DuckDuckGo App Store.app"
+            BuildableName = "DuckDuckGo.app"
             BlueprintName = "DuckDuckGo Privacy Browser App Store"
             ReferencedContainer = "container:DuckDuckGo-macOS.xcodeproj">
          </BuildableReference>

--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS Browser Review App Store.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS Browser Review App Store.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "3706FA6A293F65D500E42796"
-               BuildableName = "DuckDuckGo App Store.app"
+               BuildableName = "DuckDuckGo.app"
                BlueprintName = "DuckDuckGo Privacy Browser App Store"
                ReferencedContainer = "container:DuckDuckGo-macOS.xcodeproj">
             </BuildableReference>
@@ -45,7 +45,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "3706FA6A293F65D500E42796"
-            BuildableName = "DuckDuckGo App Store.app"
+            BuildableName = "DuckDuckGo.app"
             BlueprintName = "DuckDuckGo Privacy Browser App Store"
             ReferencedContainer = "container:DuckDuckGo-macOS.xcodeproj">
          </BuildableReference>
@@ -61,7 +61,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "3706FA6A293F65D500E42796"
-            BuildableName = "DuckDuckGo App Store.app"
+            BuildableName = "DuckDuckGo.app"
             BlueprintName = "DuckDuckGo Privacy Browser App Store"
             ReferencedContainer = "container:DuckDuckGo-macOS.xcodeproj">
          </BuildableReference>

--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS Sync End-to-End UI Tests App Store.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS Sync End-to-End UI Tests App Store.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "3706FA6A293F65D500E42796"
-               BuildableName = "DuckDuckGo App Store.app"
+               BuildableName = "DuckDuckGo.app"
                BlueprintName = "DuckDuckGo Privacy Browser App Store"
                ReferencedContainer = "container:DuckDuckGo-macOS.xcodeproj">
             </BuildableReference>
@@ -84,7 +84,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "3706FA6A293F65D500E42796"
-            BuildableName = "DuckDuckGo App Store.app"
+            BuildableName = "DuckDuckGo.app"
             BlueprintName = "DuckDuckGo Privacy Browser App Store"
             ReferencedContainer = "container:DuckDuckGo-macOS.xcodeproj">
          </BuildableReference>
@@ -122,7 +122,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "3706FA6A293F65D500E42796"
-            BuildableName = "DuckDuckGo App Store.app"
+            BuildableName = "DuckDuckGo.app"
             BlueprintName = "DuckDuckGo Privacy Browser App Store"
             ReferencedContainer = "container:DuckDuckGo-macOS.xcodeproj">
          </BuildableReference>

--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS VPN Proxy Extension.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS VPN Proxy Extension.xcscheme
@@ -45,7 +45,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "3706FA6A293F65D500E42796"
-               BuildableName = "DuckDuckGo App Store.app"
+               BuildableName = "DuckDuckGo.app"
                BlueprintName = "DuckDuckGo Privacy Browser App Store"
                ReferencedContainer = "container:DuckDuckGo-macOS.xcodeproj">
             </BuildableReference>

--- a/macOS/DuckDuckGo/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localizable.xcstrings
@@ -34987,7 +34987,7 @@
     },
     "letsmove.alert.message" : {
       "comment" : "Message of the alert shown if the app is launched not from the /Applications folder – suggesting to move it there",
-      "extractionState" : "extracted_with_value",
+      "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -35047,7 +35047,7 @@
     },
     "letsmove.alert.title" : {
       "comment" : "Title of the alert shown if the app is launched not from the /Applications folder – suggesting to move it there",
-      "extractionState" : "extracted_with_value",
+      "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -35107,7 +35107,7 @@
     },
     "letsmove.could.not.move" : {
       "comment" : "Error message when moving the app to the /Applications folder failed",
-      "extractionState" : "extracted_with_value",
+      "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -35167,7 +35167,7 @@
     },
     "letsmove.dont.move.button" : {
       "comment" : "Do Not Move to the /Applications folder button title",
-      "extractionState" : "extracted_with_value",
+      "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -35227,7 +35227,7 @@
     },
     "letsmove.move.button" : {
       "comment" : "Move the /Applications folder button title",
-      "extractionState" : "extracted_with_value",
+      "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203108348835387/1209783038178583/f

### Description

Proposes tentative fixes so that our macOS App Store builds won't trigger ghost updates to InfoPlist.xcstrings and Localizable.xcstrings.

### Testing Steps

Build App Store debug target and make sure there are no updates to commit.
Build App Store release target and make sure there are no updates to commit.
Build Sparkle debug target and make sure there are no updates to commit.

### Impact and Risks

Low: shouldn't affect much if anything.

#### What could go wrong?

Changing something that breaks CI or that breaks our release builds.

### Quality Considerations

Make sure the configuration changes don't add anything that could cause trouble for CI or release builds.

### Notes to Reviewer

I'll add inline comments.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)