### PR TITLE
Adds a daily variant to bookmarksSaveFailed pixel

### DIFF
--- a/macOS/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift
@@ -744,8 +744,10 @@ final class LocalBookmarkStore: BookmarkStore {
             let processedErrors = CoreDataErrorsParser.parse(error: error)
 
             if AppVersion.runType.requiresEnvironment {
-                PixelKit.fire(DebugEvent(GeneralPixel.bookmarksSaveFailedOnImport, error: error),
-                           withAdditionalParameters: processedErrors.errorPixelParameters)
+                PixelKit.fire(
+                    DebugEvent(GeneralPixel.bookmarksSaveFailedOnImport, error: error),
+                    frequency: .dailyAndCount,
+                    withAdditionalParameters: processedErrors.errorPixelParameters)
                 assertionFailure("LocalBookmarkStore: Saving of context failed, error: \(error.localizedDescription)")
             }
         }

--- a/macOS/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift
@@ -214,11 +214,15 @@ final class LocalBookmarkStore: BookmarkStore {
 
                 var params = processedErrors.errorPixelParameters
                 params[PixelKit.Parameters.errorSource] = source
-                PixelKit.fire(DebugEvent(GeneralPixel.bookmarksSaveFailed, error: error),
-                           withAdditionalParameters: params)
+                PixelKit.fire(
+                    DebugEvent(GeneralPixel.bookmarksSaveFailed, error: error),
+                    frequency: .dailyAndCount,
+                    withAdditionalParameters: params)
             } else {
-                PixelKit.fire(DebugEvent(GeneralPixel.bookmarksSaveFailed, error: localError),
-                           withAdditionalParameters: [PixelKit.Parameters.errorSource: source])
+                PixelKit.fire(
+                    DebugEvent(GeneralPixel.bookmarksSaveFailed, error: localError),
+                    frequency: .dailyAndCount,
+                    withAdditionalParameters: [PixelKit.Parameters.errorSource: source])
             }
         } else {
             let error = error as NSError
@@ -226,8 +230,10 @@ final class LocalBookmarkStore: BookmarkStore {
 
             var params = processedErrors.errorPixelParameters
             params[PixelKit.Parameters.errorSource] = source
-            PixelKit.fire(DebugEvent(GeneralPixel.bookmarksSaveFailed, error: error),
-                       withAdditionalParameters: params)
+            PixelKit.fire(
+                DebugEvent(GeneralPixel.bookmarksSaveFailed, error: error),
+                frequency: .dailyAndCount,
+                withAdditionalParameters: params)
         }
     }
 

--- a/macOS/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift
@@ -216,12 +216,12 @@ final class LocalBookmarkStore: BookmarkStore {
                 params[PixelKit.Parameters.errorSource] = source
                 PixelKit.fire(
                     DebugEvent(GeneralPixel.bookmarksSaveFailed, error: error),
-                    frequency: .dailyAndCount,
+                    frequency: .dailyAndStandard,
                     withAdditionalParameters: params)
             } else {
                 PixelKit.fire(
                     DebugEvent(GeneralPixel.bookmarksSaveFailed, error: localError),
-                    frequency: .dailyAndCount,
+                    frequency: .dailyAndStandard,
                     withAdditionalParameters: [PixelKit.Parameters.errorSource: source])
             }
         } else {
@@ -232,7 +232,7 @@ final class LocalBookmarkStore: BookmarkStore {
             params[PixelKit.Parameters.errorSource] = source
             PixelKit.fire(
                 DebugEvent(GeneralPixel.bookmarksSaveFailed, error: error),
-                frequency: .dailyAndCount,
+                frequency: .dailyAndStandard,
                 withAdditionalParameters: params)
         }
     }
@@ -746,7 +746,7 @@ final class LocalBookmarkStore: BookmarkStore {
             if AppVersion.runType.requiresEnvironment {
                 PixelKit.fire(
                     DebugEvent(GeneralPixel.bookmarksSaveFailedOnImport, error: error),
-                    frequency: .dailyAndCount,
+                    frequency: .dailyAndStandard,
                     withAdditionalParameters: processedErrors.errorPixelParameters)
                 assertionFailure("LocalBookmarkStore: Saving of context failed, error: \(error.localizedDescription)")
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1209666483640712?focus=true

### Description

Adds a daily variant to the `bookmarksSaveFailed` pixel

### Testing

You'll need to make two modifications to make testing easier.

1. Disable [this assertion](https://github.com/duckduckgo/apple-browsers/blob/8b93882266ecb0f0c223a5cb08fa5a3cff8e77ba/macOS/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift#L209).
2. Force-throw an error [here](https://github.com/duckduckgo/apple-browsers/blob/8b93882266ecb0f0c223a5cb08fa5a3cff8e77ba/macOS/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift#L317).

**Testing Steps:**

1. Launch console.app
2. Filter by "👾"
3. Run the app
4. Try adding a bookmark
5. Make sure Console.app shows something like this:
```
👾[Daily and Count-Fired] m_mac_debug_bookmarks_save_failed_daily ["pixelSource": "browser-dmg", "e": "1", "errorCount": "1", "coreDataCode": "1", "coreDataDomain": "test", "d": "test", "coreDataEntity": "empty", "appVersion": "1.137.0", "error_source": "save(entitiesAtIndices:completion:)", "coreDataAttribute": "empty"]
👾[Daily and Count-Fired] m_mac_debug_bookmarks_save_failed ["appVersion": "1.137.0", "d": "test", "error_source": "save(entitiesAtIndices:completion:)", "coreDataCode": "1", "coreDataDomain": "test", "e": "1", "errorCount": "1", "pixelSource": "browser-dmg", "coreDataAttribute": "empty", "coreDataEntity": "empty"]
```

### Impact and Risks

Low: can't think of any issues this would introduce.

#### What could go wrong?

Nothing I can think of.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)