### PR TITLE
Removes the app exclusions feature flag locally

### DIFF
--- a/macOS/DuckDuckGo/Common/Localizables/UserText+NetworkProtection.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText+NetworkProtection.swift
@@ -261,10 +261,6 @@ extension UserText {
 
     // MARK: - Excluded Domains
 
-    static let vpnExcludedDomainsDescription = NSLocalizedString("vpn.setting.excluded.domains.description", value: "Excluded websites will bypass the VPN.", comment: "Excluded Sites description")
-
-    static let vpnExcludedDomainsManageButtonTitle = NSLocalizedString("vpn.setting.excluded.domains.manage.button.title", value: "Manage Excluded Websites…", comment: "Excluded Sites management button title")
-
     static let vpnExcludedDomainsAddDomain = NSLocalizedString("vpn.excluded.domains.add.domain", value: "Add Website", comment: "Add Domain button for the excluded sites view")
 
     static let vpnExcludedDomainsTitle = NSLocalizedString("vpn.excluded.domains.title", value: "Excluded Websites", comment: "Title for the excluded sites view")

--- a/macOS/DuckDuckGo/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localizable.xcstrings
@@ -74418,69 +74418,9 @@
         }
       }
     },
-    "vpn.setting.excluded.domains.description" : {
-      "comment" : "Excluded Sites description",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgeschlossene Websites werden das VPN umgehen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Excluded websites will bypass the VPN."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Los sitios web excluidos evitarán la VPN."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les sites Web exclus passeront outre le VPN."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I siti web esclusi non potranno essere utilizzati dalla VPN."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uitgesloten websites zullen de VPN omzeilen."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wykluczone witryny będą pomijać VPN."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Os Websites excluídos são ignorados pela VPN."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Исключенные сайты будут работать в обход VPN."
-          }
-        }
-      }
-    },
     "vpn.setting.excluded.domains.manage.button.title" : {
       "comment" : "Excluded Sites management button title",
-      "extractionState" : "extracted_with_value",
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/macOS/DuckDuckGo/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localizable.xcstrings
@@ -74418,66 +74418,6 @@
         }
       }
     },
-    "vpn.setting.excluded.domains.manage.button.title" : {
-      "comment" : "Excluded Sites management button title",
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgeschlossene Websites verwalten …"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Manage Excluded Websites…"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Administrar sitios web excluidos..."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gérer les sites Web exclus…"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gestisci i siti esclusi..."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uitgesloten websites beheren…"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zarządzaj wykluczonymi witrynami…"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Websites excluídos…"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Управление исключенными сайтами…"
-          }
-        }
-      }
-    },
     "vpn.setting.exclusions.description" : {
       "comment" : "The description shown for the exclusions section in VPN settings",
       "extractionState" : "extracted_with_value",

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionNavBarPopoverManager.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionNavBarPopoverManager.swift
@@ -150,35 +150,6 @@ final class NetworkProtectionNavBarPopoverManager: NetPPopoverManager {
         return menuItems
     }
 
-    /// Only used if the .networkProtectionAppExclusions feature flag is disabled
-    ///
-    private func legacyStatusViewSubmenu() -> [StatusBarMenu.MenuItem] {
-        let appLauncher = AppLauncher(appBundleURL: Bundle.main.bundleURL)
-
-        if UserDefaults.netP.networkProtectionOnboardingStatus == .completed {
-            return [
-                .text(title: UserText.networkProtectionNavBarStatusViewVPNSettings, action: {
-                    try? await appLauncher.launchApp(withCommand: VPNAppLaunchCommand.showSettings)
-                }),
-                .text(title: UserText.networkProtectionNavBarStatusViewFAQ, action: {
-                    try? await appLauncher.launchApp(withCommand: VPNAppLaunchCommand.showFAQ)
-                }),
-                .text(title: UserText.networkProtectionNavBarStatusViewSendFeedback, action: {
-                    try? await appLauncher.launchApp(withCommand: VPNAppLaunchCommand.shareFeedback)
-                })
-            ]
-        } else {
-            return [
-                .text(title: UserText.networkProtectionNavBarStatusViewFAQ, action: {
-                    try? await appLauncher.launchApp(withCommand: VPNAppLaunchCommand.showFAQ)
-                }),
-                .text(title: UserText.networkProtectionNavBarStatusViewSendFeedback, action: {
-                    try? await appLauncher.launchApp(withCommand: VPNAppLaunchCommand.shareFeedback)
-                })
-            ]
-        }
-    }
-
     func show(positionedBelow view: NSView, withDelegate delegate: NSPopoverDelegate) -> NSPopover {
 
         /// Since the favicon doesn't have a publisher we force refreshing here
@@ -222,11 +193,6 @@ final class NetworkProtectionNavBarPopoverManager: NetPPopoverManager {
 
             let menuItems = { [weak self] () -> [NetworkProtectionStatusView.Model.MenuItem] in
                 guard let self else { return [] }
-
-                guard featureFlagger.isFeatureOn(.networkProtectionAppExclusions) else {
-                    return legacyStatusViewSubmenu()
-                }
-
                 return statusViewSubmenu()
             }
 

--- a/macOS/DuckDuckGo/Preferences/Model/VPNPreferencesModel.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/VPNPreferencesModel.swift
@@ -69,32 +69,18 @@ final class VPNPreferencesModel: ObservableObject {
         }
     }
 
-    private var isAppExclusionsFeatureEnabled: Bool {
-        featureFlagger.isFeatureOn(.networkProtectionAppExclusions)
-    }
-
     var isRiskySitesProtectionFeatureEnabled: Bool {
         featureFlagger.isFeatureOn(.networkProtectionRiskyDomainsProtection)
     }
 
-    private var isExclusionsFeatureAvailableInBuild: Bool {
+    /// Whether new app exclusions should be shown
+    ///
+    var showExclusionsFeature: Bool {
 #if APPSTORE
         vpnAppState.isUsingSystemExtension
 #else
         true
 #endif
-    }
-
-    /// Whether legacy app exclusions should be shown
-    ///
-    var showLegacyExclusionsFeature: Bool {
-        isExclusionsFeatureAvailableInBuild && !isAppExclusionsFeatureEnabled
-    }
-
-    /// Whether new app exclusions should be shown
-    ///
-    var showNewExclusionsFeature: Bool {
-        isExclusionsFeatureAvailableInBuild && isAppExclusionsFeatureEnabled
     }
 
     @Published

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesVPNView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesVPNView.swift
@@ -55,23 +55,6 @@ extension Preferences {
                 }
                 .padding(.bottom, 12)
 
-                if model.showLegacyExclusionsFeature {
-                    // SECTION: Excluded Sites
-
-                    PreferencePaneSection(UserText.vpnExcludedSitesTitle, spacing: 4) {
-                        Text(UserText.vpnExcludedDomainsDescription)
-                            .foregroundColor(.secondary)
-                            .padding(.bottom, 18)
-
-                        PreferencePaneSubSection {
-                            Button(UserText.vpnExcludedDomainsManageButtonTitle) {
-                                model.manageExcludedSites()
-                            }
-                        }
-                    }
-                    .padding(.bottom, 12)
-                }
-
                 // SECTION: General
 
                 PreferencePaneSection(UserText.vpnGeneralTitle) {
@@ -112,7 +95,7 @@ extension Preferences {
                 }
                 .padding(.bottom, 12)
 
-                if model.showNewExclusionsFeature {
+                if model.showExclusionsFeature {
                     // SECTION: Exclusions
 
                     PreferencePaneSection {

--- a/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
+++ b/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
@@ -420,23 +420,6 @@ final class DuckDuckGoVPNAppDelegate: NSObject, NSApplicationDelegate {
         return menuItems
     }
 
-    private func legacyStatusViewSubmenu() -> [StatusBarMenu.MenuItem] {
-        [
-            .text(title: UserText.networkProtectionStatusMenuVPNSettings, action: { [weak self] in
-                try? await self?.appLauncher.launchApp(withCommand: VPNAppLaunchCommand.showSettings)
-            }),
-            .text(title: UserText.networkProtectionStatusMenuFAQ, action: { [weak self] in
-                try? await self?.appLauncher.launchApp(withCommand: VPNAppLaunchCommand.showFAQ)
-            }),
-            .text(title: UserText.networkProtectionStatusMenuSendFeedback, action: { [weak self] in
-                try? await self?.appLauncher.launchApp(withCommand: VPNAppLaunchCommand.shareFeedback)
-            }),
-            .text(title: UserText.networkProtectionStatusMenuOpenDuckDuckGo, action: { [weak self] in
-                try? await self?.appLauncher.launchApp(withCommand: VPNAppLaunchCommand.justOpen)
-            }),
-        ]
-    }
-
     @MainActor
     private func makeStatusBarMenu() -> StatusBarMenu {
         #if DEBUG
@@ -458,11 +441,6 @@ final class DuckDuckGoVPNAppDelegate: NSObject, NSApplicationDelegate {
 
         let menuItems = { [weak self] () -> [NetworkProtectionStatusView.Model.MenuItem] in
             guard let self else { return [] }
-
-            guard featureFlagger.isFeatureOn(.networkProtectionAppExclusions) else {
-                return legacyStatusViewSubmenu()
-            }
-
             return statusViewSubmenu()
         }
 

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -39,9 +39,6 @@ public enum FeatureFlag: String, CaseIterable {
 
     case credentialsImportPromotionForExistingUsers
 
-    /// https://app.asana.com/0/0/1209150117333883/f
-    case networkProtectionAppExclusions
-
     /// https://app.asana.com/0/0/1209402073283584
     case networkProtectionAppStoreSysex
 
@@ -112,7 +109,6 @@ extension FeatureFlag: FeatureFlagDescribing {
         switch self {
         case .autofillPartialFormSaves,
                 .autocompleteTabs,
-                .networkProtectionAppExclusions,
                 .networkProtectionAppStoreSysex,
                 .networkProtectionAppStoreSysexMessage,
                 .networkProtectionRiskyDomainsProtection,
@@ -160,8 +156,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.feature(.contextualOnboarding))
         case .credentialsImportPromotionForExistingUsers:
             return .remoteReleasable(.subfeature(AutofillSubfeature.credentialsImportPromotionForExistingUsers))
-        case .networkProtectionAppExclusions:
-            return .remoteReleasable(.subfeature(NetworkProtectionSubfeature.appExclusions))
         case .networkProtectionAppStoreSysex:
             return .remoteReleasable(.subfeature(NetworkProtectionSubfeature.appStoreSystemExtension))
         case .networkProtectionAppStoreSysexMessage:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1209396183178103

### Description

Removes the app exclusions feature flag from our codebase.  This flag is no longer needed as it's been rolled out and enabled for a while now.

### Testing Steps

![Screenshot 2025-05-08 at 10 36 33 AM](https://github.com/user-attachments/assets/80e57b4a-a52b-44ff-a605-0e364c4e3982)

#### Testing Sparkle build:

1. Run the Sparkle target and make sure PrivacyPro is enabled.
2. You should see app exclusions in VPN settings as per the screenshot above.
3. Change Debug > Feature Flag Overrides > networkProtectionAppStoreSysex
<img width=600 src="https://github.com/user-attachments/assets/adecdac2-39ae-40d7-a87a-10b9adc31ac4"/>

5. Reopen VPN settings and make sure exclusions are always shown regardless of the status of said flag.
6. Uninstalling and re-enabling the VPN should always keep showing exclusions.

#### Testing App Store build:

1. Run the App Store target and make sure PrivacyPro is enabled.
2. You should see app exclusions in VPN settings as per the screenshot above.
3. Change Debug > Feature Flag Overrides > networkProtectionAppStoreSysex
4. Uninstall the VPN and reinstall it, as this is what applies the change in step 3.
5. Exclusions should be shown unless the feature flag was forced to OFF.

### Impact and Risks

Low: we're just removing a feature flag that's enabled.

#### What could go wrong?

The logic in settings was a bit tricky, so I might've made a mistake there.

### Quality Considerations

NA

### Notes to Reviewer

The logic in settings was a bit tricky, so I might've made a mistake there.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)