### PR TITLE
Issue with the pinned tabs setting fixed

### DIFF
--- a/macOS/DuckDuckGo/Preferences/View/PreferencesGeneralView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesGeneralView.swift
@@ -51,6 +51,12 @@ extension Preferences {
             }
         }
 
+        private func setPinnedTabsMode(_ newMode: PinnedTabsMode) {
+            guard tabsModel.pinnedTabsMode != newMode else { return }
+            tabsModel.pinnedTabsMode = newMode
+            firePinnedTabsPixel(newMode)
+        }
+
         var body: some View {
             PreferencePane(UserText.general) {
 
@@ -142,12 +148,10 @@ extension Preferences {
                                             pendingSelection = newValue
                                             showWarningAlert = true
                                         } else {
-                                            tabsModel.pinnedTabsMode = newValue
-                                            firePinnedTabsPixel(newValue)
+                                            setPinnedTabsMode(newValue)
                                         }
                                     } else {
-                                        tabsModel.pinnedTabsMode = newValue
-                                        firePinnedTabsPixel(newValue)
+                                        setPinnedTabsMode(newValue)
                                     }
                                 }
                             )) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1210047201922133?focus=true

### Description
Fixed an issue where selecting the same pinned tab setting erased all pinned tabs.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Run the app and pin a couple of tabs
2. Go to Settings -> General -> Tabs and select "Separate in each window"
3. Repeat the setting selection from the drop down a couple of times
4. Make sure all pinned tabs are present
5. Now select "Shared across all windows"
6. Repeat the setting selection from the drop down a couple of times
7. Make sure all pinned tabs are present

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)