### PR TITLE
[iOS] fix missing tabs bar on iPad

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2035,8 +2035,7 @@ extension MainViewController: BrowserChromeDelegate {
             let topBarsConstant = -browserTabsOffset * (1.0 - ratio)
             viewCoordinator.constraints.tabBarContainerTop.constant = topBarsConstant
         }
-        viewCoordinator.constraints.navigationBarContainerTop.constant = -navBarTopOffset * (1.0 - ratio)
-        
+        viewCoordinator.constraints.navigationBarContainerTop.constant = browserTabsOffset + -navBarTopOffset * (1.0 - ratio)
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1210034746649731
Tech Design URL:
CC:

### Description
Re-add browser tabs offset for iPad

### Testing Steps

Perform the steps below with the following combos:

* iPhone
* iPad
* new UI vs old UI (internal user + toggle experimental ui feature flag, then restart app)
* address bar at top vs address bar at the bottom

1. Open a web page
2. Scroll the view so the bars appear and disappear
3. Rotate the screen and check bars appear and disappear
4. on iPad ensure that the tabs bar is always visible in the large view (ie not when in small split screen mode)

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Could break scrolling - but change should only impact iPad as the offset is zero on a phone (or the small split screen view on iPad).

### Quality Considerations

### Notes to Reviewer
Ensure tests from #516 still pass.
