### PR TITLE
Cancel OmniBar animations on entering background

### DIFF
--- a/iOS/DuckDuckGo/Refactoring/Common/OmniBarViewController.swift
+++ b/iOS/DuckDuckGo/Refactoring/Common/OmniBarViewController.swift
@@ -138,6 +138,11 @@ class OmniBarViewController: UIViewController, OmniBar {
                                                selector: #selector(reloadSpeechRecognizerAvailability),
                                                name: .speechRecognizerDidChangeAvailability,
                                                object: nil)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(didEnterBackground),
+                                               name: UIApplication.didEnterBackgroundNotification,
+                                               object: nil)
     }
 
     private func assignActions() {
@@ -390,6 +395,10 @@ class OmniBarViewController: UIViewController, OmniBar {
         barView.customIconView.image = UIImage(named: icon.rawValue)
         barView.privacyInfoContainer.addSubview(barView.customIconView)
         barView.customIconView.isHidden = false
+    }
+
+    @objc private func didEnterBackground() {
+        cancelAllAnimations()
     }
 
     private func refreshState(_ newState: any OmniBarState) {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1209375583889148
Tech Design URL:
CC:

### Description

Animations were not completed properly when in background, leaving blank space in OmniBar. This change cancels the animations in case app is being backgrounded.

### Testing Steps
1. Open any site with trackers.
2. Wait for tracker animation to begin.
3. Put app to background
4. Go back after a few seconds, verify URL address is visible.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)