### PR TITLE
[iOS] Onboarding - Add Skip Option for Returning Users

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Onboarding/ContextualDaxDialogs/ContextualOnboardingList.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Onboarding/ContextualDaxDialogs/ContextualOnboardingList.swift
@@ -84,22 +84,19 @@ private let strokeColor = Color.blue
     public var body: some View {
         VStack {
             ForEach(list.indices, id: \.self) { index in
-                Button(action: {
-                    action(list[index])
-                }, label: {
-                    HStack {
-                        Image(list[index].imageName, bundle: bundle)
-                            .frame(width: iconSize, height: iconSize)
-                        Text(list[index].visibleTitle)
-                            .frame(alignment: .leading)
-                        Spacer(minLength: 0)
+                OnboardingBorderedButton(
+                    content: {
+                        HStack {
+                            Image(list[index].imageName, bundle: bundle)
+                                .frame(width: iconSize, height: iconSize)
+                            Text(list[index].visibleTitle)
+                                .frame(alignment: .leading)
+                            Spacer(minLength: 0)
+                        }
+                    },
+                    action: {
+                        action(list[index])
                     }
-                })
-                .buttonStyle(OnboardingStyles.ListButtonStyle())
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .inset(by: 0.5)
-                        .stroke(strokeColor, lineWidth: 1)
                 )
             }
         }

--- a/SharedPackages/BrowserServicesKit/Sources/Onboarding/ContextualDaxDialogs/OnboardingSuggestionsViewModel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Onboarding/ContextualDaxDialogs/OnboardingSuggestionsViewModel.swift
@@ -24,11 +24,11 @@ public protocol OnboardingNavigationDelegate: AnyObject {
 }
 
 public protocol OnboardingSearchSuggestionsPixelReporting {
-    func measureSearchSuggetionOptionTapped()
+    func measureSearchSuggestionOptionTapped()
 }
 
 public protocol OnboardingSiteSuggestionsPixelReporting {
-    func measureSiteSuggetionOptionTapped()
+    func measureSiteSuggestionOptionTapped()
 }
 
 public struct OnboardingSearchSuggestionsViewModel {
@@ -51,7 +51,7 @@ public struct OnboardingSearchSuggestionsViewModel {
     }
 
     public func listItemPressed(_ item: ContextualOnboardingListItem) {
-        pixelReporter.measureSearchSuggetionOptionTapped()
+        pixelReporter.measureSearchSuggestionOptionTapped()
         delegate?.searchFromOnboarding(for: item.title)
     }
 }
@@ -81,7 +81,7 @@ public struct OnboardingSiteSuggestionsViewModel {
 
     public func listItemPressed(_ item: ContextualOnboardingListItem) {
         guard let url = URL(string: item.title) else { return }
-        pixelReporter.measureSiteSuggetionOptionTapped()
+        pixelReporter.measureSiteSuggestionOptionTapped()
         delegate?.navigateFromOnboarding(to: url)
     }
 }

--- a/SharedPackages/BrowserServicesKit/Sources/Onboarding/OnboardingBorderedButton.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Onboarding/OnboardingBorderedButton.swift
@@ -1,0 +1,51 @@
+//
+//  OnboardingBorderedButton.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+
+public struct OnboardingBorderedButton<Content: View>: View {
+    let maxHeight: CGFloat
+    let content: Content
+    let action: () -> Void
+
+    public init(
+        maxHeight: CGFloat = OnboardingStyles.ListButtonStyle.defaultMaxHeight,
+        @ViewBuilder content: () -> Content,
+        action: @escaping () -> Void
+    ) {
+        self.maxHeight = maxHeight
+        self.content = content()
+        self.action = action
+    }
+
+    public var body: some View {
+        Button(action: action) {
+            content
+        }
+        .buttonStyle(OnboardingStyles.ListButtonStyle(maxHeight: maxHeight))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .inset(by: 0.5)
+                .stroke(.blue, lineWidth: 1)
+        )
+    }
+}
+
+#Preview {
+    OnboardingBorderedButton { Text(verbatim: "Hello World!!!") } action: {}
+}

--- a/SharedPackages/BrowserServicesKit/Sources/Onboarding/Styles/DaxDialogStyles.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Onboarding/Styles/DaxDialogStyles.swift
@@ -26,10 +26,11 @@ public extension OnboardingStyles {
         @Environment(\.colorScheme) private var colorScheme
 
 #if os(macOS)
-        private let maxHeight = 32.0
+        public static let defaultMaxHeight = 32.0
 #else
-        private let maxHeight = 40.0
+        public static let defaultMaxHeight = 40.0
 #endif
+        private let maxHeight: CGFloat
         private var maxWidth: CGFloat? = .infinity
 
 #if os(macOS)
@@ -40,8 +41,9 @@ public extension OnboardingStyles {
 
         @State private var isHovered = false
 
-        public init(maxWidth: CGFloat? = .infinity) {
+        public init(maxWidth: CGFloat? = .infinity, maxHeight: CGFloat = Self.defaultMaxHeight) {
             self.maxWidth = maxWidth
+            self.maxHeight = maxHeight
         }
 
         public func makeBody(configuration: Configuration) -> some View {

--- a/SharedPackages/BrowserServicesKit/Tests/OnboardingTests/OnboardingSuggestionsViewModelsTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/OnboardingTests/OnboardingSuggestionsViewModelsTests.swift
@@ -160,11 +160,11 @@ final class MockOnboaringSuggestionsPixelReporting: OnboardingSearchSuggestionsP
     private(set) var didCallTrackSearchOptionTapped = false
     private(set) var didCallTrackSiteOptionTapped = false
 
-    func measureSearchSuggetionOptionTapped() {
+    func measureSearchSuggestionOptionTapped() {
         didCallTrackSearchOptionTapped = true
     }
 
-    func measureSiteSuggetionOptionTapped() {
+    func measureSiteSuggestionOptionTapped() {
         didCallTrackSiteOptionTapped = true
     }
 

--- a/iOS/Core/NSAttributedStringExtension.swift
+++ b/iOS/Core/NSAttributedStringExtension.swift
@@ -57,6 +57,21 @@ extension NSAttributedString {
         with(attribute: .foregroundColor, value: color)
     }
 
+    /// Returns a new `NSAttributedString` with the specified font applied to the given text, if found.
+    ///
+    /// - Parameters:
+    ///   - font: The `UIFont` to apply.
+    ///   - text: The substring within the current `NSAttributedString` to which the `font` should be applied.
+    /// - Returns: A new `NSAttributedString` with the `font` applied to occurrences of `text`, or the original string if `text` is not found.
+    public func withFont(_ font: UIFont, forText text: String) -> NSAttributedString {
+        let range = self.string.range(of: text)
+        guard range.location != NSNotFound else {
+            return self
+        }
+
+        return with(attribute: .font, value: font, in: range)
+    }
+
     /// Creates a new `NSAttributedString` initialized with the characters and attributes of the current attributed string plus the specified attribute
     ///
     /// - Parameters:

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -212,6 +212,9 @@ extension Pixel {
         // MARK: - Onboarding
 
         case onboardingIntroShownUnique
+        case onboardingIntroSkipOnboardingCTAPressed
+        case onboardingIntroConfirmSkipOnboardingCTAPressed
+        case onboardingIntroResumeOnboardingCTAPressed
         case onboardingIntroComparisonChartShownUnique
         case onboardingIntroChooseBrowserCTAPressed
         case onboardingIntroChooseAppIconImpressionUnique
@@ -1284,6 +1287,9 @@ extension Pixel.Event {
         case .brokenSiteReport: return "epbf"
             
         case .onboardingIntroShownUnique: return "m_preonboarding_intro_shown_unique"
+        case .onboardingIntroSkipOnboardingCTAPressed: return "m_preonboarding_skip-onboarding-pressed"
+        case .onboardingIntroConfirmSkipOnboardingCTAPressed: return "m_preonboarding_confirm-skip-onboarding-pressed"
+        case .onboardingIntroResumeOnboardingCTAPressed: return "m_preonboarding_resume-onboarding-pressed"
         case .onboardingIntroComparisonChartShownUnique: return "m_preonboarding_comparison_chart_shown_unique"
         case .onboardingIntroChooseBrowserCTAPressed: return "m_preonboarding_choose_browser_pressed"
         case .onboardingIntroChooseAppIconImpressionUnique: return "m_preonboarding_choose_icon_impressions_unique"

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -909,6 +909,7 @@
 		9F5BEA7E2D4382430045E484 /* MaliciousSiteProtectionDatasetsFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5BEA792D4382430045E484 /* MaliciousSiteProtectionDatasetsFetcherTests.swift */; };
 		9F5BEA7F2D4382430045E484 /* MaliciousSiteProtectionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5BEA7A2D4382430045E484 /* MaliciousSiteProtectionManagerTests.swift */; };
 		9F5BEA832D438B880045E484 /* MockMaliciousSiteProtectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5BEA822D438B880045E484 /* MockMaliciousSiteProtectionManager.swift */; };
+		9F5CA45C2D9AA44500590E25 /* OnboardingView+SkipOnboardingContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5CA45B2D9AA44500590E25 /* OnboardingView+SkipOnboardingContent.swift */; };
 		9F5E5AAC2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */; };
 		9F5E5AB02C3E4C6000165F54 /* ContextualOnboardingPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */; };
 		9F5E5AB22C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */; };
@@ -2938,6 +2939,7 @@
 		9F5BEA792D4382430045E484 /* MaliciousSiteProtectionDatasetsFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionDatasetsFetcherTests.swift; sourceTree = "<group>"; };
 		9F5BEA7A2D4382430045E484 /* MaliciousSiteProtectionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionManagerTests.swift; sourceTree = "<group>"; };
 		9F5BEA822D438B880045E484 /* MockMaliciousSiteProtectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMaliciousSiteProtectionManager.swift; sourceTree = "<group>"; };
+		9F5CA45B2D9AA44500590E25 /* OnboardingView+SkipOnboardingContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+SkipOnboardingContent.swift"; sourceTree = "<group>"; };
 		9F5E5AAB2C3D0FCD00165F54 /* ContextualDaxDialogsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualDaxDialogsFactory.swift; sourceTree = "<group>"; };
 		9F5E5AAF2C3E4C6000165F54 /* ContextualOnboardingPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenter.swift; sourceTree = "<group>"; };
 		9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPresenterTests.swift; sourceTree = "<group>"; };
@@ -5645,6 +5647,7 @@
 				9FB0271A2C2927D0009EA190 /* OnboardingView.swift */,
 				9F9EE4D32C37BB1300D4118E /* OnboardingView+Landing.swift */,
 				9FB027112C2526DD009EA190 /* OnboardingView+IntroDialogContent.swift */,
+				9F5CA45B2D9AA44500590E25 /* OnboardingView+SkipOnboardingContent.swift */,
 				9FB027132C252E0C009EA190 /* OnboardingView+BrowsersComparisonContent.swift */,
 				9F7CFF752C86BB8F0012833E /* OnboardingView+AppIconPickerContent.swift */,
 				9F7CFF7E2C8A94F70012833E /* OnboardingView+AddressBarPositionContent.swift */,
@@ -9161,6 +9164,7 @@
 				6FD3F8192C41252900DA5797 /* NewTabPageControllerDelegate.swift in Sources */,
 				9FF7E9862C23D10300902BE5 /* BrowsersComparisonChart.swift in Sources */,
 				6F64AA532C47E92600CF4489 /* FavoritesFaviconLoader.swift in Sources */,
+				9F5CA45C2D9AA44500590E25 /* OnboardingView+SkipOnboardingContent.swift in Sources */,
 				4B274F602AFEAECC003F0745 /* NetworkProtectionWidgetRefreshModel.swift in Sources */,
 				312E5746283BB04A00C18FA0 /* AutofillEmptySearchView.swift in Sources */,
 				8565A34B1FC8D96B00239327 /* LaunchTabNotification.swift in Sources */,

--- a/iOS/DuckDuckGo/AppSettings.swift
+++ b/iOS/DuckDuckGo/AppSettings.swift
@@ -42,7 +42,7 @@ enum AddressBarPosition: String, CaseIterable, CustomStringConvertible {
     }
 }
 
-protocol AppSettings: AnyObject {
+protocol AppSettings: AnyObject, OnboardingDebugAppSettings {
     var autocomplete: Bool { get set }
     var recentlyVisitedSites: Bool { get set }
     var currentThemeStyle: ThemeStyle { get set }
@@ -94,4 +94,10 @@ protocol AppSettings: AnyObject {
     var duckPlayerNativeUIPrimingModalPresentationEventCount: Int { get set }
     var duckPlayerNativeUIPrimingModalTimeSinceLastPresented: Int { get set }
     var duckPlayerPillDismissCount: Int { get set }
+}
+
+// MARK: - AppSettings + OnboardingDebugSettings
+
+protocol OnboardingDebugAppSettings {
+    var onboardingUserType: OnboardingUserType { get set }
 }

--- a/iOS/DuckDuckGo/AppUserDefaults.swift
+++ b/iOS/DuckDuckGo/AppUserDefaults.swift
@@ -92,7 +92,7 @@ public class AppUserDefaults: AppSettings {
     private struct DebugKeys {
         static let inspectableWebViewsEnabledKey = "com.duckduckgo.ios.debug.inspectableWebViewsEnabled"
         static let autofillDebugScriptEnabledKey = "com.duckduckgo.ios.debug.autofillDebugScriptEnabled"
-        static let onboardingAddToDockStateKey = "com.duckduckgo.ios.debug.onboardingAddToDockState"
+        static let onboardingIsNewUserKey = "com.duckduckgo.ios.debug.onboardingIsNewUser"
     }
 
     private var userDefaults: UserDefaults? {
@@ -501,16 +501,13 @@ public class AppUserDefaults: AppSettings {
     @UserDefaultsWrapper(key: .duckPlayerPillDismissCount, defaultValue: 0)
     var duckPlayerPillDismissCount: Int
 
-    @UserDefaultsWrapper(key: .debugOnboardingHighlightsEnabledKey, defaultValue: false)
-    var onboardingHighlightsEnabled: Bool
-
-    var onboardingAddToDockState: OnboardingAddToDockState {
+    var onboardingUserType: OnboardingUserType {
         get {
-            guard let rawValue = userDefaults?.string(forKey: DebugKeys.onboardingAddToDockStateKey) else { return .disabled }
-            return OnboardingAddToDockState(rawValue: rawValue) ?? .disabled
+            guard let rawValue = userDefaults?.string(forKey: DebugKeys.onboardingIsNewUserKey) else { return .notSet }
+            return OnboardingUserType(rawValue: rawValue) ?? .notSet
         }
         set {
-            userDefaults?.set(newValue.rawValue, forKey: DebugKeys.onboardingAddToDockStateKey)
+            userDefaults?.set(newValue.rawValue, forKey: DebugKeys.onboardingIsNewUserKey)
         }
     }
 }

--- a/iOS/DuckDuckGo/DaxDialogs.swift
+++ b/iOS/DuckDuckGo/DaxDialogs.swift
@@ -35,6 +35,10 @@ protocol NewTabDialogSpecProvider {
     func dismiss()
 }
 
+protocol ContextualDaxDialogDisabling {
+    func disableContextualDaxDialogs()
+}
+
 protocol ContextualOnboardingLogic {
     var isShowingFireDialog: Bool { get }
     var shouldShowPrivacyButtonPulse: Bool { get }
@@ -674,6 +678,14 @@ extension DaxDialogs: PrivacyProPromotionCoordinating {
             settings.privacyProPromotionDialogShown = newValue
         }
     }
+}
+
+extension DaxDialogs: ContextualDaxDialogDisabling {
+
+    func disableContextualDaxDialogs() {
+        dismiss()
+    }
+
 }
 
 extension URL {

--- a/iOS/DuckDuckGo/OnboardingDebugView.swift
+++ b/iOS/DuckDuckGo/OnboardingDebugView.swift
@@ -46,8 +46,24 @@ struct OnboardingDebugView: View {
             }
 
             Section {
+                Picker(
+                    selection: $viewModel.onboardingUserType,
+                    content: {
+                        ForEach(OnboardingUserType.allCases) { state in
+                            Text(verbatim: state.description).tag(state)
+                        }
+                    },
+                    label: {
+                        Text(verbatim: "Type:")
+                    }
+                )
+            } header: {
+                Text(verbatim: "Onboarding User Type")
+            }
+
+            Section {
                 Button(action: newOnboardingIntroStartAction, label: {
-                    Text(verbatim: "Preview Onboarding Intro")
+                    Text(verbatim: "Preview Onboarding Intro - \(viewModel.onboardingUserType.description)")
                 })
             }
         }
@@ -55,15 +71,23 @@ struct OnboardingDebugView: View {
 }
 
 final class OnboardingDebugViewModel: ObservableObject {
+
+    @Published var onboardingUserType: OnboardingUserType {
+        didSet {
+            manager.onboardingUserTypeDebugValue = onboardingUserType
+        }
+    }
+
+    private let manager: OnboardingNewUserProviderDebugging
     private var settings: DaxDialogsSettings
-    let isIphone: Bool
 
     init(
-        settings: DaxDialogsSettings = DefaultDaxDialogsSettings(),
-        isIphone: Bool = UIDevice.current.userInterfaceIdiom == .phone
+        manager: OnboardingNewUserProviderDebugging = OnboardingManager(),
+        settings: DaxDialogsSettings = DefaultDaxDialogsSettings()
     ) {
+        self.manager = manager
         self.settings = settings
-        self.isIphone = isIphone
+        onboardingUserType = manager.onboardingUserTypeDebugValue
     }
 
     func resetDaxDialogs() {
@@ -91,8 +115,8 @@ final class OnboardingDebugViewModel: ObservableObject {
     OnboardingDebugView(onNewOnboardingIntroStartAction: {})
 }
 
-extension OnboardingAddToDockState: Identifiable {
-    var id: OnboardingAddToDockState {
+extension OnboardingUserType: Identifiable {
+    var id: OnboardingUserType {
         self
     }
 }

--- a/iOS/DuckDuckGo/OnboardingExperiment/AddToDock/OnboardingView+AddToDockContent.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/AddToDock/OnboardingView+AddToDockContent.swift
@@ -71,6 +71,7 @@ extension OnboardingView {
             VStack {
                 OnboardingCTAButton(
                     title: UserText.AddToDockOnboarding.Buttons.tutorial,
+                    buttonStyle: .primary(compact: false),
                     action: {
                         showTutorialAction()
                         isSkipped.wrappedValue = false

--- a/iOS/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/ContextualDaxDialogs/ContextualOnboardingDialogs.swift
@@ -195,8 +195,6 @@ struct OnboardingFinalDialog: View {
     let cta: String
     let dismissAction: () -> Void
 
-    @State private var showAddToDockTutorial = false
-
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
             DaxDialogView(logoPosition: logoPosition) {
@@ -216,7 +214,7 @@ struct OnboardingFinalDialog: View {
     private var customActionView: some View {
         OnboardingCTAButton(
             title: cta,
-            buttonStyle: .primary,
+            buttonStyle: .primary(),
             action: {
                 dismissAction()
             }
@@ -258,7 +256,7 @@ struct PrivacyProPromotionView: View {
                 .padding([.top, .bottom], 16)
             OnboardingCTAButton(
                 title: proceedText,
-                buttonStyle: .primary,
+                buttonStyle: .primary(),
                 action: {
                     proceedAction()
                 }
@@ -276,12 +274,12 @@ struct PrivacyProPromotionView: View {
 
 struct OnboardingCTAButton: View {
     enum ButtonStyle {
-        case primary
+        case primary(compact: Bool = false)
         case ghost
     }
 
     let title: String
-    var buttonStyle: ButtonStyle = .primary
+    var buttonStyle: ButtonStyle = .primary(compact: true)
     let action: () -> Void
 
 
@@ -291,8 +289,8 @@ struct OnboardingCTAButton: View {
         }
 
         switch buttonStyle {
-        case .primary:
-            button.buttonStyle(PrimaryButtonStyle(compact: true))
+        case .primary(let isCompact):
+            button.buttonStyle(PrimaryButtonStyle(compact: isCompact))
         case .ghost:
             button.buttonStyle(GhostButtonStyle())
         }

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
@@ -32,6 +32,12 @@ final class OnboardingIntroViewModel: ObservableObject {
         var animateIntroText = false
     }
 
+    struct SkipOnboardingState {
+        var animateTitle = true
+        var animateMessage = false
+        var showContent = false
+    }
+
     struct BrowserComparisonState {
         var showComparisonButton = false
         var animateComparisonText = false
@@ -58,6 +64,7 @@ final class OnboardingIntroViewModel: ObservableObject {
         }
     }
 
+    @Published var skipOnboardingState = SkipOnboardingState()
     @Published var appIconPickerContentState = AppIconPickerContentState()
     @Published var addressBarPositionContentState = AddressBarPositionContentState()
     @Published var addToDockState = AddToDockState()
@@ -73,6 +80,7 @@ final class OnboardingIntroViewModel: ObservableObject {
     private var currentIntroStep: OnboardingIntroStep
 
     private let defaultBrowserManager: DefaultBrowserManaging
+    private let contextualDaxDialogs: ContextualDaxDialogDisabling
     private let pixelReporter: LinearOnboardingPixelReporting
     private let onboardingManager: OnboardingManaging
     private let urlOpener: URLOpener
@@ -83,10 +91,11 @@ final class OnboardingIntroViewModel: ObservableObject {
         let onboardingManager = OnboardingManager()
         self.init(
             defaultBrowserManager: DefaultBrowserManager(),
+            contextualDaxDialogs: DaxDialogs.shared,
             pixelReporter: pixelReporter,
             onboardingManager: onboardingManager,
             urlOpener: UIApplication.shared,
-            currentOnboardingStep: onboardingManager.onboardingSteps.first ?? .introDialog,
+            currentOnboardingStep: onboardingManager.onboardingSteps.first ?? .introDialog(isReturningUser: false),
             appIconProvider: { AppIconManager.shared.appIcon },
             addressBarPositionProvider: { AppUserDefaults().currentAddressBarPosition }
         )
@@ -94,6 +103,7 @@ final class OnboardingIntroViewModel: ObservableObject {
 
     init(
         defaultBrowserManager: DefaultBrowserManaging,
+        contextualDaxDialogs: ContextualDaxDialogDisabling,
         pixelReporter: LinearOnboardingPixelReporting,
         onboardingManager: OnboardingManaging,
         urlOpener: URLOpener,
@@ -102,6 +112,7 @@ final class OnboardingIntroViewModel: ObservableObject {
         addressBarPositionProvider: @escaping () -> AddressBarPosition
     ) {
         self.defaultBrowserManager = defaultBrowserManager
+        self.contextualDaxDialogs = contextualDaxDialogs
         self.pixelReporter = pixelReporter
         self.onboardingManager = onboardingManager
         self.urlOpener = urlOpener
@@ -118,6 +129,19 @@ final class OnboardingIntroViewModel: ObservableObject {
     }
 
     func startOnboardingAction() {
+        makeNextViewState()
+    }
+
+    func skipOnboardingAction() {
+        // Fire Pixel
+    }
+
+    func confirmSkipOnboardingAction() {
+        contextualDaxDialogs.disableContextualDaxDialogs()
+        onCompletingOnboardingIntro?()
+    }
+
+    func cancelSkipOnboardingAction() {
         makeNextViewState()
     }
 
@@ -146,7 +170,7 @@ final class OnboardingIntroViewModel: ObservableObject {
         }
     }
 
-    func addtoDockShowTutorialAction() {
+    func addToDockShowTutorialAction() {
         pixelReporter.measureAddToDockPromoShowTutorialCTAAction()
     }
 
@@ -197,8 +221,8 @@ private extension OnboardingIntroViewModel {
         }
 
         let viewState = switch introStep {
-        case .introDialog:
-            OnboardingView.ViewState.onboarding(.init(type: .startOnboardingDialog, step: .hidden))
+        case .introDialog(let isReturningUser):
+            OnboardingView.ViewState.onboarding(.init(type: .startOnboardingDialog(canSkipTutorial: isReturningUser), step: .hidden))
         case .browserComparison:
             OnboardingView.ViewState.onboarding(.init(type: .browsersComparisonDialog, step: stepInfo()))
         case .addToDockPromo:
@@ -232,31 +256,6 @@ private extension OnboardingIntroViewModel {
         isSkipped = false
         currentIntroStep = nextIntroStep
         setViewState(introStep: currentIntroStep)
-    }
-
-    func makeViewState(for introStep: OnboardingIntroStep) -> OnboardingView.ViewState {
-        
-        func stepInfo() -> OnboardingView.ViewState.Intro.StepInfo {
-            guard let currentStepIndex = introSteps.firstIndex(of: introStep) else { return .hidden }
-
-            // Remove startOnboardingDialog from the count of total steps since we don't show the progress for that step.
-            return OnboardingView.ViewState.Intro.StepInfo(currentStep: currentStepIndex, totalSteps: introSteps.count - 1)
-        }
-
-        let viewState = switch introStep {
-        case .introDialog:
-            OnboardingView.ViewState.onboarding(.init(type: .startOnboardingDialog, step: .hidden))
-        case .browserComparison:
-            OnboardingView.ViewState.onboarding(.init(type: .browsersComparisonDialog, step: stepInfo()))
-        case .addToDockPromo:
-            OnboardingView.ViewState.onboarding(.init(type: .addToDockPromoDialog, step: stepInfo()))
-        case .appIconSelection:
-            OnboardingView.ViewState.onboarding(.init(type: .chooseAppIconDialog, step: stepInfo()))
-        case .addressBarPositionSelection:
-            OnboardingView.ViewState.onboarding(.init(type: .chooseAddressBarPositionDialog, step: stepInfo()))
-        }
-
-        return viewState
     }
 
     func measureDDGDefaultBrowserIfNeeded() {

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
@@ -128,21 +128,21 @@ final class OnboardingIntroViewModel: ObservableObject {
         makeInitialViewState()
     }
 
-    func startOnboardingAction() {
+    func startOnboardingAction(isResumingOnboarding: Bool = false) {
+        if isResumingOnboarding {
+            pixelReporter.measureResumeOnboardingCTAAction()
+        }
         makeNextViewState()
     }
 
     func skipOnboardingAction() {
-        // Fire Pixel
+        pixelReporter.measureSkipOnboardingCTAAction()
     }
 
     func confirmSkipOnboardingAction() {
+        pixelReporter.measureConfirmSkipOnboardingCTAAction()
         contextualDaxDialogs.disableContextualDaxDialogs()
         onCompletingOnboardingIntro?()
-    }
-
-    func cancelSkipOnboardingAction() {
-        makeNextViewState()
     }
 
     func setDefaultBrowserAction() {

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView+IntroDialogContent.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView+IntroDialogContent.swift
@@ -26,24 +26,42 @@ extension OnboardingView {
     struct IntroDialogContent: View {
 
         private let title: String
+        private let skipOnboardingView: AnyView?
         private var animateText: Binding<Bool>
         private var showCTA: Binding<Bool>
         private var isSkipped: Binding<Bool>
-        private let action: () -> Void
+        private let continueAction: () -> Void
+        private let skipAction: () -> Void
 
-        init(title: String,
-             animateText: Binding<Bool> = .constant(true),
-             showCTA: Binding<Bool> = .constant(false),
-             isSkipped: Binding<Bool>,
-             action: @escaping () -> Void) {
+        @State private var showSkipOnboarding = false
+
+        init(
+            title: String,
+            skipOnboardingView: AnyView?,
+            animateText: Binding<Bool> = .constant(true),
+            showCTA: Binding<Bool> = .constant(false),
+            isSkipped: Binding<Bool>,
+            continueAction: @escaping () -> Void,
+            skipAction: @escaping () -> Void
+        ) {
             self.title = title
+            self.skipOnboardingView = skipOnboardingView
             self.animateText = animateText
             self.showCTA = showCTA
             self.isSkipped = isSkipped
-            self.action = action
+            self.continueAction = continueAction
+            self.skipAction = skipAction
         }
 
         var body: some View {
+            if showSkipOnboarding {
+                skipOnboardingView
+            } else {
+                introContent
+            }
+        }
+
+        private var introContent: some View {
             VStack(spacing: 24.0) {
                 AnimatableTypingText(title, startAnimating: animateText, skipAnimation: isSkipped) {
                     withAnimation {
@@ -53,13 +71,24 @@ extension OnboardingView {
                 .foregroundColor(.primary)
                 .font(Font.system(size: 20, weight: .bold))
 
-                Button(action: action) {
-                    Text(UserText.Onboarding.Intro.cta)
+                VStack {
+                    Button(action: continueAction) {
+                        Text(UserText.Onboarding.Intro.continueCTA)
+                    }
+                    .buttonStyle(PrimaryButtonStyle())
+
+                    if skipOnboardingView != nil {
+                        OnboardingBorderedButton(maxHeight: 50.0, content: {
+                            Text(UserText.Onboarding.Intro.skipCTA)
+                        }, action: {
+                            isSkipped.wrappedValue = false
+                            showSkipOnboarding = true
+                        })
+                    }
                 }
-                .buttonStyle(PrimaryButtonStyle())
                 .visibility(showCTA.wrappedValue ? .visible : .invisible)
             }
         }
-    }
 
+    }
 }

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView+IntroDialogContent.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView+IntroDialogContent.swift
@@ -83,6 +83,7 @@ extension OnboardingView {
                         }, action: {
                             isSkipped.wrappedValue = false
                             showSkipOnboarding = true
+                            skipAction()
                         })
                     }
                 }

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView+SkipOnboardingContent.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView+SkipOnboardingContent.swift
@@ -1,0 +1,91 @@
+//
+//  OnboardingIntro+SkipOnboardingContent.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+import Onboarding
+import DuckUI
+
+extension OnboardingView {
+
+    struct SkipOnboardingContent: View {
+        private static let fireButtonCopy = "Fire Button"
+
+        typealias Copy = UserText.Onboarding.Skip
+
+        private var animateTitle: Binding<Bool>
+        private var animateMessage: Binding<Bool>
+        private var showCTA: Binding<Bool>
+        private var isSkipped: Binding<Bool>
+        private let startBrowsingAction: () -> Void
+        private let resumeOnboardingAction: () -> Void
+
+        init(
+            animateTitle: Binding<Bool>,
+            animateMessage: Binding<Bool>,
+            showCTA: Binding<Bool>,
+            isSkipped: Binding<Bool>,
+            startBrowsingAction: @escaping () -> Void,
+            resumeOnboardingAction: @escaping () -> Void
+        ) {
+            self.animateTitle = animateTitle
+            self.animateMessage = animateMessage
+            self.showCTA = showCTA
+            self.isSkipped = isSkipped
+            self.startBrowsingAction = startBrowsingAction
+            self.resumeOnboardingAction = resumeOnboardingAction
+        }
+
+        var body: some View {
+            VStack(spacing: 24.0) {
+                AnimatableTypingText(Copy.title, startAnimating: animateTitle, skipAnimation: isSkipped) {
+                    withAnimation {
+                        animateMessage.wrappedValue = true
+                    }
+                }
+                .foregroundColor(.primary)
+                .font(Font.system(size: 20, weight: .bold))
+
+                AnimatableTypingText(Copy.message.attributed.withFont(.daxBodyBold(), forText: Self.fireButtonCopy), startAnimating: animateMessage, skipAnimation: isSkipped) {
+                    withAnimation {
+                        showCTA.wrappedValue = true
+                    }
+                }
+                .foregroundColor(.primary)
+                .font(Font.system(size: 16))
+
+                VStack {
+                    Button(action: startBrowsingAction) {
+                        Text(Copy.confirmSkipOnboardingCTA)
+                    }
+                    .buttonStyle(PrimaryButtonStyle())
+
+                    OnboardingBorderedButton(
+                        maxHeight: 50.0,
+                        content: {
+                            Text(Copy.resumeOnboardingCTA)
+                        },
+                        action: resumeOnboardingAction
+                    )
+                }
+                .visibility(showCTA.wrappedValue ? .visible : .invisible)
+            }
+        }
+
+    }
+}

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView+SkipOnboardingContent.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView+SkipOnboardingContent.swift
@@ -1,5 +1,5 @@
 //
-//  OnboardingIntro+SkipOnboardingContent.swift
+//  OnboardingView+SkipOnboardingContent.swift
 //  DuckDuckGo
 //
 //  Copyright © 2025 DuckDuckGo. All rights reserved.

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
@@ -125,7 +125,7 @@ struct OnboardingView: View {
                     isSkipped: $model.isSkipped,
                     startBrowsingAction: model.confirmSkipOnboardingAction,
                     resumeOnboardingAction: {
-                        animateBrowserComparisonViewState()
+                        animateBrowserComparisonViewState(isResumingOnboarding: true)
                     }
                 )
             )
@@ -140,7 +140,7 @@ struct OnboardingView: View {
             showCTA: $model.introState.showIntroButton,
             isSkipped: $model.isSkipped,
             continueAction: {
-                animateBrowserComparisonViewState()
+                animateBrowserComparisonViewState(isResumingOnboarding: false)
             },
             skipAction: model.skipOnboardingAction
         )
@@ -197,7 +197,7 @@ struct OnboardingView: View {
         .onboardingDaxDialogStyle()
     }
 
-    private func animateBrowserComparisonViewState() {
+    private func animateBrowserComparisonViewState(isResumingOnboarding: Bool) {
         // Hide content of Intro dialog before animating
         model.introState.showIntroViewContent = false
 
@@ -209,13 +209,13 @@ struct OnboardingView: View {
 
         if #available(iOS 17, *) {
             withAnimation(animation) {
-                model.startOnboardingAction()
+                model.startOnboardingAction(isResumingOnboarding: isResumingOnboarding)
             } completion: {
                 model.browserComparisonState.animateComparisonText = true
             }
         } else {
             withAnimation(animation) {
-                model.startOnboardingAction()
+                model.startOnboardingAction(isResumingOnboarding: isResumingOnboarding)
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + animationDuration) {
                 model.browserComparisonState.animateComparisonText = true

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
@@ -74,8 +74,8 @@ struct OnboardingView: View {
                     content: {
                         VStack {
                             switch state.type {
-                            case .startOnboardingDialog:
-                                introView
+                            case .startOnboardingDialog(let shouldShowSkipOnboardingButton):
+                                introView(shouldShowSkipOnboardingButton: shouldShowSkipOnboardingButton)
                             case .browsersComparisonDialog:
                                 browsersComparisonView
                             case .addToDockPromoDialog:
@@ -115,15 +115,35 @@ struct OnboardingView: View {
             }
     }
 
-    private var introView: some View {
-        IntroDialogContent(
+    private func introView(shouldShowSkipOnboardingButton: Bool) -> some View {
+        let skipOnboardingView: AnyView? = if shouldShowSkipOnboardingButton {
+            AnyView(
+                SkipOnboardingContent(
+                    animateTitle: $model.skipOnboardingState.animateTitle,
+                    animateMessage: $model.skipOnboardingState.animateMessage,
+                    showCTA: $model.skipOnboardingState.showContent,
+                    isSkipped: $model.isSkipped,
+                    startBrowsingAction: model.confirmSkipOnboardingAction,
+                    resumeOnboardingAction: {
+                        animateBrowserComparisonViewState()
+                    }
+                )
+            )
+        } else {
+            nil
+        }
+
+        return IntroDialogContent(
             title: model.copy.introTitle,
+            skipOnboardingView: skipOnboardingView,
             animateText: $model.introState.animateIntroText,
             showCTA: $model.introState.showIntroButton,
-            isSkipped: $model.isSkipped
-        ) {
-            animateBrowserComparisonViewState()
-        }
+            isSkipped: $model.isSkipped,
+            continueAction: {
+                animateBrowserComparisonViewState()
+            },
+            skipAction: model.skipOnboardingAction
+        )
         .onboardingDaxDialogStyle()
         .visibility(model.introState.showIntroViewContent ? .visible : .invisible)
     }
@@ -148,7 +168,7 @@ struct OnboardingView: View {
             isAnimating: $model.addToDockState.isAnimating,
             isSkipped: $model.isSkipped,
             showTutorialAction: {
-                model.addtoDockShowTutorialAction()
+                model.addToDockShowTutorialAction()
             },
             dismissAction: { fromAddToDockTutorial in
                 model.addToDockContinueAction(isShowingAddToDockTutorial: fromAddToDockTutorial)
@@ -236,7 +256,7 @@ extension OnboardingView.ViewState {
 extension OnboardingView.ViewState.Intro {
 
     enum IntroType: Equatable {
-        case startOnboardingDialog
+        case startOnboardingDialog(canSkipTutorial: Bool)
         case browsersComparisonDialog
         case addToDockPromoDialog
         case chooseAppIconDialog

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
@@ -50,7 +50,7 @@ struct OnboardingView: View {
                         Button {
                             model.overrideOnboardingCompleted()
                         } label: {
-                            Text(UserText.Onboarding.Intro.skip)
+                            Text(UserText.Onboarding.Intro.Debug.skip)
                         }
                         .buttonStyle(SecondaryFillButtonStyle(compact: true, fullWidth: false))
                     }

--- a/iOS/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
@@ -205,7 +205,7 @@ extension OnboardingPixelReporter: OnboardingIntroPixelReporting {
 
 extension OnboardingPixelReporter: OnboardingSearchSuggestionsPixelReporting {
     
-    func measureSearchSuggetionOptionTapped() {
+    func measureSearchSuggestionOptionTapped() {
         // Left empty on purpose. These were temporary pixels in iOS. macOS will still use them.
     }
 
@@ -213,7 +213,7 @@ extension OnboardingPixelReporter: OnboardingSearchSuggestionsPixelReporting {
 
 extension OnboardingPixelReporter: OnboardingSiteSuggestionsPixelReporting {
     
-    func measureSiteSuggetionOptionTapped() {
+    func measureSiteSuggestionOptionTapped() {
         // Left empty on purpose. These were temporary pixels in iOS. macOS will still use them.
     }
 

--- a/iOS/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
@@ -48,6 +48,9 @@ protocol OnboardingIntroImpressionReporting {
 }
 
 protocol OnboardingIntroPixelReporting: OnboardingIntroImpressionReporting {
+    func measureSkipOnboardingCTAAction()
+    func measureConfirmSkipOnboardingCTAAction()
+    func measureResumeOnboardingCTAAction()
     func measureBrowserComparisonImpression()
     func measureChooseBrowserCTAAction()
     func measureChooseAppIconImpression()
@@ -155,6 +158,18 @@ extension OnboardingPixelReporter {
 // MARK: - OnboardingPixelReporter + Intro
 
 extension OnboardingPixelReporter: OnboardingIntroPixelReporting {
+
+    func measureSkipOnboardingCTAAction() {
+        fire(event: .onboardingIntroSkipOnboardingCTAPressed, unique: false)
+    }
+
+    func measureConfirmSkipOnboardingCTAAction() {
+        fire(event: .onboardingIntroConfirmSkipOnboardingCTAPressed, unique: false)
+    }
+
+    func measureResumeOnboardingCTAAction() {
+        fire(event: .onboardingIntroResumeOnboardingCTAPressed, unique: false)
+    }
 
     func measureOnboardingIntroImpression() {
         fire(event: .onboardingIntroShownUnique, unique: true)

--- a/iOS/DuckDuckGo/OnboardingExperiment/Styles/DaxDialogStyles.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/Styles/DaxDialogStyles.swift
@@ -18,6 +18,7 @@
 //
 
 import SwiftUI
+import Onboarding
 
 extension OnboardingStyles {
 

--- a/iOS/DuckDuckGo/OnboardingExperiment/Styles/OnboardingTextStyles.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/Styles/OnboardingTextStyles.swift
@@ -18,8 +18,7 @@
 //
 
 import SwiftUI
-
-enum OnboardingStyles {}
+import Onboarding
 
 extension OnboardingStyles {
 

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -1624,8 +1624,19 @@ Duck.ai is an optional feature that lets you chat anonymously with popular 3rd-p
 
         public enum Intro {
             public static let title = NSLocalizedString("onboarding.highlights.intro.title", value: "Hi there.\n\nReady for a faster browser that keeps you protected?", comment: "The title of the onboarding dialog popup")
-            public static let cta = NSLocalizedString("onboarding.intro.cta", value: "Let’s do it!", comment: "Button to continue the onboarding process")
-            public static let skip = NotLocalizedString("onboarding.intro.skip", value: "Skip", comment: "Button to skip the onboarding process")
+            public static let continueCTA = NSLocalizedString("onboarding.intro.cta", value: "Let’s do it!", comment: "Button to continue the onboarding process")
+            public static let skipCTA = NSLocalizedString("onboarding.intro.cta.skip", value: "I’ve been here before", comment: "Button to skip the onboarding process")
+
+            enum Debug {
+                public static let skip = NotLocalizedString("onboarding.intro.debug.skip", value: "Skip", comment: "Button to skip the onboarding process")
+            }
+        }
+
+        public enum Skip {
+            public static let title = NSLocalizedString("onboarding.skip.title", value: "Got it! I’ll skip the other tips.", comment: "The title of the skip onboarding dialog popup")
+            public static let message = NSLocalizedString("onboarding.skip.message", value: "Remember: you can delete all your tabs, history, and browsing data in two taps with the Fire Button 🔥.", comment: "The message of the skip onboarding dialog popup.")
+            public static let confirmSkipOnboardingCTA = NSLocalizedString("onboarding.skip.cta.confirmSkip", value: "Start Browsing", comment: "The title of the button to skip the onboarding and start browsing.")
+            public static let resumeOnboardingCTA = NSLocalizedString("onboarding.skip.cta.resumeOnboarding", value: "Show Tutorial", comment: "The title of the button to resume the onboarding.")
         }
 
         public enum BrowsersComparison {
@@ -1634,7 +1645,7 @@ Duck.ai is an optional feature that lets you chat anonymously with popular 3rd-p
 
             public enum Features {
                 public static let privateSearch = NSLocalizedString("onboarding.browsers.features.privateSearch.title", value: "Search privately by default", comment: "Message to highlight browser capability of private searches")
-                public static let trackerBlockers = NSLocalizedString("onboarding.highlights.browsers.features.trackerBlocker.title", value: "Block 3rd-party trackers", comment: "Message to highlight browser capability ofblocking 3rd party trackers")
+                public static let trackerBlockers = NSLocalizedString("onboarding.highlights.browsers.features.trackerBlocker.title", value: "Block 3rd-party trackers", comment: "Message to highlight browser capability of blocking 3rd party trackers")
                 public static let cookiePopups = NSLocalizedString("onboarding.highlights.browsers.features.cookiePopups.title", value: "Block cookie pop-ups", comment: "Message to highlight how the browser allows you to block cookie pop-ups")
                 public static let creepyAds = NSLocalizedString("onboarding.highlights.browsers.features.creepyAds.title", value: "Block tracking ads", comment: "Message to highlight browser capability of blocking creepy ads")
                 public static let eraseBrowsingData = NSLocalizedString("onboarding.highlights.browsers.features.eraseBrowsingData.title", value: "Delete browsing data with one button", comment: "Message to highlight browser capability of swiftly erase browsing data")

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -1634,7 +1634,7 @@ Duck.ai is an optional feature that lets you chat anonymously with popular 3rd-p
 
         public enum Skip {
             public static let title = NSLocalizedString("onboarding.skip.title", value: "Got it! I’ll skip the other tips.", comment: "The title of the skip onboarding dialog popup")
-            public static let message = NSLocalizedString("onboarding.skip.message", value: "Remember: you can delete all your tabs, history, and browsing data in two taps with the Fire Button 🔥.", comment: "The message of the skip onboarding dialog popup.")
+            public static let message = NSLocalizedString("onboarding.skip.message", value: "Remember: you can delete all your tabs, history, and browsing data in two taps with the Fire Button 🔥", comment: "The message of the skip onboarding dialog popup.")
             public static let confirmSkipOnboardingCTA = NSLocalizedString("onboarding.skip.cta.confirmSkip", value: "Start Browsing", comment: "The title of the button to skip the onboarding and start browsing.")
             public static let resumeOnboardingCTA = NSLocalizedString("onboarding.skip.cta.resumeOnboarding", value: "Show Tutorial", comment: "The title of the button to resume the onboarding.")
         }

--- a/iOS/DuckDuckGo/bg.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/bg.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Изтриване на данните за сърфиране с един бутон";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Блокиране на тракерите на трети страни";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Да го направим!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Запознат/а съм вече";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Научете повече";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Стартиране на сърфирането";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Показване на указанията";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Не забравяйте: можете да изтриете всички раздели, хронологията и данните от сърфиране с две докосвания на Fire Button 🔥";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Разбрах! Ще пропусна другите съвети.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Добави приспособлението";

--- a/iOS/DuckDuckGo/cs.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/cs.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Vymaž údaje o prohlížení jedním tlačítkem";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Blokuj trackery třetích stran";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Pojďme na to!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Tohle už znám";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Více informací";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Spustit procházení";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Zobrazit návod";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Pamatuj: všechny karty, historii a údaje o prohlížení můžeš smazat dvěma klepnutími na Fire Button 🔥";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Rozumím. Ostatní tipy přeskočím.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Přidat widget";

--- a/iOS/DuckDuckGo/da.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/da.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Slet browsingdata med én knap";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Bloker tredjeparts-trackere";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Lad os gøre det!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Jeg har været her før";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Mere info";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Start søgning";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Vis vejledning";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Husk: Du kan slette alle dine faner, historik og browserdata med to tryk på Fire Button 🔥";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Forstået! Jeg springer de andre tips over.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Tilføj widget";

--- a/iOS/DuckDuckGo/de.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/de.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Browsing-Daten mit einem Klick löschen";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Blockiert Tracker von Drittanbietern";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Los geht's!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Ich war schon einmal hier";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Mehr erfahren";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Mit dem Browsen beginnen";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Tutorial anzeigen";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Denk daran: Mit dem Fire Button musst du nur zweimal tippen, um alle deine Tabs, den Verlauf und deine Browserdaten zu löschen 🔥";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Verstanden. Ich überspringe die anderen Tipps.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Widget hinzufügen";

--- a/iOS/DuckDuckGo/el.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/el.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Διαγράψτε τα δεδομένα περιήγησης με ένα κουμπί";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Αποκλείστε εφαρμογές παρακολούθησης τρίτων";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Ας το δοκιμάσουμε!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Έχω ξαναβρεθεί εδώ";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Μάθετε περισσότερα";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Έναρξη περιήγησης";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Εμφάνιση προγράμματος εκμάθησης";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Θυμηθείτε: μπορείτε να διαγράψετε όλες τις καρτέλες, το ιστορικό και τα δεδομένα περιήγησης με δύο πατήματα με το Fire Button 🔥";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Το κατάλαβα! Θα παραλείψω τις άλλες συμβουλές.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Προσθήκη γραφικού στοιχείου";

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -2212,7 +2212,7 @@ https://duckduckgo.com/mac";
 "onboarding.skip.cta.resumeOnboarding" = "Show Tutorial";
 
 /* The message of the skip onboarding dialog popup. */
-"onboarding.skip.message" = "Remember: you can delete all your tabs, history, and browsing data in two taps with the Fire Button 🔥.";
+"onboarding.skip.message" = "Remember: you can delete all your tabs, history, and browsing data in two taps with the Fire Button 🔥";
 
 /* The title of the skip onboarding dialog popup */
 "onboarding.skip.title" = "Got it! I’ll skip the other tips.";

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -2169,7 +2169,7 @@ https://duckduckgo.com/mac";
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Delete browsing data with one button";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Block 3rd-party trackers";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2183,6 +2183,9 @@ https://duckduckgo.com/mac";
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Let’s do it!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "I’ve been here before";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Learn More";
@@ -2201,6 +2204,18 @@ https://duckduckgo.com/mac";
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Start Browsing";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Show Tutorial";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Remember: you can delete all your tabs, history, and browsing data in two taps with the Fire Button 🔥.";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Got it! I’ll skip the other tips.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Add Widget";

--- a/iOS/DuckDuckGo/es.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/es.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Elimina los datos de navegación con un solo botón";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Bloquea rastreadores de terceros";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "¡Adelante!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "He estado aquí antes";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Más información";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Empezar a navegar";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Mostrar tutorial";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Recuerda: puedes eliminar todas tus pestañas, historial y datos de navegación en dos toques con el Fire Button 🔥";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Entendido. Me saltaré los otros consejos.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Añadir widget";

--- a/iOS/DuckDuckGo/et.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/et.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Kustuta sirvimisandmed ühe nupuga";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Blokeeri kolmanda poole jälgurid";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Teeme ära!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Olen siin varem olnud";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Loe edasi";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Alusta sirvimist";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Näita õpetust";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Tuletame meelde, et nupu Fire Button 🔥 abil saate kustutada kõik oma vahekaardid, ajaloo ja sirvimisandmed kahe puudutusega.";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Sain aru! Jätan muud näpunäited vahele.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Lisa vidin";

--- a/iOS/DuckDuckGo/fi.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fi.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Poista selaustiedot yhdellä painikkeella";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Estä kolmannen osapuolen seuraimet";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Aloitetaan!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Olen ollut täällä aiemmin";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Lue lisää";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Aloita selailu";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Näytä opetusohjelma";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Muista: voit poistaa kaikki välilehdet, historian ja selaustiedot napsauttamalla kahdesti Fire Button -painiketta 🔥";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Selvä! Ohitan muut vinkit.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Lisää widget";

--- a/iOS/DuckDuckGo/fr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fr.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Supprimez les données de navigation d'un seul clic";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Bloquer les traqueurs tiers";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "C'est parti !";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Je suis déjà venu ici";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "En savoir plus";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Commencer la navigation";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Afficher le tutoriel";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "N'oubliez pas : vous pouvez supprimer tous vos onglets, votre historique et vos données de navigation en deux clics avec le Fire Button 🔥";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "J'ai compris ! Je vais ignorer les autres conseils.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Ajouter un widget";

--- a/iOS/DuckDuckGo/hr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hr.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Izbriši podatke o pregledavanju jednim gumbom";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Blokiraj alate za praćenje trećih strana";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Učinimo to!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Već sam bio ovdje";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Saznajte više";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Započni pretraživanje";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Prikaži vodič";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Zapamti: možeš izbrisati sve svoje kartice, povijest i podatke pregledavanja u dva dodira pomoću Fire Buttona 🔥";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Shvaćam! Preskočit ću ostale savjete.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Dodaj widget";

--- a/iOS/DuckDuckGo/hu.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hu.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Böngészési adatok törlése gombnyomásra";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Harmadik féltől származó nyomkövetők blokkolása";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Rajta, csináljuk!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Már jártam itt korábban";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "További részletek";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Böngészés indítása";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Útmutató megjelenítése";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Ne feledd: a Fire Button 🔥 segítségével két érintéssel törölheted az összes lapodat, előzményedet és böngészési adatodat.";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Értem! Kihagyom a többi tippet.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Minialkalmazás hozzáadása";

--- a/iOS/DuckDuckGo/it.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/it.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Cancella i dati di navigazione con un solo pulsante";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Blocca i sistemi di tracciamento di terze parti";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Continua";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Sono già stato qui prima";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Ulteriori informazioni";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Inizia a navigare";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Mostra il tutorial";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Ricorda: puoi eliminare tutte le schede, la cronologia e i dati di navigazione con due tocchi sul pulsante Fire Button 🔥";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Ho capito! Salterò gli altri suggerimenti.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Aggiungi widget";

--- a/iOS/DuckDuckGo/lt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lt.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Vienu mygtuku ištrink naršymo duomenis";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Blokuoja trečiųjų šalių stebėjimo priemones";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Pirmyn!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Jau buvau čia anksčiau";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Sužinoti daugiau";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Pradėti naršyti";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Rodyti mokymo priemonę";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Atmink: visus skirtukus, istoriją ir naršymo duomenis gali ištrinti dviem mygtuko🔥 „Fire Button“ bakstelėjimais.";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Supratau! Praleisiu kitus patarimus.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Pridėti valdiklį";

--- a/iOS/DuckDuckGo/lv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lv.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Dzēst pārlūkošanas datus ar vienu pogu";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Bloķē trešo pušu izsekotājus";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Aiziet!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Es jau esmu bijis/-usi šeit agrāk";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Uzzināt vairāk";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Sākt pārlūkošanu";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Parādīt pamācību";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Atceries: tu vari dzēst visas savas cilnes, vēsturi un pārlūkošanas datus ar diviem pieskārieniem, izmantojot pogu Fire Button 🔥";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Sapratu! Es izlaidīšu pārējos padomus.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Pievienot logrīku";

--- a/iOS/DuckDuckGo/nb.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nb.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Slett nettleserdata med én knapp";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Blokker tredjepartssporere";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Sett i gang!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Jeg har vært her før";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Finn ut mer";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Begynn å surfe";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Vis veiledning";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Husk: Du kan slette alle fanene, historikken og nettleserdataene dine med to trykk på Fire Button 🔥";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Skjønner! Jeg hopper over de andre tipsene.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Legg til widget";

--- a/iOS/DuckDuckGo/nl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nl.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Verwijder browsegegevens met één knop";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Blokkeer trackers van derden";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Laten we het doen!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Overslaan";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Meer informatie";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Beginnen met browsen";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Tutorial weergeven";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Onthoud: je kunt al je tabbladen, geschiedenis en browsegegevens in twee tikken wissen met de Fire Button 🔥";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Ik snap het! Ik sla de andere tips over.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Widget toevoegen";

--- a/iOS/DuckDuckGo/pl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pl.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Usuwanie danych przeglądania za pomocą jednego przycisku";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Blokuj mechanizmy śledzące innych firm";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Zróbmy to!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Już o tym wiem";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Dowiedz się więcej";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Rozpocznij przeglądanie";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Pokaż samouczek";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Pamiętaj: wszystkie swoje karty, historię i dane przeglądania możesz usunąć dwoma stuknięciami dzięki przyciskowi Fire Button 🔥";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Rozumiem! Pominę pozostałe wskazówki.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Dodaj widżet";

--- a/iOS/DuckDuckGo/pt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pt.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Elimina dados de navegação com um botão";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Bloqueia rastreadores de terceiros";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Vamos lá!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Já estive aqui antes";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Saiba mais";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Iniciar a navegação";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Mostrar Tutorial";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Atenção: Podes eliminar todos os separadores, o histórico e os dados de navegação com dois toques no Fire Button 🔥";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Entendido! Quero ignorar as outras dicas.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Adicionar widget";

--- a/iOS/DuckDuckGo/ro.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ro.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Șterge datele de navigare cu un singur buton";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Blochează tehnologiile de urmărire terțe";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Să începem!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Am mai fost deja aici";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Află mai multe";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Începe navigarea";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Afișează tutorialul";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Nu uita: poți șterge toate filele, istoricul și datele de navigare în două atingeri cu Fire Button 🔥";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Am înțeles! O să omit celelalte sfaturi.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Adăugare widget";

--- a/iOS/DuckDuckGo/ru.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ru.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Стирает данные браузера одним нажатием";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Блокировка сторонних трекеров";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Поехали!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Мы уже это проходили";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Узнать больше";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Начать просмотр";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Показать руководство";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Напоминаем: с помощью кнопки огня 🔥 можно за пару нажатий закрыть все вкладки, а также стереть историю и скопившиеся в браузере данные.";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Понятно. Тогда мы пропустим остальные советы.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Добавить виджет";

--- a/iOS/DuckDuckGo/sk.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sk.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Odstráni údaje prehliadania jedným tlačidlom";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Blokovať sledovanie tretími stranami";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Poďme na to!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Bol/-a som tu už predtým";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Zistite viac";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Začnite prehliadať";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Zobraziť návod";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Pamätaj: všetky karty, históriu a údaje o prehliadaní môžeš odstrániť dvoma ťuknutiami pomocou tlačidla Fire Button 🔥";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Rozumiem! Preskočím ostatné rady.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Pridať miniaplikáciu";

--- a/iOS/DuckDuckGo/sl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sl.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Izbriši podatke o brskanju z enim gumbom";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Blokirajte sledilnike tretjih oseb";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Pa začnimo!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Tukaj sem že bil/-a";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Več";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Začni brskanje";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Prikaži vadnico";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Ne pozabite: Z gumbom Fire Button 🔥 lahko z dvema dotikoma izbrišete zavihke, zgodovino in podatke o brskanju.";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Razumem! Druge nasvete bom preskočil/-a.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Dodaj gradnik";

--- a/iOS/DuckDuckGo/sv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sv.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Radera surfdata med en knapp";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Blockera spårare från tredje part";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Vi kör!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Jag har varit här förut";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Läs mer";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Börja bläddra";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Visa handledning";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Kom ihåg att du kan radera alla dina flikar, din historik och dina surfdata med två tryck på Fire Button 🔥";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Jag förstår! Jag hoppar över de andra tipsen.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Lägg till widget";

--- a/iOS/DuckDuckGo/tr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/tr.lproj/Localizable.strings
@@ -2156,7 +2156,7 @@
 /* Message to highlight browser capability of swiftly erase browsing data */
 "onboarding.highlights.browsers.features.eraseBrowsingData.title" = "Tarama verilerini tek bir düğmeyle silin";
 
-/* Message to highlight browser capability ofblocking 3rd party trackers */
+/* Message to highlight browser capability of blocking 3rd party trackers */
 "onboarding.highlights.browsers.features.trackerBlocker.title" = "Üçüncü taraf izleyicileri engelleyin";
 
 /* The title of the dialog to show the privacy features that DuckDuckGo offers */
@@ -2170,6 +2170,9 @@
 
 /* Button to continue the onboarding process */
 "onboarding.intro.cta" = "Hadi Başlayalım!";
+
+/* Button to skip the onboarding process */
+"onboarding.intro.cta.skip" = "Daha önce buradaydım";
 
 /* Button on the Privacy Pro promotion onboarding step. Tapping the button navigates to the Privacy Pro paywall. */
 "onboarding.privacypro.promo.buttons.learnMore" = "Daha Fazla Bilgi";
@@ -2188,6 +2191,18 @@
 
 /* Bold text 'VPN'. This will replace the first placeholder (%1$@) in the following string - onboarding.privacypro.promo.vpn.message. */
 "onboarding.privacypro.promo.vpn.message.vpn-bold" = "VPN";
+
+/* The title of the button to skip the onboarding and start browsing. */
+"onboarding.skip.cta.confirmSkip" = "Gezinmeye Başla";
+
+/* The title of the button to resume the onboarding. */
+"onboarding.skip.cta.resumeOnboarding" = "Eğitimi Göster";
+
+/* The message of the skip onboarding dialog popup. */
+"onboarding.skip.message" = "Unutmayın: Fire Button 🔥 ile tüm sekmeleri, geçmişi ve tarama verilerini iki dokunuşla silebilirsiniz.";
+
+/* The title of the skip onboarding dialog popup */
+"onboarding.skip.title" = "Anladım! Diğer ipuçlarını atlayacağım.";
 
 /* No comment provided by engineer. */
 "onboarding.widgets.continueButton" = "Widget Ekle";

--- a/iOS/DuckDuckGoTests/AppSettingsMock.swift
+++ b/iOS/DuckDuckGoTests/AppSettingsMock.swift
@@ -99,9 +99,8 @@ class AppSettingsMock: AppSettings {
     var newTabPageIntroMessageEnabled: Bool?
     var newTabPageIntroMessageSeenCount: Int = 0
 
-    var onboardingHighlightsEnabled: Bool = false
-    var onboardingAddToDockState: OnboardingAddToDockState = .disabled
-    
+    var onboardingUserType: OnboardingUserType = .notSet
+
     var duckPlayerNativeUISERPEnabled: Bool = true
     var duckPlayerNativeYoutubeMode: DuckDuckGo.NativeDuckPlayerYoutubeMode = .allCases.first!
     var duckPlayerNativeUIPrimingModalPresentationEventCount: Int = 0

--- a/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -23,6 +23,7 @@ import XCTest
 @MainActor
 final class OnboardingIntroViewModelTests: XCTestCase {
     private var defaultBrowserManagerMock: DefaultBrowserManagerMock!
+    private var contextualDaxDialogs: ContextualOnboardingLogicMock!
     private var pixelReporterMock: OnboardingPixelReporterMock!
     private var onboardingManagerMock: OnboardingManagerMock!
     private var urlOpenerMock: MockURLOpener!
@@ -32,6 +33,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         defaultBrowserManagerMock = DefaultBrowserManagerMock()
+        contextualDaxDialogs = ContextualOnboardingLogicMock()
         pixelReporterMock = OnboardingPixelReporterMock()
         onboardingManagerMock = OnboardingManagerMock()
         urlOpenerMock = MockURLOpener()
@@ -41,6 +43,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     override func tearDown() {
         defaultBrowserManagerMock = nil
+        contextualDaxDialogs = nil
         pixelReporterMock = nil
         onboardingManagerMock = nil
         urlOpenerMock = nil
@@ -72,7 +75,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         sut.onAppear()
 
         // THEN
-        XCTAssertEqual(sut.state, .onboarding(.init(type: .startOnboardingDialog, step: .hidden)))
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .startOnboardingDialog(canSkipTutorial: false), step: .hidden)))
     }
 
     func testWhenSetDefaultBrowserActionIsCalledThenURLOpenerOpensURL() {
@@ -96,7 +99,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     func testWhenSubscribeToViewStateAndIsIphoneFlowThenShouldSendLanding() {
         // GIVEN
-        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.defaultIPhoneFlow
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: true)
         let sut = makeSUT()
 
         // WHEN
@@ -106,23 +109,69 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         XCTAssertEqual(result, .landing)
     }
 
-    func testWhenOnAppearIsCalledAndAndIsIphoneFlowThenViewStateChangesToStartOnboardingDialogAndProgressIsHidden() {
+    func testWhenOnAppearIsCalled_AndIsNewUser_AndAndIsIphoneFlow_ThenViewStateChangesToStartOnboardingDialogAndProgressIsHidden() throws {
         // GIVEN
-        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.defaultIPhoneFlow
-        let sut = makeSUT()
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: true)
+        let currentStep = try XCTUnwrap(onboardingManagerMock.onboardingSteps.first)
+        let sut = makeSUT(currentOnboardingStep: currentStep)
         XCTAssertEqual(sut.state, .landing)
 
         // WHEN
         sut.onAppear()
 
         // THEN
-        XCTAssertEqual(sut.state, .onboarding(.init(type: .startOnboardingDialog, step: .hidden)))
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .startOnboardingDialog(canSkipTutorial: false), step: .hidden)))
     }
 
+    func testWhenOnAppearIsCalled_AndIsReturningUser_AndAndIsIphoneFlow_ThenViewStateChangesToStartOnboardingDialogAndProgressIsHidden() throws {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.returningUserSteps(isIphone: true)
+        let currentStep = try XCTUnwrap(onboardingManagerMock.onboardingSteps.first)
+        let sut = makeSUT(currentOnboardingStep: currentStep)
+        XCTAssertEqual(sut.state, .landing)
+
+        // WHEN
+        sut.onAppear()
+
+        // THEN
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .startOnboardingDialog(canSkipTutorial: true), step: .hidden)))
+    }
+
+    func testWhenCancelSkipOnboardingActionIsCalled_AndIsIphoneFlow_ThenViewStateChangesToBrowsersComparisonDialogAndProgressIs2of4() throws {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.returningUserSteps(isIphone: true)
+        let currentStep = try XCTUnwrap(onboardingManagerMock.onboardingSteps.first)
+        let sut = makeSUT(currentOnboardingStep: currentStep)
+
+        // WHEN
+        sut.cancelSkipOnboardingAction()
+
+        // THEN
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog, step: .init(currentStep: 1, totalSteps: 4))))
+    }
+
+    func testWhenConfirmSkipOnboarding_andIsIphoneFlow_ThenDismissOnboardingAndDisableDaxDialogs() throws {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.returningUserSteps(isIphone: true)
+        let currentStep = try XCTUnwrap(onboardingManagerMock.onboardingSteps.first)
+        let sut = makeSUT(currentOnboardingStep: currentStep)
+        var didCallDismissOnboarding = false
+        sut.onCompletingOnboardingIntro = {
+            didCallDismissOnboarding = true
+        }
+        XCTAssertFalse(contextualDaxDialogs.didCallDisableDaxDialogs)
+        XCTAssertFalse(didCallDismissOnboarding)
+
+        // WHEN
+        sut.confirmSkipOnboardingAction()
+
+        XCTAssertTrue(contextualDaxDialogs.didCallDisableDaxDialogs)
+        XCTAssertTrue(didCallDismissOnboarding)
+    }
 
     func testWhenSetDefaultBrowserActionIsCalledAndIsIphoneFlowThenViewStateChangesToAddToDockPromoDialogAndProgressIs2Of4() {
         // GIVEN
-        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.defaultIPhoneFlow
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: true)
         let sut = makeSUT(currentOnboardingStep: .browserComparison)
 
         // WHEN
@@ -134,7 +183,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     func testWhenCancelSetDefaultBrowserActionIsCalledAndIsIphoneFlowThenViewStateChangesToAddToDockPromoDialogAndProgressIs2Of4() {
         // GIVEN
-        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.defaultIPhoneFlow
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: true)
         let sut = makeSUT(currentOnboardingStep: .browserComparison)
 
         // WHEN
@@ -146,7 +195,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     func testWhenAddtoDockContinueActionIsCalledAndIsIphoneFlowThenThenViewStateChangesToChooseAppIconAndProgressIs3of4() {
         // GIVEN
-        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.defaultIPhoneFlow
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: true)
         let sut = makeSUT(currentOnboardingStep: .addToDockPromo)
 
         // WHEN
@@ -158,7 +207,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     func testWhenAppIconPickerContinueActionIsCalledAndIsIphoneFlowThenViewStateChangesToChooseAddressBarPositionDialogAndProgressIs4Of4() {
         // GIVEN
-        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.defaultIPhoneFlow
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: true)
         let sut = makeSUT(currentOnboardingStep: .appIconSelection)
 
         // WHEN
@@ -171,7 +220,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
     func testWhenSelectAddressBarPositionActionIsCalledAndIsIphoneFlowThenOnCompletingOnboardingIntroIsCalled() {
         // GIVEN
         var didCallOnCompletingOnboardingIntro = false
-        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.defaultIPhoneFlow
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: true)
         let sut = makeSUT(currentOnboardingStep: .addressBarPositionSelection)
         sut.onCompletingOnboardingIntro = {
             didCallOnCompletingOnboardingIntro = true
@@ -189,7 +238,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     func testWhenSubscribeToViewStateAndIsIpadFlowThenShouldSendLanding() {
         // GIVEN
-        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.defaultIPadFlow
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: false)
         let sut = makeSUT()
 
         // WHEN
@@ -199,22 +248,69 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         XCTAssertEqual(result, .landing)
     }
 
-    func testWhenOnAppearIsCalledAndAndIsIpadFlowThenViewStateChangesToStartOnboardingDialogAndProgressIsHidden() {
+    func testWhenOnAppearIsCalled_AndIsNewUser_AndAndIsIpadFlow_ThenViewStateChangesToStartOnboardingDialogAndProgressIsHidden() throws {
         // GIVEN
-        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.defaultIPadFlow
-        let sut = makeSUT()
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: false)
+        let currentStep = try XCTUnwrap(onboardingManagerMock.onboardingSteps.first)
+        let sut = makeSUT(currentOnboardingStep: currentStep)
         XCTAssertEqual(sut.state, .landing)
 
         // WHEN
         sut.onAppear()
 
         // THEN
-        XCTAssertEqual(sut.state, .onboarding(.init(type: .startOnboardingDialog, step: .hidden)))
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .startOnboardingDialog(canSkipTutorial: false), step: .hidden)))
+    }
+
+    func testWhenOnAppearIsCalled_AndIsReturningUser_AndAndIsIpadFlow_ThenViewStateChangesToStartOnboardingDialogAndProgressIsHidden() throws {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.returningUserSteps(isIphone: false)
+        let currentStep = try XCTUnwrap(onboardingManagerMock.onboardingSteps.first)
+        let sut = makeSUT(currentOnboardingStep: currentStep)
+        XCTAssertEqual(sut.state, .landing)
+
+        // WHEN
+        sut.onAppear()
+
+        // THEN
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .startOnboardingDialog(canSkipTutorial: true), step: .hidden)))
+    }
+
+    func testWhenCancelSkipOnboardingActionIsCalled_AndIsIpadFlow_ThenViewStateChangesToBrowsersComparisonDialogAndProgressIs2of4() throws {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.returningUserSteps(isIphone: false)
+        let currentStep = try XCTUnwrap(onboardingManagerMock.onboardingSteps.first)
+        let sut = makeSUT(currentOnboardingStep: currentStep)
+
+        // WHEN
+        sut.cancelSkipOnboardingAction()
+
+        // THEN
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog, step: .init(currentStep: 1, totalSteps: 2))))
+    }
+
+    func testWhenConfirmSkipOnboarding_andIsIpadFlow_ThenDismissOnboardingAndDisableDaxDialogs() throws {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.returningUserSteps(isIphone: false)
+        let currentStep = try XCTUnwrap(onboardingManagerMock.onboardingSteps.first)
+        let sut = makeSUT(currentOnboardingStep: currentStep)
+        var didCallDismissOnboarding = false
+        sut.onCompletingOnboardingIntro = {
+            didCallDismissOnboarding = true
+        }
+        XCTAssertFalse(contextualDaxDialogs.didCallDisableDaxDialogs)
+        XCTAssertFalse(didCallDismissOnboarding)
+
+        // WHEN
+        sut.confirmSkipOnboardingAction()
+
+        XCTAssertTrue(contextualDaxDialogs.didCallDisableDaxDialogs)
+        XCTAssertTrue(didCallDismissOnboarding)
     }
 
     func testWhenStartOnboardingActionIsCalledAndIsIpadFlowThenViewStateChangesToBrowsersComparisonDialogAndProgressIs1Of3() {
         // GIVEN
-        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.defaultIPadFlow
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: false)
         let sut = makeSUT()
         XCTAssertEqual(sut.state, .landing)
 
@@ -227,7 +323,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     func testWhenSetDefaultBrowserActionIsCalledAndIsIpadFlowThenViewStateChangesToChooseAppIconDialogAndProgressIs2Of3() {
         // GIVEN
-        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.defaultIPadFlow
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: false)
         let sut = makeSUT(currentOnboardingStep: .browserComparison)
 
         // WHEN
@@ -239,7 +335,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     func testWhenCancelSetDefaultBrowserActionIsCalledAndIsIpadFlowThenViewStateChangesToChooseAppIconDialogAndProgressIs2Of3() {
         // GIVEN
-        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.defaultIPadFlow
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: false)
         let sut = makeSUT(currentOnboardingStep: .browserComparison)
 
         // WHEN
@@ -252,7 +348,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
     func testWhenAppIconPickerContinueActionIsCalledAndIsIphoneFlowThenOnCompletingOnboardingIntroIsCalled() {
         // GIVEN
         var didCallOnCompletingOnboardingIntro = false
-        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.defaultIPadFlow
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: false)
         let sut = makeSUT(currentOnboardingStep: .appIconSelection)
         sut.onCompletingOnboardingIntro = {
             didCallOnCompletingOnboardingIntro = true
@@ -306,7 +402,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     func testWhenAppIconScreenPresentedThenPixelReporterTrackAppIconImpression() {
         // GIVEN
-        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.defaultIPadFlow
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: false)
         let sut = makeSUT(currentOnboardingStep: .browserComparison)
         XCTAssertFalse(pixelReporterMock.didCallMeasureBrowserComparisonImpression)
 
@@ -345,7 +441,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     func testWhenStateChangesToChooseAddressBarPositionThenPixelReporterTrackAddressBarSelectionImpression() {
         // GIVEN
-        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.defaultIPhoneFlow
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: true)
         let sut = makeSUT(currentOnboardingStep: .appIconSelection)
         XCTAssertFalse(pixelReporterMock.didCallMeasureAddressBarPositionSelectionImpression)
 
@@ -426,7 +522,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         XCTAssertFalse(pixelReporterMock.didCallMeasureAddToDockPromoShowTutorialCTAAction)
 
         // WHEN
-        sut.addtoDockShowTutorialAction()
+        sut.addToDockShowTutorialAction()
 
         // THEN
         XCTAssertTrue(pixelReporterMock.didCallMeasureAddToDockPromoShowTutorialCTAAction)
@@ -568,9 +664,10 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
 extension OnboardingIntroViewModelTests {
 
-    func makeSUT(currentOnboardingStep: OnboardingIntroStep = .introDialog) -> OnboardingIntroViewModel {
+    func makeSUT(currentOnboardingStep: OnboardingIntroStep = .introDialog(isReturningUser: false)) -> OnboardingIntroViewModel {
         OnboardingIntroViewModel(
             defaultBrowserManager: defaultBrowserManagerMock,
+            contextualDaxDialogs: contextualDaxDialogs,
             pixelReporter: pixelReporterMock,
             onboardingManager: onboardingManagerMock,
             urlOpener: urlOpenerMock,

--- a/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -137,14 +137,14 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         XCTAssertEqual(sut.state, .onboarding(.init(type: .startOnboardingDialog(canSkipTutorial: true), step: .hidden)))
     }
 
-    func testWhenCancelSkipOnboardingActionIsCalled_AndIsIphoneFlow_ThenViewStateChangesToBrowsersComparisonDialogAndProgressIs2of4() throws {
+    func testWhenStartOnboardingActionResumingTrueIsCalled_AndIsIphoneFlow_ThenViewStateChangesToBrowsersComparisonDialogAndProgressIs2of4() throws {
         // GIVEN
         onboardingManagerMock.onboardingSteps = OnboardingIntroStep.returningUserSteps(isIphone: true)
         let currentStep = try XCTUnwrap(onboardingManagerMock.onboardingSteps.first)
         let sut = makeSUT(currentOnboardingStep: currentStep)
 
         // WHEN
-        sut.cancelSkipOnboardingAction()
+        sut.startOnboardingAction(isResumingOnboarding: true)
 
         // THEN
         XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog, step: .init(currentStep: 1, totalSteps: 4))))
@@ -276,14 +276,14 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         XCTAssertEqual(sut.state, .onboarding(.init(type: .startOnboardingDialog(canSkipTutorial: true), step: .hidden)))
     }
 
-    func testWhenCancelSkipOnboardingActionIsCalled_AndIsIpadFlow_ThenViewStateChangesToBrowsersComparisonDialogAndProgressIs2of4() throws {
+    func testWhenStartOnboardingActionResumingTrueIsCalled_AndIsIpadFlow_ThenViewStateChangesToBrowsersComparisonDialogAndProgressIs2of4() throws {
         // GIVEN
         onboardingManagerMock.onboardingSteps = OnboardingIntroStep.returningUserSteps(isIphone: false)
         let currentStep = try XCTUnwrap(onboardingManagerMock.onboardingSteps.first)
         let sut = makeSUT(currentOnboardingStep: currentStep)
 
         // WHEN
-        sut.cancelSkipOnboardingAction()
+        sut.startOnboardingAction(isResumingOnboarding: true)
 
         // THEN
         XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog, step: .init(currentStep: 1, totalSteps: 2))))
@@ -476,6 +476,47 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
         // THEN
         XCTAssertFalse(pixelReporterMock.didCallMeasureChooseBottomAddressBarPosition)
+    }
+
+    // MARK: - Pixels Skip Onboarding
+
+    func testWhenSkipOnboardingActionIsCalledThenPixelReporterTrackSkipOnboardingCTA() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.returningUserSteps(isIphone: true)
+        let sut = makeSUT(currentOnboardingStep: .introDialog(isReturningUser: true))
+        XCTAssertFalse(pixelReporterMock.didCallMeasureSkipOnboardingCTAAction)
+
+        // WHEN
+        sut.skipOnboardingAction()
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallMeasureSkipOnboardingCTAAction)
+    }
+
+    func testWhenConfirmSkipOnboardingActionIsCalledThenPixelReporterTrackConfirmSkipOnboardingCTA() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.returningUserSteps(isIphone: true)
+        let sut = makeSUT(currentOnboardingStep: .introDialog(isReturningUser: true))
+        XCTAssertFalse(pixelReporterMock.didCallMeasureConfirmSkipOnboardingCTAAction)
+
+        // WHEN
+        sut.confirmSkipOnboardingAction()
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallMeasureConfirmSkipOnboardingCTAAction)
+    }
+
+    func testWhenStartOnboardingActionResumingTrueIsCalledThenPixelReporterTrackResumeOnboardingCTA() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.returningUserSteps(isIphone: true)
+        let sut = makeSUT(currentOnboardingStep: .introDialog(isReturningUser: true))
+        XCTAssertFalse(pixelReporterMock.didCallMeasureResumeOnboardingCTAAction)
+
+        // WHEN
+        sut.startOnboardingAction(isResumingOnboarding: true)
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallMeasureResumeOnboardingCTAAction)
     }
 
     // MARK: - Copy

--- a/iOS/DuckDuckGoTests/OnboardingManagerMock.swift
+++ b/iOS/DuckDuckGoTests/OnboardingManagerMock.swift
@@ -24,7 +24,7 @@ import Core
 final class OnboardingManagerMock: OnboardingSetAsDefaultExperimentManaging, OnboardingSettingsURLProvider, OnboardingStepsProvider {
     private(set) var didCallSettingsURLPath = false
 
-    var onboardingSteps: [DuckDuckGo.OnboardingIntroStep] = OnboardingIntroStep.defaultIPhoneFlow
+    var onboardingSteps: [DuckDuckGo.OnboardingIntroStep] = OnboardingIntroStep.newUserSteps(isIphone: true)
     var isEnrolledInSetAsDefaultBrowserExperiment: Bool = false
 
     var settingsURLPathToReturn: String = "www.example.com"

--- a/iOS/DuckDuckGoTests/OnboardingManagerTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingManagerTests.swift
@@ -19,32 +19,115 @@
 
 import Testing
 import class UIKit.UIDevice
+@testable import Core
 @testable import DuckDuckGo
 
 struct OnboardingManagerTests {
 
-    @Test("Check correct onboarding steps are returned for iPad")
-    func checkOnboardingSteps_iPhone() async throws {
-        // GIVEN
-        let sut = OnboardingManager(featureFlagger: MockFeatureFlagger(), variantManager: MockVariantManager(), isIphone: true)
+    struct OnboardingStepsNewUser {
+        let variantManagerMock = MockVariantManager(
+            currentVariant: VariantIOS(
+                name: "test_variant",
+                weight: 0,
+                isIncluded: VariantIOS.When.always,
+                features: []
+            )
+        )
 
-        // WHEN
-        let result = sut.onboardingSteps
+        @Test("Check correct onboarding steps are returned for iPhone")
+        func checkOnboardingSteps_iPhone() async throws {
+            // GIVEN
+            let sut = OnboardingManager(appDefaults: AppSettingsMock(), featureFlagger: MockFeatureFlagger(), variantManager: variantManagerMock, isIphone: true)
 
-        // THEN
-        #expect(result == OnboardingIntroStep.defaultIPhoneFlow)
+            // WHEN
+            let result = sut.onboardingSteps
+
+            // THEN
+            #expect(result == OnboardingIntroStep.newUserSteps(isIphone: true))
+        }
+
+        @Test("Check correct onboarding steps are returned for iPad")
+        func checkOnboardingSteps_iPad() {
+            // GIVEN
+            let sut = OnboardingManager(appDefaults: AppSettingsMock(), featureFlagger: MockFeatureFlagger(), variantManager: variantManagerMock, isIphone: false)
+
+            // WHEN
+            let result = sut.onboardingSteps
+
+            // THEN
+            #expect(result == OnboardingIntroStep.newUserSteps(isIphone: false))
+        }
+
     }
 
-    @Test("Check correct onboarding steps are returned for iPad")
-    func checkOnboardingSteps_iPad() {
-        // GIVEN
-        let sut = OnboardingManager(featureFlagger: MockFeatureFlagger(), variantManager: MockVariantManager(), isIphone: false)
+    struct OnboardingStepsReturningUser {
+        let variantManagerMock = MockVariantManager(
+            currentVariant: VariantIOS(
+                name: "ru",
+                weight: 0,
+                isIncluded: VariantIOS.When.always,
+                features: []
+            )
+        )
 
-        // WHEN
-        let result = sut.onboardingSteps
+        @Test("Check correct onboarding steps are returned for iPhone")
+        func checkOnboardingSteps_iPhone() async throws {
+            // GIVEN
+            let sut = OnboardingManager(appDefaults: AppSettingsMock(), featureFlagger: MockFeatureFlagger(), variantManager: variantManagerMock, isIphone: true)
 
-        // THEN
-        #expect(result == OnboardingIntroStep.defaultIPadFlow)
+            // WHEN
+            let result = sut.onboardingSteps
+
+            // THEN
+            #expect(result == OnboardingIntroStep.returningUserSteps(isIphone: true))
+        }
+
+        @Test("Check correct onboarding steps are returned for iPad")
+        func checkOnboardingSteps_iPad() {
+            // GIVEN
+            let sut = OnboardingManager(appDefaults: AppSettingsMock(), featureFlagger: MockFeatureFlagger(), variantManager: variantManagerMock, isIphone: false)
+
+            // WHEN
+            let result = sut.onboardingSteps
+
+            // THEN
+            #expect(result == OnboardingIntroStep.returningUserSteps(isIphone: false))
+        }
+
+    }
+
+    struct NewUserValue {
+
+        @Test(
+            "Check correct user type value is returned",
+            arguments: zip(
+                [
+                    OnboardingUserType.notSet,
+                    .newUser,
+                    .returningUser,
+                ],
+                [
+                    true,
+                    true,
+                    false,
+                ]
+            )
+        )
+        func checkUserType(_ userType: OnboardingUserType, expectedResult: Bool) {
+            // GIVEN
+            let settingsMock = AppSettingsMock()
+            settingsMock.onboardingUserType = userType
+            let variant = VariantIOS(name: "test_variant", weight: 0, isIncluded: VariantIOS.When.always, features: [])
+            let variantManagerMock = MockVariantManager(currentVariant: variant)
+            let sut = OnboardingManager(appDefaults: settingsMock, featureFlagger: MockFeatureFlagger(), variantManager: variantManagerMock)
+
+            // WHEN
+            let result = sut.isNewUser
+
+            // THEN
+            #expect(result == expectedResult)
+        }
+
     }
 
 }

--- a/iOS/DuckDuckGoTests/OnboardingPixelReporterMock.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPixelReporterMock.swift
@@ -100,11 +100,11 @@ final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, Onboardi
         didCallMeasureEndOfJourneyDialogDismiss = true
     }
 
-    func measureSiteSuggetionOptionTapped() {
+    func measureSiteSuggestionOptionTapped() {
         didCallMeasureSiteOptionTapped = true
     }
 
-    func measureSearchSuggetionOptionTapped() {
+    func measureSearchSuggestionOptionTapped() {
         didCallMeasureSearchOptionTapped = true
     }
 

--- a/iOS/DuckDuckGoTests/OnboardingPixelReporterMock.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPixelReporterMock.swift
@@ -24,6 +24,9 @@ import Onboarding
 
 final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, OnboardingSiteSuggestionsPixelReporting, OnboardingSearchSuggestionsPixelReporting, OnboardingCustomInteractionPixelReporting, OnboardingDaxDialogsReporting, OnboardingAddToDockReporting, OnboardingSetAsDefaultBrowserExperimentReporting {
     private(set) var didCallMeasureOnboardingIntroImpression = false
+    private(set) var didCallMeasureSkipOnboardingCTAAction = false
+    private(set) var didCallMeasureConfirmSkipOnboardingCTAAction = false
+    private(set) var didCallMeasureResumeOnboardingCTAAction = false
     private(set) var didCallMeasureBrowserComparisonImpression = false
     private(set) var didCallMeasureChooseBrowserCTAAction = false
     private(set) var didCallMeasureChooseAppIconImpression = false
@@ -55,6 +58,18 @@ final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, Onboardi
 
     func measureOnboardingIntroImpression() {
         didCallMeasureOnboardingIntroImpression = true
+    }
+
+    func measureSkipOnboardingCTAAction() {
+        didCallMeasureSkipOnboardingCTAAction = true
+    }
+
+    func measureConfirmSkipOnboardingCTAAction() {
+        didCallMeasureConfirmSkipOnboardingCTAAction = true
+    }
+
+    func measureResumeOnboardingCTAAction() {
+        didCallMeasureResumeOnboardingCTAAction = true
     }
 
     func measureBrowserComparisonImpression() {

--- a/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
@@ -70,6 +70,63 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(OnboardingUniquePixelFireMock.capturedIncludeParameters, [.appVersion])
     }
 
+    func testWhenMeasureSkipOnboardingCTAIsCalledThenSkipOnboardingCTAEventFires() {
+        // GIVEN
+        let expectedPixel = Pixel.Event.onboardingIntroSkipOnboardingCTAPressed
+        XCTAssertFalse(OnboardingPixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingPixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingPixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingPixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.measureSkipOnboardingCTAAction()
+
+        // THEN
+        XCTAssertTrue(OnboardingPixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingPixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, "m_preonboarding_skip-onboarding-pressed")
+        XCTAssertEqual(OnboardingPixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingPixelFireMock.capturedIncludeParameters, [.appVersion])
+    }
+
+    func testWhenMeasureConfirmSkipOnboardingCTAIsCalledThenConfirmSkipOnboardingCTAEventFires() {
+        // GIVEN
+        let expectedPixel = Pixel.Event.onboardingIntroConfirmSkipOnboardingCTAPressed
+        XCTAssertFalse(OnboardingPixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingPixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingPixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingPixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.measureConfirmSkipOnboardingCTAAction()
+
+        // THEN
+        XCTAssertTrue(OnboardingPixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingPixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, "m_preonboarding_confirm-skip-onboarding-pressed")
+        XCTAssertEqual(OnboardingPixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingPixelFireMock.capturedIncludeParameters, [.appVersion])
+    }
+
+    func testWhenMeasureCancelSkipOnboardingCTAIsCalledThenResumeOnboardingCTAEventFires() {
+        // GIVEN
+        let expectedPixel = Pixel.Event.onboardingIntroResumeOnboardingCTAPressed
+        XCTAssertFalse(OnboardingPixelFireMock.didCallFire)
+        XCTAssertNil(OnboardingPixelFireMock.capturedPixelEvent)
+        XCTAssertEqual(OnboardingPixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingPixelFireMock.capturedIncludeParameters, [])
+
+        // WHEN
+        sut.measureResumeOnboardingCTAAction()
+
+        // THEN
+        XCTAssertTrue(OnboardingPixelFireMock.didCallFire)
+        XCTAssertEqual(OnboardingPixelFireMock.capturedPixelEvent, expectedPixel)
+        XCTAssertEqual(expectedPixel.name, "m_preonboarding_resume-onboarding-pressed")
+        XCTAssertEqual(OnboardingPixelFireMock.capturedParams, [:])
+        XCTAssertEqual(OnboardingPixelFireMock.capturedIncludeParameters, [.appVersion])
+    }
+
     func testWhenMeasureBrowserComparisonImpressionThenOnboardingIntroComparisonChartShownEventFires() {
         // GIVEN
         let expectedPixel = Pixel.Event.onboardingIntroComparisonChartShownUnique

--- a/iOS/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
+++ b/iOS/DuckDuckGoTests/TabViewControllerDaxDialogTests.swift
@@ -228,7 +228,7 @@ final class TabViewControllerDaxDialogTests: XCTestCase {
 
 }
 
-final class ContextualOnboardingLogicMock: ContextualOnboardingLogic, PrivacyProPromotionCoordinating {
+final class ContextualOnboardingLogicMock: ContextualOnboardingLogic, PrivacyProPromotionCoordinating, ContextualDaxDialogDisabling {
     var expectation: XCTestExpectation?
     private(set) var didCallSetTryAnonymousSearchMessageSeen = false
     private(set) var didCallSetTryVisitSiteMessageSeen = false
@@ -238,6 +238,7 @@ final class ContextualOnboardingLogicMock: ContextualOnboardingLogic, PrivacyPro
     private(set) var didCallEnableAddFavoriteFlow = false
     private(set) var didCallSetDaxDialogDismiss = false
     private(set) var didCallClearedBrowserData = false
+    private(set) var didCallDisableDaxDialogs = false
 
     var canStartFavoriteFlow = false
 
@@ -285,6 +286,10 @@ final class ContextualOnboardingLogicMock: ContextualOnboardingLogic, PrivacyPro
     }
 
     var privacyProPromotionDialogSeen: Bool = false
+
+    func disableContextualDaxDialogs() {
+        didCallDisableDaxDialogs = true
+    }
 }
 
 extension WKNavigation {

--- a/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/OnboardingPixelReporter.swift
+++ b/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/OnboardingPixelReporter.swift
@@ -56,12 +56,12 @@ final class OnboardingPixelReporter: OnboardingSearchSuggestionsPixelReporting, 
         self.userDefaults = userDefaults
     }
 
-    func measureSiteSuggetionOptionTapped() {
-        fire(ContextualOnboardingPixel.siteSuggetionOptionTapped, .uniqueByName)
+    func measureSiteSuggestionOptionTapped() {
+        fire(ContextualOnboardingPixel.siteSuggestionOptionTapped, .uniqueByName)
     }
 
-    func measureSearchSuggetionOptionTapped() {
-        fire(ContextualOnboardingPixel.searchSuggetionOptionTapped, .uniqueByName)
+    func measureSearchSuggestionOptionTapped() {
+        fire(ContextualOnboardingPixel.searchSuggestionOptionTapped, .uniqueByName)
     }
 }
 

--- a/macOS/DuckDuckGo/Statistics/ContextualOnboardingPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/ContextualOnboardingPixel.swift
@@ -34,7 +34,7 @@ enum ContextualOnboardingPixel: PixelKitEventV2 {
      * It is triggered in  OnboardingSearchSuggestionsViewModel when one of the search suggestion button in the list is pressed (listItemPressed) in the contextual onboarding
      * Check code in that area and in OnboardingPixelReporter to check it behaves as expected
      */
-    case siteSuggetionOptionTapped
+    case siteSuggestionOptionTapped
 
     /**
      * Event Trigger: User types into the address bar when the search suggestions dialog is shown during the contextual onboarding
@@ -43,7 +43,7 @@ enum ContextualOnboardingPixel: PixelKitEventV2 {
      * It is triggered in  OnboardingSiteSuggestionsViewModel when one of the site suggestion button in the list is pressed (listItemPressed) in the contextual onboarding
      * Check code in that area and in OnboardingPixelReporter to check it behaves as expected
      */
-    case searchSuggetionOptionTapped
+    case searchSuggestionOptionTapped
 
     /**
      * Event Trigger: User types into the address bar when the search suggestions dialog is shown during the contextual onboarding
@@ -98,7 +98,7 @@ enum ContextualOnboardingPixel: PixelKitEventV2 {
      *
      * Anomaly Investigation:
      * It is triggered on fireButtonAction on MainMenuActions
-     * the OnboardingPixelProvider sends it only if the state non e' onboardingComleted
+     * the OnboardingPixelProvider sends it only if the state is not onboardingCompleted
      * Check code in that area  to check it behaves as expected
      */
     case onboardingFireButtonPressed
@@ -108,7 +108,7 @@ enum ContextualOnboardingPixel: PixelKitEventV2 {
      *
      * Anomaly Investigation:
      * It is triggered on privacyEntryPointButtonAction on AddressBarButtonViewController
-     * the OnboardingPixelProvider sends it only if the state non e' onboardingComleted
+     * the OnboardingPixelProvider sends it only if the state is not onboardingCompleted
      * Check code in that area  to check it behaves as expected
      */
     case onboardingPrivacyDashboardOpened
@@ -137,9 +137,9 @@ enum ContextualOnboardingPixel: PixelKitEventV2 {
             return "m_mac_onboarding_privacy_dashboard_opened_u"
         case .secondSiteVisited:
             return "m_mac_second_site_visit_u"
-        case .searchSuggetionOptionTapped:
+        case .searchSuggestionOptionTapped:
             return "m_mac_onboarding_search_option_tapped_u"
-        case .siteSuggetionOptionTapped:
+        case .siteSuggestionOptionTapped:
             return "m_mac_onboarding_visit_site_option_tapped_u"
         case .onboardingFireButtonTryItPressed:
             return "m_mac_onboarding_fire_button_try_it_pressed_u"

--- a/macOS/UnitTests/Onboarding/ContextualOnboarding/ContextualDaxDialogsFactoryTests.swift
+++ b/macOS/UnitTests/Onboarding/ContextualOnboarding/ContextualDaxDialogsFactoryTests.swift
@@ -246,10 +246,10 @@ class CapturingOnboardingPixelReporter: OnboardingPixelReporting {
         measureLastDialogShownCalled = true
     }
 
-    func measureSearchSuggetionOptionTapped() {
+    func measureSearchSuggestionOptionTapped() {
     }
 
-    func measureSiteSuggetionOptionTapped() {
+    func measureSiteSuggestionOptionTapped() {
     }
 
     func measureFireButtonTryIt() {

--- a/macOS/UnitTests/Onboarding/ContextualOnboarding/OnboardingPixelReporterTests.swift
+++ b/macOS/UnitTests/Onboarding/ContextualOnboarding/OnboardingPixelReporterTests.swift
@@ -46,19 +46,19 @@ final class OnboardingPixelReporterTests: XCTestCase {
         userDefaults?.removePersistentDomain(forName: "OnboardingPixelReporterTests")
     }
 
-    func test_WhenTrackSiteSuggestionOptionTapped_ThenSiteSuggetionOptionTappedEventSent() throws {
-        reporter.measureSiteSuggetionOptionTapped()
-        XCTAssertEqual(eventSent?.name, ContextualOnboardingPixel.siteSuggetionOptionTapped.name)
+    func test_WhenMeasureSiteSuggestionOptionTapped_ThenSiteSuggestionOptionTappedEventSent() throws {
+        reporter.measureSiteSuggestionOptionTapped()
+        XCTAssertEqual(eventSent?.name, ContextualOnboardingPixel.siteSuggestionOptionTapped.name)
         XCTAssertEqual(frequency, .uniqueByName)
     }
 
-    func test_WhenmeasureSearchSuggetionOptionTapped_ThenSearchSuggetionOptionTappedEventSent() throws {
-        reporter.measureSearchSuggetionOptionTapped()
-        XCTAssertEqual(eventSent?.name, ContextualOnboardingPixel.searchSuggetionOptionTapped.name)
+    func test_WhenMeasureSearchSuggestionOptionTapped_ThenSearchSuggestionOptionTappedEventSent() throws {
+        reporter.measureSearchSuggestionOptionTapped()
+        XCTAssertEqual(eventSent?.name, ContextualOnboardingPixel.searchSuggestionOptionTapped.name)
         XCTAssertEqual(frequency, .uniqueByName)
     }
 
-    func test_WhenmeasureAddressBarTypedIn_ThenDependingOnTheState_CorrectPixelsAreSent() throws {
+    func test_WhenMeasureAddressBarTypedIn_ThenDependingOnTheState_CorrectPixelsAreSent() throws {
         for state in ContextualOnboardingState.allCases {
             eventSent = nil
             frequency = nil
@@ -77,53 +77,53 @@ final class OnboardingPixelReporterTests: XCTestCase {
         }
     }
 
-    func test_WhenmeasureFireButtonSkipped_ThenOnboardingFireButtonPromptSkipPressedSent() {
+    func test_WhenMeasureFireButtonSkipped_ThenOnboardingFireButtonPromptSkipPressedSent() {
         reporter.measureFireButtonSkipped()
         XCTAssertEqual(eventSent?.name, ContextualOnboardingPixel.onboardingFireButtonPromptSkipPressed.name)
         XCTAssertEqual(frequency, .uniqueByName)
     }
 
-    func test_WhenmeasureFireButtonTryIt_ThenOnboardingFireButtonTryItPressedSent() {
+    func test_WhenMeasureFireButtonTryIt_ThenOnboardingFireButtonTryItPressedSent() {
         reporter.measureFireButtonTryIt()
         XCTAssertEqual(eventSent?.name, ContextualOnboardingPixel.onboardingFireButtonTryItPressed.name)
         XCTAssertEqual(frequency, .uniqueByName)
     }
 
-    func test_WhenmeasureLastDialogShown_ThenOnboardingFinishedSent() {
+    func test_WhenMeasureLastDialogShown_ThenOnboardingFinishedSent() {
         reporter.measureLastDialogShown()
         XCTAssertEqual(eventSent?.name, ContextualOnboardingPixel.onboardingFinished.name)
         XCTAssertEqual(frequency, .uniqueByName)
     }
 
-    func test_WhenmeasureFireButtonPressed_AndOnboardingNotCompleted_ThenOnboardingFireButtonPressedSent() {
+    func test_WhenMeasureFireButtonPressed_AndOnboardingNotCompleted_ThenOnboardingFireButtonPressedSent() {
         onboardingState.state = .showFireButton
         reporter.measureFireButtonPressed()
         XCTAssertEqual(eventSent?.name, ContextualOnboardingPixel.onboardingFireButtonPressed.name)
         XCTAssertEqual(frequency, .uniqueByName)
     }
 
-    func test_WhenmeasureFireButtonPressed_AndOnboardingCompleted_ThenNoPixelSent() {
+    func test_WhenMeasureFireButtonPressed_AndOnboardingCompleted_ThenNoPixelSent() {
         onboardingState.state = .onboardingCompleted
         reporter.measureFireButtonPressed()
         XCTAssertNil(eventSent)
         XCTAssertNil(frequency)
     }
 
-    func test_WhenmeasurePrivacyDashboardOpened_AndOnboardingNotCompleted_ThenOnboardingFireButtonPressedSent() {
+    func test_WhenMeasurePrivacyDashboardOpened_AndOnboardingNotCompleted_ThenOnboardingFireButtonPressedSent() {
         onboardingState.state = .showBlockedTrackers
         reporter.measurePrivacyDashboardOpened()
         XCTAssertEqual(eventSent?.name, ContextualOnboardingPixel.onboardingPrivacyDashboardOpened.name)
         XCTAssertEqual(frequency, .uniqueByName)
     }
 
-    func test_WhenmeasurePrivacyDashboardOpened_AndOnboardingCompleted_ThenNoPixelSent() {
+    func test_WhenMeasurePrivacyDashboardOpened_AndOnboardingCompleted_ThenNoPixelSent() {
         onboardingState.state = .onboardingCompleted
         reporter.measurePrivacyDashboardOpened()
         XCTAssertNil(eventSent)
         XCTAssertNil(frequency)
     }
 
-    func test_WhenmeasureSiteVisited_ThenSecondSiteVisitedSentOnlyTheSecondTime() {
+    func test_WhenMeasureSiteVisited_ThenSecondSiteVisitedSentOnlyTheSecondTime() {
         reporter.measureSiteVisited()
         XCTAssertNil(eventSent)
         XCTAssertNil(frequency)
@@ -137,7 +137,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
 
     // Tab Onboarding Pixel test
     @MainActor
-    func test_WhenNavigationDidFinish_ThenReportermeasureSiteVisitedCalled() {
+    func test_WhenNavigationDidFinish_ThenReporterMeasureSiteVisitedCalled() {
         let capturingReporter = CapturingOnboardingPixelReporter()
         let tab = Tab(content: .newtab, onboardingPixelReporter: capturingReporter)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1206329551987282/1209816694983045/f
Tech Design URL:
CC:

### Description

This PR enables returning users to skip the onboarding flow.

### Testing Steps

**Scenario 1 - Returning Users - Start Onboarding Flow**
1. Ensure `isNewUser` returns `false` in `OnboardingManager.swift`
2. Launch the App and wait for the onboarding intro dialog to appear.
3. Ensure the “I’ve been here before" button is visible”.
4. Tap the “Let’s do it button”
5. Ensure the user can complete the onboarding flow and that the Dax Dialogs are prompted when browsing. 

**Scenario 2 - Returning Users - Skip Onboarding Flow and then Resume it**
1. Ensure `isNewUser` returns `false` in `OnboardingManager.swift`
2. Launch the App and wait for the onboarding intro dialog to appear.
3. Ensure the “I’ve been here before" button is visible”.
4. Tap the “I’ve been here before” button.
5. Wait for the confirmation dialog to appear.
6. Tap the “Show Tutorial” button.
7. Ensure the onboarding resume from the browser comparison chart and that the Dax Dialogs are prompted when browsing. 

**Scenario 3 - Returning Users - Skip Onboarding Flow and Confirm Skip flow**
1. Ensure `isNewUser` returns `false` in `OnboardingManager.swift`
2. Launch the App and wait for the onboarding intro dialog to appear.
3. Ensure the “I’ve been here before" button is visible”.
4. Tap the “I’ve been here before” button.
5. Wait for the confirmation dialog to appear.
6. Tap the “Start Browsing” button.
7. Ensure the onboarding is dismissed and the Dax Dialogs are NOT prompted when browsing.

**Scenario 2 - New Users**
1. Ensure `isNewUser` returns `true` in `OnboardingManager.swift`.
2. Launch the App and wait for the onboarding intro dialog to appear.
3. Ensure the “I’ve been here before" button is NOT visible”.
4. Smoke test the onboarding flow and ensure the Dax Dialogs are prompted when browsing.

**Scenario 3 - Pixels**
1. Ensure `isNewUser` returns `true` in `OnboardingManager.swift`.
2. Launch the App and wait for the onboarding intro dialog to appear.
3. Tap the “I’ve been here before” button.
4. Ensure that the `m_preonboarding_skip-onboarding-pressed` pixel is fired.
5. Tap the “Start browsing” button.
6. Ensure that the 'm_preonboarding_confirm-skip-onboarding-pressed’ pixel is fired.
7. Repeat the test, tap the “Show Tutorial” button and ensure that ‘m_preonboarding_resume-onboarding-pressed’ pixel is fired.

Ensure that 'm_preonboarding_resume-onboarding-pressed’ is not fired when tapping the “Let’s do it button"

### Impact and Risks
What's the impact on users if something goes wrong?
Medium: Could disrupt specific features or user flows

#### What could go wrong?
- Wrong events reported.
- Returning users not able to skip the onboarding flow.

### Quality Considerations
- What monitoring have you added?
Pixels to measure the percentage of returning users skipping the onboarding flow.

### Notes to Reviewer
Please smoke test the whole onboarding flow.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)