### PR TITLE
Use SUI ScrollView on NTP to prevent hang

### DIFF
--- a/iOS/DuckDuckGo/SimpleNewTabPageView.swift
+++ b/iOS/DuckDuckGo/SimpleNewTabPageView.swift
@@ -73,13 +73,7 @@ private extension SimpleNewTabPageView {
     @ViewBuilder
     private var sectionsView: some View {
         GeometryReader { proxy in
-            let shadowColor = viewModel.isExperimentalAppearanceEnabled ? Color(designSystemColor: .shadowPrimary) : .clear
-            NewTabPageShadowScrollView(shadowColor: shadowColor,
-                                       overflowOffset: 50,
-                                       setUpScrollView: { scrollView in
-                scrollView.backgroundColor = .clear
-                scrollView.keyboardDismissMode = .onDrag
-            }) {
+                ScrollView {
                 VStack(spacing: Metrics.sectionSpacing) {
                     
                     messagesSectionView


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1210235241853128?focus=true
Tech Design URL:
CC:

### Description

Rolls back change that introduced infinite SwiftUI updates hang caused by UIScrollView adjusting insets along with the keyboard. 

### Testing Steps
1. Add 15-20 favorites
2. Open NTP
3. Open keyboard by tapping on URL bar

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Not much - reverting to what was used previously for a good amount of time.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)