### PR TITLE
Fix padding when pasting a long URL

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -280,7 +280,7 @@ final class AddressBarButtonsViewController: NSViewController {
         if view.window?.isPopUpWindow == false {
             updateTrackingAreaForHover()
         }
-        self.buttonsWidth = buttonsContainer.frame.size.width + 4.0
+        self.buttonsWidth = buttonsContainer.frame.size.width + 10.0
     }
 
     func updateTrackingAreaForHover() {
@@ -914,7 +914,7 @@ final class AddressBarButtonsViewController: NSViewController {
             imageButton.image = .web
         case .browsing:
             if let favicon = tabViewModel.favicon {
-                imageButton.image = tabViewModel.favicon
+                imageButton.image = favicon
             } else if isTextFieldEditorFirstResponder {
                 imageButton.image = .web
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1210001726201293?focus=true

### Description

### Testing Steps
1. Past a long URL, like [this](https://duckduckgo.com/?q=potato&atb=v464-1-wb&ia=webpotato&atb=v464-1-wb&ia=webpotato&atb=v464-1-wb&ia=webpotato&atb=v464-1-wb&ia=webpotato&atb=v464-1-wb&ia=webpotato&atb=v464-1-wb&ia=web)
2. Check if the text is overlapping the left icon

### Impact and Risks

Low: Minor visual changes

