### PR TITLE
Fix Downloads UI test

### DIFF
--- a/macOS/UITests/DownloadsTests.swift
+++ b/macOS/UITests/DownloadsTests.swift
@@ -162,6 +162,10 @@ class DownloadsTests: XCTestCase {
     }
 
     private func toggleAlwaysAskWhereToSaveFiles(_ enabled: Bool) {
+        // scroll the view to the bottom
+        // scroll view is the second scroll view in the view hierarchy
+        let scrollView = app.scrollViews.element(boundBy: 1)
+        scrollView.swipeUp()
         let toggle = app.checkBoxes["PreferencesGeneralView.alwaysAskWhereToSaveFiles"]
         XCTAssertTrue(toggle.waitForExistence(timeout: UITests.Timeouts.elementExistence))
         if (toggle.value as? Bool) != enabled {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1210206165312650?focus=true

### Description:
This change attempts fixing downloads UI test by scrolling the settings view in order to reveal
downloads-related checkbox on the screen.

### Testing Steps
Verify that [UI tests workflow](https://github.com/duckduckgo/apple-browsers/actions/runs/14964878651) passes.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)