### PR TITLE
macOS/iOS: Implement new and updated Privacy Pro Origins 

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL.swift
@@ -85,6 +85,30 @@ public enum SubscriptionURL {
     }
 }
 
+extension SubscriptionURL {
+    
+    /**
+     * Creates URL components for a subscription URL with the specified origin parameter.
+     *
+     * This method constructs a subscription URL by:
+     * 1. Using the base purchase URL
+     * 2. Appending the origin parameter to track where the subscription request originated from
+     * 3. Converting the resulting URL into URLComponents
+     *
+     * - Parameters:
+     *   - origin: A string identifying where the subscription request originated from (e.g., "funnel_appsettings_ios")
+     *   - environment: The subscription environment to use (defaults to production)
+     *
+     * - Returns: URLComponents containing the subscription URL with the origin parameter, or nil if the URL could not be parsed
+     */
+    public static func subscriptionURLComponentsWithOrigin(_ origin: String, environment: SubscriptionEnvironment.ServiceEnvironment = .production) -> URLComponents? {
+        let url = SubscriptionURL.purchase
+            .subscriptionURL(environment: environment)
+            .appendingParameter(name: AttributionParameter.origin, value: origin)
+        return URLComponents(url: url, resolvingAgainstBaseURL: false)
+    }
+}
+
 fileprivate extension URL {
 
     enum EnvironmentParameter {

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL.swift
@@ -88,9 +88,9 @@ public enum SubscriptionURL {
 extension SubscriptionURL {
 
     /**
-     * Creates URL components for a subscription URL with the specified origin parameter.
+     * Creates URL components for a subscription purchase URL with the specified origin parameter.
      *
-     * This method constructs a subscription URL by:
+     * This method constructs a subscription purchase URL by:
      * 1. Using the base purchase URL
      * 2. Appending the origin parameter to track where the subscription request originated from
      * 3. Converting the resulting URL into URLComponents
@@ -101,7 +101,7 @@ extension SubscriptionURL {
      *
      * - Returns: URLComponents containing the subscription URL with the origin parameter, or nil if the URL could not be parsed
      */
-    public static func subscriptionURLComponentsWithOrigin(_ origin: String, environment: SubscriptionEnvironment.ServiceEnvironment = .production) -> URLComponents? {
+    public static func purchaseURLComponentsWithOrigin(_ origin: String, environment: SubscriptionEnvironment.ServiceEnvironment = .production) -> URLComponents? {
         let url = SubscriptionURL.purchase
             .subscriptionURL(environment: environment)
             .appendingParameter(name: AttributionParameter.origin, value: origin)

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL.swift
@@ -86,7 +86,7 @@ public enum SubscriptionURL {
 }
 
 extension SubscriptionURL {
-    
+
     /**
      * Creates URL components for a subscription URL with the specified origin parameter.
      *

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
@@ -174,39 +174,39 @@ final class SubscriptionURLTests: XCTestCase {
         XCTAssertEqual(url, expectedURL)
     }
 
-    func testSubscriptionURLComponentsWithOriginForProduction() throws {
+    func testPurchaseURLComponentsWithOriginForProduction() throws {
         // Given
         let origin = "funnel_appsettings_ios"
         let expectedURL = URL(string: "https://duckduckgo.com/subscriptions?origin=funnel_appsettings_ios")!
 
         // When
-        let components = SubscriptionURL.subscriptionURLComponentsWithOrigin(origin, environment: .production)
+        let components = SubscriptionURL.purchaseURLComponentsWithOrigin(origin, environment: .production)
 
         // Then
         XCTAssertNotNil(components)
         XCTAssertEqual(components?.url, expectedURL)
     }
 
-    func testSubscriptionURLComponentsWithOriginForStaging() throws {
+    func testPurchaseURLComponentsWithOriginForStaging() throws {
         // Given
         let origin = "funnel_appsettings_ios"
         let expectedURL = URL(string: "https://duckduckgo.com/subscriptions?environment=staging&origin=funnel_appsettings_ios")!
 
         // When
-        let components = SubscriptionURL.subscriptionURLComponentsWithOrigin(origin, environment: .staging)
+        let components = SubscriptionURL.purchaseURLComponentsWithOrigin(origin, environment: .staging)
 
         // Then
         XCTAssertNotNil(components)
         XCTAssertEqual(components?.url, expectedURL)
     }
 
-    func testSubscriptionURLComponentsWithOriginWithEmptyOrigin() throws {
+    func testPurchaseURLComponentsWithOriginWithEmptyOrigin() throws {
         // Given
         let origin = ""
         let expectedURL = URL(string: "https://duckduckgo.com/subscriptions?origin=")!
 
         // When
-        let components = SubscriptionURL.subscriptionURLComponentsWithOrigin(origin, environment: .production)
+        let components = SubscriptionURL.purchaseURLComponentsWithOrigin(origin, environment: .production)
 
         // Then
         XCTAssertNotNil(components)

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
@@ -173,4 +173,43 @@ final class SubscriptionURLTests: XCTestCase {
         // Then
         XCTAssertEqual(url, expectedURL)
     }
+
+    func testSubscriptionURLComponentsWithOriginForProduction() throws {
+        // Given
+        let origin = "funnel_appsettings_ios"
+        let expectedURL = URL(string: "https://duckduckgo.com/subscriptions?origin=funnel_appsettings_ios")!
+
+        // When
+        let components = SubscriptionURL.subscriptionURLComponentsWithOrigin(origin, environment: .production)
+
+        // Then
+        XCTAssertNotNil(components)
+        XCTAssertEqual(components?.url, expectedURL)
+    }
+
+    func testSubscriptionURLComponentsWithOriginForStaging() throws {
+        // Given
+        let origin = "funnel_appsettings_ios"
+        let expectedURL = URL(string: "https://duckduckgo.com/subscriptions?environment=staging&origin=funnel_appsettings_ios")!
+
+        // When
+        let components = SubscriptionURL.subscriptionURLComponentsWithOrigin(origin, environment: .staging)
+
+        // Then
+        XCTAssertNotNil(components)
+        XCTAssertEqual(components?.url, expectedURL)
+    }
+
+    func testSubscriptionURLComponentsWithOriginWithEmptyOrigin() throws {
+        // Given
+        let origin = ""
+        let expectedURL = URL(string: "https://duckduckgo.com/subscriptions?origin=")!
+
+        // When
+        let components = SubscriptionURL.subscriptionURLComponentsWithOrigin(origin, environment: .production)
+
+        // Then
+        XCTAssertNotNil(components)
+        XCTAssertEqual(components?.url, expectedURL)
+    }
 }

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1080,6 +1080,7 @@
 		C1641EAF2BC2F5140012607A /* ImportPasswordsViaSyncViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1641EAE2BC2F5140012607A /* ImportPasswordsViaSyncViewController.swift */; };
 		C1641EB12BC2F52B0012607A /* ImportPasswordsViaSyncView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1641EB02BC2F52B0012607A /* ImportPasswordsViaSyncView.swift */; };
 		C1641EB32BC2F53C0012607A /* ImportPasswordsViaSyncViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1641EB22BC2F53C0012607A /* ImportPasswordsViaSyncViewModel.swift */; };
+		C167D9062DAD5BDA00FA1E70 /* SubscriptionFunnelOrigin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C167D9052DAD5BDA00FA1E70 /* SubscriptionFunnelOrigin.swift */; };
 		C16C0E392D146A1B009A81CC /* PaywallViewBucketer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C16C0E382D146A1B009A81CC /* PaywallViewBucketer.swift */; };
 		C16C0E3B2D146AF3009A81CC /* PaywallViewBucketerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C16C0E3A2D146AF3009A81CC /* PaywallViewBucketerTests.swift */; };
 		C174CE602BD6A6CE00AED2EA /* MockDDGSyncing.swift in Sources */ = {isa = PBXBuildFile; fileRef = C185ED652BD43A5500BAE9DC /* MockDDGSyncing.swift */; };
@@ -3147,6 +3148,7 @@
 		C1641EB22BC2F53C0012607A /* ImportPasswordsViaSyncViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportPasswordsViaSyncViewModel.swift; sourceTree = "<group>"; };
 		C164F9472D0861D600BAE88E /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		C164F9482D0861D600BAE88E /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
+		C167D9052DAD5BDA00FA1E70 /* SubscriptionFunnelOrigin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionFunnelOrigin.swift; sourceTree = "<group>"; };
 		C16C0E382D146A1B009A81CC /* PaywallViewBucketer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewBucketer.swift; sourceTree = "<group>"; };
 		C16C0E3A2D146AF3009A81CC /* PaywallViewBucketerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewBucketerTests.swift; sourceTree = "<group>"; };
 		C174E08E2D08625300ACE1AF /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -6694,6 +6696,7 @@
 				D664C7B02B289AA000CBFA76 /* UserScripts */,
 				D664C7932B289AA000CBFA76 /* ViewModel */,
 				D664C7AC2B289AA000CBFA76 /* Views */,
+				C167D9052DAD5BDA00FA1E70 /* SubscriptionFunnelOrigin.swift */,
 			);
 			path = Subscription;
 			sourceTree = "<group>";
@@ -9088,6 +9091,7 @@
 				6AC6DAB328804F97002723C0 /* BarsAnimator.swift in Sources */,
 				659AD5B12D76160C00420D1D /* YoutubeOembedService.swift in Sources */,
 				CB4FA44E2C78AACE00A16F5A /* SpecialErrorPageUserScript.swift in Sources */,
+				C167D9062DAD5BDA00FA1E70 /* SubscriptionFunnelOrigin.swift in Sources */,
 				EE0153ED2A6FF9E6002A8B26 /* NetworkProtectionRootView.swift in Sources */,
 				EEF0F8CC2ABC832300630031 /* NetworkProtectionDebugFeatures.swift in Sources */,
 				5644419D2D4D1EDD003C53B8 /* FeatureFlagsMenuView.swift in Sources */,

--- a/iOS/DuckDuckGo/PrivacyProPromotionExperiment/OnboardingPrivacyProPromoExperiment.swift
+++ b/iOS/DuckDuckGo/PrivacyProPromotionExperiment/OnboardingPrivacyProPromoExperiment.swift
@@ -98,7 +98,7 @@ struct OnboardingPrivacyProPromoExperiment: OnboardingPrivacyProPromoExperimenti
 
     /// Returns the URL components for the experiment.
     func redirectURLComponents() -> URLComponents? {
-        SubscriptionURL.subscriptionURLComponentsWithOrigin(SubscriptionFunnelOrigin.onboarding.rawValue)
+        SubscriptionURL.purchaseURLComponentsWithOrigin(SubscriptionFunnelOrigin.onboarding.rawValue)
     }
 
     /// Fires a pixel when the onboarding promotion is shown.

--- a/iOS/DuckDuckGo/PrivacyProPromotionExperiment/OnboardingPrivacyProPromoExperiment.swift
+++ b/iOS/DuckDuckGo/PrivacyProPromotionExperiment/OnboardingPrivacyProPromoExperiment.swift
@@ -98,8 +98,7 @@ struct OnboardingPrivacyProPromoExperiment: OnboardingPrivacyProPromoExperimenti
 
     /// Returns the URL components for the experiment.
     func redirectURLComponents() -> URLComponents? {
-        let url = SubscriptionURL.purchase.subscriptionURL(environment: .production).appendingParameter(name: AttributionParameter.origin, value: Constants.origin)
-        return URLComponents(url: url, resolvingAgainstBaseURL: true)
+        SubscriptionURL.subscriptionURLComponentsWithOrigin(Constants.origin)
     }
 
     /// Fires a pixel when the onboarding promotion is shown.

--- a/iOS/DuckDuckGo/PrivacyProPromotionExperiment/OnboardingPrivacyProPromoExperiment.swift
+++ b/iOS/DuckDuckGo/PrivacyProPromotionExperiment/OnboardingPrivacyProPromoExperiment.swift
@@ -98,7 +98,7 @@ struct OnboardingPrivacyProPromoExperiment: OnboardingPrivacyProPromoExperimenti
 
     /// Returns the URL components for the experiment.
     func redirectURLComponents() -> URLComponents? {
-        SubscriptionURL.subscriptionURLComponentsWithOrigin(Constants.origin)
+        SubscriptionURL.subscriptionURLComponentsWithOrigin(SubscriptionFunnelOrigin.onboarding.rawValue)
     }
 
     /// Fires a pixel when the onboarding promotion is shown.

--- a/iOS/DuckDuckGo/SettingsRootView.swift
+++ b/iOS/DuckDuckGo/SettingsRootView.swift
@@ -34,7 +34,7 @@ struct SettingsRootView: View {
     @State var isShowingSubscribeFlow = false
 
     private var settingPrivacyProRedirectURLComponents: URLComponents? {
-        SubscriptionURL.subscriptionURLComponentsWithOrigin(SubscriptionFunnelOrigin.appSettings.rawValue)
+        SubscriptionURL.purchaseURLComponentsWithOrigin(SubscriptionFunnelOrigin.appSettings.rawValue)
     }
 
     var body: some View {

--- a/iOS/DuckDuckGo/SettingsRootView.swift
+++ b/iOS/DuckDuckGo/SettingsRootView.swift
@@ -33,12 +33,8 @@ struct SettingsRootView: View {
     @State var deepLinkTarget: SettingsViewModel.SettingsDeepLinkSection?
     @State var isShowingSubscribeFlow = false
 
-    private enum Constants {
-        static let funnelAppSettingsOrigin = "funnel_appsettings_ios"
-    }
-
     private var settingPrivacyProRedirectURLComponents: URLComponents? {
-        SubscriptionURL.subscriptionURLComponentsWithOrigin(Constants.funnelAppSettingsOrigin)
+        SubscriptionURL.subscriptionURLComponentsWithOrigin(SubscriptionFunnelOrigin.appSettings.rawValue)
     }
 
     var body: some View {

--- a/iOS/DuckDuckGo/SettingsRootView.swift
+++ b/iOS/DuckDuckGo/SettingsRootView.swift
@@ -20,6 +20,7 @@
 import SwiftUI
 import UIKit
 import DesignResourcesKit
+import Subscription
 
 struct SettingsRootView: View {
 
@@ -32,6 +33,14 @@ struct SettingsRootView: View {
     @State var deepLinkTarget: SettingsViewModel.SettingsDeepLinkSection?
     @State var isShowingSubscribeFlow = false
 
+    private enum Constants {
+        static let funnelAppSettingsOrigin = "funnel_appsettings_ios"
+    }
+
+    private var settingPrivacyProRedirectURLComponents: URLComponents? {
+        SubscriptionURL.subscriptionURLComponentsWithOrigin(Constants.funnelAppSettingsOrigin)
+    }
+
     var body: some View {
 
         // Hidden navigationLinks for programatic navigation
@@ -42,7 +51,7 @@ struct SettingsRootView: View {
             }
         }
 
-        NavigationLink(destination: navigationDestinationView(for: .subscriptionFlow()),
+        NavigationLink(destination: navigationDestinationView(for: .subscriptionFlow(redirectURLComponents: settingPrivacyProRedirectURLComponents)),
                        isActive: $isShowingSubscribeFlow) { EmptyView() }
 
         List {

--- a/iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
+++ b/iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
@@ -1,5 +1,6 @@
 //
 //  SubscriptionFunnelOrigin.swift
+//  DuckDuckGo
 //
 //  Copyright © 2025 DuckDuckGo. All rights reserved.
 //
@@ -18,14 +19,11 @@
 
 import Foundation
 
-/// Represents the origin point from which the user enters the subscription funnel in the macOS app.
+/// Represents the origin point from which the user enters the subscription funnel in the iOS app.
 enum SubscriptionFunnelOrigin: String {
+    /// User entered the funnel via the onboarding dialog screen.
+    case onboarding = "funnel_onboarding_ios"
+
     /// User entered the funnel via the App Settings screen.
-    case appSettings = "funnel_appsettings_macos"
-
-    /// User entered the funnel via the App More Menu.
-    case appMenu = "funnel_appmenu_macos"
-
-    /// User entered the funnel via the Free Scan feature.
-    case freeScan = "funnel_freescan_macos"
+    case appSettings = "funnel_appsettings_ios"
 }

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -3177,6 +3177,8 @@
 		C153E7C62C8B21B500B9BAD7 /* Logger+FreemiumDBP.swift in Sources */ = {isa = PBXBuildFile; fileRef = C153E7C42C8B21B500B9BAD7 /* Logger+FreemiumDBP.swift */; };
 		C16127EE2BDFB46400966BB9 /* DataImportShortcutsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C16127ED2BDFB46400966BB9 /* DataImportShortcutsView.swift */; };
 		C16127EF2BDFB46400966BB9 /* DataImportShortcutsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C16127ED2BDFB46400966BB9 /* DataImportShortcutsView.swift */; };
+		C167D9032DAD561C00FA1E70 /* SubscriptionFunnelOrigin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C167D9022DAD561C00FA1E70 /* SubscriptionFunnelOrigin.swift */; };
+		C167D9042DAD561C00FA1E70 /* SubscriptionFunnelOrigin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C167D9022DAD561C00FA1E70 /* SubscriptionFunnelOrigin.swift */; };
 		C168B9AC2B31DC7E001AFAD9 /* AutofillNeverPromptWebsitesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C168B9AB2B31DC7E001AFAD9 /* AutofillNeverPromptWebsitesManager.swift */; };
 		C168B9AD2B31DC7F001AFAD9 /* AutofillNeverPromptWebsitesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C168B9AB2B31DC7E001AFAD9 /* AutofillNeverPromptWebsitesManager.swift */; };
 		C172E72F2C9329D300521D9A /* FlippedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C172E72E2C9329D300521D9A /* FlippedView.swift */; };
@@ -5196,6 +5198,7 @@
 		C153E7C12C8AD68D00B9BAD7 /* FreemiumDBPPromotionViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreemiumDBPPromotionViewCoordinator.swift; sourceTree = "<group>"; };
 		C153E7C42C8B21B500B9BAD7 /* Logger+FreemiumDBP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+FreemiumDBP.swift"; sourceTree = "<group>"; };
 		C16127ED2BDFB46400966BB9 /* DataImportShortcutsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataImportShortcutsView.swift; sourceTree = "<group>"; };
+		C167D9022DAD561C00FA1E70 /* SubscriptionFunnelOrigin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionFunnelOrigin.swift; sourceTree = "<group>"; };
 		C168B9AB2B31DC7E001AFAD9 /* AutofillNeverPromptWebsitesManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutofillNeverPromptWebsitesManager.swift; sourceTree = "<group>"; };
 		C172E72E2C9329D300521D9A /* FlippedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlippedView.swift; sourceTree = "<group>"; };
 		C172E7322C93759C00521D9A /* SyncPromoManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncPromoManagerTests.swift; sourceTree = "<group>"; };
@@ -10419,6 +10422,7 @@
 				F1DA51852BF607D200CF29FA /* SubscriptionRedirectManager.swift */,
 				F1FDC9372BF51F41006B1435 /* VPNSettings+Environment.swift */,
 				1E25A4FD2CC937120080EFD4 /* SubscriptionCookieManageEventPixelMapping.swift */,
+				C167D9022DAD561C00FA1E70 /* SubscriptionFunnelOrigin.swift */,
 			);
 			path = Subscription;
 			sourceTree = "<group>";
@@ -12590,6 +12594,7 @@
 				379857FF2D725672008773F6 /* OpenMultipleTabsWarningDialog.swift in Sources */,
 				3706FC02293F65D500E42796 /* Downloads.xcdatamodeld in Sources */,
 				37FC2A192CF903080048E226 /* MockPrivacyStats.swift in Sources */,
+				C167D9032DAD561C00FA1E70 /* SubscriptionFunnelOrigin.swift in Sources */,
 				B60C6F7829B0E286007BFAA8 /* SearchNonexistentDomainNavigationResponder.swift in Sources */,
 				9F56CFB22B843F6C00BB7F11 /* BookmarksDialogViewFactory.swift in Sources */,
 				374EFDF42D01C99E00B30939 /* ActiveRemoteMessageModel+NewTabPage.swift in Sources */,
@@ -14081,6 +14086,7 @@
 				AA5C1DD5285C780C0089850C /* RecentlyClosedCoordinator.swift in Sources */,
 				376E8C1D2D41920A00D5D2EC /* RecentActivityProvider.swift in Sources */,
 				AA88D14B252A557100980B4E /* URLRequestExtension.swift in Sources */,
+				C167D9042DAD561C00FA1E70 /* SubscriptionFunnelOrigin.swift in Sources */,
 				AA6197C6276B3168008396F0 /* FaviconHostReference.swift in Sources */,
 				3199AF792C80734A003AEBDC /* DuckPlayerOnboardingViewModel.swift in Sources */,
 				B6685E4229A61C470043D2EE /* DownloadsTabExtension.swift in Sources */,

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -1202,7 +1202,7 @@ extension NavigationBarViewController: OptionsButtonMenuDelegate {
 
     func optionsButtonMenuRequestedSubscriptionPurchasePage(_ menu: NSMenu) {
         let url = subscriptionManager.url(for: .purchase)
-        WindowControllersManager.shared.showTab(with: .subscription(url))
+        WindowControllersManager.shared.showTab(with: .subscription(url.appendingParameter(name: AttributionParameter.origin, value: SubscriptionFunnelOrigin.appMenu.rawValue)))
         PixelKit.fire(PrivacyProPixel.privacyProOfferScreenImpression)
     }
 

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesRootView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesRootView.swift
@@ -133,7 +133,7 @@ enum Preferences {
         private func makeSubscriptionViewModel() -> PreferencesSubscriptionModel {
             let openURL: (URL) -> Void = { url in
                 DispatchQueue.main.async {
-                    WindowControllersManager.shared.showTab(with: .subscription(url))
+                    WindowControllersManager.shared.showTab(with: .subscription(url.appendingParameter(name: AttributionParameter.origin, value: SubscriptionFunnelOrigin.appSettings.rawValue)))
                 }
             }
 

--- a/macOS/DuckDuckGo/Subscription/SubscriptionAttributionPixelHandler.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionAttributionPixelHandler.swift
@@ -28,10 +28,6 @@ protocol SubscriptionAttributionPixelHandler: AnyObject {
 
 final class PrivacyProSubscriptionAttributionPixelHandler: SubscriptionAttributionPixelHandler {
 
-    enum Consts {
-        static let freemiumOrigin = "funnel_freescan_macos"
-    }
-
     var origin: String?
     private let decoratedAttributionPixelHandler: AttributionPixelHandler
 

--- a/macOS/DuckDuckGo/Subscription/SubscriptionAttributionPixelHandler.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionAttributionPixelHandler.swift
@@ -29,7 +29,7 @@ protocol SubscriptionAttributionPixelHandler: AnyObject {
 final class PrivacyProSubscriptionAttributionPixelHandler: SubscriptionAttributionPixelHandler {
 
     enum Consts {
-        static let freemiumOrigin = "funnel_pro_mac_freemium"
+        static let freemiumOrigin = "funnel_freescan_macos"
     }
 
     var origin: String?

--- a/macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
@@ -1,0 +1,32 @@
+//
+//  SubscriptionFunnelOrigin.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// Represents the origin point from which the user enters the subscription funnel.
+/// Used for analytics and tracking funnel performance in the macOS app.
+enum SubscriptionFunnelOrigin: String {
+    /// User entered the funnel via the App Settings screen.
+    case appSettings = "funnel_appsettings_macos"
+
+    /// User entered the funnel via the App More Menu.
+    case appMenu = "funnel_appmenu_macos"
+
+    /// User entered the funnel via the Free Scan feature.
+    case freeScan = "funnel_freescan_macos"
+}

--- a/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeature.swift
@@ -579,7 +579,7 @@ private extension SubscriptionPagesUseSubscriptionFeature {
     ///   - `true` if the origin is set because the user has started their first Freemim PIR scan.
     ///   - `false` if a first scan has not been started and the origin is not set.
     func setFreemiumOriginIfScanPerformed() -> Bool {
-        let origin = PrivacyProSubscriptionAttributionPixelHandler.Consts.freemiumOrigin
+        let origin = SubscriptionFunnelOrigin.freeScan.rawValue
         if freemiumDBPUserStateManager.didPostFirstProfileSavedNotification {
             subscriptionSuccessPixelHandler.origin = origin
             return true

--- a/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeature.swift
@@ -573,7 +573,7 @@ private extension SubscriptionPagesUseSubscriptionFeature {
     /// Sets the origin for attribution if the user has started their first Freemium PIR scan
     ///
     /// This method checks whether the user has started their first Freemium PIR scan.
-    /// If they have, the method sets the subscription success tracking origin to `"funnel_pro_mac_freemium"` and returns `true`.
+    /// If they have, the method sets the subscription success tracking origin to `"funnel_freescan_macos"` and returns `true`.
     ///
     /// - Returns:
     ///   - `true` if the origin is set because the user has started their first Freemim PIR scan.

--- a/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeatureV2.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeatureV2.swift
@@ -585,7 +585,7 @@ private extension SubscriptionPagesUseSubscriptionFeatureV2 {
     /// Sets the origin for attribution if the user has started their first Freemium PIR scan
     ///
     /// This method checks whether the user has started their first Freemium PIR scan.
-    /// If they have, the method sets the subscription success tracking origin to `"funnel_pro_mac_freemium"` and returns `true`.
+    /// If they have, the method sets the subscription success tracking origin to `"funnel_freescan_macos"` and returns `true`.
     ///
     /// - Returns:
     ///   - `true` if the origin is set because the user has started their first Freemim PIR scan.

--- a/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeatureV2.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeatureV2.swift
@@ -591,7 +591,7 @@ private extension SubscriptionPagesUseSubscriptionFeatureV2 {
     ///   - `true` if the origin is set because the user has started their first Freemim PIR scan.
     ///   - `false` if a first scan has not been started and the origin is not set.
     func setFreemiumOriginIfScanPerformed() -> Bool {
-        let origin = PrivacyProSubscriptionAttributionPixelHandler.Consts.freemiumOrigin
+        let origin = SubscriptionFunnelOrigin.freeScan.rawValue
         if freemiumDBPUserStateManager.didPostFirstProfileSavedNotification {
             subscriptionSuccessPixelHandler.origin = origin
             return true

--- a/macOS/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
+++ b/macOS/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
@@ -1098,7 +1098,7 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
         subscriptionService.getSubscriptionResult = .success(SubscriptionMockFactory.expiredSubscription)
         mockFreemiumDBPUserStateManager.didPostFirstProfileSavedNotification = true
         feature.with(broker: broker)
-        let freeiumOrigin = PrivacyProSubscriptionAttributionPixelHandler.Consts.freemiumOrigin
+        let freeiumOrigin = SubscriptionFunnelOrigin.freeScan.rawValue
 
         // When
         let subscriptionSelectedParams = ["id": "some-subscription-id"]
@@ -1136,7 +1136,7 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
 
         mockFreemiumDBPUserStateManager.didPostFirstProfileSavedNotification = false
         feature.with(broker: broker)
-        let freeiumOrigin = PrivacyProSubscriptionAttributionPixelHandler.Consts.freemiumOrigin
+        let freeiumOrigin = SubscriptionFunnelOrigin.freeScan.rawValue
 
         // When
         let subscriptionSelectedParams = ["id": "some-subscription-id"]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/0/task/1209939561643745

### Description
The goal of these changes is significantly reduce the number of unattributed subscriptions by adding/updating Privacy Pro origins. 

### Testing Steps - iOS
**Note:** Each iOS test requires a sandbox user who is eligible for purchase (i.e not a subscriber)
**Prerequisites:**
*  Place a breakpoint at line `1224` of `SubscriptionPagesUseSubscriptionFeature` to allow observation of pixel origin
*  Add `return .treatment` to line `92` of `OnboardingPrivacyProPromoExperiment` to force onboarding experiment

#### Test 1
1. Run a fresh install of the app on a device
2. Navigate through onboarding to the privacy pro promotion (last onboarding dialog)
3. Tap `Learn More`
4. On the paywall, purchase a subscription
5. When the purchase succeeds, ensure the origin `funnel_onboarding_ios` is fired by the attribution pixel 

#### Test 2
1. Remove your subscription from the device
2. Using another eligible sandbox user, purchase a subscription after navigating to the paywall from the app settings menu (i.e `Get Privacy Pro` button)
3. When the purchase succeeds, ensure the origin `funnel_appsettings_ios` is fired by the attribution pixel 

### Testing Steps - macOS
**Prerequisites:**
1. Place a breakpoint at line `39` of `SubscriptionAttributionPixelHandler` to allow observation of pixel origin

#### Test 1
1. Run the app
2. Via the overflow more menu, open `Settings` -> `Privacy Pro` -> `Get Privacy Pro`
3. On the paywall, purchase a subscription
5. When the purchase succeeds, ensure the origin `funnel_appsettings_macos` is fired by the attribution pixel 

#### Test 2
1. Run the app
2. Via the overflow more menu, open `Privacy Pro` -> `Get Privacy Pro`
3. On the paywall, purchase a subscription
5. When the purchase succeeds, ensure the origin `funnel_appmenu_macos` is fired by the attribution pixel 

### Impact and Risks
Low

#### What could go wrong?
Incorrectly attributed subscriptions

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)