### PR TITLE
Fix Tab Crash action on macOS 15.4

### DIFF
--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -1136,7 +1136,7 @@ extension Tab {
     static let crashTabMenuOptionTitle = "Crash Tab"
 
     private enum Selector {
-        static let killWebContentProcess = NSSelectorFromString("_killWebContentProcess")
+        static let killWebContentProcessAndResetState = NSSelectorFromString("_killWebContentProcessAndResetState")
     }
 
     var canKillWebContentProcess: Bool {
@@ -1144,8 +1144,8 @@ extension Tab {
     }
 
     func killWebContentProcess() {
-        if webView.responds(to: Selector.killWebContentProcess) {
-            webView.perform(Selector.killWebContentProcess)
+        if webView.responds(to: Selector.killWebContentProcessAndResetState) {
+            webView.perform(Selector.killWebContentProcessAndResetState)
         }
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1210078432720306?focus=true

### Description
Use a different private API call to reliably crash a tab if needed.

### Testing Steps
1. Enable `tabCrashDebugTools` feature flag via Debug Menu.
2. Right click a tab and select “Crash Tab” option.
3. Verify that the tab is reloaded.

### Impact and Risks
None: Internal tooling, documentation

### Notes to the reviewer
I’ve tested it on 15.4 and 15.3.2.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)