### PR TITLE
Add TabCrashRecoveryExtension and a feature flag for tab crash recovery

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -1299,6 +1299,8 @@
 		37E307AF2D07483400599500 /* NewTabPagePixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E307AD2D07482F00599500 /* NewTabPagePixel.swift */; };
 		37E307B22D075B6500599500 /* NewTabPagePrivacyStatsEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E307B12D075B5E00599500 /* NewTabPagePrivacyStatsEventHandler.swift */; };
 		37E307B32D075B6500599500 /* NewTabPagePrivacyStatsEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E307B12D075B5E00599500 /* NewTabPagePrivacyStatsEventHandler.swift */; };
+		37E3E8022DAE58660056DEED /* TabCrashRecoveryExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3E8012DAE58620056DEED /* TabCrashRecoveryExtension.swift */; };
+		37E3E8032DAE58660056DEED /* TabCrashRecoveryExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3E8012DAE58620056DEED /* TabCrashRecoveryExtension.swift */; };
 		37EC314C2D8C02C00026C348 /* FaviconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EC314B2D8C02BC0026C348 /* FaviconTests.swift */; };
 		37EC314D2D8C02C00026C348 /* FaviconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EC314B2D8C02BC0026C348 /* FaviconTests.swift */; };
 		37EC31502D8C19270026C348 /* CapturingFaviconImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EC314F2D8C19190026C348 /* CapturingFaviconImageCache.swift */; };
@@ -4055,6 +4057,7 @@
 		37E307AA2D0745D500599500 /* PrivacyStatsErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyStatsErrorHandler.swift; sourceTree = "<group>"; };
 		37E307AD2D07482F00599500 /* NewTabPagePixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPagePixel.swift; sourceTree = "<group>"; };
 		37E307B12D075B5E00599500 /* NewTabPagePrivacyStatsEventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPagePrivacyStatsEventHandler.swift; sourceTree = "<group>"; };
+		37E3E8012DAE58620056DEED /* TabCrashRecoveryExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabCrashRecoveryExtension.swift; sourceTree = "<group>"; };
 		37E75733296F4F0500E1C162 /* UnitTestsAppStore.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = UnitTestsAppStore.xcconfig; sourceTree = "<group>"; };
 		37E75734296F4F0500E1C162 /* IntegrationTestsAppStore.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = IntegrationTestsAppStore.xcconfig; sourceTree = "<group>"; };
 		37EC314B2D8C02BC0026C348 /* FaviconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconTests.swift; sourceTree = "<group>"; };
@@ -9667,6 +9670,7 @@
 				B6BF5D842946FFDA006742B1 /* PrivacyDashboardTabExtension.swift */,
 				37C9F78B2CF1C770004D73A1 /* PrivacyStatsTabExtension.swift */,
 				56BA1E742BAAF70F001CF69F /* SpecialErrorPageTabExtension.swift */,
+				37E3E8012DAE58620056DEED /* TabCrashRecoveryExtension.swift */,
 				B6BDDA002942389000F68088 /* TabExtensions.swift */,
 				1D9A4E592B43213B00F449E2 /* TabSnapshotExtension.swift */,
 				B626A76C29928B1600053070 /* TestsClosureNavigationResponder.swift */,
@@ -12254,6 +12258,7 @@
 				319FCFF62CC83007004F9288 /* AIChatDebugMenu.swift in Sources */,
 				3706FB4C293F65D500E42796 /* SharingMenu.swift in Sources */,
 				3706FB4D293F65D500E42796 /* GrammarFeaturesManager.swift in Sources */,
+				37E3E8022DAE58660056DEED /* TabCrashRecoveryExtension.swift in Sources */,
 				3706FB50293F65D500E42796 /* SafariFaviconsReader.swift in Sources */,
 				31267C692B640C4200FEF811 /* DataBrokerProtectionFeatureGatekeeper.swift in Sources */,
 				3706FB51293F65D500E42796 /* NSScreenExtension.swift in Sources */,
@@ -14179,6 +14184,7 @@
 				B6CC266C2BAD9CD800F53F8D /* FileProgressPresenter.swift in Sources */,
 				3158B14D2B0BF74D00AF130C /* DataBrokerProtectionManager.swift in Sources */,
 				BBFB727F2C48047C0088884C /* SortBookmarksViewModel.swift in Sources */,
+				37E3E8032DAE58660056DEED /* TabCrashRecoveryExtension.swift in Sources */,
 				4BA1A6A5258B07DF00F6F690 /* EncryptedValueTransformer.swift in Sources */,
 				8400DC4B2C6E26AE006509D2 /* ItemCachingCollectionView.swift in Sources */,
 				B634DBE1293C8FD500C3C99E /* Tab+Dialogs.swift in Sources */,

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "1ed51c1731b072b1042303887539b2382448fe4d",
-        "version" : "8.11.0"
+        "revision" : "3ddfbc576d7168ac6a3fec6372d99c12fc8ee15e",
+        "version" : "8.14.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/DesignResourcesKit.git",
       "state" : {
-        "revision" : "7083d28778f86a0d6620c08ab0eb98270749f14e",
-        "version" : "4.1.0"
+        "revision" : "8c99842fed1c7fa19de28132b1bdabfb7a33908a",
+        "version" : "4.2.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "2bc93bec9cbe6d916e84b42346b925c6c057bfa5",
-        "version" : "17.0.0"
+        "revision" : "90541ed7d3a69733fc37e9c51bd92f21e0d56a57",
+        "version" : "17.1.0"
       }
     },
     {

--- a/macOS/DuckDuckGo/Tab/Model/Tab+Navigation.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab+Navigation.swift
@@ -43,6 +43,7 @@ extension Tab: NavigationResponder {
         navigationDelegate.setResponders(
             .weak(nullable: self.navigationHotkeyHandler),
             .weak(nullable: self.brokenSiteInfo),
+            .weak(nullable: self.tabCrashRecovery),
 
             // redirect to SERP for non-valid domains entered by user
             // should be before `self` to avoid Tab presenting an error screen

--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -57,6 +57,7 @@ protocol NewWindowPolicyDecisionMaker {
         var tunnelController: NetworkProtectionIPCTunnelController?
         var maliciousSiteDetector: MaliciousSiteDetecting
         var faviconManagement: FaviconManagement?
+        var featureFlagger: FeatureFlagger
     }
 
     fileprivate weak var delegate: TabDelegate?
@@ -271,6 +272,7 @@ protocol NewWindowPolicyDecisionMaker {
                 tab.delegate?.closeTab(tab)
             },
                           titlePublisher: _title.projectedValue.eraseToAnyPublisher(),
+                          errorPublisher: _error.projectedValue.eraseToAnyPublisher(),
                           userScriptsPublisher: userScriptsPublisher,
                           inheritedAttribution: parentTab?.adClickAttribution?.currentAttributionState,
                           userContentControllerFuture: userContentControllerPromise.future,
@@ -286,7 +288,8 @@ protocol NewWindowPolicyDecisionMaker {
                                                        certificateTrustEvaluator: certificateTrustEvaluator,
                                                        tunnelController: tunnelController,
                                                        maliciousSiteDetector: maliciousSiteDetector,
-                                                       faviconManagement: faviconManagement))
+                                                       faviconManagement: faviconManagement,
+                                                       featureFlagger: featureFlagger))
 
         super.init()
         tabGetter = { [weak self] in self }
@@ -300,6 +303,13 @@ protocol NewWindowPolicyDecisionMaker {
         faviconCancellable = extensions.favicons?.faviconPublisher.assign(to: \.favicon, onWeaklyHeld: self)
         if favicon == nil {
             extensions.favicons?.handleFavicon(oldValue: nil, error: error)
+        }
+
+        tabCrashRecoveryCancellable = extensions.tabCrashRecovery?.tabCrashErrorPublisher.sink { [weak self] error in
+            guard let self, let url = content.urlForWebView else {
+                return
+            }
+            loadErrorHTML(error, header: UserText.webProcessCrashPageHeader, forUnreachableURL: url, alternate: true)
         }
 
         emailDidSignOutCancellable = NotificationCenter.default.publisher(for: .emailDidSignOut)
@@ -580,6 +590,9 @@ protocol NewWindowPolicyDecisionMaker {
             updateTitle()
         }
     }
+
+    private(set) var lastCrashedAt: Date?
+
     let permissions: PermissionModel
 
     @Published private(set) var isLoading: Bool = false {
@@ -1036,6 +1049,7 @@ protocol NewWindowPolicyDecisionMaker {
     private var webViewCancellables = Set<AnyCancellable>()
     private var emailDidSignOutCancellable: AnyCancellable?
     private var faviconCancellable: AnyCancellable?
+    private var tabCrashRecoveryCancellable: AnyCancellable?
 
     private func setupWebView(shouldLoadInBackground: Bool) {
         webView.navigationDelegate = navigationDelegate
@@ -1289,41 +1303,6 @@ extension Tab/*: NavigationResponder*/ { // to be moved to Tab+Navigation.swift
         // when already displaying the error page and reload navigation fails again: don‘t navigate, just update page HTML
         let shouldPerformAlternateNavigation = navigation.url != webView.url || navigation.navigationAction.targetFrame?.url != .error
         loadErrorHTML(error, header: UserText.errorPageHeader, forUnreachableURL: url, alternate: shouldPerformAlternateNavigation)
-    }
-
-    @MainActor
-    func webContentProcessDidTerminate(with reason: WKProcessTerminationReason?) {
-        guard (error?.code.rawValue ?? WKError.Code.unknown.rawValue) != WKError.Code.webContentProcessTerminated.rawValue else { return }
-
-        let terminationReason = reason?.rawValue ?? -1
-
-        let error = WKError(.webContentProcessTerminated, userInfo: [
-            WKProcessTerminationReason.userInfoKey: terminationReason,
-            NSLocalizedDescriptionKey: UserText.webProcessCrashPageMessage,
-            NSUnderlyingErrorKey: NSError(domain: WKErrorDomain, code: terminationReason)
-        ])
-
-        let isInternalUser = internalUserDecider?.isInternalUser == true
-
-        if isInternalUser {
-            self.webView.reload()
-        } else {
-            if case.url(let url, _, _) = content {
-                self.error = error
-
-                loadErrorHTML(error, header: UserText.webProcessCrashPageHeader, forUnreachableURL: url, alternate: true)
-            }
-        }
-
-        Task {
-#if APPSTORE
-            let additionalParameters = [String: String]()
-#else
-            let additionalParameters = await SystemInfo.pixelParameters()
-#endif
-
-            PixelKit.fire(DebugEvent(GeneralPixel.webKitDidTerminate, error: error), frequency: .dailyAndStandard, withAdditionalParameters: additionalParameters)
-        }
     }
 
     @MainActor

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabCrashRecoveryExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabCrashRecoveryExtension.swift
@@ -1,0 +1,140 @@
+//
+//  TabCrashRecoveryExtension.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import BrowserServicesKit
+import Combine
+import Foundation
+import Navigation
+import WebKit
+import PixelKit
+
+/**
+ * This Tab Extension is responsible for recovering from tab crashes.
+ */
+final class TabCrashRecoveryExtension {
+    private weak var webView: WKWebView?
+    private var content: Tab.TabContent?
+    private var lastCrashedAt: Date?
+    private let featureFlagger: FeatureFlagger
+    private var webViewError: WKError?
+    private let tabCrashErrorSubject = PassthroughSubject<WKError, Never>()
+    private let firePixel: (PixelKitEvent, [String: String]) -> Void
+
+    private var cancellables = Set<AnyCancellable>()
+
+    enum Const {
+        static let crashLoopInterval: TimeInterval = 5
+    }
+
+    init(
+        featureFlagger: FeatureFlagger,
+        contentPublisher: some Publisher<Tab.TabContent, Never>,
+        webViewPublisher: some Publisher<WKWebView, Never>,
+        webViewErrorPublisher: some Publisher<WKError?, Never>,
+        firePixel: @escaping (PixelKitEvent, [String: String]) -> Void = { event, parameters in
+            PixelKit.fire(event, frequency: .dailyAndStandard, withAdditionalParameters: parameters)
+        }
+    ) {
+        self.featureFlagger = featureFlagger
+        self.firePixel = firePixel
+
+        contentPublisher.sink { [weak self] content in
+            self?.content = content
+        }
+        .store(in: &cancellables)
+
+        webViewErrorPublisher.sink { [weak self] webViewError in
+            self?.webViewError = webViewError
+        }
+        .store(in: &cancellables)
+
+        webViewPublisher.sink { [weak self] webView in
+            self?.webView = webView
+        }.store(in: &cancellables)
+    }
+}
+
+extension TabCrashRecoveryExtension: NavigationResponder {
+
+    func webContentProcessDidTerminate(with reason: WKProcessTerminationReason?) {
+        guard let webView, (webViewError?.code.rawValue ?? WKError.Code.unknown.rawValue) != WKError.Code.webContentProcessTerminated.rawValue else {
+            return
+        }
+
+        let terminationReason = reason?.rawValue ?? -1
+
+        let error = WKError(.webContentProcessTerminated, userInfo: [
+            WKProcessTerminationReason.userInfoKey: terminationReason,
+            NSLocalizedDescriptionKey: UserText.webProcessCrashPageMessage,
+            NSUnderlyingErrorKey: NSError(domain: WKErrorDomain, code: terminationReason)
+        ])
+
+        Task {
+#if APPSTORE
+            let additionalParameters = [String: String]()
+#else
+            let additionalParameters = await SystemInfo.pixelParameters()
+#endif
+            firePixel(DebugEvent(GeneralPixel.webKitDidTerminate, error: error), additionalParameters)
+        }
+
+        if featureFlagger.isFeatureOn(.tabCrashRecovery) {
+            guard let lastCrashedAt else {
+                lastCrashedAt = Date()
+                webView.reload()
+                return
+            }
+            if Date().timeIntervalSince(lastCrashedAt) > Const.crashLoopInterval {
+                self.lastCrashedAt = Date()
+                webView.reload()
+            } else {
+                if case .url = content {
+                    tabCrashErrorSubject.send(error)
+                }
+            }
+        } else {
+            let isInternalUser = featureFlagger.internalUserDecider.isInternalUser == true
+
+            if isInternalUser {
+                webView.reload()
+            } else {
+                if case .url = content {
+                    tabCrashErrorSubject.send(error)
+                }
+            }
+        }
+    }
+}
+
+protocol TabCrashRecoveryExtensionProtocol: AnyObject, NavigationResponder {
+    var tabCrashErrorPublisher: AnyPublisher<WKError, Never> { get }
+}
+
+extension TabCrashRecoveryExtension: TabCrashRecoveryExtensionProtocol, TabExtension {
+    func getPublicProtocol() -> TabCrashRecoveryExtensionProtocol { self }
+
+    var tabCrashErrorPublisher: AnyPublisher<WKError, Never> {
+        tabCrashErrorSubject.eraseToAnyPublisher()
+    }
+}
+
+extension TabExtensions {
+    var tabCrashRecovery: TabCrashRecoveryExtensionProtocol? {
+        resolve(TabCrashRecoveryExtension.self)
+    }
+}

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
@@ -76,6 +76,7 @@ protocol TabExtensionDependencies {
     var tunnelController: NetworkProtectionIPCTunnelController? { get }
     var maliciousSiteDetector: MaliciousSiteDetecting { get }
     var faviconManagement: FaviconManagement? { get }
+    var featureFlagger: FeatureFlagger { get }
 }
 
 // swiftlint:disable:next large_tuple
@@ -87,6 +88,7 @@ typealias TabExtensionsBuilderArguments = (
     setContent: (Tab.TabContent) -> Void,
     closeTab: () -> Void,
     titlePublisher: AnyPublisher<String?, Never>,
+    errorPublisher: AnyPublisher<WKError?, Never>,
     userScriptsPublisher: AnyPublisher<UserScripts?, Never>,
     inheritedAttribution: AdClickAttributionLogic.State?,
     userContentControllerFuture: Future<UserContentController, Never>,
@@ -224,6 +226,15 @@ extension TabExtensionsBuilder {
             FaviconsTabExtension(scriptsPublisher: userScripts.compactMap { $0 },
                                  contentPublisher: args.contentPublisher,
                                  faviconManagement: dependencies.faviconManagement)
+        }
+
+        add {
+            TabCrashRecoveryExtension(
+                featureFlagger: dependencies.featureFlagger,
+                contentPublisher: args.contentPublisher,
+                webViewPublisher: args.webViewFuture,
+                webViewErrorPublisher: args.errorPublisher
+            )
         }
 
 #if SPARKLE

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -71,6 +71,9 @@ public enum FeatureFlag: String, CaseIterable {
 
     /// https://app.asana.com/0/72649045549333/1209793701087222/f
     case visualRefresh
+
+    /// https://app.asana.com/1/137249556945/project/72649045549333/task/1209227311680179?focus=true
+    case tabCrashRecovery
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -105,7 +108,8 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .privacyProAuthV2,
                 .scamSiteProtection,
                 .exchangeKeysToSyncWithAnotherDevice,
-                .visualRefresh:
+                .visualRefresh,
+                .tabCrashRecovery:
             return true
         case .debugMenu,
                 .sslCertificatesBypass,
@@ -167,6 +171,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(SyncSubfeature.exchangeKeysToSyncWithAnotherDevice))
         case .visualRefresh:
             return .remoteDevelopment(.feature(.experimentalBrowserTheming))
+        case .tabCrashRecovery:
+            return .disabled
         }
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1209977265286174?focus=true

### Description
This change moves tab crash handling to a dedicated extension that responds to webContentProcessDidTerminate.
It also introduces a feature flag for the new handling of tab crashes. The feature flag is disabled by default.

### Testing Steps
**Current behavior – non-internal user**
1. Remove internal user state
2. Open some website with a known URL (example.com is fine)
3. Open Activity Monitor.app and search for example.com. You should see 1 result.
<img width="1001" alt="Screenshot 2025-04-15 at 14 06 35" src="https://github.com/user-attachments/assets/89e290ea-70a3-4b09-89c4-62755de70537" />
4. Quit the process from Activity Monitor (X button)
5. Verify that the tab presents the error.
6. Reload the page and repeat steps 3-5.

**Current behavior – non-internal user**
1. Set internal user state
2. Open some website with a known URL (example.com is fine)
3. Open Activity Monitor.app and search for example.com.
4. Quit the process from Activity Monitor (X button)
5. Verify that the tab reloads example.com.
6. Reload the page and repeat steps 3-5.

**New behavior**
1. Set internal user state
2. Enable tabCrashRecovery feature flag
3. Open some website with a known URL (example.com is fine)
4. Open Activity Monitor.app and search for example.com.
5. Quit the process from Activity Monitor (X button)
6. Verify that the tab reloads example.com.
7. Wait for more than 5 seconds and reload the page. Repeat steps 3-6 (the tab reloads).
8. Quit the process again and quickly quit it one more time. If you were faster than 5s, you would see the error page. Edit `TabCrashRecoveryExtension.Const.crashLoopInterval` to a value larger than 5 to help with testing.

### Impact and Risks
Low

#### What could go wrong?
Not much, the tab extensions framework is stable and battle-tested and I consulted with Alex when implementing this change :)

### Quality Considerations
I’m not adding unit tests because I expect the solution to evolve. Existing solution didn’t have unit tests either, but I’ll add unit tests in a further PR.

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)