### PR TITLE
Attempt to fix flaky date check tests

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/CommonTests/Extensions/DateExtensionTest.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/CommonTests/Extensions/DateExtensionTest.swift
@@ -99,7 +99,7 @@ final class DateExtensionTests: XCTestCase {
         let daysAgo = date.daysAgo(3)
         let expectedDate = Calendar.current.date(byAdding: .day, value: -3, to: date)!
 
-        XCTAssertEqual(daysAgo.startOfDay, expectedDate.startOfDay)
+        XCTAssertEqual(daysAgo.startOfDay.timeIntervalSince1970, expectedDate.startOfDay.timeIntervalSince1970, accuracy: 0.1)
     }
 
     func testStartOfMinuteNow() {
@@ -107,7 +107,7 @@ final class DateExtensionTests: XCTestCase {
         let now = Calendar.current.date(bySetting: .second, value: 0, of: Date())!
         let expectedStart = Calendar.current.date(byAdding: .minute, value: -1, to: now)!
 
-        XCTAssertEqual(startOfMinuteNow, expectedStart)
+        XCTAssertEqual(startOfMinuteNow.timeIntervalSince1970, expectedStart.timeIntervalSince1970, accuracy: 0.1)
     }
 
     func testMonthsWithIndex() {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1205237866452338/1209168582277729/f
Tech Design URL:
CC:

### Description

This PR attempts to fix a flaky test that looks to be related to date precision. The fix is to allow a `0.1` second tolerance in the checks.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that `testStartOfMinuteNow` didn't fail on CI

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)