### PR TITLE
Fix OmniBar not respecting safeArea

### DIFF
--- a/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -400,13 +400,19 @@ extension SwipeTabsCoordinator: UICollectionViewDataSource {
     }
 
     private func removeControllerForCell(_ cell: OmniBarCell) {
-        if let existingOmniBarView = cell.omniBar?.barView,
+        guard let existingOmniBarView = cell.omniBar?.barView else { return }
+
+        // Only remove controller of a "fake" OmniBar
+        if coordinator.omniBar !== cell.omniBar,
            let backingVC = coordinator.parentController?.children.first(where: { $0.view === existingOmniBarView }) {
 
             backingVC.willMove(toParent: nil)
             existingOmniBarView.removeFromSuperview()
             cell.omniBar = nil
             backingVC.removeFromParent()
+        } else { // For cell with real OmniBar just remove existing view
+            existingOmniBarView.removeFromSuperview()
+            cell.omniBar = nil
         }
     }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1210122722180829
Tech Design URL:
CC: @brindy 

### Description

#620 removed _real_ OmniBar's view controller from parent, effectively zero-ing safe area insets. This change prevents that from happening.

### Testing Steps
1. Set address bar position to top.
2. Rotate device to landscape
3. Check if OmniBarView is respecting safe area.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)