### PR TITLE
Add visual refresh feature flag for internal testing

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -72,7 +72,6 @@ public enum PrivacyFeature: String {
     case setAsDefaultAndAddToDock
     case contentScopeExperiments
     case extendedOnboarding
-    case visualRefresh
 }
 
 /// An abstraction to be implemented by any "subfeature" of a given `PrivacyConfiguration` feature.

--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -72,6 +72,7 @@ public enum PrivacyFeature: String {
     case setAsDefaultAndAddToDock
     case contentScopeExperiments
     case extendedOnboarding
+    case visualRefresh
 }
 
 /// An abstraction to be implemented by any "subfeature" of a given `PrivacyConfiguration` feature.

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -3051,6 +3051,8 @@
 		BB4339DB2C7F9606005D7ED7 /* PinnedTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4339DA2C7F9606005D7ED7 /* PinnedTabsTests.swift */; };
 		BB470EBB2C5A66D6002EE91D /* BookmarkManagementDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB470EBA2C5A66D6002EE91D /* BookmarkManagementDetailViewModel.swift */; };
 		BB470EBC2C5A66D6002EE91D /* BookmarkManagementDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB470EBA2C5A66D6002EE91D /* BookmarkManagementDetailViewModel.swift */; };
+		BB4EC6952D9B5C8000660600 /* VisualStyleConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4EC6942D9B5C7800660600 /* VisualStyleConfigurable.swift */; };
+		BB4EC6962D9B5C8000660600 /* VisualStyleConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4EC6942D9B5C7800660600 /* VisualStyleConfigurable.swift */; };
 		BB5789722B2CA70F0009DFE2 /* DataBrokerProtectionSubscriptionEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5789712B2CA70F0009DFE2 /* DataBrokerProtectionSubscriptionEventHandler.swift */; };
 		BB5F46A32C8751F6005F72DF /* BookmarkSortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5F46A22C8751F6005F72DF /* BookmarkSortTests.swift */; };
 		BB731F312CDBA6360023D2E4 /* FireWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB731F302CDBA6320023D2E4 /* FireWindowTests.swift */; };
@@ -5147,6 +5149,7 @@
 		BB3229042D08643700DA92E9 /* TabBarRemoteMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarRemoteMessageView.swift; sourceTree = "<group>"; };
 		BB4339DA2C7F9606005D7ED7 /* PinnedTabsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedTabsTests.swift; sourceTree = "<group>"; };
 		BB470EBA2C5A66D6002EE91D /* BookmarkManagementDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkManagementDetailViewModel.swift; sourceTree = "<group>"; };
+		BB4EC6942D9B5C7800660600 /* VisualStyleConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualStyleConfigurable.swift; sourceTree = "<group>"; };
 		BB5789712B2CA70F0009DFE2 /* DataBrokerProtectionSubscriptionEventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBrokerProtectionSubscriptionEventHandler.swift; sourceTree = "<group>"; };
 		BB5F46A22C8751F6005F72DF /* BookmarkSortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkSortTests.swift; sourceTree = "<group>"; };
 		BB731F302CDBA6320023D2E4 /* FireWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireWindowTests.swift; sourceTree = "<group>"; };
@@ -8532,6 +8535,7 @@
 		AA585D80248FD31100E9A3E2 /* DuckDuckGo */ = {
 			isa = PBXGroup;
 			children = (
+				BB4EC6902D9B5C6400660600 /* VisualRefresh */,
 				BBDE001A2D6DE66100109F88 /* DefaultBrowserAndAddToDockPrompts */,
 				CBECDB822CDA812A005B8B87 /* BrokenSitePrompt */,
 				31521ABE2CC0139C00248E6F /* AIChat */,
@@ -10058,6 +10062,14 @@
 				B6FA8940269C425400588ECD /* PrivacyDashboardPopover.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		BB4EC6902D9B5C6400660600 /* VisualRefresh */ = {
+			isa = PBXGroup;
+			children = (
+				BB4EC6942D9B5C7800660600 /* VisualStyleConfigurable.swift */,
+			);
+			path = VisualRefresh;
 			sourceTree = "<group>";
 		};
 		BB80DDCD2D75E94600ED1FFF /* DefaultBrowserAndAddToDockPrompts */ = {
@@ -12112,6 +12124,7 @@
 				7B4D8A222BDA857300852966 /* VPNOperationErrorRecorder.swift in Sources */,
 				3706FAE2293F65D500E42796 /* SequenceExtensions.swift in Sources */,
 				3706FAE3293F65D500E42796 /* ChromiumDataImporter.swift in Sources */,
+				BB4EC6952D9B5C8000660600 /* VisualStyleConfigurable.swift in Sources */,
 				3706FAE6293F65D500E42796 /* BWNotRespondingAlert.swift in Sources */,
 				3706FAE7293F65D500E42796 /* DebugUserScript.swift in Sources */,
 				B6CC26692BAD959500F53F8D /* DownloadProgress.swift in Sources */,
@@ -14264,6 +14277,7 @@
 				370C23112C7747E200A80A3E /* ImageProcessor.swift in Sources */,
 				373A1AB02842C4EA00586521 /* BookmarkHTMLImporter.swift in Sources */,
 				B6B5F57F2B024105008DB58A /* DataImportSummaryView.swift in Sources */,
+				BB4EC6962D9B5C8000660600 /* VisualStyleConfigurable.swift in Sources */,
 				31C3CE0228EDC1E70002C24A /* CustomRoundedCornersShape.swift in Sources */,
 				56DB9FEC2CD2515F001BEC23 /* OnboardingPixelReporter.swift in Sources */,
 				4B8D9062276D1D880078DB17 /* LocaleExtension.swift in Sources */,

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -118,6 +118,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let remoteMessagingClient: RemoteMessagingClient!
     let onboardingStateMachine: ContextualOnboardingStateMachine & ContextualOnboardingStateUpdater
     let defaultBrowserAndDockPromptPresenter: DefaultBrowserAndDockPromptPresenter
+    let visualStyleConfigurable: VisualStyleConfigurable
 
     let isAuthV2Enabled: Bool
     var subscriptionAuthV1toV2Bridge: any SubscriptionAuthV1toV2Bridge
@@ -274,6 +275,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let coordinator =  DefaultBrowserAndDockPromptCoordinator(featureFlagger: featureFlagger)
         defaultBrowserAndDockPromptPresenter = DefaultBrowserAndDockPromptPresenter(coordinator: coordinator, featureFlagger: featureFlagger)
+
+        visualStyleConfigurable = VisualStyleManager(featureFlagger: featureFlagger)
 
         onboardingStateMachine = ContextualOnboardingStateMachine()
 

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleConfigurable.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleConfigurable.swift
@@ -1,0 +1,56 @@
+//
+//  VisualStyleConfigurable.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import BrowserServicesKit
+import FeatureFlags
+
+protocol VisualStyleConfigurable {
+    var toolbarHeight: CGFloat { get }
+}
+
+struct VisualStyle {
+    let toolbarHeight: CGFloat
+
+    static func oldStyle() -> VisualStyle {
+        return VisualStyle(toolbarHeight: 44)
+    }
+
+    static func newStyle() -> VisualStyle {
+        return VisualStyle(toolbarHeight: 64)
+    }
+}
+
+final class VisualStyleManager: VisualStyleConfigurable {
+    private let featureFlagger: FeatureFlagger
+
+    private var isEnabled: Bool {
+        featureFlagger.isFeatureOn(.visualRefresh)
+    }
+
+    init(featureFlagger: FeatureFlagger) {
+        self.featureFlagger = featureFlagger
+    }
+
+    var toolbarHeight: CGFloat {
+        currentStyle.toolbarHeight
+    }
+
+    private var currentStyle: VisualStyle {
+        return isEnabled ? .newStyle() : .oldStyle()
+    }
+}

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleConfigurable.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleConfigurable.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import Combine
 import BrowserServicesKit
 import FeatureFlags
 
@@ -26,11 +27,11 @@ protocol VisualStyleConfigurable {
 struct VisualStyle {
     let toolbarHeight: CGFloat
 
-    static func oldStyle() -> VisualStyle {
+    static var old: VisualStyle {
         return VisualStyle(toolbarHeight: 44)
     }
 
-    static func newStyle() -> VisualStyle {
+    static var new: VisualStyle {
         return VisualStyle(toolbarHeight: 64)
     }
 }
@@ -38,12 +39,16 @@ struct VisualStyle {
 final class VisualStyleManager: VisualStyleConfigurable {
     private let featureFlagger: FeatureFlagger
 
+    private var cancellables: Set<AnyCancellable> = []
+
     private var isEnabled: Bool {
         featureFlagger.isFeatureOn(.visualRefresh)
     }
 
     init(featureFlagger: FeatureFlagger) {
         self.featureFlagger = featureFlagger
+
+        subscribeToLocalOverride()
     }
 
     var toolbarHeight: CGFloat {
@@ -51,6 +56,20 @@ final class VisualStyleManager: VisualStyleConfigurable {
     }
 
     private var currentStyle: VisualStyle {
-        return isEnabled ? .newStyle() : .oldStyle()
+        return isEnabled ? .new : .old
+    }
+
+    private func subscribeToLocalOverride() {
+        guard let overridesHandler = featureFlagger.localOverrides?.actionHandler as? FeatureFlagOverridesPublishingHandler<FeatureFlag> else {
+            return
+        }
+
+        overridesHandler.flagDidChangePublisher
+            .filter { $0.0 == .visualRefresh }
+            .sink { (_, enabled) in
+                /// Here I need to apply the visual changes. Should I restart the app?
+                print("Visual refresh feature flag changed to \(enabled ? "enabled" : "disabled")")
+            }
+            .store(in: &cancellables)
     }
 }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -68,6 +68,9 @@ public enum FeatureFlag: String, CaseIterable {
 
     /// https://app.asana.com/0/72649045549333/1209633877674689/f
     case exchangeKeysToSyncWithAnotherDevice
+
+    /// https://app.asana.com/0/72649045549333/1209793701087222/f
+    case visualRefresh
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -101,7 +104,8 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .popoverVsBannerExperiment,
                 .privacyProAuthV2,
                 .scamSiteProtection,
-                .exchangeKeysToSyncWithAnotherDevice:
+                .exchangeKeysToSyncWithAnotherDevice,
+                .visualRefresh:
             return true
         case .debugMenu,
                 .sslCertificatesBypass,
@@ -161,6 +165,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .disabled // .remoteDevelopment(.subfeature(PrivacyProSubfeature.privacyProAuthV2))
         case .exchangeKeysToSyncWithAnotherDevice:
             return .remoteReleasable(.subfeature(SyncSubfeature.exchangeKeysToSyncWithAnotherDevice))
+        case .visualRefresh:
+            return .remoteDevelopment(.feature(.visualRefresh))
         }
     }
 }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -166,7 +166,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .exchangeKeysToSyncWithAnotherDevice:
             return .remoteReleasable(.subfeature(SyncSubfeature.exchangeKeysToSyncWithAnotherDevice))
         case .visualRefresh:
-            return .remoteDevelopment(.feature(.visualRefresh))
+            return .remoteDevelopment(.feature(.experimentalBrowserTheming))
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1209793701087222/f
Tech Design URL:
CC:

### Description
Adds the `visualRefresh` feature flag and creates a manager to handle the old and new visual styles.

This change does not apply any style yet, it only adds the feature flag so we can add all the changes behind the feature flag so internal users can test incrementally, it will also speed up merging to main and review time, giving that I will be creating smaller PRs for each visual change.

### Testing Steps
1. Check that `visualRefresh` feature flag is part of the Local Overrides in the debug menu
2. Verify you can turn the override on and off (the default should be off)

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing I’m aware of.

### Notes to Reviewer
What do you think about the separation of styles?

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)