### PR TITLE
Update swiping tabs on navigating to new tab

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2561,7 +2561,8 @@ extension MainViewController: TabDelegate {
                                               inheritedAttribution: inheritingAttribution)
         newTab.openedByPage = true
         newTab.openingTab = tab
-        
+        swipeTabsCoordinator?.refresh(tabsModel: tabManager.model)
+
         newTabAnimation {
             guard self.tabManager.model.tabs.contains(newTab.tabModel) else { return }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1210076795711877
Tech Design URL:
CC:

### Description

Fixes an issue when the collection containing omni bar is not refreshed properly. 

### Testing Steps
(See https://app.asana.com/1/137249556945/task/1210076795711877/comment/1210081312123646 for steps video)
1. Open https://duckduckgo.com/duckduckgo-help-pages/privacy/web-tracking-protections#cname-cloaking-protection
1. Tap on _Tracker Radar_ link
1. Scroll up after the new tab opens
2. Observe if the omni bar is visible after scrolling

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Omni bar or tab can flicker or block for a split second during opening.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)