### PR TITLE
Show address bar outline borders in all states

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -73,6 +73,7 @@ final class AddressBarViewController: NSViewController {
     private let suggestionContainerViewModel: SuggestionContainerViewModel
     private let isBurner: Bool
     private let onboardingPixelReporter: OnboardingAddressBarReporting
+    private let visualStyleManager: VisualStyleManagerProviding
 
     private var aiChatSettings: AIChatPreferencesStorage
 
@@ -119,7 +120,8 @@ final class AddressBarViewController: NSViewController {
           burnerMode: BurnerMode,
           popovers: NavigationBarPopovers?,
           onboardingPixelReporter: OnboardingAddressBarReporting = OnboardingPixelReporter(),
-          aiChatSettings: AIChatPreferencesStorage = DefaultAIChatPreferencesStorage()) {
+          aiChatSettings: AIChatPreferencesStorage = DefaultAIChatPreferencesStorage(),
+          visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager) {
         self.tabCollectionViewModel = tabCollectionViewModel
         self.popovers = popovers
         self.suggestionContainerViewModel = SuggestionContainerViewModel(
@@ -129,6 +131,7 @@ final class AddressBarViewController: NSViewController {
         self.isBurner = burnerMode.isBurner
         self.onboardingPixelReporter = onboardingPixelReporter
         self.aiChatSettings = aiChatSettings
+        self.visualStyleManager = visualStyleManager
 
         super.init(coder: coder)
     }
@@ -400,7 +403,7 @@ final class AddressBarViewController: NSViewController {
 
         let isKey = self.view.window?.isKeyWindow == true
 
-        activeOuterBorderView.alphaValue = isKey && isFirstResponder && isHomePage ? 1 : 0
+        activeOuterBorderView.alphaValue = isKey && isFirstResponder && visualStyleManager.style.shouldShowOutlineBorder(isHomePage: isHomePage) ? 1 : 0
         activeOuterBorderView.backgroundColor = accentColor.withAlphaComponent(0.2)
         activeBackgroundView.borderColor = accentColor.withAlphaComponent(0.8)
 
@@ -485,7 +488,7 @@ final class AddressBarViewController: NSViewController {
                 activeBackgroundView.backgroundColor = NSColor.addressBarBackground
                 switchToTabBox.backgroundColor = NSColor.navigationBarBackground.blended(with: .addressBarBackground)
 
-                activeOuterBorderView.isHidden = !isHomePage
+                activeOuterBorderView.isHidden = !visualStyleManager.style.shouldShowOutlineBorder(isHomePage: isHomePage)
             } else {
                 activeBackgroundView.borderWidth = 0
                 activeBackgroundView.borderColor = nil

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
@@ -25,8 +25,9 @@ protocol VisualStyleProviding {
     func addressBarHeight(for type: AddressBarSizeClass) -> CGFloat
     func addressBarTopPadding(for type: AddressBarSizeClass) -> CGFloat
     func addressBarBottomPadding(for type: AddressBarSizeClass) -> CGFloat
-    var shouldShowLogoinInAddressBar: Bool { get }
+    func shouldShowOutlineBorder(isHomePage: Bool) -> Bool
 
+    var shouldShowLogoinInAddressBar: Bool { get }
     var toolbarButtonsCornerRadius: CGFloat { get }
 
     var backButtonImage: NSImage { get }
@@ -79,9 +80,9 @@ struct VisualStyle: VisualStyleProviding {
     private let addressBarBottomPaddingForDefault: CGFloat
     private let addressBarBottomPaddingForHomePage: CGFloat
     private let addressBarBottomPaddingForPopUpWindow: CGFloat
+    private let alwaysShowAddressBarOutline: Bool
 
     let shouldShowLogoinInAddressBar: Bool
-
     let toolbarButtonsCornerRadius: CGFloat
 
     let backButtonImage: NSImage
@@ -123,6 +124,10 @@ struct VisualStyle: VisualStyleProviding {
         }
     }
 
+    func shouldShowOutlineBorder(isHomePage: Bool) -> Bool {
+        return alwaysShowAddressBarOutline || isHomePage
+    }
+
     static var legacy: VisualStyleProviding {
         return VisualStyle(addressBarHeightForDefault: 48,
                            addressBarHeightForHomePage: 52,
@@ -133,6 +138,7 @@ struct VisualStyle: VisualStyleProviding {
                            addressBarBottomPaddingForDefault: 6,
                            addressBarBottomPaddingForHomePage: 8,
                            addressBarBottomPaddingForPopUpWindow: 0,
+                           alwaysShowAddressBarOutline: false,
                            shouldShowLogoinInAddressBar: false,
                            toolbarButtonsCornerRadius: 4,
                            backButtonImage: .back,
@@ -161,6 +167,7 @@ struct VisualStyle: VisualStyleProviding {
                            addressBarBottomPaddingForDefault: 6,
                            addressBarBottomPaddingForHomePage: 6,
                            addressBarBottomPaddingForPopUpWindow: 6,
+                           alwaysShowAddressBarOutline: true,
                            shouldShowLogoinInAddressBar: true,
                            toolbarButtonsCornerRadius: 9,
                            backButtonImage: .backNew,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1209793701087218?focus=true
Tech Design URL:
CC:

### Description
In the past, we only showed the outline border in the address bar when the home page was opened. Now we want to show it in all states when the address bar is the first responder and the suggestions view is not being shown.

| Before | After |
| ------ | ----- |
<img width="909" alt="Screenshot 2025-04-24 at 4 35 52 PM" src="https://github.com/user-attachments/assets/ea063339-2c81-4f6b-be04-485e234f2f9c" />|<img width="923" alt="Screenshot 2025-04-24 at 4 35 34 PM" src="https://github.com/user-attachments/assets/48b5216c-8513-4efd-8d3b-7d24e3f16499" />
            

### Testing Steps

**With FF turned on**
1. Run the app, go to Debug -> Feature Flag Overrides -> and override the `visualRefresh` FF
2. Open a new window
3. Open a site, and tap in the address bar, it should show the outline border in the address bar

**With FF turned off**
1. Run the app, go to Debug -> Feature Flag Overrides -> and remove the `visualRefresh` FF
2. Open a new window
3. Open a site, and tap in the address bar, it should not show the outline border
4. Open home page, it should show the outline border

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The change is behind a feature flag.

### Quality Considerations
Check that the outline border is shown in the described scenarios.

### Notes to Reviewer
Nothing specific.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)