### PR TITLE
AuthV2 .migrationStarted pixel removed

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
@@ -57,7 +57,6 @@ public enum SubscriptionManagerError: Error, Equatable, LocalizedError {
 
 public enum SubscriptionPixelType {
     case invalidRefreshToken
-    case migrationStarted
     case migrationSucceeded
     case migrationFailed(Error)
     case subscriptionIsActive
@@ -246,7 +245,6 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
 
         // Attempting V1 token migration
         do {
-            pixelHandler.handle(pixelType: .migrationStarted)
             try await oAuthClient.migrateV1Token()
             pixelHandler.handle(pixelType: .migrationSucceeded)
             v1MigrationNeeded = false

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -953,7 +953,6 @@ extension Pixel {
         case privacyProInvalidRefreshTokenDetected
         case privacyProInvalidRefreshTokenSignedOut
         case privacyProInvalidRefreshTokenRecovered
-        case privacyProAuthV2MigrationStarted
         case privacyProAuthV2MigrationFailed
         case privacyProAuthV2MigrationSucceeded
         case privacyProAuthV2GetTokensError
@@ -2001,7 +2000,6 @@ extension Pixel.Event {
         case .privacyProInvalidRefreshTokenDetected: return "m_privacy-pro_auth_invalid_refresh_token_detected"
         case .privacyProInvalidRefreshTokenSignedOut: return "m_privacy-pro_auth_invalid_refresh_token_signed_out"
         case .privacyProInvalidRefreshTokenRecovered: return "m_privacy-pro_auth_invalid_refresh_token_recovered"
-        case .privacyProAuthV2MigrationStarted: return "m_privacy-pro_auth_v2_migration_started"
         case .privacyProAuthV2MigrationFailed: return "m_privacy-pro_auth_v2_migration_failure"
         case .privacyProAuthV2MigrationSucceeded: return "m_privacy-pro_auth_v2_migration_success"
         case .privacyProAuthV2GetTokensError: return "m_privacy-pro_auth_v2_get_tokens_error"

--- a/iOS/DuckDuckGo/Subscription/AuthV2PixelHandler.swift
+++ b/iOS/DuckDuckGo/Subscription/AuthV2PixelHandler.swift
@@ -52,8 +52,6 @@ public struct AuthV2PixelHandler: SubscriptionPixelHandler {
             DailyPixel.fireDailyAndCount(pixel: .privacyProInvalidRefreshTokenDetected, withAdditionalParameters: sourceParam)
         case .subscriptionIsActive:
             DailyPixel.fire(pixel: .privacyProSubscriptionActive)
-        case .migrationStarted:
-            DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2MigrationStarted, withAdditionalParameters: sourceParam)
         case .migrationFailed(let error):
             DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2MigrationFailed, withAdditionalParameters: [Defaults.errorKey: error.localizedDescription].merging(sourceParam) { $1 })
         case .migrationSucceeded:

--- a/macOS/DuckDuckGo/Statistics/PrivacyProPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/PrivacyProPixel.swift
@@ -72,7 +72,6 @@ enum PrivacyProPixel: PixelKitEventV2 {
     case privacyProInvalidRefreshTokenDetected(AuthV2PixelHandler.Source)
     case privacyProInvalidRefreshTokenSignedOut
     case privacyProInvalidRefreshTokenRecovered
-    case privacyProAuthV2MigrationStarted(AuthV2PixelHandler.Source)
     case privacyProAuthV2MigrationFailed(AuthV2PixelHandler.Source, Error)
     case privacyProAuthV2MigrationSucceeded(AuthV2PixelHandler.Source)
     case privacyProAuthV2GetTokensError(AuthTokensCachePolicy, AuthV2PixelHandler.Source, Error)
@@ -120,7 +119,6 @@ enum PrivacyProPixel: PixelKitEventV2 {
         case .privacyProInvalidRefreshTokenDetected: return "m_mac_\(appDistribution)_privacy-pro_auth_invalid_refresh_token_detected"
         case .privacyProInvalidRefreshTokenSignedOut: return "m_mac_\(appDistribution)_privacy-pro_auth_invalid_refresh_token_signed_out"
         case .privacyProInvalidRefreshTokenRecovered: return "m_mac_\(appDistribution)_privacy-pro_auth_invalid_refresh_token_recovered"
-        case .privacyProAuthV2MigrationStarted: return "m_mac_\(appDistribution)_privacy-pro_auth_v2_migration_started"
         case .privacyProAuthV2MigrationFailed: return "m_mac_\(appDistribution)_privacy-pro_auth_v2_migration_failure"
         case .privacyProAuthV2MigrationSucceeded: return "m_mac_\(appDistribution)_privacy-pro_auth_v2_migration_success"
         case .privacyProAuthV2GetTokensError: return "m_mac_\(appDistribution)_privacy-pro_auth_v2_get_tokens_error"
@@ -140,7 +138,6 @@ enum PrivacyProPixel: PixelKitEventV2 {
     var parameters: [String: String]? {
         switch self {
         case .privacyProInvalidRefreshTokenDetected(let source),
-                .privacyProAuthV2MigrationStarted(let source),
                 .privacyProAuthV2MigrationSucceeded(let source):
             return [PrivacyProPixelsDefaults.sourceKey: source.description]
         case .privacyProAuthV2GetTokensError(let policy, let source, let error):

--- a/macOS/DuckDuckGo/Subscription/AuthV2PixelHandler.swift
+++ b/macOS/DuckDuckGo/Subscription/AuthV2PixelHandler.swift
@@ -50,8 +50,6 @@ public struct AuthV2PixelHandler: SubscriptionPixelHandler {
             PixelKit.fire(PrivacyProPixel.privacyProInvalidRefreshTokenDetected(source), frequency: .dailyAndCount)
         case .subscriptionIsActive:
             PixelKit.fire(PrivacyProPixel.privacyProSubscriptionActive, frequency: .daily)
-        case .migrationStarted:
-            PixelKit.fire(PrivacyProPixel.privacyProAuthV2MigrationStarted(source), frequency: .dailyAndCount)
         case .migrationFailed(let error):
             PixelKit.fire(PrivacyProPixel.privacyProAuthV2MigrationFailed(source, error), frequency: .dailyAndCount)
         case .migrationSucceeded:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205842942115003/task/1210107509728194?focus=true

### Description

The .migrationStarted adds no useful data to our dashboard but only noise. This removes it.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)