### PR TITLE
privacyProKeychainAccessError pixel parameters aligned

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Storage/V2/SubscriptionTokenKeychainStorageV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Storage/V2/SubscriptionTokenKeychainStorageV2.swift
@@ -21,6 +21,18 @@ import os.log
 import Networking
 import Common
 
+public enum KeychainErrorSource: String {
+    case browser
+    case vpn
+    case pir
+    case shared
+}
+
+public enum KeychainErrorAuthVersion: String {
+    case v1
+    case v2
+}
+
 public final class SubscriptionTokenKeychainStorageV2: AuthTokenStoring {
 
     private let keychainType: KeychainType

--- a/iOS/Core/Pixel.swift
+++ b/iOS/Core/Pixel.swift
@@ -85,6 +85,7 @@ public struct PixelParameters {
 
     public static let count = "count"
     public static let source = "source"
+    public static let authVersion = "authVersion"
 
     // Text size is the legacy name
     public static let textZoomInitial = "text_size_initial"

--- a/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
@@ -116,9 +116,9 @@ final class AppDependencyProvider: DependencyProvider {
         var accessTokenProvider: () async -> String?
         var authenticationStateProvider: (any SubscriptionAuthenticationStateProvider)!
 
-        let tokenStorageV2 = SubscriptionTokenKeychainStorageV2(keychainType: .dataProtection(.named(subscriptionAppGroup))) { keychainType, error in
+        let tokenStorageV2 = SubscriptionTokenKeychainStorageV2(keychainType: .dataProtection(.named(subscriptionAppGroup))) { accessType, error in
 
-            let parameters = [PixelParameters.privacyProKeychainAccessType: keychainType.rawValue,
+            let parameters = [PixelParameters.privacyProKeychainAccessType: accessType.rawValue,
                               PixelParameters.privacyProKeychainError: error.localizedDescription,
                               PixelParameters.source: KeychainErrorSource.browser.rawValue,
                               PixelParameters.authVersion: KeychainErrorAuthVersion.v2.rawValue]

--- a/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
@@ -117,7 +117,14 @@ final class AppDependencyProvider: DependencyProvider {
         var authenticationStateProvider: (any SubscriptionAuthenticationStateProvider)!
 
         let tokenStorageV2 = SubscriptionTokenKeychainStorageV2(keychainType: .dataProtection(.named(subscriptionAppGroup))) { keychainType, error in
-            Pixel.fire(.privacyProKeychainAccessError, withAdditionalParameters: ["type": keychainType.rawValue, "error": error.errorDescription])
+
+            let parameters = [PixelParameters.privacyProKeychainAccessType: keychainType.rawValue,
+                              PixelParameters.privacyProKeychainError: error.localizedDescription,
+                              PixelParameters.source: KeychainErrorSource.browser.rawValue,
+                              PixelParameters.authVersion: KeychainErrorAuthVersion.v2.rawValue]
+            DailyPixel.fireDailyAndCount(pixel: .privacyProKeychainAccessError,
+                                         pixelNameSuffixes: DailyPixel.Constant.legacyDailyPixelSuffixes,
+                                         withAdditionalParameters: parameters)
         }
         self.isAuthV2Enabled = featureFlagger.isFeatureOn(.privacyProAuthV2)
         vpnSettings.isAuthV2Enabled = self.isAuthV2Enabled

--- a/iOS/DuckDuckGo/Subscription/DefaultSubscriptionManager+AccountManagerKeychainAccessDelegate.swift
+++ b/iOS/DuckDuckGo/Subscription/DefaultSubscriptionManager+AccountManagerKeychainAccessDelegate.swift
@@ -33,7 +33,7 @@ extension DefaultSubscriptionManager: @retroactive AccountManagerKeychainAccessD
         }
 
         let parameters = [PixelParameters.privacyProKeychainAccessType: accessType.rawValue,
-                          PixelParameters.privacyProKeychainError: expectedError.localizedDescription,
+                          PixelParameters.privacyProKeychainError: expectedError.errorDescription,
                           PixelParameters.source: KeychainErrorSource.browser.rawValue,
                           PixelParameters.authVersion: KeychainErrorAuthVersion.v1.rawValue]
         DailyPixel.fireDailyAndCount(pixel: .privacyProKeychainAccessError,

--- a/iOS/DuckDuckGo/Subscription/DefaultSubscriptionManager+AccountManagerKeychainAccessDelegate.swift
+++ b/iOS/DuckDuckGo/Subscription/DefaultSubscriptionManager+AccountManagerKeychainAccessDelegate.swift
@@ -21,15 +21,13 @@ import Foundation
 import Core
 import Subscription
 
-extension DefaultSubscriptionManager: AccountManagerKeychainAccessDelegate {
+extension DefaultSubscriptionManager: @retroactive AccountManagerKeychainAccessDelegate {
 
     public func accountManagerKeychainAccessFailed(accessType: AccountKeychainAccessType, error: any Error) {
-        let parameters = [
-            PixelParameters.privacyProKeychainAccessType: accessType.rawValue,
-            PixelParameters.privacyProKeychainError: error.localizedDescription,
-            PixelParameters.source: "browser"
-        ]
-
+        let parameters = [PixelParameters.privacyProKeychainAccessType: accessType.rawValue,
+                          PixelParameters.privacyProKeychainError: error.localizedDescription,
+                          PixelParameters.source: KeychainErrorSource.browser.rawValue,
+                          PixelParameters.authVersion: KeychainErrorAuthVersion.v1.rawValue]
         DailyPixel.fireDailyAndCount(pixel: .privacyProKeychainAccessError,
                                      pixelNameSuffixes: DailyPixel.Constant.legacyDailyPixelSuffixes,
                                      withAdditionalParameters: parameters)

--- a/iOS/DuckDuckGo/Subscription/DefaultSubscriptionManager+AccountManagerKeychainAccessDelegate.swift
+++ b/iOS/DuckDuckGo/Subscription/DefaultSubscriptionManager+AccountManagerKeychainAccessDelegate.swift
@@ -20,12 +20,20 @@
 import Foundation
 import Core
 import Subscription
+import os.log
 
 extension DefaultSubscriptionManager: @retroactive AccountManagerKeychainAccessDelegate {
 
     public func accountManagerKeychainAccessFailed(accessType: AccountKeychainAccessType, error: any Error) {
+
+        guard let expectedError = error as? AccountKeychainAccessError else {
+            assertionFailure("Unexpected error type: \(error)")
+            Logger.subscription.fault("Unexpected error type: \(error)")
+            return
+        }
+
         let parameters = [PixelParameters.privacyProKeychainAccessType: accessType.rawValue,
-                          PixelParameters.privacyProKeychainError: error.localizedDescription,
+                          PixelParameters.privacyProKeychainError: expectedError.localizedDescription,
                           PixelParameters.source: KeychainErrorSource.browser.rawValue,
                           PixelParameters.authVersion: KeychainErrorAuthVersion.v1.rawValue]
         DailyPixel.fireDailyAndCount(pixel: .privacyProKeychainAccessError,

--- a/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -643,8 +643,15 @@ final class DefaultWireGuardInterface: WireGuardInterface {
 extension NetworkProtectionPacketTunnelProvider: AccountManagerKeychainAccessDelegate {
 
     public func accountManagerKeychainAccessFailed(accessType: AccountKeychainAccessType, error: any Error) {
+
+        guard let expectedError = error as? AccountKeychainAccessError else {
+            assertionFailure("Unexpected error type: \(error)")
+            Logger.networkProtection.fault("Unexpected error type: \(error)")
+            return
+        }
+
         let parameters = [PixelParameters.privacyProKeychainAccessType: accessType.rawValue,
-                          PixelParameters.privacyProKeychainError: error.localizedDescription,
+                          PixelParameters.privacyProKeychainError: expectedError.localizedDescription,
                           PixelParameters.source: KeychainErrorSource.vpn.rawValue,
                           PixelParameters.authVersion: KeychainErrorAuthVersion.v1.rawValue]
         DailyPixel.fireDailyAndCount(pixel: .privacyProKeychainAccessError,

--- a/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -473,8 +473,8 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
 
             // keychain storage
             let subscriptionAppGroup = Bundle.main.appGroup(bundle: .subs)
-            let tokenStorage = SubscriptionTokenKeychainStorageV2(keychainType: .dataProtection(.named(subscriptionAppGroup))) { keychainType, error in
-                let parameters = [PixelParameters.privacyProKeychainAccessType: keychainType.rawValue,
+            let tokenStorage = SubscriptionTokenKeychainStorageV2(keychainType: .dataProtection(.named(subscriptionAppGroup))) { accessType, error in
+                let parameters = [PixelParameters.privacyProKeychainAccessType: accessType.rawValue,
                                   PixelParameters.privacyProKeychainError: error.localizedDescription,
                                   PixelParameters.source: KeychainErrorSource.vpn.rawValue,
                                   PixelParameters.authVersion: KeychainErrorAuthVersion.v2.rawValue]

--- a/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -651,7 +651,7 @@ extension NetworkProtectionPacketTunnelProvider: AccountManagerKeychainAccessDel
         }
 
         let parameters = [PixelParameters.privacyProKeychainAccessType: accessType.rawValue,
-                          PixelParameters.privacyProKeychainError: expectedError.localizedDescription,
+                          PixelParameters.privacyProKeychainError: expectedError.errorDescription,
                           PixelParameters.source: KeychainErrorSource.vpn.rawValue,
                           PixelParameters.authVersion: KeychainErrorAuthVersion.v1.rawValue]
         DailyPixel.fireDailyAndCount(pixel: .privacyProKeychainAccessError,

--- a/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -474,7 +474,13 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
             // keychain storage
             let subscriptionAppGroup = Bundle.main.appGroup(bundle: .subs)
             let tokenStorage = SubscriptionTokenKeychainStorageV2(keychainType: .dataProtection(.named(subscriptionAppGroup))) { keychainType, error in
-                Pixel.fire(.privacyProKeychainAccessError, withAdditionalParameters: ["type": keychainType.rawValue, "error": error.errorDescription])
+                let parameters = [PixelParameters.privacyProKeychainAccessType: keychainType.rawValue,
+                                  PixelParameters.privacyProKeychainError: error.localizedDescription,
+                                  PixelParameters.source: KeychainErrorSource.vpn.rawValue,
+                                  PixelParameters.authVersion: KeychainErrorAuthVersion.v2.rawValue]
+                DailyPixel.fireDailyAndCount(pixel: .privacyProKeychainAccessError,
+                                             pixelNameSuffixes: DailyPixel.Constant.legacyDailyPixelSuffixes,
+                                             withAdditionalParameters: parameters)
             }
             let legacyAccountStorage = SubscriptionTokenKeychainStorage(keychainType: .dataProtection(.named(subscriptionAppGroup)))
             let authClient = DefaultOAuthClient(tokensStorage: tokenStorage,
@@ -637,12 +643,10 @@ final class DefaultWireGuardInterface: WireGuardInterface {
 extension NetworkProtectionPacketTunnelProvider: AccountManagerKeychainAccessDelegate {
 
     public func accountManagerKeychainAccessFailed(accessType: AccountKeychainAccessType, error: any Error) {
-        let parameters = [
-            PixelParameters.privacyProKeychainAccessType: accessType.rawValue,
-            PixelParameters.privacyProKeychainError: error.localizedDescription,
-            PixelParameters.source: "vpn"
-        ]
-
+        let parameters = [PixelParameters.privacyProKeychainAccessType: accessType.rawValue,
+                          PixelParameters.privacyProKeychainError: error.localizedDescription,
+                          PixelParameters.source: KeychainErrorSource.vpn.rawValue,
+                          PixelParameters.authVersion: KeychainErrorAuthVersion.v1.rawValue]
         DailyPixel.fireDailyAndCount(pixel: .privacyProKeychainAccessError,
                                      pixelNameSuffixes: DailyPixel.Constant.legacyDailyPixelSuffixes,
                                      withAdditionalParameters: parameters)

--- a/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionAndNotificationTargets/InfoPlist.xcstrings
+++ b/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionAndNotificationTargets/InfoPlist.xcstrings
@@ -14,35 +14,9 @@
       },
       "shouldTranslate" : false
     },
-    "CFBundleName" : {
-      "comment" : "Bundle name",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "com.duckduckgo.macos.vpn.network-extension"
-          }
-        }
-      },
-      "shouldTranslate" : false
-    },
-    "NSHumanReadableCopyright" : {
-      "comment" : "Copyright (human-readable)",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Copyright © 2023 DuckDuckGo. All rights reserved."
-          }
-        }
-      },
-      "shouldTranslate" : false
-    },
     "NSSystemExtensionUsageDescription" : {
       "comment" : "Privacy - System Extension Usage Description",
-      "extractionState" : "extracted_with_value",
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
@@ -758,8 +758,15 @@ final class DefaultWireGuardInterface: WireGuardInterface {
 extension MacPacketTunnelProvider: AccountManagerKeychainAccessDelegate {
 
     public func accountManagerKeychainAccessFailed(accessType: AccountKeychainAccessType, error: any Error) {
+
+        guard let expectedError = error as? AccountKeychainAccessError else {
+            assertionFailure("Unexpected error type: \(error)")
+            Logger.networkProtection.fault("Unexpected error type: \(error)")
+            return
+        }
+
         PixelKit.fire(PrivacyProErrorPixel.privacyProKeychainAccessError(accessType: accessType,
-                                                                         accessError: error,
+                                                                         accessError: expectedError,
                                                                          source: KeychainErrorSource.vpn,
                                                                          authVersion: KeychainErrorAuthVersion.v1),
                       frequency: .legacyDailyAndCount)

--- a/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
@@ -758,7 +758,10 @@ final class DefaultWireGuardInterface: WireGuardInterface {
 extension MacPacketTunnelProvider: AccountManagerKeychainAccessDelegate {
 
     public func accountManagerKeychainAccessFailed(accessType: AccountKeychainAccessType, error: any Error) {
-        PixelKit.fire(PrivacyProErrorPixel.privacyProKeychainAccessError(accessType: accessType, accessError: error),
+        PixelKit.fire(PrivacyProErrorPixel.privacyProKeychainAccessError(accessType: accessType,
+                                                                         accessError: error,
+                                                                         source: KeychainErrorSource.vpn,
+                                                                         authVersion: KeychainErrorAuthVersion.v1),
                       frequency: .legacyDailyAndCount)
     }
 }

--- a/macOS/DuckDuckGo/Statistics/PrivacyProPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/PrivacyProPixel.swift
@@ -155,7 +155,10 @@ enum PrivacyProPixel: PixelKitEventV2 {
 
 enum PrivacyProErrorPixel: PixelKitEventV2 {
 
-    case privacyProKeychainAccessError(accessType: AccountKeychainAccessType, accessError: any Error)
+    case privacyProKeychainAccessError(accessType: AccountKeychainAccessType,
+                                       accessError: any Error,
+                                       source: KeychainErrorSource,
+                                       authVersion: KeychainErrorAuthVersion )
 
     var name: String {
         switch self {
@@ -165,10 +168,12 @@ enum PrivacyProErrorPixel: PixelKitEventV2 {
 
     var parameters: [String: String]? {
         switch self {
-        case .privacyProKeychainAccessError(let accessType, let accessError):
+        case .privacyProKeychainAccessError(let accessType, let accessError, let source, let authVersion):
             return [
-                "type": accessType.rawValue,
-                "error": accessError.localizedDescription
+                "access_type": accessType.rawValue,
+                "error": accessError.localizedDescription,
+                "source": source.rawValue,
+                "authVersion": authVersion.rawValue
             ]
         }
     }

--- a/macOS/DuckDuckGo/Statistics/PrivacyProPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/PrivacyProPixel.swift
@@ -171,7 +171,7 @@ enum PrivacyProErrorPixel: PixelKitEventV2 {
         case .privacyProKeychainAccessError(let accessType, let accessError, let source, let authVersion):
             return [
                 "access_type": accessType.rawValue,
-                "error": accessError.localizedDescription,
+                "error": accessError.errorDescription,
                 "source": source.rawValue,
                 "authVersion": authVersion.rawValue
             ]

--- a/macOS/DuckDuckGo/Statistics/PrivacyProPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/PrivacyProPixel.swift
@@ -156,7 +156,7 @@ enum PrivacyProPixel: PixelKitEventV2 {
 enum PrivacyProErrorPixel: PixelKitEventV2 {
 
     case privacyProKeychainAccessError(accessType: AccountKeychainAccessType,
-                                       accessError: any Error,
+                                       accessError: AccountKeychainAccessError,
                                        source: KeychainErrorSource,
                                        authVersion: KeychainErrorAuthVersion )
 

--- a/macOS/DuckDuckGo/Subscription/SubscriptionManager+StandardConfiguration.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionManager+StandardConfiguration.swift
@@ -100,8 +100,15 @@ extension DefaultSubscriptionManager {
 extension DefaultSubscriptionManager: @retroactive AccountManagerKeychainAccessDelegate {
 
     public func accountManagerKeychainAccessFailed(accessType: AccountKeychainAccessType, error: any Error) {
+
+        guard let expectedError = error as? AccountKeychainAccessError else {
+            assertionFailure("Unexpected error type: \(error)")
+            Logger.networkProtection.fault("Unexpected error type: \(error)")
+            return
+        }
+
         PixelKit.fire(PrivacyProErrorPixel.privacyProKeychainAccessError(accessType: accessType,
-                                                                         accessError: error,
+                                                                         accessError: expectedError,
                                                                          source: KeychainErrorSource.shared,
                                                                          authVersion: KeychainErrorAuthVersion.v1),
                       frequency: .legacyDailyAndCount)

--- a/macOS/DuckDuckGo/Subscription/SubscriptionManager+StandardConfiguration.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionManager+StandardConfiguration.swift
@@ -100,7 +100,10 @@ extension DefaultSubscriptionManager {
 extension DefaultSubscriptionManager: @retroactive AccountManagerKeychainAccessDelegate {
 
     public func accountManagerKeychainAccessFailed(accessType: AccountKeychainAccessType, error: any Error) {
-        PixelKit.fire(PrivacyProErrorPixel.privacyProKeychainAccessError(accessType: accessType, accessError: error),
+        PixelKit.fire(PrivacyProErrorPixel.privacyProKeychainAccessError(accessType: accessType,
+                                                                         accessError: error,
+                                                                         source: KeychainErrorSource.shared,
+                                                                         authVersion: KeychainErrorAuthVersion.v1),
                       frequency: .legacyDailyAndCount)
     }
 }
@@ -118,7 +121,10 @@ extension DefaultSubscriptionManagerV2 {
 
         let authService = DefaultOAuthService(baseURL: environment.authEnvironment.url, apiService: APIServiceFactory.makeAPIServiceForAuthV2())
         let tokenStorage = SubscriptionTokenKeychainStorageV2(keychainType: keychainType) { keychainType, error in
-            PixelKit.fire(PrivacyProErrorPixel.privacyProKeychainAccessError(accessType: keychainType, accessError: error),
+            PixelKit.fire(PrivacyProErrorPixel.privacyProKeychainAccessError(accessType: keychainType,
+                                                                             accessError: error,
+                                                                             source: KeychainErrorSource.shared,
+                                                                             authVersion: KeychainErrorAuthVersion.v2),
                           frequency: .legacyDailyAndCount)
         }
         let legacyTokenStorage = canPerformAuthMigration == true ? SubscriptionTokenKeychainStorage(keychainType: keychainType) : nil

--- a/macOS/DuckDuckGo/Subscription/SubscriptionManager+StandardConfiguration.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionManager+StandardConfiguration.swift
@@ -127,8 +127,8 @@ extension DefaultSubscriptionManagerV2 {
                             pixelHandlingSource: AuthV2PixelHandler.Source) {
 
         let authService = DefaultOAuthService(baseURL: environment.authEnvironment.url, apiService: APIServiceFactory.makeAPIServiceForAuthV2())
-        let tokenStorage = SubscriptionTokenKeychainStorageV2(keychainType: keychainType) { keychainType, error in
-            PixelKit.fire(PrivacyProErrorPixel.privacyProKeychainAccessError(accessType: keychainType,
+        let tokenStorage = SubscriptionTokenKeychainStorageV2(keychainType: keychainType) { accessType, error in
+            PixelKit.fire(PrivacyProErrorPixel.privacyProKeychainAccessError(accessType: accessType,
                                                                              accessError: error,
                                                                              source: KeychainErrorSource.shared,
                                                                              authVersion: KeychainErrorAuthVersion.v2),

--- a/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
+++ b/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
@@ -619,7 +619,10 @@ final class DuckDuckGoVPNAppDelegate: NSObject, NSApplicationDelegate {
 extension DuckDuckGoVPNAppDelegate: AccountManagerKeychainAccessDelegate {
 
     public func accountManagerKeychainAccessFailed(accessType: AccountKeychainAccessType, error: any Error) {
-        PixelKit.fire(PrivacyProErrorPixel.privacyProKeychainAccessError(accessType: accessType, accessError: error),
+        PixelKit.fire(PrivacyProErrorPixel.privacyProKeychainAccessError(accessType: accessType,
+                                                                         accessError: error,
+                                                                         source: KeychainErrorSource.vpn,
+                                                                         authVersion: KeychainErrorAuthVersion.v1),
                       frequency: .legacyDailyAndCount)
     }
 }

--- a/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
+++ b/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
@@ -619,8 +619,15 @@ final class DuckDuckGoVPNAppDelegate: NSObject, NSApplicationDelegate {
 extension DuckDuckGoVPNAppDelegate: AccountManagerKeychainAccessDelegate {
 
     public func accountManagerKeychainAccessFailed(accessType: AccountKeychainAccessType, error: any Error) {
+
+        guard let expectedError = error as? AccountKeychainAccessError else {
+            assertionFailure("Unexpected error type: \(error)")
+            Logger.networkProtection.fault("Unexpected error type: \(error)")
+            return
+        }
+
         PixelKit.fire(PrivacyProErrorPixel.privacyProKeychainAccessError(accessType: accessType,
-                                                                         accessError: error,
+                                                                         accessError: expectedError,
                                                                          source: KeychainErrorSource.vpn,
                                                                          authVersion: KeychainErrorAuthVersion.v1),
                       frequency: .legacyDailyAndCount)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/30173902528854/task/1210090371034316?focus=true
CC: @miasma13 @diegoreymendez 

### Description

privacyProKeychainAccessError pixel's parameters were inconsistent between AuthV1, AuthV2, Old Pixel implementation and new PixelKit, now all params are aligned.
I've also added an `authVersion` to the pixel with v1 or v2.

The error sent has also been aligned, now it always is an AccountKeychainAccessError

### Testing Steps

No testing required

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)