### PR TITLE
Remove duck.ai button from pop-up window

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -391,7 +391,9 @@ final class AddressBarButtonsViewController: NSViewController {
 
     private func updateAIChatButtonVisibility() {
         aiChatButton.toolTip = isTextFieldEditorFirstResponder ? UserText.aiChatAddressBarShortcutTooltip : UserText.aiChatAddressBarTooltip
-        aiChatButton.isHidden = !aiChatMenuConfig.shouldDisplayAddressBarShortcut
+
+        let isPopUpWindow = view.window?.isPopUpWindow ?? false
+        aiChatButton.isHidden = !aiChatMenuConfig.shouldDisplayAddressBarShortcut || isPopUpWindow
         updateAIChatDividerVisibility()
         delegate?.addressBarButtonsViewController(self, didUpdateAIChatButtonVisibility: aiChatButton.isShown)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1210083533114929?focus=true
Tech Design URL:
CC:
### Description
Do not show AI Chat menu bar icon in popup window

### Testing Steps
1. Enable AI Chat in the browser navigation bar (Right click, show duck.ai)
2. Open a pop-up window on Debug -> UI Trigger Show popup window
3. Make sure AI Chat icon is not visible

### Impact and Risks
Low: Minor visual changes

#### What could go wrong?
Hide the icon on the main window when it shouldn't