### PR TITLE
iOS: DuckPlayer 62. Bugfix. Welcome message shown incorrectly

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -176,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "ae33e5941bb88d88538d0a6b19ca0b01e6c76dcf",
-        "version" : "1.3.1"
+        "revision" : "a54383ada6cecde007d374f58f864e29370ba5c3",
+        "version" : "1.3.2"
       }
     },
     {
@@ -203,8 +203,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "a6ce32a18b81b04ce7e897d1d98df6eb2da04786",
-        "version" : "3.12.2"
+        "revision" : "e8d6eba1fef23ae5b359c46b03f7d94be2f41fed",
+        "version" : "3.12.3"
       }
     },
     {

--- a/iOS/DuckDuckGo/DuckPlayer/DuckPlayerSettings.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/DuckPlayerSettings.swift
@@ -443,6 +443,7 @@ final class DuckPlayerSettingsDefault: DuckPlayerSettings {
                     self.nativeUISERPEnabled = true
                     self.nativeUIYoutubeMode = .ask
                     self.autoplay = true
+                    self.welcomeMessageShown = false
                     self.primingMessagePresented = false
 
                 case .nativeOptOut:
@@ -453,8 +454,9 @@ final class DuckPlayerSettingsDefault: DuckPlayerSettings {
                     self.autoplay = true
                     // Reset the welcome message shown flag
                     self.welcomeMessageShown = false
-                    self.primingMessagePresented = true // Never present the priming message for nativeOptOut
+                    self.primingMessagePresented = true
                 }
+                triggerNotification()
 
             }
         }

--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/DuckPlayerNativeUIPresenter.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/DuckPlayerNativeUIPresenter.swift
@@ -135,6 +135,9 @@ final class DuckPlayerNativeUIPresenter {
         constraintUpdatePublisher.eraseToAnyPublisher()
     }
 
+    // State management for pill presentation
+    private var presentedPillType: PillType?
+
     // MARK: - Public Methods
     ///
     /// - Parameter appSettings: The application settings
@@ -321,6 +324,7 @@ final class DuckPlayerNativeUIPresenter {
         // Then clean up references
         containerViewController = nil
         containerViewModel = nil
+        presentedPillType = nil
         containerCancellables.removeAll()
 
         // Finally ensure constraints are reset
@@ -384,6 +388,12 @@ extension DuckPlayerNativeUIPresenter: DuckPlayerNativeUIPresenting {
         if state.videoID != videoID {
             state.hasBeenShown = false
             state.videoID = videoID
+            presentedPillType = nil
+        }
+
+        // If the welcome pill is already presented, don't show the entry pill
+        if presentedPillType == .welcome {
+            return
         }
 
         // Determine the pill type
@@ -397,6 +407,8 @@ extension DuckPlayerNativeUIPresenter: DuckPlayerNativeUIPresenting {
             // Logic for returning users
             pillType = state.hasBeenShown ? .reEntry : .entry
         }
+
+        presentedPillType = pillType
 
         // If no specific timestamp is provided, use the current stave value
         let timestamp = timestamp ?? state.timestamp ?? 0
@@ -547,6 +559,9 @@ extension DuckPlayerNativeUIPresenter: DuckPlayerNativeUIPresenting {
 
         // Update State
         self.state.hasBeenShown = true
+        
+        // Reset the presented pill type as we are transitioning to the full player
+        self.presentedPillType = nil
 
         // Subscribe to Navigation Request Publisher
         viewModel.youtubeNavigationRequestPublisher


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204099484721401/task/1209565602144527?focus=true
Tech Design URL:
CC:

### Description
- Fixes a bug causing the Welcome pill to be presented incorrectly.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Make yourself internal User
2. HIt the fire button 🔥 
3. Go to Settings > DuckPlayer and select "Opt-in" variant from the list (if already selected, select 'Classic' go back to step 2)
4. Close settings and hit the fire button again 🔥 
5. Go directly to a Youtube video by URL -> https://m.youtube.com/watch?v=yWBz2qZJ8zY
6. 👁️  Confirm the Priming message modal is presented properly

**Now (Correct):** 
<img width="300" alt="Screenshot 2025-05-13 at 15 33 52" src="https://github.com/user-attachments/assets/e3a2a4f9-d6d0-41e6-9642-987c4fe876fb" />

**Before (Incorrect):**
<img width="300" alt="Screenshot 2025-05-13 at 15 33 52" src="https://github.com/user-attachments/assets/be238b9c-3bfe-4199-8826-41e35f7226d3" />


### Impact and Risks
(No impact in live users.  This is internal only)
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
N/A

### Quality Considerations
Bugfix covered by new tests 


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)