### PR TITLE
Fix testCorrectRecoveryCodeIsReturned

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncModels.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncModels.swift
@@ -145,7 +145,7 @@ public struct SyncCode: Codable {
         case error
     }
 
-    public struct RecoveryKey: Codable, Sendable {
+    public struct RecoveryKey: Codable, Sendable, Equatable {
         let userId: String
         let primaryKey: Data
     }

--- a/macOS/UnitTests/Sync/SyncPreferencesTests.swift
+++ b/macOS/UnitTests/Sync/SyncPreferencesTests.swift
@@ -146,18 +146,7 @@ final class SyncPreferencesTests: XCTestCase {
         let account = SyncAccount(deviceId: "some device", deviceName: "", deviceType: "", userId: "", primaryKey: Data(), secretKey: Data(), token: nil, state: .active)
         ddgSyncing.account = account
 
-        /// This function expects a base64-encoded string, decodes it,
-        /// and converts it into a JSON dictionary that could be realiably compared using `XCTAssertEqual`.
-        ///
-        /// We're doing this because two instances of `recoveryCode` may have different order
-        /// of keys within the inner JSON object, and because of that their base64 representations
-        /// will be different, while the "codes" would be functionally the same.
-        func contents(of code: String?) throws -> [String: String] {
-            let contents = try Data(base64Encoded: try XCTUnwrap(code)).flatMap { try JSONSerialization.jsonObject(with: $0) }
-            return try XCTUnwrap(contents as? [String: String])
-        }
-
-        try XCTAssertEqual(contents(of: syncPreferences.recoveryCode), contents(of: account.recoveryCode))
+        try XCTAssertEqual(SyncCode.RecoveryKey(base64Code: syncPreferences.recoveryCode), SyncCode.RecoveryKey(base64Code: account.recoveryCode))
     }
 
     @MainActor func testOnPresentRecoverSyncAccountDialogThenRecoverAccountDialogShown() async {
@@ -453,5 +442,13 @@ struct MockRemoteConnecting: RemoteConnecting {
     }
 
     func stopPolling() {
+    }
+}
+
+private extension SyncCode.RecoveryKey {
+    init(base64Code: String?) throws {
+        let contents = try Data(base64Encoded: try XCTUnwrap(base64Code))
+            .flatMap { try JSONDecoder.snakeCaseKeys.decode(SyncCode.self, from: $0) }
+        self = try XCTUnwrap(contents?.recovery)
     }
 }

--- a/macOS/UnitTests/Sync/SyncPreferencesTests.swift
+++ b/macOS/UnitTests/Sync/SyncPreferencesTests.swift
@@ -142,11 +142,22 @@ final class SyncPreferencesTests: XCTestCase {
         XCTAssertTrue(syncPreferences.isSyncEnabled)
     }
 
-    func testCorrectRecoveryCodeIsReturned() {
+    func testCorrectRecoveryCodeIsReturned() throws {
         let account = SyncAccount(deviceId: "some device", deviceName: "", deviceType: "", userId: "", primaryKey: Data(), secretKey: Data(), token: nil, state: .active)
         ddgSyncing.account = account
 
-        XCTAssertEqual(syncPreferences.recoveryCode, account.recoveryCode)
+        /// This function expects a base64-encoded string, decodes it,
+        /// and converts it into a JSON dictionary that could be realiably compared using `XCTAssertEqual`.
+        ///
+        /// We're doing this because two instances of `recoveryCode` may have different order
+        /// of keys within the inner JSON object, and because of that their base64 representations
+        /// will be different, while the "codes" would be functionally the same.
+        func contents(of code: String?) throws -> [String: String] {
+            let contents = try Data(base64Encoded: try XCTUnwrap(code)).flatMap { try JSONSerialization.jsonObject(with: $0) }
+            return try XCTUnwrap(contents as? [String: String])
+        }
+
+        try XCTAssertEqual(contents(of: syncPreferences.recoveryCode), contents(of: account.recoveryCode))
     }
 
     @MainActor func testOnPresentRecoverSyncAccountDialogThenRecoverAccountDialogShown() async {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1209980596323487?focus=true

### Description
Update SyncPreferences unit test to compare contents of the recovery code, rather than its base64 representation.

### Testing Steps
Verify that CI is green.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)