### PR TITLE
macOS / iOS - Change auto-submit behavior on duck.ai

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatConsumableDataHandling.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatConsumableDataHandling.swift
@@ -38,7 +38,7 @@ public protocol AIChatConsumableDataHandling {
 
 /// Handles prompt data for AI chat interactions.
 public final class AIChatPromptHandler: AIChatConsumableDataHandling {
-    public typealias DataType = String
+    public typealias DataType = AIChatNativePrompt
     private var data: DataType?
 
     public static let shared = AIChatPromptHandler()

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatScriptUserValues.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatScriptUserValues.swift
@@ -103,9 +103,9 @@ public struct AIChatNativePrompt: Codable {
     public let platform: String
     public let query: Query?
 
-    public static func defaultValuesWithPrompt(_ prompt: String) -> AIChatNativePrompt {
+    public static func queryPrompt(_ prompt: String, autoSubmit: Bool) -> AIChatNativePrompt {
         AIChatNativePrompt(platform: Platform.name, query: .init(prompt: prompt,
-                                                                 autoSubmit: true))
+                                                                 autoSubmit: autoSubmit))
     }
 }
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2328,6 +2328,8 @@ extension MainViewController: OmniBarDelegate {
         } else {
             /// Check if the current tab's URL is a DuckDuckGo search page
             /// If it is, get the query item and open the chat with the query item's value
+            /// Do not auto-send if the user is on SERP
+            /// https://app.asana.com/1/137249556945/project/1204167627774280/task/1210024262385459?focus=true
             if currentTab?.url?.isDuckDuckGoSearch == true {
                 let queryItem = currentTab?.url?.getQueryItems()?.filter { $0.name == "q" }.first
                 openAIChat(queryItem?.value, autoSend: false)

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2330,7 +2330,7 @@ extension MainViewController: OmniBarDelegate {
             /// If it is, get the query item and open the chat with the query item's value
             if currentTab?.url?.isDuckDuckGoSearch == true {
                 let queryItem = currentTab?.url?.getQueryItems()?.filter { $0.name == "q" }.first
-                openAIChat(queryItem?.value, autoSend: true)
+                openAIChat(queryItem?.value, autoSend: false)
             } else {
                 openAIChat()
             }

--- a/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
@@ -60,7 +60,7 @@ struct AIChatTabOpener: AIChatTabOpening {
     @MainActor
     func openAIChatTab(_ query: String?, target: AIChatTabOpenerTarget) {
         if let query = query {
-            promptHandler.setData(query)
+            promptHandler.setData(.queryPrompt(query, autoSubmit: false))
         }
         WindowControllersManager.shared.openAIChat(aiChatRemoteSettings.aiChatURL, target: target, hasPrompt: query != nil)
     }

--- a/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
@@ -54,13 +54,27 @@ struct AIChatTabOpener: AIChatTabOpening {
     @MainActor
     func openAIChatTab(_ value: AddressBarTextField.Value, target: AIChatTabOpenerTarget) {
         let query = addressBarQueryExtractor.queryForValue(value)
-        openAIChatTab(query, target: target)
+
+        // We don't want to auto-submit if the user is opening duck.ai from the SERP
+        // https://app.asana.com/1/137249556945/project/1204167627774280/task/1210024262385459?focus=true
+        let shouldAutoSubmit: Bool
+        if case let .url(_, url, _) = value {
+            shouldAutoSubmit = !url.isDuckDuckGoSearch
+        } else {
+            shouldAutoSubmit = true
+        }
+        openAIChatTab(query, target: target, autoSubmit: shouldAutoSubmit)
     }
 
     @MainActor
     func openAIChatTab(_ query: String?, target: AIChatTabOpenerTarget) {
+        openAIChatTab(query, target: target, autoSubmit: true)
+    }
+
+    @MainActor
+    private func openAIChatTab(_ query: String?, target: AIChatTabOpenerTarget, autoSubmit: Bool) {
         if let query = query {
-            promptHandler.setData(.queryPrompt(query, autoSubmit: false))
+            promptHandler.setData(.queryPrompt(query, autoSubmit: autoSubmit))
         }
         WindowControllersManager.shared.openAIChat(aiChatRemoteSettings.aiChatURL, target: target, hasPrompt: query != nil)
     }

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
@@ -58,10 +58,10 @@ extension AIChatMessageHandler {
     }
 
     private func getAIChatNativePrompt() -> Encodable? {
-        guard let prompt = promptHandler.consumeData() as? String else {
+        guard let prompt = promptHandler.consumeData() as? AIChatNativePrompt else {
             return nil
         }
 
-        return AIChatNativePrompt.defaultValuesWithPrompt(prompt)
+        return prompt
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1210025284896479?focus=true

### Description
When the user is on the SERP, we should not auto-submit the queries to duck.ai, instead it should only pre-fill the textbox.

### Testing Steps
Same steps for both iOS and macOS

1. Do a search, while you're on the SERP, click/tap the duck.ai button in the native app. It should open duck.ai with the SERP query pre-filled in the text box but not auto-submitted 
2. Start typing something in the address bar, click/tap the duck.ai button. It should open duck.ai with the query from the address bar automatically submitted.

### Impact and Risks
Low: Improvement to existing features


#### What could go wrong?
Not auto-submitting when the user is typing the query in the address bar
