### PR TITLE
Return early from navigationDidFail when it contains webkit termination error

### DIFF
--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -1319,6 +1319,9 @@ extension Tab/*: NavigationResponder*/ { // to be moved to Tab+Navigation.swift
 
     @MainActor
     func navigation(_ navigation: Navigation, didFailWith error: WKError) {
+        guard !error.isWebContentProcessTerminated else {
+            return
+        }
         let url = error.failingUrl ?? navigation.url
         guard navigation.isCurrent else { return }
         invalidateInteractionStateData()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210080097969176?focus=true
CC: @mallexxx 

### Description
Turns out that on slower machines the webkit process termination may call navigationDidFail
callback before it calls webContentProcessDidTerminate. The former is then called with
the WebKit Termination error, and causes the termination error to be handled and webview state
altered to handle navigation error, which in fact isn’t a navigation error. That broke handling
webkit termination by the crash recovery extension.
This change updates navigationDidFail handler to return early in case of webkit termination error,
so that the termination handler can do its job.

### Testing Steps
I’ve tested it on:
* Big Sur, 
* Ventura
* Sequoia.

It was also an issue for Tak, who tested the build on his Ventura machine and found the issue to be fixed.
I consulted the change with Alex as well.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)