### PR TITLE
Disable rounded corners treatment for iPad

### DIFF
--- a/iOS/DuckDuckGo/ExperimentalThemingManager/ExperimentalThemingManager.swift
+++ b/iOS/DuckDuckGo/ExperimentalThemingManager/ExperimentalThemingManager.swift
@@ -33,6 +33,10 @@ struct ExperimentalThemingManager {
         featureFlagger.isFeatureOn(for: FeatureFlag.experimentalBrowserTheming, allowOverride: true)
     }
 
+    var isRoundedCornersTreatmentEnabled: Bool {
+        isExperimentalThemingEnabled && UIDevice.current.userInterfaceIdiom != .pad
+    }
+
     func toggleExperimentalTheming() {
         featureFlagger.localOverrides?.toggleOverride(for: FeatureFlag.experimentalBrowserTheming)
 

--- a/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -251,7 +251,7 @@ extension SwipeTabsCoordinator: UICollectionViewDelegate {
         }
 
         preview?.frame.origin.x = coordinator.contentContainer.frame.width * CGFloat(modifier)
-        if ExperimentalThemingManager().isExperimentalThemingEnabled {
+        if ExperimentalThemingManager().isRoundedCornersTreatmentEnabled {
             preview?.clipsToBounds = true
             preview?.layer.cornerRadius = 12
         }
@@ -427,7 +427,7 @@ class OmniBarCell: UICollectionViewCell {
     func addMaskViewIfNeeded() {
         guard let omniBarView = omniBar?.barView else { return }
 
-        if ExperimentalThemingManager().isExperimentalThemingEnabled,
+        if ExperimentalThemingManager().isRoundedCornersTreatmentEnabled,
            AppDependencyProvider.shared.appSettings.currentAddressBarPosition == .bottom,
            isPortrait {
             let maskView = RoundedCornersMaskView(cornerRadius: 12.0,

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -609,7 +609,7 @@ class TabViewController: UIViewController {
     }
 
     @objc func updateRoundedCorners() {
-        if ExperimentalThemingManager().isExperimentalThemingEnabled {
+        if ExperimentalThemingManager().isRoundedCornersTreatmentEnabled {
             webViewContainer.clipsToBounds = true
             webViewContainer.layer.cornerRadius = isPortrait ? 12 : 0
         }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1210012760498370
Tech Design URL:
CC:

### Description

This disables rounded corners on iPad when experimental appearance is enabled.

### Testing Steps
1. Enable Experimental Appearance in Settings -> Appearance (internal user flag needs to be enabled)
2. Check rounded corners are not visible on iPad.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)