### PR TITLE
Fix bottom address bar animation glitch when transitioning from tabs list to empty tab

### DIFF
--- a/iOS/DuckDuckGo/HomeScreenTransition.swift
+++ b/iOS/DuckDuckGo/HomeScreenTransition.swift
@@ -189,7 +189,11 @@ class ToHomeScreenTransition: HomeScreenTransition {
         UIView.animateKeyframes(withDuration: TabSwitcherTransition.Constants.duration, delay: 0, options: .calculationModeLinear, animations: {
             
             UIView.addKeyframe(withRelativeStartTime: 0, relativeDuration: 1.0) {
-                self.imageContainer.frame = homeScreen.view.convert(homeScreen.rootContainerView.frame, to: nil)
+                var containerFrame = homeScreen.rootContainerView.frame
+                if mainViewController.appSettings.currentAddressBarPosition == .bottom {
+                  containerFrame.size.height = homeScreen.rootContainerView.frame.height - mainViewController.viewCoordinator.omniBar.frame.height
+                }
+                self.imageContainer.frame = homeScreen.view.convert(containerFrame, to: nil)
                 self.imageContainer.layer.cornerRadius = 0
                 self.imageContainer.backgroundColor = theme.backgroundColor
                 self.imageView.frame = CGRect(origin: .zero,


### PR DESCRIPTION
Task/Issue URL:  - (can't find a way to create)

### Description
Fix an issue with animation glitching on transition from tab views to empty tab.
Reproduces: always (both grid and list tabs view, and both portrait and lanscape)

See video with bug reproduction: https://github.com/user-attachments/assets/5994dd4d-7c6c-4b06-a06d-febc3818d409

### Testing Steps
Preconditions: set Settings->Appearance->Address Bar to Bottom
1. Have empty tab opened
2. Switch to tabs list
3. Tap on empty tab

### Impact and Risks
Low: only transition could be affected

#### What could go wrong?
-

### Quality Considerations
-

### Notes to Reviewer
-

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)