### PR TITLE
Fix stuck tab previews

### DIFF
--- a/macOS/DuckDuckGo/Common/View/AppKit/HoverTrackingArea.swift
+++ b/macOS/DuckDuckGo/Common/View/AppKit/HoverTrackingArea.swift
@@ -19,7 +19,6 @@
 import AppKit
 import Foundation
 import os.log
-import SwiftUI
 
 /// Used in `MouseOverView` and `MouseOverButton` to automatically manage `isMouseOver` state and update layer when needed
 final class HoverTrackingArea: NSTrackingArea {
@@ -129,92 +128,21 @@ final class HoverTrackingArea: NSTrackingArea {
         let description = String(format: "<HoverTrackingArea %p: %@>", self, self.view?.description ?? "<nil>")
         Logger.general.error("\(description): received delayed mouseEntered event after mouseExited: \(event.eventDescription)")
 
-        // TODO: Uncomment the following code after the issue is tested:
-        // DispatchQueue.main.async { [weak self] in
-        //     self?.sendMouseExited(event)
-        // }
-        // TODO: Remove the following code after the issue is tested:
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            guard self.view?.isMouseOver == true else { return }
-
-            let window = NSWindow(
-                contentRect: NSRect(x: 0, y: 0, width: 600, height: 200),
-                styleMask: [.borderless],
-                backing: .buffered,
-                defer: false
-            )
-            window.backgroundColor = .clear
-            window.isOpaque = false
-            window.level = .floating
-            window.hasShadow = false
-            window.isReleasedWhenClosed = false
-            let sendMouseExited = {
-                self.sendMouseExited(event)
-            }
-            let isMouseOver = {
-                self.view?.isMouseOver ?? false
-            }
-            struct NotificationBubble: View {
-                let message: String
-                weak var window: NSWindow?
-                let sendMouseExited: () -> Void
-                let isMouseOver: () -> Bool
-                @State private var remainingSeconds = 5
-                let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
-
-                var body: some View {
-                    VStack {
-                        Text(message)
-                            .font(.system(size: 21, weight: .medium))
-                            .multilineTextAlignment(.center)
-                        Text(verbatim: "Fixing in: \(remainingSeconds) seconds…")
-                            .font(.system(size: 16))
-                            .foregroundColor(.gray)
-                    }
-                    .foregroundColor(.white)
-                    .padding()
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(Color(.black))
-                            .opacity(0.9)
-                    )
-                    .onReceive(timer) { _ in
-                        if remainingSeconds > 1 && isMouseOver() {
-                            remainingSeconds -= 1
-                        } else if let window {
-                            sendMouseExited()
-                            NSAnimationContext.runAnimationGroup({ context in
-                                context.duration = 0.3
-                                window.animator().alphaValue = 0
-                            }) {
-                                window.close()
-                            }
-                        }
-                    }
-                }
-            }
-
-            let notificationView = NSHostingView(rootView:
-                NotificationBubble(message: "Mouse hover state stuck caught", window: window, sendMouseExited: sendMouseExited, isMouseOver: isMouseOver)
-                    .frame(width: 400, height: 120)
-            )
-            window.contentView = notificationView
-
-            // Position window near top right of screen
-            if let screen = NSScreen.main {
-                let screenFrame = screen.visibleFrame
-                window.setFrameOrigin(NSPoint(
-                    x: screenFrame.midX - window.frame.width / 2,
-                    y: screenFrame.midY - window.frame.height / 2
-                ))
-            }
-
-            window.orderFront(nil)
+        DispatchQueue.main.async { [weak self] in
+            self?.sendMouseExited(event)
         }
     }
 
     private func sendMouseExited(_ event: NSEvent) {
-        guard let newEvent = NSEvent.enterExitEvent(with: .mouseExited, location: view?.window?.mouseLocationOutsideOfEventStream ?? event.locationInWindow, modifierFlags: event.modifierFlags, timestamp: event.timestamp, windowNumber: event.windowNumber, context: nil, eventNumber: event.eventNumber, trackingNumber: event.trackingNumber, userData: nil) else {
+        guard let newEvent = NSEvent.enterExitEvent(with: .mouseExited,
+                                                    location: view?.window?.mouseLocationOutsideOfEventStream ?? event.locationInWindow,
+                                                    modifierFlags: event.modifierFlags,
+                                                    timestamp: event.timestamp,
+                                                    windowNumber: event.windowNumber,
+                                                    context: nil,
+                                                    eventNumber: event.eventNumber,
+                                                    trackingNumber: [.mouseEntered, .mouseExited].contains(event.type) ? event.trackingNumber : 0,
+                                                    userData: nil) else {
             assertionFailure("Failed to create new mouse exited event")
             return
         }

--- a/macOS/DuckDuckGo/Common/View/AppKit/HoverTrackingArea.swift
+++ b/macOS/DuckDuckGo/Common/View/AppKit/HoverTrackingArea.swift
@@ -18,6 +18,8 @@
 
 import AppKit
 import Foundation
+import os.log
+import SwiftUI
 
 /// Used in `MouseOverView` and `MouseOverButton` to automatically manage `isMouseOver` state and update layer when needed
 final class HoverTrackingArea: NSTrackingArea {
@@ -38,7 +40,7 @@ final class HoverTrackingArea: NSTrackingArea {
         self
     }
 
-    private weak var view: Hoverable? {
+    fileprivate weak var view: Hoverable? {
         super.owner as? Hoverable
     }
 
@@ -57,9 +59,21 @@ final class HoverTrackingArea: NSTrackingArea {
     }
 
     private var observers: [NSKeyValueObservation]?
+    private var lastEventTimestamp: TimeInterval = 0
+
+    private static let mouseExitedSelector = NSStringFromSelector(#selector(NSResponder.mouseExited))
+    private static let swizzleMouseExitedOnce: Void = {
+        guard let originalMethod = class_getInstanceMethod(NSTrackingArea.self, NSSelectorFromString("_" + mouseExitedSelector)),
+            let swizzledMethod = class_getInstanceMethod(NSTrackingArea.self, #selector(swizzled_mouseExited(_:))) else {
+            assertionFailure("Failed to swizzle _mouseExited:")
+            return
+        }
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }()
 
     init(owner: some Hoverable) {
         super.init(rect: .zero, options: [.mouseEnteredAndExited, .mouseMoved, .activeInKeyWindow, .inVisibleRect], owner: owner, userInfo: nil)
+       _=Self.swizzleMouseExitedOnce
 
         observers = [
             owner.observe(\.backgroundColor) { [weak self] _, _ in self?.updateLayer() },
@@ -104,21 +118,131 @@ final class HoverTrackingArea: NSTrackingArea {
         }
     }
 
+    /// Fixes the issue where the mouseExited event is dispatched before the mouseEntered event, and the mouseOver state is stuck
+    /// the fix is done by dispatching a new mouseExited if the mouseEntered event has a timestamp older than the last event timestamp.
+    /// The second part of the fix is done by swizzling the `_mouseExited:` method.
+    /// https://app.asana.com/1/137249556945/project/1199230911884351/task/1208347387296425?focus=true
+    private func checkLastEventTimestamp(_ event: NSEvent) {
+        // if the mouseEntered event has a timestamp older than the last event timestamp, it means it's a delayed event
+        guard self.lastEventTimestamp > event.timestamp else { return }
+
+        let description = String(format: "<HoverTrackingArea %p: %@>", self, self.view?.description ?? "<nil>")
+        Logger.general.error("\(description): received delayed mouseEntered event after mouseExited: \(event.eventDescription)")
+
+        // TODO: Uncomment the following code after the issue is tested:
+        // DispatchQueue.main.async { [weak self] in
+        //     self?.sendMouseExited(event)
+        // }
+        // TODO: Remove the following code after the issue is tested:
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            guard self.view?.isMouseOver == true else { return }
+
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 600, height: 200),
+                styleMask: [.borderless],
+                backing: .buffered,
+                defer: false
+            )
+            window.backgroundColor = .clear
+            window.isOpaque = false
+            window.level = .floating
+            window.hasShadow = false
+            window.isReleasedWhenClosed = false
+            let sendMouseExited = {
+                self.sendMouseExited(event)
+            }
+            let isMouseOver = {
+                self.view?.isMouseOver ?? false
+            }
+            struct NotificationBubble: View {
+                let message: String
+                weak var window: NSWindow?
+                let sendMouseExited: () -> Void
+                let isMouseOver: () -> Bool
+                @State private var remainingSeconds = 5
+                let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+                var body: some View {
+                    VStack {
+                        Text(message)
+                            .font(.system(size: 21, weight: .medium))
+                            .multilineTextAlignment(.center)
+                        Text(verbatim: "Fixing in: \(remainingSeconds) seconds…")
+                            .font(.system(size: 16))
+                            .foregroundColor(.gray)
+                    }
+                    .foregroundColor(.white)
+                    .padding()
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(Color(.black))
+                            .opacity(0.9)
+                    )
+                    .onReceive(timer) { _ in
+                        if remainingSeconds > 1 && isMouseOver() {
+                            remainingSeconds -= 1
+                        } else if let window {
+                            sendMouseExited()
+                            NSAnimationContext.runAnimationGroup({ context in
+                                context.duration = 0.3
+                                window.animator().alphaValue = 0
+                            }) {
+                                window.close()
+                            }
+                        }
+                    }
+                }
+            }
+
+            let notificationView = NSHostingView(rootView:
+                NotificationBubble(message: "Mouse hover state stuck caught", window: window, sendMouseExited: sendMouseExited, isMouseOver: isMouseOver)
+                    .frame(width: 400, height: 120)
+            )
+            window.contentView = notificationView
+
+            // Position window near top right of screen
+            if let screen = NSScreen.main {
+                let screenFrame = screen.visibleFrame
+                window.setFrameOrigin(NSPoint(
+                    x: screenFrame.midX - window.frame.width / 2,
+                    y: screenFrame.midY - window.frame.height / 2
+                ))
+            }
+
+            window.orderFront(nil)
+        }
+    }
+
+    private func sendMouseExited(_ event: NSEvent) {
+        guard let newEvent = NSEvent.enterExitEvent(with: .mouseExited, location: view?.window?.mouseLocationOutsideOfEventStream ?? event.locationInWindow, modifierFlags: event.modifierFlags, timestamp: event.timestamp, windowNumber: event.windowNumber, context: nil, eventNumber: event.eventNumber, trackingNumber: event.trackingNumber, userData: nil) else {
+            assertionFailure("Failed to create new mouse exited event")
+            return
+        }
+        self.mouseExited(newEvent)
+    }
+
     @objc func mouseEntered(_ event: NSEvent) {
+        checkLastEventTimestamp(event)
+
         view?.isMouseOver = true
         view?.mouseEntered(with: event)
+        self.lastEventTimestamp = event.timestamp
     }
 
     @objc func mouseMoved(_ event: NSEvent) {
+        checkLastEventTimestamp(event)
+
         if let view, !view.isMouseOver {
             view.isMouseOver = true
         }
         view?.mouseMoved(with: event)
+        self.lastEventTimestamp = event.timestamp
     }
 
     @objc func mouseExited(_ event: NSEvent) {
         view?.isMouseOver = false
         view?.mouseExited(with: event)
+        self.lastEventTimestamp = event.timestamp
     }
 
     private func mouseDownDidChange() {
@@ -142,6 +266,22 @@ final class HoverTrackingArea: NSTrackingArea {
         updateLayer(animated: false)
     }
 
+}
+
+extension NSTrackingArea {
+    /// The second part of the fix for the mouse hover state stuck issue (see above)
+    /// If the mouseExited event is dispatched before the mouseEntered event, the NSTrackingArea won‘t call the mouseExited method
+    /// here we force the call of the mouseExited method and when we receive the delayed mouseEntered event later,
+    /// we will detect that it‘s a delayed event by comparing the event timestamp and fix the mouse hover state
+    /// see `checkLastEventTimestamp`
+    /// https://app.asana.com/1/137249556945/project/1199230911884351/task/1208347387296425?focus=true
+    @objc dynamic fileprivate func swizzled_mouseExited(_ event: NSEvent) {
+        self.swizzled_mouseExited(event) // call original method
+        if let hoverTrackingArea = self as? HoverTrackingArea,
+            hoverTrackingArea.view?.isMouseOver == true {
+            hoverTrackingArea.mouseExited(event)
+        }
+    }
 }
 
 @objc protocol HoverableProperties {

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -761,7 +761,11 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
     }
 
     private func showTabPreview(for tabViewModel: TabViewModel, from xPosition: CGFloat) {
-        guard shouldDisplayTabPreviews else { return }
+        guard shouldDisplayTabPreviews else {
+            Logger.tabPreview.error("Not showing tab preview: shouldDisplayTabPreviews == false")
+            hideTabPreview(allowQuickRedisplay: true)
+            return
+        }
 
         let isSelected = tabCollectionViewModel.selectedTabViewModel === tabViewModel
         tabPreviewWindowController.tabPreviewViewController.display(tabViewModel: tabViewModel,

--- a/macOS/DuckDuckGo/TabPreview/TabPreviewWindowController.swift
+++ b/macOS/DuckDuckGo/TabPreview/TabPreviewWindowController.swift
@@ -77,11 +77,12 @@ final class TabPreviewWindowController: NSWindowController {
 
         guard let childWindows = parentWindow.childWindows,
               let tabPreviewWindow = self.window else {
-            Logger.general.error("Showing tab preview window failed")
+            Logger.tabPreview.error("Showing tab preview window failed")
             return
         }
 
         if childWindows.contains(tabPreviewWindow) {
+            Logger.tabPreview.log("Preview already shown: moving to \(topLeftPointInWindow.x)x\(topLeftPointInWindow.y)")
             layout(topLeftPoint: parentWindow.convertPoint(toScreen: topLeftPointInWindow))
             return
         }
@@ -93,7 +94,10 @@ final class TabPreviewWindowController: NSWindowController {
         } else {
             // Set up a new timer for normal delayed presentation
             previewTimer = Timer.scheduledTimer(withTimeInterval: Self.delay, repeats: false) { [weak self, weak parentWindow] _ in
-                guard shouldDisplayPreviewAfterDelay(), let self, let parentWindow else { return }
+                guard shouldDisplayPreviewAfterDelay(), let self, let parentWindow else {
+                    Logger.tabPreview.info("preview not needed anymore after delay")
+                    return
+                }
                 presentPreview(in: parentWindow, at: topLeftPointInWindow)
             }
         }
@@ -102,7 +106,11 @@ final class TabPreviewWindowController: NSWindowController {
     private func presentPreview(in parentWindow: NSWindow, at topLeftPointInWindow: NSPoint) {
         Logger.tabPreview.log("Presenting tab preview")
 
-        guard let window, parentWindow.isVisible else { return }
+        guard let window, parentWindow.isVisible else {
+            Logger.tabPreview.error("can‘t present preview")
+            return
+        }
+
         parentWindow.addChildWindow(window, ordered: .above)
         self.layout(topLeftPoint: parentWindow.convertPoint(toScreen: topLeftPointInWindow))
     }
@@ -111,7 +119,10 @@ final class TabPreviewWindowController: NSWindowController {
         Logger.tabPreview.log("Hiding tab preview allowQuickRedisplay:\(allowQuickRedisplay) delay:\(delay)")
 
         previewTimer = nil
-        guard window?.isVisible == true else { return }
+        guard window?.isVisible == true else {
+            Logger.tabPreview.info("window is not visible: return early")
+            return
+        }
 
         if delay {
             // Set up a new timer to hide the preview after 0.05 seconds
@@ -130,19 +141,14 @@ final class TabPreviewWindowController: NSWindowController {
         Logger.tabPreview.log("Removing tab preview allowQuickRedisplay:\(allowQuickRedisplay)")
 
         guard let window else {
+            Logger.tabPreview.error("no window")
             lastHideTime = nil
             return
         }
 
-        guard let parentWindow = window.parent else {
-            if !allowQuickRedisplay {
-                lastHideTime = nil
-            }
-            window.orderOut(nil)
-            return
-        }
+        let parentWindow = window.parent
 
-        parentWindow.removeChildWindow(window)
+        parentWindow?.removeChildWindow(window)
         window.orderOut(nil)
 
         // Record the hide time
@@ -150,9 +156,7 @@ final class TabPreviewWindowController: NSWindowController {
     }
 
     private func layout(topLeftPoint: NSPoint) {
-        guard let window = window else {
-            return
-        }
+        guard let window else { return }
         var topLeftPoint = topLeftPoint
 
         // Make sure preview is presented within screen

--- a/macOS/LocalPackages/AppKitExtensions/Sources/AppKitExtensions/NSEventExtension.swift
+++ b/macOS/LocalPackages/AppKitExtensions/Sources/AppKitExtensions/NSEventExtension.swift
@@ -18,6 +18,7 @@
 
 import AppKit
 import Combine
+import Common
 
 public extension NSEvent {
 
@@ -96,8 +97,8 @@ public extension NSEvent {
 #if DEBUG
     var eventDescription: String {
         let eventString: String = String(describing: self)
-        let typePattern = try! NSRegularExpression(pattern: "type=(\\w+)")
-        let locPattern = try! NSRegularExpression(pattern: "loc=\\(([-\\d,.]+)\\)")
+        let typePattern = regex("type=(\\w+)")
+        let locPattern = regex("loc=\\(([-\\d,.]+)\\)")
 
         let typeRange = NSRange(eventString.startIndex..<eventString.endIndex, in: eventString)
         let locRange = NSRange(eventString.startIndex..<eventString.endIndex, in: eventString)

--- a/macOS/LocalPackages/AppKitExtensions/Sources/AppKitExtensions/NSEventExtension.swift
+++ b/macOS/LocalPackages/AppKitExtensions/Sources/AppKitExtensions/NSEventExtension.swift
@@ -93,6 +93,40 @@ public extension NSEvent {
             .eraseToAnyPublisher()
     }
 
+#if DEBUG
+    var eventDescription: String {
+        let eventString: String = String(describing: self)
+        let typePattern = try! NSRegularExpression(pattern: "type=(\\w+)")
+        let locPattern = try! NSRegularExpression(pattern: "loc=\\(([-\\d,.]+)\\)")
+
+        let typeRange = NSRange(eventString.startIndex..<eventString.endIndex, in: eventString)
+        let locRange = NSRange(eventString.startIndex..<eventString.endIndex, in: eventString)
+
+        if let typeMatch = typePattern.firstMatch(in: eventString, range: typeRange),
+           let locMatch = locPattern.firstMatch(in: eventString, range: locRange),
+           let typeRange = Range(typeMatch.range(at: 1), in: eventString),
+           let locRange = Range(locMatch.range(at: 1), in: eventString) {
+            let type = String(eventString[typeRange])
+            let loc = String(eventString[locRange])
+
+            let trackingAreaDescr: String
+            if [.mouseEntered, .mouseExited].contains(self.type) {
+                trackingAreaDescr = ", trackingArea: \(self.trackingArea.map { String(format: "%p", $0) } ?? "<nil>")"
+            } else {
+                trackingAreaDescr = ""
+            }
+
+            return "Event type: \(type), location: \(loc), timestamp: \(self.timestamp)\(trackingAreaDescr)"
+        }
+
+        return self.description
+    }
+#else
+    var eventDescription: String {
+        self.description
+    }
+#endif
+
 }
 
 public enum KeyEquivalentElement: ExpressibleByStringLiteral, Hashable {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1208347387296425

### Description
- Mitigate issue when `mouseEntered` events are received after `mouseExited` causing Tab Previews and buttons to stack in hovered state

### Testing Steps
- Test mouse movements from the attached videos to cause the input events breakage:
https://github.com/user-attachments/assets/3d7aac49-faea-436f-8581-e0bdf4a931ff
https://github.com/user-attachments/assets/67063d95-d341-46d8-8335-1e96f5d8bbf2
- Validate the events are caught and the wrong state is noticed: the testing window will appear - keep the cursor in one place while it counts; and after the timer is done the stuck state should be recovered from (the test window code will be rolled back before merged)

### Impact and Risks
High
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
Code breakage on future macOS releases
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)