### PR TITLE
Add breakage metrics (#372)

### DIFF
--- a/BrowserServicesKit/Package.swift
+++ b/BrowserServicesKit/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit.git", exact: "3.0.0"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.5.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "3.0.0"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "8.5.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "8.6.0"),
         .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "9.0.0"),
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
         .package(url: "https://github.com/duckduckgo/bloom_cpp.git", exact: "3.0.0"),

--- a/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
+++ b/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
@@ -57,8 +57,6 @@ public struct BrokenSiteReport {
 
     }
 
-    let cookieConsentInfo: CookieConsentInfo?
-
 #if os(iOS)
     public enum SiteType: String {
 
@@ -99,6 +97,9 @@ public struct BrokenSiteReport {
     let jsPerformance: [Double]?
     let userRefreshCount: Int
     let locale: Locale
+    let cookieConsentInfo: CookieConsentInfo?
+    let debugFlags: String
+    let privacyExperiments: [String: String]
 #if os(iOS)
     let siteType: SiteType
     let atb: String
@@ -130,7 +131,9 @@ public struct BrokenSiteReport {
         jsPerformance: [Double]?,
         userRefreshCount: Int,
         locale: Locale = Locale.current,
-        cookieConsentInfo: CookieConsentInfo?
+        cookieConsentInfo: CookieConsentInfo?,
+        debugFlags: String,
+        privacyExperiments: [String: String]
     ) {
         self.siteUrl = siteUrl
         self.category = category
@@ -155,6 +158,8 @@ public struct BrokenSiteReport {
         self.userRefreshCount = userRefreshCount
         self.locale = locale
         self.cookieConsentInfo = cookieConsentInfo
+        self.debugFlags = debugFlags
+        self.privacyExperiments = privacyExperiments
     }
 #endif
 
@@ -186,7 +191,9 @@ public struct BrokenSiteReport {
         userRefreshCount: Int,
         variant: String,
         locale: Locale = Locale.current,
-        cookieConsentInfo: CookieConsentInfo?
+        cookieConsentInfo: CookieConsentInfo?,
+        debugFlags: String,
+        privacyExperiments: [String: String]
     ) {
         self.siteUrl = siteUrl
         self.category = category
@@ -215,6 +222,8 @@ public struct BrokenSiteReport {
         self.variant = variant
         self.locale = locale
         self.cookieConsentInfo = cookieConsentInfo
+        self.debugFlags = debugFlags
+        self.privacyExperiments = privacyExperiments
     }
 #endif
 
@@ -241,7 +250,8 @@ public struct BrokenSiteReport {
             "locale": locale.localeIdentifierAsJsonFormat,
             "consentManaged": boolToStringValue(cookieConsentInfo?.consentManaged),
             "consentOptoutFailed": boolToStringValue(cookieConsentInfo?.optoutFailed),
-            "consentSelftestFailed": boolToStringValue(cookieConsentInfo?.selftestFailed)
+            "consentSelftestFailed": boolToStringValue(cookieConsentInfo?.selftestFailed),
+            "debugFlags": debugFlags
         ]
 
         if mode == .regular {
@@ -266,6 +276,10 @@ public struct BrokenSiteReport {
         if let jsPerformance {
             let perf = jsPerformance.map { String($0) }.joined(separator: ",")
             result["jsPerformance"] = perf
+        }
+
+        for (key, value) in privacyExperiments {
+            result[key] = value
         }
 
 #if os(iOS)

--- a/BrowserServicesKit/Sources/PrivacyDashboard/PrivacyInfo.swift
+++ b/BrowserServicesKit/Sources/PrivacyDashboard/PrivacyInfo.swift
@@ -47,6 +47,7 @@ public final class PrivacyInfo {
     @Published public var malicousSiteThreatKind: MaliciousSiteProtection.ThreatKind?
     @Published public var isSpecialErrorPageVisible: Bool = false
     @Published public var shouldCheckServerTrust: Bool
+    public private(set) var debugFlags: String = ""
 
     public init(url: URL, parentEntity: Entity?, protectionStatus: ProtectionStatus, malicousSiteThreatKind: MaliciousSiteProtection.ThreatKind? = .none, shouldCheckServerTrust: Bool = false) {
         self.url = url
@@ -68,5 +69,13 @@ public final class PrivacyInfo {
 
     public func isFor(_ url: URL?) -> Bool {
         return self.url.host == url?.host
+    }
+
+    public func addDebugFlag(_ flag: String) {
+        if debugFlags.isEmpty {
+            debugFlags = flag
+        } else if !debugFlags.contains(flag) {
+            debugFlags.append(",\(flag)")
+        }
     }
 }

--- a/BrowserServicesKit/Tests/PrivacyDashboardTests/BrokenSiteReportMocks.swift
+++ b/BrowserServicesKit/Tests/PrivacyDashboardTests/BrokenSiteReportMocks.swift
@@ -48,7 +48,9 @@ struct BrokenSiteReportMocks {
                          jsPerformance: nil,
                          userRefreshCount: 0,
                          variant: "",
-                         cookieConsentInfo: nil)
+                         cookieConsentInfo: nil,
+                         debugFlags: "",
+                         privacyExperiments: [:])
 #else
         BrokenSiteReport(siteUrl: URL(string: "https://duckduckgo.com")!,
                          category: "test",
@@ -71,7 +73,9 @@ struct BrokenSiteReportMocks {
                          vpnOn: false,
                          jsPerformance: nil,
                          userRefreshCount: 0,
-                         cookieConsentInfo: nil)
+                         cookieConsentInfo: nil,
+                         debugFlags: "",
+                         privacyExperiments: [:])
 #endif
     }
 
@@ -102,7 +106,9 @@ struct BrokenSiteReportMocks {
                          jsPerformance: nil,
                          userRefreshCount: 0,
                          variant: "",
-                         cookieConsentInfo: nil)
+                         cookieConsentInfo: nil,
+                         debugFlags: "",
+                         privacyExperiments: [:])
 #else
         BrokenSiteReport(siteUrl: URL(string: "https://somethingelse.zz")!,
                          category: "test",
@@ -125,7 +131,9 @@ struct BrokenSiteReportMocks {
                          vpnOn: false,
                          jsPerformance: nil,
                          userRefreshCount: 0,
-                         cookieConsentInfo: nil)
+                         cookieConsentInfo: nil,
+                         debugFlags: "",
+                         privacyExperiments: [:])
 #endif
     }
 
@@ -156,7 +164,9 @@ struct BrokenSiteReportMocks {
                          jsPerformance: nil,
                          userRefreshCount: 0,
                          variant: "",
-                         cookieConsentInfo: nil)
+                         cookieConsentInfo: nil,
+                         debugFlags: "",
+                         privacyExperiments: [:])
 #else
         BrokenSiteReport(siteUrl: URL(string: "https://www.subdomain.example.com/some/pathname?t=param#aaa")!,
                          category: "test",
@@ -179,7 +189,9 @@ struct BrokenSiteReportMocks {
                          vpnOn: false,
                          jsPerformance: nil,
                          userRefreshCount: 0,
-                         cookieConsentInfo: nil)
+                         cookieConsentInfo: nil,
+                         debugFlags: "",
+                         privacyExperiments: [:])
 #endif
     }
 }

--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "8fa69d009d3205b969bc76477897e3b82095f9f6",
-        "version" : "8.5.0"
+        "revision" : "d4bccd53cf01818198f28efa45e1dfefdd53790d",
+        "version" : "8.6.0"
       }
     },
     {

--- a/iOS/DuckDuckGo/AutofillLoginListViewModel.swift
+++ b/iOS/DuckDuckGo/AutofillLoginListViewModel.swift
@@ -341,7 +341,9 @@ final class AutofillLoginListViewModel: ObservableObject {
                                       jsPerformance: nil,
                                       userRefreshCount: 0,
                                       variant: "",
-                                      cookieConsentInfo: nil)
+                                      cookieConsentInfo: nil,
+                                      debugFlags: "",
+                                      privacyExperiments: [:])
 
         try? breakageReporter.report(report, reportMode: .regular, daysToExpiry: breakageReportIntervalDays)
     }

--- a/iOS/DuckDuckGo/PrivacyDashboard/PrivacyDashboardViewController.swift
+++ b/iOS/DuckDuckGo/PrivacyDashboard/PrivacyDashboardViewController.swift
@@ -38,6 +38,7 @@ final class PrivacyDashboardViewController: UIViewController {
     private let contentBlockingManager: ContentBlockerRulesManager
     private var privacyDashboardDidTriggerDismiss: Bool = false
     private let entryPoint: PrivacyDashboardEntryPoint
+    private let featureFlagger: FeatureFlagger
 
     private let brokenSiteReporter: BrokenSiteReporter = {
         BrokenSiteReporter(pixelHandler: { parameters in
@@ -74,7 +75,8 @@ final class PrivacyDashboardViewController: UIViewController {
           entryPoint: PrivacyDashboardEntryPoint,
           privacyConfigurationManager: PrivacyConfigurationManaging,
           contentBlockingManager: ContentBlockerRulesManager,
-          breakageAdditionalInfo: BreakageAdditionalInfo?) {
+          breakageAdditionalInfo: BreakageAdditionalInfo?,
+          featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger) {
 
         let toggleReportingConfiguration = ToggleReportingConfiguration(privacyConfigurationManager: privacyConfigurationManager)
         let toggleReportingFeature = ToggleReportingFeature(toggleReportingConfiguration: toggleReportingConfiguration)
@@ -87,6 +89,7 @@ final class PrivacyDashboardViewController: UIViewController {
         self.contentBlockingManager = contentBlockingManager
         self.breakageAdditionalInfo = breakageAdditionalInfo
         self.entryPoint = entryPoint
+        self.featureFlagger = featureFlagger
         super.init(coder: coder)
         
         privacyDashboardController.delegate = self
@@ -332,6 +335,15 @@ extension PrivacyDashboardViewController {
             statusCodes = [httpStatusCode]
         }
 
+        var privacyExperimentCohorts: [String: String] {
+            var experiments: [String: String] = [:]
+            for feature in ContentScopeExperimentsFeatureFlag.allCases {
+                let cohort = featureFlagger.resolveCohort(for: feature)
+                experiments[feature.rawValue] = cohort?.rawValue
+            }
+            return experiments
+        }
+
         return BrokenSiteReport(siteUrl: breakageAdditionalInfo.currentURL,
                                 category: category,
                                 description: description,
@@ -357,7 +369,9 @@ extension PrivacyDashboardViewController {
                                 jsPerformance: webVitalsResult,
                                 userRefreshCount: breakageAdditionalInfo.userRefreshCount,
                                 variant: PixelExperiment.cohort?.rawValue ?? "",
-                                cookieConsentInfo: privacyInfo.cookieConsentManaged)
+                                cookieConsentInfo: privacyInfo.cookieConsentManaged,
+                                debugFlags: privacyInfo.debugFlags,
+                                privacyExperiments: privacyExperimentCohorts)
     }
 
 }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -2627,6 +2627,7 @@ extension TabViewController: UserContentControllerDelegate {
         userScripts.printingUserScript.delegate = self
         userScripts.loginFormDetectionScript?.delegate = self
         userScripts.autoconsentUserScript.delegate = self
+        userScripts.contentScopeUserScript.delegate = self
 
         // Special Error Page (SSL, Malicious Site protection)
         specialErrorPageNavigationHandler.setUserScript(userScripts.specialErrorPageUserScript)
@@ -2732,6 +2733,13 @@ extension TabViewController: AutoconsentUserScriptDelegate {
     
     func autoconsentUserScript(_ script: AutoconsentUserScript, didUpdateCookieConsentStatus cookieConsentStatus: PrivacyDashboard.CookieConsentInfo) {
         privacyInfo?.cookieConsentManaged = cookieConsentStatus
+    }
+}
+
+// MARK: - ContentScopeUserScriptDelegate
+extension TabViewController: ContentScopeUserScriptDelegate {
+    func contentScopeUserScript(_ script: BrowserServicesKit.ContentScopeUserScript, didReceiveDebugFlag debugFlag: String) {
+        privacyInfo?.addDebugFlag(debugFlag)
     }
 }
 

--- a/iOS/DuckDuckGoTests/BrokenSiteReportingTests.swift
+++ b/iOS/DuckDuckGoTests/BrokenSiteReportingTests.swift
@@ -120,7 +120,9 @@ final class BrokenSiteReportingTests: XCTestCase {
                                       jsPerformance: nil,
                                       userRefreshCount: 0,
                                       variant: "",
-                                      cookieConsentInfo: CookieConsentInfo(consentManaged: true, cosmetic: true, optoutFailed: true, selftestFailed: true))
+                                      cookieConsentInfo: CookieConsentInfo(consentManaged: true, cosmetic: true, optoutFailed: true, selftestFailed: true),
+                                      debugFlags: "",
+                                      privacyExperiments: [:])
 
         let reporter = BrokenSiteReporter(pixelHandler: { params in
             

--- a/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
+++ b/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
@@ -71,6 +71,7 @@ final class PrivacyDashboardViewController: NSViewController {
     }
     var sizeDelegate: PrivacyDashboardViewControllerSizeDelegate?
     private weak var tabViewModel: TabViewModel?
+    let featureFlagger: FeatureFlagger
 
     private let privacyDashboardEvents = EventMapping<PrivacyDashboardEvents> { event, _, parameters, _ in
         let domainEvent: NonStandardPixel
@@ -88,10 +89,12 @@ final class PrivacyDashboardViewController: NSViewController {
 
     init(privacyInfo: PrivacyInfo? = nil,
          entryPoint: PrivacyDashboardEntryPoint = .dashboard,
-         privacyConfigurationManager: PrivacyConfigurationManaging = ContentBlocking.shared.privacyConfigurationManager) {
+         privacyConfigurationManager: PrivacyConfigurationManaging = ContentBlocking.shared.privacyConfigurationManager,
+         featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger) {
         let toggleReportingConfiguration = ToggleReportingConfiguration(privacyConfigurationManager: privacyConfigurationManager)
         let toggleReportingFeature = ToggleReportingFeature(toggleReportingConfiguration: toggleReportingConfiguration)
         let toggleReportingManager = ToggleReportingManager(feature: toggleReportingFeature)
+        self.featureFlagger = featureFlagger
         self.privacyDashboardController = PrivacyDashboardController(privacyInfo: privacyInfo,
                                                                      entryPoint: entryPoint,
                                                                      toggleReportingManager: toggleReportingManager,
@@ -344,6 +347,15 @@ extension PrivacyDashboardViewController {
             statusCodes = [httpStatusCode]
         }
 
+        var privacyExperimentCohorts: [String: String] {
+            var experiments: [String: String] = [:]
+            for feature in ContentScopeExperimentsFeatureFlag.allCases {
+                let cohort = featureFlagger.resolveCohort(for: feature)
+                experiments[feature.rawValue] = cohort?.rawValue
+            }
+            return experiments
+        }
+
         let websiteBreakage = BrokenSiteReport(siteUrl: currentURL,
                                                category: category.lowercased(),
                                                description: description,
@@ -365,7 +377,9 @@ extension PrivacyDashboardViewController {
                                                vpnOn: currentTab.networkProtection?.tunnelController.isConnected ?? false,
                                                jsPerformance: webVitals,
                                                userRefreshCount: currentTab.brokenSiteInfo?.refreshCountSinceLoad ?? -1,
-                                               cookieConsentInfo: currentTab.privacyInfo?.cookieConsentManaged)
+                                               cookieConsentInfo: currentTab.privacyInfo?.cookieConsentManaged,
+                                               debugFlags: currentTab.privacyInfo?.debugFlags ?? "",
+                                               privacyExperiments: privacyExperimentCohorts)
         return websiteBreakage
     }
 }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PrivacyDashboardTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PrivacyDashboardTabExtension.swift
@@ -43,6 +43,7 @@ final class PrivacyDashboardTabExtension {
     init(contentBlocking: some ContentBlockingProtocol,
          certificateTrustEvaluator: CertificateTrustEvaluating,
          autoconsentUserScriptPublisher: some Publisher<UserScriptWithAutoconsent?, Never>,
+         contentScopeUserScriptPublisher: some Publisher<UserScriptWithContentScope?, Never>,
          didUpgradeToHttpsPublisher: some Publisher<URL, Never>,
          trackersPublisher: some Publisher<DetectedTracker, Never>,
          webViewPublisher: some Publisher<WKWebView, Never>,
@@ -54,6 +55,10 @@ final class PrivacyDashboardTabExtension {
 
         autoconsentUserScriptPublisher.sink { [weak self] autoconsentUserScript in
             autoconsentUserScript?.delegate = self
+        }.store(in: &cancellables)
+
+        contentScopeUserScriptPublisher.sink { [weak self] contentScopeUserScript in
+            contentScopeUserScript?.delegate = self
         }.store(in: &cancellables)
 
         didUpgradeToHttpsPublisher.sink { [weak self] upgradedUrl in
@@ -190,6 +195,14 @@ extension PrivacyDashboardTabExtension: AutoconsentUserScriptDelegate {
 
     func autoconsentUserScript(consentStatus: CookieConsentInfo) {
         self.privacyInfo?.cookieConsentManaged = consentStatus
+    }
+
+}
+
+extension PrivacyDashboardTabExtension: ContentScopeUserScriptDelegate {
+
+    func contentScopeUserScript(_ script: BrowserServicesKit.ContentScopeUserScript, didReceiveDebugFlag debugFlag: String) {
+        self.privacyInfo?.addDebugFlag(debugFlag)
     }
 
 }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
@@ -137,6 +137,7 @@ extension TabExtensionsBuilder {
             PrivacyDashboardTabExtension(contentBlocking: dependencies.privacyFeatures.contentBlocking,
                                          certificateTrustEvaluator: dependencies.certificateTrustEvaluator,
                                          autoconsentUserScriptPublisher: userScripts.map(\.?.autoconsentUserScript),
+                                         contentScopeUserScriptPublisher: userScripts.map(\.?.contentScopeUserScript),
                                          didUpgradeToHttpsPublisher: httpsUpgrade.didUpgradeToHttpsPublisher,
                                          trackersPublisher: contentBlocking.trackersPublisher,
                                          webViewPublisher: args.webViewFuture,

--- a/macOS/UnitTests/PrivacyReferenceTests/BrokenSiteReportingReferenceTests.swift
+++ b/macOS/UnitTests/PrivacyReferenceTests/BrokenSiteReportingReferenceTests.swift
@@ -95,7 +95,9 @@ final class BrokenSiteReportingReferenceTests: XCTestCase {
                                             vpnOn: false,
                                             jsPerformance: nil,
                                             userRefreshCount: 0,
-                                            cookieConsentInfo: nil)
+                                            cookieConsentInfo: nil,
+                                            debugFlags: "",
+                                            privacyExperiments: [:])
 
             let request = makeURLRequest(with: breakage.requestParameters)
 

--- a/macOS/UnitTests/WebsiteBreakageReport/WebsiteBreakageReportTests.swift
+++ b/macOS/UnitTests/WebsiteBreakageReport/WebsiteBreakageReportTests.swift
@@ -77,7 +77,9 @@ class WebsiteBreakageReportTests: XCTestCase {
             vpnOn: false,
             jsPerformance: nil,
             userRefreshCount: 0,
-            cookieConsentInfo: nil
+            cookieConsentInfo: nil,
+            debugFlags: "",
+            privacyExperiments: [:]
         )
 
         let urlRequest = makeURLRequest(with: breakage.requestParameters)
@@ -126,7 +128,9 @@ class WebsiteBreakageReportTests: XCTestCase {
             vpnOn: false,
             jsPerformance: nil,
             userRefreshCount: 0,
-            cookieConsentInfo: CookieConsentInfo(consentManaged: true, cosmetic: true, optoutFailed: true, selftestFailed: true)
+            cookieConsentInfo: CookieConsentInfo(consentManaged: true, cosmetic: true, optoutFailed: true, selftestFailed: true),
+            debugFlags: "",
+            privacyExperiments: [:]
         )
 
         let urlRequest = makeURLRequest(with: breakage.requestParameters)


### PR DESCRIPTION
Task/Issue URL:
https://app.asana.com/0/1204186595873227/1209774321274642

### Description Adds cohort and C-S-S debug Flags to the breakage report pixel

<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL:
Tech Design URL:
CC:

### Description

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1.
2.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)