### PR TITLE
Fix the script reporting failed unit tests to Asana so that it gracefully handles empty input

### DIFF
--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -66,6 +66,15 @@ jobs:
       - name: Run tests
         run: set -o pipefail && swift test | tee -a build-log.txt | xcbeautify --report junit --report-path . --junit-report-filename package-tests.xml
 
+      - name: Upload JUnit XML as artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: bsk-macos-unittests.xml
+          path: |
+            SharedPackages/BrowserServicesKit/package-tests.xml
+          retention-days: 7
+
       - name: Publish Unit Tests Report
         uses: mikepenz/action-junit-report@v4
         if: always()
@@ -166,6 +175,15 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             | tee -a ios-build-log.txt \
             | xcbeautify --report junit --report-path . --junit-report-filename bsk-ios-unittests.xml
+
+      - name: Upload JUnit XML as artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: bsk-ios-unittests.xml
+          path: |
+            SharedPackages/BrowserServicesKit/bsk-ios-unittests.xml
+          retention-days: 7
 
       - name: Publish Unit Tests Report
         uses: mikepenz/action-junit-report@v4

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -130,7 +130,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: unittests.xml
+        name: ios-unittests.xml
         path: |
           iOS/unittests.xml
         retention-days: 7

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -126,6 +126,15 @@ jobs:
           | tee xcodebuild.log \
           | xcbeautify --report junit --report-path . --junit-report-filename unittests.xml
 
+    - name: Upload JUnit XML as artifact
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: unittests.xml
+        path: |
+          iOS/unittests.xml
+        retention-days: 7
+
     - name: Upload logs if workflow failed
       uses: actions/upload-artifact@v4
       if: failure() || cancelled()

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -236,6 +236,14 @@ jobs:
           fi
         fi
 
+    - name: Upload JUnit XML as artifact
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: macos-unittests.xml
+        path: macOS/${{ matrix.flavor }}*.xml
+        retention-days: 7
+
     - name: Publish unit tests report
       uses: mikepenz/action-junit-report@v4
       if: always() # always run even if the previous step fails

--- a/SharedPackages/BrowserServicesKit/scripts/report-failed-unit-test.sh
+++ b/SharedPackages/BrowserServicesKit/scripts/report-failed-unit-test.sh
@@ -45,6 +45,11 @@ read_command_line_arguments() {
 
 	shift $((OPTIND-1))
 
+	if (( $# == 0 )); then
+		echo "Nothing to do"
+		exit 0
+	fi
+
 	if (( $# < 4 )); then
 		print_usage_and_exit "Missing arguments"
 	fi

--- a/iOS/scripts/report-failed-unit-test.sh
+++ b/iOS/scripts/report-failed-unit-test.sh
@@ -45,6 +45,11 @@ read_command_line_arguments() {
 
 	shift $((OPTIND-1))
 
+	if (( $# == 0 )); then
+		echo "Nothing to do"
+		exit 0
+	fi
+
 	if (( $# < 4 )); then
 		print_usage_and_exit "Missing arguments"
 	fi

--- a/macOS/scripts/report-failed-unit-test.sh
+++ b/macOS/scripts/report-failed-unit-test.sh
@@ -41,6 +41,11 @@ read_command_line_arguments() {
 
 	shift $((OPTIND-1))
 
+	if (( $# == 0 )); then
+		echo "Nothing to do"
+		exit 0
+	fi
+
 	if (( $# < 4 )); then
 		print_usage_and_exit "Missing arguments"
 	fi


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1210188079291154?focus=true

### Description
This change updates report-failed-unit-tests.sh scripts to exit cleanly on empty input.
This deals with a changed behavior of GHA runners where no input would cause the script to fail.

### Testing Steps
Verify that CI is green.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)