### PR TITLE
Open duck.ai on new tab

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -310,11 +310,17 @@ final class AddressBarButtonsViewController: NSViewController {
         let isCommandPressed = NSEvent.modifierFlags.contains(.command)
         let isShiftPressed = NSApplication.shared.isShiftPressed
 
-        let target: AIChatTabOpenerTarget
+        var target: AIChatTabOpenerTarget = .sameTab
+
         if isCommandPressed {
             target = isShiftPressed ? .newTabSelected : .newTabUnselected
-        } else {
-            target = .sameTab
+        }
+
+        if let tabViewModel = tabViewModel,
+           let tabURL = tabViewModel.tab.url,
+           !tabURL.isDuckAIURL,
+           tabViewModel.tab.content != .newtab {
+            target = .newTabSelected
         }
 
         if let value = textFieldValue {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209671977594486/task/1210034275067258?focus=true

### Description
Open duck.ai on a new tab

### Testing Steps
1. On the new tab page, click the duck.ai button, it should open in the current tab
2. Do a search. On the SERP, click the duck.ai button, it should open in a new tab
3. Open a random website, click the duck.ai button, it should open in a new tab
4. Open duck.ai, click the duck.ai button, nothing should happen
5. Open duck.ai, write some text in the address bar, click the duck.ai button, the query should be submitted to duck.ai

### Impact and Risks
Low: improvement to existing features

#### What could go wrong?
Opening duck.ai on the new tab when it should be on the current one or vice-versa
