### PR TITLE
Fix ambiguity when compiling using iOS SDK 18.4

### DIFF
--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerWebView.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/Views/DuckPlayerWebView.swift
@@ -113,7 +113,7 @@ struct DuckPlayerWebView: UIViewRepresentable {
        @MainActor
        func getCurrentTimestamp(_ webView: WKWebView) async -> TimeInterval {
            do {
-               let result = try await (webView.evaluateJavaScript("getCurrentTime()") as Any)
+               let result: Any? = try await webView.evaluateJavaScript("getCurrentTime()")
                if let timestamp = result as? TimeInterval {
                    return timestamp
                } else {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1210001303846098
Tech Design URL:
CC:

### Description

Compilation fails on Xcode 16.3 because of function ambiguity. This helps the compiler with choosing a proper function. Backwards compatible with Xcode 16.2.

### Testing Steps
1. Verify compilation succeeds

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Duck player timestamp reading could stop working.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)