### PR TITLE
[iOS]Add new pixels to measure app launches

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -31,6 +31,7 @@ extension Pixel {
 
         case appInstall
         case appLaunch
+        case appLaunchFromExternalLink
         case refreshPressed
         case pullToRefresh
 
@@ -1089,6 +1090,7 @@ extension Pixel.Event {
         switch self {
         case .appInstall: return "m_install"
         case .appLaunch: return "ml"
+        case .appLaunchFromExternalLink: return "m_third-party_launch"
         case .refreshPressed: return "m_r"
         case .pullToRefresh: return "m_pull-to-reload"
 

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -32,6 +32,7 @@ extension Pixel {
         case appInstall
         case appLaunch
         case appLaunchFromExternalLink
+        case appLaunchFromShareExtension
         case refreshPressed
         case pullToRefresh
 
@@ -1090,7 +1091,8 @@ extension Pixel.Event {
         switch self {
         case .appInstall: return "m_install"
         case .appLaunch: return "ml"
-        case .appLaunchFromExternalLink: return "m_third-party_launch"
+        case .appLaunchFromExternalLink: return "m_app-launch_tapped-external-link"
+        case .appLaunchFromShareExtension: return "m_app-launch_shared-link"
         case .refreshPressed: return "m_r"
         case .pullToRefresh: return "m_pull-to-reload"
 

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -31,7 +31,13 @@ extension Pixel {
 
         case appInstall
         case appLaunch
+        /// Fires when the app launches as a result of tapping an http/https link outside the DDG browser.
+        ///
+        /// For more info check the [Asana Task](https://app.asana.com/0/72649045549333/1209593812414962/f)
         case appLaunchFromExternalLink
+        /// Fires when the app launches as a result of an external app sharing a link with the DDG browser.
+        ///
+        /// For more info check the [Asana Task](https://app.asana.com/0/72649045549333/1209593812414962/f)
         case appLaunchFromShareExtension
         case refreshPressed
         case pullToRefresh

--- a/iOS/DuckDuckGo/UICoordination/LaunchActionHandler.swift
+++ b/iOS/DuckDuckGo/UICoordination/LaunchActionHandler.swift
@@ -18,6 +18,7 @@
 //
 
 import UIKit
+import Core
 import enum Core.AppDeepLinkSchemes
 
 enum LaunchAction {
@@ -52,13 +53,16 @@ final class LaunchActionHandler: LaunchActionHandling {
     private let urlHandler: URLHandling
     private let shortcutItemHandler: ShortcutItemHandling
     private let keyboardPresenter: KeyboardPresenting
+    private let pixelFiring: PixelFiring.Type
 
     init(urlHandler: URLHandling,
          shortcutItemHandler: ShortcutItemHandling,
-         keyboardPresenter: KeyboardPresenting) {
+         keyboardPresenter: KeyboardPresenting,
+         pixelFiring: PixelFiring.Type = Pixel.self) {
         self.urlHandler = urlHandler
         self.shortcutItemHandler = shortcutItemHandler
         self.keyboardPresenter = keyboardPresenter
+        self.pixelFiring = pixelFiring
     }
 
     func handleLaunchAction(_ action: LaunchAction) {
@@ -87,13 +91,12 @@ final class LaunchActionHandler: LaunchActionHandling {
 
     private func fireAppLaunchedWithExternalLinkPixel(url: URL) {
         // Websites or searches opened via share extensions have `ddgQuickLink` scheme.
-        // If scheme is either `http` or `https` we know the app has been opened by clicking on an external link and the browser is the default one.
-        guard url.scheme == "http" || url.scheme == "https" else {
-            Logger(subsystem: "REPORTING", category: "REPORTING").debug("~~~THIRD PARTY EXTERNAL LAUNCH: \(false)")
-            return
+        // If scheme is either `http` or `https` we know the app has been opened by clicking directly an external link.
+        if url.scheme == "http" || url.scheme == "https" {
+            pixelFiring.fire(.appLaunchFromExternalLink, withAdditionalParameters: [:])
+        } else if url.scheme == AppDeepLinkSchemes.quickLink.rawValue {
+            pixelFiring.fire(.appLaunchFromShareExtension, withAdditionalParameters: [:])
         }
-
-        Logger(subsystem: "REPORTING", category: "REPORTING").debug("~~~THIRD PARTY EXTERNAL LAUNCH: \(true)")
     }
 
 }

--- a/iOS/DuckDuckGo/UICoordination/LaunchActionHandler.swift
+++ b/iOS/DuckDuckGo/UICoordination/LaunchActionHandler.swift
@@ -18,6 +18,7 @@
 //
 
 import UIKit
+import enum Core.AppDeepLinkSchemes
 
 enum LaunchAction {
 
@@ -73,6 +74,7 @@ final class LaunchActionHandler: LaunchActionHandling {
 
     private func openURL(_ url: URL) {
         Logger.sync.debug("App launched with url \(url.absoluteString)")
+        fireAppLaunchedWithExternalLinkPixel(url: url)
         guard urlHandler.shouldProcessDeepLink(url) else { return }
         NotificationCenter.default.post(name: AutofillLoginListAuthenticator.Notifications.invalidateContext, object: nil)
         urlHandler.handleURL(url)
@@ -81,6 +83,17 @@ final class LaunchActionHandler: LaunchActionHandling {
     private func handleShortcutItem(_ shortcutItem: UIApplicationShortcutItem) {
         Logger.general.debug("Handling shortcut item: \(shortcutItem.type)")
         shortcutItemHandler.handleShortcutItem(shortcutItem)
+    }
+
+    private func fireAppLaunchedWithExternalLinkPixel(url: URL) {
+        // Websites or searches opened via share extensions have `ddgQuickLink` scheme.
+        // If scheme is either `http` or `https` we know the app has been opened by clicking on an external link and the browser is the default one.
+        guard url.scheme == "http" || url.scheme == "https" else {
+            Logger(subsystem: "REPORTING", category: "REPORTING").debug("~~~THIRD PARTY EXTERNAL LAUNCH: \(false)")
+            return
+        }
+
+        Logger(subsystem: "REPORTING", category: "REPORTING").debug("~~~THIRD PARTY EXTERNAL LAUNCH: \(true)")
     }
 
 }

--- a/iOS/DuckDuckGo/UICoordination/LaunchActionHandler.swift
+++ b/iOS/DuckDuckGo/UICoordination/LaunchActionHandler.swift
@@ -19,7 +19,6 @@
 
 import UIKit
 import Core
-import enum Core.AppDeepLinkSchemes
 
 enum LaunchAction {
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209593812414962

### Description

This PR adds new pixels to measure:
1. When the app is launched by tapping an external link (cold start and resume from backround)
2 When the app is launched by sharing a link/search via the share extension. (cold start and resume from background)

**NOTE**
I will open the Privacy Triage once the review has been approved to avoid creating extra works for Privacy team if we decide to change pixels name or add more of them. Hence, the `DO NOT MERGE` label.

**Privacy Triage**
[Privacy Triage Approved](https://app.asana.com/0/69071770703008/1209811367393595/f)

### Testing Steps

**Scenario 1 - Measure App launched by external link (cold start)** ✅ 
1. Ensure to select `iOS Browser` scheme and change app launch to “Wait for executable to be launched” in `Edit Scheme` -> `Run` -> `Info`.
<img width="468" alt="Screenshot 2025-03-26 at 7 41 06 am" src="https://github.com/user-attachments/assets/dac6628c-2241-4862-b973-c4fe4d71f875" />

2. Ensure DDG is set as default browser in system settings.
3. Build and run the app. (Bear in mind the App won’t launch as usual but it will wait for an event to happen).
4. Save a link in Notes app, e.g https://www.apple.com.
5. Tap on the link just added in Notes.
6. The App will launch.
7. Ensure that `m.app-launch.tapped-external-link` pixel fires.
8. Repeat the test using an ‘http’ URL.

**Scenario 2 - Measure App launched by external link (resume from background)** ✅ 
1. Ensure DDG is set as default browser in system settings.
2. Launch the App.
3. Background the App.
4. Save a link in Notes app, e.g https://www.apple.com.
5. Tap on the link just added in Notes.
6. Ensure that the app comes to foreground and `m.app-launch.tapped-external-link` pixel fires.
7. Repeat the test using an ‘http’ URL.

**Scenario 3 - Measure App launched by share extension (cold start)**  ✅
1. Ensure to select `iOS Browser` scheme and change app launch to “Wait for executable to be launched” in `Edit Scheme` -> `Run` -> `Info`.
<img width="468" alt="Screenshot 2025-03-26 at 7 41 06 am" src="https://github.com/user-attachments/assets/dac6628c-2241-4862-b973-c4fe4d71f875" />

2. Build and run the app. (Bear in mind the App won’t launch as usual but it will wait for an event to happen).
3. Open a link in Safari, e.g https://www.apple.com.
4. Press the share button -> More -> Select DuckDuckGo app.
5. The App will launch.
7. Ensure that `m.app-launch.shared-link` pixel fires.

**Scenario 4 - Measure App launched by share extension (resume from background)** ✅
1. Launch the app.
2. Put the app in background.
2. Open a link in Safari, e.g https://www.apple.com.
3. Press the share button -> More -> Select DuckDuckGo app.
4. Ensure that the app comes to foreground and `m.app-launch.shared-link` pixel fires.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features.

#### What could go wrong?
Possibility of inaccurate measurements if the implementation is incorrect.

### Quality Considerations
There are other deep link schemes that we could measure. We can add them in the future if we’re interested in those.

### Notes to Reviewer
I will open the Privacy Triage once the review has been approved to avoid creating extra works for Privacy team if we decide to change pixels name or add more of them.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)