### PR TITLE
Fix handling Asana V1 inbox URLs in focused mode

### DIFF
--- a/.github/workflows/create_asana_pr_subtask.yml
+++ b/.github/workflows/create_asana_pr_subtask.yml
@@ -21,7 +21,7 @@ jobs:
             task_id=$(grep -i "task/issue url.*https://app.asana.com/" <<< "$BODY" \
               | perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?|\1|; \
                 s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?|\1|; \
-                s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)|\1|'
+                s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?|\1|'
             )
             echo "task_id=${task_id//[^0-9]/}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ios_adhoc.yml
+++ b/.github/workflows/ios_adhoc.yml
@@ -104,7 +104,7 @@ jobs:
           task_id=$(echo "$ASANA_TASK_URL" \
             | perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?|\1|; \
               s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?|\1|; \
-              s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)|\1|'
+              s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?|\1|'
           )
           echo "task_id=${task_id//[^0-9]/}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ios_pr_task_url.yml
+++ b/.github/workflows/ios_pr_task_url.yml
@@ -32,7 +32,7 @@ jobs:
         task_id=$(grep -i "task/issue url.*https://app.asana.com/" <<< "$BODY" \
           | perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?|\1|; \
             s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?|\1|; \
-            s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)|\1|'
+            s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?|\1|'
         )
         echo "task_id=${task_id//[^0-9]/}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/macos_pr_task_url.yml
+++ b/.github/workflows/macos_pr_task_url.yml
@@ -32,7 +32,7 @@ jobs:
         task_id=$(grep -i "task/issue url.*https://app.asana.com/" <<< "$BODY" \
           | perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?|\1|; \
             s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?|\1|; \
-            s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)|\1|'
+            s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?|\1|'
         )
         echo "task_id=${task_id//[^0-9]/}" >> $GITHUB_OUTPUT
 

--- a/iOS/scripts/get_tasks_in_last_internal_release.sh
+++ b/iOS/scripts/get_tasks_in_last_internal_release.sh
@@ -31,7 +31,7 @@ get_task_id() {
 	local task_id
 	task_id="$(perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?|\1|; \
                 s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?|\1|; \
-                s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)|\1|' <<< "$url")"
+                s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?|\1|' <<< "$url")"
 	if [[ -n "$task_id" ]]; then
 		local http_code
 		http_code="$(curl -fLSs "${asana_api_url}/tasks/${task_id}?opt_fields=gid" \

--- a/macOS/scripts/get_tasks_in_last_internal_release.sh
+++ b/macOS/scripts/get_tasks_in_last_internal_release.sh
@@ -31,7 +31,7 @@ get_task_id() {
 	local task_id
 	task_id="$(perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?|\1|; \
                 s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?|\1|; \
-                s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)|\1|' <<< "$url")"
+                s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?|\1|' <<< "$url")"
 	if [[ -n "$task_id" ]]; then
 		local http_code
 		http_code="$(curl -fLSs "${asana_api_url}/tasks/${task_id}?opt_fields=gid" \


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1210099002002088?focus=true

### Description
This change fixes handling of Asana V1 inbox URLs with 'focus=true’ query parameters
in GHA workflows and bash scripts (fastlane plugin handles them correctly otherwise).

### Testing Steps
Verify that this:
```
perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?|\1|; \
    s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?|\1|; \
    s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?|\1|' \
    <<< "https://app.asana.com/1/137249556945/inbox/1205736674596206/item/1210082295267504/story/1210084645776832?focus=true"
```
outputs this:
```
1210082295267504
```

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)