### PR TITLE
Support for staging App Store storefront region override on iOS

### DIFF
--- a/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
@@ -139,7 +139,22 @@ final class AppDependencyProvider: DependencyProvider {
                                                        subscriptionEndpointService: subscriptionEndpointService,
                                                        authEndpointService: authService)
 
-            let storePurchaseManager = DefaultStorePurchaseManager(subscriptionFeatureMappingCache: subscriptionFeatureMappingCache)
+            let internalUserDecider = featureFlagger.internalUserDecider
+            let subscriptionFeatureFlagger: FeatureFlaggerMapping<SubscriptionFeatureFlags> = FeatureFlaggerMapping { feature in
+                switch feature {
+                case .usePrivacyProUSARegionOverride:
+                    return (internalUserDecider.isInternalUser &&
+                            subscriptionEnvironment.serviceEnvironment == .staging &&
+                            subscriptionUserDefaults.storefrontRegionOverride == .usa)
+                case .usePrivacyProROWRegionOverride:
+                    return (internalUserDecider.isInternalUser &&
+                            subscriptionEnvironment.serviceEnvironment == .staging &&
+                            subscriptionUserDefaults.storefrontRegionOverride == .restOfWorld)
+                }
+            }
+
+            let storePurchaseManager = DefaultStorePurchaseManager(subscriptionFeatureMappingCache: subscriptionFeatureMappingCache,
+                                                                   subscriptionFeatureFlagger: subscriptionFeatureFlagger)
 
             let subscriptionManager = DefaultSubscriptionManager(storePurchaseManager: storePurchaseManager,
                                                                  accountManager: accountManager,
@@ -203,7 +218,23 @@ final class AppDependencyProvider: DependencyProvider {
             }
             let subscriptionEndpointService = DefaultSubscriptionEndpointServiceV2(apiService: apiService,
                                                                                    baseURL: subscriptionEnvironment.serviceEnvironment.url)
-            let storePurchaseManager = DefaultStorePurchaseManagerV2(subscriptionFeatureMappingCache: subscriptionEndpointService)
+
+            let internalUserDecider = featureFlagger.internalUserDecider
+            let subscriptionFeatureFlagger: FeatureFlaggerMapping<SubscriptionFeatureFlags> = FeatureFlaggerMapping { feature in
+                switch feature {
+                case .usePrivacyProUSARegionOverride:
+                    return (internalUserDecider.isInternalUser &&
+                            subscriptionEnvironment.serviceEnvironment == .staging &&
+                            subscriptionUserDefaults.storefrontRegionOverride == .usa)
+                case .usePrivacyProROWRegionOverride:
+                    return (internalUserDecider.isInternalUser &&
+                            subscriptionEnvironment.serviceEnvironment == .staging &&
+                            subscriptionUserDefaults.storefrontRegionOverride == .restOfWorld)
+                }
+            }
+
+            let storePurchaseManager = DefaultStorePurchaseManagerV2(subscriptionFeatureMappingCache: subscriptionEndpointService,
+                                                                     subscriptionFeatureFlagger: subscriptionFeatureFlagger)
             let pixelHandler: SubscriptionManagerV2.PixelHandler = { type in
                 switch type {
                 case .deadToken:

--- a/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
+++ b/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
@@ -28,7 +28,9 @@ import Networking
 
 final class SubscriptionDebugViewController: UITableViewController {
 
-    let subscriptionAppGroup = Bundle.main.appGroup(bundle: .subs)
+    private let subscriptionAppGroup = Bundle.main.appGroup(bundle: .subs)
+    private lazy var subscriptionUserDefaults = UserDefaults(suiteName: subscriptionAppGroup)!
+
     private var subscriptionManagerV1: SubscriptionManager {
         AppDependencyProvider.shared.subscriptionManager!
     }
@@ -54,6 +56,7 @@ final class SubscriptionDebugViewController: UITableViewController {
         Sections.customBaseSubscriptionURL: "Custom Base Subscription URL",
         Sections.pixels: "Promo Pixel Parameters",
         Sections.metadata: "StoreKit Metadata",
+        Sections.regionOverride: "Region override for App Store Sandbox",
         Sections.featureFlags: "Feature Flags"
     ]
 
@@ -65,6 +68,7 @@ final class SubscriptionDebugViewController: UITableViewController {
         case customBaseSubscriptionURL
         case pixels
         case metadata
+        case regionOverride
         case featureFlags
     }
 
@@ -103,6 +107,10 @@ final class SubscriptionDebugViewController: UITableViewController {
         case countryCode
     }
 
+    enum RegionOverrideRows: Int, CaseIterable {
+        case currentRegionOverride
+    }
+
     enum FeatureFlagRows: Int, CaseIterable {
         case privacyProFreeTrialJan25
     }
@@ -138,6 +146,7 @@ final class SubscriptionDebugViewController: UITableViewController {
 
         cell.textLabel?.textColor = UIColor.label
         cell.detailTextLabel?.text = nil
+        cell.accessoryView = nil
         cell.accessoryType = .none
 
         switch Sections(rawValue: indexPath.section) {
@@ -229,6 +238,47 @@ final class SubscriptionDebugViewController: UITableViewController {
                 break
             }
 
+        case .regionOverride:
+            switch RegionOverrideRows(rawValue: indexPath.row) {
+            case .currentRegionOverride:
+                cell.textLabel?.text = "Current override"
+
+                var cfg = UIButton.Configuration.plain()
+//                cfg.titleAlignment = .leading
+                let button = UIButton(configuration: cfg)
+
+                let adjustMenuButtonWidth = {
+                    button.frame = CGRect(x: 0, y: 0, width: 200, height: 40)
+                    button.sizeToFit()
+//                    cell.layoutIfNeeded()
+                }
+
+                let currentRegionOverride = subscriptionUserDefaults.storefrontRegionOverride
+
+                button.menu = UIMenu(options: [.singleSelection], children: [
+                    UIAction(title: "None", state: currentRegionOverride == nil ? .on : .off, handler: { [weak self] action in
+                        self?.subscriptionUserDefaults.storefrontRegionOverride = nil
+                        adjustMenuButtonWidth()
+                    }),
+                    UIAction(title: "USA", state: currentRegionOverride == .usa ? .on : .off, handler: { [weak self] action in
+                        self?.subscriptionUserDefaults.storefrontRegionOverride = .usa
+                        adjustMenuButtonWidth()
+                    }),
+                    UIAction(title: "Rest of World", state: currentRegionOverride == .restOfWorld ? .on : .off, handler: { [weak self] action in
+                        self?.subscriptionUserDefaults.storefrontRegionOverride = .restOfWorld
+                        adjustMenuButtonWidth()
+                    }),
+                ])
+
+                button.showsMenuAsPrimaryAction = true
+                button.changesSelectionAsPrimaryAction = true
+
+                cell.accessoryView = button
+                adjustMenuButtonWidth()
+            case .none:
+                break
+            }
+
         case .featureFlags:
             switch FeatureFlagRows(rawValue: indexPath.row) {
             case .privacyProFreeTrialJan25:
@@ -254,6 +304,7 @@ final class SubscriptionDebugViewController: UITableViewController {
         case .customBaseSubscriptionURL: return CustomBaseSubscriptionURLRows.allCases.count
         case .pixels: return PixelsRows.allCases.count
         case .metadata: return MetadataRows.allCases.count
+        case .regionOverride: return RegionOverrideRows.allCases.count
         case .featureFlags: return FeatureFlagRows.allCases.count
         case .none: return 0
         }
@@ -294,6 +345,8 @@ final class SubscriptionDebugViewController: UITableViewController {
             default: break
             }
         case .metadata:
+            break
+        case .regionOverride:
             break
         case .featureFlags:
             switch FeatureFlagRows(rawValue: indexPath.row) {
@@ -605,7 +658,6 @@ final class SubscriptionDebugViewController: UITableViewController {
 
     private func setEnvironment(_ environment: SubscriptionEnvironment.ServiceEnvironment) async {
 
-        let subscriptionUserDefaults = UserDefaults(suiteName: subscriptionAppGroup)!
         let currentSubscriptionEnvironment = DefaultSubscriptionManager.getSavedOrDefaultEnvironment(userDefaults: subscriptionUserDefaults)
         var newSubscriptionEnvironment = SubscriptionEnvironment.default
         newSubscriptionEnvironment.serviceEnvironment = environment
@@ -630,7 +682,6 @@ final class SubscriptionDebugViewController: UITableViewController {
 
     private func setCustomBaseSubscriptionURL(_ url: URL?) {
 
-        let subscriptionUserDefaults = UserDefaults(suiteName: subscriptionAppGroup)!
         let currentSubscriptionEnvironment = DefaultSubscriptionManager.getSavedOrDefaultEnvironment(userDefaults: subscriptionUserDefaults)
 
         if currentSubscriptionEnvironment.customBaseSubscriptionURL != url {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1209352855429093/f
cc: @federicocappelli 

### Description
Similar to how it is done on macOS implement debug menu option for setting a fixed storefront region override that can be used during testing. Set override region is used instead of getting value via StoreKit API to determine available subscription products for purchase.
override value can be set to one of three values: "None", "USA", "Rest of World"
override is only used when internal user mode is enabled and using staging environment

Implementation for using override is already in place (used by macOS), we miss debug menu option to set the value and configuration to read and pass the current override value to the StorePurchaseManager. 

⚠️ Change of override may require app restart to take effect. 

### Testing Steps (iOS)
Ensure you are using Alpha build for testing and test on real device

**When:**
- Internal user mode is enabled
- subscription environment is set to staging
- region override is set to "None" 

**Then:** 
- Purchase page shows products (description on the page, purchase options in the footer and matching ToS) for the current Apple IDs region (or one shown in the debug menu)

---

**When:**
- Internal user mode is enabled
- subscription environment is set to staging
- region override is set to "USA" 
**Then:** 
- Purchase page shows products (description on the page, purchase options in the footer and matching ToS) for the US region
- After purchase user is granted 3 US Privacy Pro entitlements (VPN, PIR, ITR) and its features are listed in Settings
 
---

**When:**
- Internal user mode is enabled
- subscription environment is set to staging
- region override is set to "Rest of World" 
**Then:** 
- Purchase page shows products (description on the page, purchase options in the footer and matching ToS) for the US region
- After purchase user is granted 2 Rest of World Privacy Pro entitlements (VPN, ITR) and its features are listed in Settings

---

**When:**
- Internal user mode is disabled
- subscription environment is set to staging
- region override is set to "USA" or "Rest of World" 
**Then:** 
- Override is not applied and purchase page shows products (description on the page, purchase options in the footer and matching ToS) for the current Apple IDs region (or one shown in the debug menu)

---

**When:**
- Internal user mode is enabled
- subscription environment is set to production
- region override is set to "USA" or "Rest of World" 
**Then:** 
- Override is not applied and purchase page shows products (description on the page, purchase options in the footer and matching ToS) for the current Apple IDs region (or one shown in the debug menu)


### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Little to no risks, region override is only available in the debug menu and its application is guarded by internal user mode and staging environment.
Also implementation to apply the logic is already present as being already used on macOS.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)