### PR TITLE
Ignore initial (nil) favicon event in favicon publisher

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/FaviconsTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/FaviconsTabExtension.swift
@@ -112,7 +112,7 @@ extension FaviconsTabExtension: FaviconsTabExtensionProtocol, TabExtension {
     func getPublicProtocol() -> FaviconsTabExtensionProtocol { self }
 
     var faviconPublisher: AnyPublisher<NSImage?, Never> {
-        $favicon.eraseToAnyPublisher()
+        $favicon.dropFirst().eraseToAnyPublisher()
     }
 }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1209796699357949/f

### Description
This change fixes favicons being initially cleared on all tabs upon state restoration.

### Testing Steps
1. Open a few tabs
2. Enable state restoration
3. Quit the app (cmd+q, not via Xcode or the state won’t be persisted).
4. Launch the app and verify that favicons are immediately shown on tabs, even before lazy loading starts.

### Impact and Risks
None: clear bug fix.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)