### PR TITLE
Disable rounded corners treatment

### DIFF
--- a/iOS/DuckDuckGo/ExperimentalThemingManager/ExperimentalThemingManager.swift
+++ b/iOS/DuckDuckGo/ExperimentalThemingManager/ExperimentalThemingManager.swift
@@ -33,9 +33,7 @@ struct ExperimentalThemingManager {
         featureFlagger.isFeatureOn(for: FeatureFlag.experimentalBrowserTheming, allowOverride: true)
     }
 
-    var isRoundedCornersTreatmentEnabled: Bool {
-        isExperimentalThemingEnabled && UIDevice.current.userInterfaceIdiom != .pad
-    }
+    let isRoundedCornersTreatmentEnabled = false
 
     func toggleExperimentalTheming() {
         featureFlagger.localOverrides?.toggleOverride(for: FeatureFlag.experimentalBrowserTheming)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1210065032087720
Tech Design URL:
CC:

### Description

Disables the rounded corners WebView styling on iPhone.

### Testing Steps
1. Enable experimental appearance (internal user flag required). Restart app.
2. Check rounded corners are not visible for top and bottom bar setting and during pull-to-refresh.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Rounded corners could be only partially disabled.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)