### PR TITLE
Revert changes around SuggestionTrayViewController

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1385,7 +1385,7 @@ class MainViewController: UIViewController {
 
     private func applyWidthToTrayController() {
         if AppWidthObserver.shared.isLargeWidth {
-            self.suggestionTrayController?.float(under: self.viewCoordinator.omniBar.barView.searchContainer)
+            self.suggestionTrayController?.float(withWidth: self.viewCoordinator.omniBar.barView.searchContainerWidth)
         } else {
             self.suggestionTrayController?.fill()
         }

--- a/iOS/DuckDuckGo/SuggestionTray.storyboard
+++ b/iOS/DuckDuckGo/SuggestionTray.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="GVY-7c-Fnx">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="GVY-7c-Fnx">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -26,6 +26,7 @@
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" priority="999" constant="908" id="1GN-2u-5xs"/>
+                                    <constraint firstAttribute="width" priority="999" constant="1366" id="ywM-Lu-N4B"/>
                                 </constraints>
                             </view>
                         </subviews>
@@ -40,7 +41,7 @@
                             <constraint firstItem="ki7-21-ggp" firstAttribute="bottom" secondItem="64L-Y0-7ie" secondAttribute="bottom" id="ac9-7J-RDs"/>
                             <constraint firstItem="vmf-xs-TwY" firstAttribute="height" secondItem="64L-Y0-7ie" secondAttribute="height" id="ebY-43-deK"/>
                             <constraint firstItem="ki7-21-ggp" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="64L-Y0-7ie" secondAttribute="bottom" id="mSE-jr-Q7R"/>
-                            <constraint firstItem="64L-Y0-7ie" firstAttribute="centerX" secondItem="j0c-gb-rpc" secondAttribute="centerX" priority="250" id="rtq-3b-s1Z"/>
+                            <constraint firstItem="64L-Y0-7ie" firstAttribute="centerX" secondItem="j0c-gb-rpc" secondAttribute="centerX" id="rtq-3b-s1Z"/>
                         </constraints>
                     </view>
                     <connections>
@@ -50,6 +51,7 @@
                         <outlet property="fullWidthConstraint" destination="OLF-Z3-QnI" id="r8w-cl-frK"/>
                         <outlet property="topConstraint" destination="FqW-UB-Q8G" id="QxI-zE-Vdh"/>
                         <outlet property="variableHeightConstraint" destination="1GN-2u-5xs" id="Y0N-ld-Gc3"/>
+                        <outlet property="variableWidthConstraint" destination="ywM-Lu-N4B" id="cfE-Wh-pAR"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="zkh-30-c2N" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/iOS/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/iOS/DuckDuckGo/SuggestionTrayViewController.swift
@@ -29,12 +29,12 @@ class SuggestionTrayViewController: UIViewController {
     
     @IBOutlet weak var backgroundView: UIView!
     @IBOutlet weak var containerView: UIView!
+    @IBOutlet var variableWidthConstraint: NSLayoutConstraint!
     @IBOutlet var fullWidthConstraint: NSLayoutConstraint!
     @IBOutlet var topConstraint: NSLayoutConstraint!
     @IBOutlet var variableHeightConstraint: NSLayoutConstraint!
     @IBOutlet var fullHeightConstraint: NSLayoutConstraint!
-
-
+    
     weak var autocompleteDelegate: AutocompleteViewControllerDelegate?
     weak var favoritesOverlayDelegate: FavoritesOverlayDelegate?
     
@@ -161,7 +161,7 @@ class SuggestionTrayViewController: UIViewController {
         autocompleteController?.keyboardMoveSelectionUp()
     }
     
-    func float(under view: UIView) {
+    func float(withWidth width: CGFloat) {
 
         containerView.layer.cornerRadius = 16
         containerView.layer.masksToBounds = true
@@ -181,11 +181,9 @@ class SuggestionTrayViewController: UIViewController {
             variableHeightConstraint.constant = Constant.suggestionTrayInitialHeight
         }
 
+        variableWidthConstraint.constant = width
         fullWidthConstraint.isActive = false
         fullHeightConstraint.isActive = false
-
-        view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor).isActive = true
-        view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor).isActive = true
     }
     
     func fill() {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1210031492395115
Tech Design URL:
CC:

### Description

This rolls back partial changes around `SuggestionTrayViewController` from https://github.com/duckduckgo/apple-browsers/pull/448/ which caused a crash in the background on iPad.

### Testing Steps
1. Make sure Experimental appearance is turned off in Settings. Restart app if the flag was on.
2. Edit OmniBar contents, to make suggestion tray appear.
3. Rotate the device
4. Retry these steps with favorites present.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Suggestion tray may not be aligned with OmniBar's URL field.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)