### PR TITLE
Use alert favicon for crashed pinned tabs

### DIFF
--- a/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
+++ b/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
@@ -335,6 +335,8 @@ struct PinnedTabInnerView: View {
     private var faviconImage: NSImage? {
         if let error = model.error, (error as NSError as? URLError)?.code == .serverCertificateUntrusted || (error as NSError as? MaliciousSiteError != nil) {
             return .redAlertCircle16
+        } else if model.error?.isWebContentProcessTerminated == true {
+            return .alertCircleColor16
         } else if let favicon = model.favicon {
             return favicon
         }

--- a/macOS/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
+++ b/macOS/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
@@ -525,7 +525,7 @@ final class TabViewModel {
                 return .redAlertCircle16
             }
         default:
-            return.alertCircleColor16
+            return .alertCircleColor16
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1210079281181693?focus=true

### Description
When a pinned tab crashes, display a yellow alert favicon in place of the website favicon.

### Testing Steps
1. Enable `tabCrashRecovery` and `tabCrashDebugTools` feature flags.
2. Pin a tab
3. Use pinned tab context menu -> Crash Tab to crash the pinned tab
4. After it reloads, crash it again within 5 seconds so that it displays the error page.
5. Verify that the pinned tab favicon displays a yellow alert icon.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)