### PR TITLE
scroll to tab when opened

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1085,7 +1085,7 @@ class MainViewController: UIViewController {
             refreshOmniBar()
             refreshTabIcon()
             refreshControls()
-            tabsBarController?.refresh(tabsModel: tabManager.model)
+            tabsBarController?.refresh(tabsModel: tabManager.model, scrollToSelected: true)
             swipeTabsCoordinator?.refresh(tabsModel: tabManager.model, scrollToSelected: true)
         }
 
@@ -1604,7 +1604,7 @@ class MainViewController: UIViewController {
             tabManager.addHomeTab()
         }
         attachHomeScreen()
-        tabsBarController?.refresh(tabsModel: tabManager.model)
+        tabsBarController?.refresh(tabsModel: tabManager.model, scrollToSelected: true)
         swipeTabsCoordinator?.refresh(tabsModel: tabManager.model, scrollToSelected: true)
         newTabPageViewController?.openedAsNewTab(allowingKeyboard: allowingKeyboard)
         themeColorManager.updateThemeColor()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414709148257752/1209917049731178/f
Tech Design URL:
CC:

### Description
Scrolls to the newly opened tab.

### Testing Steps
Setup
* Open enough tabs such that you need to scroll the tabs bar. 
* Select the last tab
* Scroll to the first tab, but don't select it

Flow 1
* Switch to Safari
* Share a URL (that is not already opened) to our app 

Flow 2
* Kill the app
* Switch to Safari
* Share a URL (that is not already opened) to our app 

Flow 3
* Kill the app
* Set app as default
* Open a URL (that is not already opened)

### Impact and Risks
Low: small bug fixes

#### What could go wrong?
Tabs bar on iPad could get screwy

### Quality Considerations


### Notes to Reviewer


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)