### PR TITLE
Redirect to correct settings on cookie popup consent

### DIFF
--- a/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
+++ b/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
@@ -233,7 +233,7 @@ extension PrivacyDashboardViewController: PrivacyDashboardControllerDelegate {
 
         switch target {
         case .cookiePopupManagement:
-            tabCollection.appendNewTab(with: .settings(pane: .dataClearing), selected: true)
+            tabCollection.appendNewTab(with: .settings(pane: .cookiePopupProtection), selected: true)
         default:
             tabCollection.appendNewTab(with: .anySettingsPane, selected: true)
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210040780002107?focus=true
Tech Design URL:
CC:

### Description
Redirect to the correct settings section when users tap ‘Disable in Settings’ for the cookie popup consent.

### Testing Steps
1. Go to https://vimeo.com/
2. Click the shield icon to open the privacy dashboard.
3. Click “Cookie Pop-up Hidden”
4. Click “Disable in Settings”
5. It should take you to the ‘Cookie Pop-Up Protection’ section instead of ‘Data Clearing'

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing.

### Quality Considerations
I do not see any specific considerations.

### Notes to Reviewer
Nothing specific, trivial change.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)