### PR TITLE
Allows Duck Player Native to run non-isolated

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentScopeScript/ContentScopeUserScript.swift
@@ -222,7 +222,12 @@ extension ContentScopeUserScript: WKScriptMessageHandlerWithReply {
         propagateDebugFlag(message)
         // Don't propagate the message for ContentScopeScript non isolated context
         if message.name == MessageName.contentScopeScripts.rawValue {
-            return (nil, nil)
+            guard let dict = message.messageBody as? [String: Any],
+                  let featureName = dict["featureName"] as? String,
+                  featureName == "duckPlayerNative"
+            else {
+                return (nil, nil)
+            }
         }
         // Propagate the message for ContentScopeScriptIsolated and other context like "dbpui"
         let action = broker.messageHandlerFor(message)

--- a/iOS/DuckDuckGo/UserScripts.swift
+++ b/iOS/DuckDuckGo/UserScripts.swift
@@ -119,7 +119,7 @@ final class UserScripts: UserScriptsProvider {
             } else {
                 if duckPlayerNativeUserScript == nil {
                     duckPlayerNativeUserScript = DuckPlayerNativeUserScript(duckPlayer: duckPlayer)
-                    duckPlayerNativeUserScript.map { contentScopeUserScriptIsolated.registerSubfeature(delegate: $0) }
+                    duckPlayerNativeUserScript.map { contentScopeUserScript.registerSubfeature(delegate: $0) }
                 }
             }
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206594217596623/task/1210068574004795?focus=true
CC: @afterxleep 

### Description

Enables Duck Player Native to run as a regular C-S-S user script (instead of the usual non-isolated mode)

### Testing Steps
1. Run this branch alongside the C-S-S branch [pr-releases/pr-1604](https://github.com/duckduckgo/content-scope-scripts/tree/pr-releases/pr-1604)
2. Go to Settings > Duck Player > Use Native UI
3. Open a YouTube video on each Duck Player mode to confirm they work

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)