### PR TITLE
Fix toolbar and OmniBar alignment

### DIFF
--- a/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarView.swift
+++ b/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarView.swift
@@ -236,7 +236,7 @@ final class UpdatedOmniBarView: UIView, OmniBarView {
     }
 
     init() {
-        super.init(frame: CGRect(x: 0, y: 0, width: 300, height: 68))
+        super.init(frame: CGRect(x: 0, y: 0, width: 300, height: Metrics.height))
 
         setUpSubviews()
         setUpConstraints()

--- a/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -406,7 +406,7 @@ class OmniBarCell: UICollectionViewCell {
 
     weak var coordinator: MainViewCoordinator?
     var roundCornersMaskView: RoundedCornersMaskView?
-    weak var controller: OmniBarViewController?
+    var controller: OmniBarViewController?
 
     weak var omniBar: OmniBar? {
         didSet {
@@ -448,6 +448,11 @@ class OmniBarCell: UICollectionViewCell {
             bringSubviewToFront(maskView)
                 
         }
+    }
+
+    deinit {
+        controller?.removeFromParent()
+        controller = nil
     }
 }
 

--- a/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -365,13 +365,12 @@ extension SwipeTabsCoordinator: UICollectionViewDataSource {
             fatalError("Not \(OmniBarCell.self)")
         }
 
-        removeControllerForCell(cell)
-
         if !isEnabled || tabsModel.currentIndex == indexPath.row {
             cell.omniBar = coordinator.omniBar
         } else {
             // Strong reference while we use the omnibar
-            let controller = OmniBarFactory.createOmniBarViewController(with: omnibarDependencies)
+            let controller = cell.controller ?? OmniBarFactory.createOmniBarViewController(with: omnibarDependencies)
+            let url = tabsModel.safeGetTabAt(indexPath.row)?.link?.url
 
             coordinator.parentController?.addChild(controller)
 
@@ -382,28 +381,23 @@ extension SwipeTabsCoordinator: UICollectionViewDataSource {
 
             if let url = tabsModel.safeGetTabAt(indexPath.row)?.link?.url {
                 cell.omniBar?.startBrowsing()
-                cell.omniBar?.refreshText(forUrl: url, forceFullURL: appSettings.showFullSiteAddress)
-                cell.omniBar?.resetPrivacyIcon(for: url)
                 cell.omniBar?.updateAccessoryType(omnibarAccessoryHandler.omnibarAccessory(for: url))
+                cell.omniBar?.resetPrivacyIcon(for: url)
+            } else {
+                cell.omniBar?.stopBrowsing()
+                // It's always chat just now (this might change in the future) and this prevents a flash when on new tab
+                cell.omniBar?.updateAccessoryType(.chat)
             }
 
+            cell.omniBar?.refreshText(forUrl: url, forceFullURL: appSettings.showFullSiteAddress)
+
             controller.didMove(toParent: coordinator.parentController)
+            cell.controller = controller
         }
 
         cell.setNeedsUpdateConstraints()
 
         return cell
-    }
-
-    private func removeControllerForCell(_ cell: OmniBarCell) {
-        if let existingOmniBarView = cell.omniBar?.barView,
-           let backingVC = coordinator.parentController?.children.first(where: { $0.view === existingOmniBarView }) {
-
-            backingVC.willMove(toParent: nil)
-            existingOmniBarView.removeFromSuperview()
-            cell.omniBar = nil
-            backingVC.removeFromParent()
-        }
     }
 
 }
@@ -412,6 +406,7 @@ class OmniBarCell: UICollectionViewCell {
 
     weak var coordinator: MainViewCoordinator?
     var roundCornersMaskView: RoundedCornersMaskView?
+    weak var controller: OmniBarViewController?
 
     weak var omniBar: OmniBar? {
         didSet {

--- a/iOS/DuckDuckGo/ToolbarStateHandling.swift
+++ b/iOS/DuckDuckGo/ToolbarStateHandling.swift
@@ -197,7 +197,7 @@ final class ToolbarHandler: ToolbarStateHandling {
 }
 
 private extension UIBarButtonItem {
-    private static let additionalHorizontalSpace = 10.0
+    private static let additionalHorizontalSpace = 14.0
 
     static func additionalFixedSpaceItem() -> UIBarButtonItem {
         .fixedSpace(additionalHorizontalSpace)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1209879279509902
Tech Design URL:
CC:

### Description

Toolbar horizontal spacing is adjusted to align with OmniBar buttons. In order to fix safe area alignment for the OmniBar, changes containing a fix for OmniBar disappearing were cherry-picked from #657.

### Testing Steps
1. Enable experimental appearance. Restart the app.
2. Set address bar to bottom position.
3. Verify left-most and right-most buttons align with buttons on the toolbar.
4. Rotate to landscape and verify alignment.
5. Check the same on a device with different screen size.

**Disappearing OmniBar fix:**
1. Open example.com
2. Rotate device to landscape
3. Scroll to hide the bars, verify omni bar is not disappearing from container. (See [task](https://app.asana.com/1/137249556945/project/414709148257752/task/1210150959864255) for video).

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)