### PR TITLE
Disable duck.ai during onboarding

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -388,6 +388,11 @@ final class AddressBarButtonsViewController: NSViewController {
         aiChatButton.isHidden = !aiChatMenuConfig.shouldDisplayAddressBarShortcut
         updateAIChatDividerVisibility()
         delegate?.addressBarButtonsViewController(self, didUpdateAIChatButtonVisibility: aiChatButton.isShown)
+
+        // Check if the current tab is in the onboarding state and disable the AI chat button if it is
+        guard let tabViewModel else { return }
+        let isOnboarding = [.onboarding].contains(tabViewModel.tab.content)
+        aiChatButton.isEnabled = !isOnboarding
     }
 
     @objc func hideAIChatButtonAction(_ sender: NSMenuItem) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1210040423761004?focus=true

### Description
Disable duck.ai during onboarding

### Testing Steps
1. Open duck://onboarding
2. Check that the duck.ai button is disable during the onboarding
3. Check that the duck.ai button is enabled once onboarding finishes 

### Impact and Risks
Low: Minor visual changes


#### What could go wrong?
Duck.ai button always disabled