### PR TITLE
Prevent 1px line from appearing below Tab Bar

### DIFF
--- a/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -199,6 +199,9 @@ final class MainWindowController: NSWindowController {
 
         tabBarViewController.view.removeFromSuperview()
         if toTitlebarView {
+            // Prevent 1px line from appearing below Tab Bar when hiding and subsequently showing it in fullscreen mode
+            // https://app.asana.com/1/137249556945/project/1201048563534612/task/1209999815083499?focus=true
+            newParentView.layer?.masksToBounds = true
             newParentView.addSubview(tabBarViewController.view)
         } else {
             newParentView.addSubview(tabBarViewController.view, positioned: .below, relativeTo: mainViewController.fireViewController.view)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1209999815083499?focus=true

### Description

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Enter Full Screen mode
2. Hide the Tab Bar (View → Show Tabs and Bookmarks Bar in Full Screen)
3. Show the Tab Bar again
4. Make sure the 1px line doesn‘t appear below the tab bar
![line_below_tab_bar](https://github.com/user-attachments/assets/ff719805-b41c-4034-b11a-69fb0fb5d4f1)
5. Test the Tab Bar controls (selection/closing/new tab), Navigation bar controls (Back/Forward/Address Bar/Menu) - they should work

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
Tab bar or navigation bar becomes unresponsive 

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)