### PR TITLE
Fix lingering site theme color when switching between sites

### DIFF
--- a/iOS/DuckDuckGo/SiteThemeColorManager.swift
+++ b/iOS/DuckDuckGo/SiteThemeColorManager.swift
@@ -76,21 +76,23 @@ final class SiteThemeColorManager {
     private func startObservingThemeColor() {
         themeColorObservation = tabViewController?.webView?.observe(\.themeColor, options: [.initial, .new]) { [weak self] webView, change in
 
-            guard self?.isCurrentTabShowingDaxPlayer == false else {
+            guard let self, self.isCurrentTabShowingDaxPlayer == false else {
                 return
             }
 
-            guard let self,
-                  let newColor = change.newValue as? UIColor,
-                  let host = webView.url?.host,
-            self.shouldApplyColorToCurrentTab else {
-                self?.resetThemeColor()
+            guard self.shouldApplyColorToCurrentTab, let host = webView.url?.host else {
+                self.resetThemeColor()
                 return
             }
 
-            colorCache[host] = newColor
-            if isCurrentTab {
-                updateThemeColor(newColor)
+            if let newColor = change.newValue as? UIColor {
+                colorCache[host] = newColor
+                if isCurrentTab {
+                    updateThemeColor(newColor)
+                }
+            } else {
+                self.resetThemeColor()
+                self.colorCache[host] = nil
             }
         }
     }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1209909254596927
Tech Design URL:
CC:

### Description

In some cases the theme color can linger to another site which does not share a css-theme metatag. This attempts to fix this issue by clearing cached colors for domain where the theme color is not returned.

### Testing Steps
1. Enable experimental theming in Settings -> Appearance (you need to have internal user flag set)
2. Set address bar location to bottom.
3. Visit site with theme metatag published (e.g. github.com)
4. Navigate directly to serp search (type a search term in the address bar)
5. Navigate backwards and forward and observe if the status bar area color updates between website theme and gray.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)