### PR TITLE
AuthV2 token adoption improvements

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/NetworkProtection/PacketTunnelProvider.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/NetworkProtection/PacketTunnelProvider.swift
@@ -644,9 +644,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             Logger.networkProtection.log("Set new token container")
             do {
                 try await tokenHandlerProvider.adoptToken(newTokenContainer)
-                // It’s important to force refresh the token to immediately branch the one used by the system extension from the one used in the main app.
-                // See discussion https://app.asana.com/0/1199230911884351/1208785842165508/f
-                try await tokenHandlerProvider.refreshToken()
             } catch {
                 Logger.networkProtection.fault("Error adopting token container: \(error, privacy: .public)")
                 throw TunnelError.startingTunnelWithoutAuthToken(internalError: error)

--- a/SharedPackages/BrowserServicesKit/Sources/Networking/Auth/OAuthClient.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Networking/Auth/OAuthClient.swift
@@ -21,8 +21,7 @@ import os.log
 
 public enum OAuthClientError: Error, LocalizedError, Equatable {
     case internalError(String)
-    case missingTokens
-    case missingRefreshToken
+    case missingTokenContainer
     case unauthenticated
     /// When both access token and refresh token are expired
     case refreshTokenExpired
@@ -33,10 +32,8 @@ public enum OAuthClientError: Error, LocalizedError, Equatable {
         switch self {
         case .internalError(let error):
             return "Internal error: \(error)"
-        case .missingTokens:
-            return "No token available"
-        case .missingRefreshToken:
-            return "No refresh token available, please re-authenticate"
+        case .missingTokenContainer:
+            return "No tokens available"
         case .unauthenticated:
             return "The account is not authenticated, please re-authenticate"
         case .refreshTokenExpired:
@@ -225,11 +222,10 @@ final public actor DefaultOAuthClient: @preconcurrency OAuthClient {
         }
 
         switch policy {
-
         case .local:
             guard let localTokenContainer else {
                 Logger.OAuthClient.log("Tokens not found")
-                throw OAuthClientError.missingTokens
+                throw OAuthClientError.missingTokenContainer
             }
             Logger.OAuthClient.log("Local tokens found, expiry: \(localTokenContainer.decodedAccessToken.exp.value, privacy: .public)")
             return localTokenContainer
@@ -237,7 +233,7 @@ final public actor DefaultOAuthClient: @preconcurrency OAuthClient {
         case .localValid:
             guard let localTokenContainer else {
                 Logger.OAuthClient.log("Tokens not found")
-                throw OAuthClientError.missingTokens
+                throw OAuthClientError.missingTokenContainer
             }
             let tokenExpiryDate = localTokenContainer.decodedAccessToken.exp.value
             Logger.OAuthClient.log("Local tokens found, expiry: \(tokenExpiryDate, privacy: .public)")
@@ -256,15 +252,15 @@ final public actor DefaultOAuthClient: @preconcurrency OAuthClient {
             }
 
         case .localForceRefresh:
-            guard let refreshToken = localTokenContainer?.refreshToken else {
-                Logger.OAuthClient.log("Refresh token not found")
-                throw OAuthClientError.missingRefreshToken
+            guard let localTokenContainer else {
+                Logger.OAuthClient.log("Tokens not found")
+                throw OAuthClientError.missingTokenContainer
             }
             do {
-                let refreshTokenResponse = try await authService.refreshAccessToken(clientID: Constants.clientID, refreshToken: refreshToken)
+                let refreshTokenResponse = try await authService.refreshAccessToken(clientID: Constants.clientID, refreshToken: localTokenContainer.refreshToken)
                 let refreshedTokens = try await decode(accessToken: refreshTokenResponse.accessToken, refreshToken: refreshTokenResponse.refreshToken)
                 Logger.OAuthClient.log("Tokens refreshed, expiry: \(refreshedTokens.decodedAccessToken.exp.value.description, privacy: .public)")
-                tokenStorage.tokenContainer = refreshedTokens
+                try tokenStorage.saveTokenContainer(refreshedTokens)
                 return refreshedTokens
             } catch OAuthServiceError.authAPIError(let code) where code == OAuthRequest.BodyErrorCode.invalidTokenRequest {
                 Logger.OAuthClient.error("Failed to refresh token: invalidTokenRequest")

--- a/SharedPackages/BrowserServicesKit/Sources/Networking/Auth/OAuthClient.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Networking/Auth/OAuthClient.swift
@@ -260,7 +260,7 @@ final public actor DefaultOAuthClient: @preconcurrency OAuthClient {
                 let refreshTokenResponse = try await authService.refreshAccessToken(clientID: Constants.clientID, refreshToken: localTokenContainer.refreshToken)
                 let refreshedTokens = try await decode(accessToken: refreshTokenResponse.accessToken, refreshToken: refreshTokenResponse.refreshToken)
                 Logger.OAuthClient.log("Tokens refreshed, expiry: \(refreshedTokens.decodedAccessToken.exp.value.description, privacy: .public)")
-                try tokenStorage.saveTokenContainer(refreshedTokens)
+                tokenStorage.tokenContainer = refreshedTokens
                 return refreshedTokens
             } catch OAuthServiceError.authAPIError(let code) where code == OAuthRequest.BodyErrorCode.invalidTokenRequest {
                 Logger.OAuthClient.error("Failed to refresh token: invalidTokenRequest")

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlowV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlowV2.swift
@@ -119,7 +119,7 @@ public final class DefaultAppStorePurchaseFlowV2: AppStorePurchaseFlowV2 {
                 Logger.subscriptionAppStorePurchaseFlow.log("Failed to restore an account from a past purchase: \(error.localizedDescription, privacy: .public)")
                 do {
                     externalID = try await subscriptionManager.getTokenContainer(policy: .createIfNeeded).decodedAccessToken.externalID
-                } catch Networking.OAuthClientError.missingTokens {
+                } catch Networking.OAuthClientError.missingTokenContainer {
                     Logger.subscriptionStripePurchaseFlow.error("Failed to create a new account: \(error.localizedDescription, privacy: .public)")
                     return .failure(.accountCreationFailed(error))
                 } catch {

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/Extensions/SubscriptionManagerV2+SubscriptionTokenHandling.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/Extensions/SubscriptionManagerV2+SubscriptionTokenHandling.swift
@@ -37,7 +37,7 @@ extension DefaultSubscriptionManagerV2: SubscriptionTokenHandling {
 
     public func adoptToken(_ someKindOfToken: Any) async throws {
         if let tokenContainer = someKindOfToken as? TokenContainer {
-            adopt(tokenContainer: tokenContainer)
+            try await adopt(tokenContainer: tokenContainer)
         } else {
             Logger.subscription.fault("Trying to adopt the wrong kind of token")
             assertionFailure("Trying to adopt the wrong kind of token")

--- a/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionManagerMockV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionManagerMockV2.swift
@@ -47,7 +47,7 @@ public final class SubscriptionManagerMockV2: SubscriptionManagerV2 {
 
     public func getSubscriptionFrom(lastTransactionJWSRepresentation: String) async throws -> Subscription.PrivacyProSubscription? {
         guard let resultSubscription else {
-            throw OAuthClientError.missingTokens
+            throw OAuthClientError.missingTokenContainer
         }
         return resultSubscription
     }
@@ -91,12 +91,12 @@ public final class SubscriptionManagerMockV2: SubscriptionManagerV2 {
         switch policy {
         case .local, .localValid, .localForceRefresh:
             guard let resultTokenContainer else {
-                throw OAuthClientError.missingTokens
+                throw OAuthClientError.missingTokenContainer
             }
             return resultTokenContainer
         case .createIfNeeded:
             guard let resultCreateAccountTokenContainer else {
-                throw OAuthClientError.missingTokens
+                throw OAuthClientError.missingTokenContainer
             }
             resultTokenContainer = resultCreateAccountTokenContainer
             return resultCreateAccountTokenContainer
@@ -106,7 +106,7 @@ public final class SubscriptionManagerMockV2: SubscriptionManagerV2 {
     public var resultExchangeTokenContainer: Networking.TokenContainer?
     public func exchange(tokenV1: String) async throws -> Networking.TokenContainer {
         guard let resultExchangeTokenContainer else {
-           throw OAuthClientError.missingTokens
+           throw OAuthClientError.missingTokenContainer
         }
         resultTokenContainer = resultExchangeTokenContainer
         return resultExchangeTokenContainer
@@ -160,7 +160,7 @@ public final class SubscriptionManagerMockV2: SubscriptionManagerV2 {
         }
     }
 
-    public func adopt(tokenContainer: Networking.TokenContainer) {
+    public func adopt(tokenContainer: Networking.TokenContainer) async throws {
         self.resultTokenContainer = tokenContainer
     }
 

--- a/SharedPackages/BrowserServicesKit/Tests/NetworkingTests/Auth/OAuthClientTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/NetworkingTests/Auth/OAuthClientTests.swift
@@ -162,7 +162,7 @@ final class OAuthClientTests: XCTestCase {
             _ = try await oAuthClient.getTokens(policy: .localForceRefresh)
             XCTFail("Error expected")
         } catch {
-            XCTAssertEqual(error as? Networking.OAuthClientError, .missingRefreshToken)
+            XCTAssertEqual(error as? Networking.OAuthClientError, .missingTokenContainer)
         }
     }
 

--- a/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
+++ b/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
@@ -567,7 +567,7 @@ final class SubscriptionDebugViewController: UITableViewController {
             do {
                 let tokenContainer = try await subscriptionManagerV2.getTokenContainer(policy: .localValid)
                 showAlert(title: "Token details", message: "\(tokenContainer.debugDescription)")
-            } catch OAuthClientError.missingTokens {
+            } catch OAuthClientError.missingTokenContainer {
                 showAlert(title: "Not authenticated", message: "No authenticated user found! - Token not available")
             } catch {
                 showAlert(title: "Error Validating Token", message: "\(error)")
@@ -646,7 +646,7 @@ final class SubscriptionDebugViewController: UITableViewController {
                     return entitlement.rawValue
                 }.joined(separator: "\n")
                 showAlert(title: "Available Entitlements", message: entitlementsDescription)
-            } catch OAuthClientError.missingTokens {
+            } catch OAuthClientError.missingTokenContainer {
                 showAlert(title: "Not authenticated", message: "No authenticated user found! - Token not available")
             } catch {
                 showAlert(title: "Error retrieving entitlements", message: "\(error)")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/inbox/1205736674596206/item/1210153624525907/story/1210153788477661?focus=true
CC:

### Description

A couple of improvements to the AuthV2 token adoption:

#### Error handling: 
- `.missingTokens` error has been renamed `missingTokenContainer`
- `.missingRefreshToken` has been removed and replaced with a clearer `.missingTokenContainer`

#### Adoption + Refresh
The force refresh is now part of the adoption process, this shouldn't change anything but 

### Testing Steps

Normal Subscription + VPN operations

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)