### PR TITLE
Improve sync connection pixel reporting

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
@@ -51,8 +51,6 @@ public enum SyncConnectionError: Error {
 
     case failedToCreateAccount
     case failedToTransmitConnectRecoveryKey
-
-    case foundExistingAccount
 }
 
 public protocol SyncConnectionControlling {

--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -227,8 +227,10 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
     }
 
     private func firePixelIfNeededFor(event: Pixel.Event, error: Error?) {
-        if let syncError = error as? SyncError, !syncError.isServerError {
-            Pixel.fire(pixel: event, error: syncError, withAdditionalParameters: syncError.errorParameters)
+        if let syncError = error as? SyncError {
+            if !syncError.isServerError {
+                Pixel.fire(pixel: event, error: syncError, withAdditionalParameters: syncError.errorParameters)
+            }
         } else if let error {
             Pixel.fire(pixel: event, error: error)
         } else {

--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -227,9 +227,12 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
     }
 
     private func firePixelIfNeededFor(event: Pixel.Event, error: Error?) {
-        guard let syncError = error as? SyncError else { return }
-        if !syncError.isServerError {
-            Pixel.fire(pixel: event, withAdditionalParameters: syncError.errorParameters)
+        if let syncError = error as? SyncError, !syncError.isServerError {
+            Pixel.fire(pixel: event, error: syncError, withAdditionalParameters: syncError.errorParameters)
+        } else if let error {
+            Pixel.fire(pixel: event, error: error)
+        } else {
+            Pixel.fire(pixel: event)
         }
     }
 

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -515,8 +515,6 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
             handleError(.unableToSyncWithDevice, error: underlyingError, event: .syncLoginError)
         case .failedToCreateAccount:
             handleError(.unableToSyncWithDevice, error: underlyingError, event: .syncSignupError)
-        case .foundExistingAccount:
-            handleError(.unableToMergeTwoAccounts, error: error, event: .syncLoginExistingAccountError)
         }
     }
 }

--- a/macOS/DuckDuckGo/Preferences/Model/SyncPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/SyncPreferences.swift
@@ -975,11 +975,9 @@ extension SyncPreferences: SyncConnectionControllerDelegate {
         case .unableToRecognizeCode:
             handleError(.unableToRecognizeCode, error: underlyingError, pixelEvent: nil)
         case .failedToFetchPublicKey, .failedToTransmitExchangeRecoveryKey, .failedToFetchConnectRecoveryKey, .failedToLogIn, .failedToTransmitExchangeKey, .failedToFetchExchangeRecoveryKey, .failedToTransmitConnectRecoveryKey:
-            handleError(.unableToSyncToOtherDevice, error: error, pixelEvent: GeneralPixel.syncLoginError(error: error))
+            handleError(.unableToSyncToOtherDevice, error: underlyingError, pixelEvent: GeneralPixel.syncLoginError(error: underlyingError ?? error))
         case .failedToCreateAccount:
-            handleError(.unableToSyncToOtherDevice, error: underlyingError, pixelEvent: GeneralPixel.syncSignupError(error: error))
-        case .foundExistingAccount:
-            handleError(.unableToMergeTwoAccounts, error: underlyingError, pixelEvent: nil)
+            handleError(.unableToSyncToOtherDevice, error: underlyingError, pixelEvent: GeneralPixel.syncSignupError(error: underlyingError ?? error))
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202926619870900/task/1210047340594635?focus=true

### Description

There has been a slight rise in macOS login errors after rolling out [✓ Align the sync connect flow with the recovery flow](https://app.asana.com/1/137249556945/task/1209569901379921).

This improves Pixel reporting to include underlying specific errors (which we already should be doing).

### Testing Steps

Low risk as just pixels and somewhat hard to test

1. Make sure you're plugged into the debugger so you can watch the console.
2. Using a proxy (e.g Charles or Proxyman) stub the `sync/login` so it returns an error of some kind
3. Go to Settings -> Sync and Backup
4. Follow the sync flow with another device
5. Check that a `...login_error...` Pixel is sent with an `e` parameter containing the underlying error code and `d` with the underlying domain

### Impact and Risks
Low: Just debug instrumentation changes

#### What could go wrong?


### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)