### PR TITLE
Keep selected Tab edge fixed when resizing window

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -78,6 +78,7 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
     private var selectionIndexCancellable: AnyCancellable?
     private var mouseDownCancellable: AnyCancellable?
     private var cancellables = Set<AnyCancellable>()
+    private var previousScrollViewWidth: CGFloat = .zero
 
     // TabBarRemoteMessagePresentable
     var tabBarRemoteMessageViewModel: TabBarRemoteMessageViewModel
@@ -128,8 +129,6 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
     }
 
     override func viewDidLoad() {
-        super.viewDidLoad()
-
         scrollView.updateScrollElasticity(with: tabMode)
         observeToScrollNotifications()
         subscribeToSelectionIndex()
@@ -142,8 +141,6 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
     }
 
     override func viewWillAppear() {
-        super.viewWillAppear()
-
         updateEmptyTabArea()
         tabCollectionViewModel.delegate = self
         reloadSelection()
@@ -154,24 +151,20 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
         addTabBarRemoteMessageListener()
     }
 
-    override func viewWillDisappear() {
-        super.viewWillDisappear()
+    override func viewDidAppear() {
+        enableScrollButtons()
+    }
 
+    override func viewWillDisappear() {
         mouseDownCancellable = nil
         tabBarRemoteMessageCancellable = nil
     }
 
     override func viewDidLayout() {
-        super.viewDidLayout()
-
         frozenLayout = view.isMouseLocationInsideBounds()
         updateTabMode()
         updateEmptyTabArea()
         collectionView.invalidateLayout()
-    }
-
-    deinit {
-        NotificationCenter.default.removeObserver(self)
     }
 
     @objc func addButtonAction(_ sender: NSButton) {
@@ -600,13 +593,18 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
     private func observeToScrollNotifications() {
         scrollView.contentView.postsBoundsChangedNotifications = true
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(scrollViewBoundsDidChange(_:)),
-                                               name: NSView.boundsDidChangeNotification,
-                                               object: scrollView.contentView)
+        NotificationCenter.default.addObserver(self, selector: #selector(scrollViewContentSizeDidChange(_:)), name: NSView.boundsDidChangeNotification, object: scrollView.contentView)
+        previousScrollViewWidth = scrollView.bounds.size.width
+        NotificationCenter.default.addObserver(self, selector: #selector(scrollViewFrameDidChange(_:)), name: NSView.frameDidChangeNotification, object: scrollView)
     }
 
-    @objc private func scrollViewBoundsDidChange(_ sender: Any) {
+    @objc private func scrollViewContentSizeDidChange(_ notification: Notification) {
+        enableScrollButtons()
+        hideTabPreview(allowQuickRedisplay: true)
+    }
+
+    @objc private func scrollViewFrameDidChange(_ notification: Notification) {
+        adjustScrollPositionOnResize()
         enableScrollButtons()
         hideTabPreview(allowQuickRedisplay: true)
     }
@@ -623,6 +621,39 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
         rightShadowImageView.isHidden = scrollViewsAreHidden
         leftShadowImageView.isHidden = scrollViewsAreHidden
         addTabButton.isHidden = scrollViewsAreHidden
+    }
+
+    /// Adjust the right edge scroll position to keep Selected Tab visible when resizing (or bring it into view expanding the right edge when it‘s behind the edge)
+    private func adjustScrollPositionOnResize() {
+        let newWidth = scrollView.bounds.size.width
+        let resizeAmount = newWidth - previousScrollViewWidth
+        previousScrollViewWidth = newWidth
+
+        guard resizeAmount != 0,
+              let selectedIndexPath = collectionView.selectionIndexPaths.first,
+              let layoutAttributes = collectionView.layoutAttributesForItem(at: selectedIndexPath) else { return }
+
+        let visibleRect = collectionView.visibleRect
+        let selectedItemFrame = layoutAttributes.frame
+
+        let isExpanding = resizeAmount > 0
+
+        let selectedItemLeft = selectedItemFrame.minX
+        let selectedItemRight = selectedItemFrame.maxX
+        let visibleLeft = visibleRect.minX
+        let visibleRight = visibleRect.maxX
+        let currentOriginX = scrollView.documentVisibleRect.origin.x
+
+        // CONTRACTING: if selected item is beyond the right edge, preserve right edge
+        if !isExpanding && selectedItemRight > visibleRight {
+            let newOriginX = currentOriginX + abs(resizeAmount)
+            collectionView.scroll(NSPoint(x: newOriginX, y: 0))
+
+        // EXPANDING: if selected item is beyond the left edge, preserve right edge
+        } else if isExpanding && selectedItemLeft < visibleLeft {
+            let newOriginX = max(0, currentOriginX - abs(resizeAmount))
+            collectionView.scroll(NSPoint(x: newOriginX, y: 0))
+        }
     }
 
     private func setupAddTabButton() {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1207340338530322/1208618055976987/f

### Description
- When expanding prefer expanding Tab Bar scrollable area to the selected Tab
- Keep selected tab visible when contracting

### Testing Steps
1. Open multiple tabs to enter overflow mode
2. Validate Selected Tab wants to get into view when expanding/contracting (see the video)
3. Validate non-overflow mode is not affected by the change

https://github.com/user-attachments/assets/20b942cd-0f5b-4a0e-8203-4afb8a718781


### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)