### PR TITLE
Disables a flakey test

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS Browser App Store.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS Browser App Store.xcscheme
@@ -164,6 +164,12 @@
                   Identifier = "HTTPSUpgradeIntegrationTests">
                </Test>
                <Test
+                  Identifier = "MaliciousSiteProtectionIntegrationTests/testFeatureDisabledAndMalwareDetection_tabIsNotMarkedMalware()">
+               </Test>
+               <Test
+                  Identifier = "MaliciousSiteProtectionIntegrationTests/testFeatureDisabledAndScamDetection_tabIsNotMarkedScam()">
+               </Test>
+               <Test
                   Identifier = "NavigationProtectionIntegrationTests/testAMPLinks()">
                </Test>
                <Test

--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS Browser.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS Browser.xcscheme
@@ -196,6 +196,9 @@
                   Identifier = "MaliciousSiteProtectionIntegrationTests/testFeatureDisabledAndMalwareDetection_tabIsNotMarkedMalware()">
                </Test>
                <Test
+                  Identifier = "MaliciousSiteProtectionIntegrationTests/testFeatureDisabledAndScamDetection_tabIsNotMarkedScam()">
+               </Test>
+               <Test
                   Identifier = "NavigationProtectionIntegrationTests/testAMPLinks()">
                </Test>
                <Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200194497630846/1209802344094592/f

### Description

This was brought to my attention by https://app.asana.com/0/1205237866452338/1209801961396805/f

I had previously brought it up in the team channel that these tests were being quite flakey lately so I disabled them.

### Testing Steps

NA

### Impact and Risks

Low

#### What could go wrong?

Scam and malware detection failing would be bad for optics, but disabling these tests isn't introducing an issue - just making the CI focus on what we know NOT to be broken.

### Quality Considerations

NA

### Notes to Reviewer

I've opened [a task](https://app.asana.com/0/1200194497630846/1209802344094592/f) to report these tests are being disabled.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)