### PR TITLE
Fix crashing in tab deallocation check in CI

### DIFF
--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -313,20 +313,24 @@ protocol NewWindowPolicyDecisionMaker {
 
 #if DEBUG
     func addDeallocationChecks(for webView: WKWebView) {
+        /// Deallocation checks cause random crashes in CI for integration tests.
+        /// https://app.asana.com/0/1201037661562251/1209884224558923/f
+        guard AppVersion.runType != .integrationTests else {
+            return
+        }
         let processPool = webView.configuration.processPool
         let webViewValue = NSValue(nonretainedObject: webView)
-        let timeout: TimeInterval = AppVersion.runType == .integrationTests ? 10.0 : 1.0
 
         webView.onDeinit { [weak self] in
             // Tab should deallocate with the WebView
-            self?.ensureObjectDeallocated(after: timeout, do: .interrupt)
+            self?.ensureObjectDeallocated(after: 1.0, do: .interrupt)
 
             // unregister WebView from the ProcessPool
             processPool.webViewsUsingProcessPool.remove(webViewValue)
 
             if processPool.webViewsUsingProcessPool.isEmpty {
                 // when the last WebView is deallocated the ProcessPool should be deallocated
-                processPool.ensureObjectDeallocated(after: timeout, do: .log)
+                processPool.ensureObjectDeallocated(after: 1, do: .log)
                 // by the moment the ProcessPool is dead all the UserContentControllers that were using it should be deallocated
                 let knownUserContentControllers = processPool.knownUserContentControllers
                 processPool.onDeinit {

--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -315,7 +315,7 @@ protocol NewWindowPolicyDecisionMaker {
     func addDeallocationChecks(for webView: WKWebView) {
         let processPool = webView.configuration.processPool
         let webViewValue = NSValue(nonretainedObject: webView)
-        let timeout: TimeInterval = [AppVersion.AppRunType.unitTests, .integrationTests].contains(AppVersion.runType) ? 10.0 : 1.0
+        let timeout: TimeInterval = [AppVersion.AppRunType.unitTests, .integrationTests].contains(AppVersion.runType) ? 1.0 : 1.0
 
         webView.onDeinit { [weak self] in
             // Tab should deallocate with the WebView

--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -315,7 +315,7 @@ protocol NewWindowPolicyDecisionMaker {
     func addDeallocationChecks(for webView: WKWebView) {
         let processPool = webView.configuration.processPool
         let webViewValue = NSValue(nonretainedObject: webView)
-        let timeout: TimeInterval = AppVersion.runType == .integrationTests ? 3.0 : 1.0
+        let timeout: TimeInterval = AppVersion.runType == .integrationTests ? 1.0 : 1.0
 
         webView.onDeinit { [weak self] in
             // Tab should deallocate with the WebView

--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -315,17 +315,18 @@ protocol NewWindowPolicyDecisionMaker {
     func addDeallocationChecks(for webView: WKWebView) {
         let processPool = webView.configuration.processPool
         let webViewValue = NSValue(nonretainedObject: webView)
+        let timeout: TimeInterval = [AppVersion.AppRunType.unitTests, .integrationTests].contains(AppVersion.runType) ? 10.0 : 1.0
 
         webView.onDeinit { [weak self] in
             // Tab should deallocate with the WebView
-            self?.ensureObjectDeallocated(after: 10.0, do: .interrupt)
+            self?.ensureObjectDeallocated(after: timeout, do: .interrupt)
 
             // unregister WebView from the ProcessPool
             processPool.webViewsUsingProcessPool.remove(webViewValue)
 
             if processPool.webViewsUsingProcessPool.isEmpty {
                 // when the last WebView is deallocated the ProcessPool should be deallocated
-                processPool.ensureObjectDeallocated(after: 10, do: .log)
+                processPool.ensureObjectDeallocated(after: timeout, do: .log)
                 // by the moment the ProcessPool is dead all the UserContentControllers that were using it should be deallocated
                 let knownUserContentControllers = processPool.knownUserContentControllers
                 processPool.onDeinit {

--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -315,7 +315,7 @@ protocol NewWindowPolicyDecisionMaker {
     func addDeallocationChecks(for webView: WKWebView) {
         let processPool = webView.configuration.processPool
         let webViewValue = NSValue(nonretainedObject: webView)
-        let timeout: TimeInterval = [AppVersion.AppRunType.unitTests, .integrationTests].contains(AppVersion.runType) ? 1.0 : 1.0
+        let timeout: TimeInterval = [AppVersion.AppRunType.unitTests, .integrationTests].contains(AppVersion.runType) ? 3.0 : 1.0
 
         webView.onDeinit { [weak self] in
             // Tab should deallocate with the WebView

--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -315,7 +315,7 @@ protocol NewWindowPolicyDecisionMaker {
     func addDeallocationChecks(for webView: WKWebView) {
         let processPool = webView.configuration.processPool
         let webViewValue = NSValue(nonretainedObject: webView)
-        let timeout: TimeInterval = AppVersion.runType == .integrationTests ? 3.0 : 1.0
+        let timeout: TimeInterval = AppVersion.runType == .integrationTests ? 10.0 : 1.0
 
         webView.onDeinit { [weak self] in
             // Tab should deallocate with the WebView

--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -318,14 +318,14 @@ protocol NewWindowPolicyDecisionMaker {
 
         webView.onDeinit { [weak self] in
             // Tab should deallocate with the WebView
-            self?.ensureObjectDeallocated(after: 1.0, do: .interrupt)
+            self?.ensureObjectDeallocated(after: 10.0, do: .interrupt)
 
             // unregister WebView from the ProcessPool
             processPool.webViewsUsingProcessPool.remove(webViewValue)
 
             if processPool.webViewsUsingProcessPool.isEmpty {
                 // when the last WebView is deallocated the ProcessPool should be deallocated
-                processPool.ensureObjectDeallocated(after: 1, do: .log)
+                processPool.ensureObjectDeallocated(after: 10, do: .log)
                 // by the moment the ProcessPool is dead all the UserContentControllers that were using it should be deallocated
                 let knownUserContentControllers = processPool.knownUserContentControllers
                 processPool.onDeinit {

--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -315,7 +315,7 @@ protocol NewWindowPolicyDecisionMaker {
     func addDeallocationChecks(for webView: WKWebView) {
         let processPool = webView.configuration.processPool
         let webViewValue = NSValue(nonretainedObject: webView)
-        let timeout: TimeInterval = [AppVersion.AppRunType.unitTests, .integrationTests].contains(AppVersion.runType) ? 3.0 : 1.0
+        let timeout: TimeInterval = AppVersion.runType == .integrationTests ? 1.0 : 1.0
 
         webView.onDeinit { [weak self] in
             // Tab should deallocate with the WebView

--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -315,7 +315,7 @@ protocol NewWindowPolicyDecisionMaker {
     func addDeallocationChecks(for webView: WKWebView) {
         let processPool = webView.configuration.processPool
         let webViewValue = NSValue(nonretainedObject: webView)
-        let timeout: TimeInterval = AppVersion.runType == .integrationTests ? 1.0 : 1.0
+        let timeout: TimeInterval = AppVersion.runType == .integrationTests ? 3.0 : 1.0
 
         webView.onDeinit { [weak self] in
             // Tab should deallocate with the WebView


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1209884224558923/f

### Description
This change disables tab deallocation check for integration tests runs.

### Testing Steps
Verify that CI is green.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)