### PR TITLE
Fixes an issue that was causing the VPN to start on its own during the auth v2 migration

### DIFF
--- a/macOS/DuckDuckGoVPN/VPNAppEventsHandler.swift
+++ b/macOS/DuckDuckGoVPN/VPNAppEventsHandler.swift
@@ -51,6 +51,10 @@ final class VPNAppEventsHandler {
 
             if appState.isAuthV2Enabled && !appState.isMigratedToAuthV2 {
                 Task {
+                    guard await !tunnelController.isConnected else {
+                        return
+                    }
+
                     await tunnelController.stop()
                     await tunnelController.start()
                     appState.isMigratedToAuthV2 = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207603085593419/task/1210114952670833?focus=true

### Description

Fixes an issue that was causing the VPN to start on its own during the auth v2 migration

### Testing Steps

1. To make testing easier you can force reproduce the issue by forcing [this condition](https://github.com/duckduckgo/apple-browsers/blob/0b3707d267adf0a7735002ef85fcb6e8f2e9b8fc/macOS/DuckDuckGoVPN/VPNAppEventsHandler.swift#L52) to succeed.  The same condition-change can be used to validate the original issue in `main` or disabling the guard added in this PR.
2. Please test using the "macOS VPN Agent" scheme.  You'll need to disable VPN agents following these steps in Terminal.app:
    - `launchctl list | grep duck"
    - Pick the ID for the agent you want to disable
    - `launchtl remove <agent_id>`
3. Ensure the VPN extensions have been uninstalled going to System Settings > General > Login Items & Extensions > Scroll down to Network Extensions > Click (i)
3. Run the VPN agent app, if the guard is removed you'll see the prompt.  If the guard from this PR is left-in, the prompt will no longer show.

### Impact and Risks

None: at most this will cause the VPN not to start properly during the migration to authV2 but that's a minor hassle, and in truth I don't see why it should happen.

#### What could go wrong?

Nothing I can think of.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)