### PR TITLE
Fix e2e sync tests by always showing recovery codes

### DIFF
--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -499,11 +499,7 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         mapDevices(registeredDevices)
         Pixel.fire(pixel: .syncLogin, includedParameters: [.appVersion])
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            if isRecovery {
-                self.dismissPresentedViewController()
-            } else {
-                self.dismissVCAndShowRecoveryPDF()
-            }
+            self.dismissVCAndShowRecoveryPDF()
         }
     }
     

--- a/macOS/DuckDuckGo/Preferences/Model/SyncPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/SyncPreferences.swift
@@ -957,11 +957,7 @@ extension SyncPreferences: SyncConnectionControllerDelegate {
         mapDevices(registeredDevices)
         PixelKit.fire(GeneralPixel.syncLogin)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            if isRecovery {
-                self.showDevicesSynced()
-            } else {
-                self.presentDialog(for: .saveRecoveryCode(self.recoveryCode ?? ""))
-            }
+            self.presentDialog(for: .saveRecoveryCode(self.recoveryCode ?? ""))
             self.stopPollingForRecoveryKey()
         }
     }

--- a/macOS/SyncE2EUITests/CriticalPathsTests.swift
+++ b/macOS/SyncE2EUITests/CriticalPathsTests.swift
@@ -157,6 +157,7 @@ final class CriticalPathsTests: XCTestCase {
         settingsWindow.buttons["Recover Synced Data"].click()
         sheetsQuery.buttons["Get Started"].click()
         sheetsQuery.buttons["Paste"].click()
+        sheetsQuery.buttons["Next"].click()
         sheetsQuery.buttons["Done"].click()
         XCTAssertTrue(syncEnabledElement.exists, "Sync Enabled text is not visible")
 
@@ -289,9 +290,7 @@ final class CriticalPathsTests: XCTestCase {
         let settingsSheetsQuery = settingsWindow.sheets
         settingsSheetsQuery.buttons["Enter Code"].click()
         settingsSheetsQuery.buttons["Paste"].click()
-        if settingsSheetsQuery.buttons["Next"].exists {
-            settingsSheetsQuery.buttons["Next"].click()
-        }
+        settingsSheetsQuery.buttons["Next"].click()
         settingsSheetsQuery.buttons["Done"].click()
         let secondDevice = settingsWindow.images["SyncedDeviceMobile"]
         XCTAssertTrue(secondDevice.exists, "Original Device not visible")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1210077330627570?focus=true

### Description
Fixes tests by always showing recovery screen. See context: https://app.asana.com/1/137249556945/project/414709148257752/task/1210091492822574?focus=true

### Testing Steps
https://github.com/duckduckgo/apple-browsers/actions/runs/14731588440
https://github.com/duckduckgo/apple-browsers/actions/runs/14734921075

1. Go to Settings -> Sync and Backup on both macOS and iOS
2. Make sure sync is not activated.
3. Select "Sync and Back Up This Device" on iOS.
4. Copy the recovery code.
5. Select "Turn off..."
6. Select "Sync With Another Device" again.
7. Select Manually Enter Code
8. Paste the code.
9. **You should see the recovery codes as part of the flow** 
10. Repeat steps 2 - 9 on macOS

### Notes to Reviewer


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)