### PR TITLE
Adds feature flag for my upcoming app-updates work

### DIFF
--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -55,6 +55,7 @@ public enum FeatureFlag: String, CaseIterable {
     case historyView
 
     case autoUpdateInDEBUG
+    case updatesWontAutomaticallyRestartApp
 
     case autofillPartialFormSaves
     case autocompleteTabs
@@ -126,6 +127,7 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .historyView,
                 .webExtensions,
                 .autoUpdateInDEBUG,
+                .updatesWontAutomaticallyRestartApp,
                 .popoverVsBannerExperiment,
                 .privacyProAuthV2,
                 .scamSiteProtection,
@@ -177,6 +179,8 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .historyView:
             return .remoteReleasable(.subfeature(HTMLHistoryPageSubfeature.isLaunched))
         case .autoUpdateInDEBUG:
+            return .disabled
+        case .updatesWontAutomaticallyRestartApp:
             return .disabled
         case .autofillPartialFormSaves:
             return .remoteReleasable(.subfeature(AutofillSubfeature.partialFormSaves))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206580121312550/task/1210207266901701

### Description

Adds a local feature flag for testing upcoming work on updates.

### Testing Steps

Simply verify that as an internal user you can see the feature flag in Debug > Feature Flags, and that it's off by default.

### Impact and Risks

Zero risk or impact.

#### What could go wrong?

NA

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)