### PR TITLE
Remove AddressBarTextField.isSearchBox

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -28,29 +28,6 @@ import os.log
 
 final class AddressBarTextField: NSTextField {
 
-    /**
-     * This property controls address bar mode and influences view styling.
-     *
-     * If set to `false` (default), the view is styled for displaying as the regular address bar
-     * in the navigation bar. If set to `true`, it's styled for displaying as a standalone view
-     * on the New Tab Page.
-     */
-    var isSearchBox: Bool = false
-
-    /**
-     * This property keeps the preferred appearance (color scheme) of the New Tab Page.
-     *
-     * It's non-nil when a custom NTP background is in use. Its value is used to properly
-     * style the suggestion window when it's shown.
-     */
-    var homePagePreferredAppearance: NSAppearance? {
-        didSet {
-            if suggestionWindowController != nil {
-                suggestionViewController.view.appearance = homePagePreferredAppearance
-            }
-        }
-    }
-
     var tabCollectionViewModel: TabCollectionViewModel! {
         didSet {
             subscribeToSelectedTabViewModel()
@@ -617,20 +594,6 @@ final class AddressBarTextField: NSTextField {
         guard let window = window, let suggestionWindow = suggestionWindowController?.window else {
             Logger.general.error("AddressBarTextField: Window not available")
             return
-        }
-
-        if isSearchBox {
-            suggestionViewController.innerBorderViewTopConstraint.constant = 0
-            suggestionViewController.innerBorderViewBottomConstraint.constant = 0
-            suggestionViewController.innerBorderViewLeadingConstraint.constant = 0
-            suggestionViewController.innerBorderViewTrailingConstraint.constant = 0
-            suggestionViewController.backgroundView.borderWidth = 0
-
-            suggestionViewController.view.appearance = homePagePreferredAppearance
-            suggestionViewController.view.effectiveAppearance.performAsCurrentDrawingAppearance {
-                suggestionViewController.backgroundView.backgroundColor = .homePageAddressBarBackground
-                suggestionViewController.innerBorderView.borderColor = .homePageAddressBarBorder
-            }
         }
 
         guard !suggestionWindow.isVisible, isFirstResponder else { return }

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -47,7 +47,6 @@ final class AddressBarViewController: NSViewController, ObservableObject {
     private let suggestionContainerViewModel: SuggestionContainerViewModel
     private let isBurner: Bool
     private let onboardingPixelReporter: OnboardingAddressBarReporting
-    let isSearchBox: Bool
 
     enum Mode: Equatable {
         enum EditingMode {
@@ -105,7 +104,6 @@ final class AddressBarViewController: NSViewController, ObservableObject {
           tabCollectionViewModel: TabCollectionViewModel,
           burnerMode: BurnerMode,
           popovers: NavigationBarPopovers?,
-          isSearchBox: Bool = false,
           onboardingPixelReporter: OnboardingAddressBarReporting = OnboardingPixelReporter()) {
         self.tabCollectionViewModel = tabCollectionViewModel
         self.popovers = popovers
@@ -115,7 +113,6 @@ final class AddressBarViewController: NSViewController, ObservableObject {
             suggestionContainer: SuggestionContainer(burnerMode: burnerMode))
         self.isBurner = burnerMode.isBurner
         self.onboardingPixelReporter = onboardingPixelReporter
-        self.isSearchBox = isSearchBox
 
         super.init(coder: coder)
     }
@@ -126,7 +123,6 @@ final class AddressBarViewController: NSViewController, ObservableObject {
         view.wantsLayer = true
         view.layer?.masksToBounds = false
 
-        addressBarTextField.isSearchBox = isSearchBox
         addressBarTextField.placeholderString = UserText.addressBarPlaceholder
         addressBarTextField.setAccessibilityIdentifier("AddressBarViewController.addressBarTextField")
 
@@ -355,7 +351,7 @@ final class AddressBarViewController: NSViewController, ObservableObject {
     }
 
     private func updateView() {
-        let isFirstResponderOrBigSearchBox = isFirstResponder || isSearchBox
+        let isFirstResponderOrBigSearchBox = isFirstResponder
 
         let isPassiveTextFieldHidden = isFirstResponderOrBigSearchBox || mode.isEditing
         addressBarTextField.alphaValue = isPassiveTextFieldHidden ? 1 : 0
@@ -367,21 +363,9 @@ final class AddressBarViewController: NSViewController, ObservableObject {
 
         let isKey = self.view.window?.isKeyWindow == true
 
-        if isSearchBox {
-            let appearance = addressBarTextField.homePagePreferredAppearance ?? NSApp.effectiveAppearance
-
-            appearance.performAsCurrentDrawingAppearance {
-                activeOuterBorderView.alphaValue = isKey && isFirstResponder ? 1 : 0
-                activeOuterBorderView.backgroundColor = accentColor.withAlphaComponent(0.2)
-                activeBackgroundView.borderWidth = 1.0
-                activeBackgroundView.borderColor = isKey && isFirstResponder ? accentColor.withAlphaComponent(0.8) : NSColor.homePageAddressBarBorder
-                activeBackgroundView.backgroundColor = NSColor.homePageAddressBarBackground
-            }
-        } else {
-            activeOuterBorderView.alphaValue = isKey && isFirstResponder && isHomePage ? 1 : 0
-            activeOuterBorderView.backgroundColor = accentColor.withAlphaComponent(0.2)
-            activeBackgroundView.borderColor = accentColor.withAlphaComponent(0.8)
-        }
+        activeOuterBorderView.alphaValue = isKey && isFirstResponder && isHomePage ? 1 : 0
+        activeOuterBorderView.backgroundColor = accentColor.withAlphaComponent(0.2)
+        activeBackgroundView.borderColor = accentColor.withAlphaComponent(0.8)
 
         addressBarTextField.placeholderString = tabViewModel?.tab.content == .newtab ? UserText.addressBarPlaceholder : ""
     }
@@ -425,9 +409,6 @@ final class AddressBarViewController: NSViewController, ObservableObject {
         activeOuterBorderView.isHidden = isSuggestionsWindowVisible || view.window?.isKeyWindow != true
         activeBackgroundView.isHidden = isSuggestionsWindowVisible
         activeBackgroundViewWithSuggestions.isHidden = !isSuggestionsWindowVisible
-        if isSearchBox {
-            innerBorderView.isHidden = true
-        }
     }
 
     private func layoutShadowView() {
@@ -460,35 +441,21 @@ final class AddressBarViewController: NSViewController, ObservableObject {
 
         guard let window = view.window, AppVersion.runType != .unitTests else { return }
 
-        if isSearchBox {
-            let appearance = addressBarTextField.homePagePreferredAppearance ?? NSApp.effectiveAppearance
+        NSAppearance.withAppAppearance {
+            if window.isKeyWindow {
+                activeBackgroundView.borderWidth = 2.0
+                activeBackgroundView.borderColor = accentColor.withAlphaComponent(0.6)
+                activeBackgroundView.backgroundColor = NSColor.addressBarBackground
+                switchToTabBox.backgroundColor = NSColor.navigationBarBackground.blended(with: .addressBarBackground)
 
-            appearance.performAsCurrentDrawingAppearance {
-                activeBackgroundView.borderWidth = 1.0
-                activeBackgroundView.borderColor = NSColor.homePageAddressBarBorder
-                activeBackgroundView.backgroundColor = NSColor.homePageAddressBarBackground
-                activeBackgroundViewWithSuggestions.borderColor = NSColor.homePageAddressBarBorder
-                activeBackgroundViewWithSuggestions.backgroundColor = NSColor.homePageAddressBarBackground
-                switchToTabBox.backgroundColor = NSColor.homePageAddressBarBackground
-            }
+                activeOuterBorderView.isHidden = !isHomePage
+            } else {
+                activeBackgroundView.borderWidth = 0
+                activeBackgroundView.borderColor = nil
+                activeBackgroundView.backgroundColor = NSColor.inactiveSearchBarBackground
+                switchToTabBox.backgroundColor = NSColor.navigationBarBackground.blended(with: .inactiveSearchBarBackground)
 
-        } else {
-            NSAppearance.withAppAppearance {
-                if window.isKeyWindow {
-                    activeBackgroundView.borderWidth = 2.0
-                    activeBackgroundView.borderColor = accentColor.withAlphaComponent(0.6)
-                    activeBackgroundView.backgroundColor = NSColor.addressBarBackground
-                    switchToTabBox.backgroundColor = NSColor.navigationBarBackground.blended(with: .addressBarBackground)
-
-                    activeOuterBorderView.isHidden = !isHomePage
-                } else {
-                    activeBackgroundView.borderWidth = 0
-                    activeBackgroundView.borderColor = nil
-                    activeBackgroundView.backgroundColor = NSColor.inactiveSearchBarBackground
-                    switchToTabBox.backgroundColor = NSColor.navigationBarBackground.blended(with: .inactiveSearchBarBackground)
-
-                    activeOuterBorderView.isHidden = true
-                }
+                activeOuterBorderView.isHidden = true
             }
         }
     }

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -351,15 +351,13 @@ final class AddressBarViewController: NSViewController, ObservableObject {
     }
 
     private func updateView() {
-        let isFirstResponderOrBigSearchBox = isFirstResponder
-
-        let isPassiveTextFieldHidden = isFirstResponderOrBigSearchBox || mode.isEditing
+        let isPassiveTextFieldHidden = isFirstResponder || mode.isEditing
         addressBarTextField.alphaValue = isPassiveTextFieldHidden ? 1 : 0
         passiveTextField.alphaValue = isPassiveTextFieldHidden ? 0 : 1
 
-        updateShadowViewPresence(isFirstResponderOrBigSearchBox)
-        inactiveBackgroundView.alphaValue = isFirstResponderOrBigSearchBox ? 0 : 1
-        activeBackgroundView.alphaValue = isFirstResponderOrBigSearchBox ? 1 : 0
+        updateShadowViewPresence(isFirstResponder)
+        inactiveBackgroundView.alphaValue = isFirstResponder ? 0 : 1
+        activeBackgroundView.alphaValue = isFirstResponder ? 1 : 0
 
         let isKey = self.view.window?.isKeyWindow == true
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1201037661562251/1209784430748045/f

### Description:
This change removes the native NTP dead code from the address bar classes.

### Testing Steps
Run the app and smoke test the address bar:
1. Verify that it displays correctly in dark and light mode
2. Verify that suggestions window displays correctly (shadow + border color) in dark and light mode.

### Impact and Risks
Low/None: removing unused code branches.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)