### PR TITLE
Properly handle gesture recognizer events for New Tab Shortcut

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -785,7 +785,8 @@ class MainViewController: UIViewController {
             button.imageView?.contentMode = .scaleAspectFit
             button.addAction(UIAction(handler: { _ in self.showTabSwitcher() }), for: .touchUpInside)
 
-            let longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(launchNewTab))
+            let longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(onNewTabLongPressRecognizer))
+            longPressRecognizer.minimumPressDuration = 0.4
             button.addGestureRecognizer(longPressRecognizer)
 
             viewCoordinator.toolbarTabSwitcherButton.customView = button
@@ -797,7 +798,14 @@ class MainViewController: UIViewController {
         viewCoordinator.toolbarTabSwitcherButton.isAccessibilityElement = true
         viewCoordinator.toolbarTabSwitcherButton.accessibilityTraits = .button
     }
-    
+
+    @objc private func onNewTabLongPressRecognizer(_ recognizer: UILongPressGestureRecognizer) {
+        guard recognizer.state == .began else { return }
+
+        UIImpactFeedbackGenerator(style: .heavy).impactOccurred()
+        newTabShortcutAction()
+    }
+
     private func initMenuButton() {
         viewCoordinator.menuToolbarButton.customView = menuButton
         viewCoordinator.menuToolbarButton.isAccessibilityElement = true
@@ -2220,6 +2228,12 @@ extension MainViewController: OmniBarDelegate {
                                  website: .addressBarClearPressedOnWebsite)
     }
 
+    private func newTabShortcutAction() {
+        Pixel.fire(pixel: .tabSwitchLongPressNewTab)
+        performCancel()
+        newTab()
+    }
+
     private var isSERPPresented: Bool {
         guard let tabURL = currentTab?.url else { return false }
         return tabURL.isDuckDuckGoSearch
@@ -2869,14 +2883,9 @@ extension MainViewController: BookmarksDelegate {
 }
 
 extension MainViewController: TabSwitcherButtonDelegate {
-    
+
     @objc func launchNewTab(_ button: TabSwitcherButton) {
-        if ExperimentalThemingManager().isExperimentalThemingEnabled {
-            UIImpactFeedbackGenerator(style: .heavy).impactOccurred()
-        }
-        Pixel.fire(pixel: .tabSwitchLongPressNewTab)
-        performCancel()
-        newTab()
+        newTabShortcutAction()
     }
 
     func showTabSwitcher(_ button: TabSwitcherButton) {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1209974629791759
Tech Design URL:
CC:

### Description

### Testing Steps
1. Enable Experimental appearance in Settings -> Appearance (internal user flag is required)
2. Long press tab switcher icon to open new tab.
3. Ensure a **single** tab is created and a haptic feedback is fired.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)