### PR TITLE
Close Fire popover when opening new Fire Window

### DIFF
--- a/macOS/DuckDuckGo/Fire/View/FirePopoverViewController.swift
+++ b/macOS/DuckDuckGo/Fire/View/FirePopoverViewController.swift
@@ -143,6 +143,7 @@ final class FirePopoverViewController: NSViewController {
 
     @IBAction func openNewBurnerWindowAction(_ sender: Any) {
         NSApp.delegateTyped.newBurnerWindow(self)
+        delegate?.firePopoverViewControllerDidCancel(self)
     }
 
     @IBAction func openDetailsButtonAction(_ sender: Any) {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210218566503698?focus=true

### Description
This change updates Fire Popover so that when a new Fire Window is requested from the popover,
the popover is automatically closed.

### Testing Steps
1. Click Fire Button
2. Click “Open new Fire Window” button in the Fire popover.
3. Verify that the Fire Window is opened and that the Fire popover is closed.

### Impact and Risks
Low: Minor visual bug fix.

### Notes to Reviewer
Please note that the app will fail an assertion after closing Fire Window which is [a known issue tracked elsewhere](https://app.asana.com/1/137249556945/project/1201037661562251/task/1210156034682808?focus=true).

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)