### PR TITLE
Fix lag when moving and opening standard tabs

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -33,6 +33,8 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
         case buttonPadding = 4
     }
 
+    private let standardTabHeight: CGFloat
+
     @IBOutlet weak var visualEffectBackgroundView: NSVisualEffectView!
     @IBOutlet weak var pinnedTabsContainerView: NSView!
     @IBOutlet private weak var collectionView: TabBarCollectionView!
@@ -155,6 +157,8 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
             self.pinnedTabsView = nil
             self.pinnedTabsHostingView = nil
         }
+
+        standardTabHeight = visualStyleManager.style.tabStyleProvider.standardTabHeight
 
         super.init(coder: coder)
     }
@@ -1024,7 +1028,7 @@ extension TabBarViewController: NSCollectionViewDelegateFlowLayout {
 
     func collectionView(_ collectionView: NSCollectionView, layout collectionViewLayout: NSCollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> NSSize {
         let isItemSelected = tabCollectionViewModel.selectionIndex == .unpinned(indexPath.item)
-        return NSSize(width: self.currentTabWidth(selected: isItemSelected), height: visualStyleManager.style.tabStyleProvider.standardTabHeight)
+        return NSSize(width: self.currentTabWidth(selected: isItemSelected), height: standardTabHeight)
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210092843803521?focus=true
Tech Design URL:
CC:

### Description
Fix a bug that lags opening and re-ordering standard tabs

### Testing Steps
1. Open a lot of new tabs with CMD+T (it shouldn’t be lagging)
2. Re-order them and check no lag is present

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Hopefully nothing.

### Quality Considerations
Nothing.

### Notes to Reviewer
Nothing.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)