### PR TITLE
Layout suggestions window every time the window is resized

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -88,10 +88,6 @@ final class AddressBarTextField: NSTextField {
         currentEditor()?.selectAll(self)
     }
 
-    func viewDidLayout() {
-        layoutSuggestionWindow()
-    }
-
     // MARK: Observation
 
     private func subscribeToSuggestionResult() {

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -58,6 +58,7 @@ final class AddressBarTextField: NSTextField {
     private var selectedTabViewModelCancellable: AnyCancellable?
     private var addressBarStringCancellable: AnyCancellable?
     private var contentTypeCancellable: AnyCancellable?
+    private var windowFrameCancellable: AnyCancellable?
 
     weak var onboardingDelegate: OnboardingAddressBarReporting?
 
@@ -634,6 +635,12 @@ final class AddressBarTextField: NSTextField {
         guard !suggestionWindow.isVisible, isFirstResponder else { return }
 
         window.addChildWindow(suggestionWindow, ordered: .above)
+
+        windowFrameCancellable = window.publisher(for: \.frame)
+            .sink { [weak self] _ in
+                self?.layoutSuggestionWindow()
+            }
+
         layoutSuggestionWindow()
     }
 
@@ -643,6 +650,8 @@ final class AddressBarTextField: NSTextField {
 
         parent.removeChildWindow(suggestionWindow)
         suggestionWindow.orderOut(nil)
+        windowFrameCancellable?.cancel()
+        windowFrameCancellable = nil
     }
 
     private func layoutSuggestionWindow() {

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -204,7 +204,6 @@ final class AddressBarViewController: NSViewController {
     }
 
     override func viewDidLayout() {
-        addressBarTextField.viewDidLayout()
         updateSwitchToTabBoxAppearance()
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210239511758406?focus=true

### Description
This change adds a new observer to always layout suggestions window when the parent window frame changes.
It replaces the existing solution that would layout suggestions window only when address bar text field frame changed.

### Testing Steps
1. Type in the address bar to display autocomplete suggestions window.
2. While suggestions window is shown, resize the app window horizontally and vertically and move it freely. Verify that the suggestions window always follows address bar.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)