### PR TITLE
Fix macos sync UI tests

### DIFF
--- a/macOS/SyncE2EUITests/CriticalPathsTests.swift
+++ b/macOS/SyncE2EUITests/CriticalPathsTests.swift
@@ -289,9 +289,8 @@ final class CriticalPathsTests: XCTestCase {
         let settingsSheetsQuery = settingsWindow.sheets
         settingsSheetsQuery.buttons["Enter Code"].click()
         settingsSheetsQuery.buttons["Paste"].click()
-        let nextButton = settingsSheetsQuery.buttons["Next"]
-        if nextButton.exists {
-            nextButton.click()
+        if settingsSheetsQuery.buttons["Next"].exists {
+            settingsSheetsQuery.buttons["Next"].click()
         }
         settingsSheetsQuery.buttons["Done"].click()
         let secondDevice = settingsWindow.images["SyncedDeviceMobile"]

--- a/macOS/SyncE2EUITests/CriticalPathsTests.swift
+++ b/macOS/SyncE2EUITests/CriticalPathsTests.swift
@@ -289,7 +289,10 @@ final class CriticalPathsTests: XCTestCase {
         let settingsSheetsQuery = settingsWindow.sheets
         settingsSheetsQuery.buttons["Enter Code"].click()
         settingsSheetsQuery.buttons["Paste"].click()
-        settingsSheetsQuery.buttons["Next"].click()
+        let nextButton = settingsSheetsQuery.buttons["Next"]
+        if nextButton.exists {
+            nextButton.click()
+        }
         settingsSheetsQuery.buttons["Done"].click()
         let secondDevice = settingsWindow.images["SyncedDeviceMobile"]
         XCTAssertTrue(secondDevice.exists, "Original Device not visible")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1209998672880350?focus=true

### Description

There's been a slight change in the sync logic determining what is a recovery. Previously, the recovery codes was used for connecting as well as recovery, but now it's only used for recovery. This means that the recovery code modal will not show when logging in in the UI tests (as they only ever use a recovery code). 

This change should capture both the old and new flow.

### Testing Steps
CI on the sync e2e job should be green: https://github.com/duckduckgo/apple-browsers/actions/runs/14492806184

### Impact and Risks
Low

#### What could go wrong?
Failing tests

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)