### PR TITLE
Fix color of toolbars and navigation bars of certain views

### DIFF
--- a/iOS/DuckDuckGo/DownloadsListHostingController.swift
+++ b/iOS/DuckDuckGo/DownloadsListHostingController.swift
@@ -34,16 +34,17 @@ class DownloadsListHostingController: UIHostingController<DownloadsList> {
             self?.presentActivityView(for: url, from: rectangle)
         }
     }
-    
+
     private func setUpAppearances() {
         // Required due to lack of SwiftUI APIs for changing the background color of List and nav bars
         let appearance = UITableView.appearance(whenContainedInInstancesOf: [DownloadsListHostingController.self])
         appearance.backgroundColor = UIColor(designSystemColor: .background)
         
         let navAppearance = UINavigationBar.appearance(whenContainedInInstancesOf: [DownloadsListHostingController.self])
-        navAppearance.backgroundColor = UIColor(designSystemColor: .background)
-        navAppearance.barTintColor = UIColor(designSystemColor: .background)
-        navAppearance.shadowImage = UIImage()
+        decorateNavigationBar(navAppearance)
+
+        let toolbarAppearance = UIToolbar.appearance(whenContainedInInstancesOf: [DownloadsListHostingController.self])
+        decorateToolbar()
     }
     
     private func presentActivityView(for url: URL, from rect: CGRect) {

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -523,15 +523,7 @@ extension SyncSettingsViewController {
         let theme = ThemeManager.shared.currentTheme
         view.backgroundColor = theme.backgroundColor
 
-        navigationController?.navigationBar.barTintColor = theme.barBackgroundColor
-        navigationController?.navigationBar.tintColor = theme.navigationBarTintColor
-
-        let appearance = UINavigationBarAppearance()
-        appearance.shadowColor = .clear
-        appearance.backgroundColor = theme.backgroundColor
-
-        navigationController?.navigationBar.standardAppearance = appearance
-        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        decorateNavigationBar()
 
     }
 

--- a/iOS/DuckDuckGo/Themable.swift
+++ b/iOS/DuckDuckGo/Themable.swift
@@ -20,11 +20,14 @@ import UIKit
 
 extension UIViewController {
 
-    func decorateNavigationBar(with theme: Theme = ThemeManager.shared.currentTheme) {
-        navigationController?.navigationBar.barTintColor = theme.barBackgroundColor
-        navigationController?.navigationBar.tintColor = theme.navigationBarTintColor
-        
-        var titleAttrs = navigationController?.navigationBar.titleTextAttributes ?? [:]
+    func decorateNavigationBar(_ navigationBar: UINavigationBar? = nil, with theme: Theme = ThemeManager.shared.currentTheme) {
+
+        guard let targetNavigationBar = navigationBar ?? self.navigationController?.navigationBar else { return }
+
+        targetNavigationBar.barTintColor = theme.barBackgroundColor
+        targetNavigationBar.tintColor = theme.navigationBarTintColor
+
+        var titleAttrs = targetNavigationBar.titleTextAttributes ?? [:]
         titleAttrs[NSAttributedString.Key.foregroundColor] = theme.navigationBarTitleColor
         navigationController?.navigationBar.titleTextAttributes = titleAttrs
         
@@ -33,27 +36,29 @@ extension UIViewController {
         appearance.backgroundColor = theme.backgroundColor
         appearance.titleTextAttributes = titleAttrs
 
-        navigationController?.navigationBar.standardAppearance = appearance
-        navigationController?.navigationBar.scrollEdgeAppearance = appearance
-        navigationController?.navigationBar.compactAppearance = appearance
-        navigationController?.navigationBar.compactScrollEdgeAppearance = appearance
+        targetNavigationBar.standardAppearance = appearance
+        targetNavigationBar.scrollEdgeAppearance = appearance
+        targetNavigationBar.compactAppearance = appearance
+        targetNavigationBar.compactScrollEdgeAppearance = appearance
     }
     
-    func decorateToolbar(with theme: Theme = ThemeManager.shared.currentTheme) {
+    func decorateToolbar(_ toolbar: UIToolbar? = nil, with theme: Theme = ThemeManager.shared.currentTheme) {
 
-        guard let appearance = navigationController?.toolbar.standardAppearance else {
+        guard let targetToolbar = toolbar ?? navigationController?.toolbar else {
             return
         }
+
+        let appearance = targetToolbar.standardAppearance
 
         appearance.backgroundColor = theme.barBackgroundColor
         if ExperimentalThemingManager().isExperimentalThemingEnabled {
             appearance.shadowColor = .clear
         }
 
-        navigationController?.toolbar.standardAppearance = appearance
-        navigationController?.toolbar.compactAppearance = appearance
-        navigationController?.toolbar.tintColor = theme.barTintColor
-
-        navigationController?.toolbar.scrollEdgeAppearance = appearance
+        targetToolbar.standardAppearance = appearance
+        targetToolbar.compactAppearance = appearance
+        targetToolbar.scrollEdgeAppearance = appearance
+        
+        targetToolbar.tintColor = theme.barTintColor
     }
 }

--- a/iOS/DuckDuckGo/Themable.swift
+++ b/iOS/DuckDuckGo/Themable.swift
@@ -35,14 +35,25 @@ extension UIViewController {
 
         navigationController?.navigationBar.standardAppearance = appearance
         navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        navigationController?.navigationBar.compactAppearance = appearance
+        navigationController?.navigationBar.compactScrollEdgeAppearance = appearance
     }
     
     func decorateToolbar(with theme: Theme = ThemeManager.shared.currentTheme) {
-        navigationController?.toolbar.barTintColor = theme.barBackgroundColor
-        navigationController?.toolbar.backgroundColor = theme.barBackgroundColor
+
+        guard let appearance = navigationController?.toolbar.standardAppearance else {
+            return
+        }
+
+        appearance.backgroundColor = theme.barBackgroundColor
+        if ExperimentalThemingManager().isExperimentalThemingEnabled {
+            appearance.shadowColor = .clear
+        }
+
+        navigationController?.toolbar.standardAppearance = appearance
+        navigationController?.toolbar.compactAppearance = appearance
         navigationController?.toolbar.tintColor = theme.barTintColor
-        
-        let appearance = navigationController?.toolbar.standardAppearance
+
         navigationController?.toolbar.scrollEdgeAppearance = appearance
     }
 }

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/DeviceConnectedView.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/DeviceConnectedView.swift
@@ -43,6 +43,7 @@ public struct DeviceConnectedView: View {
             }
             .padding(.horizontal, 20)
             .padding(.top, 56)
+            .foregroundStyle(Color(designSystemColor: .textPrimary))
         } foregroundContent: {
             VStack {
                 Button {
@@ -69,6 +70,7 @@ public struct DeviceConnectedView: View {
             .padding(.horizontal, 30)
         }
         .padding(.bottom)
+        .background(Color(designSystemColor: .background))
     }
 
     public var body: some View {

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/PreparingToSyncView.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/PreparingToSyncView.swift
@@ -41,9 +41,11 @@ public struct PreparingToSyncView: View {
                     .multilineTextAlignment(.center)
             }
             .padding(.horizontal, 20)
+            .foregroundStyle(Color(designSystemColor: .textPrimary))
         } foregroundContent: {
             Text(UserText.preparingToSyncSheetFooter)
                 .foregroundColor(Color(designSystemColor: .textSecondary))
         }
+        .background(Color(designSystemColor: .background))
     }
 }

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/RecoverSyncedDataView.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/RecoverSyncedDataView.swift
@@ -37,7 +37,6 @@ public struct RecoverSyncedDataView: View {
                 HStack {
                     Button(action: onCancel, label: {
                         Text(UserText.cancelButton)
-                            .foregroundColor(.primary)
                     })
                     Spacer()
                 }
@@ -54,6 +53,7 @@ public struct RecoverSyncedDataView: View {
                         .multilineTextAlignment(.center)
             }
             .padding(.horizontal, 20)
+            .foregroundStyle(Color(designSystemColor: .textPrimary))
         } foregroundContent: {
             Button {
                 model.recoverSyncDataPressed()
@@ -65,5 +65,6 @@ public struct RecoverSyncedDataView: View {
             .padding(.horizontal, 30)
             .padding(.bottom, 8)
         }
+        .background(Color(designSystemColor: .background))
     }
 }

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SaveRecoveryKeyView.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SaveRecoveryKeyView.swift
@@ -125,10 +125,10 @@ public struct SaveRecoveryKeyView: View {
             Text(UserText.saveRecoveryCodeSheetFooter)
                 .daxCaption()
                 .multilineTextAlignment(.center)
-                .foregroundColor(.primary.opacity(0.6))
         }
         .padding(.top, isCompact ? 0 : 56)
         .padding(.horizontal, 30)
+        .foregroundStyle(Color(designSystemColor: .textPrimary))
     }
 
     @ViewBuilder
@@ -152,6 +152,7 @@ public struct SaveRecoveryKeyView: View {
         } foregroundContent: {
             nextButton()
         }
+        .background(Color(designSystemColor: .background))
     }
 
 }

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncWithServerView.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncWithServerView.swift
@@ -37,7 +37,6 @@ public struct SyncWithServerView: View {
                 HStack {
                     Button(action: onCancel, label: {
                         Text(UserText.cancelButton)
-                            .foregroundColor(.primary)
                     })
                     Spacer()
                 }
@@ -58,6 +57,7 @@ public struct SyncWithServerView: View {
                         .multilineTextAlignment(.center)
                 }
             }
+            .foregroundStyle(Color(designSystemColor: .textPrimary))
             .padding(.horizontal, 20)
         } foregroundContent: {
             VStack(spacing: 8) {
@@ -75,5 +75,6 @@ public struct SyncWithServerView: View {
                     .foregroundColor(Color(designSystemColor: .textSecondary))
             }
         }
+        .background(Color(designSystemColor: .background))
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1210176081574723
Tech Design URL:
CC:

### Description

This makes sure correct navigation/toolbar color is set for the following:
* Bookmarks
* Downloads
* Sync settings

Design system background and foreground colors are now used for Sync settings and pairing views.

### Testing Steps
1. Enable experimental appearance. Restart the app.
2. Download any file, go to downloads make sure navigation bar and toolbar are shown as "continuous surface" without shadows and separators
3. Open Bookmarks, verify toolbar has the same color as view background and separator is not visible.
4. Open Sync settings, turn off Sync & backup
5. Open each option under "other options", validate if background color matches the main screen
6. Choose "Sync and backup this device" and enable sync. Validate background color of each screen matches the main screen background color.
7. Disable experimental appearance. Restart the app.
8. Verify if the above looks good.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Colors may look off for a corner case scenario I didn't know about in modified views.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)