### PR TITLE
Do not pretty print JSON injected into C-S-S script.

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfigurationData.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfigurationData.swift
@@ -390,7 +390,7 @@ extension PrivacyConfigurationData {
     /// Returns the JSON Data representation.
     public func toJSONData() throws -> Data {
         let jsonDict = self.toJSONDictionary()
-        return try JSONSerialization.data(withJSONObject: jsonDict, options: [.prettyPrinted])
+        return try JSONSerialization.data(withJSONObject: jsonDict, options: [])
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1163321984198618/task/1209286025185882?focus=true
Tech Design URL:
CC: @jonathanKingston 

### Description
Currently, the privacy config is encoded as JSON to be injected into the C-S-S script. This allows C-S-S to use values from the config after injection.

The current implementation 'pretty prints' the config data (i.e. adding tabs and new lines so it is human readable). This is not needed, as the data is just directly consumed by the JS parser after injection. Switching to this compact encoding reduced the config size by 49% (350k -> 180k), and the resulting C-S-S script size by 27% (638k -> 468k).

### Testing Steps
1. Validate that C-S-S is still working, e.g. by checking that the tests on https://privacy-test-pages.site/features/element-hiding/ still pass.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low: Should provide a small performance improvement.

#### What could go wrong?
This JSON encoding function is only used by C-S-S, so I don't expect an unexpected issues.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)