### PR TITLE
Fix omnibar button padding

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -39,7 +39,7 @@ final class AddressBarViewController: NSViewController, ObservableObject {
     @IBOutlet var switchToTabBoxMinXConstraint: NSLayoutConstraint!
     private static let defaultActiveTextFieldMinX: CGFloat = 40
 
-    @IBOutlet weak var addressBarPassiveTextTrailingConstraint: NSLayoutConstraint!
+    @IBOutlet weak var addressBarPassiveTextCenterXConstraint: NSLayoutConstraint!
     @IBOutlet weak var addressBarTextTrailingConstraint: NSLayoutConstraint!
     private let popovers: NavigationBarPopovers?
     var addressBarButtonsViewController: AddressBarButtonsViewController?
@@ -603,9 +603,8 @@ extension AddressBarViewController {
 
 extension AddressBarViewController: AddressBarButtonsViewControllerDelegate {
     func addressBarButtonsViewController(_ controller: AddressBarButtonsViewController, didUpdateAIChatButtonVisibility isVisible: Bool) {
-        let padding: CGFloat = isVisible ? 80 : 45
-        addressBarTextTrailingConstraint.constant = padding
-        addressBarPassiveTextTrailingConstraint.constant = padding
+        addressBarTextTrailingConstraint.constant = isVisible ? 80 : 45
+        addressBarPassiveTextCenterXConstraint.constant = isVisible ? -20 : 0
     }
 
     func addressBarButtonsViewControllerClearButtonClicked(_ addressBarButtonsViewController: AddressBarButtonsViewController) {

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -39,6 +39,7 @@ final class AddressBarViewController: NSViewController, ObservableObject {
     @IBOutlet var switchToTabBoxMinXConstraint: NSLayoutConstraint!
     private static let defaultActiveTextFieldMinX: CGFloat = 40
 
+    @IBOutlet weak var addressBarPassiveTextTrailingConstraint: NSLayoutConstraint!
     @IBOutlet weak var addressBarTextTrailingConstraint: NSLayoutConstraint!
     private let popovers: NavigationBarPopovers?
     var addressBarButtonsViewController: AddressBarButtonsViewController?
@@ -602,7 +603,9 @@ extension AddressBarViewController {
 
 extension AddressBarViewController: AddressBarButtonsViewControllerDelegate {
     func addressBarButtonsViewController(_ controller: AddressBarButtonsViewController, didUpdateAIChatButtonVisibility isVisible: Bool) {
-        addressBarTextTrailingConstraint.constant = isVisible ? 80 : 45
+        let padding: CGFloat = isVisible ? 80 : 45
+        addressBarTextTrailingConstraint.constant = padding
+        addressBarPassiveTextTrailingConstraint.constant = padding
     }
 
     func addressBarButtonsViewControllerClearButtonClicked(_ addressBarButtonsViewController: AddressBarButtonsViewController) {

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
@@ -587,7 +587,6 @@
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="zaX-wZ-E3D" secondAttribute="trailing" constant="45" id="3qw-n4-evE"/>
                             <constraint firstItem="Zjk-bE-Xft" firstAttribute="top" secondItem="wj6-L2-5rJ" secondAttribute="top" constant="-3" id="7Hj-tq-lmj"/>
                             <constraint firstItem="JKb-5c-xaF" firstAttribute="leading" secondItem="wj6-L2-5rJ" secondAttribute="leading" priority="300" constant="550" id="9CH-r6-Spp"/>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="le0-Hn-ZAC" secondAttribute="trailing" constant="45" id="BQS-RT-fLY"/>
                             <constraint firstAttribute="trailing" secondItem="ENV-0H-Fcc" secondAttribute="trailing" constant="2" id="Cig-ek-031"/>
                             <constraint firstItem="zaX-wZ-E3D" firstAttribute="height" relation="lessThanOrEqual" secondItem="wj6-L2-5rJ" secondAttribute="height" multiplier="0.55" id="E0Q-AU-qRQ"/>
                             <constraint firstItem="e0p-7S-Gan" firstAttribute="leading" secondItem="wj6-L2-5rJ" secondAttribute="leading" id="E5D-iA-uu3"/>
@@ -622,7 +621,7 @@
                         <outlet property="activeBackgroundViewWithSuggestions" destination="Ij9-fc-CLI" id="JWC-g2-hrM"/>
                         <outlet property="activeOuterBorderView" destination="Zjk-bE-Xft" id="u6o-fc-V76"/>
                         <outlet property="activeTextFieldMinXConstraint" destination="bY3-LA-cuF" id="Sln-8O-mrq"/>
-                        <outlet property="addressBarPassiveTextTrailingConstraint" destination="BQS-RT-fLY" id="0d8-Wr-Fpa"/>
+                        <outlet property="addressBarPassiveTextCenterXConstraint" destination="GIk-xf-3Bn" id="R7K-GQ-6Nm"/>
                         <outlet property="addressBarTextField" destination="zaX-wZ-E3D" id="pfO-d4-i46"/>
                         <outlet property="addressBarTextTrailingConstraint" destination="3qw-n4-evE" id="Hgt-4m-g06"/>
                         <outlet property="buttonsContainerView" destination="bOl-8Z-hTh" id="UHc-27-JaK"/>

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="o2v-eH-jTI">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="o2v-eH-jTI">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -587,6 +587,7 @@
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="zaX-wZ-E3D" secondAttribute="trailing" constant="45" id="3qw-n4-evE"/>
                             <constraint firstItem="Zjk-bE-Xft" firstAttribute="top" secondItem="wj6-L2-5rJ" secondAttribute="top" constant="-3" id="7Hj-tq-lmj"/>
                             <constraint firstItem="JKb-5c-xaF" firstAttribute="leading" secondItem="wj6-L2-5rJ" secondAttribute="leading" priority="300" constant="550" id="9CH-r6-Spp"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="le0-Hn-ZAC" secondAttribute="trailing" constant="45" id="BQS-RT-fLY"/>
                             <constraint firstAttribute="trailing" secondItem="ENV-0H-Fcc" secondAttribute="trailing" constant="2" id="Cig-ek-031"/>
                             <constraint firstItem="zaX-wZ-E3D" firstAttribute="height" relation="lessThanOrEqual" secondItem="wj6-L2-5rJ" secondAttribute="height" multiplier="0.55" id="E0Q-AU-qRQ"/>
                             <constraint firstItem="e0p-7S-Gan" firstAttribute="leading" secondItem="wj6-L2-5rJ" secondAttribute="leading" id="E5D-iA-uu3"/>
@@ -621,6 +622,7 @@
                         <outlet property="activeBackgroundViewWithSuggestions" destination="Ij9-fc-CLI" id="JWC-g2-hrM"/>
                         <outlet property="activeOuterBorderView" destination="Zjk-bE-Xft" id="u6o-fc-V76"/>
                         <outlet property="activeTextFieldMinXConstraint" destination="bY3-LA-cuF" id="Sln-8O-mrq"/>
+                        <outlet property="addressBarPassiveTextTrailingConstraint" destination="BQS-RT-fLY" id="0d8-Wr-Fpa"/>
                         <outlet property="addressBarTextField" destination="zaX-wZ-E3D" id="pfO-d4-i46"/>
                         <outlet property="addressBarTextTrailingConstraint" destination="3qw-n4-evE" id="Hgt-4m-g06"/>
                         <outlet property="buttonsContainerView" destination="bOl-8Z-hTh" id="UHc-27-JaK"/>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210000017647881?focus=true
Tech Design URL:
CC:

### Description
Fix bookmarks padding

### Testing Steps
1. Open a long URL, like [this](https://duckduckgo.com/?q=wgsdgsgdsgsdgdsgdsgsgwgsdgsgdsgsdgdsgdsgsgwgsdgsgdsgsdgdsgdsgsgwgsdgsgdsgsdgddddsgdsgsg&ia=web)
2. Enable Show Full Website Address
3. Check if when you hover the mouse in the address bar, the bookmark button is not beneath the url text

### Impact and Risks
Low: Minor visual change

#### What could go wrong?
Missing some state where this new constraint might break the UI
