### PR TITLE
Hide tab preview before displaying context menu for a tab item view

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -1238,6 +1238,10 @@ extension TabBarViewController: TabBarViewItemDelegate {
         BookmarksDialogViewFactory.makeBookmarkAllOpenTabsView(websitesInfo: websitesInfo).show()
     }
 
+    func tabBarViewItemWillOpenContextMenu(_: TabBarViewItem) {
+        hideTabPreview()
+    }
+
     func tabBarViewItemCloseAction(_ tabBarViewItem: TabBarViewItem) {
         guard let indexPath = collectionView.indexPath(for: tabBarViewItem) else {
             assertionFailure("TabBarViewController: Failed to get index path of tab bar view item")

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -54,6 +54,7 @@ protocol TabBarViewItemDelegate: AnyObject {
     @MainActor func tabBarViewItemIsAlreadyBookmarked(_: TabBarViewItem) -> Bool
     @MainActor func tabBarViewAllItemsCanBeBookmarked(_: TabBarViewItem) -> Bool
 
+    @MainActor func tabBarViewItemWillOpenContextMenu(_: TabBarViewItem)
     @MainActor func tabBarViewItemCloseAction(_: TabBarViewItem)
     @MainActor func tabBarViewItemTogglePermissionAction(_: TabBarViewItem)
     @MainActor func tabBarViewItemCloseOtherAction(_: TabBarViewItem)
@@ -693,6 +694,12 @@ final class TabBarViewItem: NSCollectionViewItem {
 extension TabBarViewItem: NSMenuDelegate {
 
     func menuNeedsUpdate(_ menu: NSMenu) {
+        /// Trigger context menu callback from here.
+        /// It can't be called from `mouseClickView(_:rightMouseDownEvent:)`
+        /// because that one is called after handling the right click,
+        /// which means it would be delivered only after the context menu was closed.
+        delegate?.tabBarViewItemWillOpenContextMenu(self)
+
         // Initial setup
         menu.removeAllItems()
         let otherItemsState = delegate?.otherTabBarViewItemsState(for: self) ?? .init(hasItemsToTheLeft: true,
@@ -1110,6 +1117,7 @@ extension TabBarViewItem {
         func tabBarViewItemCanBeBookmarked(_: TabBarViewItem) -> Bool { false }
         func tabBarViewItemIsAlreadyBookmarked(_: TabBarViewItem) -> Bool { false }
         func tabBarViewAllItemsCanBeBookmarked(_: TabBarViewItem) -> Bool { false }
+        func tabBarViewItemWillOpenContextMenu(_: TabBarViewItem) {}
         func tabBarViewItemCloseAction(_: TabBarViewItem) {}
         func tabBarViewItemTogglePermissionAction(_ item: TabBarViewItem) {
             // swiftlint:disable:next force_cast

--- a/macOS/UnitTests/TabBar/View/MockTabViewItemDelegate.swift
+++ b/macOS/UnitTests/TabBar/View/MockTabViewItemDelegate.swift
@@ -29,12 +29,17 @@ class MockTabViewItemDelegate: TabBarViewItemDelegate {
     var audioState: WKWebView.AudioState?
     var isTabBarItemAlreadyBookmarked = false
 
+    private(set) var tabBarViewItemWillOpenContextMenuCalled = false
     private(set) var tabBarViewItemBookmarkThisPageActionCalled = false
     private(set) var tabBarViewItemRemoveBookmarkActionCalled = false
     private(set) var tabBarViewItemBookmarkAllOpenTabsActionCalled = false
 
     func tabBarViewItem(_ tabBarViewItem: DuckDuckGo_Privacy_Browser.TabBarViewItem, isMouseOver: Bool) {
 
+    }
+
+    func tabBarViewItemWillOpenContextMenu(_ tabBarViewItem: DuckDuckGo_Privacy_Browser.TabBarViewItem) {
+        tabBarViewItemWillOpenContextMenuCalled = true
     }
 
     func tabBarViewItemCloseAction(_ tabBarViewItem: DuckDuckGo_Privacy_Browser.TabBarViewItem) {

--- a/macOS/UnitTests/TabBar/View/TabBarViewItemTests.swift
+++ b/macOS/UnitTests/TabBar/View/TabBarViewItemTests.swift
@@ -40,6 +40,13 @@ final class TabBarViewItemTests: XCTestCase {
     }
 
     @MainActor
+    func testThatMenuNeedsUpdateCallsContextMenuDelegateCallback() {
+        XCTAssertFalse(delegate.tabBarViewItemWillOpenContextMenuCalled)
+        tabBarViewItem.menuNeedsUpdate(menu)
+        XCTAssertTrue(delegate.tabBarViewItemWillOpenContextMenuCalled)
+    }
+
+    @MainActor
     func testThatAllExpectedItemsAreShown() {
         let tabBarViewModel = TabBarViewModelMock(audioState: .unmuted(isPlayingAudio: true))
         tabBarViewItem.subscribe(to: tabBarViewModel)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1208937634215685/1209014735687766/f

### Description
This change adds a delegate callback to TabBarViewItem, triggered before showing context menu.
This callback is handled in TabBarViewController by hiding any tab preview shown.

### Testing Steps
1. Launch the app and hover over a tab bar item view.
2. Wait until a tab preview is shown, and trigger context menu.
3. Verify that the tab preview was hidden before context menu was shown.

### Impact and Risks
Low

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)