### PR TITLE
Change ‘DuckDuckGo on Other Platforms’ URL

### DIFF
--- a/macOS/DuckDuckGo/Preferences/Model/PreferencesSection.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/PreferencesSection.swift
@@ -124,7 +124,7 @@ enum PreferencePaneIdentifier: String, Equatable, Hashable, Identifiable, CaseIt
     case autofill
     case accessibility
     case duckPlayer = "duckplayer"
-    case otherPlatforms = "https://duckduckgo.com/app?origin=funnel_app_macos"
+    case otherPlatforms = "https://duckduckgo.com/app/devices?origin=funnel_app_macos"
     case aiChat = "aichat"
     case about
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209810971334424/f
Tech Design URL:
CC:

### Description
Changes ‘DuckDuckGo on Other Platforms’ URL to point to `https://duckduckgo.com/app/devices?origin=funnel_app_macos` instead of `https://duckduckgo.com/app?origin=funnel_app_macos`

### Testing Steps
1. Go to settings
2. Tap on 'DuckDuckGo on Other Platforms’ (below About)
3. Check the URL is pointing to: https://duckduckgo.com/app/devices?origin=funnel_app_macos

### Impact and Risks
Low

#### What could go wrong?
Nothing

### Quality Considerations
No impact

### Notes to Reviewer
Nothing.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)