### PR TITLE
Fix OmniBar not responding to events after a link opens in new tab

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2563,7 +2563,7 @@ extension MainViewController: TabDelegate {
                                               inheritedAttribution: inheritingAttribution)
         newTab.openedByPage = true
         newTab.openingTab = tab
-        swipeTabsCoordinator?.refresh(tabsModel: tabManager.model)
+        swipeTabsCoordinator?.refresh(tabsModel: tabManager.model, scrollToSelected: true)
 
         newTabAnimation {
             guard self.tabManager.model.tabs.contains(newTab.tabModel) else { return }

--- a/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -365,6 +365,8 @@ extension SwipeTabsCoordinator: UICollectionViewDataSource {
             fatalError("Not \(OmniBarCell.self)")
         }
 
+        removeControllerForCell(cell)
+
         if !isEnabled || tabsModel.currentIndex == indexPath.row {
             cell.omniBar = coordinator.omniBar
         } else {
@@ -396,7 +398,18 @@ extension SwipeTabsCoordinator: UICollectionViewDataSource {
 
         return cell
     }
-    
+
+    private func removeControllerForCell(_ cell: OmniBarCell) {
+        if let existingOmniBarView = cell.omniBar?.barView,
+           let backingVC = coordinator.parentController?.children.first(where: { $0.view === existingOmniBarView }) {
+
+            backingVC.willMove(toParent: nil)
+            existingOmniBarView.removeFromSuperview()
+            cell.omniBar = nil
+            backingVC.removeFromParent()
+        }
+    }
+
 }
 
 class OmniBarCell: UICollectionViewCell {
@@ -407,8 +420,6 @@ class OmniBarCell: UICollectionViewCell {
     weak var omniBar: OmniBar? {
         didSet {
             guard let omniBarView = omniBar?.barView else { return }
-
-            subviews.forEach { $0.removeFromSuperview() }
 
             omniBarView.translatesAutoresizingMaskIntoConstraints = false
             addSubview(omniBarView)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1210107711476853
Tech Design URL:
CC:

### Description

Proper OmniBar was not attached to a selected tab, because the backing CollectionView was not refreshing the target cell. This makes sure the offset is updated properly and cells are refreshed.

Also the OmniBarVC instances were not removed properly from parent controller. This was also fixed here.

### Testing Steps
1. Perform any search on DDG SERP
2. Enable open Links In A New Tab in SERP Settings
3. Tap on any search result
4. Verify OmniBar responds to query changes, go keyboard key etc.
5. Swipe between two tabs back and forth, check if the count of OmniBarViewController instances are equal or less than number of open tabs.

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
OmniBar can misbehave

### Quality Considerations
- How does this affect performance?
Reduces the memory footprint by removing the redundant VC instances.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)