### PR TITLE
Fix rendering bookmarks bar popovers

### DIFF
--- a/macOS/DuckDuckGo/Bookmarks/View/BookmarkOutlineCellView.swift
+++ b/macOS/DuckDuckGo/Bookmarks/View/BookmarkOutlineCellView.swift
@@ -260,16 +260,19 @@ final class BookmarkOutlineCellView: NSTableCellView {
 
     private func updateUIAtNarrowWidths() {
         // Hide cell contents if menu button is visible
-        // and cell is too small to show at least menu and favicon without overlap
-        if frame.width < Constants.menuWidth + Constants.faviconWidth {
-            faviconImageWidthConstraint.constant = menuButton.isShown ? 0 : Constants.faviconWidth
-            titleLabel.widthAnchor.constraint(equalToConstant: 0)
-                .autoDeactivatedWhenViewIsHidden(menuButton)
-            urlLabel.widthAnchor.constraint(equalToConstant: 0)
-                .autoDeactivatedWhenViewIsHidden(menuButton)
-            countLabel.widthAnchor.constraint(equalToConstant: 0)
-                .autoDeactivatedWhenViewIsHidden(menuButton)
+        // and cell is too small to show at least menu and favicon without overlap.
+        // Skip adjustments until the view is on a window to not affect bookmarks bar popovers sizing.
+        guard window != nil, frame.width < Constants.menuWidth + Constants.faviconWidth else {
+            return
         }
+
+        faviconImageWidthConstraint.constant = menuButton.isShown ? 0 : Constants.faviconWidth
+        titleLabel.widthAnchor.constraint(equalToConstant: 0)
+            .autoDeactivatedWhenViewIsHidden(menuButton)
+        urlLabel.widthAnchor.constraint(equalToConstant: 0)
+            .autoDeactivatedWhenViewIsHidden(menuButton)
+        countLabel.widthAnchor.constraint(equalToConstant: 0)
+            .autoDeactivatedWhenViewIsHidden(menuButton)
     }
 
     override func layout() {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210231998767740?focus=true

### Description
This change skips applying sizing logic for narrow frames of BookmarkOutlineCellView until it’s added to the view hierarchy.
This ensures that the cell view is correctly sized before being displayed in a popover, while not breaking
existing logic to handle narrow application windows (when cells are used inside Bookmarks Manager).

### Testing Steps
1. Add bookmarks folder to boomarks
2. Show bookmarks bar
3. Click on a folder
4. Verify that bookmarks are not truncated.
5. Open Bookmarks Manager and shrink the window horizontally. Verify that bookmarks outline view (side panel) is correctly shrank.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)