### PR TITLE
Tab selection visual refresh

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -267,12 +267,13 @@ final class TabBarItemCellView: NSView {
         ]
         mouseOverView.layer?.addSublayer(borderLayer)
 
-        roundedBackgroundColorView.cornerRadius = 6
-
         titleTextField.textColor = visualStyle.textPrimaryColor
 
         addSubview(mouseOverView)
-        addSubview(roundedBackgroundColorView)
+        if visualStyle.tabStyleProvider.isRoundedBackgroundPresentOnHover {
+            roundedBackgroundColorView.cornerRadius = 6
+            addSubview(roundedBackgroundColorView)
+        }
         addSubview(faviconImageView)
         addSubview(crashIndicatorButton)
         addSubview(audioButton)
@@ -289,10 +290,12 @@ final class TabBarItemCellView: NSView {
     override func layout() {
         super.layout()
         mouseOverView.frame = bounds
-        roundedBackgroundColorView.frame = NSRect(x: bounds.origin.x + 4,
-                                                  y: bounds.origin.y + 6,
-                                                  width: bounds.width - 8,
-                                                  height: bounds.height - 8)
+        if visualStyle.tabStyleProvider.isRoundedBackgroundPresentOnHover {
+            roundedBackgroundColorView.frame = NSRect(x: bounds.origin.x + 4,
+                                                      y: bounds.origin.y + 6,
+                                                      width: bounds.width - 8,
+                                                      height: bounds.height - 8)
+        }
 
         withoutAnimation {
             borderLayer.frame = bounds
@@ -703,7 +706,6 @@ final class TabBarViewItem: NSCollectionViewItem {
                 } else {
                     cell.mouseOverView.mouseOverColor = .tabMouseOver
                     cell.mouseOverView.backgroundColor = nil
-                    cell.roundedBackgroundColorView.isHidden = true
                 }
 
             }

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -206,6 +206,12 @@ final class TabBarItemCellView: NSView {
         return mouseOverView
     }()
 
+    fileprivate let roundedBackgroundColorView = {
+        let view = ColorView(frame: .zero)
+        view.alphaValue = 0.8
+        return view
+    }()
+
     fileprivate let rightSeparatorView = ColorView(frame: .zero)
 
     fileprivate lazy var borderLayer: CALayer = {
@@ -261,9 +267,12 @@ final class TabBarItemCellView: NSView {
         ]
         mouseOverView.layer?.addSublayer(borderLayer)
 
+        roundedBackgroundColorView.cornerRadius = 6
+
         titleTextField.textColor = visualStyle.textPrimaryColor
 
         addSubview(mouseOverView)
+        addSubview(roundedBackgroundColorView)
         addSubview(faviconImageView)
         addSubview(crashIndicatorButton)
         addSubview(audioButton)
@@ -280,6 +289,10 @@ final class TabBarItemCellView: NSView {
     override func layout() {
         super.layout()
         mouseOverView.frame = bounds
+        roundedBackgroundColorView.frame = NSRect(x: bounds.origin.x + 4,
+                                                  y: bounds.origin.y + 6,
+                                                  width: bounds.width - 8,
+                                                  height: bounds.height - 8)
 
         withoutAnimation {
             borderLayer.frame = bounds
@@ -427,6 +440,8 @@ final class TabBarViewItem: NSCollectionViewItem {
 
     private var currentURL: URL?
     private var cancellables = Set<AnyCancellable>()
+
+    private let tabVisualProvider: TabStyleProviding = NSApp.delegateTyped.visualStyleManager.style.tabStyleProvider
 
     weak var delegate: TabBarViewItemDelegate?
     var tabViewModel: TabBarViewModel? {
@@ -680,8 +695,17 @@ final class TabBarViewItem: NSCollectionViewItem {
                 cell.mouseOverView.mouseOverColor = nil
                 cell.mouseOverView.backgroundColor = visualStyleManager.style.navigationBackgroundColor
             } else {
-                cell.mouseOverView.mouseOverColor = .tabMouseOver
-                cell.mouseOverView.backgroundColor = nil
+                if tabVisualProvider.isRoundedBackgroundPresentOnHover {
+                    cell.mouseOverView.mouseOverColor = nil
+                    cell.mouseOverView.backgroundColor = visualStyleManager.style.baseBackgroundColor
+                    cell.roundedBackgroundColorView.backgroundColor = visualStyleManager.style.navigationBackgroundColor
+                    cell.roundedBackgroundColorView.isHidden = !isMouseOver || isSelected
+                } else {
+                    cell.mouseOverView.mouseOverColor = .tabMouseOver
+                    cell.mouseOverView.backgroundColor = nil
+                    cell.roundedBackgroundColorView.isHidden = true
+                }
+
             }
             cell.borderLayer.isHidden = !isSelected
         }

--- a/macOS/DuckDuckGo/VisualRefresh/TabStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/TabStyleProviding.swift
@@ -23,6 +23,8 @@ protocol TabStyleProviding {
     var standardTabHeight: CGFloat { get }
     var pinnedTabHeight: CGFloat { get }
     var pinnedTabWidth: CGFloat { get }
+
+    var isRoundedBackgroundPresentOnHover: Bool { get }
 }
 
 final class LegacyTabStyleProvider: TabStyleProviding {
@@ -31,6 +33,7 @@ final class LegacyTabStyleProvider: TabStyleProviding {
     let standardTabHeight: CGFloat = 34
     let pinnedTabWidth: CGFloat = 34
     let pinnedTabHeight: CGFloat = 34
+    var isRoundedBackgroundPresentOnHover = false
 }
 
 final class NewlineTabStyleProvider: TabStyleProviding {
@@ -39,4 +42,5 @@ final class NewlineTabStyleProvider: TabStyleProviding {
     let standardTabHeight: CGFloat = 38
     let pinnedTabWidth: CGFloat = 34
     let pinnedTabHeight: CGFloat = 36
+    var isRoundedBackgroundPresentOnHover = true
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210166303108615?focus=true

### Description
Visual refresh for hover state of unselected tabs

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Set internal user and turn on the visual refresh feature flag
2. Open a new window with bunch of tabs, mouse mouse over them and verify the visual style is aligned with [Figma](https://www.figma.com/design/hiyClFzZVkiYfLicSaN3iJ/Toolbar-Spec-2025?node-id=36-0&m=dev)
3. Turn of the feature flag, open a new window with bunch of tabs and verify the design is unaffected

Note: I believe the label in the tab should be centered vertically. I think this is going to be covered in other PRs, so I rather didn't touch this logic to avoid conflicts. Let me know if you'd like me to handle it too


### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)