### PR TITLE
Propagate navigation buttons state for iPad

### DIFF
--- a/iOS/DuckDuckGo/Refactoring/Common/OmniBarViewController.swift
+++ b/iOS/DuckDuckGo/Refactoring/Common/OmniBarViewController.swift
@@ -27,9 +27,17 @@ class OmniBarViewController: UIViewController, OmniBar {
 
     // swiftlint:disable:next force_cast
     var barView: any OmniBarView { view as! OmniBarView }
-
-    var isBackButtonEnabled: Bool = false
-    var isForwardButtonEnabled: Bool = false
+    
+    var isBackButtonEnabled: Bool {
+        get { barView.backButton.isEnabled }
+        set { barView.backButton.isEnabled = newValue }
+    }
+    
+    var isForwardButtonEnabled: Bool {
+        get { barView.forwardButton.isEnabled }
+        set { barView.forwardButton.isEnabled = newValue }
+    }
+    
     var text: String? {
         get { textField.text }
         set { textField.text = newValue }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1210076064653891
Tech Design URL:
CC:

### Description

The state was not propagated to underlying view.  Fix was taken from PR that's already merged (https://github.com/duckduckgo/apple-browsers/pull/527).

### Testing Steps
1. Open a web page in new tab on **iPad**. 
2. Validate back and forward buttons are disabled.
3. Navigate to some link, verify back button is enabled.
4. Navigate back, verify forward button is enabled and back is disabled.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Buttons may remain in disabled state, preventing users from navigating through history.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)