### PR TITLE
Fix NTP User Script leak

### DIFF
--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageWebViewModel.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageWebViewModel.swift
@@ -72,6 +72,13 @@ final class NewTabPageWebViewModel: NSObject {
             }
             .store(in: &cancellables)
     }
+
+    func removeUserScripts() {
+        if let controller = webView.configuration.userContentController as? NewTabPageUserContentController {
+            controller.removeUserScripts()
+        }
+    }
+
 }
 
 extension NewTabPageWebViewModel: WKNavigationDelegate {

--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -192,6 +192,7 @@ final class BrowserTabViewController: NSViewController {
     @objc
     private func windowWillClose(_ notification: NSNotification) {
         self.removeWebViewFromHierarchy()
+        self.newTabPageWebViewModel.removeUserScripts()
     }
 
     @objc

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/NewTabPageUserContentController.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/NewTabPageUserContentController.swift
@@ -41,6 +41,12 @@ public final class NewTabPageUserContentController: WKUserContentController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    public func removeUserScripts() {
+        removeAllUserScripts()
+        removeAllScriptMessageHandlers()
+    }
+
 }
 
 @MainActor


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1199333091098016/1209821590760695/f
Tech Design URL:
CC:

### Description

This PR fixes (in a not so ideal way) a leak with the NTP user scripts. I'll elaborate on why it's not ideal in the comments.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Open and close a bunch of windows
2. Open the memory graph debugger
3. Filter for `NewTab` and check that you don't see a large number of user content controllers, user scripts, etc.
4. Test that the repro steps in the [original Asana task](https://app.asana.com/0/1201037661562251/1209767015721459/f) are fixed too

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)