### PR TITLE
Bring privacy info container to front to enable touches on the shield icon

### DIFF
--- a/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarSearchView.swift
+++ b/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarSearchView.swift
@@ -75,10 +75,12 @@ final class UpdatedOmniBarSearchView: UIView {
         leftIconContainerPlaceholder.addSubview(leftIconContainer)
 
         mainStackView.addSubview(notificationContainer)
-        mainStackView.addSubview(privacyInfoContainer)
+
         mainStackView.addArrangedSubview(leftIconContainerPlaceholder)
         mainStackView.addArrangedSubview(textField)
         mainStackView.addArrangedSubview(trailingItemsContainer)
+
+        mainStackView.addSubview(privacyInfoContainer)
 
         trailingItemsContainer.addArrangedSubview(clearButton)
         trailingItemsContainer.addArrangedSubview(voiceSearchButton)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1210206286741189
Tech Design URL:
CC:

### Description

PrivacyContainer was moved down in the view hierarchy so other views were intercepting touches.

### Testing Steps
1. Enable experimental appearance. Restart the app.
2. Open website with protections enabled. 
3. While tracker animation is ongoing tap on url area to enter edit mode. Animations should be canceled.
4. Open Privacy Dashboard by tapping shield. 
5. Switch protections off. Wait for the site to reload.
6. Open Privacy Dashboard by tapping the shield.
7. Tap on different places on URL bar and confirm editing is started.

### Impact and Risks
Medium: Could disrupt specific features or user flows

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)