### PR TITLE
Reduce clear button spacing when next to microphone

### DIFF
--- a/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarSearchView.swift
+++ b/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarSearchView.swift
@@ -65,6 +65,10 @@ final class UpdatedOmniBarSearchView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    func reduceClearButtonSpacing(_ isReduced: Bool) {
+        trailingItemsContainer.setCustomSpacing(isReduced ? -8 : 0, after: clearButton)
+    }
+
     private func setUpSubviews() {
         addSubview(mainStackView)
 

--- a/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarView.swift
+++ b/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarView.swift
@@ -109,7 +109,12 @@ final class UpdatedOmniBarView: UIView, OmniBarView {
     }
     var isVoiceSearchButtonHidden: Bool {
         get { searchAreaView.voiceSearchButton.isHidden }
-        set { searchAreaView.voiceSearchButton.isHidden = newValue }
+        set {
+            searchAreaView.voiceSearchButton.isHidden = newValue
+            // We want the clear button closer to the microphone if they're both visible
+            // https://app.asana.com/1/137249556945/project/1206226850447395/task/1209950595275304
+            searchAreaView.reducedButtonSpacing(isEnabled: !newValue)
+        }
     }
     var isAbortButtonHidden: Bool {
         get { searchAreaView.cancelButton.isHidden }

--- a/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarView.swift
+++ b/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarView.swift
@@ -113,7 +113,7 @@ final class UpdatedOmniBarView: UIView, OmniBarView {
             searchAreaView.voiceSearchButton.isHidden = newValue
             // We want the clear button closer to the microphone if they're both visible
             // https://app.asana.com/1/137249556945/project/1206226850447395/task/1209950595275304
-            searchAreaView.reducedButtonSpacing(isEnabled: !newValue)
+            searchAreaView.reduceClearButtonSpacing(!newValue)
         }
     }
     var isAbortButtonHidden: Bool {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1209950595275304
Tech Design URL:
CC:

### Description

The spacing between clear and microphone caused an illusion of having too large spacing in between. This adjusts the spacing to be negative so that it reduces this illusion.

### Testing Steps
1. Enable experimental appearance. Restart the app
2. Enable voice search and type something into the search field - microphone and clear button should be a bit closer to each other. To validate that press down both buttons simultaneously. Notice highlighted areas overlapping.
3. Disable voice search and start editing the search field - clear button should not appear to close to the separator.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Weird placement of clear button in a corner case scenario.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)