### PR TITLE
macOS: Fix cancelled uninstall attempts

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -627,8 +627,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         initializeSync()
 
-        vpnAppEventsHandler.applicationDidBecomeActive()
-
         let freemiumDBPUserStateManager = DefaultFreemiumDBPUserStateManager(userDefaults: .dbp)
         let pirGatekeeper = DefaultDataBrokerProtectionFeatureGatekeeper(subscriptionManager: subscriptionAuthV1toV2Bridge,
                                                                          freemiumDBPUserStateManager: freemiumDBPUserStateManager)

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNAppEventsHandler.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNAppEventsHandler.swift
@@ -72,16 +72,7 @@ final class VPNAppEventsHandler {
         let loginItemsManager = LoginItemsManager()
 
         Task { @MainActor in
-            await featureGatekeeper.disableIfUserHasNoAccess()
             restartNetworkProtectionIfVersionChanged(using: loginItemsManager)
-        }
-    }
-
-    /// Call this method when the app becomes active to run the associated NetP logic.
-    ///
-    func applicationDidBecomeActive() {
-        Task { @MainActor in
-            await featureGatekeeper.disableIfUserHasNoAccess()
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210072526046001?focus=true

### Description

Make some changes to that macOS won't fire unnecessary uninstall attempts.

### Testing Steps

1. Place a breakpoint [here](https://github.com/duckduckgo/apple-browsers/blob/dcd685ef93a1444d327ce313d0b03624fb650fb9/macOS/DuckDuckGo/Waitlist/VPNUninstaller.swift#L178).
2. Enable the VPN on AuthV1.
3. Enable AuthV2.
4. When launching the app again make sure the breakpoint isn't hit.

### Impact and Risks

Medium: could affect VPN uninstallation when the subscription expires, which is not a huge issue since users without a subscription won't be able to connect anyway.

#### What could go wrong?

That this was necessary to properly expire subscriptions, but we've tested that.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)