### PR TITLE
AuthV2 Token branching between main app and SysExt fix

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -644,6 +644,9 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             Logger.networkProtection.log("Set new token container")
             do {
                 try await tokenHandlerProvider.adoptToken(newTokenContainer)
+                // It’s important to force refresh the token to immediately branch the one used by the system extension from the one used in the main app.
+                // See discussion https://app.asana.com/0/1199230911884351/1208785842165508/f
+                try await tokenHandlerProvider.refreshToken()
             } catch {
                 Logger.networkProtection.fault("Error adopting token container: \(error, privacy: .public)")
                 throw TunnelError.startingTunnelWithoutAuthToken(internalError: error)

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
@@ -679,7 +679,7 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
             let tokenContainer = try await fetchTokenContainer()
             options[NetworkProtectionOptionKey.tokenContainer] = tokenContainer.data
 
-            // Important: Here we force the token refresh in order to immediately branch the one used by the main app from the system extension one.
+            // It’s important to force refresh the token here to immediately branch the token used by the main app from the one sent to the system extension.
             // See discussion https://app.asana.com/0/1199230911884351/1208785842165508/f
             try await subscriptionManagerV2.getTokenContainer(policy: .localForceRefresh)
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/inbox/1205736674596206/item/1210082295267504/story/1210084645776832?focus=true
CC: @miasma13 

### Description

In [this task](https://app.asana.com/1/137249556945/inbox/1205736674596206/item/1210082295267504/story/1210084645776832?focus=true) Thomas noticed that, with AuthV2, we are getting a lot of 401 errors from the macOS VPN SysExt.

**What the app was doing:**
the main app uses token T1
the main app sends T1 to the SysExt
the main app force refresh T1 and obtains T2
the main app uses T2 from now on
the SysExt receives T1 and uses T1 from now on
Issue: The first time SysExt tries to refresh the token, it fails because T1 has already been refreshed more than 1h before.

**The fix:**
the main app uses token T1
the main app sends T1 to the SysExt
the main app force refresh T1 and obtains T2
the main app uses T2 from now on
the SysExt receives T1
the SysExt receives force refresh T1 and obtains T3
the SysExt uses T3 from now on

### Testing Steps

The best way to test this is by Thomas checking the backend, as nothing is noticeable from the client side.
The tests will be performed before merging.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)