### PR TITLE
Disable tab auto-reload when tab crash debugging flag is set and crash recovery flag is not set

### DIFF
--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -1140,7 +1140,7 @@ extension Tab {
     }
 
     var canKillWebContentProcess: Bool {
-        featureFlagger.isFeatureOn(.tabCrashDebugTools)
+        featureFlagger.isFeatureOn(.tabCrashDebugging)
     }
 
     func killWebContentProcess() {

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabCrashRecoveryExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabCrashRecoveryExtension.swift
@@ -159,7 +159,8 @@ extension TabCrashRecoveryExtension: NavigationResponder {
 
             shouldAutoReload = !isCrashLoop
         } else {
-            shouldAutoReload = featureFlagger.internalUserDecider.isInternalUser
+            // disable auto-reload if tab crash debugging flag is enabled, to allow testing
+            shouldAutoReload = featureFlagger.internalUserDecider.isInternalUser && !featureFlagger.isFeatureOn(.tabCrashDebugging)
         }
 
         handleTabCrash(error, in: webView, shouldAutoReload: shouldAutoReload)

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -73,7 +73,7 @@ public enum FeatureFlag: String, CaseIterable {
     case visualRefresh
 
     /// https://app.asana.com/1/137249556945/project/72649045549333/task/1209227311680179?focus=true
-    case tabCrashDebugTools
+    case tabCrashDebugging
 
     /// https://app.asana.com/1/137249556945/project/72649045549333/task/1209227311680179?focus=true
     case tabCrashRecovery
@@ -113,7 +113,7 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .scamSiteProtection,
                 .exchangeKeysToSyncWithAnotherDevice,
                 .visualRefresh,
-                .tabCrashDebugTools,
+                .tabCrashDebugging,
                 .tabCrashRecovery:
             return true
         case .debugMenu,
@@ -176,7 +176,7 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(SyncSubfeature.exchangeKeysToSyncWithAnotherDevice))
         case .visualRefresh:
             return .remoteDevelopment(.feature(.experimentalBrowserTheming))
-        case .tabCrashDebugTools:
+        case .tabCrashDebugging:
             return .disabled
         case .tabCrashRecovery:
             return .remoteReleasable(.feature(.tabCrashRecovery))

--- a/macOS/UnitTests/DuckSchemeHandler/DuckSchemeHandlerTests.swift
+++ b/macOS/UnitTests/DuckSchemeHandler/DuckSchemeHandlerTests.swift
@@ -32,7 +32,7 @@ final class DuckSchemeHandlerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         featureFlagger = MockFeatureFlagger()
-        featureFlagger.isFeatureOn = false
+        featureFlagger.isFeatureOn = { _ in false }
 
         handler = DuckURLSchemeHandler(featureFlagger: featureFlagger)
     }

--- a/macOS/UnitTests/History/Services/HistoryGroupingProviderTests.swift
+++ b/macOS/UnitTests/History/Services/HistoryGroupingProviderTests.swift
@@ -44,7 +44,7 @@ final class HistoryGroupingProviderTests: XCTestCase {
     // MARK: - getRecentVisits with deduplication
 
     func testWhenHistoryViewIsEnabledThenRecentVisitsAreDeduplicatedLeavingMostRecentVisit() async throws {
-        featureFlagger.isFeatureOn = true
+        featureFlagger.isFeatureOn = { _ in true }
 
         let date = Date.noonToday
         dataSource.history = [
@@ -62,7 +62,7 @@ final class HistoryGroupingProviderTests: XCTestCase {
     }
 
     func testWhenHistoryViewIsEnabledThenRecentVisitsAreSortedByMostRecentVisit() async throws {
-        featureFlagger.isFeatureOn = true
+        featureFlagger.isFeatureOn = { _ in true }
 
         let date = Date.noonToday
         dataSource.history = [
@@ -86,7 +86,7 @@ final class HistoryGroupingProviderTests: XCTestCase {
     }
 
     func testWhenHistoryViewIsEnabledThenRecentVisitsAreLimitedToMaxCount() async throws {
-        featureFlagger.isFeatureOn = true
+        featureFlagger.isFeatureOn = { _ in true }
 
         let date = Date.noonToday
         dataSource.history = [
@@ -117,7 +117,7 @@ final class HistoryGroupingProviderTests: XCTestCase {
     }
 
     func testWhenHistoryViewIsEnabledThenRecentVisitsAreLimitedToCurrentDay() async throws {
-        featureFlagger.isFeatureOn = true
+        featureFlagger.isFeatureOn = { _ in true }
 
         let date = Date.noonToday
         dataSource.history = [
@@ -150,7 +150,7 @@ final class HistoryGroupingProviderTests: XCTestCase {
     // MARK: - getRecentVisits without deduplication
 
     func testWhenHistoryViewIsDisabledThenRecentVisitsAreNotDeduplicated() async throws {
-        featureFlagger.isFeatureOn = false
+        featureFlagger.isFeatureOn = { _ in false }
 
         let date = Date.noonToday
         dataSource.history = [
@@ -171,7 +171,7 @@ final class HistoryGroupingProviderTests: XCTestCase {
     }
 
     func testWhenHistoryViewIsDisabledThenRecentVisitsAreSortedByMostRecentVisit() async throws {
-        featureFlagger.isFeatureOn = false
+        featureFlagger.isFeatureOn = { _ in false }
 
         let date = Date.noonToday
         dataSource.history = [
@@ -205,7 +205,7 @@ final class HistoryGroupingProviderTests: XCTestCase {
     }
 
     func testWhenHistoryViewIsDisabledThenRecentVisitsAreLimitedToMaxCount() async throws {
-        featureFlagger.isFeatureOn = false
+        featureFlagger.isFeatureOn = { _ in false }
 
         let date = Date.noonToday
         dataSource.history = [
@@ -230,7 +230,7 @@ final class HistoryGroupingProviderTests: XCTestCase {
     }
 
     func testWhenHistoryViewIsDisabledThenRecentVisitsAreLimitedToCurrentDay() async throws {
-        featureFlagger.isFeatureOn = false
+        featureFlagger.isFeatureOn = { _ in false }
 
         let date = Date.noonToday
         dataSource.history = [
@@ -257,7 +257,7 @@ final class HistoryGroupingProviderTests: XCTestCase {
     // MARK: - getVisitGroupings with deduplication
 
     func testWhenHistoryViewIsEnabledThenVisitGroupingsAreDeduplicated() async throws {
-        featureFlagger.isFeatureOn = true
+        featureFlagger.isFeatureOn = { _ in true }
 
         let date = Date.noonToday
         dataSource.history = [
@@ -343,7 +343,7 @@ final class HistoryGroupingProviderTests: XCTestCase {
     // MARK: - getVisitGroupings without deduplication
 
     func testWhenHistoryViewIsDisabledThenVisitGroupingsAreNotDeduplicated() async throws {
-        featureFlagger.isFeatureOn = false
+        featureFlagger.isFeatureOn = { _ in false }
 
         let date = Date.noonToday
         dataSource.history = [

--- a/macOS/UnitTests/History/View/Onboarding/HistoryViewOnboardingDeciderTests.swift
+++ b/macOS/UnitTests/History/View/Onboarding/HistoryViewOnboardingDeciderTests.swift
@@ -36,16 +36,16 @@ final class HistoryViewOnboardingDeciderTests: XCTestCase {
         settingsPersistor = MockHistoryViewOnboardingViewSettingsPersistor()
         decider = HistoryViewOnboardingDecider(featureFlagger: featureFlagger, settingsPersistor: settingsPersistor, isContextualOnboardingCompleted: { self.isContextualOnboardingCompleted }, isNewUser: { self.isNewUser })
 
-        featureFlagger.isFeatureOn = true
+        featureFlagger.isFeatureOn = { _ in true }
     }
 
     func testWhenFeatureFlagIsDisabledThenOnboardingShouldNotBePresented() {
-        featureFlagger.isFeatureOn = false
+        featureFlagger.isFeatureOn = { _ in false }
         XCTAssertFalse(decider.shouldPresentOnboarding)
     }
 
     func testWhenFeatureFlagIsEnabledThenOnboardingShouldBePresented() {
-        featureFlagger.isFeatureOn = true
+        featureFlagger.isFeatureOn = { _ in true }
         XCTAssertTrue(decider.shouldPresentOnboarding)
     }
 

--- a/macOS/UnitTests/Tab/Model/TabTests.swift
+++ b/macOS/UnitTests/Tab/Model/TabTests.swift
@@ -119,7 +119,7 @@ final class TabTests: XCTestCase {
         let internalUserDecider = InternalUserDeciderMock()
         internalUserDecider.isInternalUser = true
 
-        let featureFlagger = FeatureFlaggerMock(internalUserDecider: internalUserDecider, enabledFeatureFlags: [.tabCrashDebugTools])
+        let featureFlagger = FeatureFlaggerMock(internalUserDecider: internalUserDecider, enabledFeatureFlags: [.tabCrashDebugging])
 
         let tab = Tab(content: .newtab, featureFlagger: featureFlagger)
         XCTAssertTrue(tab.canKillWebContentProcess)

--- a/macOS/UnitTests/TabExtensionsTests/ErrorPageTabExtensionTest.swift
+++ b/macOS/UnitTests/TabExtensionsTests/ErrorPageTabExtensionTest.swift
@@ -548,9 +548,9 @@ class MockFeatureFlagger: FeatureFlagger {
         self.internalUserDecider = internalUserDecider
     }
 
-    var isFeatureOn = true
+    var isFeatureOn: (any FeatureFlagDescribing) -> Bool = { _ in true }
     func isFeatureOn<Flag: FeatureFlagDescribing>(for featureFlag: Flag, allowOverride: Bool) -> Bool {
-        return isFeatureOn
+        return isFeatureOn(featureFlag)
     }
 
     func getCohortIfEnabled(_ subfeature: any PrivacySubfeature) -> CohortID? {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210107348381777?focus=true

### Description
When Tab crash recovery flag is disabled, the app falls back to the legacy mechanism of auto-reloading
after all crashes for internal users. This prevents testing (observing) tab crashes. This change updates
the logic so that when tabCrashDebugging flag is enabled and tabCrashRecovery is disabled, auto-reload
is disabled for internal users.

### Testing Steps
1. Override `tabCrashRecovery` flag to be disabled.
2. Override `tabCrashDebugging` flag to be enabled.
3. Crash a tab and verify that it wasn’t auto-reloaded.
4. Disable `tabCrashDebugging` flag.
5. Crash a tab and verify that it was auto-reloaded.

### Impact and Risks
None: Internal tooling, documentation

### Quality Considerations
Unit test is provided to handle this scenario.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)