### PR TITLE
Prevent OmniBar "ghosting" and fix scroll-related glitches

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -453,6 +453,7 @@
 		6FB2A67A2C2C5BAE004D20C8 /* FavoritePlaceholderItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB2A6792C2C5BAE004D20C8 /* FavoritePlaceholderItemView.swift */; };
 		6FB2A67E2C2DAFB4004D20C8 /* NewTabPageGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB2A67D2C2DAFB4004D20C8 /* NewTabPageGridView.swift */; };
 		6FB2A6802C2EA950004D20C8 /* FavoritesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB2A67F2C2EA950004D20C8 /* FavoritesViewModel.swift */; };
+		6FBC4DF72DB00DCC009BCF21 /* MockOmniBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBC4DF62DB00DCC009BCF21 /* MockOmniBar.swift */; };
 		6FBF0F8B2BD7C0A900136CF0 /* AllProtectedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBF0F8A2BD7C0A900136CF0 /* AllProtectedCell.swift */; };
 		6FC9059C2D65E2ED00E90A0B /* ExperimentalThemingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC9059B2D65E2ED00E90A0B /* ExperimentalThemingManager.swift */; };
 		6FD0C41F2C5BF097000561C9 /* NewTabPageIntroMessageSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD0C41E2C5BF097000561C9 /* NewTabPageIntroMessageSetupTests.swift */; };
@@ -2014,6 +2015,7 @@
 		6FB2A6792C2C5BAE004D20C8 /* FavoritePlaceholderItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritePlaceholderItemView.swift; sourceTree = "<group>"; };
 		6FB2A67D2C2DAFB4004D20C8 /* NewTabPageGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageGridView.swift; sourceTree = "<group>"; };
 		6FB2A67F2C2EA950004D20C8 /* FavoritesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesViewModel.swift; sourceTree = "<group>"; };
+		6FBC4DF62DB00DCC009BCF21 /* MockOmniBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOmniBar.swift; sourceTree = "<group>"; };
 		6FBF0F8A2BD7C0A900136CF0 /* AllProtectedCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllProtectedCell.swift; sourceTree = "<group>"; };
 		6FC9059B2D65E2ED00E90A0B /* ExperimentalThemingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentalThemingManager.swift; sourceTree = "<group>"; };
 		6FD0C41E2C5BF097000561C9 /* NewTabPageIntroMessageSetupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageIntroMessageSetupTests.swift; sourceTree = "<group>"; };
@@ -7366,6 +7368,7 @@
 		F17669A91E412A17003D3222 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				6FBC4DF62DB00DCC009BCF21 /* MockOmniBar.swift */,
 				8581F4D42D8B012B00D93DA6 /* MockTabPreviewsSource.swift */,
 				31CE145F2D552EBB0027F11D /* MockAIChatSettingsProvider.swift */,
 				31CE145D2D552E8D0027F11D /* MockOmnibarDependency.swift */,
@@ -9597,6 +9600,7 @@
 				D625AAEC2BBEF27600BC189A /* TabURLInterceptorTests.swift in Sources */,
 				EE7623BE2C5D038200FA061C /* MockFeatureFlagger.swift in Sources */,
 				5694372B2BE3F2D900C0881B /* SyncErrorHandlerTests.swift in Sources */,
+				6FBC4DF72DB00DCC009BCF21 /* MockOmniBar.swift in Sources */,
 				4B27FBB52C927435007E21A7 /* PersistentPixelTests.swift in Sources */,
 				987130C7294AAB9F00AB05E0 /* MenuBookmarksViewModelTests.swift in Sources */,
 				9F1C69212D7FEA5C0072F97D /* OnboardingManager+SetDefaultBrowserExperimentTests.swift in Sources */,

--- a/iOS/DuckDuckGo/BarsAnimator.swift
+++ b/iOS/DuckDuckGo/BarsAnimator.swift
@@ -91,8 +91,7 @@ class BarsAnimator {
 
         // Check if we need to perform additional changes
         let ratioMatchesCurrentState =
-        (barsState == .hidden && ratio == 1.0) ||
-        (barsState == .revealed && ratio == 0) ||
+        ((barsState == .hidden && ratio == 1.0) || (barsState == .revealed && ratio == 0)) &&
         transitionProgress == ratio
 
         guard !ratioMatchesCurrentState else {

--- a/iOS/DuckDuckGo/BarsAnimator.swift
+++ b/iOS/DuckDuckGo/BarsAnimator.swift
@@ -33,7 +33,7 @@ class BarsAnimator {
     private var bottomRevealGestureState: BottomBounceRevealing = .possible
     private var combinedBarsHeight: CGFloat {
         guard let delegate = delegate else { return 0 }
-        return delegate.toolbarHeight + delegate.omniBar.barView.frame.height
+        return delegate.toolbarHeight + delegate.omniBar.barView.expectedHeight
     }
 
     enum State: String {
@@ -89,45 +89,24 @@ class BarsAnimator {
     private func transitioningAndScrolling(in scrollView: UIScrollView) {
         let ratio = calculateTransitionRatio(for: scrollView.contentOffset.y)
 
+        // Check if we need to perform additional changes
+        let ratioMatchesCurrentState =
+        (barsState == .hidden && ratio == 1.0) ||
+        (barsState == .revealed && ratio == 0) ||
+        transitionProgress == ratio
+
+        guard !ratioMatchesCurrentState else {
+            return
+        }
+
         if ratio == 1.0 {
             barsState = .hidden
-            delegate?.setBarsVisibility(0, animated: false, animationDuration: nil)
         } else if ratio == 0 {
             barsState = .revealed
-            delegate?.setBarsVisibility(1, animated: false, animationDuration: nil)
         }
 
-        // On iOS 18 we end up in a loop after setBarsVisibility.
-        // It seems to trigger a new didScrollEvent when rendering some PDF files
-        // That causes an infinite loop.
-        // Are viewDidScroll calls happening more often for PDF's on iOS 18?
-        // Adding a debouncer while we investigate further
-        // https://app.asana.com/0/1204099484721401/1208671955053442/f
-        let debounceDelay: TimeInterval = 0.01
-        struct Debounce {
-            static var workItem: DispatchWorkItem?
-        }
-        Debounce.workItem?.cancel()
-
-        Debounce.workItem = DispatchWorkItem { [weak self] in
-            guard let self = self else { return }
-
-            let ratio = self.calculateTransitionRatio(for: scrollView.contentOffset.y)
-
-            if ratio == 1.0 {
-                self.barsState = .hidden
-            } else if ratio == 0 {
-                self.barsState = .revealed
-            } else if self.transitionProgress == ratio {
-                return
-            }
-
-            self.delegate?.setBarsVisibility(1.0 - ratio, animated: false, animationDuration: nil)
-            self.transitionProgress = ratio
-        }
-
-        // Schedule the work item
-        DispatchQueue.main.asyncAfter(deadline: .now() + debounceDelay, execute: Debounce.workItem!)
+        transitionProgress = ratio
+        delegate?.setBarsVisibility(1.0 - ratio, animated: false, animationDuration: nil)
     }
 
     private func hiddenAndScrolling(in scrollView: UIScrollView) {
@@ -155,7 +134,7 @@ class BarsAnimator {
 
     private func calculateTransitionRatio(for contentOffset: CGFloat) -> CGFloat {
         let distance = contentOffset - transitionStartPosY
-        let barsHeight = delegate?.barsMaxHeight ?? CGFloat.infinity
+        let barsHeight = combinedBarsHeight
 
         let cumulativeDistance = (barsHeight * transitionProgress) + distance
         let normalizedDistance = max(cumulativeDistance, 0)

--- a/iOS/DuckDuckGo/BrowserChromeManager.swift
+++ b/iOS/DuckDuckGo/BrowserChromeManager.swift
@@ -54,7 +54,6 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
     
     private var observation: NSKeyValueObservation?
 
-    private var dragging = false
     private var startZoomScale: CGFloat = 0
     
     func attach(to scrollView: UIScrollView) {
@@ -82,7 +81,7 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         guard !scrollView.isZooming else { return }
         
-        guard dragging else { return }
+        guard scrollView.isDragging else { return }
         guard canHideBars(for: scrollView) else {
             if animator.barsState != .revealed {
                 animator.revealBars(animated: true)
@@ -115,7 +114,6 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
 
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         guard !scrollView.isZooming else { return }
-        dragging = true
         
         animator.didStartScrolling(in: scrollView)
     }
@@ -128,7 +126,7 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
     }
 
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-        dragging = false
+        // no-op
     }
 
     func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {

--- a/iOS/DuckDuckGo/MainView.swift
+++ b/iOS/DuckDuckGo/MainView.swift
@@ -280,8 +280,7 @@ extension MainViewFactory {
 
         coordinator.constraints.contentContainerTop = contentContainer.constrainView(coordinator.topSlideContainer!, by: .top, to: .bottom)
         coordinator.constraints.contentContainerBottomToToolbarTop = contentContainer.constrainView(toolbar, by: .bottom, to: .top)
-        coordinator.constraints.contentContainerBottomToNavigationBarContainerTop
-            = contentContainer.constrainView(navigationBarContainer, by: .bottom, to: .top)
+        coordinator.constraints.contentContainerBottomToSafeArea = contentContainer.constrainView(superview, by: .bottom)
 
         NSLayoutConstraint.activate([
             contentContainer.constrainView(superview, by: .leading),

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -765,8 +765,10 @@ class MainViewController: UIViewController {
             self.viewCoordinator.constraints.navigationBarContainerHeight.constant = max(omniBarHeight, containerHeight)
 
             // Temporary fix, see https://app.asana.com/0/392891325557410/1207990702991361/f
-            let keyboardHeightInWebView = self.currentTab?.webView.convert(keyboardFrame, from: nil).height ?? 0
-            self.currentTab?.webView.scrollView.contentInset = .init(top: 0, left: 0, bottom: keyboardHeightInWebView > 0 ? omniBarHeight : 0, right: 0)
+            if let currentTab {
+                let inset = intersection.height > 0 ? omniBarHeight : 0
+                currentTab.webView.scrollView.contentInset = .init(top: 0, left: 0, bottom: inset, right: 0)
+            }
 
             UIView.animate(withDuration: duration, delay: 0, options: animationCurve) {
                 self.viewCoordinator.navigationBarContainer.superview?.layoutIfNeeded()
@@ -2025,7 +2027,8 @@ extension MainViewController: BrowserChromeDelegate {
             let topBarsConstant = -browserTabsOffset * (1.0 - ratio)
             viewCoordinator.constraints.tabBarContainerTop.constant = topBarsConstant
         }
-        viewCoordinator.constraints.navigationBarContainerTop.constant = browserTabsOffset + -navBarTopOffset * (1.0 - ratio)
+        viewCoordinator.constraints.navigationBarContainerTop.constant = -navBarTopOffset * (1.0 - ratio)
+        
     }
 
 }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1956,12 +1956,20 @@ extension MainViewController: BrowserChromeDelegate {
         }
            
         if animated {
+            self.view.layoutIfNeeded()
             UIView.animate(withDuration: animationDuration ?? ChromeAnimationConstants.duration) {
                 updateBlock()
                 self.view.layoutIfNeeded()
             }
         } else {
             updateBlock()
+
+            // Calling this here is important as it causes the layout to run immediately inside current run loop,
+            // instead of deferring it until next update block.
+            // Late layout after change here could potentially cause a scroll offset update right before the next one,
+            // which may cause an infitie loop layout loop in certain scenarios.
+            // See https://app.asana.com/1/137249556945/project/414709148257752/task/1208671955053442 for details.
+            self.view.layoutIfNeeded()
         }
     }
 
@@ -1992,7 +2000,7 @@ extension MainViewController: BrowserChromeDelegate {
     }
     
     var barsMaxHeight: CGFloat {
-        return max(toolbarHeight, viewCoordinator.omniBar.barView.frame.size.height)
+        max(toolbarHeight, viewCoordinator.omniBar.barView.expectedHeight)
     }
 
     // 1.0 - full size, 0.0 - hidden

--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -86,7 +86,7 @@ class MainViewCoordinator {
         var statusBackgroundToNavigationBarContainerBottom: NSLayoutConstraint!
         var statusBackgroundBottomToSafeAreaTop: NSLayoutConstraint!
         var contentContainerBottomToToolbarTop: NSLayoutConstraint!
-        var contentContainerBottomToNavigationBarContainerTop: NSLayoutConstraint!
+        var contentContainerBottomToSafeArea: NSLayoutConstraint!
         var topSlideContainerBottomToNavigationBarBottom: NSLayoutConstraint!
         var topSlideContainerBottomToStatusBackgroundBottom: NSLayoutConstraint!
         var topSlideContainerTopToNavigationBar: NSLayoutConstraint!
@@ -140,8 +140,9 @@ class MainViewCoordinator {
         // Hiding the container won't suffice as it still defines the contentContainer.bottomY through constraints
         navigationBarContainer.isHidden = true
 
-        constraints.contentContainerBottomToNavigationBarContainerTop.isActive = false
-        constraints.contentContainerBottomToToolbarTop.isActive = true
+        constraints.contentContainerBottomToToolbarTop.isActive = false
+        constraints.contentContainerBottomToSafeArea.isActive = true
+
     }
 
     func showNavigationBarWithBottomPosition() {
@@ -150,6 +151,9 @@ class MainViewCoordinator {
         }
 
         navigationBarContainer.isHidden = false
+
+        constraints.contentContainerBottomToToolbarTop.isActive = true
+        constraints.contentContainerBottomToSafeArea.isActive = false
     }
 
     func setAddressBarTopActive(_ active: Bool) {

--- a/iOS/DuckDuckGoTests/BarsAnimatorTests.swift
+++ b/iOS/DuckDuckGoTests/BarsAnimatorTests.swift
@@ -225,4 +225,3 @@ private class BrowserChromeDelegateMock: BrowserChromeDelegate {
 
     var tabBarContainer: UIView = UIView()
 }
-

--- a/iOS/DuckDuckGoTests/BarsAnimatorTests.swift
+++ b/iOS/DuckDuckGoTests/BarsAnimatorTests.swift
@@ -18,6 +18,7 @@
 //
 
 import XCTest
+import PrivacyDashboard
 
 @testable import DuckDuckGo
 
@@ -51,15 +52,9 @@ class BarsAnimatorTests: XCTestCase {
 
         scrollView.contentOffset.y = 300
         sut.didScroll(in: scrollView)
+        XCTAssertEqual(sut.barsState, .hidden)
+        XCTAssertEqual(delegate.receivedMessages.last, .setBarsVisibility(0.0))
 
-        let expectation = XCTestExpectation(description: "Wait for bars state to update to hidden")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-            XCTAssertEqual(sut.barsState, .hidden)
-            XCTAssertEqual(delegate.receivedMessages, [.setBarsVisibility(0.0), .setBarsVisibility(0.0), .setBarsVisibility(0.0)])
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 0.3)
     }
 
     func testBarStateHiddenWhenScrollDownKeepsHiddenState() {
@@ -76,32 +71,18 @@ class BarsAnimatorTests: XCTestCase {
 
         scrollView.contentOffset.y = 300
         sut.didScroll(in: scrollView)
-
-        // Add delay before checking hidden state
-        let expectation1 = XCTestExpectation(description: "Wait for bars state to update to hidden")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-            XCTAssertEqual(sut.barsState, .hidden)
-            expectation1.fulfill()
-        }
-
-        wait(for: [expectation1], timeout: 0.3)
+        XCTAssertEqual(sut.barsState, .hidden)
 
         scrollView.contentOffset.y = 100
         sut.didScroll(in: scrollView)
+        XCTAssertEqual(sut.barsState, .hidden)
 
-        // Add another delay before checking that barsState remains hidden
-        let expectation2 = XCTestExpectation(description: "Wait to confirm bars state remains hidden")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-            XCTAssertEqual(sut.barsState, .hidden)
-            XCTAssertTrue(delegate.receivedMessages.count >= 2, "Expected at least 2 messages, got \(delegate.receivedMessages.count)")
-            XCTAssertTrue(delegate.receivedMessages.allSatisfy { $0 == .setBarsVisibility(0.0) }, "All messages should be .setBarsVisibility(0.0), got \(delegate.receivedMessages)")
-            expectation2.fulfill()
-        }
-
-        wait(for: [expectation2], timeout: 0.3)
+        XCTAssertEqual(delegate.receivedMessages.count, 2)
+        XCTAssertLessThan(delegate.receivedMessages.first?.percent ?? 2.0, 1.0, "Message should be .setBarsVisibility(< 1.0), got \(delegate.receivedMessages)")
+        XCTAssertEqual(delegate.receivedMessages.last, .setBarsVisibility(0.0), "Message should be .setBarsVisibility(0.0), got \(delegate.receivedMessages)")
     }
 
-    func testBarStateHiddenWhenScrollUpUpdatesToRevealedState() {
+    func testBarStateHiddenWhenScrollUpUpdatesToRevealedState() throws {
         let (sut, delegate) = makeSUT()
         let scrollView = mockScrollView()
 
@@ -115,15 +96,7 @@ class BarsAnimatorTests: XCTestCase {
 
         scrollView.contentOffset.y = 400
         sut.didScroll(in: scrollView)
-
-        // Add delay before checking hidden state
-        let expectation1 = XCTestExpectation(description: "Wait for bars state to update to hidden")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-            XCTAssertEqual(sut.barsState, .hidden)
-            expectation1.fulfill()
-        }
-
-        wait(for: [expectation1], timeout: 0.3)
+        XCTAssertEqual(sut.barsState, .hidden)
 
         scrollView.contentOffset.y = -100
         sut.didStartScrolling(in: scrollView)
@@ -132,38 +105,27 @@ class BarsAnimatorTests: XCTestCase {
 
         scrollView.contentOffset.y = -150
         sut.didScroll(in: scrollView)
+        XCTAssertEqual(sut.barsState, .revealed)
 
-        // Add another delay before checking revealed state
-        let expectation2 = XCTestExpectation(description: "Wait for bars state to update to revealed")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-            XCTAssertEqual(sut.barsState, .revealed)
+        // Verify message pattern: first some 0.0 values, then some 1.0 values
+        XCTAssertTrue(delegate.receivedMessages.count >= 4, "Expected at least 4 messages, got \(delegate.receivedMessages.count)")
 
-            // Verify message pattern: first some 0.0 values, then some 1.0 values
-            XCTAssertTrue(delegate.receivedMessages.count >= 4, "Expected at least 4 messages, got \(delegate.receivedMessages.count)")
-
-            // Find where the transition from 0.0 to 1.0 happens
-            let transitionIndex = delegate.receivedMessages.firstIndex {
-                if case .setBarsVisibility(1.0) = $0 { return true } else { return false }
-            }
-
-            XCTAssertNotNil(transitionIndex, "Expected to find at least one .setBarsVisibility(1.0) message")
-
-            if let transitionIndex = transitionIndex {
-                // Check that all messages before transition are 0.0
-                let beforeTransition = delegate.receivedMessages[0..<transitionIndex]
-                XCTAssertTrue(beforeTransition.allSatisfy { $0 == .setBarsVisibility(0.0) },
-                              "All messages before transition should be .setBarsVisibility(0.0), got \(beforeTransition)")
-
-                // Check that all messages after and including transition are 1.0
-                let afterTransition = delegate.receivedMessages[transitionIndex...]
-                XCTAssertTrue(afterTransition.allSatisfy { $0 == .setBarsVisibility(1.0) },
-                              "All messages after transition should be .setBarsVisibility(1.0), got \(afterTransition)")
-            }
-
-            expectation2.fulfill()
+        // Find where the transition from 0.0 to 1.0 happens
+        let transitionIndex = delegate.receivedMessages.firstIndex {
+            if case .setBarsVisibility(1.0) = $0 { return true } else { return false }
         }
 
-        wait(for: [expectation2], timeout: 0.3)
+        let index = try XCTUnwrap(transitionIndex, "Expected to find at least one .setBarsVisibility(1.0) message")
+
+        // Check that all messages before transition are 0.0
+        let beforeTransition = delegate.receivedMessages[0..<index]
+        XCTAssertTrue(beforeTransition.allSatisfy { $0.percent ?? 2.0 <= 1 },
+                      "All messages before transition should be .setBarsVisibility(<= 1), got \(beforeTransition)")
+
+        // Check that all messages after and including transition are 1.0
+        let afterTransition = delegate.receivedMessages[index...]
+        XCTAssertTrue(afterTransition.allSatisfy { $0 == .setBarsVisibility(1.0) },
+                      "All messages after transition should be .setBarsVisibility(1.0), got \(afterTransition)")
     }
 
     func testBarStateRevealedWhenScrollUpDoNotChangeCurrentState() {
@@ -218,6 +180,15 @@ private class BrowserChromeDelegateMock: BrowserChromeDelegate {
         case setNavigationBarHidden(Bool)
         case setBarsVisibility(CGFloat)
         case setRefreshControlEnabled(Bool)
+
+        var percent: CGFloat? {
+            switch self {
+            case .setBarsVisibility(let value):
+                return value
+            default:
+                return nil
+            }
+        }
     }
 
     var receivedMessages: [Message] = []
@@ -242,18 +213,16 @@ private class BrowserChromeDelegateMock: BrowserChromeDelegate {
 
     var isToolbarHidden: Bool = false
 
-    var toolbarHeight: CGFloat = 0.0
+    var toolbarHeight: CGFloat = 0
 
-    var barsMaxHeight: CGFloat = 30
+    var barsMaxHeight: CGFloat = 0
 
-    var omniBar: OmniBar = DefaultOmniBarViewController(
-        dependencies: MockOmnibarDependency(
-            voiceSearchHelper: MockVoiceSearchHelper(
-                isSpeechRecognizerAvailable: true,
-                voiceSearchEnabled: true
-            )
-        )
-    )
+    var omniBar: OmniBar = {
+        let omniBar = MockOmniBar()
+        omniBar.mockBarView.expectedHeight = 52
+        return omniBar
+    }()
 
     var tabBarContainer: UIView = UIView()
 }
+

--- a/iOS/DuckDuckGoTests/MockOmniBar.swift
+++ b/iOS/DuckDuckGoTests/MockOmniBar.swift
@@ -1,0 +1,142 @@
+//
+//  MockOmniBar.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+import PrivacyDashboard
+
+@testable import DuckDuckGo
+
+final class MockOmniBar: OmniBar {
+    var mockBarView = MockOmniBarView()
+    var barView: any DuckDuckGo.OmniBarView {
+        mockBarView
+    }
+    var isBackButtonEnabled: Bool = false
+    var isForwardButtonEnabled: Bool = false
+    var omniDelegate: (any DuckDuckGo.OmniBarDelegate)?
+    var isTextFieldEditing: Bool = false
+    var text: String?
+    
+    func updateQuery(_ query: String?) { }
+    func refreshText(forUrl url: URL?, forceFullURL: Bool) { }
+    func beginEditing() { }
+    func endEditing() { }
+    func showSeparator() { }
+    func hideSeparator() { }
+    func moveSeparatorToTop() { }
+    func moveSeparatorToBottom() { }
+    func enterPhoneState() { }
+    func enterPadState() { }
+    func startBrowsing() { }
+    func stopBrowsing() { }
+    func startLoading() { }
+    func stopLoading() { }
+    func cancel() { }
+    func removeTextSelection() { }
+    func selectTextToEnd(_ offset: Int) { }
+    func updateAccessoryType(_ type: DuckDuckGo.OmniBarAccessoryType) { }
+    func showOrScheduleCookiesManagedNotification(isCosmetic: Bool) { }
+    func showOrScheduleOnboardingPrivacyIconAnimation() { }
+    func dismissOnboardingPrivacyIconAnimation() { }
+    func startTrackersAnimation(_ privacyInfo: PrivacyDashboard.PrivacyInfo, forDaxDialog: Bool) { }
+    func updatePrivacyIcon(for privacyInfo: PrivacyDashboard.PrivacyInfo?) { }
+    func hidePrivacyIcon() { }
+    func resetPrivacyIcon(for url: URL?) { }
+    func cancelAllAnimations() { }
+    func completeAnimationForDaxDialog() { }
+
+    final class MockOmniBarView: UIView, OmniBarView {
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        init() {
+            super.init(frame: .zero)
+        }
+
+        var text: String?
+        var expectedHeight: CGFloat = 52
+        var textField: DuckDuckGo.TextFieldWithInsets!
+        var accessoryType: DuckDuckGo.OmniBarAccessoryType = .chat
+        var privacyInfoContainer: DuckDuckGo.PrivacyInfoContainerView!
+        var notificationContainer: DuckDuckGo.OmniBarNotificationContainerView!
+        var searchContainer: UIView! = UIView()
+        var searchLoupe: UIView! = UIView()
+        var dismissButton: UIButton! = UIButton()
+        var backButton: UIButton! = UIButton()
+        var forwardButton: UIButton! = UIButton()
+        var settingsButton: UIButton! = UIButton()
+        var cancelButton: UIButton! = UIButton()
+        var bookmarksButton: UIButton! = UIButton()
+        var accessoryButton: UIButton! = UIButton()
+        var menuButton: UIButton! = UIButton()
+        var refreshButton: UIButton! = UIButton()
+        var leftIconContainerView: UIView! = UIView()
+        var customIconView: UIImageView = UIImageView()
+        var clearButton: UIButton! = UIButton()
+
+        func showSeparator() { }
+        func hideSeparator() { }
+        func moveSeparatorToTop() { }
+        func moveSeparatorToBottom() { }
+
+        var progressView: DuckDuckGo.ProgressView?
+        var privacyIconView: UIView?
+        var searchContainerWidth: CGFloat = 0
+        var menuButtonContent: DuckDuckGo.MenuButton = .init()
+        var onTextEntered: (() -> Void)?
+        var onVoiceSearchButtonPressed: (() -> Void)?
+        var onAbortButtonPressed: (() -> Void)?
+        var onClearButtonPressed: (() -> Void)?
+        var onPrivacyIconPressed: (() -> Void)?
+        var onMenuButtonPressed: (() -> Void)?
+        var onTrackersViewPressed: (() -> Void)?
+        var onSettingsButtonPressed: (() -> Void)?
+        var onCancelPressed: (() -> Void)?
+        var onRefreshPressed: (() -> Void)?
+        var onBackPressed: (() -> Void)?
+        var onForwardPressed: (() -> Void)?
+        var onBookmarksPressed: (() -> Void)?
+        var onAccessoryPressed: (() -> Void)?
+        var onDismissPressed: (() -> Void)?
+        var onSettingsLongPress: (() -> Void)?
+        var onAccessoryLongPress: (() -> Void)?
+
+        static func create() -> Self {
+            Self.init()
+        }
+
+        var isPrivacyInfoContainerHidden: Bool = true
+        var isClearButtonHidden: Bool = true
+        var isMenuButtonHidden: Bool = true
+        var isSettingsButtonHidden: Bool = true
+        var isCancelButtonHidden: Bool = true
+        var isRefreshButtonHidden: Bool = true
+        var isVoiceSearchButtonHidden: Bool = true
+        var isAbortButtonHidden: Bool = true
+        var isBackButtonHidden: Bool = true
+        var isForwardButtonHidden: Bool = true
+        var isBookmarksButtonHidden: Bool = true
+        var isAccessoryButtonHidden: Bool = true
+        var isSearchLoupeHidden: Bool = true
+        var isDismissButtonHidden: Bool = true
+
+    }
+}


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1208698793834668
Tech Design URL:
CC: @afterxleep 

### Description

https://github.com/duckduckgo/iOS/pull/3519 introduced a debounce which was supposed to prevent hangs in some cases ([see Asana](https://app.asana.com/1/137249556945/project/414709148257752/task/1208671955053442?focus=true)), however it introduced a bug when some of the events could be fired out of order, causing the bars to remain in mid-transition state.
I removed the debounce and forced a layout pass after applying the transition to prevent late layout loop right before going to the next update.

Additionally I improved the scrolling experience to not show up blank bars container when find in page control is visible (additional constraint).

### Testing Steps

Do each for bottom and top bar setting:

1. On a random page, check whether showing and hiding bars is not stopping mid-point when doing a quick and short "flick" scroll. Do a general smoke check on hiding bars.
2. Open Find In Page and check if scroll insets are properly adjusted.
3. On a page with form inputs check if all input fields are accessible.
4. Verify if scrolling / zooming / rotating (rapidly in opposite directions) on https://randomtests.netlify.app/sample3.pdf does not cause a hang.

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
App can hang in rare cases, webView insets can be calculated in a wrong way.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)