### PR TITLE
Pinned tabs setting migration refactored to avoid unexpected behavior

### DIFF
--- a/macOS/DuckDuckGo/Preferences/Model/TabsPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/TabsPreferences.swift
@@ -35,7 +35,7 @@ struct TabsPreferencesUserDefaultsPersistor: TabsPreferencesPersistor {
     @UserDefaultsWrapper(key: .newTabPosition, defaultValue: .atEnd)
     var newTabPosition: NewTabPosition
 
-    @UserDefaultsWrapper(key: .sharedPinnedTabs, defaultValue: false)
+    @UserDefaultsWrapper(key: .sharedPinnedTabs, defaultValue: true)
     var sharedPinnedTabs: Bool
 }
 
@@ -76,6 +76,23 @@ final class TabsPreferences: ObservableObject, PreferencesTabOpening {
     }
 
     private var persistor: TabsPreferencesPersistor
+
+    // MARK: - Pinned Tabs Setting Migration
+
+    @UserDefaultsWrapper(key: .pinnedTabsMigrated, defaultValue: false)
+    var pinnedTabsMigrated: Bool
+
+    func migratePinnedTabsSettingIfNecessary(_ collection: TabCollection?) {
+        guard !pinnedTabsMigrated else { return }
+        pinnedTabsMigrated = true
+
+        // Set the shared pinned tabs setting only in case shared pinned tabs are restored
+        if let collection, !collection.tabs.isEmpty {
+            pinnedTabsMode = .shared
+        } else {
+            pinnedTabsMode = .separate
+        }
+    }
 }
 
 enum NewTabPosition: String, CaseIterable {

--- a/macOS/DuckDuckGo/Preferences/Model/TabsPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/TabsPreferences.swift
@@ -79,7 +79,7 @@ final class TabsPreferences: ObservableObject, PreferencesTabOpening {
 
     // MARK: - Pinned Tabs Setting Migration
 
-    @UserDefaultsWrapper(key: .pinnedTabsMigrated, defaultValue: true)
+    @UserDefaultsWrapper(key: .pinnedTabsMigrated, defaultValue: false)
     var pinnedTabsMigrated: Bool
 
     func migratePinnedTabsSettingIfNecessary(_ collection: TabCollection?) {

--- a/macOS/DuckDuckGo/Preferences/Model/TabsPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/TabsPreferences.swift
@@ -79,7 +79,7 @@ final class TabsPreferences: ObservableObject, PreferencesTabOpening {
 
     // MARK: - Pinned Tabs Setting Migration
 
-    @UserDefaultsWrapper(key: .pinnedTabsMigrated, defaultValue: false)
+    @UserDefaultsWrapper(key: .pinnedTabsMigrated, defaultValue: true)
     var pinnedTabsMigrated: Bool
 
     func migratePinnedTabsSettingIfNecessary(_ collection: TabCollection?) {

--- a/macOS/DuckDuckGo/StateRestoration/AppStateRestorationManager.swift
+++ b/macOS/DuckDuckGo/StateRestoration/AppStateRestorationManager.swift
@@ -129,6 +129,7 @@ final class AppStateRestorationManager: NSObject {
             let state = restoreLastSessionState(interactive: false, includeRegularTabs: restoreRegularTabs)
             cleanTabSnapshots(state: state)
         } else {
+            migratePinnedTabsSettingIfNecessary()
             restorePinnedTabs()
             cleanTabSnapshots()
         }
@@ -152,5 +153,9 @@ final class AppStateRestorationManager: NSObject {
     @MainActor
     private func persistAppState(sync: Bool = false) {
         service.persistState(using: WindowControllersManager.shared.encodeState(with:), sync: sync)
+    }
+
+    private func migratePinnedTabsSettingIfNecessary() {
+        TabsPreferences.shared.migratePinnedTabsSettingIfNecessary(nil)
     }
 }

--- a/macOS/DuckDuckGo/StateRestoration/WindowManager+StateRestoration.swift
+++ b/macOS/DuckDuckGo/StateRestoration/WindowManager+StateRestoration.swift
@@ -28,8 +28,8 @@ extension WindowsManager {
             throw coder.error ?? NSError(domain: "WindowsManagerStateRestoration", code: -1, userInfo: nil)
         }
 
+        TabsPreferences.shared.migratePinnedTabsSettingIfNecessary(state.applicationPinnedTabs)
         if let pinnedTabsCollection = state.applicationPinnedTabs {
-            migrateSharedPinnedTabsSettingIfNecessary(pinnedTabsCollection)
             WindowControllersManager.shared.restorePinnedTabs(pinnedTabsCollection)
         }
         if includeWindows {
@@ -67,20 +67,6 @@ extension WindowsManager {
         if let pinnedTabs = item.pinnedTabs, let pinnedTabsManager, pinnedTabsManager !== Application.appDelegate.pinnedTabsManager {
             pinnedTabsManager.setUp(with: pinnedTabs)
         }
-    }
-
-    // Shared pinned tabs migration
-
-    @UserDefaultsWrapper(key: .pinnedTabsMigrated, defaultValue: false)
-    static var pinnedTabsMigrated: Bool
-
-    private class func migrateSharedPinnedTabsSettingIfNecessary(_ collection: TabCollection) {
-        guard !pinnedTabsMigrated else { return }
-        pinnedTabsMigrated = true
-
-        // Set the shared pinned tabs setting only in case shared pinned tabs are restored
-        guard !collection.tabs.isEmpty else { return }
-        TabsPreferences.shared.pinnedTabsMode = .shared
     }
 
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1201037661562251/1209850219424385/f

### Description
This refactor fixes unexpected behavior in windows after the pinned tabs setting has been migrated.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
**Test migration of pinned tabs from previous version**
1. Download [1.132.0.400](https://staticcdn.duckduckgo.com/macos-desktop-browser/duckduckgo-1.132.0.400.dmg) and install it
2. Pin a couple of tabs
3. Quit the app
4. Open Xcode, checkout `tom/pinned-tabs-presented` and edit the build configuration to `RELEASE`
5. Run the app
6. Verify pinned tabs from previous session are visible in the restored window
7. Make sure Settings for Pinned tabs are set to "Shared across all windows"
<img width="186" alt="Screenshot 2025-03-31 at 22 15 57" src="https://github.com/user-attachments/assets/f000d781-d872-4324-a4a2-d8a9288f0eb0" />
<img width="393" alt="Screenshot 2025-03-31 at 22 16 05" src="https://github.com/user-attachments/assets/c00aed22-94ee-41c1-aabd-6e1f7efc749b" />


**Test default setting**
1. Edit the build configuration back to `DEBUG`
2. Erase data to simulate the clean installation `./macOS/clean-app.sh debug`
3. Run the app
4. Verify the default setting for pinned tabs is "Separate in each window"
<img width="382" alt="Screenshot 2025-03-31 at 22 23 52" src="https://github.com/user-attachments/assets/05e8c234-fd65-4b26-8f44-5b4f1db75b64" />

### Impact and Risks

Medium: Could disrupt specific features or user flows

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)