### PR TITLE
[Release PR] Skip waiting for iOS build processing

### DIFF
--- a/iOS/fastlane/Fastfile
+++ b/iOS/fastlane/Fastfile
@@ -238,7 +238,8 @@ platform :ios do
     build_release
 
     upload_to_testflight(
-      api_key: get_api_key
+      api_key: get_api_key,
+      skip_waiting_for_build_processing: true
     )
   end
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1203301625297703/1209796700502819/f
Tech Design URL:
CC:

### Description

This PR skips waiting for iOS build processing, as the processing times have gotten extremely long recently.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that the diff looks good - not sure we can test this otherwise without doing an actual build upload
2. Check that no other iOS uses of `upload_to_testflight` need to be modified

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

### Notes to Reviewer
I'm sending this to the release branch since that's where we are most affected by this right now. Another PR will be available for the macOS branch soon.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)