### PR TITLE
Apply corner radius to navigation bar buttons depending on style

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -53,6 +53,7 @@ final class NavigationBarViewController: NSViewController {
     @IBOutlet weak var addressBarContainer: NSView!
     @IBOutlet weak var daxLogo: NSImageView!
     @IBOutlet weak var addressBarStack: NSStackView!
+
     @IBOutlet weak var menuButtons: NSStackView!
 
     @IBOutlet weak var aiChatButton: MouseOverButton!
@@ -192,6 +193,7 @@ final class NavigationBarViewController: NSViewController {
         addressBarContainer.wantsLayer = true
         addressBarContainer.layer?.masksToBounds = false
 
+        setupNavigationButtonsCornerRadius()
         setupNavigationButtonMenus()
         addContextMenu()
 
@@ -686,6 +688,20 @@ final class NavigationBarViewController: NSViewController {
         goBackButton.toolTip = UserText.navigateBackTooltip
         goForwardButton.toolTip = UserText.navigateForwardTooltip
         refreshOrStopButton.toolTip = UserText.refreshPageTooltip
+    }
+
+    private func setupNavigationButtonsCornerRadius() {
+        goBackButton.setCornerRadius(visualStyleManager.style.toolbarButtonsCornerRadius)
+        goForwardButton.setCornerRadius(visualStyleManager.style.toolbarButtonsCornerRadius)
+        refreshOrStopButton.setCornerRadius(visualStyleManager.style.toolbarButtonsCornerRadius)
+        homeButton.setCornerRadius(visualStyleManager.style.toolbarButtonsCornerRadius)
+
+        aiChatButton.setCornerRadius(visualStyleManager.style.toolbarButtonsCornerRadius)
+        downloadsButton.setCornerRadius(visualStyleManager.style.toolbarButtonsCornerRadius)
+        passwordManagementButton.setCornerRadius(visualStyleManager.style.toolbarButtonsCornerRadius)
+        bookmarkListButton.setCornerRadius(visualStyleManager.style.toolbarButtonsCornerRadius)
+        networkProtectionButton.setCornerRadius(visualStyleManager.style.toolbarButtonsCornerRadius)
+        optionsButton.setCornerRadius(visualStyleManager.style.toolbarButtonsCornerRadius)
     }
 
     private func subscribeToSelectedTabViewModel() {

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
@@ -24,6 +24,8 @@ protocol VisualStyleProviding {
     func addressBarHeight(for type: AddressBarSizeClass) -> CGFloat
     func addressBarTopPadding(for type: AddressBarSizeClass) -> CGFloat
     func addressBarBottomPadding(for type: AddressBarSizeClass) -> CGFloat
+
+    var toolbarButtonsCornerRadius: CGFloat { get }
 }
 
 protocol VisualStyleManagerProviding {
@@ -61,6 +63,8 @@ struct VisualStyle: VisualStyleProviding {
     private let addressBarBottomPaddingForHomePage: CGFloat
     private let addressBarBottomPaddingForPopUpWindow: CGFloat
 
+    let toolbarButtonsCornerRadius: CGFloat
+
     func addressBarHeight(for type: AddressBarSizeClass) -> CGFloat {
         switch type {
         case .default: return addressBarHeightForDefault
@@ -94,7 +98,8 @@ struct VisualStyle: VisualStyleProviding {
                            addressBarTopPaddingForPopUpWindow: 0,
                            addressBarBottomPaddingForDefault: 6,
                            addressBarBottomPaddingForHomePage: 8,
-                           addressBarBottomPaddingForPopUpWindow: 0)
+                           addressBarBottomPaddingForPopUpWindow: 0,
+                           toolbarButtonsCornerRadius: 4)
     }
 
     static var current: VisualStyleProviding {
@@ -106,7 +111,8 @@ struct VisualStyle: VisualStyleProviding {
                            addressBarTopPaddingForPopUpWindow: 6,
                            addressBarBottomPaddingForDefault: 6,
                            addressBarBottomPaddingForHomePage: 6,
-                           addressBarBottomPaddingForPopUpWindow: 6)
+                           addressBarBottomPaddingForPopUpWindow: 6,
+                           toolbarButtonsCornerRadius: 9)
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204006570077678/1209793701087213/f
Tech Design URL:
CC:

### Description
The corner radius of the navigation bar buttons will be changed depending on the style. It will be 9px for the new/current style and 4px for the legacy.

| Before | After |
| ------ | ----- |
![Screenshot 2025-04-03 at 9 56 52 AM](https://github.com/user-attachments/assets/18cb5a1c-1ea2-4702-b947-551f25221fd7)|![Screenshot 2025-04-03 at 9 56 48 AM](https://github.com/user-attachments/assets/57a58958-045d-4e93-bd93-dc869e84a8ce)

### Testing Steps
1. Turn on the override of `visualRefresh`
2. Open a new window
3. Hover the different buttons in the navigation bar
4. Check they are more rounded.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing I can think of.

### Quality Considerations
N/A

### Notes to Reviewer
N/A

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)