### PR TITLE
Add UI based on site theme color

### DIFF
--- a/iOS/Core/UIColorExtension.swift
+++ b/iOS/Core/UIColorExtension.swift
@@ -121,4 +121,10 @@ extension UIColor {
         return self
     }
 
+    var brightnessPercentage: CGFloat {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        getRed(&r, green: &g, blue: &b, alpha: &a)
+        return (r * 299 + g * 587 + b * 114) / 1000 * 100
+    }
+
 }

--- a/iOS/Core/UIColorExtension.swift
+++ b/iOS/Core/UIColorExtension.swift
@@ -101,4 +101,24 @@ extension UIColor {
         )
     }
 
+    /// Adjusts the brightness of the color by the specified amount
+    /// - Parameter amount: Value between -1.0 and 1.0. Positive values make the color brighter, negative values make it darker
+    /// - Returns: A new UIColor with adjusted brightness
+    func adjustBrightness(by amount: CGFloat) -> UIColor {
+        var hue: CGFloat = 0
+        var saturation: CGFloat = 0
+        var brightness: CGFloat = 0
+        var alpha: CGFloat = 0
+
+        // Convert to HSB color space
+        if self.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha) {
+            // Adjust brightness, keeping it within 0-1 range
+            let newBrightness = max(0, min(1, brightness + amount))
+            return UIColor(hue: hue, saturation: saturation, brightness: newBrightness, alpha: alpha)
+        }
+
+        // Fallback for colors that can't be converted to HSB
+        return self
+    }
+
 }

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1167,6 +1167,7 @@
 		CB3C788B2D06D3A700A7E4ED /* Launching.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAD0EFA2CFE1D3F006267B8 /* Launching.swift */; };
 		CB3C788C2D06D3A700A7E4ED /* AppStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAD0F052CFE270D006267B8 /* AppStateMachine.swift */; };
 		CB3C788E2D06D3A700A7E4ED /* Initializing.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAD0EF82CFE1D35006267B8 /* Initializing.swift */; };
+		CB3CC3372D9EFFB4004D6B33 /* SiteThemeColorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3CC3362D9EFFB4004D6B33 /* SiteThemeColorManager.swift */; };
 		CB4FA44E2C78AACE00A16F5A /* SpecialErrorPageUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4FA44D2C78AACE00A16F5A /* SpecialErrorPageUserScript.swift */; };
 		CB5516D0286500290079B175 /* TrackerRadarIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85519124247468580010FDD0 /* TrackerRadarIntegrationTests.swift */; };
 		CB5516D1286500290079B175 /* ContentBlockingRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA904C24FD2DB000D41DDF /* ContentBlockingRulesTests.swift */; };
@@ -3237,6 +3238,7 @@
 		CB3B4D532D648C44006DAD63 /* AuthenticationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationServiceTests.swift; sourceTree = "<group>"; };
 		CB3B4D552D649DC8006DAD63 /* AutoClearServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoClearServiceTests.swift; sourceTree = "<group>"; };
 		CB3B4D582D64AADD006DAD63 /* MockOverlayWindowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOverlayWindowManager.swift; sourceTree = "<group>"; };
+		CB3CC3362D9EFFB4004D6B33 /* SiteThemeColorManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteThemeColorManager.swift; sourceTree = "<group>"; };
 		CB4448752AF6D51D001F93F7 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		CB4FA44D2C78AACE00A16F5A /* SpecialErrorPageUserScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialErrorPageUserScript.swift; sourceTree = "<group>"; };
 		CB5038622AF6D563007FD69F /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -7504,6 +7506,7 @@
 				8577A1C4255D2C0D00D43FCD /* HitTestingToolbar.swift */,
 				85DDE03F2AC6FF65006ABCA2 /* MainView.swift */,
 				F17669D61E43401C003D3222 /* MainViewController.swift */,
+				CB3CC3362D9EFFB4004D6B33 /* SiteThemeColorManager.swift */,
 				31D4CD4A2D4D1C2600BC27C6 /* ToolbarStateHandling.swift */,
 				566B736F2BECD46800FF1959 /* MainViewController+SyncAlerts.swift */,
 				981CA7E92617797500E119D5 /* MainViewController+AddFavoriteFlow.swift */,
@@ -9040,6 +9043,7 @@
 				7B4F87EE2D0739EB0010B18F /* SiriBubbleView.swift in Sources */,
 				85DFEDF124C7EEA400973FE7 /* LargeOmniBarState.swift in Sources */,
 				CBF259812D42852B00AC63E4 /* PixelConfiguration.swift in Sources */,
+				CB3CC3372D9EFFB4004D6B33 /* SiteThemeColorManager.swift in Sources */,
 				9880722A25FA497B0039EF4B /* MenuButton.swift in Sources */,
 				D6E83C602B22B3C9006C8AFB /* SettingsState.swift in Sources */,
 				D6E83C482B20C812006C8AFB /* SettingsHostingController.swift in Sources */,

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -189,6 +189,9 @@ class MainViewController: UIViewController {
 
     var appDidFinishLaunchingStartTime: CFAbsoluteTime?
     let maliciousSiteProtectionPreferencesManager: MaliciousSiteProtectionPreferencesManaging
+    private lazy var themeColorManager: SiteThemeColorManager = {
+        SiteThemeColorManager(viewCoordinator: viewCoordinator, currentTabViewController: { [weak self] in self?.currentTab }())
+    }()
 
     private lazy var aiChatViewControllerManager: AIChatViewControllerManager = {
         let manager = AIChatViewControllerManager()
@@ -652,6 +655,7 @@ class MainViewController: UIViewController {
         viewCoordinator.moveAddressBarToPosition(appSettings.currentAddressBarPosition)
         refreshViewsBasedOnAddressBarPosition(appSettings.currentAddressBarPosition)
         updateStatusBarBackgroundColor()
+        themeColorManager.updateThemeColor()
     }
 
     @objc private func onShowFullURLAddressChanged() {
@@ -1176,6 +1180,7 @@ class MainViewController: UIViewController {
             attachTab(tab: tab)
             refreshControls()
         }
+        themeColorManager.updateThemeColor()
         tabsBarController?.refresh(tabsModel: tabManager.model, scrollToSelected: true)
         swipeTabsCoordinator?.refresh(tabsModel: tabManager.model, scrollToSelected: true)
         if DaxDialogs.shared.shouldShowFireButtonPulse {
@@ -1589,6 +1594,7 @@ class MainViewController: UIViewController {
         hideSuggestionTray()
         hideNotificationBarIfBrokenSitePromptShown()
         currentTab?.dismiss()
+        themeColorManager.updateThemeColor()
 
         if reuseExisting, let existing = tabManager.firstHomeTab() {
             tabManager.selectTab(existing)
@@ -2186,6 +2192,7 @@ extension MainViewController: OmniBarDelegate {
         dismissOmniBar()
         omniBar.cancel()
         hideSuggestionTray()
+        themeColorManager.updateThemeColor()
         self.showMenuHighlighterIfNeeded()
     }
 
@@ -2231,6 +2238,7 @@ extension MainViewController: OmniBarDelegate {
         } else {
             tryToShowSuggestionTray(.favorites)
         }
+        themeColorManager.updateThemeColor()
     }
 
     func onTextFieldDidBeginEditing(_ omniBar: OmniBarView) -> Bool {
@@ -2510,6 +2518,7 @@ extension MainViewController: TabDelegate {
         hideNotificationBarIfBrokenSitePromptShown()
         showBars()
         currentTab?.dismiss()
+        themeColorManager.updateThemeColor()
 
         // Don't use a request or else the page gets stuck on "about:blank"
         let newTab = tabManager.addURLRequest(nil,
@@ -2539,6 +2548,7 @@ extension MainViewController: TabDelegate {
         }
         tabManager.save()
         tabsBarController?.refresh(tabsModel: tabManager.model)
+        themeColorManager.updateThemeColor()
         // note: model in swipeTabsCoordinator doesn't need to be updated here
         // https://app.asana.com/0/414235014887631/1206847376910045/f
     }
@@ -2758,6 +2768,7 @@ extension MainViewController: TabSwitcherDelegate {
         if newTabPageViewController != nil {
             animateLogoAppearance()
         }
+        themeColorManager.updateThemeColor()
     }
 
     func tabSwitcher(_ tabSwitcher: TabSwitcherViewController, didSelectTab tab: Tab) {
@@ -2765,6 +2776,7 @@ extension MainViewController: TabSwitcherDelegate {
         if DaxDialogs.shared.shouldShowFireButtonPulse {
             showFireButtonPulse()
         }
+        themeColorManager.updateThemeColor()
     }
     
     func tabSwitcher(_ tabSwitcher: TabSwitcherViewController, editBookmarkForUrl url: URL) {
@@ -2801,6 +2813,7 @@ extension MainViewController: TabSwitcherDelegate {
         guard let index = tabManager.model.indexOf(tab: tab) else { return }
         hideSuggestionTray()
         hideNotificationBarIfBrokenSitePromptShown()
+        themeColorManager.updateThemeColor()
 
         if shouldOpen {
             let newTab = Tab()
@@ -3074,6 +3087,7 @@ extension MainViewController {
         super.traitCollectionDidChange(previousTraitCollection)
 
         updateStatusBarBackgroundColor()
+        themeColorManager.updateThemeColor()
     }
 
     private func updateStatusBarBackgroundColor() {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -190,7 +190,9 @@ class MainViewController: UIViewController {
     var appDidFinishLaunchingStartTime: CFAbsoluteTime?
     let maliciousSiteProtectionPreferencesManager: MaliciousSiteProtectionPreferencesManaging
     private lazy var themeColorManager: SiteThemeColorManager = {
-        SiteThemeColorManager(viewCoordinator: viewCoordinator, currentTabViewController: { [weak self] in self?.currentTab }())
+        SiteThemeColorManager(viewCoordinator: viewCoordinator,
+                              currentTabViewController: { [weak self] in self?.currentTab }(),
+                              appSettings: appSettings)
     }()
 
     private lazy var aiChatViewControllerManager: AIChatViewControllerManager = {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1201,6 +1201,7 @@ class MainViewController: UIViewController {
         
         tab.progressWorker.progressBar = viewCoordinator.progress
         chromeManager.attach(to: tab.webView.scrollView)
+        themeColorManager.attach(to: tab)
         tab.chromeDelegate = self
     }
 
@@ -1594,7 +1595,6 @@ class MainViewController: UIViewController {
         hideSuggestionTray()
         hideNotificationBarIfBrokenSitePromptShown()
         currentTab?.dismiss()
-        themeColorManager.updateThemeColor()
 
         if reuseExisting, let existing = tabManager.firstHomeTab() {
             tabManager.selectTab(existing)
@@ -1605,6 +1605,7 @@ class MainViewController: UIViewController {
         tabsBarController?.refresh(tabsModel: tabManager.model)
         swipeTabsCoordinator?.refresh(tabsModel: tabManager.model, scrollToSelected: true)
         newTabPageViewController?.openedAsNewTab(allowingKeyboard: allowingKeyboard)
+        themeColorManager.updateThemeColor()
     }
     
     func updateFindInPage() {
@@ -2548,7 +2549,6 @@ extension MainViewController: TabDelegate {
         }
         tabManager.save()
         tabsBarController?.refresh(tabsModel: tabManager.model)
-        themeColorManager.updateThemeColor()
         // note: model in swipeTabsCoordinator doesn't need to be updated here
         // https://app.asana.com/0/414235014887631/1206847376910045/f
     }

--- a/iOS/DuckDuckGo/PullToRefreshViewAdapter.swift
+++ b/iOS/DuckDuckGo/PullToRefreshViewAdapter.swift
@@ -83,8 +83,18 @@ final class PullToRefreshViewAdapter: NSObject {
     var backgroundColor: UIColor? {
         didSet {
             fakeScrollView.backgroundColor = backgroundColor ?? UIColor(designSystemColor: .background)
-            refreshControl.tintColor = UIColor(designSystemColor: .iconsSecondary)
+            // Set refresh control tint color based on background brightness
+            refreshControl.tintColor = determineRefreshControlTintColor(for: backgroundColor)
         }
+    }
+
+    private func determineRefreshControlTintColor(for backgroundColor: UIColor?) -> UIColor {
+        guard let backgroundColor = backgroundColor else {
+            return UIColor(designSystemColor: .iconsSecondary)
+        }
+
+        let userInterfaceStyle: UIUserInterfaceStyle = backgroundColor.brightnessPercentage < 50 ? .dark : .light
+        return UIColor(designSystemColor: .iconsSecondary).resolvedColor(with: .init(userInterfaceStyle: userInterfaceStyle))
     }
 
     /**

--- a/iOS/DuckDuckGo/PullToRefreshViewAdapter.swift
+++ b/iOS/DuckDuckGo/PullToRefreshViewAdapter.swift
@@ -80,6 +80,13 @@ final class PullToRefreshViewAdapter: NSObject {
     private weak var pullableView: UIView?
     private let onRefresh: () -> Void
 
+    var backgroundColor: UIColor? {
+        didSet {
+            fakeScrollView.backgroundColor = backgroundColor ?? UIColor(designSystemColor: .background)
+            refreshControl.tintColor = .red
+        }
+    }
+
     /**
      * Initializes the pull-to-refresh logic with the necessary components.
      *

--- a/iOS/DuckDuckGo/PullToRefreshViewAdapter.swift
+++ b/iOS/DuckDuckGo/PullToRefreshViewAdapter.swift
@@ -83,7 +83,7 @@ final class PullToRefreshViewAdapter: NSObject {
     var backgroundColor: UIColor? {
         didSet {
             fakeScrollView.backgroundColor = backgroundColor ?? UIColor(designSystemColor: .background)
-            refreshControl.tintColor = .red
+            refreshControl.tintColor = UIColor(designSystemColor: .iconsSecondary)
         }
     }
 

--- a/iOS/DuckDuckGo/SiteThemeColorManager.swift
+++ b/iOS/DuckDuckGo/SiteThemeColorManager.swift
@@ -25,51 +25,86 @@ final class SiteThemeColorManager {
     private let themeManager: ThemeManager
     private let currentTabViewController: () -> TabViewController?
 
-    private let defaultColor: UIColor = UIColor(designSystemColor: .background)
-    private var currentSiteThemeColor: UIColor?
+    private weak var tabViewController: TabViewController?
+    private var colorCache: [String: UIColor] = [:]
+    private var themeColorObservation: NSKeyValueObservation?
 
-    init(viewCoordinator: MainViewCoordinator,
-         currentTabViewController: @autoclosure @escaping () -> TabViewController?,
-         themeManager: ThemeManager = ThemeManager.shared) {
+
+    init(
+        viewCoordinator: MainViewCoordinator,
+        currentTabViewController: @autoclosure @escaping () -> TabViewController?,
+        themeManager: ThemeManager = ThemeManager.shared
+    ) {
         self.viewCoordinator = viewCoordinator
         self.themeManager = themeManager
         self.currentTabViewController = currentTabViewController
     }
 
+    deinit {
+        themeColorObservation?.invalidate()
+    }
+
+    // MARK: - Public Methods
+
+    func attach(to tabViewController: TabViewController) {
+        self.tabViewController = tabViewController
+        startObservingThemeColor()
+    }
+
     func updateThemeColor() {
-        guard ExperimentalThemingManager().isExperimentalThemingEnabled else { return }
-        guard viewCoordinator.suggestionTrayContainer.isHidden else {
+        guard let host = currentTabViewController()?.url?.host,
+              let cachedColor = colorCache[host] else {
+            resetThemeColor()
+            return
+        }
+        updateThemeColor(cachedColor)
+    }
+
+    func resetThemeColor() {
+        applyThemeColor(UIColor(designSystemColor: .background))
+    }
+
+    // MARK: - Private Methods
+
+    private func startObservingThemeColor() {
+        themeColorObservation = tabViewController?.webView?.observe(\.themeColor, options: [.new]) { [weak self] webView, change in
+            guard let self = self,
+                  self.isCurrentTab(),
+                  let newColor = change.newValue as? UIColor,
+                  let host = webView.url?.host else {
+                self?.resetThemeColor()
+                return
+            }
+
+            self.colorCache[host] = newColor
+            self.updateThemeColor(newColor)
+        }
+    }
+
+    private func isCurrentTab() -> Bool {
+        return tabViewController?.tabModel == currentTabViewController()?.tabModel
+    }
+
+    private func updateThemeColor(_ color: UIColor) {
+        guard ExperimentalThemingManager().isExperimentalThemingEnabled,
+              viewCoordinator.suggestionTrayContainer.isHidden else {
             resetThemeColor()
             return
         }
 
-        guard let siteThemeColor = currentTabViewController()?.webView?.themeColor else {
-            resetThemeColor()
-            return
-        }
-
-        guard currentSiteThemeColor != siteThemeColor else { return }
-        currentSiteThemeColor = siteThemeColor
-
-        let adjustedColor = adjustColor(siteThemeColor)
-        applyThemeColor(adjustedColor)
+        applyThemeColor(adjustColor(color))
     }
 
     private func adjustColor(_ color: UIColor) -> UIColor {
-        if themeManager.currentInterfaceStyle == .light {
-            return color.adjustBrightness(by: 0.04)
-        }
-        return color.adjustBrightness(by: -0.04)
+        let brightnessAdjustment = themeManager.currentInterfaceStyle == .light ? 0.04 : -0.04
+        return color.adjustBrightness(by: brightnessAdjustment)
     }
 
     private func applyThemeColor(_ color: UIColor) {
         viewCoordinator.statusBackground.backgroundColor = color
-        currentTabViewController()?.pullToRefreshViewAdapter?.backgroundColor = color
-        currentTabViewController()?.webView?.underPageBackgroundColor = color
-    }
-
-    private func resetThemeColor() {
-        applyThemeColor(defaultColor)
+        tabViewController?.pullToRefreshViewAdapter?.backgroundColor = color
+        tabViewController?.webView?.underPageBackgroundColor = color
     }
 
 }
+

--- a/iOS/DuckDuckGo/SiteThemeColorManager.swift
+++ b/iOS/DuckDuckGo/SiteThemeColorManager.swift
@@ -1,0 +1,75 @@
+//
+//  SiteThemeColorManager.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+
+final class SiteThemeColorManager {
+
+    private let viewCoordinator: MainViewCoordinator
+    private let themeManager: ThemeManager
+    private let currentTabViewController: () -> TabViewController?
+
+    private let defaultColor: UIColor = UIColor(designSystemColor: .background)
+    private var currentSiteThemeColor: UIColor?
+
+    init(viewCoordinator: MainViewCoordinator,
+         currentTabViewController: @autoclosure @escaping () -> TabViewController?,
+         themeManager: ThemeManager = ThemeManager.shared) {
+        self.viewCoordinator = viewCoordinator
+        self.themeManager = themeManager
+        self.currentTabViewController = currentTabViewController
+    }
+
+    func updateThemeColor() {
+        guard ExperimentalThemingManager().isExperimentalThemingEnabled else { return }
+        guard viewCoordinator.suggestionTrayContainer.isHidden else {
+            resetThemeColor()
+            return
+        }
+
+        guard let siteThemeColor = currentTabViewController()?.webView?.themeColor else {
+            resetThemeColor()
+            return
+        }
+
+        guard currentSiteThemeColor != siteThemeColor else { return }
+        currentSiteThemeColor = siteThemeColor
+
+        let adjustedColor = adjustColor(siteThemeColor)
+        applyThemeColor(adjustedColor)
+    }
+
+    private func adjustColor(_ color: UIColor) -> UIColor {
+        if themeManager.currentInterfaceStyle == .light {
+            return color.adjustBrightness(by: 0.04)
+        }
+        return color.adjustBrightness(by: -0.04)
+    }
+
+    private func applyThemeColor(_ color: UIColor) {
+        viewCoordinator.statusBackground.backgroundColor = color
+        currentTabViewController()?.pullToRefreshViewAdapter?.backgroundColor = color
+        currentTabViewController()?.webView?.underPageBackgroundColor = color
+    }
+
+    private func resetThemeColor() {
+        applyThemeColor(defaultColor)
+    }
+
+}

--- a/iOS/DuckDuckGo/SiteThemeColorManager.swift
+++ b/iOS/DuckDuckGo/SiteThemeColorManager.swift
@@ -48,6 +48,7 @@ final class SiteThemeColorManager {
 
     func attach(to tabViewController: TabViewController) {
         self.tabViewController = tabViewController
+        themeColorObservation?.invalidate()
         startObservingThemeColor()
     }
 

--- a/iOS/DuckDuckGo/SiteThemeColorManager.swift
+++ b/iOS/DuckDuckGo/SiteThemeColorManager.swift
@@ -29,12 +29,9 @@ final class SiteThemeColorManager {
     private var colorCache: [String: UIColor] = [:]
     private var themeColorObservation: NSKeyValueObservation?
 
-
-    init(
-        viewCoordinator: MainViewCoordinator,
+    init(viewCoordinator: MainViewCoordinator,
         currentTabViewController: @autoclosure @escaping () -> TabViewController?,
-        themeManager: ThemeManager = ThemeManager.shared
-    ) {
+        themeManager: ThemeManager = ThemeManager.shared) {
         self.viewCoordinator = viewCoordinator
         self.themeManager = themeManager
         self.currentTabViewController = currentTabViewController
@@ -68,30 +65,29 @@ final class SiteThemeColorManager {
 
     private func startObservingThemeColor() {
         themeColorObservation = tabViewController?.webView?.observe(\.themeColor, options: [.new]) { [weak self] webView, change in
-            guard let self = self,
-                  self.isCurrentTab(),
+            guard let self,
                   let newColor = change.newValue as? UIColor,
                   let host = webView.url?.host else {
                 self?.resetThemeColor()
                 return
             }
 
-            self.colorCache[host] = newColor
-            self.updateThemeColor(newColor)
+            colorCache[host] = newColor
+            if isCurrentTab {
+                updateThemeColor(newColor)
+            }
         }
     }
 
-    private func isCurrentTab() -> Bool {
-        return tabViewController?.tabModel == currentTabViewController()?.tabModel
+    private var isCurrentTab: Bool {
+        tabViewController?.tabModel == currentTabViewController()?.tabModel
     }
 
     private func updateThemeColor(_ color: UIColor) {
-        guard ExperimentalThemingManager().isExperimentalThemingEnabled,
-              viewCoordinator.suggestionTrayContainer.isHidden else {
+        guard viewCoordinator.suggestionTrayContainer.isHidden else {
             resetThemeColor()
             return
         }
-
         applyThemeColor(adjustColor(color))
     }
 
@@ -101,10 +97,10 @@ final class SiteThemeColorManager {
     }
 
     private func applyThemeColor(_ color: UIColor) {
+        guard ExperimentalThemingManager().isExperimentalThemingEnabled else { return }
         viewCoordinator.statusBackground.backgroundColor = color
         tabViewController?.pullToRefreshViewAdapter?.backgroundColor = color
         tabViewController?.webView?.underPageBackgroundColor = color
     }
 
 }
-

--- a/iOS/DuckDuckGo/SiteThemeColorManager.swift
+++ b/iOS/DuckDuckGo/SiteThemeColorManager.swift
@@ -23,6 +23,7 @@ final class SiteThemeColorManager {
 
     private let viewCoordinator: MainViewCoordinator
     private let themeManager: ThemeManager
+    private let appSettings: AppSettings
     private let currentTabViewController: () -> TabViewController?
 
     private weak var tabViewController: TabViewController?
@@ -31,8 +32,10 @@ final class SiteThemeColorManager {
 
     init(viewCoordinator: MainViewCoordinator,
          currentTabViewController: @autoclosure @escaping () -> TabViewController?,
+         appSettings: AppSettings,
          themeManager: ThemeManager = ThemeManager.shared) {
         self.viewCoordinator = viewCoordinator
+        self.appSettings = appSettings
         self.themeManager = themeManager
         self.currentTabViewController = currentTabViewController
     }
@@ -98,7 +101,12 @@ final class SiteThemeColorManager {
 
     private func applyThemeColor(_ color: UIColor) {
         guard ExperimentalThemingManager().isExperimentalThemingEnabled else { return }
-        viewCoordinator.statusBackground.backgroundColor = color
+        // We do not support top address bar position in this 1st iteration
+        if appSettings.currentAddressBarPosition == .bottom {
+            viewCoordinator.statusBackground.backgroundColor = color
+        } else {
+            viewCoordinator.statusBackground.backgroundColor = UIColor(designSystemColor: .background)
+        }
         tabViewController?.pullToRefreshViewAdapter?.backgroundColor = color
         tabViewController?.webView?.underPageBackgroundColor = color
     }

--- a/iOS/DuckDuckGo/SiteThemeColorManager.swift
+++ b/iOS/DuckDuckGo/SiteThemeColorManager.swift
@@ -68,7 +68,7 @@ final class SiteThemeColorManager {
     // MARK: - Private Methods
 
     private func startObservingThemeColor() {
-        themeColorObservation = tabViewController?.webView?.observe(\.themeColor, options: [.new]) { [weak self] webView, change in
+        themeColorObservation = tabViewController?.webView?.observe(\.themeColor, options: [.initial, .new]) { [weak self] webView, change in
             guard let self,
                   let newColor = change.newValue as? UIColor,
                   let host = webView.url?.host else {
@@ -110,6 +110,7 @@ final class SiteThemeColorManager {
         }
         tabViewController?.pullToRefreshViewAdapter?.backgroundColor = color
         tabViewController?.webView?.underPageBackgroundColor = color
+        tabViewController?.webView?.scrollView.backgroundColor = color
     }
 
 }

--- a/iOS/DuckDuckGo/SiteThemeColorManager.swift
+++ b/iOS/DuckDuckGo/SiteThemeColorManager.swift
@@ -30,8 +30,8 @@ final class SiteThemeColorManager {
     private var themeColorObservation: NSKeyValueObservation?
 
     init(viewCoordinator: MainViewCoordinator,
-        currentTabViewController: @autoclosure @escaping () -> TabViewController?,
-        themeManager: ThemeManager = ThemeManager.shared) {
+         currentTabViewController: @autoclosure @escaping () -> TabViewController?,
+         themeManager: ThemeManager = ThemeManager.shared) {
         self.viewCoordinator = viewCoordinator
         self.themeManager = themeManager
         self.currentTabViewController = currentTabViewController

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -215,7 +215,7 @@ class TabViewController: UIViewController {
     let syncService: DDGSyncing
 
     private let daxDialogsDebouncer = Debouncer(mode: .common)
-    private var pullToRefreshViewAdapter: PullToRefreshViewAdapter?
+    var pullToRefreshViewAdapter: PullToRefreshViewAdapter?
 
     public var url: URL? {
         willSet {
@@ -497,7 +497,6 @@ class TabViewController: UIViewController {
 
         unregisterFromResignActive()
         tabInteractionStateSource?.saveState(webView.interactionState, for: tabModel)
-
     }
 
     private func registerForAddressBarLocationNotifications() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201392122292466/1209485028986795/f
Figma spec: https://www.figma.com/design/triNDLtPcx4by8Hsw9CzYt/%F0%9F%96%8D%EF%B8%8F-2025-Visual-Design-Update-%26-1-Tap-AI-ChatOS-%2B-Android?node-id=4986-136394&p=f&t=kmrB3uAPfU8inDSj-0
CC: @dus7 

### Description
Change parts of UI based on site's theme color.
Please note, there's no decision yet on how want to change the color of activity indicator so it contrasts with the site's color.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Have your search bar at the bottom.
2. Visit a site with a theme color, e.g. www.filmweb.pl (black one).
3. Notice the color change of the top status bar and webview background.
4. Try to break it, refresh, open new site, open new tab, close tab, long press, open favorites, rotate, change dynamically bar position (in settings), swipe between tabs, go forward/back etc. and see if the top status bar acts correctly.

### Impact and Risks
None: Should be behind flag

#### What could go wrong?
Make sure nothing changes if the experimental flag is off.