### PR TITLE
Duck player new tab policy

### DIFF
--- a/macOS/DuckDuckGo/YoutubePlayer/YoutubeOverlayUserScript.swift
+++ b/macOS/DuckDuckGo/YoutubePlayer/YoutubeOverlayUserScript.swift
@@ -24,7 +24,7 @@ import PixelKit
 import Combine
 
 protocol YoutubeOverlayUserScriptDelegate: AnyObject {
-    func youtubeOverlayUserScriptDidRequestDuckPlayer(with url: URL, in webView: WKWebView)
+    @MainActor func youtubeOverlayUserScriptDidRequestDuckPlayer(with url: URL, in webView: WKWebView)
 }
 
 final class YoutubeOverlayUserScript: NSObject, Subfeature {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/0/1201048563534612/1203487090719153/f

### Description
- Refactor Duck Player to use `LinkOpenBehavior` 

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
- Install Middle Click from https://github.com/artginzburg/MiddleClick/releases (that will enable three-finger trackpad press to simulate middle click)
1. Open youtube; enable Duck Player 
2. Validate cmd+/cmd+shift/cmd+opt/cmd+opt+shift/middle/middle+shift/middle+cmd+shift/middle+opt/middle+cmd+opt/[+shift] - clicking links correctly opens Duck Player in expected tab configurations


### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)