### PR TITLE
Move camera permissions handling a step earlier

### DIFF
--- a/.maestro/shared/sync_login.yaml
+++ b/.maestro/shared/sync_login.yaml
@@ -5,12 +5,12 @@ appId: com.duckduckgo.mobile.ios
 - tapOn: Sync with Another Device
 - inputText: "0000"
 - pressKey: Enter
-- assertVisible: Scan QR Code
 - runFlow:
     when:
       visible: Allows you to upload photographs and videos
     commands:
         - tapOn: "Allow"
+- assertVisible: Scan QR Code
 - tapOn: Manually Enter Code
 - tapOn: Paste
 - assertVisible: Save Recovery Code

--- a/.maestro/sync_tests/06_delete_account.yaml
+++ b/.maestro/sync_tests/06_delete_account.yaml
@@ -27,12 +27,12 @@ name: 06_delete_account
 - tapOn: Sync with Another Device
 - inputText: "0000"
 - pressKey: Enter
-- assertVisible: Scan QR Code
 - runFlow:
     when:
       visible: Allows you to upload photographs and videos
     commands:
         - tapOn: "Allow"
+- assertVisible: Scan QR Code
 - tapOn: Manually Enter Code
 - tapOn: Paste
 - assertVisible: Sync & Backup Error


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202926619870900/1209806750098525/f

### Description

Noticed the delete account test was flaking due to the timing of the camera alert handling. Will see if moving it earlier also works as it might result in less flakiness 🤞

### Testing Steps
Just run Sync e2e tests

### Impact and Risks
None: Test improvement

#### What could go wrong?
Could make flakiness worse, but we can always revert if that happens

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)