### PR TITLE
Pixel handler improvements

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
@@ -64,6 +64,11 @@ public enum SubscriptionPixelType {
     case getTokensError(AuthTokensCachePolicy, Error)
 }
 
+/// Pixels handler
+public protocol SubscriptionPixelHandler {
+    func handle(pixelType: SubscriptionPixelType)
+}
+
 public protocol SubscriptionManagerV2: SubscriptionTokenProvider, SubscriptionAuthenticationStateProvider, SubscriptionAuthV1toV2Bridge {
 
     // Environment
@@ -110,9 +115,6 @@ public protocol SubscriptionManagerV2: SubscriptionTokenProvider, SubscriptionAu
     /// Confirm a purchase with a platform signature
     func confirmPurchase(signature: String, additionalParams: [String: String]?) async throws -> PrivacyProSubscription
 
-    /// Pixels handler
-    typealias PixelHandler = (SubscriptionPixelType) -> Void
-
     /// Closure called when an expired refresh token is detected and the Subscription login is invalid. An attempt to automatically recover it can be performed or the app can ask the user to do it manually
     typealias TokenRecoveryHandler = () async throws -> Void
 
@@ -157,7 +159,7 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
     var oAuthClient: any OAuthClient
     private let _storePurchaseManager: StorePurchaseManagerV2?
     private let subscriptionEndpointService: SubscriptionEndpointServiceV2
-    private let pixelHandler: PixelHandler?
+    private let pixelHandler: SubscriptionPixelHandler
     public var tokenRecoveryHandler: TokenRecoveryHandler?
     public let currentEnvironment: SubscriptionEnvironment
     private let isInternalUserEnabled: () -> Bool
@@ -168,7 +170,7 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
                 oAuthClient: any OAuthClient,
                 subscriptionEndpointService: SubscriptionEndpointServiceV2,
                 subscriptionEnvironment: SubscriptionEnvironment,
-                pixelHandler: PixelHandler? = nil,
+                pixelHandler: SubscriptionPixelHandler,
                 tokenRecoveryHandler: TokenRecoveryHandler? = nil,
                 initForPurchase: Bool = true,
                 legacyAccountStorage: AccountKeychainStorage? = nil,
@@ -243,14 +245,14 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
 
         // Attempting V1 token migration
         do {
-            pixelHandler?(.migrationStarted)
+            pixelHandler.handle(pixelType: .migrationStarted)
             if (try await oAuthClient.migrateV1Token()) != nil {
-                pixelHandler?(.migrationSucceeded)
+                pixelHandler.handle(pixelType: .migrationSucceeded)
             }
             v1MigrationNeeded = false
         } catch {
             Logger.subscription.error("Failed to migrate V1 token: \(error, privacy: .public)")
-            pixelHandler?(.migrationFailed(error))
+            pixelHandler.handle(pixelType: .migrationFailed(error))
             switch error {
             case OAuthServiceError.authAPIError(let code) where code ==  OAuthRequest.BodyErrorCode.invalidToken:
                 // Case where the token is not valid anymore, probably because the BE deleted the account: https://app.asana.com/0/1205842942115003/1209427500692943/f
@@ -270,7 +272,7 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
             let subscription = try await getSubscription(cachePolicy: .returnCacheDataDontLoad)
             Logger.subscription.log("Subscription is \(subscription.isActive ? "active" : "not active", privacy: .public)")
             if subscription.isActive {
-                pixelHandler?(.subscriptionIsActive)
+                pixelHandler.handle(pixelType: .subscriptionIsActive)
             }
         } catch SubscriptionEndpointServiceError.noData {
             Logger.subscription.log("No Subscription available")
@@ -428,14 +430,14 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
             case OAuthClientError.missingTokens: // Expected when no tokens are available
                 throw SubscriptionManagerError.tokenUnavailable(error: error)
             case OAuthClientError.refreshTokenExpired, OAuthClientError.invalidTokenRequest:
-                pixelHandler?(.getTokensError(policy, error))
+                pixelHandler.handle(pixelType: .getTokensError(policy, error))
                 do {
                     return try await attemptTokenRecovery()
                 } catch {
                     throw error
                 }
             default:
-                pixelHandler?(.getTokensError(policy, error))
+                pixelHandler.handle(pixelType: .getTokensError(policy, error))
                 throw SubscriptionManagerError.tokenUnavailable(error: error)
             }
         }
@@ -448,7 +450,7 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
         }
 
         Logger.subscription.log("The refresh token is expired, attempting subscription recovery...")
-        pixelHandler?(.invalidRefreshToken)
+        pixelHandler.handle(pixelType: .invalidRefreshToken)
         await signOut(notifyUI: false)
 
         try await tokenRecoveryHandler()

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
@@ -303,7 +303,7 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
             subscription = try await subscriptionEndpointService.getSubscription(accessToken: "",
                                                                                  cachePolicy: .returnCacheDataDontLoad)
         }
-        
+
         if subscription.isActive {
             pixelHandler.handle(pixelType: .subscriptionIsActive)
         }

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
@@ -271,9 +271,6 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
             _ = try await currentSubscriptionFeatures(forceRefresh: true)
             let subscription = try await getSubscription(cachePolicy: .returnCacheDataDontLoad)
             Logger.subscription.log("Subscription is \(subscription.isActive ? "active" : "not active", privacy: .public)")
-            if subscription.isActive {
-                pixelHandler.handle(pixelType: .subscriptionIsActive)
-            }
         } catch SubscriptionEndpointServiceError.noData {
             Logger.subscription.log("No Subscription available")
             clearSubscriptionCache()
@@ -288,25 +285,29 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
             throw SubscriptionEndpointServiceError.noData
         }
 
+        var subscription: PrivacyProSubscription
         // NOTE: This is ugly, the subscription cache will be moved from the endpoint service to here and handled properly https://app.asana.com/0/0/1209015691872191
         switch cachePolicy {
-
         case .reloadIgnoringLocalCacheData:
             let tokenContainer = try await getTokenContainer(policy: .localValid)
-            return try await subscriptionEndpointService.getSubscription(accessToken: tokenContainer.accessToken,
-                                                                         cachePolicy: cachePolicy)
-
+            subscription = try await subscriptionEndpointService.getSubscription(accessToken: tokenContainer.accessToken,
+                                                                                 cachePolicy: cachePolicy)
         case .returnCacheDataElseLoad:
-            guard let tokenContainer = try? await getTokenContainer(policy: .localValid) else {
-                return try await getSubscription(cachePolicy: .returnCacheDataDontLoad)
+            if let tokenContainer = try? await getTokenContainer(policy: .localValid) {
+                subscription = try await subscriptionEndpointService.getSubscription(accessToken: tokenContainer.accessToken,
+                                                                                     cachePolicy: .returnCacheDataElseLoad)
+            } else {
+                subscription = try await getSubscription(cachePolicy: .returnCacheDataDontLoad)
             }
-            return try await subscriptionEndpointService.getSubscription(accessToken: tokenContainer.accessToken,
-                                                                         cachePolicy: .returnCacheDataElseLoad)
-
         case .returnCacheDataDontLoad:
-            return try await subscriptionEndpointService.getSubscription(accessToken: "",
-                                                                         cachePolicy: .returnCacheDataDontLoad)
+            subscription = try await subscriptionEndpointService.getSubscription(accessToken: "",
+                                                                                 cachePolicy: .returnCacheDataDontLoad)
         }
+        
+        if subscription.isActive {
+            pixelHandler.handle(pixelType: .subscriptionIsActive)
+        }
+        return subscription
     }
 
     public func isSubscriptionPresent() -> Bool {

--- a/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/MockPixelHandler.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/MockPixelHandler.swift
@@ -1,0 +1,28 @@
+//
+//  MockPixelHandler.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Subscription
+
+public struct MockPixelHandler: SubscriptionPixelHandler {
+
+    public init() {}
+
+    public func handle(pixelType: Subscription.SubscriptionPixelType) {
+        print("Pixel fired: \(pixelType)")
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/MockPixelHandler.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/MockPixelHandler.swift
@@ -17,12 +17,13 @@
 //
 
 import Subscription
+import os.log
 
 public struct MockPixelHandler: SubscriptionPixelHandler {
 
     public init() {}
 
     public func handle(pixelType: Subscription.SubscriptionPixelType) {
-        print("Pixel fired: \(pixelType)")
+        Logger.subscription.debug("Pixel fired: \(String(describing: pixelType))")
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests+CustomURL.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests+CustomURL.swift
@@ -37,7 +37,7 @@ extension SubscriptionManagerV2Tests {
             oAuthClient: mockOAuthClient,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: subscriptionEnvironment,
-            pixelHandler: { _ in },
+            pixelHandler: MockPixelHandler(),
             isInternalUserEnabled: isInternalUserEnabled
         )
 
@@ -62,7 +62,7 @@ extension SubscriptionManagerV2Tests {
             oAuthClient: mockOAuthClient,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: subscriptionEnvironment,
-            pixelHandler: { _ in },
+            pixelHandler: MockPixelHandler(),
             isInternalUserEnabled: isInternalUserEnabled
         )
 
@@ -85,7 +85,7 @@ extension SubscriptionManagerV2Tests {
             oAuthClient: mockOAuthClient,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: subscriptionEnvironment,
-            pixelHandler: { _ in },
+            pixelHandler: MockPixelHandler(),
             isInternalUserEnabled: isInternalUserEnabled
         )
 

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests+Redirect.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests+Redirect.swift
@@ -58,7 +58,7 @@ extension SubscriptionManagerV2Tests {
             oAuthClient: mockOAuthClient,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: stagingEnvironment,
-            pixelHandler: { _ in },
+            pixelHandler: MockPixelHandler(),
             tokenRecoveryHandler: {
                 if let overrideTokenResponse = self.overrideTokenResponseInRecoveryHandler {
                     self.mockOAuthClient.getTokensResponse = overrideTokenResponse

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests.swift
@@ -49,7 +49,7 @@ class SubscriptionManagerV2Tests: XCTestCase {
             oAuthClient: mockOAuthClient,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: SubscriptionEnvironment(serviceEnvironment: .production, purchasePlatform: .appStore),
-            pixelHandler: { _ in }
+            pixelHandler: MockPixelHandler()
         )
 
         subscriptionManager.tokenRecoveryHandler = {
@@ -138,7 +138,7 @@ class SubscriptionManagerV2Tests: XCTestCase {
             oAuthClient: mockOAuthClient,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: environment,
-            pixelHandler: { _ in }
+            pixelHandler: MockPixelHandler()
         )
 
         let helpURL = subscriptionManager.url(for: .purchase)
@@ -196,7 +196,7 @@ class SubscriptionManagerV2Tests: XCTestCase {
             oAuthClient: mockOAuthClient,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: productionEnvironment,
-            pixelHandler: { _ in }
+            pixelHandler: MockPixelHandler()
         )
 
         // When
@@ -215,7 +215,7 @@ class SubscriptionManagerV2Tests: XCTestCase {
             oAuthClient: mockOAuthClient,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: stagingEnvironment,
-            pixelHandler: { _ in }
+            pixelHandler: MockPixelHandler()
         )
 
         // When

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/PrivacyProSubscriptionV2IntegrationTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/PrivacyProSubscriptionV2IntegrationTests.swift
@@ -54,16 +54,13 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
         storePurchaseManager = StorePurchaseManagerMockV2()
         let subscriptionEndpointService = DefaultSubscriptionEndpointServiceV2(apiService: apiService,
                                                                                baseURL: subscriptionEnvironment.serviceEnvironment.url)
-        let pixelHandler: SubscriptionManagerV2.PixelHandler = { type in
-            print("Pixel fired: \(type)")
-        }
         subscriptionFeatureFlagger = FeatureFlaggerMapping<SubscriptionFeatureFlags>(mapping: { $0.defaultState })
 
         subscriptionManager = DefaultSubscriptionManagerV2(storePurchaseManager: storePurchaseManager,
                                                            oAuthClient: authClient,
                                                            subscriptionEndpointService: subscriptionEndpointService,
                                                            subscriptionEnvironment: subscriptionEnvironment,
-                                                           pixelHandler: pixelHandler)
+                                                           pixelHandler: MockPixelHandler())
 
         appStoreRestoreFlow = DefaultAppStoreRestoreFlowV2(subscriptionManager: subscriptionManager,
                                                            storePurchaseManager: storePurchaseManager)

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1381,6 +1381,8 @@
 		F1D2D2572D71F6BD00985A2C /* SubscriptionSettingsViewModelV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D2D2562D71F6BD00985A2C /* SubscriptionSettingsViewModelV2.swift */; };
 		F1D43AFA2B99C1D300BAB743 /* BareBonesBrowserKit in Frameworks */ = {isa = PBXBuildFile; productRef = F1D43AF92B99C1D300BAB743 /* BareBonesBrowserKit */; };
 		F1D43AFC2B99C56000BAB743 /* RootDebugViewController+VanillaBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D43AFB2B99C56000BAB743 /* RootDebugViewController+VanillaBrowser.swift */; };
+		F1D4472D2D9EB2470085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D4472C2D9EB2470085809A /* AuthV2PixelHandler.swift */; };
+		F1D4472E2D9EB2470085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D4472C2D9EB2470085809A /* AuthV2PixelHandler.swift */; };
 		F1D477C61F2126CC0031ED49 /* OmniBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D477C51F2126CC0031ED49 /* OmniBarState.swift */; };
 		F1D477C91F2139410031ED49 /* SmallOmniBarStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D477C81F2139410031ED49 /* SmallOmniBarStateTests.swift */; };
 		F1D477CB1F2149C40031ED49 /* Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D477CA1F2149C40031ED49 /* Type.swift */; };
@@ -3502,6 +3504,7 @@
 		F1CB8EA21F26B39000A7171B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		F1D2D2562D71F6BD00985A2C /* SubscriptionSettingsViewModelV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionSettingsViewModelV2.swift; sourceTree = "<group>"; };
 		F1D43AFB2B99C56000BAB743 /* RootDebugViewController+VanillaBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RootDebugViewController+VanillaBrowser.swift"; sourceTree = "<group>"; };
+		F1D4472C2D9EB2470085809A /* AuthV2PixelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthV2PixelHandler.swift; sourceTree = "<group>"; };
 		F1D477C51F2126CC0031ED49 /* OmniBarState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OmniBarState.swift; sourceTree = "<group>"; };
 		F1D477C81F2139410031ED49 /* SmallOmniBarStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SmallOmniBarStateTests.swift; sourceTree = "<group>"; };
 		F1D477CA1F2149C40031ED49 /* Type.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Type.swift; sourceTree = "<group>"; };
@@ -6585,6 +6588,7 @@
 		D664C7922B289AA000CBFA76 /* Subscription */ = {
 			isa = PBXGroup;
 			children = (
+				F1D4472C2D9EB2470085809A /* AuthV2PixelHandler.swift */,
 				D6D95CE42B6DA3F200960317 /* AsyncHeadlessWebview */,
 				1E53508E2C7C9A1F00818DAA /* DefaultSubscriptionManager+AccountManagerKeychainAccessDelegate.swift */,
 				D664C7962B289AA000CBFA76 /* Extensions */,
@@ -8629,6 +8633,7 @@
 				BDFF03232BA3D8E300F324C9 /* NetworkProtectionFeatureVisibility.swift in Sources */,
 				021440762C7FAB4100426724 /* ConfigurationStore.swift in Sources */,
 				021440742C7FAB1900426724 /* ConfigurationManager.swift in Sources */,
+				F1D4472E2D9EB2470085809A /* AuthV2PixelHandler.swift in Sources */,
 				EEEB80A32A421CE600386378 /* NetworkProtectionPacketTunnelProvider.swift in Sources */,
 				0214407A2C7FB28F00426724 /* VPNAgentConfigurationURLProvider.swift in Sources */,
 				EE3766DE2AC5945500AAB575 /* NetworkProtectionUNNotificationPresenter.swift in Sources */,
@@ -9121,6 +9126,7 @@
 				CBD79F4D2D130F6500DBB45A /* Simulated.swift in Sources */,
 				37A6A8FE2AFD0208008580A3 /* FaviconsFetcherOnboarding.swift in Sources */,
 				F1CA3C3B1F045B65005FADB3 /* Authenticator.swift in Sources */,
+				F1D4472D2D9EB2470085809A /* AuthV2PixelHandler.swift in Sources */,
 				CBD4F13D279EBFA000B20FD7 /* HomeMessageCollectionViewCell.swift in Sources */,
 				8505836D219F424500ED4EDB /* Point.swift in Sources */,
 				3158461A281B08F5004ADB8B /* AutofillLoginListViewModel.swift in Sources */,

--- a/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
@@ -195,23 +195,7 @@ final class AppDependencyProvider: DependencyProvider {
                 }
             }
             let storePurchaseManager = DefaultStorePurchaseManagerV2(subscriptionFeatureMappingCache: subscriptionEndpointService)
-            let pixelHandler: SubscriptionManagerV2.PixelHandler = { type in
-                switch type {
-                case .invalidRefreshToken:
-                    DailyPixel.fireDailyAndCount(pixel: .privacyProInvalidRefreshTokenDetected)
-                case .subscriptionIsActive:
-                    DailyPixel.fire(pixel: .privacyProSubscriptionActive)
-                case .migrationStarted:
-                    DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2MigrationStarted)
-                case .migrationFailed(let error):
-                    DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2MigrationFailed, withAdditionalParameters: ["error": error.localizedDescription])
-                case .migrationSucceeded:
-                    DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2MigrationSucceeded)
-                case .getTokensError(let policy, let error):
-                    DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2GetTokensError, withAdditionalParameters: ["error": error.localizedDescription,
-                                                                                                                    "policycache": policy.description])
-                }
-            }
+            let pixelHandler = AuthV2PixelHandler(source: .mainApp)
             let subscriptionManager = DefaultSubscriptionManagerV2(storePurchaseManager: storePurchaseManager,
                                                                    oAuthClient: authClient,
                                                                    subscriptionEndpointService: subscriptionEndpointService,

--- a/iOS/DuckDuckGo/Subscription/AuthV2PixelHandler.swift
+++ b/iOS/DuckDuckGo/Subscription/AuthV2PixelHandler.swift
@@ -39,8 +39,14 @@ public struct AuthV2PixelHandler: SubscriptionPixelHandler {
 
     let source: Source
 
+    struct Defaults {
+        static let errorKey = "error"
+        static let policyCacheKey = "policycache"
+        static let sourceKey = "source"
+    }
+
     public func handle(pixelType: Subscription.SubscriptionPixelType) {
-        let sourceParam = ["source": source.description]
+        let sourceParam = [Defaults.sourceKey: source.description]
         switch pixelType {
         case .invalidRefreshToken:
             DailyPixel.fireDailyAndCount(pixel: .privacyProInvalidRefreshTokenDetected, withAdditionalParameters: sourceParam)
@@ -49,12 +55,12 @@ public struct AuthV2PixelHandler: SubscriptionPixelHandler {
         case .migrationStarted:
             DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2MigrationStarted, withAdditionalParameters: sourceParam)
         case .migrationFailed(let error):
-            DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2MigrationFailed, withAdditionalParameters: ["error": error.localizedDescription].merging(sourceParam) { $1 })
+            DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2MigrationFailed, withAdditionalParameters: [Defaults.errorKey: error.localizedDescription].merging(sourceParam) { $1 })
         case .migrationSucceeded:
             DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2MigrationSucceeded, withAdditionalParameters: sourceParam)
         case .getTokensError(let policy, let error):
-            DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2GetTokensError, withAdditionalParameters: ["error": error.localizedDescription,
-                                                                                                            "policycache": policy.description].merging(sourceParam) { $1 })
+            DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2GetTokensError, withAdditionalParameters: [Defaults.errorKey: error.localizedDescription,
+                                                                                                            Defaults.policyCacheKey: policy.description].merging(sourceParam) { $1 })
         }
     }
 

--- a/iOS/DuckDuckGo/Subscription/AuthV2PixelHandler.swift
+++ b/iOS/DuckDuckGo/Subscription/AuthV2PixelHandler.swift
@@ -1,5 +1,6 @@
 //
 //  AuthV2PixelHandler.swift
+//  DuckDuckGo
 //
 //  Copyright © 2025 DuckDuckGo. All rights reserved.
 //
@@ -48,12 +49,12 @@ public struct AuthV2PixelHandler: SubscriptionPixelHandler {
         case .migrationStarted:
             DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2MigrationStarted, withAdditionalParameters: sourceParam)
         case .migrationFailed(let error):
-            DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2MigrationFailed, withAdditionalParameters: ["error": error.localizedDescription].merging(sourceParam){ $1 } )
+            DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2MigrationFailed, withAdditionalParameters: ["error": error.localizedDescription].merging(sourceParam) { $1 })
         case .migrationSucceeded:
             DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2MigrationSucceeded, withAdditionalParameters: sourceParam)
         case .getTokensError(let policy, let error):
             DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2GetTokensError, withAdditionalParameters: ["error": error.localizedDescription,
-                                                                                                            "policycache": policy.description].merging(sourceParam){ $1 } )
+                                                                                                            "policycache": policy.description].merging(sourceParam) { $1 })
         }
     }
 

--- a/iOS/DuckDuckGo/Subscription/AuthV2PixelHandler.swift
+++ b/iOS/DuckDuckGo/Subscription/AuthV2PixelHandler.swift
@@ -1,0 +1,60 @@
+//
+//  AuthV2PixelHandler.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Subscription
+import Core
+
+public struct AuthV2PixelHandler: SubscriptionPixelHandler {
+
+    public enum Source {
+        case mainApp
+        case systemExtension
+        
+        var description: String {
+            switch self {
+            case .mainApp:
+                return "MainApp"
+            case .systemExtension:
+                return "SysExt"
+            }
+        }
+    }
+
+    let source: Source
+
+    public func handle(pixelType: Subscription.SubscriptionPixelType) {
+        let sourceParam = ["source": source.description]
+        switch pixelType {
+        case .invalidRefreshToken:
+            DailyPixel.fireDailyAndCount(pixel: .privacyProInvalidRefreshTokenDetected, withAdditionalParameters: sourceParam)
+        case .subscriptionIsActive:
+            DailyPixel.fire(pixel: .privacyProSubscriptionActive)
+        case .migrationStarted:
+            DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2MigrationStarted, withAdditionalParameters: sourceParam)
+        case .migrationFailed(let error):
+            DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2MigrationFailed, withAdditionalParameters: ["error": error.localizedDescription].merging(sourceParam){ $1 } )
+        case .migrationSucceeded:
+            DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2MigrationSucceeded, withAdditionalParameters: sourceParam)
+        case .getTokensError(let policy, let error):
+            DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2GetTokensError, withAdditionalParameters: ["error": error.localizedDescription,
+                                                                                                            "policycache": policy.description].merging(sourceParam){ $1 } )
+        }
+    }
+
+}

--- a/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -483,11 +483,12 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
             let subscriptionEndpointService = DefaultSubscriptionEndpointServiceV2(apiService: APIServiceFactory.makeAPIServiceForSubscription(),
                                                                                    baseURL: subscriptionEnvironment.serviceEnvironment.url)
             let storePurchaseManager = DefaultStorePurchaseManagerV2(subscriptionFeatureMappingCache: subscriptionEndpointService)
-
+            let pixelHandler = AuthV2PixelHandler(source: .systemExtension)
             let subscriptionManager = DefaultSubscriptionManagerV2(storePurchaseManager: storePurchaseManager,
                                                                    oAuthClient: authClient,
                                                                    subscriptionEndpointService: subscriptionEndpointService,
                                                                    subscriptionEnvironment: subscriptionEnvironment,
+                                                                   pixelHandler: pixelHandler,
                                                                    tokenRecoveryHandler: {
                 Logger.networkProtection.error("Expired refresh token detected")
             },

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -3416,12 +3416,12 @@
 		F1D447232D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */; };
 		F1D447242D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */; };
 		F1D447252D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */; };
-		F1D447262D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */; };
 		F1D447272D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */; };
 		F1D447282D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */; };
 		F1D447292D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */; };
 		F1D4472A2D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */; };
 		F1D4472B2D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */; };
+		F1D4472F2D9ECEE90085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */; };
 		F1DA51862BF607D200CF29FA /* SubscriptionAttributionPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DA51842BF607D200CF29FA /* SubscriptionAttributionPixelHandler.swift */; };
 		F1DA51872BF607D200CF29FA /* SubscriptionAttributionPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DA51842BF607D200CF29FA /* SubscriptionAttributionPixelHandler.swift */; };
 		F1DA51882BF607D200CF29FA /* SubscriptionAttributionPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DA51842BF607D200CF29FA /* SubscriptionAttributionPixelHandler.swift */; };
@@ -13423,6 +13423,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				02FDA6642C765D0F0024CD8B /* VPNAgentConfigurationURLProvider.swift in Sources */,
+				F1D4472F2D9ECEE90085809A /* AuthV2PixelHandler.swift in Sources */,
 				7B2DDCFB2A93B25F0039D884 /* KeychainType+ClientDefault.swift in Sources */,
 				B6F92BA32A691583002ABA6B /* UserDefaultsWrapper.swift in Sources */,
 				4BA7C4DB2B3F63AE00AFE511 /* NetworkExtensionController.swift in Sources */,
@@ -13578,7 +13579,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B97CD5C2B7E0BBB004FEF43 /* UserDefaultsWrapper.swift in Sources */,
-				F1D447262D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */,
 				7BDA36F52B7E055800AD5388 /* MacTransparentProxyProvider.swift in Sources */,
 				7B97CD5D2B7E0BCE004FEF43 /* BundleExtension.swift in Sources */,
 			);

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -3413,6 +3413,15 @@
 		F1D43AEF2B98D8DF00BAB743 /* MainMenuActions+VanillaBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D43AED2B98D8DF00BAB743 /* MainMenuActions+VanillaBrowser.swift */; };
 		F1D43AF32B98E47800BAB743 /* BareBonesBrowserKit in Frameworks */ = {isa = PBXBuildFile; productRef = F1D43AF22B98E47800BAB743 /* BareBonesBrowserKit */; };
 		F1D43AF52B98E48900BAB743 /* BareBonesBrowserKit in Frameworks */ = {isa = PBXBuildFile; productRef = F1D43AF42B98E48900BAB743 /* BareBonesBrowserKit */; };
+		F1D447232D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */; };
+		F1D447242D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */; };
+		F1D447252D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */; };
+		F1D447262D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */; };
+		F1D447272D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */; };
+		F1D447282D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */; };
+		F1D447292D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */; };
+		F1D4472A2D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */; };
+		F1D4472B2D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */; };
 		F1DA51862BF607D200CF29FA /* SubscriptionAttributionPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DA51842BF607D200CF29FA /* SubscriptionAttributionPixelHandler.swift */; };
 		F1DA51872BF607D200CF29FA /* SubscriptionAttributionPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DA51842BF607D200CF29FA /* SubscriptionAttributionPixelHandler.swift */; };
 		F1DA51882BF607D200CF29FA /* SubscriptionAttributionPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DA51842BF607D200CF29FA /* SubscriptionAttributionPixelHandler.swift */; };
@@ -5284,6 +5293,7 @@
 		F1D042932BFBA12300A31506 /* DataBrokerProtectionSettings+Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataBrokerProtectionSettings+Environment.swift"; sourceTree = "<group>"; };
 		F1D042982BFBABA100A31506 /* SubscriptionManager+StandardConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SubscriptionManager+StandardConfiguration.swift"; sourceTree = "<group>"; };
 		F1D43AED2B98D8DF00BAB743 /* MainMenuActions+VanillaBrowser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MainMenuActions+VanillaBrowser.swift"; sourceTree = "<group>"; };
+		F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthV2PixelHandler.swift; sourceTree = "<group>"; };
 		F1DA51842BF607D200CF29FA /* SubscriptionAttributionPixelHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionAttributionPixelHandler.swift; sourceTree = "<group>"; };
 		F1DA51852BF607D200CF29FA /* SubscriptionRedirectManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionRedirectManager.swift; sourceTree = "<group>"; };
 		F1F861142C1B25D4005DB446 /* SubscriptionUIHandlerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionUIHandlerMock.swift; sourceTree = "<group>"; };
@@ -10384,6 +10394,7 @@
 			isa = PBXGroup;
 			children = (
 				F1C70D7B2BFF510000599292 /* SubscriptionEnvironment+Default.swift */,
+				F1D447222D9EAA950085809A /* AuthV2PixelHandler.swift */,
 				F1476FBF2C1359FB00EAE46A /* SubscriptionUIHandler.swift */,
 				F1D042932BFBA12300A31506 /* DataBrokerProtectionSettings+Environment.swift */,
 				F118EA7C2BEA2B8700F77634 /* DefaultSubscriptionFeatureAvailability+DefaultInitializer.swift */,
@@ -12242,6 +12253,7 @@
 				3199AF7A2C80734A003AEBDC /* DuckPlayerOnboardingViewModel.swift in Sources */,
 				C1B1CBE22BE1915100B6049C /* DataImportShortcutsViewModel.swift in Sources */,
 				857E5AF62A790B7000FC0FB4 /* PixelExperiment.swift in Sources */,
+				F1D447242D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */,
 				9F33445F2BBFA77F0040CBEB /* BookmarksBarVisibilityManager.swift in Sources */,
 				3706FB58293F65D500E42796 /* LinkButton.swift in Sources */,
 				4B0EF7272B578096009D6481 /* AppVersionExtension.swift in Sources */,
@@ -13331,6 +13343,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4B25377A2A11C01700610219 /* UserText+NetworkProtectionExtensions.swift in Sources */,
+				F1D447272D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */,
 				B65DA5F42A77D3FA00CBEE8D /* BundleExtension.swift in Sources */,
 				4B52354D2C854CB600AFAF64 /* DuckDuckGoUserAgent.swift in Sources */,
 				EE66418D2B9B1981005BCD17 /* NetworkProtectionTokenStore+SubscriptionTokenKeychainStorage.swift in Sources */,
@@ -13359,6 +13372,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				02FDA6632C765D0F0024CD8B /* VPNAgentConfigurationURLProvider.swift in Sources */,
+				F1D447292D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */,
 				B6F92BA22A691580002ABA6B /* UserDefaultsWrapper.swift in Sources */,
 				7BA7CC3A2AD11E2D0042E5CE /* DuckDuckGoVPNAppDelegate.swift in Sources */,
 				7BAF9E4C2A8A3CCA002D3B6E /* UserDefaults+NetworkProtectionShared.swift in Sources */,
@@ -13489,6 +13503,7 @@
 				F1DA51922BF6081C00CF29FA /* AttributionPixelHandler.swift in Sources */,
 				4B4D60A52A0B2EC000BCD287 /* UserText+NetworkProtectionExtensions.swift in Sources */,
 				4BF0E50C2AD2552300FFEC9E /* NetworkProtectionPixelEvent.swift in Sources */,
+				F1D447252D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */,
 				B65DA5F22A77D3C600CBEE8D /* UserDefaultsWrapper.swift in Sources */,
 				F1DA51882BF607D200CF29FA /* SubscriptionAttributionPixelHandler.swift in Sources */,
 				F1FDC93A2BF51F41006B1435 /* VPNSettings+Environment.swift in Sources */,
@@ -13516,6 +13531,7 @@
 				7BC3E43C2D6DF517009787CD /* MacPacketTunnelProvider.swift in Sources */,
 				7BC3E4412D6DF584009787CD /* DuckDuckGoUserAgent.swift in Sources */,
 				7BC3E4382D6DF4FC009787CD /* UserText+NetworkProtectionExtensions.swift in Sources */,
+				F1D447282D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */,
 				7BC3E43B2D6DF510009787CD /* NetworkProtectionNotificationsPresenterFactory.swift in Sources */,
 				7BC3E43D2D6DF51D009787CD /* MacTransparentProxyProvider.swift in Sources */,
 				7BC3E4322D6DF481009787CD /* main.swift in Sources */,
@@ -13562,6 +13578,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B97CD5C2B7E0BBB004FEF43 /* UserDefaultsWrapper.swift in Sources */,
+				F1D447262D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */,
 				7BDA36F52B7E055800AD5388 /* MacTransparentProxyProvider.swift in Sources */,
 				7B97CD5D2B7E0BCE004FEF43 /* BundleExtension.swift in Sources */,
 			);
@@ -13605,6 +13622,7 @@
 				BDD30ACE2D8A2A8A00457A89 /* VPNBypassServiceExtensions.swift in Sources */,
 				9D9AE9212AAA3B450026E7DC /* UserText.swift in Sources */,
 				31ECDA132BED339600AE679F /* DataBrokerAuthenticationManagerBuilder.swift in Sources */,
+				F1D4472A2D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */,
 				F1D0429F2BFBABA100A31506 /* SubscriptionManager+StandardConfiguration.swift in Sources */,
 				31ECDA0E2BED317300AE679F /* BundleExtension.swift in Sources */,
 			);
@@ -13623,6 +13641,7 @@
 				BDD30ACD2D8A2A8A00457A89 /* VPNBypassServiceExtensions.swift in Sources */,
 				9D9AE9222AAA3B450026E7DC /* UserText.swift in Sources */,
 				31ECDA142BED339600AE679F /* DataBrokerAuthenticationManagerBuilder.swift in Sources */,
+				F1D4472B2D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */,
 				F1D042A02BFBABA100A31506 /* SubscriptionManager+StandardConfiguration.swift in Sources */,
 				31ECDA0F2BED317300AE679F /* BundleExtension.swift in Sources */,
 			);
@@ -14271,6 +14290,7 @@
 				AA9FF95D24A1FA1C0039E328 /* TabCollection.swift in Sources */,
 				1DA84D322C119AE70011C80F /* UpdateMenuItemFactory.swift in Sources */,
 				3772BEDE2D019CE90019B9EF /* DefaultsFavoritesActionHandler.swift in Sources */,
+				F1D447232D9EAA950085809A /* AuthV2PixelHandler.swift in Sources */,
 				B6B4D1CF2B0E0DD000C26286 /* DataImportNoDataView.swift in Sources */,
 				B688B4DA273E6D3B0087BEAF /* MainView.swift in Sources */,
 				B61E2CD5294346C000773D8A /* Tab+Navigation.swift in Sources */,

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -309,7 +309,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                                                    featureFlagger: featureFlagger,
                                                                    userDefaults: subscriptionUserDefaults,
                                                                    canPerformAuthMigration: true,
-                                                                   canHandlePixels: true)
+                                                                   pixelHandlingSource: .mainApp)
 
             // Expired refresh token recovery
             if #available(iOS 15.0, macOS 12.0, *) {

--- a/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
@@ -472,11 +472,13 @@ final class MacPacketTunnelProvider: PacketTunnelProvider {
 
         let subscriptionEndpointServiceV2 = DefaultSubscriptionEndpointServiceV2(apiService: APIServiceFactory.makeAPIServiceForSubscription(),
                                                                                baseURL: subscriptionEnvironment.serviceEnvironment.url)
+        let pixelHandler = AuthV2PixelHandler(source: .systemExtension)
         let subscriptionManager = DefaultSubscriptionManagerV2(oAuthClient: authClient,
-                                                             subscriptionEndpointService: subscriptionEndpointServiceV2,
-                                                             subscriptionEnvironment: subscriptionEnvironment,
-                                                             tokenRecoveryHandler: nil,
-                                                             initForPurchase: false)
+                                                               subscriptionEndpointService: subscriptionEndpointServiceV2,
+                                                               subscriptionEnvironment: subscriptionEnvironment,
+                                                               pixelHandler: pixelHandler,
+                                                               tokenRecoveryHandler: nil,
+                                                               initForPurchase: false)
 
         let entitlementsCheck: (() async -> Result<Bool, Error>) = {
             Logger.networkProtection.log("Subscription Entitlements check...")

--- a/macOS/DuckDuckGo/Statistics/PrivacyProPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/PrivacyProPixel.swift
@@ -133,19 +133,25 @@ enum PrivacyProPixel: PixelKitEventV2 {
         return nil
     }
 
+    private struct PrivacyProPixelsDefaults {
+        static let errorKey = "error"
+        static let policyCacheKey = "policycache"
+        static let sourceKey = "source"
+    }
+
     var parameters: [String: String]? {
         switch self {
         case .privacyProInvalidRefreshTokenDetected(let source),
                 .privacyProAuthV2MigrationStarted(let source),
                 .privacyProAuthV2MigrationSucceeded(let source):
-            return ["source": source.description]
+            return [PrivacyProPixelsDefaults.sourceKey: source.description]
         case .privacyProAuthV2GetTokensError(let policy, let source, let error):
-            return ["error": error.localizedDescription,
-                    "policycache": policy.description,
-                    "source": source.description]
+            return [PrivacyProPixelsDefaults.errorKey: error.localizedDescription,
+                    PrivacyProPixelsDefaults.policyCacheKey: policy.description,
+                    PrivacyProPixelsDefaults.sourceKey: source.description]
         case .privacyProAuthV2MigrationFailed(let source, let error):
-            return ["error": error.localizedDescription,
-                    "source": source.description]
+            return [PrivacyProPixelsDefaults.errorKey: error.localizedDescription,
+                    PrivacyProPixelsDefaults.sourceKey: source.description]
         default:
             return nil
         }

--- a/macOS/DuckDuckGo/Statistics/PrivacyProPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/PrivacyProPixel.swift
@@ -70,13 +70,13 @@ enum PrivacyProPixel: PixelKitEventV2 {
     case privacyProAddEmailSuccess
     case privacyProWelcomeFAQClick
     // Auth v2
-    case privacyProInvalidRefreshTokenDetected
+    case privacyProInvalidRefreshTokenDetected(AuthV2PixelHandler.Source)
     case privacyProInvalidRefreshTokenSignedOut
     case privacyProInvalidRefreshTokenRecovered
-    case privacyProAuthV2MigrationStarted
-    case privacyProAuthV2MigrationFailed(Error)
-    case privacyProAuthV2MigrationSucceeded
-    case privacyProAuthV2GetTokensError(AuthTokensCachePolicy, Error)
+    case privacyProAuthV2MigrationStarted(AuthV2PixelHandler.Source)
+    case privacyProAuthV2MigrationFailed(AuthV2PixelHandler.Source, Error)
+    case privacyProAuthV2MigrationSucceeded(AuthV2PixelHandler.Source)
+    case privacyProAuthV2GetTokensError(AuthTokensCachePolicy, AuthV2PixelHandler.Source, Error)
 
     var name: String {
         switch self {
@@ -135,11 +135,17 @@ enum PrivacyProPixel: PixelKitEventV2 {
 
     var parameters: [String: String]? {
         switch self {
-        case .privacyProAuthV2GetTokensError(let policy, let error):
+        case .privacyProInvalidRefreshTokenDetected(let source),
+                .privacyProAuthV2MigrationStarted(let source),
+                .privacyProAuthV2MigrationSucceeded(let source):
+            return ["source": source.description]
+        case .privacyProAuthV2GetTokensError(let policy, let source, let error):
             return ["error": error.localizedDescription,
-                    "policycache": policy.description]
-        case .privacyProAuthV2MigrationFailed(let error):
-            return ["error": error.localizedDescription]
+                    "policycache": policy.description,
+                    "source": source.description]
+        case .privacyProAuthV2MigrationFailed(let source, let error):
+            return ["error": error.localizedDescription,
+                    "source": source.description]
         default:
             return nil
         }

--- a/macOS/DuckDuckGo/Subscription/AuthV2PixelHandler.swift
+++ b/macOS/DuckDuckGo/Subscription/AuthV2PixelHandler.swift
@@ -1,0 +1,64 @@
+//
+//  AuthV2PixelHandler.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Subscription
+import PixelKit
+
+public struct AuthV2PixelHandler: SubscriptionPixelHandler {
+
+    public enum Source {
+        case mainApp
+        case systemExtension
+        case vpnApp
+        case dbp
+        
+        var description: String {
+            switch self {
+            case .mainApp:
+                return "MainApp"
+            case .systemExtension:
+                return "SysExt"
+            case .vpnApp:
+                return "VPNApp"
+            case .dbp:
+                return "DBP"
+            }
+        }
+    }
+
+    let source: Source
+
+    public func handle(pixelType: Subscription.SubscriptionPixelType) {
+        switch pixelType {
+        case .invalidRefreshToken:
+            PixelKit.fire(PrivacyProPixel.privacyProInvalidRefreshTokenDetected(source), frequency: .dailyAndCount)
+        case .subscriptionIsActive:
+            PixelKit.fire(PrivacyProPixel.privacyProSubscriptionActive, frequency: .daily)
+        case .migrationStarted:
+            PixelKit.fire(PrivacyProPixel.privacyProAuthV2MigrationStarted(source), frequency: .dailyAndCount)
+        case .migrationFailed(let error):
+            PixelKit.fire(PrivacyProPixel.privacyProAuthV2MigrationFailed(source, error), frequency: .dailyAndCount)
+        case .migrationSucceeded:
+            PixelKit.fire(PrivacyProPixel.privacyProAuthV2MigrationSucceeded(source), frequency: .dailyAndCount)
+        case .getTokensError(let policy, let error):
+            PixelKit.fire(PrivacyProPixel.privacyProAuthV2GetTokensError(policy, source, error), frequency: .dailyAndCount)
+        }
+    }
+
+}

--- a/macOS/DuckDuckGo/Subscription/AuthV2PixelHandler.swift
+++ b/macOS/DuckDuckGo/Subscription/AuthV2PixelHandler.swift
@@ -27,7 +27,7 @@ public struct AuthV2PixelHandler: SubscriptionPixelHandler {
         case systemExtension
         case vpnApp
         case dbp
-        
+
         var description: String {
             switch self {
             case .mainApp:

--- a/macOS/DuckDuckGoDBPBackgroundAgent/DuckDuckGoDBPBackgroundAgentAppDelegate.swift
+++ b/macOS/DuckDuckGoDBPBackgroundAgent/DuckDuckGoDBPBackgroundAgentAppDelegate.swift
@@ -102,7 +102,7 @@ final class DuckDuckGoDBPBackgroundAgentAppDelegate: NSObject, NSApplicationDele
                                                                environment: subscriptionEnvironment,
                                                                userDefaults: subscriptionUserDefaults,
                                                                canPerformAuthMigration: false,
-                                                               canHandlePixels: false)
+                                                               pixelHandlingSource: .dbp)
         }
     }
 

--- a/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
+++ b/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
@@ -75,7 +75,7 @@ final class DuckDuckGoVPNApplication: NSApplication {
                                                              environment: subscriptionEnvironment,
                                                              userDefaults: subscriptionUserDefaults,
                                                              canPerformAuthMigration: false,
-                                                             canHandlePixels: false)
+                                                             pixelHandlingSource: .vpnApp)
 
         _delegate = DuckDuckGoVPNAppDelegate(accountManager: accountManager,
                                              subscriptionManagerV2: subscriptionManagerV2,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1209710701141726
CC: @miasma13

### Description

All Subscription AuthV2 related pixels are now fired from the same struct, and now all parts of the iOS and macOS apps are firing them.
I've also added a`source` parameter to every relevant pixel that will be usefull for filtering them in the grafana board

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)