### PR TITLE
Fix returning inactive subscription to the user script

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
@@ -123,7 +123,7 @@ extension SubscriptionUserScript {
             static let notSubscribed: Self = .init(isSubscribed: false, billingPeriod: nil, startedAt: nil, expiresOrRenewsAt: nil, paymentPlatform: nil, status: nil)
 
             init(_ subscription: PrivacyProSubscription) {
-                isSubscribed = subscription.isActive
+                isSubscribed = true
                 billingPeriod = subscription.billingPeriod.rawValue
                 startedAt = Int(subscription.startedAt.timeIntervalSince1970 * 1000)
                 expiresOrRenewsAt = Int(subscription.expiresOrRenewsAt.timeIntervalSince1970 * 1000)

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
@@ -48,7 +48,7 @@ final class SubscriptionUserScriptHandler: SubscriptionUserScriptHandling {
     }
 
     func subscriptionDetails(params: Any, message: any UserScriptMessage) async throws -> DataModel.SubscriptionDetails {
-        guard let subscription = try? await subscriptionManager.getSubscription(cachePolicy: .returnCacheDataElseLoad), subscription.isActive else {
+        guard let subscription = try? await subscriptionManager.getSubscription(cachePolicy: .returnCacheDataElseLoad) else {
             return .notSubscribed
         }
         return .init(subscription)

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionUserScript/SubscriptionUserScriptHandlerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionUserScript/SubscriptionUserScriptHandlerTests.swift
@@ -50,20 +50,6 @@ final class SubscriptionUserScriptHandlerTests: XCTestCase {
         XCTAssertEqual(handshake.availableMessages, [.subscriptionDetails])
     }
 
-    func testWhenSubscriptionIsInactiveThenSubscriptionDetailsReturnsNotSubscribedState() async throws {
-        subscriptionManager.returnSubscription = .success(PrivacyProSubscription(status: .inactive))
-        handler = .init(platform: .ios, subscriptionManager: subscriptionManager)
-        let subscriptionDetails = try await handler.subscriptionDetails(params: [], message: WKScriptMessage())
-        XCTAssertEqual(subscriptionDetails, .init(isSubscribed: false, billingPeriod: nil, startedAt: nil, expiresOrRenewsAt: nil, paymentPlatform: nil, status: nil))
-    }
-
-    func testWhenSubscriptionIsExpiredThenSubscriptionDetailsReturnsNotSubscribedState() async throws {
-        subscriptionManager.returnSubscription = .success(PrivacyProSubscription(status: .expired))
-        handler = .init(platform: .ios, subscriptionManager: subscriptionManager)
-        let subscriptionDetails = try await handler.subscriptionDetails(params: [], message: WKScriptMessage())
-        XCTAssertEqual(subscriptionDetails, .init(isSubscribed: false, billingPeriod: nil, startedAt: nil, expiresOrRenewsAt: nil, paymentPlatform: nil, status: nil))
-    }
-
     func testWhenSubscriptionFailsToBeFetchedThenSubscriptionDetailsReturnsNotSubscribedState() async throws {
         struct SampleError: Error {}
         subscriptionManager.returnSubscription = .failure(SampleError())

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionUserScript/SubscriptionUserScriptHandlerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionUserScript/SubscriptionUserScriptHandlerTests.swift
@@ -84,6 +84,24 @@ final class SubscriptionUserScriptHandlerTests: XCTestCase {
             status: subscription.status.rawValue
         ))
     }
+
+    func testWhenSubscriptionIsExpiredThenSubscriptionDetailsReturnsSubscriptionData() async throws {
+        let subscription = PrivacyProSubscription(status: .expired)
+
+        subscriptionManager.returnSubscription = .success(subscription)
+        handler = .init(platform: .ios, subscriptionManager: subscriptionManager)
+        let subscriptionDetails = try await handler.subscriptionDetails(params: [], message: WKScriptMessage())
+        XCTAssertTrue(subscriptionDetails.isSubscribed)
+    }
+
+    func testWhenSubscriptionIsInactiveThenSubscriptionDetailsReturnsSubscriptionData() async throws {
+        let subscription = PrivacyProSubscription(status: .inactive)
+
+        subscriptionManager.returnSubscription = .success(subscription)
+        handler = .init(platform: .ios, subscriptionManager: subscriptionManager)
+        let subscriptionDetails = try await handler.subscriptionDetails(params: [], message: WKScriptMessage())
+        XCTAssertTrue(subscriptionDetails.isSubscribed)
+    }
 }
 
 private extension PrivacyProSubscription {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209882303470922/task/1210209647989736?focus=true

### Description
This change fixes how inactive subscriptions are reported to SERP via SubscriptionUserScript.

### Testing Steps
1. Use this privacy config override for testing: https://duckduckgo.github.io/privacy-configuration/pr-3106/v4/macos-config.json
2. Set a breakpoint in SubscriptionUserScript.swift:51.
3. Enter a state where you have an inactive subscription.
4. Open https://duckduckgo.com (root domain URL).
5. Verify that the app stops at the breakpoint and that the function returns a subscription object with `isSubscribed: true`.

### Impact and Risks
None: simple bugfix

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)