### PR TITLE
Add pixels for Tab Crash recovery

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -72,6 +72,7 @@ public enum PrivacyFeature: String {
     case setAsDefaultAndAddToDock
     case contentScopeExperiments
     case extendedOnboarding
+    case tabCrashRecovery
 }
 
 /// An abstraction to be implemented by any "subfeature" of a given `PrivacyConfiguration` feature.

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -314,6 +314,9 @@ struct UserText {
     static let sslErrorPageTabTitle = NSLocalizedString("ssl.error.page.tab.title", value: "Warning: Site May Be Insecure", comment: "Title shown in an error page tab that warn users of security risks on a website due to SSL issues")
     static let maliciousSiteErrorPageTabTitle = NSLocalizedString("malicious.site.error.page.tab.title", value: "Warning: Security Risk", comment: "Title shown in an error page tab that warn users of security risks on a website that has been flagged as Malicious.")
 
+    static let tabCrashPopoverTitle = NSLocalizedString("tab.crash.popover.title", value: "This tab has crashed", comment: "The title of an info popover informing the user about a tab crash")
+    static let tabCrashPopoverMessage = NSLocalizedString("tab.crash.popover.message", value: "This page was reloaded automatically. Tab history and any info entered in a form have been lost.", comment: "The message in an info popover informing the user about a tab crash")
+
     static let openSystemPreferences = NSLocalizedString("open.preferences", value: "Open System Preferences", comment: "Open System Preferences (to re-enable permission for the App) (up to and including macOS 12")
     static let openSystemSettings = NSLocalizedString("open.settings", value: "Open System Settings…", comment: "This string represents a prompt or button label prompting the user to open system settings")
     static let checkForUpdate = NSLocalizedString("check.for.update", value: "Check for Update", comment: "Button users can use to check for a new update")

--- a/macOS/DuckDuckGo/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localizable.xcstrings
@@ -67811,6 +67811,30 @@
         }
       }
     },
+    "tab.crash.popover.message" : {
+      "comment" : "The message in an info popover informing the user about a tab crash",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This page was reloaded automatically. Tab history and any info entered in a form have been lost."
+          }
+        }
+      }
+    },
+    "tab.crash.popover.title" : {
+      "comment" : "The title of an info popover informing the user about a tab crash",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This tab has crashed"
+          }
+        }
+      }
+    },
     "tab.empty.title" : {
       "comment" : "Title for an empty tab without a title",
       "extractionState" : "extracted_with_value",

--- a/macOS/DuckDuckGo/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localizable.xcstrings
@@ -67815,10 +67815,58 @@
       "comment" : "The message in an info popover informing the user about a tab crash",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Seite wurde automatisch neu geladen. Der Tab-Verlauf und alle in Formulare eingegebenen Informationen sind verloren gegangen."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This page was reloaded automatically. Tab history and any info entered in a form have been lost."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta página se ha recargado automáticamente. Se ha perdido el historial de pestañas y cualquier información introducida en un formulario."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cette page a été rechargée automatiquement. L'historique des onglets et toutes les informations saisies dans un formulaire ont été perdues."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questa pagina è stata ricaricata automaticamente. La cronologia delle schede e tutte le informazioni inserite in un modulo sono andate perse."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deze pagina werd automatisch opnieuw geladen. De tabbladgeschiedenis en alle informatie die in een formulier is ingevoerd, zijn verloren gegaan."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ta strona została automatycznie załadowana ponownie. Historia kart oraz wszelkie informacje wprowadzone w formularzu zostały utracone."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta página foi recarregada automaticamente. O histórico do separador e qualquer informação introduzida num formulário foram perdidos."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Страница перезагрузилась автоматически. История вкладок и данные, внесенные в формы, не сохранились."
           }
         }
       }
@@ -67827,10 +67875,58 @@
       "comment" : "The title of an info popover informing the user about a tab crash",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieser Tab ist abgestürzt"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "This tab has crashed"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta pestaña ha fallado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cet onglet a planté"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questa scheda ha subito un arresto anomalo"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dit tabblad is gecrasht."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ta zakładka uległa awarii"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este separador falhou"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сбой на вкладке"
           }
         }
       }

--- a/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
+++ b/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
@@ -312,8 +312,8 @@ struct PinnedTabInnerView: View {
         .popover(isPresented: $tabCrashIndicatorModel.isShowingPopover, arrowEdge: .bottom) {
             PopoverMessageView(
                 viewModel: .init(
-                    title: "This tab has crashed",
-                    message: "The page was reloaded automatically. Tab history and form data has been lost.",
+                    title: UserText.tabCrashPopoverTitle,
+                    message: UserText.tabCrashPopoverMessage,
                     maxWidth: TabCrashIndicatorModel.Const.popoverWidth
                 ),
                 onClick: {

--- a/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -341,6 +341,8 @@ enum GeneralPixel: PixelKitEventV2 {
 
     case webKitDidTerminate
     case userViewedWebKitTerminationErrorPage
+    case webKitTerminationLoop
+    case webKitTerminationIndicatorClicked
 
     case removedInvalidBookmarkManagedObjects
 
@@ -983,10 +985,18 @@ enum GeneralPixel: PixelKitEventV2 {
         case .adAttributionLogicWrongVendorOnFailedCompilation:
             return "ad_attribution_logic_wrong_vendor_on_failed_compilation"
 
+        /// Event trigger: WebKit process crashes
         case .webKitDidTerminate:
             return "webkit_did_terminate"
+        /// Event trigger: Error page is displayed in response to the WebKit process crash
         case .userViewedWebKitTerminationErrorPage:
             return "webkit-termination-error-page-viewed"
+        /// Event trigger: WebKit process crash loop is detected
+        case .webKitTerminationLoop:
+            return "webkit_termination_loop"
+        /// Event trigger: User clicked WebKit process crash indicator icon
+        case .webKitTerminationIndicatorClicked:
+            return "webkit_termination_indicator_clicked"
 
         case .removedInvalidBookmarkManagedObjects:
             return "removed_invalid_bookmark_managed_objects"

--- a/macOS/DuckDuckGo/Tab/Model/TabCrashIndicatorModel.swift
+++ b/macOS/DuckDuckGo/Tab/Model/TabCrashIndicatorModel.swift
@@ -65,7 +65,7 @@ final class TabCrashIndicatorModel: ObservableObject {
 
     enum Const {
         static let maxIndicatorPresentationDuration: RunLoop.SchedulerTimeType.Stride = .seconds(20)
-        static let popoverWidth: CGFloat = 252
+        static let popoverWidth: CGFloat = 262
     }
 
     private let maxPresentationDuration: RunLoop.SchedulerTimeType.Stride

--- a/macOS/DuckDuckGo/Tab/Model/TabCrashIndicatorModel.swift
+++ b/macOS/DuckDuckGo/Tab/Model/TabCrashIndicatorModel.swift
@@ -18,6 +18,7 @@
 
 import Combine
 import Foundation
+import PixelKit
 
 /// This class manages the visibility of tab crash indicator.
 ///
@@ -28,12 +29,22 @@ import Foundation
 final class TabCrashIndicatorModel: ObservableObject {
 
     @Published private(set) var isShowingIndicator: Bool = false
-    @Published var isShowingPopover: Bool = false
+    @Published var isShowingPopover: Bool = false {
+        didSet {
+            if isShowingPopover && !oldValue {
+                firePixel(GeneralPixel.webKitTerminationIndicatorClicked)
+            }
+        }
+    }
 
     /// This initializer allows for parametrizing presentation duration
     /// in order to simplify unit testing.
-    init(maxPresentationDuration: RunLoop.SchedulerTimeType.Stride = Const.maxIndicatorPresentationDuration) {
+    init(
+        maxPresentationDuration: RunLoop.SchedulerTimeType.Stride = Const.maxIndicatorPresentationDuration,
+        firePixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0, frequency: .dailyAndStandard) }
+    ) {
         self.maxPresentationDuration = maxPresentationDuration
+        self.firePixel = firePixel
     }
 
     func setUp(with crashPublisher: AnyPublisher<TabCrashType, Never>) {
@@ -69,5 +80,6 @@ final class TabCrashIndicatorModel: ObservableObject {
     }
 
     private let maxPresentationDuration: RunLoop.SchedulerTimeType.Stride
+    private let firePixel: (PixelKitEvent) -> Void
     private var cancellables: Set<AnyCancellable> = []
 }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabCrashRecoveryExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabCrashRecoveryExtension.swift
@@ -151,6 +151,10 @@ extension TabCrashRecoveryExtension: NavigationResponder {
             tabDidCrashSubject.send(isCrashLoop ? .crashLoop : .single)
             lastCrashedAt = crashTimestamp
 
+            if isCrashLoop {
+                firePixel(GeneralPixel.webKitTerminationLoop, [:])
+            }
+
             shouldAutoReload = !isCrashLoop
         } else {
             shouldAutoReload = featureFlagger.internalUserDecider.isInternalUser

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -1229,8 +1229,8 @@ extension TabBarViewController: TabBarViewItemDelegate {
 
         DispatchQueue.main.async {
             let viewController = PopoverMessageViewController(
-                title: "This tab has crashed",
-                message: "The page was reloaded automatically. Tab history and form data has been lost.",
+                title: UserText.tabCrashPopoverTitle,
+                message: UserText.tabCrashPopoverMessage,
                 presentMultiline: true,
                 maxWidth: TabCrashIndicatorModel.Const.popoverWidth,
                 autoDismissDuration: nil,

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -179,7 +179,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .tabCrashDebugTools:
             return .disabled
         case .tabCrashRecovery:
-            return .disabled
+            return .remoteReleasable(.feature(.tabCrashRecovery))
         }
     }
 }

--- a/macOS/UnitTests/TabExtensionsTests/TabCrashRecoveryExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/TabCrashRecoveryExtensionTests.swift
@@ -243,6 +243,5 @@ final class TabCrashRecoveryExtensionTests: XCTestCase {
         tabCrashRecoveryExtension.webContentProcessDidTerminate(with: nil)
 
         await fulfillment(of: [expectation], timeout: 1)
-        XCTAssertEqual(firePixelCallCount, 1)
     }
 }

--- a/macOS/UnitTests/TabExtensionsTests/TabCrashRecoveryExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/TabCrashRecoveryExtensionTests.swift
@@ -226,4 +226,23 @@ final class TabCrashRecoveryExtensionTests: XCTestCase {
             .init(secondCrashTimestamp, firstCrashTimestamp)
         ])
     }
+
+    @MainActor
+    func testThatCrashLoopFiresCrashLoopPixel() async {
+
+        let expectation = expectation(description: "pixel fired")
+        firePixelHandler = { event, _ in
+            if case GeneralPixel.webKitTerminationLoop = event {
+                expectation.fulfill()
+            }
+        }
+        featureFlagger.isFeatureOn = true
+        crashLoopDetector.isCrashLoop = { _, _ in true }
+        setUpRegularTab()
+
+        tabCrashRecoveryExtension.webContentProcessDidTerminate(with: nil)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        XCTAssertEqual(firePixelCallCount, 1)
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1209974112904841?focus=true

### Description
This change adds 2 pixels to track tab crash recovery, and also updates translations for the tab crash popover.

### Testing Steps
Note that both pixels have no extra parameters (just app version and pixel source).
1. Enable `tabCrashRecovery` and `tabCrashDebugTools` feature flags.
2. Crash a tab and then crash is again to cause a crash loop.
3. Verify that `m_mac_webkit_termination_loop` and `m_mac_webkit_termination_loop_daily` are fired.
4. Crash a tab one more time and click the icon to display a popover.
5. Verify that `m_mac_webkit_termination_indicator_clicked` and `m_mac_webkit_termination_indicator_clicked_daily` are fired.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

### Quality Considerations
Tests for pixels are added.

### Notes to Reviewer
Pixels are pending Privacy Triage but it’s an equivalent of Windows pixels so it should go smoothly.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)