### PR TITLE
Make sure recovery code displayed on backup

### DIFF
--- a/macOS/DuckDuckGo/Preferences/Model/SyncPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/SyncPreferences.swift
@@ -815,7 +815,9 @@ extension SyncPreferences: ManagementDialogModelDelegate {
         if isSyncEnabled && !featureFlagger.isFeatureOn(.exchangeKeysToSyncWithAnotherDevice) {
             code = recoveryCode
         } else {
-            code = codeToDisplay
+            // Fall back to recovery code if no other codeToDisplay is set as, if available,
+            // a recovery code will always work for connection
+            code = codeToDisplay ?? recoveryCode
         }
         guard let code else { return }
         let pasteboard = NSPasteboard.general


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1199230911884351/task/1209962162926952?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/1199230911884351/task/1209571867429615?focus=true

### Description
I found an issue where the "Copy Code" button for sync doesn't work on macOS at the end of the backup flow. I think this was masked before because codes often remain on the pasteboard after testing another flow. This fixes it and also generally makes the copyCode function more robust than it was before.

### Testing Steps
See linked asana task

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
This could have a side-effect I haven't spotted yet. But I'm pretty happy that the updated logic is more robust.

### Notes to Reviewer
Just this sync bug and other flows that show the recovery code dialog (generally after logging in / connecting accounts).

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)