### PR TITLE
Fix macOS PR checks artifacts

### DIFF
--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -240,7 +240,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: macos-unittests.xml
+        name: macos-${{ matrix.flavor }}-unittests.xml
         path: macOS/${{ matrix.flavor }}*.xml
         retention-days: 7
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1210190001303534?focus=true

### Description
Use distinct names for unittests.xml artifacts for macOS Sandbox and non-Sandbox flavors.

### Testing Steps
Verify that [macOS PR Checks workflow](https://github.com/duckduckgo/apple-browsers/actions/runs/14907598981?pr=694) published 2 unittests.xml artifacts, for Sandbox and Non-Sandbox flavor.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)