### PR TITLE
Remote broker delivery: Add eTag to BrokerDB

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Model/DataBroker.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Model/DataBroker.swift
@@ -124,6 +124,7 @@ public struct DataBroker: Codable, Sendable {
     public let parent: String?
     public let mirrorSites: [MirrorSite]
     public let optOutUrl: String
+    public var eTag: String
 
     public var isFakeBroker: Bool {
         name.contains("fake") // A future improvement will be to add a property in the JSON file.
@@ -138,6 +139,11 @@ public struct DataBroker: Codable, Sendable {
         case parent
         case mirrorSites
         case optOutUrl
+        case eTag
+    }
+
+    enum Constants {
+        static let defaultETag = "MIGRATED_OLD_BROKER_WITH_NO_ETAG"
     }
 
     init(id: Int64? = nil,
@@ -148,7 +154,8 @@ public struct DataBroker: Codable, Sendable {
          schedulingConfig: DataBrokerScheduleConfig,
          parent: String? = nil,
          mirrorSites: [MirrorSite] = [MirrorSite](),
-         optOutUrl: String
+         optOutUrl: String,
+         eTag: String
     ) {
         self.id = id
         self.name = name
@@ -165,6 +172,7 @@ public struct DataBroker: Codable, Sendable {
         self.parent = parent
         self.mirrorSites = mirrorSites
         self.optOutUrl = optOutUrl
+        self.eTag = eTag
     }
 
     public init(from decoder: Decoder) throws {
@@ -198,7 +206,17 @@ public struct DataBroker: Codable, Sendable {
 
         optOutUrl = (try? container.decode(String.self, forKey: .optOutUrl)) ?? ""
 
+        do {
+            eTag = try container.decode(String.self, forKey: .eTag)
+        } catch {
+            eTag = Constants.defaultETag
+        }
+
         id = nil
+    }
+
+    public mutating func setETag(_ eTag: String) {
+        self.eTag = eTag
     }
 
     public func scanStep() throws -> Step {

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/DataBrokerProtectionDatabaseProvider.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/DataBrokerProtectionDatabaseProvider.swift
@@ -119,7 +119,7 @@ public final class DefaultDataBrokerProtectionDatabaseProvider: GRDBSecureStorag
     public static func create<T: MigrationsProvider>(file: URL,
                                                      key: Data,
                                                      migrationProvider: T.Type = DefaultDataBrokerProtectionDatabaseMigrationsProvider.self) throws -> DefaultDataBrokerProtectionDatabaseProvider {
-        try DefaultDataBrokerProtectionDatabaseProvider(file: file, key: key, registerMigrationsHandler: migrationProvider.v5Migrations)
+        try DefaultDataBrokerProtectionDatabaseProvider(file: file, key: key, registerMigrationsHandler: migrationProvider.v6Migrations)
     }
 
     public init(file: URL,

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/Mappers.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/Mappers.swift
@@ -59,7 +59,7 @@ public struct MapperToDB {
 
     func mapToDB(_ broker: DataBroker, id: Int64? = nil) throws -> BrokerDB {
         let encodedBroker = try jsonEncoder.encode(broker)
-        return .init(id: id, name: broker.name, json: encodedBroker, version: broker.version, url: broker.url)
+        return .init(id: id, name: broker.name, json: encodedBroker, version: broker.version, url: broker.url, eTag: broker.eTag)
     }
 
     func mapToDB(_ profileQuery: ProfileQuery, relatedTo profileId: Int64) throws -> ProfileQueryDB {
@@ -178,7 +178,8 @@ struct MapperToModel {
             schedulingConfig: decodedBroker.schedulingConfig,
             parent: decodedBroker.parent,
             mirrorSites: decodedBroker.mirrorSites,
-            optOutUrl: decodedBroker.optOutUrl
+            optOutUrl: decodedBroker.optOutUrl,
+            eTag: decodedBroker.eTag
         )
     }
 

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/SchedulerSchema.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/SchedulerSchema.swift
@@ -95,6 +95,7 @@ public struct BrokerDB: Codable {
     let json: Data
     let version: String
     let url: String
+    let eTag: String
 }
 
 extension BrokerDB: PersistableRecord, FetchableRecord {
@@ -106,6 +107,7 @@ extension BrokerDB: PersistableRecord, FetchableRecord {
         case json
         case version
         case url
+        case eTag
     }
 
     public init(row: Row) throws {
@@ -114,6 +116,7 @@ extension BrokerDB: PersistableRecord, FetchableRecord {
         json = row[Columns.json]
         version = row[Columns.version]
         url = row[Columns.url]
+        eTag = row[Columns.eTag]
     }
 
     public func encode(to container: inout PersistenceContainer) throws {
@@ -122,6 +125,7 @@ extension BrokerDB: PersistableRecord, FetchableRecord {
         container[Columns.json] = json
         container[Columns.version] = version
         container[Columns.url] = url
+        container[Columns.eTag] = eTag
     }
 }
 

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/SchedulerSchema.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/SchedulerSchema.swift
@@ -100,6 +100,7 @@ public struct BrokerDB: Codable {
 
 extension BrokerDB: PersistableRecord, FetchableRecord {
     public static let databaseTableName: String = "broker"
+    static let missingETagValue = "MISSING_ETAG_VALUE"
 
     enum Columns: String, ColumnExpression {
         case id
@@ -116,7 +117,11 @@ extension BrokerDB: PersistableRecord, FetchableRecord {
         json = row[Columns.json]
         version = row[Columns.version]
         url = row[Columns.url]
-        eTag = row[Columns.eTag]
+        if row.hasColumn(Columns.eTag.rawValue) {
+            eTag = row[Columns.eTag]
+        } else {
+            eTag = Self.missingETagValue
+        }
     }
 
     public func encode(to container: inout PersistenceContainer) throws {

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
@@ -52,7 +52,8 @@ public extension BrokerProfileQueryData {
                 schedulingConfig: DataBrokerScheduleConfig.mock,
                 parent: parentURL,
                 mirrorSites: mirrorSites,
-                optOutUrl: optOutUrl ?? ""
+                optOutUrl: optOutUrl ?? "",
+                eTag: ""
             ),
             profileQuery: ProfileQuery(firstName: "John", lastName: "Doe", city: "Miami", state: "FL", birthYear: 50, deprecated: deprecated),
             scanJobData: ScanJobData(brokerId: 1,
@@ -574,9 +575,9 @@ public final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecu
 
     public func fetchBroker(with name: String) throws -> DataBroker? {
         if shouldReturnOldVersionBroker {
-            return .init(id: 1, name: "Broker", url: "broker.com", steps: [Step](), version: "1.0.0", schedulingConfig: .mock, optOutUrl: "")
+            return .init(id: 1, name: "Broker", url: "broker.com", steps: [Step](), version: "1.0.0", schedulingConfig: .mock, optOutUrl: "", eTag: "")
         } else if shouldReturnNewVersionBroker {
-            return .init(id: 1, name: "Broker", url: "broker.com", steps: [Step](), version: "1.0.1", schedulingConfig: .mock, optOutUrl: "")
+            return .init(id: 1, name: "Broker", url: "broker.com", steps: [Step](), version: "1.0.1", schedulingConfig: .mock, optOutUrl: "", eTag: "")
         }
 
         return nil
@@ -1233,7 +1234,8 @@ public extension DataBroker {
                 maintenanceScan: 0,
                 maxAttempts: -1
             ),
-            optOutUrl: ""
+            optOutUrl: "", 
+            eTag: ""
         )
     }
 }
@@ -1806,7 +1808,8 @@ public extension BrokerDB {
             BrokerDB(id: nil, name: .random(length: 4),
                      json: try! JSONSerialization.data(withJSONObject: [:], options: []),
                      version: "\($0).\($0).\($0)",
-                     url: "www.testbroker.com")
+                     url: "www.testbroker.com",
+                     eTag: "")
         }
     }
 }
@@ -1865,6 +1868,7 @@ public struct MockMigrationsProvider: DataBrokerProtectionDatabaseMigrationsProv
     public static var didCallV3Migrations = false
     public static var didCallV4Migrations = false
     public static var didCallV5Migrations = false
+    public static var didCallV6Migrations = false
 
     public static var v2Migrations: (inout GRDB.DatabaseMigrator) throws -> Void {
         didCallV2Migrations = true
@@ -1883,6 +1887,11 @@ public struct MockMigrationsProvider: DataBrokerProtectionDatabaseMigrationsProv
 
     public static var v5Migrations: (inout GRDB.DatabaseMigrator) throws -> Void {
         didCallV5Migrations = true
+        return { _ in }
+    }
+
+    public static var v6Migrations: (inout GRDB.DatabaseMigrator) throws -> Void {
+        didCallV6Migrations = true
         return { _ in }
     }
 }
@@ -1948,7 +1957,8 @@ public extension DataBroker {
                 maintenanceScan: 0,
                 maxAttempts: -1
             ),
-            optOutUrl: ""
+            optOutUrl: "",
+            eTag: ""
         )
     }
 
@@ -1969,7 +1979,8 @@ public extension DataBroker {
                 maxAttempts: -1
             ),
             parent: "some",
-            optOutUrl: ""
+            optOutUrl: "", 
+            eTag: ""
         )
     }
 
@@ -1985,7 +1996,8 @@ public extension DataBroker {
                 maintenanceScan: 0,
                 maxAttempts: -1
             ),
-            optOutUrl: ""
+            optOutUrl: "",
+            eTag: ""
         )
     }
 
@@ -2000,7 +2012,8 @@ public extension DataBroker {
                 maintenanceScan: 0,
                 maxAttempts: -1
               ),
-              optOutUrl: ""
+              optOutUrl: "",
+              eTag: ""
         )
     }
 
@@ -2021,7 +2034,8 @@ public extension DataBroker {
                 maxAttempts: -1
             ),
             mirrorSites: mirroSites,
-            optOutUrl: ""
+            optOutUrl: "",
+            eTag: ""
         )
     }
 }

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
@@ -1234,7 +1234,7 @@ public extension DataBroker {
                 maintenanceScan: 0,
                 maxAttempts: -1
             ),
-            optOutUrl: "", 
+            optOutUrl: "",
             eTag: ""
         )
     }
@@ -1979,7 +1979,7 @@ public extension DataBroker {
                 maxAttempts: -1
             ),
             parent: "some",
-            optOutUrl: "", 
+            optOutUrl: "",
             eTag: ""
         )
     }

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProfileQueryOperationManagerTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProfileQueryOperationManagerTests.swift
@@ -45,7 +45,7 @@ final class DataBrokerProfileQueryOperationManagerTests: XCTestCase {
             let extractedProfileId: Int64 = 1
             let currentPreferredRunDate = Date()
 
-            let mockDataBroker = DataBroker(name: "databroker", url: "databroker.com", steps: [Step](), version: "1.0", schedulingConfig: config, optOutUrl: "")
+            let mockDataBroker = DataBroker(name: "databroker", url: "databroker.com", steps: [Step](), version: "1.0", schedulingConfig: config, optOutUrl: "", eTag: "")
             let mockProfileQuery = ProfileQuery(id: profileQueryId, firstName: "a", lastName: "b", city: "c", state: "d", birthYear: 1222)
 
             let historyEvents = [HistoryEvent(extractedProfileId: extractedProfileId, brokerId: brokerId, profileQueryId: profileQueryId, type: .optOutRequested)]
@@ -93,7 +93,7 @@ final class DataBrokerProfileQueryOperationManagerTests: XCTestCase {
             let extractedProfileId: Int64 = 1
             let currentPreferredRunDate = Date()
 
-            let mockDataBroker = DataBroker(name: "databroker", url: "databroker.com", steps: [Step](), version: "1.0", schedulingConfig: config, optOutUrl: "")
+            let mockDataBroker = DataBroker(name: "databroker", url: "databroker.com", steps: [Step](), version: "1.0", schedulingConfig: config, optOutUrl: "", eTag: "")
             let mockProfileQuery = ProfileQuery(id: profileQueryId, firstName: "a", lastName: "b", city: "c", state: "d", birthYear: 1222)
 
             let historyEvents = [HistoryEvent(extractedProfileId: extractedProfileId, brokerId: brokerId, profileQueryId: profileQueryId, type: .optOutRequested)]
@@ -144,7 +144,7 @@ pixelHandler: MockDataBrokerProtectionPixelsHandler(),
             let extractedProfileId: Int64 = 1
             let currentPreferredRunDate = Date()
 
-            let mockDataBroker = DataBroker(name: "databroker", url: "databroker.com", steps: [Step](), version: "1.0", schedulingConfig: config, optOutUrl: "")
+            let mockDataBroker = DataBroker(name: "databroker", url: "databroker.com", steps: [Step](), version: "1.0", schedulingConfig: config, optOutUrl: "", eTag: "")
             let mockProfileQuery = ProfileQuery(id: profileQueryId, firstName: "a", lastName: "b", city: "c", state: "d", birthYear: 1222)
 
             let historyEvents = [HistoryEvent(extractedProfileId: extractedProfileId, brokerId: brokerId, profileQueryId: profileQueryId, type: .optOutRequested)]
@@ -897,7 +897,7 @@ pixelHandler: MockDataBrokerProtectionPixelsHandler(),
         let extractedProfileId: Int64 = 1
         let currentPreferredRunDate = Date()
 
-        let mockDataBroker = DataBroker(name: "databroker", url: "databroker.com", steps: [Step](), version: "1.0", schedulingConfig: config, optOutUrl: "")
+        let mockDataBroker = DataBroker(name: "databroker", url: "databroker.com", steps: [Step](), version: "1.0", schedulingConfig: config, optOutUrl: "", eTag: "")
         let mockProfileQuery = ProfileQuery(id: profileQueryId, firstName: "a", lastName: "b", city: "c", state: "d", birthYear: 1222)
 
         let historyEvents = [HistoryEvent(extractedProfileId: extractedProfileId, brokerId: brokerId, profileQueryId: profileQueryId, type: .optOutRequested)]
@@ -924,7 +924,7 @@ pixelHandler: MockDataBrokerProtectionPixelsHandler(),
         let currentPreferredRunDate = Date()
         let expectedPreferredRunDate = Date().addingTimeInterval(config.confirmOptOutScan.hoursToSeconds)
 
-        let mockDataBroker = DataBroker(name: "databroker", url: "databroker.com", steps: [Step](), version: "1.0", schedulingConfig: config, optOutUrl: "")
+        let mockDataBroker = DataBroker(name: "databroker", url: "databroker.com", steps: [Step](), version: "1.0", schedulingConfig: config, optOutUrl: "", eTag: "")
         let mockProfileQuery = ProfileQuery(id: profileQueryId, firstName: "a", lastName: "b", city: "c", state: "d", birthYear: 1222)
 
         let historyEvents = [HistoryEvent(extractedProfileId: extractedProfileId, brokerId: brokerId, profileQueryId: profileQueryId, type: .optOutRequested)]

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionDatabaseProviderTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionDatabaseProviderTests.swift
@@ -180,6 +180,8 @@ final class DataBrokerProtectionDatabaseProviderTests: XCTestCase {
                     try db.execute(sql: "PRAGMA foreign_keys = ON")
                 }
 
+            } catch let error as GRDB.DatabaseError where error.message == "table broker has no column named eTag" {
+                // no-op, BrokerDB.eTag doesn't exist as of v3 migration so we expect this
             } catch {
                 XCTFail("Failed to setup invalid data")
             }

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionUpdaterTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionUpdaterTests.swift
@@ -113,7 +113,7 @@ final class DataBrokerProtectionUpdaterTests: XCTestCase {
         if let vault = self.vault {
             let sut = DefaultDataBrokerProtectionBrokerUpdater(repository: repository, resources: resources, vault: vault, pixelHandler: pixelHandler)
             repository.lastCheckedVersion = nil
-            resources.brokersList = [.init(id: 1, name: "Broker", url: "broker.com", steps: [Step](), version: "1.0.1", schedulingConfig: .mock, optOutUrl: "")]
+            resources.brokersList = [.init(id: 1, name: "Broker", url: "broker.com", steps: [Step](), version: "1.0.1", schedulingConfig: .mock, optOutUrl: "", eTag: "")]
             vault.shouldReturnOldVersionBroker = true
 
             sut.checkForUpdatesInBrokerJSONFiles()
@@ -131,7 +131,7 @@ final class DataBrokerProtectionUpdaterTests: XCTestCase {
         if let vault = self.vault {
             let sut = DefaultDataBrokerProtectionBrokerUpdater(repository: repository, resources: resources, vault: vault, pixelHandler: pixelHandler)
             repository.lastCheckedVersion = nil
-            resources.brokersList = [.init(id: 1, name: "Broker", url: "broker.com", steps: [Step](), version: "1.0.1", schedulingConfig: .mock, optOutUrl: "")]
+            resources.brokersList = [.init(id: 1, name: "Broker", url: "broker.com", steps: [Step](), version: "1.0.1", schedulingConfig: .mock, optOutUrl: "", eTag: "")]
             vault.shouldReturnNewVersionBroker = true
 
             sut.checkForUpdatesInBrokerJSONFiles()

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionUpdaterTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionUpdaterTests.swift
@@ -148,7 +148,7 @@ final class DataBrokerProtectionUpdaterTests: XCTestCase {
         if let vault = self.vault {
             let sut = DefaultDataBrokerProtectionBrokerUpdater(repository: repository, resources: resources, vault: vault, pixelHandler: pixelHandler)
             repository.lastCheckedVersion = nil
-            resources.brokersList = [.init(id: 1, name: "Broker", url: "broker.com", steps: [Step](), version: "1.0.0", schedulingConfig: .mock, optOutUrl: "")]
+            resources.brokersList = [.init(id: 1, name: "Broker", url: "broker.com", steps: [Step](), version: "1.0.0", schedulingConfig: .mock, optOutUrl: "", eTag: "")]
             vault.profileQueries = [.mock]
 
             sut.checkForUpdatesInBrokerJSONFiles()

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/MapperToModelTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/MapperToModelTests.swift
@@ -42,10 +42,11 @@ final class MapperToModelTests: XCTestCase {
             schedulingConfig: DataBrokerScheduleConfig(retryError: 1, confirmOptOutScan: 2, maintenanceScan: 3, maxAttempts: -1),
             parent: "ParentBroker",
             mirrorSites: [],
-            optOutUrl: "https://example.com/opt-out"
+            optOutUrl: "https://example.com/opt-out",
+            eTag: ""
         )
         let jsonData = try jsonEncoder.encode(brokerData)
-        let brokerDB = BrokerDB(id: 1, name: "TestBroker", json: jsonData, version: "1.0", url: "https://example.com")
+        let brokerDB = BrokerDB(id: 1, name: "TestBroker", json: jsonData, version: "1.0", url: "https://example.com", eTag: "")
 
         // When
         let result = try sut.mapToModel(brokerDB)
@@ -72,7 +73,7 @@ final class MapperToModelTests: XCTestCase {
                 "schedulingConfig": {"retryError": 1, "confirmOptOutScan": 2, "maintenanceScan": 3, "maxAttempts": -1}
             }
             """.data(using: .utf8)!
-        let brokerDB = BrokerDB(id: 1, name: "TestBroker", json: brokerData, version: "1.0", url: "https://example.com")
+        let brokerDB = BrokerDB(id: 1, name: "TestBroker", json: brokerData, version: "1.0", url: "https://example.com", eTag: "")
 
         // When
         let result = try sut.mapToModel(brokerDB)
@@ -90,7 +91,7 @@ final class MapperToModelTests: XCTestCase {
                 "invalidKey": "value"
             }
             """.data(using: .utf8)!
-        let brokerDB = BrokerDB(id: 1, name: "InvalidBroker", json: invalidJsonData, version: "1.0", url: "https://example.com")
+        let brokerDB = BrokerDB(id: 1, name: "InvalidBroker", json: invalidJsonData, version: "1.0", url: "https://example.com", eTag: "")
 
         // When & Then
         XCTAssertThrowsError(try sut.mapToModel(brokerDB)) { error in
@@ -108,7 +109,7 @@ final class MapperToModelTests: XCTestCase {
                 "schedulingConfig": {"retryError": 1, "confirmOptOutScan": 2, "maintenanceScan": 3, "maxAttempts": -1}
             }
             """.data(using: .utf8)!
-        let brokerDB = BrokerDB(id: 1, name: "TestBroker", json: brokerData, version: "1.0", url: "")
+        let brokerDB = BrokerDB(id: 1, name: "TestBroker", json: brokerData, version: "1.0", url: "", eTag: "")
 
         // When
         let result = try sut.mapToModel(brokerDB)

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/MismatchCalculatorUseCaseTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/MismatchCalculatorUseCaseTests.swift
@@ -157,7 +157,8 @@ extension BrokerProfileQueryData {
                 steps: [Step](),
                 version: "1.0.0",
                 schedulingConfig: DataBrokerScheduleConfig.mock,
-                optOutUrl: ""
+                optOutUrl: "",
+                eTag: ""
             ),
             profileQuery: ProfileQuery(firstName: "John", lastName: "Doe", city: "Miami", state: "FL", birthYear: 50),
             scanJobData: ScanJobData(brokerId: 1, profileQueryId: 1, historyEvents: historyEvents)
@@ -173,7 +174,8 @@ extension BrokerProfileQueryData {
                 version: "1.0.0",
                 schedulingConfig: DataBrokerScheduleConfig.mock,
                 parent: "parent.com",
-                optOutUrl: ""
+                optOutUrl: "",
+                eTag: ""
             ),
             profileQuery: ProfileQuery(firstName: "John", lastName: "Doe", city: "Miami", state: "FL", birthYear: 50),
             scanJobData: ScanJobData(brokerId: 2, profileQueryId: 1, historyEvents: historyEvents)

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/OperationPreferredDateUpdaterTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/OperationPreferredDateUpdaterTests.swift
@@ -45,7 +45,8 @@ final class OperationPreferredDateUpdaterTests: XCTestCase {
                 maintenanceScan: 1,
                 maxAttempts: -1
             ),
-            optOutUrl: ""
+            optOutUrl: "",
+            eTag: ""
         )
         databaseMock.childBrokers = [childBroker]
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1205508328452434?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1209813786547143
CC:

### Description

Adds the new `etag` column to the BrokerDB table in a new migration step.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
Scenario 1:
1. Run PIR as a new user
2. Open the DB browser
3. Expect to see the DataBrokers table with the new `etag` column

Scenario 2:
1. Run PIR as an existing user
2. Open the DB browser
3. Expect to see the DataBrokers table with the new `etag` column

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

Database migration

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)