### PR TITLE
re-order constraints to prevent crash

### DIFF
--- a/iOS/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/iOS/DuckDuckGo/SuggestionTrayViewController.swift
@@ -181,11 +181,11 @@ class SuggestionTrayViewController: UIViewController {
             variableHeightConstraint.constant = Constant.suggestionTrayInitialHeight
         }
 
-        view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor).isActive = true
-        view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor).isActive = true
-
         fullWidthConstraint.isActive = false
         fullHeightConstraint.isActive = false
+
+        view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor).isActive = true
+        view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor).isActive = true
     }
     
     func fill() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1210031492395115
Tech Design URL:
CC:

### Description
Reorder constant activation to prevent crash caused by exclusive constraints.

### Testing Steps
1. On an iPad mini simulator open our app and another app in Split View in landscape mode.  Our app should be in "phone" mode.
3. Type in to the search bar so that the suggestions appear
4. Rotate the device - the suggestion should change into a floating suggestion window
5. Repeat the above steps, but put the device into the background before rotating
6. Foreground the app - the suggestion tray has likely been closed, if not it should now be a floating tray

![Simulator Screenshot - iPad mini (6th generation) - 2025-04-22 at 11 34 34](https://github.com/user-attachments/assets/4b02cdeb-d873-4214-9bae-078350115057)

![Simulator Screenshot - iPad mini (6th generation) - 2025-04-22 at 11 35 12](https://github.com/user-attachments/assets/e07af80b-2f99-43b7-b2d9-bc8c05ace0d2)


### Impact and Risks
Medium: Could disrupt specific features or user flows - might not fix the crash detected.

#### What could go wrong?
* This is a speculative crash fix and might not fix the problem.

### Quality Considerations
* Try scenarios that involve the suggestion tray.

### Notes to Reviewer
?

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)