### PR TITLE
[macOS] Add overflow menu for pinned nav bar buttons

### DIFF
--- a/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -470,6 +470,7 @@ fileprivate extension NavigationBarViewController {
     var controlsForUserPrevention: [NSControl?] {
         return [homeButton,
                 optionsButton,
+                overflowButton,
                 bookmarkListButton,
                 passwordManagementButton,
                 addressBarViewController?.addressBarTextField,

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -181,8 +181,6 @@ final class AddressBarButtonsViewController: NSViewController {
     private let aiChatTabOpener: AIChatTabOpening
     private let aiChatMenuConfig: AIChatMenuVisibilityConfigurable
 
-    static let addressBarButtonsChangedNotificationWidthKey = "addressBar.visibleButtonsChanged.widthKey"
-
     init?(coder: NSCoder,
           tabCollectionViewModel: TabCollectionViewModel,
           accessibilityPreferences: AccessibilityPreferences = AccessibilityPreferences.shared,
@@ -783,17 +781,6 @@ final class AddressBarButtonsViewController: NSViewController {
                 self?.updateSeparator()
             }
             .store(in: &cancellables)
-
-        NotificationCenter.default.publisher(for: NSView.frameDidChangeNotification, object: view)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                guard let self else {
-                    return
-                }
-                let optionalButtonsContainerWidth = buttonsContainer.frame.width - privacyEntryPointButton.frame.width
-                notifyAddressBarWidthChange(optionalButtonsContainerWidth)
-            }
-            .store(in: &cancellables)
     }
 
     private func subscribeToAIChatPreferences() {
@@ -972,12 +959,6 @@ final class AddressBarButtonsViewController: NSViewController {
         separator.isShown = privacyEntryPointButton.isVisible && (
             (permissionButtons.subviews.contains(where: { $0.isVisible })) || zoomButton.isVisible
         )
-    }
-
-    private func notifyAddressBarWidthChange(_ newWidth: CGFloat) {
-        NotificationCenter.default.post(name: .AddressBarButtonsChanged, object: nil, userInfo: [
-            Self.addressBarButtonsChangedNotificationWidthKey: newWidth
-        ])
     }
 
     // MARK: Tracker Animation
@@ -1301,12 +1282,4 @@ extension URL {
         }
         return false
     }
-}
-
-// MARK: - NSNotification
-
-extension NSNotification.Name {
-
-    static let AddressBarButtonsChanged = NSNotification.Name("addressBar.visibleButtonsChanged")
-
 }

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -181,6 +181,8 @@ final class AddressBarButtonsViewController: NSViewController {
     private let aiChatTabOpener: AIChatTabOpening
     private let aiChatMenuConfig: AIChatMenuVisibilityConfigurable
 
+    static let addressBarButtonsChangedNotificationWidthKey = "addressBar.visibleButtonsChanged.widthKey"
+
     init?(coder: NSCoder,
           tabCollectionViewModel: TabCollectionViewModel,
           accessibilityPreferences: AccessibilityPreferences = AccessibilityPreferences.shared,
@@ -781,6 +783,17 @@ final class AddressBarButtonsViewController: NSViewController {
                 self?.updateSeparator()
             }
             .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: NSView.frameDidChangeNotification, object: view)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else {
+                    return
+                }
+                let optionalButtonsContainerWidth = buttonsContainer.frame.width - privacyEntryPointButton.frame.width
+                notifyAddressBarWidthChange(optionalButtonsContainerWidth)
+            }
+            .store(in: &cancellables)
     }
 
     private func subscribeToAIChatPreferences() {
@@ -959,6 +972,12 @@ final class AddressBarButtonsViewController: NSViewController {
         separator.isShown = privacyEntryPointButton.isVisible && (
             (permissionButtons.subviews.contains(where: { $0.isVisible })) || zoomButton.isVisible
         )
+    }
+
+    private func notifyAddressBarWidthChange(_ newWidth: CGFloat) {
+        NotificationCenter.default.post(name: .AddressBarButtonsChanged, object: nil, userInfo: [
+            Self.addressBarButtonsChangedNotificationWidthKey: newWidth
+        ])
     }
 
     // MARK: Tracker Animation
@@ -1282,4 +1301,12 @@ extension URL {
         }
         return false
     }
+}
+
+// MARK: - NSNotification
+
+extension NSNotification.Name {
+
+    static let AddressBarButtonsChanged = NSNotification.Name("addressBar.visibleButtonsChanged")
+
 }

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
@@ -156,7 +156,7 @@
                                     <real value="3.4028234663852886e+38"/>
                                 </customSpacing>
                             </stackView>
-                            <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="16" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gIy-el-24l" userLabel="Address Bar">
+                            <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="16" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gIy-el-24l" userLabel="Address Bar">
                                 <rect key="frame" x="422" y="6" width="832" height="56"/>
                                 <subviews>
                                     <containerView translatesAutoresizingMaskIntoConstraints="NO" id="Wba-nA-FYj">
@@ -177,8 +177,8 @@
                                     <real value="3.4028234663852886e+38"/>
                                 </customSpacing>
                             </stackView>
-                            <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aWu-Jm-Oaz" userLabel="Menu Buttons">
-                                <rect key="frame" x="1567" y="18" width="96" height="32"/>
+                            <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aWu-Jm-Oaz" userLabel="Menu Buttons">
+                                <rect key="frame" x="1535" y="18" width="128" height="32"/>
                                 <subviews>
                                     <button hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="l0L-Gq-8p3" userLabel="Downloads Button" customClass="MouseOverButton" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="32" height="32"/>
@@ -284,8 +284,34 @@
                                             <action selector="networkProtectionButtonAction:" target="o2v-eH-jTI" id="DeW-ut-BEh"/>
                                         </connections>
                                     </button>
-                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="iIF-Ky-unr" customClass="MoreOptionsMenuButton" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target">
+                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="NvC-7a-4eG" userLabel="Overflow Button" customClass="MouseOverButton" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target">
                                         <rect key="frame" x="64" y="0.0" width="32" height="32"/>
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="Chevron-Double-Right-16" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="Eo9-Y2-FKc">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <color key="contentTintColor" name="ButtonColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="32" id="9kl-8f-u1e"/>
+                                            <constraint firstAttribute="height" constant="32" id="jN5-Ge-fDt"/>
+                                        </constraints>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="mouseOverColor">
+                                                <color key="value" name="ButtonMouseOverColor"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="mouseDownColor">
+                                                <color key="value" name="ButtonMouseDownColor"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="4"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="overflowButtonAction:" target="o2v-eH-jTI" id="c2X-Pj-Kye"/>
+                                        </connections>
+                                    </button>
+                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="iIF-Ky-unr" customClass="MoreOptionsMenuButton" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target">
+                                        <rect key="frame" x="96" y="0.0" width="32" height="32"/>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="Settings" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="N7m-mn-k3W">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -317,8 +343,10 @@
                                     <integer value="1000"/>
                                     <integer value="1000"/>
                                     <integer value="1000"/>
+                                    <integer value="1000"/>
                                 </visibilityPriorities>
                                 <customSpacing>
+                                    <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
@@ -355,6 +383,7 @@
                         <outlet property="addressBarContainer" destination="Wba-nA-FYj" id="VEq-Sp-Ns1"/>
                         <outlet property="addressBarHeightConstraint" destination="KjG-nj-hqf" id="pT7-bY-Rf2"/>
                         <outlet property="addressBarLeftToNavButtonsConstraint" destination="rfA-3F-QAf" id="IJE-cK-DQ6"/>
+                        <outlet property="addressBarMinWidthConstraint" destination="cjs-qz-wlM" id="Zd3-Mb-E0r"/>
                         <outlet property="addressBarProportionalWidthConstraint" destination="rqL-Vd-lnY" id="zxF-f6-8wE"/>
                         <outlet property="addressBarStack" destination="gIy-el-24l" id="vlT-AD-nDv"/>
                         <outlet property="addressBarTopConstraint" destination="km5-nE-hfK" id="dR8-qN-sMa"/>
@@ -369,6 +398,7 @@
                         <outlet property="navigationButtons" destination="eEh-kf-smR" id="XC4-bo-89V"/>
                         <outlet property="networkProtectionButton" destination="iKf-yR-au9" id="HWJ-gT-EXa"/>
                         <outlet property="optionsButton" destination="iIF-Ky-unr" id="vvZ-mm-idv"/>
+                        <outlet property="overflowButton" destination="NvC-7a-4eG" id="uvf-br-tuC"/>
                         <outlet property="passwordManagementButton" destination="1nW-I1-nut" id="wDs-oE-b7d"/>
                         <outlet property="refreshOrStopButton" destination="B2U-XM-Vo0" id="EaI-Kz-Qwi"/>
                     </connections>
@@ -1052,6 +1082,7 @@
         <image name="Camera-Active" width="16" height="12"/>
         <image name="Camera-Icon" width="16" height="12"/>
         <image name="Camera-Tab-Blocked" width="16" height="14"/>
+        <image name="Chevron-Double-Right-16" width="16" height="16"/>
         <image name="Clear" width="9" height="9"/>
         <image name="Downloads" width="16" height="16"/>
         <image name="ExternalAppScheme" width="16" height="16"/>

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -43,6 +43,7 @@ final class NavigationBarViewController: NSViewController {
     @IBOutlet weak var goForwardButton: NSButton!
     @IBOutlet weak var refreshOrStopButton: NSButton!
     @IBOutlet weak var optionsButton: MouseOverButton!
+    @IBOutlet weak var overflowButton: MouseOverButton!
     @IBOutlet weak var bookmarkListButton: MouseOverButton!
     @IBOutlet weak var passwordManagementButton: MouseOverButton!
     @IBOutlet weak var homeButton: MouseOverButton!
@@ -62,6 +63,7 @@ final class NavigationBarViewController: NSViewController {
     @IBOutlet var addressBarBottomConstraint: NSLayoutConstraint!
     @IBOutlet var addressBarHeightConstraint: NSLayoutConstraint!
     @IBOutlet var buttonsTopConstraint: NSLayoutConstraint!
+    @IBOutlet var addressBarMinWidthConstraint: NSLayoutConstraint!
 
     private let downloadListCoordinator: DownloadListCoordinator
 
@@ -191,6 +193,7 @@ final class NavigationBarViewController: NSViewController {
         setupNavigationButtonMenus()
         setupNavigationButtonIcons()
         addContextMenu()
+        setupOverflowMenu()
 
         optionsButton.sendAction(on: .leftMouseDown)
         bookmarkListButton.sendAction(on: .leftMouseDown)
@@ -230,6 +233,7 @@ final class NavigationBarViewController: NSViewController {
         listenToMessageNotifications()
         listenToFeedbackFormNotifications()
         subscribeToDownloads()
+        subscribeToNavigationBarWidthChanges()
 
         updateDownloadsButton(source: .default)
         updatePasswordManagementButton()
@@ -243,6 +247,7 @@ final class NavigationBarViewController: NSViewController {
             optionsButton.isHidden = true
             homeButton.isHidden = true
             homeButtonSeparator.isHidden = true
+            overflowButton.isHidden = true
             addressBarTopConstraint.constant = 0
             addressBarBottomConstraint.constant = 0
             addressBarLeftToNavButtonsConstraint.isActive = false
@@ -254,6 +259,12 @@ final class NavigationBarViewController: NSViewController {
                 .leading: .leading(multiplier: 1.0, const: 72)
             ]))
         }
+    }
+
+    override func viewDidAppear() {
+        super.viewDidAppear()
+
+        updateNavigationBarForCurrentWidth()
     }
 
     /**
@@ -375,6 +386,14 @@ final class NavigationBarViewController: NSViewController {
         selectedTabViewModel.tab.openHomePage()
     }
 
+    @IBAction func overflowButtonAction(_ sender: NSButton) {
+        guard let menu = overflowButton.menu else {
+            return
+        }
+        let location = NSPoint(x: -menu.size.width + sender.bounds.width, y: sender.bounds.height + 4)
+        menu.popUp(positioning: nil, at: location, in: sender)
+    }
+
     @IBAction func optionsButtonAction(_ sender: NSButton) {
         let internalUserDecider = NSApp.delegateTyped.internalUserDecider
         let freemiumDBPFeature = Application.appDelegate.freemiumDBPFeature
@@ -453,6 +472,7 @@ final class NavigationBarViewController: NSViewController {
             if let userInfo = notification.userInfo as? [String: Any],
                let viewType = userInfo[LocalPinningManager.pinnedViewChangedNotificationViewTypeKey] as? String,
                let view = PinnableView(rawValue: viewType) {
+                updateNavigationBarForCurrentWidth()
                 switch view {
                 case .autofill:
                     self.updatePasswordManagementButton()
@@ -700,6 +720,7 @@ final class NavigationBarViewController: NSViewController {
         passwordManagementButton.image = visualStyleManager.style.passwordManagerButtonImage
         bookmarkListButton.image = visualStyleManager.style.bookmarksButtonImage
         optionsButton.image = visualStyleManager.style.moreOptionsbuttonImage
+        overflowButton.image = visualStyleManager.style.overflowButtonImage
     }
 
     private func setupNavigationButtonsCornerRadius() {
@@ -713,6 +734,7 @@ final class NavigationBarViewController: NSViewController {
         bookmarkListButton.setCornerRadius(visualStyleManager.style.toolbarButtonsCornerRadius)
         networkProtectionButton.setCornerRadius(visualStyleManager.style.toolbarButtonsCornerRadius)
         optionsButton.setCornerRadius(visualStyleManager.style.toolbarButtonsCornerRadius)
+        overflowButton.setCornerRadius(visualStyleManager.style.toolbarButtonsCornerRadius)
     }
 
     private func subscribeToSelectedTabViewModel() {
@@ -890,7 +912,6 @@ final class NavigationBarViewController: NSViewController {
             homeButtonSeparator.isHidden = true
         }
     }
-
     private enum DownloadsButtonUpdateSource {
         case pinnedViewsNotification
         case popoverDidClose
@@ -1056,6 +1077,198 @@ final class NavigationBarViewController: NSViewController {
             .store(in: &navigationButtonsCancellables)
     }
 
+    // MARK: - Overflow menu
+
+    private struct OverflowableItem: Hashable {
+        let navBarViews: [NSView]
+        let menuItem: NSMenuItem
+
+        var isVisibleInNavBar: Bool {
+            navBarViews.contains { !$0.isHidden }
+        }
+
+        var navBarWidth: CGFloat {
+            navBarViews.map( \.bounds.width ).reduce( 0, + )
+        }
+    }
+
+    var pinnedViews: [PinnableView] {
+        let allButtons: [PinnableView] = [.downloads, .autofill, .bookmarks, .networkProtection, .homeButton]
+        return allButtons.filter(LocalPinningManager.shared.isPinned)
+    }
+
+    private var visiblePinnedItems: [OverflowableItem] {
+        pinnedViews.map(overflowableItem).filter(\.isVisibleInNavBar)
+    }
+
+    private var visiblePinnedViewsRequiredWidth: CGFloat {
+        let visiblePinnedViewsWidth = visiblePinnedItems.map(\.navBarWidth).reduce(0, +)
+        let overflowButtonWidth = overflowButton.isVisible ? overflowButton.bounds.width : 0
+        return visiblePinnedViewsWidth + overflowButtonWidth
+    }
+
+    private var overflowItems: [OverflowableItem] {
+        pinnedViews.map(overflowableItem).filter { !$0.isVisibleInNavBar }
+    }
+
+    private var addressBarButtonsAddedWidth: CGFloat = 0
+
+    private var overflowThreshold: CGFloat {
+        let availableWidth = view.bounds.width - 24 // account for leading and trailing space
+        let alwaysVisibleButtonsWidth = goBackButton.bounds.width + goForwardButton.bounds.width + refreshOrStopButton.bounds.width + optionsButton.bounds.width
+        let addressBarMinWidth = addressBarMinWidthConstraint.constant + addressBarButtonsAddedWidth + 24 // account for leading and trailing space
+        return availableWidth - alwaysVisibleButtonsWidth - addressBarMinWidth - 3
+    }
+
+    private func setupOverflowMenu() {
+        overflowButton.menu = NSMenu()
+        overflowButton.isHidden = true
+        overflowButton.sendAction(on: .leftMouseDown)
+    }
+
+    private func subscribeToNavigationBarWidthChanges() {
+        NotificationCenter.default.publisher(for: NSView.frameDidChangeNotification, object: view)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.updateNavigationBarForCurrentWidth()
+            }
+            .store(in: &cancellables)
+
+        // Listen for changes to the buttons inside the address bar (e.g. zoom or permissions)
+        NotificationCenter.default.publisher(for: .AddressBarButtonsChanged)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                if let self, let userInfo = notification.userInfo as? [String: Any],
+                   let buttonWidth = userInfo[AddressBarButtonsViewController.addressBarButtonsChangedNotificationWidthKey] as? CGFloat {
+                    let buttonContainerSpacing: CGFloat = buttonWidth > 0 ? 4 : 0
+                    addressBarButtonsAddedWidth = ( buttonWidth * 2 ) + buttonContainerSpacing // The address bar expands by twice the button width to center the displayed address
+                    updateNavigationBarForCurrentWidth()
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    private func updateNavigationBarForCurrentWidth() {
+        guard !pinnedViews.isEmpty else {
+            return
+        }
+
+        if visiblePinnedViewsRequiredWidth >= overflowThreshold {
+            // Move buttons into overflow menu if needed
+            while visiblePinnedViewsRequiredWidth >= overflowThreshold {
+                guard let itemToOverflow = visiblePinnedItems.last else {
+                    break
+                }
+                updateNavBarViews(with: itemToOverflow, isHidden: true)
+            }
+        } else if !overflowItems.isEmpty {
+            // Restore buttons into nav bar if possible
+            while let itemToRestore = overflowItems.first {
+                let restorableButtonWidth = itemToRestore.navBarWidth
+                let newMaximumWidth = visiblePinnedViewsRequiredWidth + restorableButtonWidth
+
+                if newMaximumWidth < overflowThreshold {
+                    updateNavBarViews(with: itemToRestore, isHidden: false)
+                } else {
+                    break
+                }
+            }
+        }
+    }
+
+    private func updateNavBarViews(with item: OverflowableItem, isHidden: Bool) {
+        for view in item.navBarViews {
+            view.isHidden = isHidden
+        }
+        updateOverflowMenu()
+    }
+
+    private func updateOverflowMenu() {
+        overflowButton.menu?.removeAllItems()
+        if overflowItems.isEmpty {
+            overflowButton.isHidden = true
+        } else {
+            for item in overflowItems {
+                overflowButton.menu?.addItem(item.menuItem)
+            }
+            overflowButton.isHidden = false
+        }
+    }
+
+    private func overflowableItem(for pinnableView: PinnableView) -> OverflowableItem {
+        OverflowableItem(navBarViews: navBarButtonViews(for: pinnableView), menuItem: overflowMenuItem(for: pinnableView))
+    }
+
+    private func overflowMenuItem(for view: PinnableView) -> NSMenuItem {
+        switch view {
+        case .autofill:
+            return NSMenuItem(title: UserText.autofill, action: #selector(overflowMenuRequestedLoginsPopover), keyEquivalent: "")
+                .targetting(self)
+                .withImage(.passwordMenuNew)
+        case .bookmarks:
+            return NSMenuItem(title: UserText.bookmarks, action: #selector(overflowMenuRequestedBookmarkPopover), keyEquivalent: "")
+                .targetting(self)
+                .withImage(.bookmarksNew)
+        case .downloads:
+            return NSMenuItem(title: UserText.downloads, action: #selector(overflowMenuRequestedDownloadsPopover), keyEquivalent: "")
+                .targetting(self)
+                .withImage(.downloadsNew)
+        case .homeButton:
+            return NSMenuItem(title: UserText.homeButtonTooltip, action: #selector(overflowMenuRequestedHomeButton), keyEquivalent: "")
+                .targetting(self)
+                .withImage(.homeNew)
+        case .networkProtection:
+            return NSMenuItem(title: UserText.networkProtection, action: #selector(overflowMenuRequestedNetworkProtectionPopover), keyEquivalent: "")
+                .targetting(self)
+                .withImage(.vpnNew)
+        }
+    }
+
+    @objc
+    func overflowMenuRequestedLoginsPopover(_ menu: NSMenu) {
+        popovers.showPasswordManagementPopover(selectedCategory: nil, from: passwordManagementButton, withDelegate: self, source: .overflow)
+    }
+
+    @objc
+    func overflowMenuRequestedBookmarkPopover(_ menu: NSMenu) {
+        popovers.showBookmarkListPopover(from: bookmarkListButton, withDelegate: self, forTab: tabCollectionViewModel.selectedTabViewModel?.tab)
+    }
+
+    @objc
+    func overflowMenuRequestedNetworkProtectionPopover(_ menu: NSMenu) {
+        toggleNetworkProtectionPopover()
+    }
+
+    @objc
+    func overflowMenuRequestedHomeButton(_ menu: NSMenu) {
+        guard let selectedTabViewModel = tabCollectionViewModel.selectedTabViewModel else {
+            Logger.navigation.error("Selected tab view model is nil")
+            return
+        }
+        selectedTabViewModel.tab.openHomePage()
+    }
+
+    @objc
+    func overflowMenuRequestedDownloadsPopover(_ menu: NSMenu) {
+        toggleDownloadsPopover(keepButtonVisible: true)
+    }
+
+    private func navBarButtonViews(for view: PinnableView) -> [NSView] {
+        switch view {
+        case .autofill:
+            return [passwordManagementButton]
+        case .bookmarks:
+            return [bookmarkListButton]
+        case .downloads:
+            return [downloadsButton]
+        case .homeButton where Self.homeButtonPosition == .left:
+            return [homeButton, homeButtonSeparator]
+        case .homeButton:
+            return [homeButton]
+        case .networkProtection:
+            return [networkProtectionButton]
+        }
+    }
 }
 
 extension NavigationBarViewController: NSMenuDelegate {

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -267,6 +267,12 @@ final class NavigationBarViewController: NSViewController {
         updateNavigationBarForCurrentWidth()
     }
 
+    override func viewWillLayout() {
+        super.viewWillLayout()
+
+        updateNavigationBarForCurrentWidth()
+    }
+
     /**
      * Presents History View onboarding.
      *
@@ -1127,23 +1133,15 @@ final class NavigationBarViewController: NSViewController {
     }
 
     private func subscribeToNavigationBarWidthChanges() {
-        NotificationCenter.default.publisher(for: NSView.frameDidChangeNotification, object: view)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                self?.updateNavigationBarForCurrentWidth()
-            }
-            .store(in: &cancellables)
-
-        // Listen for changes to the buttons inside the address bar (e.g. zoom or permissions)
-        NotificationCenter.default.publisher(for: .AddressBarButtonsChanged)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] notification in
-                if let self, let userInfo = notification.userInfo as? [String: Any],
-                   let buttonWidth = userInfo[AddressBarButtonsViewController.addressBarButtonsChangedNotificationWidthKey] as? CGFloat {
-                    let buttonContainerSpacing: CGFloat = buttonWidth > 0 ? 4 : 0
-                    addressBarButtonsAddedWidth = ( buttonWidth * 2 ) + buttonContainerSpacing // The address bar expands by twice the button width to center the displayed address
-                    updateNavigationBarForCurrentWidth()
+        addressBarViewController?.addressBarButtonsViewController?.$buttonsWidth
+            .sink { [weak self] totalWidth in
+                guard let self,
+                        let staticButton = addressBarViewController?.addressBarButtonsViewController?.privacyEntryPointButton else {
+                    return
                 }
+                let optionalButtonsWidth = totalWidth - staticButton.bounds.width
+                addressBarButtonsAddedWidth = optionalButtonsWidth * 2 // The address bar expands by twice the button width to center the displayed address
+                updateNavigationBarForCurrentWidth()
             }
             .store(in: &cancellables)
     }

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -1104,6 +1104,7 @@ final class NavigationBarViewController: NSViewController {
         return visiblePinnedViewsWidth + overflowButtonWidth
     }
 
+    /// Width of displayed address bar buttons that add to the minimum width of the address bar (e.g. zoom, permissions)
     private var addressBarButtonsAddedWidth: CGFloat = 0
 
     private var overflowThreshold: CGFloat {

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -1224,18 +1224,35 @@ final class NavigationBarViewController: NSViewController {
         }
     }
 
+    private func makeSpaceInNavBarIfNeeded(for button: NSButton) {
+        guard visiblePinnedViewsRequiredWidth + button.frame.width > overflowThreshold else {
+            return
+        }
+
+        guard let itemToOverflow = visiblePinnedItems.last else {
+            return
+        }
+        updateNavBarViews(with: itemToOverflow, isHidden: true)
+    }
+
     @objc
     func overflowMenuRequestedLoginsPopover(_ menu: NSMenu) {
+        makeSpaceInNavBarIfNeeded(for: passwordManagementButton)
+        updateNavBarViews(with: overflowableItem(for: .autofill), isHidden: false)
         popovers.showPasswordManagementPopover(selectedCategory: nil, from: passwordManagementButton, withDelegate: self, source: .overflow)
     }
 
     @objc
     func overflowMenuRequestedBookmarkPopover(_ menu: NSMenu) {
+        makeSpaceInNavBarIfNeeded(for: bookmarkListButton)
+        updateNavBarViews(with: overflowableItem(for: .bookmarks), isHidden: false)
         popovers.showBookmarkListPopover(from: bookmarkListButton, withDelegate: self, forTab: tabCollectionViewModel.selectedTabViewModel?.tab)
     }
 
     @objc
     func overflowMenuRequestedNetworkProtectionPopover(_ menu: NSMenu) {
+        makeSpaceInNavBarIfNeeded(for: networkProtectionButton)
+        updateNavBarViews(with: overflowableItem(for: .networkProtection), isHidden: false)
         toggleNetworkProtectionPopover()
     }
 
@@ -1250,6 +1267,8 @@ final class NavigationBarViewController: NSViewController {
 
     @objc
     func overflowMenuRequestedDownloadsPopover(_ menu: NSMenu) {
+        makeSpaceInNavBarIfNeeded(for: downloadsButton)
+        updateNavBarViews(with: overflowableItem(for: .downloads), isHidden: false)
         toggleDownloadsPopover(keepButtonVisible: true)
     }
 

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -1121,9 +1121,9 @@ final class NavigationBarViewController: NSViewController {
 
     private var overflowThreshold: CGFloat {
         let availableWidth = view.bounds.width - 24 // account for leading and trailing space
-        let alwaysVisibleButtonsWidth = goBackButton.bounds.width + goForwardButton.bounds.width + refreshOrStopButton.bounds.width + optionsButton.bounds.width
+        let alwaysVisibleButtonsWidth = [goBackButton, goForwardButton, refreshOrStopButton, optionsButton].map(\.bounds.width).reduce(0, +)
         let addressBarMinWidth = addressBarMinWidthConstraint.constant + addressBarButtonsAddedWidth + 24 // account for leading and trailing space
-        return availableWidth - alwaysVisibleButtonsWidth - addressBarMinWidth - 3
+        return availableWidth - alwaysVisibleButtonsWidth - addressBarMinWidth
     }
 
     private func setupOverflowMenu() {

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -1085,36 +1085,23 @@ final class NavigationBarViewController: NSViewController {
 
     // MARK: - Overflow menu
 
-    private struct OverflowableItem: Hashable {
-        let navBarViews: [NSView]
-        let menuItem: NSMenuItem
-
-        var isVisibleInNavBar: Bool {
-            navBarViews.contains { !$0.isHidden }
-        }
-
-        var navBarWidth: CGFloat {
-            navBarViews.map( \.bounds.width ).reduce( 0, + )
-        }
-    }
-
     var pinnedViews: [PinnableView] {
         let allButtons: [PinnableView] = [.downloads, .autofill, .bookmarks, .networkProtection, .homeButton]
         return allButtons.filter(LocalPinningManager.shared.isPinned)
     }
 
-    private var visiblePinnedItems: [OverflowableItem] {
-        pinnedViews.map(overflowableItem).filter(\.isVisibleInNavBar)
+    private var visiblePinnedItems: [PinnableView] {
+        pinnedViews.filter { isVisibleInNavBar($0) }
+    }
+
+    private var overflowItems: [PinnableView] {
+        pinnedViews.filter { !isVisibleInNavBar($0) }
     }
 
     private var visiblePinnedViewsRequiredWidth: CGFloat {
-        let visiblePinnedViewsWidth = visiblePinnedItems.map(\.navBarWidth).reduce(0, +)
+        let visiblePinnedViewsWidth = visiblePinnedItems.map(navBarWidth).reduce(0, +)
         let overflowButtonWidth = overflowButton.isVisible ? overflowButton.bounds.width : 0
         return visiblePinnedViewsWidth + overflowButtonWidth
-    }
-
-    private var overflowItems: [OverflowableItem] {
-        pinnedViews.map(overflowableItem).filter { !$0.isVisibleInNavBar }
     }
 
     private var addressBarButtonsAddedWidth: CGFloat = 0
@@ -1162,7 +1149,7 @@ final class NavigationBarViewController: NSViewController {
         } else if !overflowItems.isEmpty {
             // Restore buttons into nav bar if possible
             while let itemToRestore = overflowItems.first {
-                let restorableButtonWidth = itemToRestore.navBarWidth
+                let restorableButtonWidth = navBarWidth(for: itemToRestore)
                 let newMaximumWidth = visiblePinnedViewsRequiredWidth + restorableButtonWidth
 
                 if newMaximumWidth < overflowThreshold {
@@ -1174,29 +1161,58 @@ final class NavigationBarViewController: NSViewController {
         }
     }
 
-    private func updateNavBarViews(with item: OverflowableItem, isHidden: Bool) {
-        for view in item.navBarViews {
+    /// Checks whether a pinned view is visible in the navigation bar
+    func isVisibleInNavBar(_ viewType: PinnableView) -> Bool {
+        navBarButtonViews(for: viewType).contains { !$0.isHidden }
+    }
+
+    /// Returns the width of any navigation bar views related to the provided pinned view
+    func navBarWidth(for viewType: PinnableView) -> CGFloat {
+        navBarButtonViews(for: viewType).map(\.bounds.width).reduce(0, +)
+    }
+
+    /// Moves the provided pinned view between the nav bar and overflow menu.
+    /// When `isHidden` is `true`, the view is moved from the nav bar to the overflow menu, and vice versa.
+    private func updateNavBarViews(with pinnedView: PinnableView, isHidden: Bool) {
+        for view in navBarButtonViews(for: pinnedView) {
             view.isHidden = isHidden
         }
         updateOverflowMenu()
     }
 
+    /// Updates the overflow menu with the expected menu items, and shows/hides the overflow button as needed.
     private func updateOverflowMenu() {
         overflowButton.menu?.removeAllItems()
         if overflowItems.isEmpty {
             overflowButton.isHidden = true
         } else {
             for item in overflowItems {
-                overflowButton.menu?.addItem(item.menuItem)
+                let menuItem = overflowMenuItem(for: item)
+                overflowButton.menu?.addItem(menuItem)
             }
             overflowButton.isHidden = false
         }
     }
 
-    private func overflowableItem(for pinnableView: PinnableView) -> OverflowableItem {
-        OverflowableItem(navBarViews: navBarButtonViews(for: pinnableView), menuItem: overflowMenuItem(for: pinnableView))
+    /// Provides the views to display in the navigation bar for a given pinned view.
+    private func navBarButtonViews(for view: PinnableView) -> [NSView] {
+        switch view {
+        case .autofill:
+            return [passwordManagementButton]
+        case .bookmarks:
+            return [bookmarkListButton]
+        case .downloads:
+            return [downloadsButton]
+        case .homeButton where Self.homeButtonPosition == .left:
+            return [homeButton, homeButtonSeparator]
+        case .homeButton:
+            return [homeButton]
+        case .networkProtection:
+            return [networkProtectionButton]
+        }
     }
 
+    /// Provides the menu items to display in the overflow menu for a given pinned view.
     private func overflowMenuItem(for view: PinnableView) -> NSMenuItem {
         switch view {
         case .autofill:
@@ -1222,8 +1238,10 @@ final class NavigationBarViewController: NSViewController {
         }
     }
 
-    private func makeSpaceInNavBarIfNeeded(for button: NSButton) {
-        guard visiblePinnedViewsRequiredWidth + button.frame.width > overflowThreshold else {
+    /// Moves the next pinned view into the overflow menu, to make space to show the provided pinned view.
+    /// This is used to ensure there is space to show a pinned view in the nav bar when it is selected from the overflow menu.
+    private func makeSpaceInNavBarIfNeeded(for view: PinnableView) {
+        guard visiblePinnedViewsRequiredWidth + navBarWidth(for: view) > overflowThreshold else {
             return
         }
 
@@ -1235,22 +1253,22 @@ final class NavigationBarViewController: NSViewController {
 
     @objc
     func overflowMenuRequestedLoginsPopover(_ menu: NSMenu) {
-        makeSpaceInNavBarIfNeeded(for: passwordManagementButton)
-        updateNavBarViews(with: overflowableItem(for: .autofill), isHidden: false)
+        makeSpaceInNavBarIfNeeded(for: .autofill)
+        updateNavBarViews(with: .autofill, isHidden: false)
         popovers.showPasswordManagementPopover(selectedCategory: nil, from: passwordManagementButton, withDelegate: self, source: .overflow)
     }
 
     @objc
     func overflowMenuRequestedBookmarkPopover(_ menu: NSMenu) {
-        makeSpaceInNavBarIfNeeded(for: bookmarkListButton)
-        updateNavBarViews(with: overflowableItem(for: .bookmarks), isHidden: false)
+        makeSpaceInNavBarIfNeeded(for: .bookmarks)
+        updateNavBarViews(with: .bookmarks, isHidden: false)
         popovers.showBookmarkListPopover(from: bookmarkListButton, withDelegate: self, forTab: tabCollectionViewModel.selectedTabViewModel?.tab)
     }
 
     @objc
     func overflowMenuRequestedNetworkProtectionPopover(_ menu: NSMenu) {
-        makeSpaceInNavBarIfNeeded(for: networkProtectionButton)
-        updateNavBarViews(with: overflowableItem(for: .networkProtection), isHidden: false)
+        makeSpaceInNavBarIfNeeded(for: .networkProtection)
+        updateNavBarViews(with: .networkProtection, isHidden: false)
         toggleNetworkProtectionPopover()
     }
 
@@ -1265,26 +1283,9 @@ final class NavigationBarViewController: NSViewController {
 
     @objc
     func overflowMenuRequestedDownloadsPopover(_ menu: NSMenu) {
-        makeSpaceInNavBarIfNeeded(for: downloadsButton)
-        updateNavBarViews(with: overflowableItem(for: .downloads), isHidden: false)
+        makeSpaceInNavBarIfNeeded(for: .downloads)
+        updateNavBarViews(with: .downloads, isHidden: false)
         toggleDownloadsPopover(keepButtonVisible: true)
-    }
-
-    private func navBarButtonViews(for view: PinnableView) -> [NSView] {
-        switch view {
-        case .autofill:
-            return [passwordManagementButton]
-        case .bookmarks:
-            return [bookmarkListButton]
-        case .downloads:
-            return [downloadsButton]
-        case .homeButton where Self.homeButtonPosition == .left:
-            return [homeButton, homeButtonSeparator]
-        case .homeButton:
-            return [homeButton]
-        case .networkProtection:
-            return [networkProtectionButton]
-        }
     }
 }
 

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
@@ -36,6 +36,7 @@ protocol VisualStyleProviding {
     var passwordManagerButtonImage: NSImage { get }
     var bookmarksButtonImage: NSImage { get }
     var moreOptionsbuttonImage: NSImage { get }
+    var overflowButtonImage: NSImage { get }
     var vpnNavigationIconsProvider: IconProvider { get }
     var fireButtonStyleProvider: FireButtonIconStyleProviding { get }
     var moreOptionsMenuIconsProvider: MoreOptionsMenuIconsProviding { get }
@@ -74,6 +75,7 @@ struct VisualStyle: VisualStyleProviding {
     let passwordManagerButtonImage: NSImage
     let bookmarksButtonImage: NSImage
     let moreOptionsbuttonImage: NSImage
+    let overflowButtonImage: NSImage
     let vpnNavigationIconsProvider: IconProvider
     let fireButtonStyleProvider: FireButtonIconStyleProviding
     let moreOptionsMenuIconsProvider: MoreOptionsMenuIconsProviding
@@ -123,6 +125,7 @@ struct VisualStyle: VisualStyleProviding {
                            passwordManagerButtonImage: .passwordManagement,
                            bookmarksButtonImage: .bookmarks,
                            moreOptionsbuttonImage: .settings,
+                           overflowButtonImage: .chevronDoubleRight16,
                            vpnNavigationIconsProvider: NavigationBarIconProvider(),
                            fireButtonStyleProvider: LegacyFireButtonIconStyleProvider(),
                            moreOptionsMenuIconsProvider: LegacyMoreOptionsMenuIcons(),
@@ -149,6 +152,7 @@ struct VisualStyle: VisualStyleProviding {
                            passwordManagerButtonImage: .passwordManagerNew,
                            bookmarksButtonImage: .bookmarksNew,
                            moreOptionsbuttonImage: .optionsNew,
+                           overflowButtonImage: .chevronDoubleRight16,
                            vpnNavigationIconsProvider: NewVPNNavigationBarIconProvider(),
                            fireButtonStyleProvider: NewFireButtonIconStyleProvider(),
                            moreOptionsMenuIconsProvider: NewMoreOptionsMenuIcons(),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1209813459676820?focus=true

### Description

This adds an overflow menu to the browser navigation bar. When the browser window is resized to a small width, and there are buttons pinned to the nav bar (e.g. the home button, or shortcuts like downloads, passwords), the overflow menu is displayed if the buttons overflow the available width.

#### Expected behavior

* When a window/tab is opened, a new button is added to the navigation bar, or the window is resized, the overflow menu will appear if needed.
* When the overflow menu is needed, buttons will be moved one at a time from the navigation bar to the overflow menu.
* When more space is available in the navigation bar, buttons will be moved one at a time from the overflow menu back to the navigation bar.
* When a menu item in the overflow menu is clicked on, and has a related popover, it will become visible in the navigation bar and the popover will be displayed.

#### Primary Changes

* Adds an overflow menu button that is hidden by default.
* Tracks the pinned views, and which views are visible in the navigation bar or moved into the overflow menu. These properties also determine the order that views will be moved in/out of the overflow menu.
* Tracks the required width for the pinned views, and the available space for showing the in the navigation bar (`overflowThreshold` - this is the threshold for moving items into the overflow menu).
* When the view appears, the view is resized, the shortcut buttons in the navigation bar change, or the zoom/permissions buttons in the address bar change, the navigation bar is updated (moving items in or out of the overflow menu) based on the window’s width and available space.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Right-click in the navigation bar to enable the optional pinned views:
   * Home button
   * Passwords shortcut
   * Bookmarks shortcut
   * Downloads shortcut
   * VPN shortcut
2. Open a website and zoom in or trigger permissions (e.g. camera/microphone, pop-up window).
3. Confirm you can resize the window to a large size and all buttons are visible in the navigation bar.
4. Confirm you can resize the window to the smallest width (544 pt) and buttons are progressively moved into the overflow menu.
5. Open the overflow menu and select an item. Confirm it performs the expected action (e.g. “Home” takes you to homepage; other buttons are moved back to the navigation bar and their respective popovers are opened).

### Impact and Risks
Low: Minor visual changes

#### What could go wrong?
Buttons could be hidden/shown unexpectedly at small window widths, or resize the window unexpectedly 

### Notes to Reviewer

https://github.com/user-attachments/assets/3aa6b066-1207-4d94-ab22-683e9fea1cc8




—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)