### PR TITLE
Visual Refresh: Increase standard and pinned tabs height

### DIFF
--- a/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
+++ b/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
@@ -25,7 +25,8 @@ struct PinnedTabView: View, DropDelegate {
         static let cornerRadius: CGFloat = 10
     }
 
-    private let visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager
+    let width: CGFloat
+    let height: CGFloat
 
     @ObservedObject var model: Tab
     @EnvironmentObject var collectionModel: PinnedTabsViewModel
@@ -43,7 +44,8 @@ struct PinnedTabView: View, DropDelegate {
                 }
             } label: {
                 PinnedTabInnerView(
-                    tabStyleProvider: visualStyleManager.style.tabStyleProvider,
+                    width: width,
+                    height: height,
                     foregroundColor: foregroundColor,
                     drawSeparator: !collectionModel.itemsWithoutSeparator.contains(model)
                 )
@@ -213,7 +215,8 @@ private struct BorderView: View {
 }
 
 struct PinnedTabInnerView: View {
-    let tabStyleProvider: TabStyleProviding
+    let width: CGFloat
+    let height: CGFloat
     var foregroundColor: Color
     var drawSeparator: Bool = true
 
@@ -240,7 +243,7 @@ struct PinnedTabInnerView: View {
                 .frame(maxWidth: 16, maxHeight: 16)
                 .aspectRatio(contentMode: .fit)
         }
-        .frame(width: tabStyleProvider.pinnedTabWidth)
+        .frame(width: width)
     }
 
     @ViewBuilder

--- a/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
+++ b/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
@@ -22,9 +22,10 @@ import SwiftUIExtensions
 
 struct PinnedTabView: View, DropDelegate {
     enum Const {
-        static let dimension: CGFloat = 34
         static let cornerRadius: CGFloat = 10
     }
+
+    private let visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager
 
     @ObservedObject var model: Tab
     @EnvironmentObject var collectionModel: PinnedTabsViewModel
@@ -42,6 +43,7 @@ struct PinnedTabView: View, DropDelegate {
                 }
             } label: {
                 PinnedTabInnerView(
+                    tabStyleProvider: visualStyleManager.style.tabStyleProvider,
                     foregroundColor: foregroundColor,
                     drawSeparator: !collectionModel.itemsWithoutSeparator.contains(model)
                 )
@@ -211,6 +213,7 @@ private struct BorderView: View {
 }
 
 struct PinnedTabInnerView: View {
+    let tabStyleProvider: TabStyleProviding
     var foregroundColor: Color
     var drawSeparator: Bool = true
 
@@ -237,7 +240,7 @@ struct PinnedTabInnerView: View {
                 .frame(maxWidth: 16, maxHeight: 16)
                 .aspectRatio(contentMode: .fit)
         }
-        .frame(width: PinnedTabView.Const.dimension)
+        .frame(width: tabStyleProvider.pinnedTabWidth)
     }
 
     @ViewBuilder

--- a/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabsView.swift
+++ b/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabsView.swift
@@ -27,7 +27,10 @@ struct PinnedTabsView: View {
     var body: some View {
         HStack(alignment: .bottom, spacing: 0) {
             ForEach(model.items) { item in
-                PinnedTabView(model: item, showsHover: draggedTab == nil)
+                PinnedTabView(width: tabStyleProvider.pinnedTabWidth,
+                              height: tabStyleProvider.pinnedTabHeight,
+                              model: item,
+                              showsHover: draggedTab == nil)
                     .environmentObject(model)
                     .frame(maxWidth: tabStyleProvider.pinnedTabWidth,
                            maxHeight: tabStyleProvider.pinnedTabHeight)

--- a/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabsView.swift
+++ b/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabsView.swift
@@ -19,6 +19,8 @@
 import SwiftUI
 
 struct PinnedTabsView: View {
+    private let tabStyleProvider: TabStyleProviding = NSApp.delegateTyped.visualStyleManager.style.tabStyleProvider
+
     @ObservedObject var model: PinnedTabsViewModel
     @State private var draggedTab: Tab?
 
@@ -27,10 +29,11 @@ struct PinnedTabsView: View {
             ForEach(model.items) { item in
                 PinnedTabView(model: item, showsHover: draggedTab == nil)
                     .environmentObject(model)
-                    .frame(maxWidth: PinnedTabView.Const.dimension, maxHeight: PinnedTabView.Const.dimension)
+                    .frame(maxWidth: tabStyleProvider.pinnedTabWidth,
+                           maxHeight: tabStyleProvider.pinnedTabHeight)
             }
         }
-        .frame(minHeight: PinnedTabView.Const.dimension)
+        .frame(minHeight: tabStyleProvider.pinnedTabHeight)
         .simultaneousGesture(dragGesture)
     }
 
@@ -63,7 +66,7 @@ struct PinnedTabsView: View {
     }
 
     private func itemIndex(for x: CGFloat) -> Int {
-        max(0, min(Int(x / CGFloat(PinnedTabView.Const.dimension)), model.items.count - 1))
+        max(0, min(Int(x / CGFloat(tabStyleProvider.pinnedTabWidth)), model.items.count - 1))
     }
 }
 
@@ -71,9 +74,9 @@ extension PinnedTabsView {
 
     func index(forItemAt point: CGPoint) -> Int? {
         guard !model.items.isEmpty,
-              (0..<PinnedTabView.Const.dimension).contains(point.y) else { return nil }
+              (0..<tabStyleProvider.pinnedTabWidth).contains(point.y) else { return nil }
 
-        let possibleItemIndex = min(model.items.count - 1, Int(point.x / PinnedTabView.Const.dimension))
+        let possibleItemIndex = min(model.items.count - 1, Int(point.x / tabStyleProvider.pinnedTabWidth))
         return model.items.index(model.items.startIndex, offsetBy: possibleItemIndex, limitedBy: model.items.endIndex)
     }
 

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -1023,7 +1023,7 @@ extension TabBarViewController: NSCollectionViewDelegateFlowLayout {
 
     func collectionView(_ collectionView: NSCollectionView, layout collectionViewLayout: NSCollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> NSSize {
         let isItemSelected = tabCollectionViewModel.selectionIndex == .unpinned(indexPath.item)
-        return NSSize(width: self.currentTabWidth(selected: isItemSelected), height: TabBarViewItem.Height.standard)
+        return NSSize(width: self.currentTabWidth(selected: isItemSelected), height: visualStyleManager.style.tabStyleProvider.standardTabHeight)
     }
 
 }

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -762,7 +762,8 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
             return
         }
 
-        let position = pinnedTabsContainerView.frame.minX + PinnedTabView.Const.dimension * CGFloat(index)
+        let pinnedTabWidth = visualStyleManager.style.tabStyleProvider.pinnedTabWidth
+        let position = pinnedTabsContainerView.frame.minX + pinnedTabWidth * CGFloat(index)
         showTabPreview(for: tabViewModel, from: position)
     }
 
@@ -1314,9 +1315,10 @@ extension TabBarViewController: TabBarViewItemDelegate {
             self.pinnedTabsDiscoveryPopover = popover
 
             guard let view = self.pinnedTabsHostingView else { return }
-            popover.show(relativeTo: NSRect(x: view.bounds.maxX - PinnedTabView.Const.dimension,
+            let pinnedTabWidth = visualStyleManager.style.tabStyleProvider.pinnedTabWidth
+            popover.show(relativeTo: NSRect(x: view.bounds.maxX - pinnedTabWidth,
                                             y: view.bounds.minY,
-                                            width: PinnedTabView.Const.dimension,
+                                            width: pinnedTabWidth,
                                             height: view.bounds.height),
                          of: view,
                          preferredEdge: .maxY)

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -389,9 +389,6 @@ final class TabBarViewItem: NSCollectionViewItem {
 
     static let identifier = NSUserInterfaceItemIdentifier(rawValue: "TabBarViewItem")
 
-    enum Height {
-        static let standard: CGFloat = 34
-    }
     enum Width {
         static let minimum: CGFloat = 52
         static let minimumSelected: CGFloat = 120
@@ -1117,11 +1114,15 @@ extension TabBarViewItem {
             }
         }
 
+        private let tabVisualProvider: TabStyleProviding
+
         let sections: [[TabBarViewModelMock]]
         var collectionViews = [NSCollectionView]()
 
-        init(sections: [[TabBarViewModelMock]]) {
+        init(sections: [[TabBarViewModelMock]],
+             visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager) {
             self.sections = sections
+            self.tabVisualProvider = visualStyleManager.style.tabStyleProvider
             super.init(nibName: nil, bundle: nil)
         }
 
@@ -1194,7 +1195,7 @@ extension TabBarViewItem {
         func collectionView(_ cv: NSCollectionView, layout: NSCollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> NSSize {
             let section = collectionViews.firstIndex(where: { $0 === cv })!
             let item = sections[section][indexPath.item]
-            return NSSize(width: item.width, height: TabBarViewItem.Height.standard)
+            return NSSize(width: item.width, height: tabVisualProvider.standardTabHeight)
         }
 
         func tabBarViewItem(_: TabBarViewItem, isMouseOver: Bool) {}

--- a/macOS/DuckDuckGo/VisualRefresh/TabStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/TabStyleProviding.swift
@@ -19,14 +19,18 @@
 protocol TabStyleProviding {
     var separatorColor: NSColor { get }
     var separatorHeight: CGFloat { get }
+
+    var standardTabHeight: CGFloat { get }
 }
 
 final class LegacyTabStyleProvider: TabStyleProviding {
     let separatorColor: NSColor = .separator
     let separatorHeight: CGFloat = 20
+    let standardTabHeight: CGFloat = 34
 }
 
 final class NewlineTabStyleProvider: TabStyleProviding {
     let separatorColor: NSColor = .tabSeparatorNew
     let separatorHeight: CGFloat = 16
+    let standardTabHeight: CGFloat = 38
 }

--- a/macOS/DuckDuckGo/VisualRefresh/TabStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/TabStyleProviding.swift
@@ -21,16 +21,22 @@ protocol TabStyleProviding {
     var separatorHeight: CGFloat { get }
 
     var standardTabHeight: CGFloat { get }
+    var pinnedTabHeight: CGFloat { get }
+    var pinnedTabWidth: CGFloat { get }
 }
 
 final class LegacyTabStyleProvider: TabStyleProviding {
     let separatorColor: NSColor = .separator
     let separatorHeight: CGFloat = 20
     let standardTabHeight: CGFloat = 34
+    let pinnedTabWidth: CGFloat = 34
+    let pinnedTabHeight: CGFloat = 34
 }
 
 final class NewlineTabStyleProvider: TabStyleProviding {
     let separatorColor: NSColor = .tabSeparatorNew
     let separatorHeight: CGFloat = 16
     let standardTabHeight: CGFloat = 38
+    let pinnedTabWidth: CGFloat = 34
+    let pinnedTabHeight: CGFloat = 36
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1209350566464644?focus=true
Tech Design URL:
CC:

### Description
Increases the height of tabs so no space is left between the top and tabs.

### Testing Steps
1. Run the app, go to Debug -> Feature Flag Overrides -> and select `visualRefresh`
2. Open a new window, open some standard tabs and some pinned tabs
3. Check no space is between the top and the tabs.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing comes to mind. Simple change

### Notes to Reviewer
@ayoy check if there is something I need to change related to the logic of some pinned tabs calculations done with the old value.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)