### PR TITLE
[iOS][Onboarding] Fix flaky tests by avoid replacing the host app root window in tests

### DIFF
--- a/iOS/DuckDuckGoTests/ContextualDaxDialogsFactoryTests.swift
+++ b/iOS/DuckDuckGoTests/ContextualDaxDialogsFactoryTests.swift
@@ -33,8 +33,6 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
     private var window: UIWindow!
 
     override func setUpWithError() throws {
-        throw XCTSkip("Potentially flaky")
-        try super.setUpWithError()
         delegate = ContextualOnboardingDelegateMock()
         settingsMock = ContextualOnboardingSettingsMock()
         pixelReporterMock = OnboardingPixelReporterMock()
@@ -47,7 +45,7 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
             onboardingManager: onboardingManagerMock
         )
         window = UIWindow(frame: UIScreen.main.bounds)
-        window.makeKeyAndVisible()
+        window.isHidden = false
     }
 
     override func tearDownWithError() throws {
@@ -512,7 +510,7 @@ extension ContextualDaxDialogsFactoryTests {
         XCTAssertNotNil(host.view)
 
         // THEN
-        waitForExpectations(timeout: 10.0)
+        waitForExpectations(timeout: 2)
         completionHandler()
     }
 

--- a/iOS/DuckDuckGoTests/ContextualOnboardingNewTabDialogFactoryTests.swift
+++ b/iOS/DuckDuckGoTests/ContextualOnboardingNewTabDialogFactoryTests.swift
@@ -33,7 +33,6 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
     var window: UIWindow!
 
     override func setUpWithError() throws {
-        throw XCTSkip("Potentially flaky")
         try super.setUpWithError()
         mockDelegate = CapturingOnboardingNavigationDelegate()
         contextualOnboardingLogicMock = ContextualOnboardingLogicMock()
@@ -45,7 +44,7 @@ class ContextualOnboardingNewTabDialogFactoryTests: XCTestCase {
             onboardingPixelReporter: pixelReporterMock
         )
         window = UIWindow(frame: UIScreen.main.bounds)
-        window.makeKeyAndVisible()
+        window.isHidden = false
     }
 
     override func tearDown() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1208837629360126?focus=true

### Description

Re-enable DaxDialogs factory tests that were flaky. 

**Background:**

Some of these tests rely on SwiftUI’s `onAppear` being triggered in order to assert certain conditions.
For onAppear to be called, the view must be part of a view hierarchy attached to a window. Simply creating a `UIHostingController` is not enough — and even presenting it from another `UIViewController` does not trigger `onAppear`. The view needs to be rendered inside a visible (non-hidden) window for the SwiftUI lifecycle to begin.

Previously, the tests were using `makeKeyAndVisible()` on a dummy `UIWindow` to satisfy this requirement. However, this unintentionally replaced the main window of the host app, causing flaky behaviour and side effects across tests.

**Fix:**

This fix avoids calling `makeKeyAndVisible()` and instead attaches the view to a dummy `UIWindow` with `isHidden = false`. This is sufficient to trigger onAppear, without interfering with the app's main window or UI state.

### Testing Steps
Ensure CI is green

### Impact and Risks
Introduce flakiness in tests.

### Notes to Reviewer
The ticket also mentions "Tests use waitForExpectations while underlying calls potentially spawn Tasks - we should not mix structured concurrency with that API as it could produce unexpected deadlocks.” There are no tasks spawn from the SUT and its mocks. So the current fix should be enough.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)