### PR TITLE
pir: added a flag to breakage report

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
@@ -100,7 +100,7 @@ public struct BrokenSiteReport {
     let cookieConsentInfo: CookieConsentInfo?
     let debugFlags: String
     let privacyExperiments: [String: String]
-    let isPIREnabled: Bool?
+    let isPirEnabled: Bool?
 #if os(iOS)
     let siteType: SiteType
     let atb: String
@@ -135,7 +135,7 @@ public struct BrokenSiteReport {
         cookieConsentInfo: CookieConsentInfo?,
         debugFlags: String,
         privacyExperiments: [String: String],
-        isPIREnabled: Bool?
+        isPirEnabled: Bool?
     ) {
         self.siteUrl = siteUrl
         self.category = category
@@ -162,7 +162,7 @@ public struct BrokenSiteReport {
         self.cookieConsentInfo = cookieConsentInfo
         self.debugFlags = debugFlags
         self.privacyExperiments = privacyExperiments
-        self.isPIREnabled = isPIREnabled
+        self.isPirEnabled = isPirEnabled
     }
 #endif
 
@@ -197,7 +197,7 @@ public struct BrokenSiteReport {
         cookieConsentInfo: CookieConsentInfo?,
         debugFlags: String,
         privacyExperiments: [String: String],
-        isPIREnabled: Bool?
+        isPirEnabled: Bool?
     ) {
         self.siteUrl = siteUrl
         self.category = category
@@ -228,7 +228,7 @@ public struct BrokenSiteReport {
         self.cookieConsentInfo = cookieConsentInfo
         self.debugFlags = debugFlags
         self.privacyExperiments = privacyExperiments
-        self.isPIREnabled = isPIREnabled
+        self.isPirEnabled = isPirEnabled
     }
 #endif
 
@@ -287,8 +287,8 @@ public struct BrokenSiteReport {
             result[key] = value
         }
 
-        if isPIREnabled == true {
-            result["isPIREnabled"] = boolToStringValue(isPIREnabled)
+        if isPirEnabled == true {
+            result["isPirEnabled"] = "true"
         }
 
 #if os(iOS)

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
@@ -100,6 +100,7 @@ public struct BrokenSiteReport {
     let cookieConsentInfo: CookieConsentInfo?
     let debugFlags: String
     let privacyExperiments: [String: String]
+    let isPIREnabled: Bool?
 #if os(iOS)
     let siteType: SiteType
     let atb: String
@@ -133,7 +134,8 @@ public struct BrokenSiteReport {
         locale: Locale = Locale.current,
         cookieConsentInfo: CookieConsentInfo?,
         debugFlags: String,
-        privacyExperiments: [String: String]
+        privacyExperiments: [String: String],
+        isPIREnabled: Bool?
     ) {
         self.siteUrl = siteUrl
         self.category = category
@@ -160,6 +162,7 @@ public struct BrokenSiteReport {
         self.cookieConsentInfo = cookieConsentInfo
         self.debugFlags = debugFlags
         self.privacyExperiments = privacyExperiments
+        self.isPIREnabled = isPIREnabled
     }
 #endif
 
@@ -193,7 +196,8 @@ public struct BrokenSiteReport {
         locale: Locale = Locale.current,
         cookieConsentInfo: CookieConsentInfo?,
         debugFlags: String,
-        privacyExperiments: [String: String]
+        privacyExperiments: [String: String],
+        isPIREnabled: Bool?
     ) {
         self.siteUrl = siteUrl
         self.category = category
@@ -224,6 +228,7 @@ public struct BrokenSiteReport {
         self.cookieConsentInfo = cookieConsentInfo
         self.debugFlags = debugFlags
         self.privacyExperiments = privacyExperiments
+        self.isPIREnabled = isPIREnabled
     }
 #endif
 
@@ -280,6 +285,10 @@ public struct BrokenSiteReport {
 
         for (key, value) in privacyExperiments {
             result[key] = value
+        }
+
+        if isPIREnabled == true {
+            result["isPIREnabled"] = boolToStringValue(isPIREnabled)
         }
 
 #if os(iOS)

--- a/SharedPackages/BrowserServicesKit/Tests/PrivacyDashboardTests/BrokenSiteReportMocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PrivacyDashboardTests/BrokenSiteReportMocks.swift
@@ -51,7 +51,7 @@ struct BrokenSiteReportMocks {
                          cookieConsentInfo: nil,
                          debugFlags: "",
                          privacyExperiments: [:],
-                         isPIREnabled: nil)
+                         isPirEnabled: nil)
 #else
         BrokenSiteReport(siteUrl: URL(string: "https://duckduckgo.com")!,
                          category: "test",
@@ -77,7 +77,7 @@ struct BrokenSiteReportMocks {
                          cookieConsentInfo: nil,
                          debugFlags: "",
                          privacyExperiments: [:],
-                         isPIREnabled: nil)
+                         isPirEnabled: nil)
 #endif
     }
 
@@ -111,7 +111,7 @@ struct BrokenSiteReportMocks {
                          cookieConsentInfo: nil,
                          debugFlags: "",
                          privacyExperiments: [:],
-                         isPIREnabled: nil)
+                         isPirEnabled: nil)
 #else
         BrokenSiteReport(siteUrl: URL(string: "https://somethingelse.zz")!,
                          category: "test",
@@ -137,7 +137,7 @@ struct BrokenSiteReportMocks {
                          cookieConsentInfo: nil,
                          debugFlags: "",
                          privacyExperiments: [:],
-                         isPIREnabled: nil)
+                         isPirEnabled: nil)
 #endif
     }
 
@@ -171,7 +171,7 @@ struct BrokenSiteReportMocks {
                          cookieConsentInfo: nil,
                          debugFlags: "",
                          privacyExperiments: [:],
-                         isPIREnabled: nil)
+                         isPirEnabled: nil)
 #else
         BrokenSiteReport(siteUrl: URL(string: "https://www.subdomain.example.com/some/pathname?t=param#aaa")!,
                          category: "test",
@@ -197,7 +197,7 @@ struct BrokenSiteReportMocks {
                          cookieConsentInfo: nil,
                          debugFlags: "",
                          privacyExperiments: [:],
-                         isPIREnabled: nil)
+                         isPirEnabled: nil)
 #endif
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/PrivacyDashboardTests/BrokenSiteReportMocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PrivacyDashboardTests/BrokenSiteReportMocks.swift
@@ -50,7 +50,8 @@ struct BrokenSiteReportMocks {
                          variant: "",
                          cookieConsentInfo: nil,
                          debugFlags: "",
-                         privacyExperiments: [:])
+                         privacyExperiments: [:],
+                         isPIREnabled: nil)
 #else
         BrokenSiteReport(siteUrl: URL(string: "https://duckduckgo.com")!,
                          category: "test",
@@ -75,7 +76,8 @@ struct BrokenSiteReportMocks {
                          userRefreshCount: 0,
                          cookieConsentInfo: nil,
                          debugFlags: "",
-                         privacyExperiments: [:])
+                         privacyExperiments: [:],
+                         isPIREnabled: nil)
 #endif
     }
 
@@ -108,7 +110,8 @@ struct BrokenSiteReportMocks {
                          variant: "",
                          cookieConsentInfo: nil,
                          debugFlags: "",
-                         privacyExperiments: [:])
+                         privacyExperiments: [:],
+                         isPIREnabled: nil)
 #else
         BrokenSiteReport(siteUrl: URL(string: "https://somethingelse.zz")!,
                          category: "test",
@@ -133,7 +136,8 @@ struct BrokenSiteReportMocks {
                          userRefreshCount: 0,
                          cookieConsentInfo: nil,
                          debugFlags: "",
-                         privacyExperiments: [:])
+                         privacyExperiments: [:],
+                         isPIREnabled: nil)
 #endif
     }
 
@@ -166,7 +170,8 @@ struct BrokenSiteReportMocks {
                          variant: "",
                          cookieConsentInfo: nil,
                          debugFlags: "",
-                         privacyExperiments: [:])
+                         privacyExperiments: [:],
+                         isPIREnabled: nil)
 #else
         BrokenSiteReport(siteUrl: URL(string: "https://www.subdomain.example.com/some/pathname?t=param#aaa")!,
                          category: "test",
@@ -191,7 +196,8 @@ struct BrokenSiteReportMocks {
                          userRefreshCount: 0,
                          cookieConsentInfo: nil,
                          debugFlags: "",
-                         privacyExperiments: [:])
+                         privacyExperiments: [:],
+                         isPIREnabled: nil)
 #endif
     }
 }

--- a/iOS/DuckDuckGo/AutofillLoginListViewModel.swift
+++ b/iOS/DuckDuckGo/AutofillLoginListViewModel.swift
@@ -344,7 +344,7 @@ final class AutofillLoginListViewModel: ObservableObject {
                                       cookieConsentInfo: nil,
                                       debugFlags: "",
                                       privacyExperiments: [:],
-                                      isPIREnabled: nil)
+                                      isPirEnabled: nil)
 
         try? breakageReporter.report(report, reportMode: .regular, daysToExpiry: breakageReportIntervalDays)
     }

--- a/iOS/DuckDuckGo/AutofillLoginListViewModel.swift
+++ b/iOS/DuckDuckGo/AutofillLoginListViewModel.swift
@@ -343,7 +343,8 @@ final class AutofillLoginListViewModel: ObservableObject {
                                       variant: "",
                                       cookieConsentInfo: nil,
                                       debugFlags: "",
-                                      privacyExperiments: [:])
+                                      privacyExperiments: [:],
+                                      isPIREnabled: nil)
 
         try? breakageReporter.report(report, reportMode: .regular, daysToExpiry: breakageReportIntervalDays)
     }

--- a/iOS/DuckDuckGo/PrivacyDashboard/PrivacyDashboardViewController.swift
+++ b/iOS/DuckDuckGo/PrivacyDashboard/PrivacyDashboardViewController.swift
@@ -372,7 +372,8 @@ extension PrivacyDashboardViewController {
                                 variant: PixelExperiment.cohort?.rawValue ?? "",
                                 cookieConsentInfo: privacyInfo.cookieConsentManaged,
                                 debugFlags: privacyInfo.debugFlags,
-                                privacyExperiments: privacyExperimentCohorts)
+                                privacyExperiments: privacyExperimentCohorts,
+                                isPIREnabled: nil)
     }
 
 }

--- a/iOS/DuckDuckGo/PrivacyDashboard/PrivacyDashboardViewController.swift
+++ b/iOS/DuckDuckGo/PrivacyDashboard/PrivacyDashboardViewController.swift
@@ -373,7 +373,7 @@ extension PrivacyDashboardViewController {
                                 cookieConsentInfo: privacyInfo.cookieConsentManaged,
                                 debugFlags: privacyInfo.debugFlags,
                                 privacyExperiments: privacyExperimentCohorts,
-                                isPIREnabled: nil)
+                                isPirEnabled: nil)
     }
 
 }

--- a/iOS/DuckDuckGoTests/BrokenSiteReportingTests.swift
+++ b/iOS/DuckDuckGoTests/BrokenSiteReportingTests.swift
@@ -122,7 +122,8 @@ final class BrokenSiteReportingTests: XCTestCase {
                                       variant: "",
                                       cookieConsentInfo: CookieConsentInfo(consentManaged: true, cosmetic: true, optoutFailed: true, selftestFailed: true),
                                       debugFlags: "",
-                                      privacyExperiments: [:])
+                                      privacyExperiments: [:],
+                                      isPIREnabled: nil)
 
         let reporter = BrokenSiteReporter(pixelHandler: { params in
             

--- a/iOS/DuckDuckGoTests/BrokenSiteReportingTests.swift
+++ b/iOS/DuckDuckGoTests/BrokenSiteReportingTests.swift
@@ -123,7 +123,7 @@ final class BrokenSiteReportingTests: XCTestCase {
                                       cookieConsentInfo: CookieConsentInfo(consentManaged: true, cosmetic: true, optoutFailed: true, selftestFailed: true),
                                       debugFlags: "",
                                       privacyExperiments: [:],
-                                      isPIREnabled: nil)
+                                      isPirEnabled: nil)
 
         let reporter = BrokenSiteReporter(pixelHandler: { params in
             

--- a/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
+++ b/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
@@ -318,6 +318,16 @@ extension PrivacyDashboardViewController {
         return webVitalsResult
     }
 
+    private func isPIREnabledAndUserHasProfile() async -> Bool {
+        let isPIRFeatureEnabled = try? await Application.appDelegate.subscriptionAuthV1toV2Bridge.isEnabled(feature: .dataBrokerProtection)
+        guard let isPIRFeatureEnabled,
+              isPIRFeatureEnabled == true else {
+            return false
+        }
+        let profile = try? DataBrokerProtectionManager.shared.dataManager?.fetchProfile()
+        return profile != nil
+    }
+
     private func makeBrokenSiteReport(category: String = "",
                                       description: String = "",
                                       source: BrokenSiteReport.Source) async throws -> BrokenSiteReport {
@@ -356,6 +366,8 @@ extension PrivacyDashboardViewController {
             return experiments
         }
 
+        let isPIREnabled = await isPIREnabledAndUserHasProfile()
+
         let websiteBreakage = BrokenSiteReport(siteUrl: currentURL,
                                                category: category.lowercased(),
                                                description: description,
@@ -379,7 +391,8 @@ extension PrivacyDashboardViewController {
                                                userRefreshCount: currentTab.brokenSiteInfo?.refreshCountSinceLoad ?? -1,
                                                cookieConsentInfo: currentTab.privacyInfo?.cookieConsentManaged,
                                                debugFlags: currentTab.privacyInfo?.debugFlags ?? "",
-                                               privacyExperiments: privacyExperimentCohorts)
+                                               privacyExperiments: privacyExperimentCohorts,
+                                               isPIREnabled: isPIREnabled)
         return websiteBreakage
     }
 }

--- a/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
+++ b/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
@@ -318,7 +318,7 @@ extension PrivacyDashboardViewController {
         return webVitalsResult
     }
 
-    private func isPIREnabledAndUserHasProfile() async -> Bool {
+    private func isPirEnabledAndUserHasProfile() async -> Bool {
         let isPIRFeatureEnabled = try? await Application.appDelegate.subscriptionAuthV1toV2Bridge.isEnabled(feature: .dataBrokerProtection)
         guard let isPIRFeatureEnabled,
               isPIRFeatureEnabled == true else {
@@ -366,7 +366,7 @@ extension PrivacyDashboardViewController {
             return experiments
         }
 
-        let isPIREnabled = await isPIREnabledAndUserHasProfile()
+        let isPirEnabled = await isPirEnabledAndUserHasProfile()
 
         let websiteBreakage = BrokenSiteReport(siteUrl: currentURL,
                                                category: category.lowercased(),
@@ -392,7 +392,7 @@ extension PrivacyDashboardViewController {
                                                cookieConsentInfo: currentTab.privacyInfo?.cookieConsentManaged,
                                                debugFlags: currentTab.privacyInfo?.debugFlags ?? "",
                                                privacyExperiments: privacyExperimentCohorts,
-                                               isPIREnabled: isPIREnabled)
+                                               isPirEnabled: isPirEnabled)
         return websiteBreakage
     }
 }

--- a/macOS/UnitTests/PrivacyReferenceTests/BrokenSiteReportingReferenceTests.swift
+++ b/macOS/UnitTests/PrivacyReferenceTests/BrokenSiteReportingReferenceTests.swift
@@ -97,7 +97,8 @@ final class BrokenSiteReportingReferenceTests: XCTestCase {
                                             userRefreshCount: 0,
                                             cookieConsentInfo: nil,
                                             debugFlags: "",
-                                            privacyExperiments: [:])
+                                            privacyExperiments: [:],
+                                            isPIREnabled: nil)
 
             let request = makeURLRequest(with: breakage.requestParameters)
 

--- a/macOS/UnitTests/PrivacyReferenceTests/BrokenSiteReportingReferenceTests.swift
+++ b/macOS/UnitTests/PrivacyReferenceTests/BrokenSiteReportingReferenceTests.swift
@@ -98,7 +98,7 @@ final class BrokenSiteReportingReferenceTests: XCTestCase {
                                             cookieConsentInfo: nil,
                                             debugFlags: "",
                                             privacyExperiments: [:],
-                                            isPIREnabled: nil)
+                                            isPirEnabled: nil)
 
             let request = makeURLRequest(with: breakage.requestParameters)
 

--- a/macOS/UnitTests/WebsiteBreakageReport/WebsiteBreakageReportTests.swift
+++ b/macOS/UnitTests/WebsiteBreakageReport/WebsiteBreakageReportTests.swift
@@ -79,7 +79,8 @@ class WebsiteBreakageReportTests: XCTestCase {
             userRefreshCount: 0,
             cookieConsentInfo: nil,
             debugFlags: "",
-            privacyExperiments: [:]
+            privacyExperiments: [:],
+            isPIREnabled: nil
         )
 
         let urlRequest = makeURLRequest(with: breakage.requestParameters)
@@ -130,7 +131,8 @@ class WebsiteBreakageReportTests: XCTestCase {
             userRefreshCount: 0,
             cookieConsentInfo: CookieConsentInfo(consentManaged: true, cosmetic: true, optoutFailed: true, selftestFailed: true),
             debugFlags: "",
-            privacyExperiments: [:]
+            privacyExperiments: [:],
+            isPIREnabled: true
         )
 
         let urlRequest = makeURLRequest(with: breakage.requestParameters)
@@ -155,6 +157,7 @@ class WebsiteBreakageReportTests: XCTestCase {
         XCTAssertEqual(queryItems[valueFor: "consentManaged"], "1")
         XCTAssertEqual(queryItems[valueFor: "consentOptoutFailed"], "1")
         XCTAssertEqual(queryItems[valueFor: "consentSelftestFailed"], "1")
+        XCTAssertEqual(queryItems[valueFor: "isPIREnabled"], "1")
     }
 
     func makeURLRequest(with parameters: [String: String]) -> URLRequest {

--- a/macOS/UnitTests/WebsiteBreakageReport/WebsiteBreakageReportTests.swift
+++ b/macOS/UnitTests/WebsiteBreakageReport/WebsiteBreakageReportTests.swift
@@ -80,7 +80,7 @@ class WebsiteBreakageReportTests: XCTestCase {
             cookieConsentInfo: nil,
             debugFlags: "",
             privacyExperiments: [:],
-            isPIREnabled: nil
+            isPirEnabled: nil
         )
 
         let urlRequest = makeURLRequest(with: breakage.requestParameters)
@@ -132,7 +132,7 @@ class WebsiteBreakageReportTests: XCTestCase {
             cookieConsentInfo: CookieConsentInfo(consentManaged: true, cosmetic: true, optoutFailed: true, selftestFailed: true),
             debugFlags: "",
             privacyExperiments: [:],
-            isPIREnabled: true
+            isPirEnabled: true
         )
 
         let urlRequest = makeURLRequest(with: breakage.requestParameters)
@@ -157,7 +157,7 @@ class WebsiteBreakageReportTests: XCTestCase {
         XCTAssertEqual(queryItems[valueFor: "consentManaged"], "1")
         XCTAssertEqual(queryItems[valueFor: "consentOptoutFailed"], "1")
         XCTAssertEqual(queryItems[valueFor: "consentSelftestFailed"], "1")
-        XCTAssertEqual(queryItems[valueFor: "isPIREnabled"], "1")
+        XCTAssertEqual(queryItems[valueFor: "isPirEnabled"], "true")
     }
 
     func makeURLRequest(with parameters: [String: String]) -> URLRequest {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201141132935289/task/1210044338818074?focus=true
Tech Design URL:
CC:

### Description

The goal here is to add a new param to the breakage form submission. the new param should ONLY be present if the current user has PIR available AND has been through the onboarding phase (so, they currently have a profile stored).

### Testing Steps
- When PIR is not available to you, the new param should be absent when you send a report from the privacy dashboard
- But, when you are a PIR user and you have a profile stored, the field should be present and should be a "true"

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)