### PR TITLE
Back/Forward buttons standard new tab policy

### DIFF
--- a/macOS/DuckDuckGo/Common/View/AppKit/MouseOverButton.swift
+++ b/macOS/DuckDuckGo/Common/View/AppKit/MouseOverButton.swift
@@ -63,6 +63,14 @@ internal class MouseOverButton: NSButton, Hoverable {
         return size
     }
 
+    private var eventTypeMask: NSEvent.EventTypeMask = .leftMouseUp
+
+    @discardableResult
+    override func sendAction(on mask: NSEvent.EventTypeMask) -> Int {
+        self.eventTypeMask = mask
+        return Int(truncatingIfNeeded: mask.rawValue)
+    }
+
     var normalTintColor: NSColor? {
         didSet {
             updateTintColor()
@@ -198,6 +206,19 @@ internal class MouseOverButton: NSButton, Hoverable {
         isMouseDown = true
         super.mouseDown(with: event)
         isMouseDown = false
+    }
+
+
+    override func otherMouseDown(with event: NSEvent) {
+        if eventTypeMask.contains(.init(type: event.type)), let action {
+            NSApp.sendAction(action, to: target, from: self)
+        }
+    }
+
+    override func otherMouseUp(with event: NSEvent) {
+        if eventTypeMask.contains(.init(type: event.type)), let action {
+            NSApp.sendAction(action, to: target, from: self)
+        }
     }
 
 }

--- a/macOS/DuckDuckGo/Common/View/AppKit/MouseOverButton.swift
+++ b/macOS/DuckDuckGo/Common/View/AppKit/MouseOverButton.swift
@@ -208,7 +208,6 @@ internal class MouseOverButton: NSButton, Hoverable {
         isMouseDown = false
     }
 
-
     override func otherMouseDown(with event: NSEvent) {
         if eventTypeMask.contains(.init(type: event.type)), let action {
             NSApp.sendAction(action, to: target, from: self)

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -658,21 +658,22 @@ extension MainViewController {
 
     func otherMouseUp(with event: NSEvent) -> NSEvent? {
         guard event.window === self.view.window,
-              mainView.webContainerView.isMouseLocationInsideBounds(event.locationInWindow)
+              mainView.webContainerView.isMouseLocationInsideBounds(event.locationInWindow),
+              let selectedTabViewModel = tabCollectionViewModel.selectedTabViewModel
         else { return event }
 
-        if event.buttonNumber == 3,
-           tabCollectionViewModel.selectedTabViewModel?.canGoBack == true {
-            tabCollectionViewModel.selectedTabViewModel?.tab.goBack()
+        switch event.button {
+        case .back:
+            guard selectedTabViewModel.canGoBack else { return nil }
+            selectedTabViewModel.tab.goBack()
             return nil
-        } else if event.buttonNumber == 4,
-                  tabCollectionViewModel.selectedTabViewModel?.canGoForward == true {
-            tabCollectionViewModel.selectedTabViewModel?.tab.goForward()
+        case .forward:
+            guard selectedTabViewModel.canGoForward else { return nil }
+            selectedTabViewModel.tab.goForward()
             return nil
+        default:
+            return event
         }
-
-        return event
-
     }
 }
 

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -321,13 +321,7 @@ final class NavigationBarViewController: NSViewController {
             Logger.navigation.error("Selected tab view model is nil")
             return
         }
-
-        if NSApp.isCommandPressed,
-           // don‘t open a new tab when the window is cmd-clicked in background
-           sender.window?.isKeyWindow == true && NSApp.isActive,
-           let backItem = selectedTabViewModel.tab.webView.backForwardList.backItem {
-            openBackForwardHistoryItemInNewChildTab(with: backItem.url)
-        } else {
+        if !openBackForwardHistoryItemInNewTabIfNeeded(with: selectedTabViewModel.tab.webView.backForwardList.backItem?.url) {
             selectedTabViewModel.tab.goBack()
         }
     }
@@ -337,20 +331,36 @@ final class NavigationBarViewController: NSViewController {
             Logger.navigation.error("Selected tab view model is nil")
             return
         }
-
-        if NSApp.isCommandPressed,
-           // don‘t open a new tab when the window is cmd-clicked in background
-           sender.window?.isKeyWindow == true && NSApp.isActive,
-           let forwardItem = selectedTabViewModel.tab.webView.backForwardList.forwardItem {
-            openBackForwardHistoryItemInNewChildTab(with: forwardItem.url)
-        } else {
+        if !openBackForwardHistoryItemInNewTabIfNeeded(with: selectedTabViewModel.tab.webView.backForwardList.forwardItem?.url) {
             selectedTabViewModel.tab.goForward()
         }
     }
 
-    private func openBackForwardHistoryItemInNewChildTab(with url: URL) {
-        let tab = Tab(content: .url(url, source: .historyEntry), parentTab: tabCollectionViewModel.selectedTabViewModel?.tab, shouldLoadInBackground: true, burnerMode: tabCollectionViewModel.burnerMode)
-        tabCollectionViewModel.insert(tab, selected: false)
+    /// When ⌘+ or middle- clicked open the back/forward item in a new tab
+    /// - returns:`true` if opened in a new tab
+    private func openBackForwardHistoryItemInNewTabIfNeeded(with url: URL?) -> Bool {
+        guard let url,
+              // don‘t open a new tab when the window is cmd-clicked in background
+              !NSApp.isCommandPressed || (view.window?.isKeyWindow == true && NSApp.isActive) else { return false }
+
+        // Create behavior using current event
+        let behavior = LinkOpenBehavior(
+            event: NSApp.currentEvent,
+            switchToNewTabWhenOpenedPreference: TabsPreferences.shared.switchToNewTabWhenOpened,
+            canOpenLinkInCurrentTab: true
+        )
+
+        lazy var tab = Tab(content: .url(url, source: .historyEntry), parentTab: tabCollectionViewModel.selectedTabViewModel?.tab, shouldLoadInBackground: true, burnerMode: tabCollectionViewModel.burnerMode)
+        switch behavior {
+        case .currentTab:
+            return false
+
+        case .newTab(let selected):
+            tabCollectionViewModel.insert(tab, selected: selected)
+        case .newWindow(let selected):
+            WindowsManager.openNewWindow(with: tab, showWindow: selected)
+        }
+        return true
     }
 
     @IBAction func refreshOrStopAction(_ sender: NSButton) {
@@ -681,9 +691,11 @@ final class NavigationBarViewController: NSViewController {
         let backButtonMenu = NSMenu()
         backButtonMenu.delegate = goBackButtonMenuDelegate
         goBackButton.menu = backButtonMenu
+        goBackButton.sendAction(on: [.leftMouseUp, .otherMouseDown])
         let forwardButtonMenu = NSMenu()
         forwardButtonMenu.delegate = goForwardButtonMenuDelegate
         goForwardButton.menu = forwardButtonMenu
+        goForwardButton.sendAction(on: [.leftMouseUp, .otherMouseDown])
 
         goBackButton.toolTip = UserText.navigateBackTooltip
         goForwardButton.toolTip = UserText.navigateForwardTooltip

--- a/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabsHostingView.swift
+++ b/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabsHostingView.swift
@@ -28,7 +28,7 @@ final class PinnedTabsHostingView: NSHostingView<PinnedTabsView> {
     }
 
     override func otherMouseDown(with event: NSEvent) {
-        guard event.buttonNumber == 2 else { return }
+        guard case .middle = event.button else { return }
 
         let locationInView = convert(event.locationInWindow, from: nil)
         middleClickSubject.send(locationInView)

--- a/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
@@ -24,16 +24,6 @@ import WebKitExtensions
 enum NavigationDecision {
     case allow(NewWindowPolicy)
     case cancel
-
-    /**
-     * Replaces `.tab` with `.window` when user prefers windows over tabs.
-     */
-    func preferringTabsToWindows(_ prefersTabsToWindows: Bool) -> NavigationDecision {
-        guard case .allow(let targetKind) = self, !prefersTabsToWindows else {
-            return self
-        }
-        return .allow(targetKind.preferringTabsToWindows(prefersTabsToWindows))
-    }
 }
 
 @MainActor

--- a/macOS/DuckDuckGo/YoutubePlayer/YoutubeOverlayUserScript.swift
+++ b/macOS/DuckDuckGo/YoutubePlayer/YoutubeOverlayUserScript.swift
@@ -24,7 +24,7 @@ import PixelKit
 import Combine
 
 protocol YoutubeOverlayUserScriptDelegate: AnyObject {
-    func youtubeOverlayUserScriptDidRequestDuckPlayer(with url: URL, in webView: WKWebView)
+    @MainActor func youtubeOverlayUserScriptDidRequestDuckPlayer(with url: URL, in webView: WKWebView)
 }
 
 final class YoutubeOverlayUserScript: NSObject, Subfeature {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1201048563534612/1203487090719153/f

### Description
- Refactor Back/Forward buttons  to use `LinkOpenBehavior` 
- Support middle click

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
- Install Middle Click from https://github.com/artginzburg/MiddleClick/releases (that will enable three-finger trackpad press to simulate middle click)
1. Navigate somewhere to have back/forward history
2. Middle-click back, forward buttons to validate new background tab is created
3. If Activate new tab setting is on, active tab should be created
5. When Shift+; Opt+; Cmd+; Cmd+Shift; Cmd+Opt+Shift; Opt+Shift - middle click should act accordingly
6. Clicking the buttons with modifiers should act accordingly (new active/background tab; new active/background window)

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)