### PR TITLE
iOS: DuckPlayer: 48. Add grab handle to DuckPlayer Pill

### DIFF
--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/DuckPlayerNativeUIPresenter.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/DuckPlayerNativeUIPresenter.swift
@@ -150,6 +150,16 @@ final class DuckPlayerNativeUIPresenter {
                 hasBackground: false,
                 onDismiss: { [weak self] in
                     self?.dismissPill()
+                },
+                onPresentDuckPlayer: { [weak self] in
+                    guard let self = self else { return }
+                    _ = self.presentDuckPlayer(
+                        videoID: videoID,
+                        source: .youtube,
+                        in: self.hostView!,
+                        title: nil,
+                        timestamp: timestamp
+                    )
                 }
             ) { _ in
                 AnyView(DuckPlayerEntryPillView(viewModel: pillViewModel))
@@ -169,6 +179,16 @@ final class DuckPlayerNativeUIPresenter {
                 hasBackground: false,
                 onDismiss: { [weak self] in
                     self?.dismissPill()
+                },
+                onPresentDuckPlayer: { [weak self] in
+                    guard let self = self else { return }
+                    _ = self.presentDuckPlayer(
+                        videoID: videoID,
+                        source: .youtube,
+                        in: self.hostView!,
+                        title: nil,
+                        timestamp: timestamp
+                    )
                 }
             ) { _ in
                 AnyView(DuckPlayerMiniPillView(viewModel: miniPillViewModel))

--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/DuckPlayerNativeUIPresenter.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/DuckPlayerNativeUIPresenter.swift
@@ -243,12 +243,12 @@ final class DuckPlayerNativeUIPresenter {
     private func removePillContainer() {
         // First remove from superview
         containerViewController?.view.removeFromSuperview()
-        
+
         // Then clean up references
         containerViewController = nil
         containerViewModel = nil
         containerCancellables.removeAll()
-        
+
         // Finally ensure constraints are reset
         resetWebViewConstraint()
     }
@@ -398,7 +398,6 @@ extension DuckPlayerNativeUIPresenter: DuckPlayerNativeUIPresenting {
 
         // Store reference to the hosting controller
         containerViewController = hostingController
-        containerViewModel.show()
 
         // Subscribe to the sheet animation completed event
         containerViewModel.$sheetAnimationCompleted.sink { [weak self] completed in
@@ -415,6 +414,11 @@ extension DuckPlayerNativeUIPresenter: DuckPlayerNativeUIPresenting {
                 self?.updateWebViewConstraintForPillHeight()
             }
         }.store(in: &containerCancellables)
+
+        // Show the container view if it's not already visible
+        if !containerViewModel.sheetVisible {
+            containerViewModel.show()
+        }
     }
 
     /// Dismisses the currently presented entry pill
@@ -487,6 +491,7 @@ extension DuckPlayerNativeUIPresenter: DuckPlayerNativeUIPresenting {
                 guard let videoID = self.state.videoID, let hostView = self.hostView else { return }
                 self.state.timestamp = timestamp
                 self.presentPill(for: videoID, in: hostView, timestamp: timestamp)
+                self.containerViewModel?.show()
             }
             .store(in: &playerCancellables)
 

--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerContainer.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerContainer.swift
@@ -32,8 +32,7 @@ public enum DuckPlayerContainer {
             static let springBounce: Double = 0.2
         }
 
-        enum Offset {
-            static let extraHeight: Double = 200.0
+        enum Offset {            
             static let initialValue: Double = 500.0
             static let fixedContainerHeight: Double = 300.0
         }
@@ -113,7 +112,26 @@ public enum DuckPlayerContainer {
 // MARK: - Private
 
 private func calculateSheetOffset(for visible: Bool, containerHeight: Double) -> Double {
-    visible ? 0 : containerHeight + DuckPlayerContainer.Constants.Offset.extraHeight
+    visible ? 25 : containerHeight
+}
+
+@MainActor
+private struct GrabHandle: View {
+
+    struct Constants {
+        static let grabHandleHeight: CGFloat = 4
+        static let grabHandleWidth: CGFloat = 36
+        static let grabHandleTopPadding: CGFloat = 4
+        static let grabHandleBottomPadding: CGFloat = 8
+    }
+
+    var body: some View {
+        Capsule()
+            .fill(Color(designSystemColor: .textPrimary).opacity(0.3))
+            .frame(width: Constants.grabHandleWidth, height: Constants.grabHandleHeight)
+            .padding(.top, Constants.grabHandleTopPadding)
+            .padding(.bottom, Constants.grabHandleBottomPadding)
+    }
 }
 
 @MainActor
@@ -154,14 +172,20 @@ private struct SheetView<Content: View>: View {
 
     var body: some View {
         VStack(alignment: .center) {
-
             if let sheetWidth {
-                content(DuckPlayerContainer.PresentationMetrics(contentWidth: sheetWidth))
+                VStack {
+                    GrabHandle()
+                    content(DuckPlayerContainer.PresentationMetrics(contentWidth: sheetWidth))
+                }
+                .padding(.horizontal, 16)                
             }
         }
         .onWidthChange { newWidth in
             sheetWidth = newWidth
         }
+        .padding(.bottom, 40) // Add some bottom padding to account for the grab handle
+        .background(Color(designSystemColor: .surface))
+        .cornerRadius(16, corners: [.topLeft, .topRight])
         .frame(maxWidth: .infinity)
         .offset(y: sheetOffset)
         .opacity(opacity)

--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerContainer.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerContainer.swift
@@ -247,7 +247,8 @@ private struct SheetView<Content: View>: View {
             sheetWidth = newWidth
         }
         .padding(.bottom, 44)
-        .background(Color(designSystemColor: .surface))
+        .background(Color(designSystemColor: .panel))
+        .border(Color(designSystemColor: .border), width: 0.5)
         .frame(maxWidth: .infinity)
         .offset(y: sheetOffset)
         .opacity(opacity)

--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerContainer.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerContainer.swift
@@ -20,8 +20,6 @@
 import Combine
 import SwiftUI
 
-private let sheetTopMargin = 44.0
-
 public enum DuckPlayerContainer {
 
     public struct Constants {
@@ -29,7 +27,7 @@ public enum DuckPlayerContainer {
         static let shortDuration: Double = 0.2
         static let springDuration: Double = 0.5
         static let springBounce: Double = 0.2
-        static let initialOffsetValue: Double = 500.0        
+        static let initialOffsetValue: Double = 500.0
         static let dragThreshold: CGFloat = 10
         static let dragAreaHeight: CGFloat = 44
         static let contentTopPadding: CGFloat = 24
@@ -74,7 +72,10 @@ public enum DuckPlayerContainer {
         let onDismiss: () -> Void
         let onPresentDuckPlayer: () -> Void
 
-        public init(viewModel: ViewModel, hasBackground: Bool = true, onDismiss: @escaping () -> Void, onPresentDuckPlayer: @escaping () -> Void, @ViewBuilder content: @escaping (PresentationMetrics) -> Content) {
+        public init(
+            viewModel: ViewModel, hasBackground: Bool = true, onDismiss: @escaping () -> Void, onPresentDuckPlayer: @escaping () -> Void,
+            @ViewBuilder content: @escaping (PresentationMetrics) -> Content
+        ) {
             self.viewModel = viewModel
             self.hasBackground = hasBackground
             self.content = content
@@ -94,7 +95,7 @@ public enum DuckPlayerContainer {
         }
 
         public var body: some View {
-            VStack(spacing: 0) {                
+            VStack(spacing: 0) {
                 if hasBackground {
                     Color.black
                         .ignoresSafeArea()
@@ -180,10 +181,10 @@ private struct SheetView<Content: View>: View {
                 VStack(spacing: 0) {
                     ZStack(alignment: .top) {
                         GrabHandle()
-                        
+
                         content(DuckPlayerContainer.PresentationMetrics(contentWidth: sheetWidth))
                             .padding(.top, DuckPlayerContainer.Constants.contentTopPadding)
-                        
+
                         Rectangle()
                             .fill(Color.clear)
                             .frame(height: DuckPlayerContainer.Constants.dragAreaHeight)
@@ -198,7 +199,7 @@ private struct SheetView<Content: View>: View {
                                     }
                                     .onChanged { value in
                                         guard let dragStartOffset else { return }
-                                        
+
                                         let offsetY = value.translation.height
                                         if offsetY > 0 {
                                             withAnimation(.spring(duration: 0.3, bounce: 0.2)) {
@@ -207,22 +208,22 @@ private struct SheetView<Content: View>: View {
                                         } else if offsetY < 0 {
                                             let y = 1.0 / (1.0 + exp(-1 * (abs(offsetY) / 50.0))) - 0.5
                                             withAnimation(.spring(duration: 0.3, bounce: 0.2)) {
-                                                sheetOffset = dragStartOffset + y * max(offsetY, -150)
+                                                sheetOffset = dragStartOffset + y * max(offsetY, -50)
                                             }
                                         }
                                     }
                                     .onEnded { value in
                                         viewModel.setDragging(false)
                                         let offsetY = value.translation.height
-                                        
+
                                         if offsetY > DuckPlayerContainer.Constants.dragThreshold || value.velocity.height > 50 {
                                             onDismiss()
                                         } else if offsetY < -DuckPlayerContainer.Constants.dragThreshold || value.velocity.height < -50 {
                                             isAnimatingToTop = true
-                                            
+
                                             // Start presenting DuckPlayer immediately
                                             onPresentDuckPlayer()
-                                            
+
                                             // Animate the pill to top and fade out
                                             withAnimation(.easeOut(duration: 0.3)) {
                                                 opacity = 0

--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerContainer.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerContainer.swift
@@ -177,15 +177,14 @@ private struct SheetView<Content: View>: View {
                     GrabHandle()
                     content(DuckPlayerContainer.PresentationMetrics(contentWidth: sheetWidth))
                 }
-                .padding(.horizontal, 16)                
+                .padding(.horizontal, 16)
             }
         }
         .onWidthChange { newWidth in
             sheetWidth = newWidth
         }
-        .padding(.bottom, 40) // Add some bottom padding to account for the grab handle
+        .padding(.bottom, 44) // Add some bottom padding to account for the grab handle
         .background(Color(designSystemColor: .surface))
-        .cornerRadius(16, corners: [.topLeft, .topRight])
         .frame(maxWidth: .infinity)
         .offset(y: sheetOffset)
         .opacity(opacity)

--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerContainer.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerContainer.swift
@@ -24,20 +24,14 @@ private let sheetTopMargin = 44.0
 
 public enum DuckPlayerContainer {
 
-    public struct Constants {
-        enum Animation {
-            static let easeInOutDuration: Double = 0.3
-            static let shortDuration: Double = 0.2
-            static let springDuration: Double = 0.5
-            static let springBounce: Double = 0.2
-        }
-
-        enum Offset {            
-            static let initialValue: Double = 500.0
-            static let fixedContainerHeight: Double = 300.0
-        }
+    public struct AnimationConstants {
+        static let easeInOutDuration: Double = 0.3
+        static let shortDuration: Double = 0.2
+        static let springDuration: Double = 0.5
+        static let springBounce: Double = 0.2
+        static let initialValue: Double = 500.0
+        static let fixedContainerHeight: Double = 300.0
     }
-
     public struct PresentationMetrics {
         public let contentWidth: Double
     }
@@ -102,7 +96,7 @@ public enum DuckPlayerContainer {
                 }
 
                 // Use a fixed container height for offset calculations
-                sheet(containerHeight: DuckPlayerContainer.Constants.Offset.fixedContainerHeight)
+                sheet(containerHeight: DuckPlayerContainer.AnimationConstants.fixedContainerHeight)
                     .frame(alignment: .bottom)
             }
         }
@@ -144,7 +138,7 @@ private struct SheetView<Content: View>: View {
     @State private var sheetHeight: Double = 0
     @State private var sheetWidth: Double?
     @State private var opacity: Double = 0
-    @State private var sheetOffset = DuckPlayerContainer.Constants.Offset.initialValue
+    @State private var sheetOffset = DuckPlayerContainer.AnimationConstants.initialValue
 
     // Animate the sheet offset with a spring animation
     private func animateOffset(to visible: Bool) {
@@ -152,7 +146,7 @@ private struct SheetView<Content: View>: View {
         if #available(iOS 17.0, *) {
             withAnimation(
                 .spring(
-                    duration: DuckPlayerContainer.Constants.Animation.springDuration, bounce: DuckPlayerContainer.Constants.Animation.springBounce)
+                    duration: DuckPlayerContainer.AnimationConstants.springDuration, bounce: DuckPlayerContainer.AnimationConstants.springBounce)
             ) {
                 sheetOffset = calculateSheetOffset(for: visible, containerHeight: containerHeight)
             } completion: {
@@ -161,7 +155,7 @@ private struct SheetView<Content: View>: View {
         } else {
             withAnimation(
                 .spring(
-                    duration: DuckPlayerContainer.Constants.Animation.springDuration, bounce: DuckPlayerContainer.Constants.Animation.springBounce)
+                    duration: DuckPlayerContainer.AnimationConstants.springDuration, bounce: DuckPlayerContainer.AnimationConstants.springBounce)
             ) {
                 sheetOffset = calculateSheetOffset(for: visible, containerHeight: containerHeight)
             }
@@ -183,17 +177,17 @@ private struct SheetView<Content: View>: View {
         .onWidthChange { newWidth in
             sheetWidth = newWidth
         }
-        .padding(.bottom, 44) // Add some bottom padding to account for the grab handle
+        .padding(.bottom, 44)  // Add some bottom padding to account for the grab handle
         .background(Color(designSystemColor: .surface))
         .frame(maxWidth: .infinity)
         .offset(y: sheetOffset)
         .opacity(opacity)
-        .animation(.easeInOut(duration: DuckPlayerContainer.Constants.Animation.easeInOutDuration), value: opacity)
+        .animation(.easeInOut(duration: DuckPlayerContainer.AnimationConstants.easeInOutDuration), value: opacity)
 
         .onAppear {
 
             // Always start with the initial large offset value
-            sheetOffset = DuckPlayerContainer.Constants.Offset.initialValue
+            sheetOffset = DuckPlayerContainer.AnimationConstants.initialValue
             opacity = viewModel.sheetVisible ? 1 : 0
 
             // If the sheet should be visible, animate it into view after a tiny delay

--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerContainer.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerContainer.swift
@@ -138,6 +138,8 @@ private struct GrabHandle: View {
 @MainActor
 private struct SheetView<Content: View>: View {
     @ObservedObject var viewModel: DuckPlayerContainer.ViewModel
+    @Environment(\.colorScheme) private var colorScheme
+
     let containerHeight: Double
     let content: (DuckPlayerContainer.PresentationMetrics) -> Content
     let onHeightChange: (Double) -> Void
@@ -175,6 +177,45 @@ private struct SheetView<Content: View>: View {
         }
     }
 
+    private func handleDragGesture(value: DragGesture.Value, dragStartOffset: Double?) {
+        guard let dragStartOffset else { return }
+        let offsetY = value.translation.height
+        if offsetY > 0 {
+            withAnimation(.spring(duration: 0.3, bounce: 0.2)) {
+                sheetOffset = dragStartOffset + offsetY
+            }
+        } else if offsetY < 0 {
+            let y = 1.0 / (1.0 + exp(-1 * (abs(offsetY) / 50.0))) - 0.5
+            withAnimation(.spring(duration: 0.3, bounce: 0.2)) {
+                sheetOffset = dragStartOffset + y * max(offsetY, -50)
+            }
+        }
+    }
+
+    private func handleEndedGesture(value: DragGesture.Value, dragStartOffset: Double?) {
+        viewModel.setDragging(false)
+        let offsetY = value.translation.height
+
+        if offsetY > DuckPlayerContainer.Constants.dragThreshold || value.velocity.height > 50 {
+            onDismiss()
+        } else if offsetY < -DuckPlayerContainer.Constants.dragThreshold || value.velocity.height < -50 {
+            isAnimatingToTop = true
+
+            // Start presenting DuckPlayer immediately
+            onPresentDuckPlayer()
+
+            // Animate the pill to top and fade out
+            withAnimation(.spring(duration: 0.5, bounce: 0.2)) {
+                sheetOffset = -containerHeight
+                opacity = 0
+            }
+        } else {
+            withAnimation(.spring(duration: 0.2, bounce: 0.4)) {
+                sheetOffset = calculateSheetOffset(for: viewModel.sheetVisible, containerHeight: containerHeight)
+            }
+        }
+    }
+
     var body: some View {
         VStack(alignment: .center, spacing: 0) {
             if let sheetWidth {
@@ -198,44 +239,10 @@ private struct SheetView<Content: View>: View {
                                         }
                                     }
                                     .onChanged { value in
-                                        guard let dragStartOffset else { return }
-
-                                        let offsetY = value.translation.height
-                                        if offsetY > 0 {
-                                            withAnimation(.spring(duration: 0.3, bounce: 0.2)) {
-                                                sheetOffset = dragStartOffset + offsetY
-                                            }
-                                        } else if offsetY < 0 {
-                                            let y = 1.0 / (1.0 + exp(-1 * (abs(offsetY) / 50.0))) - 0.5
-                                            withAnimation(.spring(duration: 0.3, bounce: 0.2)) {
-                                                sheetOffset = dragStartOffset + y * max(offsetY, -50)
-                                            }
-                                        }
+                                        handleDragGesture(value: value, dragStartOffset: dragStartOffset)
                                     }
                                     .onEnded { value in
-                                        viewModel.setDragging(false)
-                                        let offsetY = value.translation.height
-
-                                        if offsetY > DuckPlayerContainer.Constants.dragThreshold || value.velocity.height > 50 {
-                                            onDismiss()
-                                        } else if offsetY < -DuckPlayerContainer.Constants.dragThreshold || value.velocity.height < -50 {
-                                            isAnimatingToTop = true
-
-                                            // Start presenting DuckPlayer immediately
-                                            onPresentDuckPlayer()
-
-                                            // Animate the pill to top and fade out
-                                            withAnimation(.easeOut(duration: 0.3)) {
-                                                opacity = 0
-                                            }
-                                            withAnimation(.spring(duration: 0.5, bounce: 0.2)) {
-                                                sheetOffset = -containerHeight
-                                            }
-                                        } else {
-                                            withAnimation(.spring(duration: 0.2, bounce: 0.4)) {
-                                                sheetOffset = calculateSheetOffset(for: viewModel.sheetVisible, containerHeight: containerHeight)
-                                            }
-                                        }
+                                        handleEndedGesture(value: value, dragStartOffset: dragStartOffset)
                                     }
                             )
                     }
@@ -248,7 +255,14 @@ private struct SheetView<Content: View>: View {
         }
         .padding(.bottom, 44)
         .background(Color(designSystemColor: .panel))
-        .border(Color(designSystemColor: .border), width: 0.5)
+        .overlay(
+            Rectangle()
+                .frame(height: 0.5)
+                .foregroundColor(Color(designSystemColor: .border).opacity(0.7))
+                .position(x: UIScreen.main.bounds.width/2, y: 0)
+                .environment(\.colorScheme, .light)
+                .opacity(colorScheme == .light ? 1 : 0)
+        )
         .frame(maxWidth: .infinity)
         .offset(y: sheetOffset)
         .opacity(opacity)

--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerEntryPillView.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerEntryPillView.swift
@@ -33,23 +33,22 @@ struct DuckPlayerEntryPillView: View {
         static let daxLogo = "Home"
         static let playImage = "play.fill"
 
-        enum Layout {
-            static let iconSize: CGFloat = 40
-            static let vStackSpacing: CGFloat = 4
-            static let hStackSpacing: CGFloat = 10
-            static let fontSize: CGFloat = 16
-            static let playButtonFont: CGFloat = 16
-            static let cornerRadius: CGFloat = 12
-            static let shadowOpacity: CGFloat = 0.2
-            static let shadowRadius: CGFloat = 8
-            static let shadowOffset: CGSize = CGSize(width: 0, height: 4)
-            static let regularPadding: CGFloat = 16
-        }
+        // Layout
+        static let iconSize: CGFloat = 40
+        static let vStackSpacing: CGFloat = 4
+        static let hStackSpacing: CGFloat = 10
+        static let fontSize: CGFloat = 16
+        static let playButtonFont: CGFloat = 16
+        static let cornerRadius: CGFloat = 12
+        static let shadowOpacity: CGFloat = 0.2
+        static let shadowRadius: CGFloat = 8
+        static let shadowOffset: CGSize = CGSize(width: 0, height: 4)
+        static let regularPadding: CGFloat = 16
     }
 
     private var playButton: some View {
         Image(systemName: Constants.playImage)
-            .font(.system(size: Constants.Layout.playButtonFont))
+            .font(.system(size: Constants.playButtonFont))
             .foregroundColor(Color(designSystemColor: .buttonsPrimaryText))
             .frame(width: iconSize, height: iconSize)
             .background(Color(designSystemColor: .buttonsPrimaryDefault))
@@ -60,12 +59,12 @@ struct DuckPlayerEntryPillView: View {
         Button(
             action: { viewModel.openInDuckPlayer() },
             label: {
-                VStack(spacing: Constants.Layout.vStackSpacing) {
-                    HStack(spacing: Constants.Layout.hStackSpacing) {
+                VStack(spacing: Constants.vStackSpacing) {
+                    HStack(spacing: Constants.hStackSpacing) {
 
                         Image(Constants.daxLogo)
                             .resizable()
-                            .frame(width: Constants.Layout.iconSize, height: Constants.Layout.iconSize)
+                            .frame(width: Constants.iconSize, height: Constants.iconSize)
 
                         VStack(alignment: .leading) {
                             Text(UserText.duckPlayerNativeOpenInDuckPlayer)
@@ -88,16 +87,16 @@ struct DuckPlayerEntryPillView: View {
 
                         playButton
                     }
-                    .padding(Constants.Layout.regularPadding)
+                    .padding(Constants.regularPadding)
                     .background(
                         Color(designSystemColor: colorScheme == .dark ? .container : .backgroundSheets)
                     )
 
                 }
-                .cornerRadius(Constants.Layout.cornerRadius)
+                .cornerRadius(Constants.cornerRadius)
                 .shadow(
-                    color: Color.black.opacity(Constants.Layout.shadowOpacity), radius: Constants.Layout.shadowRadius,
-                    x: Constants.Layout.shadowOffset.width, y: Constants.Layout.shadowOffset.height
+                    color: Color.black.opacity(Constants.shadowOpacity), radius: Constants.shadowRadius,
+                    x: Constants.shadowOffset.width, y: Constants.shadowOffset.height
                 )
 
             })

--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerEntryPillView.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerEntryPillView.swift
@@ -108,10 +108,5 @@ struct DuckPlayerEntryPillView: View {
             Color(designSystemColor: .panel)
             sheetContent
         }
-        .clipShape(CustomRoundedCorners(radius: Constants.Layout.cornerRadius, corners: [.topLeft, .topRight]))
-        .shadow(
-            color: Color.black.opacity(Constants.Layout.shadowOpacity), radius: Constants.Layout.shadowRadius, x: Constants.Layout.shadowOffset.width,
-            y: Constants.Layout.shadowOffset.height
-        )
     }
 }

--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerEntryPillView.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerEntryPillView.swift
@@ -43,12 +43,7 @@ struct DuckPlayerEntryPillView: View {
             static let shadowOpacity: CGFloat = 0.2
             static let shadowRadius: CGFloat = 8
             static let shadowOffset: CGSize = CGSize(width: 0, height: 4)
-            static let viewOffset: CGFloat = 20
             static let regularPadding: CGFloat = 16
-            static let bottomSpacer: CGFloat = 25
-            static let grabHandleHeight: CGFloat = 4
-            static let grabHandleWidth: CGFloat = 36
-            static let grabHandleTopPadding: CGFloat = 8
         }
     }
 
@@ -61,18 +56,10 @@ struct DuckPlayerEntryPillView: View {
             .clipShape(Circle())
     }
 
-    private var grabHandle: some View {
-        Capsule()
-            .fill(Color(designSystemColor: .textPrimary).opacity(0.3))
-            .frame(width: Constants.Layout.grabHandleWidth, height: Constants.Layout.grabHandleHeight)
-            .padding(.top, Constants.Layout.grabHandleTopPadding)
-    }
-
     private var sheetContent: some View {
-        VStack(spacing: 0) {
-            grabHandle
-
-            Button(action: { viewModel.openInDuckPlayer() }) {
+        Button(
+            action: { viewModel.openInDuckPlayer() },
+            label: {
                 VStack(spacing: Constants.Layout.vStackSpacing) {
                     HStack(spacing: Constants.Layout.hStackSpacing) {
 
@@ -107,17 +94,13 @@ struct DuckPlayerEntryPillView: View {
                     )
 
                 }
-                .background(Color(designSystemColor: .surface))
                 .cornerRadius(Constants.Layout.cornerRadius)
                 .shadow(
                     color: Color.black.opacity(Constants.Layout.shadowOpacity), radius: Constants.Layout.shadowRadius,
                     x: Constants.Layout.shadowOffset.width, y: Constants.Layout.shadowOffset.height
                 )
-                .padding(.horizontal, Constants.Layout.regularPadding)
-                .padding(.vertical, Constants.Layout.regularPadding)
-                .padding(.bottom, Constants.Layout.bottomSpacer)  // Add padding to cover border during animation
-            }
-        }
+
+            })
     }
 
     var body: some View {
@@ -130,6 +113,5 @@ struct DuckPlayerEntryPillView: View {
             color: Color.black.opacity(Constants.Layout.shadowOpacity), radius: Constants.Layout.shadowRadius, x: Constants.Layout.shadowOffset.width,
             y: Constants.Layout.shadowOffset.height
         )
-        .offset(y: Constants.Layout.viewOffset)
     }
 }

--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerMiniPillView.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerMiniPillView.swift
@@ -66,39 +66,39 @@ struct DuckPlayerMiniPillView: View {
     struct Constants {
         static let playImage = "play.fill"
 
-        enum Layout {
-            static let thumbnailSize: (w: CGFloat, h: CGFloat) = (60, 33.7)
-            static let thumbnailCornerRadius: CGFloat = 8
-            static let vStackSpacing: CGFloat = 4
-            static let hStackSpacing: CGFloat = 10
-            static let fontSize: CGFloat = 16
-            static let playButtonFont: CGFloat = 20
-            static let cornerRadius: CGFloat = 12
-            static let shadowOpacity: CGFloat = 0.2
-            static let shadowRadius: CGFloat = 8
-            static let shadowOffset: CGSize = CGSize(width: 0, height: 4)
-            static let viewOffset: CGFloat = 20
-            static let regularPadding: CGFloat = 16
-        }
+        // Layout
+        static let thumbnailSize: (w: CGFloat, h: CGFloat) = (60, 33.7)
+        static let thumbnailCornerRadius: CGFloat = 8
+        static let vStackSpacing: CGFloat = 4
+        static let hStackSpacing: CGFloat = 10
+        static let fontSize: CGFloat = 16
+        static let playButtonFont: CGFloat = 20
+        static let cornerRadius: CGFloat = 12
+        static let shadowOpacity: CGFloat = 0.2
+        static let shadowRadius: CGFloat = 8
+        static let shadowOffset: CGSize = CGSize(width: 0, height: 4)
+        static let viewOffset: CGFloat = 20
+        static let regularPadding: CGFloat = 16
+       
     }
 
     private var sheetContent: some View {
         Button(
             action: { viewModel.openInDuckPlayer() },
             label: {
-                VStack(spacing: Constants.Layout.vStackSpacing) {
-                    HStack(spacing: Constants.Layout.hStackSpacing) {
+                VStack(spacing: Constants.vStackSpacing) {
+                    HStack(spacing: Constants.hStackSpacing) {
 
                         // YouTube thumbnail image
                         Group {
                             AnimatedAsyncImage(
                                 url: viewModel.thumbnailURL,
-                                width: Constants.Layout.thumbnailSize.w,
-                                height: Constants.Layout.thumbnailSize.h
+                                width: Constants.thumbnailSize.w,
+                                height: Constants.thumbnailSize.h
                             )
                         }
-                        .frame(width: Constants.Layout.thumbnailSize.w, height: Constants.Layout.thumbnailSize.h)
-                        .clipShape(RoundedRectangle(cornerRadius: Constants.Layout.thumbnailCornerRadius))
+                        .frame(width: Constants.thumbnailSize.w, height: Constants.thumbnailSize.h)
+                        .clipShape(RoundedRectangle(cornerRadius: Constants.thumbnailCornerRadius))
 
                         VStack(alignment: .leading) {
                             Text(UserText.duckPlayerNativeResumeInDuckPlayer)
@@ -118,16 +118,16 @@ struct DuckPlayerMiniPillView: View {
                         .layoutPriority(1)
 
                     }
-                    .padding(Constants.Layout.regularPadding)
+                    .padding(Constants.regularPadding)
                     .background(
                         Color(designSystemColor: colorScheme == .dark ? .container : .backgroundSheets)
                     )
 
                 }
-                .cornerRadius(Constants.Layout.cornerRadius)
+                .cornerRadius(Constants.cornerRadius)
                 .shadow(
-                    color: Color.black.opacity(Constants.Layout.shadowOpacity), radius: Constants.Layout.shadowRadius,
-                    x: Constants.Layout.shadowOffset.width, y: Constants.Layout.shadowOffset.height
+                    color: Color.black.opacity(Constants.shadowOpacity), radius: Constants.shadowRadius,
+                    x: Constants.shadowOffset.width, y: Constants.shadowOffset.height
                 )
 
             })

--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerMiniPillView.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerMiniPillView.swift
@@ -69,7 +69,8 @@ struct DuckPlayerMiniPillView: View {
         enum Layout {
             static let thumbnailSize: (w: CGFloat, h: CGFloat) = (60, 33.7)
             static let thumbnailCornerRadius: CGFloat = 8
-            static let stackSpacing: CGFloat = 12
+            static let vStackSpacing: CGFloat = 4
+            static let hStackSpacing: CGFloat = 10
             static let fontSize: CGFloat = 16
             static let playButtonFont: CGFloat = 20
             static let cornerRadius: CGFloat = 12
@@ -78,27 +79,16 @@ struct DuckPlayerMiniPillView: View {
             static let shadowOffset: CGSize = CGSize(width: 0, height: 4)
             static let viewOffset: CGFloat = 20
             static let regularPadding: CGFloat = 16
-            static let bottomSpacer: CGFloat = 25
-            static let grabHandleHeight: CGFloat = 4
-            static let grabHandleWidth: CGFloat = 36
-            static let grabHandleTopPadding: CGFloat = 8
         }
     }
 
-    private var grabHandle: some View {
-        Capsule()
-            .fill(Color(designSystemColor: .textPrimary).opacity(0.3))
-            .frame(width: Constants.Layout.grabHandleWidth, height: Constants.Layout.grabHandleHeight)
-            .padding(.top, Constants.Layout.grabHandleTopPadding)
-    }
-
     private var sheetContent: some View {
-        VStack(spacing: 0) {
-            grabHandle
+        Button(
+            action: { viewModel.openInDuckPlayer() },
+            label: {
+                VStack(spacing: Constants.Layout.vStackSpacing) {
+                    HStack(spacing: Constants.Layout.hStackSpacing) {
 
-            Button(action: { viewModel.openInDuckPlayer() }) {
-                VStack(spacing: Constants.Layout.stackSpacing) {
-                    HStack(spacing: Constants.Layout.stackSpacing) {
                         // YouTube thumbnail image
                         Group {
                             AnimatedAsyncImage(
@@ -122,27 +112,25 @@ struct DuckPlayerMiniPillView: View {
                                 .daxFootnoteRegular()
                                 .foregroundColor(Color(designSystemColor: .textSecondary))
                                 .multilineTextAlignment(.leading)
-                                .lineLimit(1)
+                                .lineLimit(2)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
                         .layoutPriority(1)
+
                     }
                     .padding(Constants.Layout.regularPadding)
                     .background(
                         Color(designSystemColor: colorScheme == .dark ? .container : .backgroundSheets)
                     )
+
                 }
-                .background(Color(designSystemColor: .surface))
                 .cornerRadius(Constants.Layout.cornerRadius)
                 .shadow(
                     color: Color.black.opacity(Constants.Layout.shadowOpacity), radius: Constants.Layout.shadowRadius,
                     x: Constants.Layout.shadowOffset.width, y: Constants.Layout.shadowOffset.height
                 )
-                .padding(.horizontal, Constants.Layout.regularPadding)
-                .padding(.vertical, Constants.Layout.regularPadding)
-                .padding(.bottom, Constants.Layout.bottomSpacer)  // Add padding to cover border during animation
-            }
-        }
+
+            })
     }
 
     var body: some View {
@@ -150,11 +138,5 @@ struct DuckPlayerMiniPillView: View {
             Color(designSystemColor: .panel)
             sheetContent
         }
-        .clipShape(CustomRoundedCorners(radius: Constants.Layout.cornerRadius, corners: [.topLeft, .topRight]))
-        .shadow(
-            color: Color.black.opacity(Constants.Layout.shadowOpacity), radius: Constants.Layout.shadowRadius, x: Constants.Layout.shadowOffset.width,
-            y: Constants.Layout.shadowOffset.height
-        )
-        .offset(y: Constants.Layout.viewOffset)
     }
 }

--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerViewUtils.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerViewUtils.swift
@@ -32,3 +32,9 @@ struct CustomRoundedCorners: Shape {
         return Path(path.cgPath)
     }
 }
+
+extension View {
+    func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
+        clipShape(CustomRoundedCorners(radius: radius, corners: corners))
+    }
+}

--- a/iOS/DuckDuckGo/SettingsDuckPlayerView.swift
+++ b/iOS/DuckDuckGo/SettingsDuckPlayerView.swift
@@ -101,7 +101,7 @@ struct SettingsDuckPlayerView: View {
                                         .disabled(viewModel.shouldDisplayDuckPlayerContingencyMessage)
                     }
 
-                    Section {
+                    Section(footer: Text(UserText.duckPlayerNativeAutoplayVideosDescription)) {
                         SettingsCellView(label: UserText.duckPlayerNativeAutoplayVideos,
                                         accessory: .toggle(isOn: viewModel.duckPlayerAutoplay))
                                         .disabled(viewModel.shouldDisplayDuckPlayerContingencyMessage)

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -1537,22 +1537,23 @@ Take back control of your personal information with the browser designed for dat
     static let duckPlayerContingencyMessageCTA = NSLocalizedString("duck-player.video-contingency-cta", value: "Learn More", comment: "Button for the message explaining to the user that Duck Player is not available so the user can learn more")
 
     // Duck Player Native UI
-    static let duckPlayerNativeWatchOnYouTube = NSLocalizedString("duck-player.native-watch-on-youtube", value: "Watch in Youtube", comment: "Text for the button to watch a video on YouTube")
-    static let duckPlayerNativeAutoplayVideos = NSLocalizedString("duck-player.native-autoplay-videos", value: "Autoplay Videos", comment: "Text for the toggle to autoplay videos")
+    static let duckPlayerNativeWatchOnYouTube = NSLocalizedString("duck-player.native-watch-on-youtube", value: "Watch in Youtube", comment: "Text for the button to watch a video on YouTube")    
     static let duckPlayerNativeOpenInDuckPlayer = NSLocalizedString("duck-player.native-open-in-duckplayer", value: "Play this video in Duck Player", comment: "Text for the button to watch a video on DuckPlayer")
     static let duckPlayerNativeResumeInDuckPlayer = NSLocalizedString("duck-player.native-resume-in-duckplayer", value: "Resume in Duck Player", comment: "Text for the button to resume watching a video on DuckPlayer")
     public static let duckPlayerTapToWatchWithoutAds = NSLocalizedString("duckplayer.pill.watch.without.ads", value: "No targeted ads, always private", comment: "Caption for Duck Player entry point")
-    public static let duckPlayerNativeUseOnSERPLabel = NSLocalizedString("duckPlayerNative.use.on.serp.label", value: "Use on Search Results", comment: "Label for the use DuckPlayer on SERP toggle")
-    public static let duckPlayerNativeUseOnSERPFooter = NSLocalizedString("duckPlayerNative.use.on.serp.footer", value: "YouTube videos on DuckDuckGo search results will open in Duck Player.", comment: "Label for the use DuckPlayer on Youtube toggle footer")
+    public static let duckPlayerNativeUseOnSERPLabel = NSLocalizedString("duckPlayerNative.use.on.serp.label", value: "DuckDuckGo Search Results", comment: "Label for the use DuckPlayer on SERP toggle")
+    public static let duckPlayerNativeUseOnSERPFooter = NSLocalizedString("duckPlayerNative.use.on.serp.footer", value: "Clicking on YouTube videos in DuckDuckGo search results will open in Duck Player.", comment: "Label for the use DuckPlayer on Youtube toggle footer")
     public static let duckPlayerNativeUseOnYoutubeLabel = NSLocalizedString("duckPlayerNative.use.on.youtube.label", value: "Use on Youtube.com", comment: "Label for the use DuckPlayer on Youtube toggle")
-    public static let duckPlayerNativeUseOnYoutubeFooter = NSLocalizedString("duckPlayerNative.use.on.youtube.footer", value: "Makes Duck Player available on Youtube video pages.", comment: "Label for the use DuckPlayer on Youtube toggle footer")
+    public static let duckPlayerNativeUseOnYoutubeFooter = NSLocalizedString("duckPlayerNative.use.on.youtube.footer", value: "Choose how you would like Duck Player to handle YouTube videos when navigating from the YouTube website.", comment: "Label for the use DuckPlayer on Youtube toggle footer")
     public static let duckPlayerNativeYoutubeAutoLabel = NSLocalizedString("duckPlayerNative.auto.label", value: "Automatically", comment: "Text displayed when DuckPlayer is automatically enabled for Youtube")
     public static let duckPlayerNativeYoutubeAskLabel = NSLocalizedString("duckPlayerNative.ask.label", value: "Let me choose", comment: "Text displayed when DuckPlayer is in 'Ask' mode for Youtube.")
     public static let duckPlayerNativeYoutubeNeverLabel = NSLocalizedString("duckPlayerNative.never.label", value: "Don't Show", comment: "Text displayed when DuckPlayer is in off for youtube.")
     public static let duckPlayerNativeAutoOpenLabel = NSLocalizedString("duckPlayerNative.auto.open.label", value: "Auto-open Duck Player on Youtube", comment: "Label for the automatic youtube video opening")
-    
-    public static let duckPlayerNativeModalTitle = NSLocalizedString("duckPlayerNative.modal.title", value: "Try Duck Player Mode for a private YouTube experience with DuckDuckGo", comment: "Title for DuckPlayer priming modal")
-    public static let duckPlayerNativeModalDescription = NSLocalizedString("duckPlayerNative.modal.description", value: "Watch YouTube without targeted ads or influencing your recommendations.", comment: "Description for DuckPlayer priming modal")
+    static let duckPlayerNativeAutoplayVideos = NSLocalizedString("duck-player.native-autoplay-videos", value: "Autoplay Videos", comment: "Text for the toggle to autoplay videos")
+    static let duckPlayerNativeAutoplayVideosDescription = NSLocalizedString("duck-player.native-autoplay-videos.description", value: "Videos opened in Duck Player will automatically begin playback. Turn this off if you would like to manually start playback of videos opened in Duck Player.", comment: "Text for the description about autoplay videos")
+
+    public static let duckPlayerNativeModalTitle = NSLocalizedString("duckPlayerNative.modal.title", value: "Play this video in Duck Player to watch without targeted ads!", comment: "Title for DuckPlayer priming modal")
+    public static let duckPlayerNativeModalDescription = NSLocalizedString("duckPlayerNative.modal.description", value: "Plus, what you watch in Duck Player won’t influence your YouTube recommendations.", comment: "Description for DuckPlayer priming modal")
     public static let duckPlayerNativeModalCTA = NSLocalizedString("duckPlayerNative.modal.cta", value: "Watch Now Privately", comment: "CTA for DuckPlayer priming modal")
 
     // MARK: - AI Chat

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -1178,6 +1178,9 @@
 /* Text for the toggle to autoplay videos */
 "duck-player.native-autoplay-videos" = "Autoplay Videos";
 
+/* Text for the description about autoplay videos */
+"duck-player.native-autoplay-videos.description" = "Videos opened in Duck Player will automatically begin playback. Turn this off if you would like to manually start playback of videos opened in Duck Player.";
+
 /* Text for the button to watch a video on DuckPlayer */
 "duck-player.native-open-in-duckplayer" = "Play this video in Duck Player";
 
@@ -1264,22 +1267,22 @@
 "duckPlayerNative.modal.cta" = "Watch Now Privately";
 
 /* Description for DuckPlayer priming modal */
-"duckPlayerNative.modal.description" = "Watch YouTube without targeted ads or influencing your recommendations.";
+"duckPlayerNative.modal.description" = "Plus, what you watch in Duck Player won’t influence your YouTube recommendations.";
 
 /* Title for DuckPlayer priming modal */
-"duckPlayerNative.modal.title" = "Try Duck Player Mode for a private YouTube experience with DuckDuckGo";
+"duckPlayerNative.modal.title" = "Play this video in Duck Player to watch without targeted ads!";
 
 /* Text displayed when DuckPlayer is in off for youtube. */
 "duckPlayerNative.never.label" = "Don't Show";
 
 /* Label for the use DuckPlayer on Youtube toggle footer */
-"duckPlayerNative.use.on.serp.footer" = "YouTube videos on DuckDuckGo search results will open in Duck Player.";
+"duckPlayerNative.use.on.serp.footer" = "Clicking on YouTube videos in DuckDuckGo search results will open in Duck Player.";
 
 /* Label for the use DuckPlayer on SERP toggle */
-"duckPlayerNative.use.on.serp.label" = "Use on Search Results";
+"duckPlayerNative.use.on.serp.label" = "DuckDuckGo Search Results";
 
 /* Label for the use DuckPlayer on Youtube toggle footer */
-"duckPlayerNative.use.on.youtube.footer" = "Makes Duck Player available on Youtube video pages.";
+"duckPlayerNative.use.on.youtube.footer" = "Choose how you would like Duck Player to handle YouTube videos when navigating from the YouTube website.";
 
 /* Label for the use DuckPlayer on Youtube toggle */
 "duckPlayerNative.use.on.youtube.label" = "Use on Youtube.com";


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/0/1209731245273066
Tech Design URL:
CC:

### Description
- Adds ability to dismiss DuckPlayer pill, or drag up to open DuckPlayer

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Set yourself as internal user
2. Enable DuckPlayer Native UI (Settings > DuckPlayer), confirm it's on "Let me choose" mode
3. Go to a youtube.com and open a video
4. Grab Duckplayer pill by the handle and drag it outside the view
5. Scroll through the page, and refresh
**6. Confirm the pill keeps hidden**
7. Navigate to other video
8. Confirm Pill shows up again
9. Drag up and release
**10. Confirm DuckPlayer opens**


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)