### PR TITLE
iOS: Add debug pixels for potential webView issues

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -769,6 +769,11 @@ extension Pixel {
 
         case debugBreakageExperiment
 
+        case debugWebViewNotInVisibleTabHierarchy
+        case debugWebViewInVisibleTabHidden
+        case debugWebViewNotAttachedToWindow
+        case debugWebViewHasZeroFrameSize
+
         // Return user measurement
         case debugReturnUserAddATB
         case debugReturnUserUpdateATB
@@ -1820,6 +1825,11 @@ extension Pixel.Event {
         case .debugSetAsDefaultBrowserMaxNumberOfAttemptsFailure: return "m_debug_set-default-browser_failure-max-number-of-attempts-reached"
         case .debugSetAsDefaultBrowserMaxNumberOfAttemptsNoExistingResultPersistedFailure: return "m_debug_set-default-browser_failure-max-number-of-attempts-reached-no-persisted-result"
         case .debugSetAsDefaultBrowserUnknownFailure: return "m_debug_set-default-browser_failure-unknown-error"
+
+        case .debugWebViewInVisibleTabHidden: return "m_debug_webview_in_visible_tab_hidden"
+        case .debugWebViewNotInVisibleTabHierarchy: return "m_debug_webview_not_in_visible_tab_hierarchy"
+        case .debugWebViewNotAttachedToWindow: return "m_debug_webview_not_attached_to_window"
+        case .debugWebViewHasZeroFrameSize: return "m_debug_webview_has_zero_frame_size"
 
             // MARK: Ad Attribution
 

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -572,6 +572,7 @@ class TabViewController: UIViewController {
         duckPlayerNavigationHandler.updateDuckPlayerForWebViewAppearance(self)
         
         updateRoundedCorners()
+        fireWebViewDebugPixels()
     }
 
     override func buildActivities() -> [UIActivity] {
@@ -617,6 +618,21 @@ class TabViewController: UIViewController {
         if ExperimentalThemingManager().isRoundedCornersTreatmentEnabled {
             webViewContainer.clipsToBounds = true
             webViewContainer.layer.cornerRadius = isPortrait ? 12 : 0
+        }
+    }
+
+    private func fireWebViewDebugPixels() {
+        if !webView.isDescendant(of: view) {
+            DailyPixel.fireDailyAndCount(pixel: .debugWebViewNotInVisibleTabHierarchy)
+        }
+        if webView.window == nil {
+            DailyPixel.fireDailyAndCount(pixel: .debugWebViewNotAttachedToWindow)
+        }
+        if webView.isHidden {
+            DailyPixel.fireDailyAndCount(pixel: .debugWebViewInVisibleTabHidden)
+        }
+        if webView.frame == .zero {
+            DailyPixel.fireDailyAndCount(pixel: .debugWebViewHasZeroFrameSize)
         }
     }
 
@@ -765,7 +781,7 @@ class TabViewController: UIViewController {
             doLoad()
         }
     }
-    
+
     public func executeBookmarklet(url: URL) {
         if let js = url.toDecodedBookmarklet() {
             webView.evaluateJavaScript(js)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1210184959177115?focus=true

### Description
Sometimes on switching tabs, the view of that selected tab is blank even if the tabs url is reloaded. We've been unable to replicate this, so to try and debug it, we'll add some short-term debug pixels to see if the webView:

- Isn't in the view hierarchy
- Isn't in the window
- Is hidden
- Has a zero frame size

### Testing Steps
1. Run iOS with the debugger connected
2. Open a few tabs and switch between them
3. Make sure that none of the pixels are firing

### Impact and Risks
Low: Just simple pixels

#### What could go wrong?
They're the wrong pixels / they don't show up any issue we're looking for

### Quality Considerations
- What monitoring have you added?
Just the pixels mentioned
- How does this impact privacy/security?
As mentioned in the Privacy triage, the only info beyond the pixel name is the app version. Nothing about users at all.

### Notes to Reviewer
Please say if you think any of these are unnecessary. The window check is probably a bit of a stretch.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)