### PR TITLE
Run macOS Sandbox unit tests on xlarge runner

### DIFF
--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -117,9 +117,13 @@ jobs:
             flavor: Non-Sandbox
           - cache-key: sandbox-
             flavor: Sandbox
+          - runs-on: macos-15
+            flavor: Non-Sandbox
+          - runs-on: macos-15-xlarge
+            flavor: Sandbox
 
-    runs-on: macos-15
-    timeout-minutes: 60
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 30
 
     outputs:
       private-api-check-report: ${{ steps.private-api.outputs.report }}

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -119,7 +119,7 @@ jobs:
             flavor: Sandbox
 
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     outputs:
       private-api-check-report: ${{ steps.private-api.outputs.report }}


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1210224221508071?focus=true

### Description
This change brings back macos-15-xlarge runner for macOS App Store unit tests, that may otherwise time out at 30 minutes.

### Testing Steps
Verify that CI is green.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)