### PR TITLE
[macOS] Revert unnecessary change to UI tests

### DIFF
--- a/macOS/UITests/BookmarksBarTests.swift
+++ b/macOS/UITests/BookmarksBarTests.swift
@@ -190,7 +190,7 @@ private extension BookmarksBarTests {
         app.typeKey("n", modifierFlags: [.command])
         app.typeKey("l", modifierFlags: [.command]) // Get address bar focus without addressing multiple address bars by identifier
         XCTAssertTrue( // Use home page logo as a test to know if a new window is fully ready before we type
-            app.buttons["AddressBarButtonsViewController.homePageLogo"].waitForExistence(timeout: UITests.Timeouts.elementExistence),
+            app.images["HomePageLogo"].waitForExistence(timeout: UITests.Timeouts.elementExistence),
             "The Home Page Logo did not exist when it was expected."
         )
         app.typeURL(urlForBookmarksBar)


### PR DESCRIPTION
### Description

This reverts a change (accidentally included in https://github.com/duckduckgo/apple-browsers/pull/656) to `BookmarksBarTests` that caused UI tests to fail.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Run UI tests for macOS.
2. Confirm `BookmarksBarTests` now pass.

### Impact and Risks
None: Internal tooling

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)