### PR TITLE
Add a workflow to sync signing assets

### DIFF
--- a/.github/workflows/update_code_signing.yml
+++ b/.github/workflows/update_code_signing.yml
@@ -1,0 +1,81 @@
+name: Update Code Signing Assets
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Code Signing target"
+        type: choice
+        required: true
+        options:
+           - ios-release-appstore
+           - ios-release-adhoc
+           - ios-alpha-appstore
+           - ios-alpha-adhoc
+           - macos-release-appstore
+           - macos-release-dmg
+           - macos-review-dmg
+           - macos-ci
+
+jobs:
+  update_code_signing:
+    runs-on: macos-15
+    name: Update Code Signing Assets
+
+    steps:
+
+      - name: Register SSH keys for access to certificates
+        uses: webfactory/ssh-agent@v0.9.1
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
+
+      - name: Check out the code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Prepare fastlane
+        run: bundle install
+
+      - name: Archive and upload the app
+        env:
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+        run: |
+          case "${{ inputs.target }}" in
+            ios-release-appstore)
+              platform="ios"
+              lane="sync_signing"
+              ;;
+            ios-release-adhoc)
+              platform="ios"
+              lane="sync_signing_adhoc"
+              ;;
+            ios-alpha-appstore)
+              platform="ios"
+              lane="sync_signing_alpha"
+              ;;
+            ios-alpha-adhoc)
+              platform="ios"
+              lane="sync_signing_alpha_adhoc"
+              ;;
+            macos-release-appstore)
+              platform="mac"
+              lane="sync_signing"
+              ;;
+            macos-release-dmg)
+              platform="mac"
+              lane="sync_signing_dmg_release"
+              ;;
+            macos-review-dmg)
+              platform="mac"
+              lane="sync_signing_dmg_review"
+              ;;
+            macos-ci)
+              platform="mac"
+              lane="sync_signing_ci"
+              ;;
+          esac
+ 
+          bundle exec fastlane ${platform} ${lane}

--- a/.github/workflows/update_code_signing.yml
+++ b/.github/workflows/update_code_signing.yml
@@ -30,11 +30,6 @@ jobs:
 
       - name: Check out the code
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Prepare fastlane
-        run: bundle install
 
       - name: Archive and upload the app
         env:
@@ -45,37 +40,39 @@ jobs:
         run: |
           case "${{ inputs.target }}" in
             ios-release-appstore)
-              platform="ios"
+              platform="iOS"
               lane="sync_signing"
               ;;
             ios-release-adhoc)
-              platform="ios"
+              platform="iOS"
               lane="sync_signing_adhoc"
               ;;
             ios-alpha-appstore)
-              platform="ios"
+              platform="iOS"
               lane="sync_signing_alpha"
               ;;
             ios-alpha-adhoc)
-              platform="ios"
+              platform="iOS"
               lane="sync_signing_alpha_adhoc"
               ;;
             macos-release-appstore)
-              platform="mac"
+              platform="macOS"
               lane="sync_signing"
               ;;
             macos-release-dmg)
-              platform="mac"
+              platform="macOS"
               lane="sync_signing_dmg_release"
               ;;
             macos-review-dmg)
-              platform="mac"
+              platform="macOS"
               lane="sync_signing_dmg_review"
               ;;
             macos-ci)
-              platform="mac"
+              platform="macOS"
               lane="sync_signing_ci"
               ;;
           esac
  
-          bundle exec fastlane ${platform} ${lane}
+          cd "$platform"
+          bundle install
+          bundle exec fastlane ${lane}

--- a/.github/workflows/update_code_signing.yml
+++ b/.github/workflows/update_code_signing.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v4
 
-      - name: Archive and upload the app
+      - name: Update code signing assets
         env:
           APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/iOS/fastlane/Fastfile
+++ b/iOS/fastlane/Fastfile
@@ -346,11 +346,10 @@ platform :ios do
   end
 
   private_lane :do_sync_signing do |options|
-    is_adhoc = lane_context[SharedValues::LANE_NAME].include?("adhoc")
     sync_code_signing(
       api_key: get_api_key,
       username: get_username(options),
-      readonly: is_ci && !is_adhoc
+      readonly: !is_ci
     )
   end
 

--- a/macOS/fastlane/Fastfile
+++ b/macOS/fastlane/Fastfile
@@ -396,7 +396,7 @@ platform :mac do
     sync_code_signing(
       api_key: get_api_key,
       username: get_username(options),
-      readonly: is_ci
+      readonly: !is_ci
     )
   end
 

--- a/macOS/fastlane/README.md
+++ b/macOS/fastlane/README.md
@@ -69,7 +69,7 @@ Makes App Store release build and uploads it to TestFlight
 [bundle exec] fastlane mac promote_latest_testflight_to_appstore
 ```
 
-Promotes the latest testflight build to appstore without submitting for review
+Promotes the latest TestFlight build to App Store without submitting for review
 
 ### mac release_appstore
 
@@ -134,6 +134,14 @@ Updates embedded files and pushes to remote.
 ```
 
 Executes the release preparation work in the repository
+
+### mac create_keychain_ui_tests
+
+```sh
+[bundle exec] fastlane mac create_keychain_ui_tests
+```
+
+Creates a new Kechain to use on UI tests
 
 ----
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1201899738287924/1209731854785342/f

### Description:
This change adds a new workflow to be used to update code signing assets

### Testing Steps
See historical runs [here](https://github.com/duckduckgo/apple-browsers/actions/workflows/update_code_signing.yml)

### Impact and Risks
None: Internal tooling

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)