### PR TITLE
macOS UI test workflow changes

### DIFF
--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -317,7 +317,7 @@ jobs:
     # workflow_call is used by bump_internal_release and is followed by a proper release job
     if: github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event_name == 'pull_request')
 
-    runs-on: macos-15
+    runs-on: macos-15-xlarge
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -118,7 +118,7 @@ jobs:
           - cache-key: sandbox-
             flavor: Sandbox
 
-    runs-on: macos-15-xlarge
+    runs-on: macos-15
     timeout-minutes: 30
 
     outputs:
@@ -317,7 +317,7 @@ jobs:
     # workflow_call is used by bump_internal_release and is followed by a proper release job
     if: github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event_name == 'pull_request')
 
-    runs-on: macos-15-xlarge
+    runs-on: macos-15
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -66,8 +66,8 @@ jobs:
           # scheduled runs don't have inputs so let's default to true for all_os_versions
           all_os_versions="${{ inputs.all_os_versions || 'true' }}"
           if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "push" || "$all_os_versions" == "false" ]]; then
-            runner='["macos-15-xlarge"]'
-            include='[{"runner": "macos-15-xlarge", "os-version": "15", "xcode-version": "16.2"}]'
+            runner='["macos-15"]'
+            include='[{"runner": "macos-15", "os-version": "15", "xcode-version": "16.2"}]'
           else
             runner='["macos-13-xlarge", "macos-14-xlarge", "macos-15-xlarge"]'
             include=$(jq -c <<< '[

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -23,8 +23,6 @@ on:
     paths:
       - '.github/**'
       - '.xcode-version'
-      - 'BrowserServicesKit/**'
-      - 'macOS/**'
 
 jobs:
   create-notarized-app:
@@ -66,8 +64,8 @@ jobs:
           # scheduled runs don't have inputs so let's default to true for all_os_versions
           all_os_versions="${{ inputs.all_os_versions || 'true' }}"
           if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "push" || "$all_os_versions" == "false" ]]; then
-            runner='["macos-15"]'
-            include='[{"runner": "macos-15", "os-version": "15", "xcode-version": "16.2"}]'
+            runner='["macos-15-xlarge"]'
+            include='[{"runner": "macos-15-xlarge", "os-version": "15", "xcode-version": "16.2"}]'
           else
             runner='["macos-13-xlarge", "macos-14-xlarge", "macos-15-xlarge"]'
             include=$(jq -c <<< '[


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1210139982909034?focus=true
Tech Design URL:
CC:

### Description

This PR disables macOS UI test runs for all PRs (they will still run on main and release branch merges, and nightly), and moves the PR checks workflow to the free runners. These are a few minutes slower, so I'll communicate the change to the team and undo the change if the speed becomes a problem. Overall the important thing is that the UI test runs are less frequent.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI is green

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)