### PR TITLE
Increase navigation bar size and change paddings for new visual refresh

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -3049,8 +3049,8 @@
 		BB4339DB2C7F9606005D7ED7 /* PinnedTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4339DA2C7F9606005D7ED7 /* PinnedTabsTests.swift */; };
 		BB470EBB2C5A66D6002EE91D /* BookmarkManagementDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB470EBA2C5A66D6002EE91D /* BookmarkManagementDetailViewModel.swift */; };
 		BB470EBC2C5A66D6002EE91D /* BookmarkManagementDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB470EBA2C5A66D6002EE91D /* BookmarkManagementDetailViewModel.swift */; };
-		BB4EC6952D9B5C8000660600 /* VisualStyleConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4EC6942D9B5C7800660600 /* VisualStyleConfigurable.swift */; };
-		BB4EC6962D9B5C8000660600 /* VisualStyleConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4EC6942D9B5C7800660600 /* VisualStyleConfigurable.swift */; };
+		BB4EC6952D9B5C8000660600 /* VisualStyleProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4EC6942D9B5C7800660600 /* VisualStyleProviding.swift */; };
+		BB4EC6962D9B5C8000660600 /* VisualStyleProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4EC6942D9B5C7800660600 /* VisualStyleProviding.swift */; };
 		BB5789722B2CA70F0009DFE2 /* DataBrokerProtectionSubscriptionEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5789712B2CA70F0009DFE2 /* DataBrokerProtectionSubscriptionEventHandler.swift */; };
 		BB5F46A32C8751F6005F72DF /* BookmarkSortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5F46A22C8751F6005F72DF /* BookmarkSortTests.swift */; };
 		BB731F312CDBA6360023D2E4 /* FireWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB731F302CDBA6320023D2E4 /* FireWindowTests.swift */; };
@@ -5120,7 +5120,7 @@
 		BB3229042D08643700DA92E9 /* TabBarRemoteMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarRemoteMessageView.swift; sourceTree = "<group>"; };
 		BB4339DA2C7F9606005D7ED7 /* PinnedTabsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedTabsTests.swift; sourceTree = "<group>"; };
 		BB470EBA2C5A66D6002EE91D /* BookmarkManagementDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkManagementDetailViewModel.swift; sourceTree = "<group>"; };
-		BB4EC6942D9B5C7800660600 /* VisualStyleConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualStyleConfigurable.swift; sourceTree = "<group>"; };
+		BB4EC6942D9B5C7800660600 /* VisualStyleProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualStyleProviding.swift; sourceTree = "<group>"; };
 		BB5789712B2CA70F0009DFE2 /* DataBrokerProtectionSubscriptionEventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBrokerProtectionSubscriptionEventHandler.swift; sourceTree = "<group>"; };
 		BB5F46A22C8751F6005F72DF /* BookmarkSortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkSortTests.swift; sourceTree = "<group>"; };
 		BB731F302CDBA6320023D2E4 /* FireWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireWindowTests.swift; sourceTree = "<group>"; };
@@ -10003,7 +10003,7 @@
 		BB4EC6902D9B5C6400660600 /* VisualRefresh */ = {
 			isa = PBXGroup;
 			children = (
-				BB4EC6942D9B5C7800660600 /* VisualStyleConfigurable.swift */,
+				BB4EC6942D9B5C7800660600 /* VisualStyleProviding.swift */,
 			);
 			path = VisualRefresh;
 			sourceTree = "<group>";
@@ -12060,7 +12060,7 @@
 				7B4D8A222BDA857300852966 /* VPNOperationErrorRecorder.swift in Sources */,
 				3706FAE2293F65D500E42796 /* SequenceExtensions.swift in Sources */,
 				3706FAE3293F65D500E42796 /* ChromiumDataImporter.swift in Sources */,
-				BB4EC6952D9B5C8000660600 /* VisualStyleConfigurable.swift in Sources */,
+				BB4EC6952D9B5C8000660600 /* VisualStyleProviding.swift in Sources */,
 				3706FAE6293F65D500E42796 /* BWNotRespondingAlert.swift in Sources */,
 				3706FAE7293F65D500E42796 /* DebugUserScript.swift in Sources */,
 				B6CC26692BAD959500F53F8D /* DownloadProgress.swift in Sources */,
@@ -14211,7 +14211,7 @@
 				370C23112C7747E200A80A3E /* ImageProcessor.swift in Sources */,
 				373A1AB02842C4EA00586521 /* BookmarkHTMLImporter.swift in Sources */,
 				B6B5F57F2B024105008DB58A /* DataImportSummaryView.swift in Sources */,
-				BB4EC6962D9B5C8000660600 /* VisualStyleConfigurable.swift in Sources */,
+				BB4EC6962D9B5C8000660600 /* VisualStyleProviding.swift in Sources */,
 				31C3CE0228EDC1E70002C24A /* CustomRoundedCornersShape.swift in Sources */,
 				56DB9FEC2CD2515F001BEC23 /* OnboardingPixelReporter.swift in Sources */,
 				4B8D9062276D1D880078DB17 /* LocaleExtension.swift in Sources */,

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -118,7 +118,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let remoteMessagingClient: RemoteMessagingClient!
     let onboardingStateMachine: ContextualOnboardingStateMachine & ContextualOnboardingStateUpdater
     let defaultBrowserAndDockPromptPresenter: DefaultBrowserAndDockPromptPresenter
-    let visualStyleProvider: VisualStyleProviding
+    let visualStyleManager: VisualStyleManager
 
     let isAuthV2Enabled: Bool
     var subscriptionAuthV1toV2Bridge: any SubscriptionAuthV1toV2Bridge
@@ -277,7 +277,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let coordinator =  DefaultBrowserAndDockPromptCoordinator(featureFlagger: featureFlagger)
         defaultBrowserAndDockPromptPresenter = DefaultBrowserAndDockPromptPresenter(coordinator: coordinator, featureFlagger: featureFlagger)
 
-        visualStyleProvider = VisualStyleProvider(featureFlagger: featureFlagger)
+        visualStyleManager = VisualStyleManager(featureFlagger: featureFlagger)
 
         onboardingStateMachine = ContextualOnboardingStateMachine()
 

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -118,7 +118,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let remoteMessagingClient: RemoteMessagingClient!
     let onboardingStateMachine: ContextualOnboardingStateMachine & ContextualOnboardingStateUpdater
     let defaultBrowserAndDockPromptPresenter: DefaultBrowserAndDockPromptPresenter
-    let visualStyleManager: VisualStyleManager
+    let visualStyleManager: VisualStyleManagerProviding
 
     let isAuthV2Enabled: Bool
     var subscriptionAuthV1toV2Bridge: any SubscriptionAuthV1toV2Bridge

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -118,7 +118,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let remoteMessagingClient: RemoteMessagingClient!
     let onboardingStateMachine: ContextualOnboardingStateMachine & ContextualOnboardingStateUpdater
     let defaultBrowserAndDockPromptPresenter: DefaultBrowserAndDockPromptPresenter
-    let visualStyleConfigurable: VisualStyleConfigurable
+    let visualStyleProvider: VisualStyleProviding
 
     let isAuthV2Enabled: Bool
     var subscriptionAuthV1toV2Bridge: any SubscriptionAuthV1toV2Bridge
@@ -277,7 +277,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let coordinator =  DefaultBrowserAndDockPromptCoordinator(featureFlagger: featureFlagger)
         defaultBrowserAndDockPromptPresenter = DefaultBrowserAndDockPromptPresenter(coordinator: coordinator, featureFlagger: featureFlagger)
 
-        visualStyleConfigurable = VisualStyleManager(featureFlagger: featureFlagger)
+        visualStyleProvider = VisualStyleProvider(featureFlagger: featureFlagger)
 
         onboardingStateMachine = ContextualOnboardingStateMachine()
 

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="o2v-eH-jTI">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="o2v-eH-jTI">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,7 +17,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="1675" height="68"/>
                             </customView>
                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eEh-kf-smR">
-                                <rect key="frame" x="12" y="28" width="128" height="32"/>
+                                <rect key="frame" x="12" y="18" width="128" height="32"/>
                                 <subviews>
                                     <customView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3o5-MS-AWl">
                                         <rect key="frame" x="0.0" y="0.0" width="21" height="32"/>
@@ -183,7 +183,7 @@
                                 </customSpacing>
                             </stackView>
                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aWu-Jm-Oaz" userLabel="Menu Buttons">
-                                <rect key="frame" x="1567" y="28" width="96" height="32"/>
+                                <rect key="frame" x="1567" y="18" width="96" height="32"/>
                                 <subviews>
                                     <button hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="G8p-di-fq4" userLabel="AI Chat Button" customClass="MouseOverButton" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="32" height="32"/>
@@ -369,10 +369,10 @@
                             <constraint firstAttribute="bottom" secondItem="gIy-el-24l" secondAttribute="bottom" constant="6" id="Xaz-X5-bmg"/>
                             <constraint firstItem="EQw-GG-GMA" firstAttribute="top" secondItem="hYV-nu-QIp" secondAttribute="top" id="ctd-w7-EMF"/>
                             <constraint firstItem="aWu-Jm-Oaz" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="gIy-el-24l" secondAttribute="trailing" constant="16" id="eSb-tj-UdD"/>
+                            <constraint firstItem="eEh-kf-smR" firstAttribute="centerY" secondItem="Wba-nA-FYj" secondAttribute="centerY" id="fcj-rV-KVD"/>
                             <constraint firstItem="EQw-GG-GMA" firstAttribute="leading" secondItem="hYV-nu-QIp" secondAttribute="leading" id="hpe-5Y-XTJ"/>
                             <constraint firstItem="gIy-el-24l" firstAttribute="top" secondItem="hYV-nu-QIp" secondAttribute="top" constant="6" id="km5-nE-hfK"/>
                             <constraint firstAttribute="trailing" secondItem="EQw-GG-GMA" secondAttribute="trailing" id="oYK-XH-0iN"/>
-                            <constraint firstItem="eEh-kf-smR" firstAttribute="top" secondItem="hYV-nu-QIp" secondAttribute="top" constant="8" id="qeF-30-DZN"/>
                             <constraint firstItem="gIy-el-24l" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="eEh-kf-smR" secondAttribute="trailing" constant="16" id="rfA-3F-QAf"/>
                             <constraint firstItem="gIy-el-24l" firstAttribute="width" secondItem="hYV-nu-QIp" secondAttribute="width" multiplier="0.6" id="rqL-Vd-lnY"/>
                             <constraint firstItem="gIy-el-24l" firstAttribute="centerX" secondItem="hYV-nu-QIp" secondAttribute="centerX" id="zgI-LQ-Zj3"/>
@@ -393,7 +393,6 @@
                         <outlet property="addressBarTopConstraint" destination="km5-nE-hfK" id="dR8-qN-sMa"/>
                         <outlet property="aiChatButton" destination="G8p-di-fq4" id="s1c-9f-UFg"/>
                         <outlet property="bookmarkListButton" destination="4sj-qN-UUY" id="Fjs-KE-Lfp"/>
-                        <outlet property="buttonsTopConstraint" destination="qeF-30-DZN" id="WfB-NP-nV7"/>
                         <outlet property="daxLogo" destination="8Ha-or-PB2" id="Id4-3e-U4K"/>
                         <outlet property="downloadsButton" destination="l0L-Gq-8p3" id="ujH-qR-rUH"/>
                         <outlet property="goBackButton" destination="kky-0N-Cfd" id="RA9-yE-URS"/>
@@ -1031,7 +1030,7 @@
         <image name="Arrow-Right-12" width="9" height="9"/>
         <image name="Back" width="16" height="16"/>
         <image name="Bookmark" width="16" height="16"/>
-        <image name="Bookmarks" width="16" height="16"/>
+        <image name="Bookmarks" width="24" height="24"/>
         <image name="Camera-Active" width="16" height="12"/>
         <image name="Camera-Icon" width="16" height="12"/>
         <image name="Camera-Tab-Blocked" width="16" height="14"/>

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -115,6 +115,7 @@ final class NavigationBarViewController: NSViewController {
     private let aiChatMenuConfig: AIChatMenuVisibilityConfigurable
     private let brokenSitePromptLimiter: BrokenSitePromptLimiter
     private let featureFlagger: FeatureFlagger
+    private let visualStyleConfigurable: VisualStyleConfigurable
 
     @UserDefaultsWrapper(key: .homeButtonPosition, defaultValue: .right)
     static private var homeButtonPosition: HomeButtonPosition
@@ -131,7 +132,8 @@ final class NavigationBarViewController: NSViewController {
                        autofillPopoverPresenter: AutofillPopoverPresenter,
                        aiChatMenuConfig: AIChatMenuVisibilityConfigurable,
                        brokenSitePromptLimiter: BrokenSitePromptLimiter,
-                       featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger
+                       featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
+                       visualStyleConfigurable: VisualStyleConfigurable = NSApp.delegateTyped.visualStyleConfigurable
     ) -> NavigationBarViewController {
         NSStoryboard(name: "NavigationBar", bundle: nil).instantiateInitialController { coder in
             self.init(
@@ -144,7 +146,8 @@ final class NavigationBarViewController: NSViewController {
                 autofillPopoverPresenter: autofillPopoverPresenter,
                 aiChatMenuConfig: aiChatMenuConfig,
                 brokenSitePromptLimiter: brokenSitePromptLimiter,
-                featureFlagger: featureFlagger
+                featureFlagger: featureFlagger,
+                visualStyleConfigurable: visualStyleConfigurable
             )
         }!
     }
@@ -159,7 +162,8 @@ final class NavigationBarViewController: NSViewController {
         autofillPopoverPresenter: AutofillPopoverPresenter,
         aiChatMenuConfig: AIChatMenuVisibilityConfigurable,
         brokenSitePromptLimiter: BrokenSitePromptLimiter,
-        featureFlagger: FeatureFlagger
+        featureFlagger: FeatureFlagger,
+        visualStyleConfigurable: VisualStyleConfigurable
     ) {
 
         self.popovers = NavigationBarPopovers(networkProtectionPopoverManager: networkProtectionPopoverManager, autofillPopoverPresenter: autofillPopoverPresenter, isBurner: tabCollectionViewModel.isBurner)
@@ -170,6 +174,7 @@ final class NavigationBarViewController: NSViewController {
         self.aiChatMenuConfig = aiChatMenuConfig
         self.brokenSitePromptLimiter = brokenSitePromptLimiter
         self.featureFlagger = featureFlagger
+        self.visualStyleConfigurable = visualStyleConfigurable
         goBackButtonMenuDelegate = NavigationButtonMenuDelegate(buttonType: .back, tabCollectionViewModel: tabCollectionViewModel)
         goForwardButtonMenuDelegate = NavigationButtonMenuDelegate(buttonType: .forward, tabCollectionViewModel: tabCollectionViewModel)
         super.init(coder: coder)
@@ -699,50 +704,6 @@ final class NavigationBarViewController: NSViewController {
             })
     }
 
-    enum AddressBarSizeClass {
-        case `default`
-        case homePage
-        case popUpWindow
-
-        fileprivate var height: CGFloat {
-            switch self {
-            case .homePage: 52
-            case .popUpWindow: 42
-            case .default: 48
-            }
-        }
-
-        fileprivate var topPadding: CGFloat {
-            switch self {
-            case .homePage: 10
-            case .popUpWindow: 0
-            case .default: 6
-            }
-        }
-
-        fileprivate var bottomPadding: CGFloat {
-            switch self {
-            case .homePage: 8
-            case .popUpWindow: 0
-            case .default: 6
-            }
-        }
-
-        fileprivate var logoWidth: CGFloat {
-            switch self {
-            case .homePage: 44
-            case .popUpWindow, .default: 0
-            }
-        }
-
-        fileprivate var isLogoVisible: Bool {
-            switch self {
-            case .homePage: true
-            case .popUpWindow, .default: false
-            }
-        }
-    }
-
     private var daxFadeInAnimation: DispatchWorkItem?
     private var heightChangeAnimation: DispatchWorkItem?
     func resizeAddressBar(for sizeClass: AddressBarSizeClass, animated: Bool) {
@@ -755,13 +716,13 @@ final class NavigationBarViewController: NSViewController {
             guard let self else { return }
 
             let height: NSLayoutConstraint = animated ? addressBarHeightConstraint.animator() : addressBarHeightConstraint
-            height.constant = sizeClass.height
+            height.constant = visualStyleConfigurable.addressBarHeight(for: sizeClass)
 
             let barTop: NSLayoutConstraint = animated ? addressBarTopConstraint.animator() : addressBarTopConstraint
-            barTop.constant = sizeClass.topPadding
+            barTop.constant = visualStyleConfigurable.addressBarTopPaddig(for: sizeClass)
 
             let bottom: NSLayoutConstraint = animated ? addressBarBottomConstraint.animator() : addressBarBottomConstraint
-            bottom.constant = sizeClass.bottomPadding
+            bottom.constant = visualStyleConfigurable.addressBarBottomPaddig(for: sizeClass)
 
             let logoWidth: NSLayoutConstraint = animated ? logoWidthConstraint.animator() : logoWidthConstraint
             logoWidth.constant = sizeClass.logoWidth

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -115,7 +115,7 @@ final class NavigationBarViewController: NSViewController {
     private let aiChatMenuConfig: AIChatMenuVisibilityConfigurable
     private let brokenSitePromptLimiter: BrokenSitePromptLimiter
     private let featureFlagger: FeatureFlagger
-    private let visualStyleProvider: VisualStyleProviding
+    private let visualStyleManager: VisualStyleManager
 
     @UserDefaultsWrapper(key: .homeButtonPosition, defaultValue: .right)
     static private var homeButtonPosition: HomeButtonPosition
@@ -133,7 +133,7 @@ final class NavigationBarViewController: NSViewController {
                        aiChatMenuConfig: AIChatMenuVisibilityConfigurable,
                        brokenSitePromptLimiter: BrokenSitePromptLimiter,
                        featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
-                       visualStyleProvider: VisualStyleProviding = NSApp.delegateTyped.visualStyleProvider
+                       visualStyleManager: VisualStyleManager = NSApp.delegateTyped.visualStyleManager
     ) -> NavigationBarViewController {
         NSStoryboard(name: "NavigationBar", bundle: nil).instantiateInitialController { coder in
             self.init(
@@ -147,7 +147,7 @@ final class NavigationBarViewController: NSViewController {
                 aiChatMenuConfig: aiChatMenuConfig,
                 brokenSitePromptLimiter: brokenSitePromptLimiter,
                 featureFlagger: featureFlagger,
-                visualStyleConfigurable: visualStyleProvider
+                visualStyleManager: visualStyleManager
             )
         }!
     }
@@ -163,7 +163,7 @@ final class NavigationBarViewController: NSViewController {
         aiChatMenuConfig: AIChatMenuVisibilityConfigurable,
         brokenSitePromptLimiter: BrokenSitePromptLimiter,
         featureFlagger: FeatureFlagger,
-        visualStyleConfigurable: VisualStyleProviding
+        visualStyleManager: VisualStyleManager
     ) {
 
         self.popovers = NavigationBarPopovers(networkProtectionPopoverManager: networkProtectionPopoverManager, autofillPopoverPresenter: autofillPopoverPresenter, isBurner: tabCollectionViewModel.isBurner)
@@ -174,7 +174,7 @@ final class NavigationBarViewController: NSViewController {
         self.aiChatMenuConfig = aiChatMenuConfig
         self.brokenSitePromptLimiter = brokenSitePromptLimiter
         self.featureFlagger = featureFlagger
-        self.visualStyleProvider = visualStyleConfigurable
+        self.visualStyleManager = visualStyleManager
         goBackButtonMenuDelegate = NavigationButtonMenuDelegate(buttonType: .back, tabCollectionViewModel: tabCollectionViewModel)
         goForwardButtonMenuDelegate = NavigationButtonMenuDelegate(buttonType: .forward, tabCollectionViewModel: tabCollectionViewModel)
         super.init(coder: coder)
@@ -716,13 +716,13 @@ final class NavigationBarViewController: NSViewController {
             guard let self else { return }
 
             let height: NSLayoutConstraint = animated ? addressBarHeightConstraint.animator() : addressBarHeightConstraint
-            height.constant = visualStyleProvider.addressBarHeight(for: sizeClass)
+            height.constant = visualStyleManager.style.addressBarHeight(for: sizeClass)
 
             let barTop: NSLayoutConstraint = animated ? addressBarTopConstraint.animator() : addressBarTopConstraint
-            barTop.constant = visualStyleProvider.addressBarTopPaddig(for: sizeClass)
+            barTop.constant = visualStyleManager.style.addressBarTopPadding(for: sizeClass)
 
             let bottom: NSLayoutConstraint = animated ? addressBarBottomConstraint.animator() : addressBarBottomConstraint
-            bottom.constant = visualStyleProvider.addressBarBottomPaddig(for: sizeClass)
+            bottom.constant = visualStyleManager.style.addressBarBottomPadding(for: sizeClass)
 
             let logoWidth: NSLayoutConstraint = animated ? logoWidthConstraint.animator() : logoWidthConstraint
             logoWidth.constant = sizeClass.logoWidth

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -115,7 +115,7 @@ final class NavigationBarViewController: NSViewController {
     private let aiChatMenuConfig: AIChatMenuVisibilityConfigurable
     private let brokenSitePromptLimiter: BrokenSitePromptLimiter
     private let featureFlagger: FeatureFlagger
-    private let visualStyleManager: VisualStyleManager
+    private let visualStyleManager: VisualStyleManagerProviding
 
     @UserDefaultsWrapper(key: .homeButtonPosition, defaultValue: .right)
     static private var homeButtonPosition: HomeButtonPosition
@@ -133,7 +133,7 @@ final class NavigationBarViewController: NSViewController {
                        aiChatMenuConfig: AIChatMenuVisibilityConfigurable,
                        brokenSitePromptLimiter: BrokenSitePromptLimiter,
                        featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
-                       visualStyleManager: VisualStyleManager = NSApp.delegateTyped.visualStyleManager
+                       visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager
     ) -> NavigationBarViewController {
         NSStoryboard(name: "NavigationBar", bundle: nil).instantiateInitialController { coder in
             self.init(
@@ -163,7 +163,7 @@ final class NavigationBarViewController: NSViewController {
         aiChatMenuConfig: AIChatMenuVisibilityConfigurable,
         brokenSitePromptLimiter: BrokenSitePromptLimiter,
         featureFlagger: FeatureFlagger,
-        visualStyleManager: VisualStyleManager
+        visualStyleManager: VisualStyleManagerProviding
     ) {
 
         self.popovers = NavigationBarPopovers(networkProtectionPopoverManager: networkProtectionPopoverManager, autofillPopoverPresenter: autofillPopoverPresenter, isBurner: tabCollectionViewModel.isBurner)

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -115,7 +115,7 @@ final class NavigationBarViewController: NSViewController {
     private let aiChatMenuConfig: AIChatMenuVisibilityConfigurable
     private let brokenSitePromptLimiter: BrokenSitePromptLimiter
     private let featureFlagger: FeatureFlagger
-    private let visualStyleConfigurable: VisualStyleConfigurable
+    private let visualStyleProvider: VisualStyleProviding
 
     @UserDefaultsWrapper(key: .homeButtonPosition, defaultValue: .right)
     static private var homeButtonPosition: HomeButtonPosition
@@ -133,7 +133,7 @@ final class NavigationBarViewController: NSViewController {
                        aiChatMenuConfig: AIChatMenuVisibilityConfigurable,
                        brokenSitePromptLimiter: BrokenSitePromptLimiter,
                        featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
-                       visualStyleConfigurable: VisualStyleConfigurable = NSApp.delegateTyped.visualStyleConfigurable
+                       visualStyleProvider: VisualStyleProviding = NSApp.delegateTyped.visualStyleProvider
     ) -> NavigationBarViewController {
         NSStoryboard(name: "NavigationBar", bundle: nil).instantiateInitialController { coder in
             self.init(
@@ -147,7 +147,7 @@ final class NavigationBarViewController: NSViewController {
                 aiChatMenuConfig: aiChatMenuConfig,
                 brokenSitePromptLimiter: brokenSitePromptLimiter,
                 featureFlagger: featureFlagger,
-                visualStyleConfigurable: visualStyleConfigurable
+                visualStyleConfigurable: visualStyleProvider
             )
         }!
     }
@@ -163,7 +163,7 @@ final class NavigationBarViewController: NSViewController {
         aiChatMenuConfig: AIChatMenuVisibilityConfigurable,
         brokenSitePromptLimiter: BrokenSitePromptLimiter,
         featureFlagger: FeatureFlagger,
-        visualStyleConfigurable: VisualStyleConfigurable
+        visualStyleConfigurable: VisualStyleProviding
     ) {
 
         self.popovers = NavigationBarPopovers(networkProtectionPopoverManager: networkProtectionPopoverManager, autofillPopoverPresenter: autofillPopoverPresenter, isBurner: tabCollectionViewModel.isBurner)
@@ -174,7 +174,7 @@ final class NavigationBarViewController: NSViewController {
         self.aiChatMenuConfig = aiChatMenuConfig
         self.brokenSitePromptLimiter = brokenSitePromptLimiter
         self.featureFlagger = featureFlagger
-        self.visualStyleConfigurable = visualStyleConfigurable
+        self.visualStyleProvider = visualStyleConfigurable
         goBackButtonMenuDelegate = NavigationButtonMenuDelegate(buttonType: .back, tabCollectionViewModel: tabCollectionViewModel)
         goForwardButtonMenuDelegate = NavigationButtonMenuDelegate(buttonType: .forward, tabCollectionViewModel: tabCollectionViewModel)
         super.init(coder: coder)
@@ -716,13 +716,13 @@ final class NavigationBarViewController: NSViewController {
             guard let self else { return }
 
             let height: NSLayoutConstraint = animated ? addressBarHeightConstraint.animator() : addressBarHeightConstraint
-            height.constant = visualStyleConfigurable.addressBarHeight(for: sizeClass)
+            height.constant = visualStyleProvider.addressBarHeight(for: sizeClass)
 
             let barTop: NSLayoutConstraint = animated ? addressBarTopConstraint.animator() : addressBarTopConstraint
-            barTop.constant = visualStyleConfigurable.addressBarTopPaddig(for: sizeClass)
+            barTop.constant = visualStyleProvider.addressBarTopPaddig(for: sizeClass)
 
             let bottom: NSLayoutConstraint = animated ? addressBarBottomConstraint.animator() : addressBarBottomConstraint
-            bottom.constant = visualStyleConfigurable.addressBarBottomPaddig(for: sizeClass)
+            bottom.constant = visualStyleProvider.addressBarBottomPaddig(for: sizeClass)
 
             let logoWidth: NSLayoutConstraint = animated ? logoWidthConstraint.animator() : logoWidthConstraint
             logoWidth.constant = sizeClass.logoWidth

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleConfigurable.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleConfigurable.swift
@@ -21,18 +21,88 @@ import BrowserServicesKit
 import FeatureFlags
 
 protocol VisualStyleConfigurable {
-    var toolbarHeight: CGFloat { get }
+    func addressBarHeight(for type: AddressBarSizeClass) -> CGFloat
+    func addressBarTopPaddig(for type: AddressBarSizeClass) -> CGFloat
+    func addressBarBottomPaddig(for type: AddressBarSizeClass) -> CGFloat
+}
+
+enum AddressBarSizeClass {
+    case `default`
+    case homePage
+    case popUpWindow
+
+    var logoWidth: CGFloat {
+        switch self {
+        case .homePage: 44
+        case .popUpWindow, .default: 0
+        }
+    }
+
+    var isLogoVisible: Bool {
+        switch self {
+        case .homePage: true
+        case .popUpWindow, .default: false
+        }
+    }
 }
 
 struct VisualStyle {
-    let toolbarHeight: CGFloat
+    private let addressBarHeightForDefault: CGFloat
+    private let addressBarHeightForHomePage: CGFloat
+    private let addressBarHeightForPopUpWindow: CGFloat
+    private let addressBarTopPaddingForDefault: CGFloat
+    private let addressBarTopPaddingForHomePage: CGFloat
+    private let addressBarTopPaddingForPopUpWindow: CGFloat
+    private let addressBarBottomPaddingForDefault: CGFloat
+    private let addressBarBottomPaddingForHomePage: CGFloat
+    private let addressBarBottomPaddingForPopUpWindow: CGFloat
+
+    func addressBarHeight(for type: AddressBarSizeClass) -> CGFloat {
+        switch type {
+        case .default: return addressBarHeightForDefault
+        case .homePage: return addressBarHeightForHomePage
+        case .popUpWindow: return addressBarHeightForPopUpWindow
+        }
+    }
+
+    func addressBarTopPaddig(for type: AddressBarSizeClass) -> CGFloat {
+        switch type {
+        case .default: return addressBarTopPaddingForDefault
+        case .homePage: return addressBarTopPaddingForHomePage
+        case .popUpWindow: return addressBarTopPaddingForPopUpWindow
+        }
+    }
+
+    func addressBarBottomPaddig(for type: AddressBarSizeClass) -> CGFloat {
+        switch type {
+        case .default: return addressBarBottomPaddingForDefault
+        case .homePage: return addressBarBottomPaddingForHomePage
+        case .popUpWindow: return addressBarBottomPaddingForPopUpWindow
+        }
+    }
 
     static var old: VisualStyle {
-        return VisualStyle(toolbarHeight: 44)
+        return VisualStyle(addressBarHeightForDefault: 48,
+                           addressBarHeightForHomePage: 52,
+                           addressBarHeightForPopUpWindow: 42,
+                           addressBarTopPaddingForDefault: 6,
+                           addressBarTopPaddingForHomePage: 10,
+                           addressBarTopPaddingForPopUpWindow: 0,
+                           addressBarBottomPaddingForDefault: 6,
+                           addressBarBottomPaddingForHomePage: 8,
+                           addressBarBottomPaddingForPopUpWindow: 0)
     }
 
     static var new: VisualStyle {
-        return VisualStyle(toolbarHeight: 64)
+        return VisualStyle(addressBarHeightForDefault: 52,
+                           addressBarHeightForHomePage: 52,
+                           addressBarHeightForPopUpWindow: 52,
+                           addressBarTopPaddingForDefault: 6,
+                           addressBarTopPaddingForHomePage: 6,
+                           addressBarTopPaddingForPopUpWindow: 6,
+                           addressBarBottomPaddingForDefault: 6,
+                           addressBarBottomPaddingForHomePage: 6,
+                           addressBarBottomPaddingForPopUpWindow: 6)
     }
 }
 
@@ -41,18 +111,30 @@ final class VisualStyleManager: VisualStyleConfigurable {
 
     private var cancellables: Set<AnyCancellable> = []
 
-    private var isEnabled: Bool {
-        featureFlagger.isFeatureOn(.visualRefresh)
-    }
-
     init(featureFlagger: FeatureFlagger) {
         self.featureFlagger = featureFlagger
 
         subscribeToLocalOverride()
     }
 
-    var toolbarHeight: CGFloat {
-        currentStyle.toolbarHeight
+    // MARK: - VisualStyleConfigurable implementation
+
+    func addressBarHeight(for type: AddressBarSizeClass) -> CGFloat {
+        return currentStyle.addressBarHeight(for: type)
+    }
+
+    func addressBarTopPaddig(for type: AddressBarSizeClass) -> CGFloat {
+        return currentStyle.addressBarTopPaddig(for: type)
+    }
+
+    func addressBarBottomPaddig(for type: AddressBarSizeClass) -> CGFloat {
+        return currentStyle.addressBarBottomPaddig(for: type)
+    }
+
+    // MARK: - Private properties
+
+    private var isEnabled: Bool {
+        featureFlagger.isFeatureOn(.visualRefresh)
     }
 
     private var currentStyle: VisualStyle {
@@ -67,7 +149,7 @@ final class VisualStyleManager: VisualStyleConfigurable {
         overridesHandler.flagDidChangePublisher
             .filter { $0.0 == .visualRefresh }
             .sink { (_, enabled) in
-                /// Here I need to apply the visual changes. Should I restart the app?
+                /// Here I need to apply the visual changes. The easier way should be to restart the app.
                 print("Visual refresh feature flag changed to \(enabled ? "enabled" : "disabled")")
             }
             .store(in: &cancellables)

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
@@ -22,8 +22,8 @@ import FeatureFlags
 
 protocol VisualStyleProviding {
     func addressBarHeight(for type: AddressBarSizeClass) -> CGFloat
-    func addressBarTopPaddig(for type: AddressBarSizeClass) -> CGFloat
-    func addressBarBottomPaddig(for type: AddressBarSizeClass) -> CGFloat
+    func addressBarTopPadding(for type: AddressBarSizeClass) -> CGFloat
+    func addressBarBottomPadding(for type: AddressBarSizeClass) -> CGFloat
 }
 
 enum AddressBarSizeClass {
@@ -123,11 +123,11 @@ final class VisualStyleProvider: VisualStyleProviding {
         return currentStyle.addressBarHeight(for: type)
     }
 
-    func addressBarTopPaddig(for type: AddressBarSizeClass) -> CGFloat {
+    func addressBarTopPadding(for type: AddressBarSizeClass) -> CGFloat {
         return currentStyle.addressBarTopPaddig(for: type)
     }
 
-    func addressBarBottomPaddig(for type: AddressBarSizeClass) -> CGFloat {
+    func addressBarBottomPadding(for type: AddressBarSizeClass) -> CGFloat {
         return currentStyle.addressBarBottomPaddig(for: type)
     }
 

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
@@ -133,12 +133,8 @@ final class VisualStyleProvider: VisualStyleProviding {
 
     // MARK: - Private properties
 
-    private var isEnabled: Bool {
-        featureFlagger.isFeatureOn(.visualRefresh)
-    }
-
     private var currentStyle: VisualStyle {
-        return isEnabled ? .current : .legacy
+        return featureFlagger.isFeatureOn(.visualRefresh) ? .current : .legacy
     }
 
     private func subscribeToLocalOverride() {

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
@@ -81,7 +81,7 @@ struct VisualStyle {
         }
     }
 
-    static var old: VisualStyle {
+    static var legacy: VisualStyle {
         return VisualStyle(addressBarHeightForDefault: 48,
                            addressBarHeightForHomePage: 52,
                            addressBarHeightForPopUpWindow: 42,
@@ -93,7 +93,7 @@ struct VisualStyle {
                            addressBarBottomPaddingForPopUpWindow: 0)
     }
 
-    static var new: VisualStyle {
+    static var current: VisualStyle {
         return VisualStyle(addressBarHeightForDefault: 52,
                            addressBarHeightForHomePage: 52,
                            addressBarHeightForPopUpWindow: 52,
@@ -138,7 +138,7 @@ final class VisualStyleProvider: VisualStyleProviding {
     }
 
     private var currentStyle: VisualStyle {
-        return isEnabled ? .new : .old
+        return isEnabled ? .current : .legacy
     }
 
     private func subscribeToLocalOverride() {

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
@@ -46,7 +46,7 @@ enum AddressBarSizeClass {
     }
 }
 
-struct VisualStyle {
+struct VisualStyle: VisualStyleProviding {
     private let addressBarHeightForDefault: CGFloat
     private let addressBarHeightForHomePage: CGFloat
     private let addressBarHeightForPopUpWindow: CGFloat
@@ -65,7 +65,7 @@ struct VisualStyle {
         }
     }
 
-    func addressBarTopPaddig(for type: AddressBarSizeClass) -> CGFloat {
+    func addressBarTopPadding(for type: AddressBarSizeClass) -> CGFloat {
         switch type {
         case .default: return addressBarTopPaddingForDefault
         case .homePage: return addressBarTopPaddingForHomePage
@@ -73,7 +73,7 @@ struct VisualStyle {
         }
     }
 
-    func addressBarBottomPaddig(for type: AddressBarSizeClass) -> CGFloat {
+    func addressBarBottomPadding(for type: AddressBarSizeClass) -> CGFloat {
         switch type {
         case .default: return addressBarBottomPaddingForDefault
         case .homePage: return addressBarBottomPaddingForHomePage
@@ -81,7 +81,7 @@ struct VisualStyle {
         }
     }
 
-    static var legacy: VisualStyle {
+    static var legacy: VisualStyleProviding {
         return VisualStyle(addressBarHeightForDefault: 48,
                            addressBarHeightForHomePage: 52,
                            addressBarHeightForPopUpWindow: 42,
@@ -93,7 +93,7 @@ struct VisualStyle {
                            addressBarBottomPaddingForPopUpWindow: 0)
     }
 
-    static var current: VisualStyle {
+    static var current: VisualStyleProviding {
         return VisualStyle(addressBarHeightForDefault: 52,
                            addressBarHeightForHomePage: 52,
                            addressBarHeightForPopUpWindow: 52,
@@ -106,7 +106,7 @@ struct VisualStyle {
     }
 }
 
-final class VisualStyleProvider: VisualStyleProviding {
+final class VisualStyleManager {
     private let featureFlagger: FeatureFlagger
 
     private var cancellables: Set<AnyCancellable> = []
@@ -117,24 +117,8 @@ final class VisualStyleProvider: VisualStyleProviding {
         subscribeToLocalOverride()
     }
 
-    // MARK: - VisualStyleProviding implementation
-
-    func addressBarHeight(for type: AddressBarSizeClass) -> CGFloat {
-        return currentStyle.addressBarHeight(for: type)
-    }
-
-    func addressBarTopPadding(for type: AddressBarSizeClass) -> CGFloat {
-        return currentStyle.addressBarTopPaddig(for: type)
-    }
-
-    func addressBarBottomPadding(for type: AddressBarSizeClass) -> CGFloat {
-        return currentStyle.addressBarBottomPaddig(for: type)
-    }
-
-    // MARK: - Private properties
-
-    private var currentStyle: VisualStyle {
-        return featureFlagger.isFeatureOn(.visualRefresh) ? .current : .legacy
+    var style: any VisualStyleProviding {
+        return featureFlagger.isFeatureOn(.visualRefresh) ? VisualStyle.current : VisualStyle.legacy
     }
 
     private func subscribeToLocalOverride() {

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
@@ -26,6 +26,10 @@ protocol VisualStyleProviding {
     func addressBarBottomPadding(for type: AddressBarSizeClass) -> CGFloat
 }
 
+protocol VisualStyleManagerProviding {
+    var style: any VisualStyleProviding { get }
+}
+
 enum AddressBarSizeClass {
     case `default`
     case homePage
@@ -106,7 +110,7 @@ struct VisualStyle: VisualStyleProviding {
     }
 }
 
-final class VisualStyleManager {
+final class VisualStyleManager: VisualStyleManagerProviding {
     private let featureFlagger: FeatureFlagger
 
     private var cancellables: Set<AnyCancellable> = []

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
@@ -1,5 +1,5 @@
 //
-//  VisualStyleConfigurable.swift
+//  VisualStyleProviding.swift
 //
 //  Copyright © 2025 DuckDuckGo. All rights reserved.
 //
@@ -20,7 +20,7 @@ import Combine
 import BrowserServicesKit
 import FeatureFlags
 
-protocol VisualStyleConfigurable {
+protocol VisualStyleProviding {
     func addressBarHeight(for type: AddressBarSizeClass) -> CGFloat
     func addressBarTopPaddig(for type: AddressBarSizeClass) -> CGFloat
     func addressBarBottomPaddig(for type: AddressBarSizeClass) -> CGFloat
@@ -106,7 +106,7 @@ struct VisualStyle {
     }
 }
 
-final class VisualStyleManager: VisualStyleConfigurable {
+final class VisualStyleProvider: VisualStyleProviding {
     private let featureFlagger: FeatureFlagger
 
     private var cancellables: Set<AnyCancellable> = []
@@ -117,7 +117,7 @@ final class VisualStyleManager: VisualStyleConfigurable {
         subscribeToLocalOverride()
     }
 
-    // MARK: - VisualStyleConfigurable implementation
+    // MARK: - VisualStyleProviding implementation
 
     func addressBarHeight(for type: AddressBarSizeClass) -> CGFloat {
         return currentStyle.addressBarHeight(for: type)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1209350564013383/f
Tech Design URL:
CC:

### Description
This adds the new height for the navigation bar; now, it is `52` for both the default and home page. The pop-up remains unchanged.

It also changes the paddings, and now we have `6` for both the top and bottom.

This change introduces how we will use the feature flag to apply the different changes.

### Testing Steps
1. Select the feature flag from `Debug -> Feature Flag Overrides -> visualRefresh`
2. Open a new window
3. The navigation bar should be taller compared to the other one
4. Turn off the override
5. Open another window
6. The navigation bar size should be back to production values


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
I moved some logic around in the `AddressBarSizeClass`. Now, part of that logic for calculating the address bar height and padding is part of the `VisualStyleConfigurable`.

### Quality Considerations
Nothing to consider.

### Notes to Reviewer
It’s a simple change. The Dax logo will be larger when the address bar height increases, but we will move the logo to inside the address bar in the next PR, so I’m not fixing that now.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)