### PR TITLE
macOS: Fix issues with Watch In Youtube from Duck Player

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -1939,6 +1939,8 @@
 		56DB9FEA2CD24B47001BEC23 /* ContextualOnboardingPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DB9FE82CD24B47001BEC23 /* ContextualOnboardingPixel.swift */; };
 		56DB9FEC2CD2515F001BEC23 /* OnboardingPixelReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DB9FEB2CD2515F001BEC23 /* OnboardingPixelReporter.swift */; };
 		56DB9FED2CD2515F001BEC23 /* OnboardingPixelReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DB9FEB2CD2515F001BEC23 /* OnboardingPixelReporter.swift */; };
+		6590DB552DB7D59F007D6046 /* DuckPlayerTabExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6590DB542DB7D59F007D6046 /* DuckPlayerTabExtensionTests.swift */; };
+		6590DB562DB7D59F007D6046 /* DuckPlayerTabExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6590DB542DB7D59F007D6046 /* DuckPlayerTabExtensionTests.swift */; };
 		7B00997D2B6508B700FE7C31 /* NetworkProtectionProxy in Frameworks */ = {isa = PBXBuildFile; productRef = 7B00997C2B6508B700FE7C31 /* NetworkProtectionProxy */; };
 		7B00997F2B6508C200FE7C31 /* NetworkProtectionProxy in Frameworks */ = {isa = PBXBuildFile; productRef = 7B00997E2B6508C200FE7C31 /* NetworkProtectionProxy */; };
 		7B0099822B65C6B300FE7C31 /* MacTransparentProxyProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0099802B65C6B300FE7C31 /* MacTransparentProxyProvider.swift */; };
@@ -4467,6 +4469,7 @@
 		56D145F029E6F06D00E3488A /* MockBookmarkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBookmarkManager.swift; sourceTree = "<group>"; };
 		56DB9FE82CD24B47001BEC23 /* ContextualOnboardingPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPixel.swift; sourceTree = "<group>"; };
 		56DB9FEB2CD2515F001BEC23 /* OnboardingPixelReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPixelReporter.swift; sourceTree = "<group>"; };
+		6590DB542DB7D59F007D6046 /* DuckPlayerTabExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckPlayerTabExtensionTests.swift; sourceTree = "<group>"; };
 		7B0099802B65C6B300FE7C31 /* MacTransparentProxyProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacTransparentProxyProvider.swift; sourceTree = "<group>"; };
 		7B05829D2A812AC000AC3F7C /* NetworkProtectionOnboardingMenu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkProtectionOnboardingMenu.swift; sourceTree = "<group>"; };
 		7B0694972B6E980F00FA4DBA /* VPNProxyLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNProxyLauncher.swift; sourceTree = "<group>"; };
@@ -9966,6 +9969,7 @@
 		B6CA4822298CDC0B0067ECCE /* TabExtensionsTests */ = {
 			isa = PBXGroup;
 			children = (
+				6590DB542DB7D59F007D6046 /* DuckPlayerTabExtensionTests.swift */,
 				31031EB92CC9736500684340 /* AIChatOnboardingTabExtensionTests.swift */,
 				B6CA4823298CDC2E0067ECCE /* AdClickAttributionTabExtensionTests.swift */,
 				B626A7632992506A00053070 /* SerpHeadersNavigationResponderTests.swift */,
@@ -13167,6 +13171,7 @@
 				3706FE46293F661700E42796 /* EncryptedValueTransformerTests.swift in Sources */,
 				9F3910632B68C35600CB5112 /* DownloadsTabExtensionTests.swift in Sources */,
 				3706FE47293F661700E42796 /* URLExtensionTests.swift in Sources */,
+				6590DB552DB7D59F007D6046 /* DuckPlayerTabExtensionTests.swift in Sources */,
 				9F8D57332BCCCB9A00AEA660 /* UserDefaultsBookmarkFoldersStoreTests.swift in Sources */,
 				1DB9617B29F1D06D00CF5568 /* InternalUserDeciderMock.swift in Sources */,
 				F1F861172C1B25D4005DB446 /* SubscriptionUIHandlerMock.swift in Sources */,
@@ -14889,6 +14894,7 @@
 				B62EB47C25BAD3BB005745C6 /* WKWebViewPrivateMethodsAvailabilityTests.swift in Sources */,
 				9F0FFFBB2BCCAEC2007C87DD /* AddEditBookmarkFolderDialogViewModelMock.swift in Sources */,
 				4BBC16A527C488C900E00A38 /* DeviceAuthenticatorTests.swift in Sources */,
+				6590DB562DB7D59F007D6046 /* DuckPlayerTabExtensionTests.swift in Sources */,
 				3798580A2D73034E008773F6 /* VisitIdentifierTests.swift in Sources */,
 				4B3F641E27A8D3BD00E0C118 /* BrowserProfileTests.swift in Sources */,
 				37DB56EF2C3B31CD0093D4DC /* MockRemoteMessagingAvailabilityProvider.swift in Sources */,

--- a/macOS/DuckDuckGo/YoutubePlayer/DuckPlayer.swift
+++ b/macOS/DuckDuckGo/YoutubePlayer/DuckPlayer.swift
@@ -370,7 +370,7 @@ final class DuckPlayer {
     private var isCustomErrorFeatureEnabled: Bool
     private var customErrorSignInRequiredSelector: String?
     private let onboardingDecider: DuckPlayerOnboardingDecider
-    private var shouldOpenNextVideoOnYoutube: Bool = false
+    private(set) var shouldOpenNextVideoOnYoutube: Bool = false
 
     private func bindDuckPlayerModeIfNeeded() {
         if isFeatureEnabled {

--- a/macOS/UnitTests/TabExtensionsTests/DuckPlayerTabExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/DuckPlayerTabExtensionTests.swift
@@ -1,0 +1,154 @@
+//
+//  DuckPlayerTabExtensionTests.swift
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Combine
+import WebKit
+import BrowserServicesKit
+@testable import Navigation
+
+@testable import DuckDuckGo_Privacy_Browser
+
+// Helper extension for creating test frames
+extension WKFrameInfo {
+    static func mock(url: URL) -> WKFrameInfo {
+        return WKFrameInfoMock(
+            webView: WKWebView(),
+            securityOrigin: WKSecurityOriginMock.new(url: url),
+            request: URLRequest(url: url),
+            isMainFrame: true
+        )
+    }
+}
+
+final class MockWKNavigationAction: WKNavigationAction {
+    private let mockRequest: URLRequest
+    private let mockTargetFrame: WKFrameInfo?
+    private let mockSourceFrame: WKFrameInfo
+
+    init(request: URLRequest, targetFrame: WKFrameInfo?, sourceFrame: WKFrameInfo) {
+        self.mockRequest = request
+        self.mockTargetFrame = targetFrame
+        self.mockSourceFrame = sourceFrame
+        super.init()
+    }
+
+    override var request: URLRequest {
+        return mockRequest
+    }
+
+    override var targetFrame: WKFrameInfo? {
+        return mockTargetFrame
+    }
+
+    override var sourceFrame: WKFrameInfo {
+        return mockSourceFrame
+    }
+}
+
+@MainActor
+final class DuckPlayerTabExtensionTests: XCTestCase {
+
+    private var duckPlayer: DuckPlayer!
+    private var preferences: DuckPlayerPreferences!
+    private var webView: WKWebView!
+    private var navigationAction: NavigationAction!
+    private var tabExtension: DuckPlayerTabExtension!
+    private var navigationPreferences: NavigationPreferences!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        // Setup DuckPlayer with enabled mode
+        duckPlayer = DuckPlayer.mock(withMode: .enabled)
+
+        // Setup preferences
+        let preferencesPersistor = DuckPlayerPreferencesPersistorMock(
+            duckPlayerMode: .enabled,
+            duckPlayerOpenInNewTab: false
+        )
+        preferences = DuckPlayerPreferences(persistor: preferencesPersistor)
+
+        // Setup webView
+        webView = WKWebView()
+
+        // Setup tab extension
+        let scriptsPublisher = PassthroughSubject<UserScripts, Never>()
+        let webViewPublisher = PassthroughSubject<WKWebView, Never>()
+        let onboardingDecider = DefaultDuckPlayerOnboardingDecider()
+
+        tabExtension = DuckPlayerTabExtension(
+            duckPlayer: duckPlayer,
+            isBurner: false,
+            scriptsPublisher: scriptsPublisher.eraseToAnyPublisher(),
+            webViewPublisher: webViewPublisher.eraseToAnyPublisher(),
+            preferences: preferences,
+            onboardingDecider: onboardingDecider
+        )
+
+        navigationPreferences = NavigationPreferences(
+            userAgent: "test",
+            preferences: WKWebpagePreferences()
+        )
+
+    }
+
+    func testNavigatingWhenNavigatingFromDuckPlayerToSameVideo_DisablesDuckPlayerForNextVideo() async {
+        // Setup
+        preferences.duckPlayerMode = .enabled
+
+        // Simulate navigating to DuckPlayer
+        navigationAction = NavigationAction(
+            webView: webView,
+            navigationAction: MockWKNavigationAction(request: URLRequest(url: URL(string: "duck://player/test123")!),
+                                                     targetFrame: nil,
+                                                     sourceFrame: WKFrameInfo.mock(url: URL(string: "duck://player/test123")!)),
+            currentHistoryItemIdentity: nil,
+            redirectHistory: [],
+            mainFrameNavigation: nil
+        )
+
+        var prefs = navigationPreferences!
+        let result = await tabExtension.decidePolicy(for: navigationAction, preferences: &prefs)
+
+        XCTAssertNotNil(result)
+        if case .allow = result { } else {
+            XCTFail("Expected .allow but got \(String(describing: result))")
+        }
+
+        // When
+
+        // Now navigate to the same video in youtube, to simulate "Watch in Youtube"
+        navigationAction = NavigationAction(
+            webView: webView,
+            navigationAction: MockWKNavigationAction(request: URLRequest(url: URL(string: "https://www.youtube.com/watch?v=HdTCDxX-UnQ")!),
+                                                     targetFrame: WKFrameInfo.mock(url: URL(string: "duck://player/HdTCDxX-UnQ")!),
+                                                     sourceFrame: WKFrameInfo.mock(url: URL(string: "https://www.youtube.com/watch?v=HdTCDxX-UnQ")!)),
+            currentHistoryItemIdentity: nil,
+            redirectHistory: [],
+            mainFrameNavigation: nil
+        )
+
+        _ = await tabExtension.decidePolicy(for: navigationAction, preferences: &prefs)
+
+        // Then
+        XCTAssertTrue(duckPlayer.shouldOpenNextVideoOnYoutube)
+
+    }
+
+}


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1209942314782124?focus=true
Tech Design URL:
CC:

### Description
Fixes an issue on macOS 15.4+ breaking the functionality of the "Watch in Youtube" button in DuckPlayer when DuckPlayer is Enabled

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1.  Use macOS 15.4
2. Go to Settings > Duck Player and set it to "Always Open Videos in Duck Player."
3. Go to Youtube.com and open a video - Confirm opens in Duck Player
4. Click "Watch in YouTube" button - Confirm opens in Youtube

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
- There are no unit tests for DuckPlayer navigation so this may have some unexpected side effects.  Make sure to smoke test Duckplayer in both 15.3 and 15.4

### Quality Considerations
- Added tests for this specific scenario
- 

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210047152623186