### PR TITLE
Upload dSYM for iOS adhoc builds to S3

### DIFF
--- a/.github/workflows/ios_adhoc.yml
+++ b/.github/workflows/ios_adhoc.yml
@@ -86,6 +86,15 @@ jobs:
           name: ${{ env.dsyms_filename }}
           path: ${{ env.dsyms_path }}
 
+      - name: Upload dSYM to S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
+          DSYM_S3_PATH: s3://${{ vars.DSYM_BUCKET_NAME }}/${{ vars.IOS_DSYM_BUCKET_PREFIX }}/
+        run: |
+          aws s3 cp "${{ env.dsyms_path }}" ${{ env.DSYM_S3_PATH }}
+
       - name: Get Asana Task ID
         if: inputs.asana-task-url
         id: get-task-id


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1210057070554701?focus=true

### Description
This change updates ios_adhoc.yml so that it uploads dSYM archive to S3. The archive contains a timestamp
and an optional suffix, so the target file name won’t clash with any release dSYMs.

### Testing Steps
Verify that [this workflow](https://github.com/duckduckgo/apple-browsers/actions/runs/14639278095/job/41077629475#step:11:1) uploaded dSYM archive to S3.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)