### PR TITLE
Fix logic when moving to previously active tab

### DIFF
--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
@@ -124,6 +124,10 @@ final class TabCollectionViewModel: NSObject {
         return homePage
     }
 
+    /// This property logic will be true when the user appends a new tab
+    /// it will be set to false when the user moves selects an existing tab
+    private var shouldReturnToPreviousActiveTab: Bool = false
+
     init(
         tabCollection: TabCollection,
         selectionIndex: TabIndex = .unpinned(0),
@@ -226,6 +230,7 @@ final class TabCollectionViewModel: NSObject {
     // MARK: - Selection
 
     @discardableResult func select(at index: TabIndex, forceChange: Bool = false) -> Bool {
+        shouldReturnToPreviousActiveTab = false
         switch index {
         case .unpinned(let i):
             return selectUnpinnedTab(at: i, forceChange: forceChange)
@@ -331,6 +336,7 @@ final class TabCollectionViewModel: NSObject {
     func append(tab: Tab, selected: Bool = true, forceChange: Bool = false) {
         guard changesEnabled || forceChange else { return }
 
+        shouldReturnToPreviousActiveTab = true
         tabCollection.append(tab: tab)
         if tab.content == .newtab {
             NotificationCenter.default.post(name: HomePage.Models.newHomePageTabOpen, object: nil)
@@ -491,8 +497,12 @@ final class TabCollectionViewModel: NSObject {
 
         let newSelectionIndex: TabIndex
 
-        if let calculatedIndex = selectionIndex.calculateSelectedTabIndexAfterClosing(for: self, removedTab: tab) {
+        /// 1. We first check if the current active tab is going to be closed. If the active tab is being closed we calculate the new index using` calculateSelectedTabIndexAfterClosing`
+        /// 2. If we are closing a tab that is not the active we need to stay in the current tab, given that the current tab index will change we need to calculate it.
+        if index == selectionIndex, let calculatedIndex = selectionIndex.calculateSelectedTabIndexAfterClosing(for: self, removedTab: tab) {
             newSelectionIndex = calculatedIndex
+        } else if selectionIndex > index, selectionIndex.isInSameSection(as: index) {
+            newSelectionIndex = selectionIndex.previous(in: self)
         } else {
             newSelectionIndex = selectionIndex.sanitized(for: self)
         }
@@ -501,7 +511,11 @@ final class TabCollectionViewModel: NSObject {
         select(at: newSelectionIndex, forceChange: forced)
     }
 
-    func getLastSelectedTab() -> TabIndex? {
+    func getPreviosulyActiveTab() -> TabIndex? {
+        guard shouldReturnToPreviousActiveTab else {
+            return nil
+        }
+
         let recentlyOpenedPinnedTab = pinnedTabs.max(by: { $0.lastSelectedAt ?? Date.distantPast < $1.lastSelectedAt ?? Date.distantPast })
         let recentlyOpenedNormalTab = tabs.max(by: { $0.lastSelectedAt ?? Date.distantPast < $1.lastSelectedAt ?? Date.distantPast })
 

--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabIndex.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabIndex.swift
@@ -174,14 +174,15 @@ extension TabIndex {
 
     // MARK: - Logic when closing a tab
 
-    /// When closing a tab, the following rules will be used to find the appropriate tab to activate. Rules will be evaluated top to bottom and evaluation stops once a tab has been found:
+    /// When closing an active tab, the following rules will be used to find the appropriate tab to activate. Rules will be evaluated top to bottom and evaluation stops once a tab has been found:
     /// 1. If this tab has a parent (i.e. has been opened via "Open In New Tab"):
     ///     a. Try to find the next tab with the same parent tab
     ///     b. Try to find the previous tab with the same parent tab
     ///     c. Try to find the parent tab
     /// 2. Try to find the next tab that has the closing tab as it's parent
     /// 3. Try to find the previous tab that has the closing tab as it's parent
-    /// 4. Try to find the previously closed tab.
+    /// 4. Try to find the previously active tab.
+    ///     a. The previously active tab is only remembered until the user moves to an existing tab or creates new tabs.
     /// 5. Try to find the next tab
     /// 6. Try to find the previous tab
     @MainActor
@@ -253,7 +254,8 @@ extension TabIndex {
     /// The rules are:
     /// 1. Try to find the next tab that has the closed tab as its parent
     /// 2. Try to find the previous tab that has the closed tab as its parent
-    /// 3. Try to find the recently opened tab
+    /// 3. Try to find the recently active tab
+    ///     a. The previously active tab is only remembered until the user moves to an existing tab or creates new tabs.
     /// 4. Try to find the current tab index (if it still exists)
     /// 5. Try to find the next tab
     /// 6. Try to find the previous tab
@@ -267,7 +269,7 @@ extension TabIndex {
             return previousTabWithRemovedTabAsParent
         }
 
-        if let recentlyClosedTabIndex = viewModel.getLastSelectedTab() {
+        if let recentlyClosedTabIndex = viewModel.getPreviosulyActiveTab() {
             return recentlyClosedTabIndex
         }
 

--- a/macOS/UITests/TabBarTests.swift
+++ b/macOS/UITests/TabBarTests.swift
@@ -36,19 +36,6 @@ class TabBarTests: UITestCase {
         UITests.firstRun()
     }
 
-    func testRecentlyClosedTabIsSelected_whenTabIsClosedAndHasNoRelationships() {
-        openThreeSitesOnSameWindow()
-        pinsPageOne()
-
-        /// Move to the last tab
-        app.typeKey("[", modifierFlags: [.command, .shift])
-        /// Closes last tab
-        app.typeKey("w", modifierFlags: [.command])
-
-        /// Asserts that the pinned tab is the one being shown
-        XCTAssertTrue(app.staticTexts["Sample text for Page #1"].waitForExistence(timeout: UITests.Timeouts.elementExistence))
-    }
-
     func testClosesChildTabIsSelected_whenSibilingTabIsClosed() {
         openPrivacyTestPagesSite()
 
@@ -124,6 +111,36 @@ class TabBarTests: UITestCase {
         XCTAssertTrue(app.staticTexts["Privacy Test Pages"].waitForExistence(timeout: UITests.Timeouts.elementExistence))
     }
 
+    func testRecentlyActiveTabIsSelected_whenNewTabIsClosedAndNoOtherTabWasSelected() {
+        /// We open three sites  and then we select the first tab
+        openFourSitesOnSameWindow()
+        app.typeKey("1", modifierFlags: [.command])
+
+        /// We open a new tab and we close it
+        app.typeKey("t", modifierFlags: [.command])
+        app.menuItems["Close Tab"].tap()
+
+        /// Asserts that the recently active tab is visible
+        XCTAssertTrue(app.staticTexts["Sample text for Page #1"].waitForExistence(timeout: UITests.Timeouts.elementExistence))
+    }
+
+    func testRecentlyActiveTabIsNotSelected_ifAnotherTabWasSelectedBeforeTheTabWasClosed() {
+        /// We open three sites  and then we select the first tab
+        openFourSitesOnSameWindow()
+        app.typeKey("1", modifierFlags: [.command])
+
+        /// We open a new tab
+        app.typeKey("t", modifierFlags: [.command])
+        /// We move to the third tab
+        app.typeKey("3", modifierFlags: [.command])
+        /// We move to the last tab and we close it
+        app.typeKey("5", modifierFlags: [.command])
+        app.menuItems["Close Tab"].tap()
+
+        /// Asserts that the tab to the right is shown
+        XCTAssertTrue(app.staticTexts["Sample text for Page #4"].waitForExistence(timeout: UITests.Timeouts.elementExistence))
+    }
+
     // MARK: - Utilities
 
     private func resetPinnedTabs() {
@@ -139,7 +156,7 @@ class TabBarTests: UITestCase {
         sleep(1)
     }
 
-    private func openThreeSitesOnSameWindow() {
+    private func openFourSitesOnSameWindow() {
         openSite(pageTitle: "Page #1")
         app.openNewTab()
         openSite(pageTitle: "Page #2")

--- a/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests+PinnedTabs.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests+PinnedTabs.swift
@@ -298,6 +298,7 @@ extension TabCollectionViewModelTests {
         let childTab1 = Tab(parentTab: parentTab)
         tabCollectionViewModel.append(tab: childTab1, selected: false)
 
+        tabCollectionViewModel.select(at: .unpinned(2))
         tabCollectionViewModel.remove(at: .unpinned(2))
 
         XCTAssertIdentical(tabCollectionViewModel.selectedTabViewModel?.tab, parentTab)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1209785407607138/f
Tech Design URL:
CC:

### Description
This change fixes two things:
- With the previous change, I introduced a bug in which if the closed tab was not active, we applied the logic as if it was active, which was wrong and unintentional.
- The rule of returning to the previous active tab was missing some logic. On Windows, the previously active tab is only remembered until the user moves to an existing tab or creates new tabs.

### Testing Steps

**Testing steps of the first bug**
1. Open some site like Wikipedia, and open some links from there using CMD + Tap
2. Open a new tab and keep that tab selected
3. Right tap one of the child tabs and close it
4. The active tab should be the new tab and no other sibiling or parent of the closed tab should be selected

**Testing steps of the new rule logic when returning to the previous active tab**
1. Open five tabs (no related)
2. Select the first tab
3. Use CMD + T or tapping the + in the tab bar to open a new tab
4. Close that tab
5. The first tab should be selected

1. Open five tabs (no related)
2. Select the first tab
3. Use CMD + T or tapping the + in the tab bar to open a new tab
4. Select tab number 5 (the one before the recently opened)
5. Go back to the last tab and close it
6. Tab number 5 should be selected instead of the first tab

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
The scenario disrupts other flows when closing tabs.

### Quality Considerations
I’ve added unit tests and UI tests to cover this new scenarios.

### Notes to Reviewer
Do as much test as you can for your user flows.