### PR TITLE
Prevent background color bleeding into bottom part of screen

### DIFF
--- a/iOS/DuckDuckGo/PullToRefreshViewAdapter.swift
+++ b/iOS/DuckDuckGo/PullToRefreshViewAdapter.swift
@@ -67,7 +67,7 @@ final class PullToRefreshViewAdapter: NSObject {
         return min(max(calculatedThreshold, Constant.minimumTriggerThreshold), Constant.maximumTriggerThreshold)
     }
 
-    private var fakeScrollView: UIScrollView!
+    private let fakeScrollView = UIScrollView()
     private let refreshControl = UIRefreshControl()
     private var panGestureRecognizer: UIPanGestureRecognizer?
 
@@ -125,8 +125,8 @@ final class PullToRefreshViewAdapter: NSObject {
     }
 
     private func setupBackgroundScrollView(basedOn view: UIView) {
-        // Create the background scroll view that will be visible when pulling down
-        fakeScrollView = UIScrollView()
+        // Set up the background scroll view that will be visible when pulling down
+        fakeScrollView.backgroundColor = .clear
         fakeScrollView.translatesAutoresizingMaskIntoConstraints = false
         fakeScrollView.isScrollEnabled = true // Enable scrolling for refresh control
 
@@ -137,7 +137,7 @@ final class PullToRefreshViewAdapter: NSObject {
             fakeScrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             fakeScrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             fakeScrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            fakeScrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+            fakeScrollView.bottomAnchor.constraint(equalTo: view.centerYAnchor)
         ])
 
         let fakeContentView = UIView()


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210054319052224?focus=true
Tech Design URL:
CC:

### Description

When transitioning to hidden bars position, the color bled through the semi-transparent omni bar creating a bad visual effect. Additionally for sites with theme color defined as less neutral tone the effect was intensified. This removes the theme color from the bottom part of the main view.

### Testing Steps
1. Set bar position to bottom.
2. Go to a page with a theme color (e.g. github.com).
3. Scroll to hide bars
4. Verify the color of bottom bar is not affected by the theme color.
5. While performing pull to refresh verify the color matches the top section of UI.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)