### PR TITLE
Update macoOS autofill pixels names for consistency

### DIFF
--- a/macOS/DuckDuckGo/Autofill/AutofillPixelEvent.swift
+++ b/macOS/DuckDuckGo/Autofill/AutofillPixelEvent.swift
@@ -30,11 +30,11 @@ enum AutofillPixelKitEvent: PixelKitEventV2 {
 
     var name: String {
         switch self {
-        case .importCredentialsFlowStarted: "autofill_import_credentials_flow_started"
-        case .importCredentialsFlowCancelled: "autofill_import_credentials_flow_cancelled"
-        case .importCredentialsFlowHadCredentials: "autofill_import_credentials_flow_had_credentials"
-        case .importCredentialsFlowEnded: "autofill_import_credentials_flow_ended"
-        case .importCredentialsPromptNeverAgainClicked: "autofill_import_credentials_prompt_never_again_clicked"
+        case .importCredentialsFlowStarted: "autofill_import_credentials_flow_started_mac"
+        case .importCredentialsFlowCancelled: "autofill_import_credentials_flow_cancelled_mac"
+        case .importCredentialsFlowHadCredentials: "autofill_import_credentials_flow_had_credentials_mac"
+        case .importCredentialsFlowEnded: "autofill_import_credentials_flow_ended_mac"
+        case .importCredentialsPromptNeverAgainClicked: "autofill_import_credentials_prompt_never_again_clicked_mac"
         case .autofillSettingsOpened: "autofill_settings_opened"
         }
     }

--- a/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -617,7 +617,7 @@ enum GeneralPixel: PixelKitEventV2 {
             if pixel.isEmailPixel {
                 return "\(pixel.pixelName)_macos_desktop"
             } else if pixel.isCredentialsImportPromotionPixel {
-                return pixel.pixelName
+                return "\(pixel.pixelName)_mac"
             } else {
                 return "m_mac_\(pixel.pixelName)"
             }

--- a/macOS/DuckDuckGo/Sync/Promotion/SyncPromoPixelKitEvent.swift
+++ b/macOS/DuckDuckGo/Sync/Promotion/SyncPromoPixelKitEvent.swift
@@ -26,9 +26,9 @@ enum SyncPromoPixelKitEvent: PixelKitEventV2 {
 
     var name: String {
         switch self {
-        case .syncPromoDisplayed: return "sync_promotion_displayed_macos_desktop"
-        case .syncPromoConfirmed: return "sync_promotion_confirmed_macos_desktop"
-        case .syncPromoDismissed: return "sync_promotion_dismissed_macos_desktop"
+        case .syncPromoDisplayed: return "sync_promotion_displayed_mac"
+        case .syncPromoConfirmed: return "sync_promotion_confirmed_mac"
+        case .syncPromoDismissed: return "sync_promotion_dismissed_mac"
         }
     }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201462886803403/task/1210000018374573
Tech Design URL:
CC:

### Description
Updates some autofill pixels for a more consistent naming convention

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Lightly test the sync promo & onboarding prompts to confirm the pixel names are updated to use `_mac` suffix as per the asana task

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)