### PR TITLE
Remove temporary pixels for history view onboarding dialog

### DIFF
--- a/macOS/DuckDuckGo/History/View/Onboarding/HistoryViewOnboardingViewModel.swift
+++ b/macOS/DuckDuckGo/History/View/Onboarding/HistoryViewOnboardingViewModel.swift
@@ -42,29 +42,23 @@ final class UserDefaultsHistoryViewOnboardingViewSettingsPersistor: HistoryViewO
 
 final class HistoryViewOnboardingViewModel: ObservableObject {
     let settingsStorage: HistoryViewOnboardingViewSettingsPersisting
-    let firePixel: (HistoryViewPixel) -> Void
     let ctaCallback: (Bool) -> Void
 
     internal init(settingsStorage: any HistoryViewOnboardingViewSettingsPersisting = UserDefaultsHistoryViewOnboardingViewSettingsPersistor(),
-                  firePixel: @escaping (HistoryViewPixel) -> Void = { PixelKit.fire($0, frequency: .dailyAndStandard) },
                   ctaCallback: @escaping (Bool) -> Void) {
         self.settingsStorage = settingsStorage
-        self.firePixel = firePixel
         self.ctaCallback = ctaCallback
     }
 
     func markAsShown() {
         settingsStorage.didShowOnboardingView = true
-        firePixel(.onboardingDialogShown)
     }
 
     func notNow() {
         ctaCallback(false)
-        firePixel(.onboardingDialogDismissed)
     }
 
     func showHistory() {
         ctaCallback(true)
-        firePixel(.onboardingDialogAccepted)
     }
 }

--- a/macOS/DuckDuckGo/Statistics/HistoryViewPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/HistoryViewPixel.swift
@@ -74,22 +74,6 @@ enum HistoryViewPixel: PixelKitEventV2 {
      */
     case multipleItemsDeleted(DeletedBatchKind, burn: Bool)
 
-    // MARK: - Temporary Pixels
-    /**
-     * Event Trigger: History View onboarding dialog was shown.
-     */
-    case onboardingDialogShown
-
-    /**
-     * Event Trigger: History View onboarding dialog was dismissed.
-     */
-    case onboardingDialogDismissed
-
-    /**
-     * Event Trigger: History View onboarding dialog was accepted.
-     */
-    case onboardingDialogAccepted
-
     // MARK: -
 
     enum HistoryPageSource: String {
@@ -152,9 +136,6 @@ enum HistoryViewPixel: PixelKitEventV2 {
         case .delete: return "history-page_any-delete"
         case .singleItemDeleted: return "history-page_item-deleted"
         case .multipleItemsDeleted: return "history-page_items-deleted"
-        case .onboardingDialogShown: return "history-page_intro_dialog_shown"
-        case .onboardingDialogDismissed: return "history-page_intro_dialog_not_now"
-        case .onboardingDialogAccepted: return "history-page_intro_dialog_view_history"
         }
     }
 
@@ -176,12 +157,6 @@ enum HistoryViewPixel: PixelKitEventV2 {
             return nil
         case .multipleItemsDeleted(let batchKind, let burn):
             return [Parameters.filter: batchKind.rawValue, Parameters.type: burn ? "burn" : "delete"]
-        case .onboardingDialogShown:
-            return nil
-        case .onboardingDialogDismissed:
-            return nil
-        case .onboardingDialogAccepted:
-            return nil
         }
     }
 

--- a/macOS/UnitTests/History/View/Onboarding/HistoryViewOnboardingViewModelTests.swift
+++ b/macOS/UnitTests/History/View/Onboarding/HistoryViewOnboardingViewModelTests.swift
@@ -21,45 +21,32 @@ import XCTest
 
 final class HistoryViewOnboardingViewModelTests: XCTestCase {
 
+    var settingsStorage: MockHistoryViewOnboardingViewSettingsPersistor!
     var viewModel: HistoryViewOnboardingViewModel!
-    var pixels: [HistoryViewPixel] = []
+    var ctaCalls: [Bool] = []
 
     override func setUp() async throws {
-        pixels = []
+        settingsStorage = MockHistoryViewOnboardingViewSettingsPersistor()
+        ctaCalls = []
         viewModel = HistoryViewOnboardingViewModel(
-            settingsStorage: MockHistoryViewOnboardingViewSettingsPersistor(),
-            firePixel: { self.pixels.append($0) },
-            ctaCallback: { _ in }
+            settingsStorage: settingsStorage,
+            ctaCallback: { self.ctaCalls.append($0) }
         )
     }
 
-    func testThatMarkAsShownFiresPixel() throws {
+    func testThatMarkAsShownUpdatesStorageAndDoesNotTriggerCTA() throws {
         viewModel.markAsShown()
-        XCTAssertEqual(pixels.count, 1)
-        let pixel = try XCTUnwrap(pixels.first)
-        guard case .onboardingDialogShown = pixel else {
-            XCTFail("Unexpected pixel fired")
-            return
-        }
+        XCTAssertEqual(ctaCalls.count, 0)
+        XCTAssertTrue(settingsStorage.didShowOnboardingView)
     }
 
-    func testThatNotNowFiresPixel() throws {
+    func testThatNotNowDoesTriggersCTAWithFalse() throws {
         viewModel.notNow()
-        XCTAssertEqual(pixels.count, 1)
-        let pixel = try XCTUnwrap(pixels.first)
-        guard case .onboardingDialogDismissed = pixel else {
-            XCTFail("Unexpected pixel fired")
-            return
-        }
+        XCTAssertEqual(ctaCalls, [false])
     }
 
-    func testThatShowHistoryFiresPixel() throws {
+    func testThatShowHistoryTriggersCTAWithTrue() throws {
         viewModel.showHistory()
-        XCTAssertEqual(pixels.count, 1)
-        let pixel = try XCTUnwrap(pixels.first)
-        guard case .onboardingDialogAccepted = pixel else {
-            XCTFail("Unexpected pixel fired")
-            return
-        }
+        XCTAssertEqual(ctaCalls, [true])
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1209580853634525?focus=true

### Description
This change removes temporary pixels and updates a unit test to test the onboarding view model logic.

### Testing Steps
Verify that CI is green.

### Impact and Risks
None

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)