### PR TITLE
Update Sync BookmarksFaviconsFetcher to access FaviconManager on main thread

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Bookmarks/FaviconsFetcher/BookmarksFaviconsFetcher.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Bookmarks/FaviconsFetcher/BookmarksFaviconsFetcher.swift
@@ -105,7 +105,7 @@ public final class BookmarksFaviconsFetcher {
         database: CoreDataDatabase,
         stateStore: BookmarksFaviconsFetcherStateStoring,
         fetcher: FaviconFetching,
-        faviconStore: FaviconStoring,
+        faviconStore: @escaping @MainActor () async -> FaviconStoring,
         errorEvents: EventMapping<BookmarksFaviconsFetcherError>?
     ) {
         self.database = database
@@ -182,7 +182,8 @@ public final class BookmarksFaviconsFetcher {
      *
      * This function cancels any pending fetch operation and schedules a new operation.
      */
-    public func startFetching() {
+    public func startFetching() async {
+        let faviconStore = await faviconStore()
         cancelOngoingFetchingIfNeeded()
         let operation = FaviconsFetchOperation(
             database: database,
@@ -236,7 +237,7 @@ public final class BookmarksFaviconsFetcher {
     private let database: CoreDataDatabase
     private let stateStore: BookmarksFaviconsFetcherStateStoring
     private let fetcher: FaviconFetching
-    private let faviconStore: FaviconStoring
+    private let faviconStore: @MainActor () async -> FaviconStoring
 
     private var isFetchingInProgressCancellable: AnyCancellable?
     private let fetchingDidStartSubject = PassthroughSubject<Void, Never>()

--- a/SharedPackages/BrowserServicesKit/Sources/Bookmarks/FaviconsFetcher/BookmarksFaviconsFetcher.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Bookmarks/FaviconsFetcher/BookmarksFaviconsFetcher.swift
@@ -183,13 +183,12 @@ public final class BookmarksFaviconsFetcher {
      * This function cancels any pending fetch operation and schedules a new operation.
      */
     public func startFetching() async {
-        let faviconStore = await faviconStore()
         cancelOngoingFetchingIfNeeded()
         let operation = FaviconsFetchOperation(
             database: database,
             stateStore: stateStore,
             fetcher: fetcher,
-            faviconStore: faviconStore
+            faviconStore: await faviconStore()
         )
         operation.didStart = { [weak self] in
             self?.fetchingDidStartSubject.send()

--- a/SharedPackages/BrowserServicesKit/Tests/BookmarksTests/FaviconsFetcher/BookmarksFaviconsFetcherTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BookmarksTests/FaviconsFetcher/BookmarksFaviconsFetcherTests.swift
@@ -70,7 +70,7 @@ final class BookmarksFaviconsFetcherTests: XCTestCase {
             database: bookmarksDatabase,
             stateStore: stateStore,
             fetcher: fetcher,
-            faviconStore: faviconStore,
+            faviconStore: { self.faviconStore },
             errorEvents: eventMapper
         )
     }
@@ -188,7 +188,7 @@ final class BookmarksFaviconsFetcherTests: XCTestCase {
         var results: [Result<Void, Error>] = []
         let cancellable = bookmarksFaviconsFetcher.fetchingDidFinishPublisher.sink { results.append($0) }
 
-        bookmarksFaviconsFetcher.startFetching()
+        await bookmarksFaviconsFetcher.startFetching()
 
         await runAfterOperationsFinished {
             XCTAssertEqual(results.count, 1)
@@ -213,7 +213,7 @@ final class BookmarksFaviconsFetcherTests: XCTestCase {
         var results: [Result<Void, Error>] = []
         let cancellable = bookmarksFaviconsFetcher.fetchingDidFinishPublisher.sink { results.append($0) }
 
-        bookmarksFaviconsFetcher.startFetching()
+        await bookmarksFaviconsFetcher.startFetching()
         try await Task.sleep(nanoseconds: 10_000_000)
         bookmarksFaviconsFetcher.cancelOngoingFetchingIfNeeded()
 
@@ -246,11 +246,11 @@ final class BookmarksFaviconsFetcherTests: XCTestCase {
 
         await withTaskGroup(of: Void.self) { group in
             group.addTask {
-                self.bookmarksFaviconsFetcher.startFetching()
+                await self.bookmarksFaviconsFetcher.startFetching()
             }
             try? await Task.sleep(nanoseconds: 10_000_000)
             group.addTask {
-                self.bookmarksFaviconsFetcher.startFetching()
+                await self.bookmarksFaviconsFetcher.startFetching()
             }
         }
 

--- a/iOS/Core/SyncBookmarksAdapter.swift
+++ b/iOS/Core/SyncBookmarksAdapter.swift
@@ -144,7 +144,9 @@ public final class SyncBookmarksAdapter {
                             deleted: faviconsFetcherInput.deletedBookmarksUUIDs
                         )
                     }
-                    faviconsFetcher.startFetching()
+                    Task {
+                        await faviconsFetcher.startFetching()
+                    }
                 }
             }
         )
@@ -176,7 +178,7 @@ public final class SyncBookmarksAdapter {
             database: database,
             stateStore: stateStore,
             fetcher: FaviconFetcher(),
-            faviconStore: faviconStoring,
+            faviconStore: { self.faviconStoring },
             errorEvents: BookmarksFaviconsFetcherErrorHandler()
         )
     }

--- a/macOS/DuckDuckGo/Sync/SyncBookmarksAdapter.swift
+++ b/macOS/DuckDuckGo/Sync/SyncBookmarksAdapter.swift
@@ -119,7 +119,9 @@ final class SyncBookmarksAdapter {
                             deleted: faviconsFetcherInput.deletedBookmarksUUIDs
                         )
                     }
-                    faviconsFetcher.startFetching()
+                    Task {
+                        await faviconsFetcher.startFetching()
+                    }
                 }
             }
         )
@@ -149,7 +151,7 @@ final class SyncBookmarksAdapter {
             database: database,
             stateStore: stateStore,
             fetcher: FaviconFetcher(),
-            faviconStore: NSApp.delegateTyped.faviconManager,
+            faviconStore: { NSApp.delegateTyped.faviconManager },
             errorEvents: BookmarksFaviconsFetcherErrorHandler()
         )
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1209852916533543/f

### Description
Make sure that favicons fetcher store is accessed on main thread now that we’ve removed FaviconsManager.shared
and replaced it with an instance owned by App Delegate.

### Testing Steps
1. Verify that [macOS Sync E2E Tests](https://github.com/duckduckgo/apple-browsers/actions/runs/14217350676) and [iOS Sync E2E Tests](https://github.com/duckduckgo/apple-browsers/actions/runs/14217355529) workflows pass 
2. Launch the macOS app and set up Sync
3. Verify that it doesn’t crash and that it also doesn’t display main thread checker warnings in runtime.

### Impact and Risks
Low: 

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)