### PR TITLE
PIR shared code extraction: Pixelkit iOS support

### DIFF
--- a/BrowserServicesKit/Sources/PixelKit/PixelKit.swift
+++ b/BrowserServicesKit/Sources/PixelKit/PixelKit.swift
@@ -422,12 +422,19 @@ public final class PixelKit {
             fireRequest(pixelName, headers, parameters, allowedQueryReservedCharacters, callBackOnMainThread, onComplete)
         }
 
-    // Only set up for macOS and for Experiments
     private func prefixedAndSuffixedName(for event: Event, namePrefix: String?) -> String {
         let pixelName = (namePrefix ?? "") + event.name
         if pixelName.hasPrefix("experiment") {
             return addPlatformSuffix(to: pixelName)
         }
+
+#if os(iOS)
+        return pixelName
+#else
+        // Many macOS pixel names need "correcting" after the fact
+        // However, we should try and move away from this approach
+        // (and towards the more deliberate approach above with the prefix and experiment suffix)
+        // This approach won't work for iOS as the names have a very varied set of prefixes
         if pixelName.hasPrefix("m_mac_") {
             // Can be a debug event or not, if already prefixed the name remains unchanged
             return pixelName
@@ -440,6 +447,7 @@ public final class PixelKit {
         } else {
             return "m_mac_\(pixelName)"
         }
+#endif
     }
 
     private func addPlatformSuffix(to name: String) -> String {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/0/1209797430851748/f
Tech Design URL:
CC:

### Description
Makes it so pixelkit pixels on iOS won't errantly get macOS prefixes

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Run the iOS app and use it a bit then check the console that no pixel names have changed (e.g. nothing has two prefixes, or zero prefixes). (Pixel kit isn't really being used on iOS, so this really is just double checking)
2. Run the macOS app and use it a bit, including using PIR (e.g. edit profile data and set scans running)
3. Check that PIR pixels haven't changed and have the correct Mac prefix
4. Check that debug pixels haven't changed and have the correct debug prefix. One you can look for is m_mac_debug_content_blocking_lookup_rules_succeeded

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)