### PR TITLE
Control + shift + tab shortcut fixed

### DIFF
--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -647,6 +647,11 @@ extension MainViewController {
             return false
         }
 
+        if event.keyCode == kVK_Tab, [.control, [.control, .shift]].contains(flags) {
+            NSApp.menu?.performKeyEquivalent(with: event)
+            return true
+        }
+
         // Handle browser tab/window actions
         if isWebViewFocused {
             switch (key, flags, flags.contains(.command)) {
@@ -657,12 +662,6 @@ extension MainViewController {
                  ("r", [.command], _):
                 NSApp.menu?.performKeyEquivalent(with: event)
                 return true
-
-            case ("\t", [.control], _),
-                 ("\t", [.control, .shift], _):
-                NSApp.menu?.performKeyEquivalent(with: event)
-                return true
-
             default:
                 break
             }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1210131003489346?focus=true
CC:

### Description

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Run the app and open bunch of tabs (websites, new tabs and internal sites)
2. Verify CONTROL + SHIFT + TAB and CONTROL + TAB switches tabs
3. Optionally, verify other shortcuts like new tab, new window, CMD + number, etc..

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Other keyboard shortcuts can break

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)