### PR TITLE
Fix back/forward menu not showing up when visual updates are enabled

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3277,11 +3277,11 @@ extension MainViewController {
         
         let backMenu = historyMenu(with: currentTab.webView.backForwardList.backList.reversed())
         viewCoordinator.omniBar.barView.backButton.menu = backMenu
-        viewCoordinator.toolbarBackButton.menu = backMenu
+        viewCoordinator.toolbarBackButton.setCustomItemMenu(backMenu)
 
         let forwardMenu = historyMenu(with: currentTab.webView.backForwardList.forwardList)
         viewCoordinator.omniBar.barView.forwardButton.menu = forwardMenu
-        viewCoordinator.toolbarForwardButton.menu = forwardMenu
+        viewCoordinator.toolbarForwardButton.setCustomItemMenu(forwardMenu)
     }
 
     private func historyMenu(with backForwardList: [WKBackForwardListItem]) -> UIMenu {
@@ -3351,6 +3351,14 @@ private extension UIBarButtonItem {
             customControl.addTarget(target, action: action, for: .touchUpInside)
         } else {
             self.action = action
+        }
+    }
+
+    func setCustomItemMenu(_ menu: UIMenu) {
+        if let customControl = customView as? UIButton {
+            customControl.menu = menu
+        } else {
+            self.menu = menu
         }
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1210165870762384
Tech Design URL:
CC:

### Description

Conditionally sets the menu on either `UIBarButtonItem` or a custom control that's set as a custom view.

### Testing Steps
1. Create a navigation history by navigating to a bunch of web pages in a single tab
2. Long press go back button - history menu should show up
3. Navigate back - long press go forward button - history menu should show up
4. Repeat with (or without) experimental appearance enabled.

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Could break the same feature on production (regular) appearance.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)