### PR TITLE
macOS: Launch VPN on V2 right after the migration

### DIFF
--- a/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
+++ b/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
@@ -328,7 +328,7 @@ final class DuckDuckGoVPNAppDelegate: NSObject, NSApplicationDelegate {
 
     @MainActor
     private lazy var vpnAppEventsHandler = {
-        VPNAppEventsHandler(tunnelController: tunnelController)
+        VPNAppEventsHandler(tunnelController: tunnelController, appState: vpnAppState)
     }()
 
     @MainActor

--- a/macOS/DuckDuckGoVPN/VPNAppEventsHandler.swift
+++ b/macOS/DuckDuckGoVPN/VPNAppEventsHandler.swift
@@ -20,12 +20,17 @@ import Foundation
 import Common
 import NetworkProtection
 import os.log
+import VPNAppState
 
 final class VPNAppEventsHandler {
 
+    private let appState: VPNAppState
     private let tunnelController: NetworkProtectionTunnelController
 
-    init(tunnelController: NetworkProtectionTunnelController) {
+    init(tunnelController: NetworkProtectionTunnelController,
+         appState: VPNAppState) {
+
+        self.appState = appState
         self.tunnelController = tunnelController
     }
 
@@ -36,10 +41,19 @@ final class VPNAppEventsHandler {
             versionStore.lastAgentVersionRun = currentVersion
         }
 
-        let restartTunnel = {
+        let restartTunnel = { [appState, tunnelController] in
             self.tunnelController.ensureRiskyDomainsEnabledIfNeeded()
             Logger.networking.info("App updated from \(versionStore.lastAgentVersionRun ?? "null", privacy: .public) to \(currentVersion, privacy: .public): updating login items")
-            self.restartTunnel()
+
+            if tunnelController.settings.isAuthV2Enabled && !appState.isMigratedToAuthV2 {
+                Task {
+                    await tunnelController.stop()
+                    await tunnelController.start()
+                    appState.isMigratedToAuthV2 = true
+                }
+            } else {
+                self.restartTunnel()
+            }
         }
 
 #if DEBUG || REVIEW // Since DEBUG and REVIEW builds may not change version No. we want them to always reset.

--- a/macOS/DuckDuckGoVPN/VPNAppEventsHandler.swift
+++ b/macOS/DuckDuckGoVPN/VPNAppEventsHandler.swift
@@ -32,6 +32,10 @@ final class VPNAppEventsHandler {
 
         self.appState = appState
         self.tunnelController = tunnelController
+
+        if !tunnelController.settings.isAuthV2Enabled {
+            appState.resetIsMigratedToAuthV2()
+        }
     }
 
     func appDidFinishLaunching() {

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/VPNAppState/Extensions/UserDefaults+isVPNMigratedToAuthV2.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/VPNAppState/Extensions/UserDefaults+isVPNMigratedToAuthV2.swift
@@ -1,0 +1,46 @@
+//
+//  UserDefaults+isVPNMigratedToAuthV2.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import Foundation
+
+extension UserDefaults {
+    @objc
+    public dynamic var isVPNMigratedToAuthV2: Bool {
+        get {
+            bool(forKey: #keyPath(isVPNMigratedToAuthV2))
+        }
+
+        set {
+            guard newValue != bool(forKey: #keyPath(isVPNMigratedToAuthV2)) else {
+                return
+            }
+
+            guard newValue else {
+                removeObject(forKey: #keyPath(isVPNMigratedToAuthV2))
+                return
+            }
+
+            set(newValue, forKey: #keyPath(isVPNMigratedToAuthV2))
+        }
+    }
+
+    func resetIsVPNMigratedToAuthV2() {
+        removeObject(forKey: #keyPath(isVPNMigratedToAuthV2))
+    }
+}

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/VPNAppState/VPNAppState.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/VPNAppState/VPNAppState.swift
@@ -54,4 +54,16 @@ public final class VPNAppState {
             defaults.vpnIsUsingSystemExtension = newValue
         }
     }
+
+    // MARK: - AuthV2 migration support
+
+    public var isMigratedToAuthV2: Bool {
+        get {
+            defaults.isVPNMigratedToAuthV2
+        }
+
+        set {
+            defaults.isVPNMigratedToAuthV2 = newValue
+        }
+    }
 }

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/VPNAppState/VPNAppState.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/VPNAppState/VPNAppState.swift
@@ -37,6 +37,7 @@ public final class VPNAppState {
 
     public func resetToDefaults() {
         defaults.resetVPNIsUsingSystemExtension()
+        defaults.resetIsVPNMigratedToAuthV2()
     }
 
     // MARK: - System Extension support
@@ -65,5 +66,9 @@ public final class VPNAppState {
         set {
             defaults.isVPNMigratedToAuthV2 = newValue
         }
+    }
+
+    public func resetIsMigratedToAuthV2() {
+        defaults.resetIsVPNMigratedToAuthV2()
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209809380088650

### Description

Make sure the VPN is launched on V2 right after the first migration by restarting the VPN manually.

### Testing Steps

1. Launch the VPN on V1
2. Switch on the V2 flag
3. Relaunch the app

Ensure the VPN is running on V2 immediately.

### Impact and Risks

Low

#### What could go wrong?

I can't think of anything.

### Quality Considerations

If we roll back v2 we'll need to change this default to something else.

### Notes to Reviewer

None

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)