### PR TITLE
Unused AuthToken removed, it wouldn't work anyway with AuthV2

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/API/APIClient.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/API/APIClient.swift
@@ -100,11 +100,10 @@ struct APIClient {
 
     typealias Platform = MaliciousSiteDetector.APIEnvironment.Platform
     let platform: Platform
-    let authToken: String?
     let environment: APIClientEnvironment
     private let service: APIService
 
-    init(environment: APIClientEnvironment, platform: Platform? = nil, authToken: String? = nil, service: APIService = DefaultAPIService(urlSession: .shared)) {
+    init(environment: APIClientEnvironment, platform: Platform? = nil, service: APIService = DefaultAPIService(urlSession: .shared)) {
         if let platform {
             self.platform = platform
         } else {
@@ -116,14 +115,13 @@ struct APIClient {
             fatalError("Unsupported platform")
 #endif
         }
-        self.authToken = authToken
         self.environment = environment
         self.service = service
     }
 
     func load<R: Request>(_ requestConfig: R) async throws -> R.Response {
         let requestType = requestConfig.requestType
-        let headers = environment.headers(for: requestType, platform: platform, authToken: authToken)
+        let headers = environment.headers(for: requestType, platform: platform, authToken: nil)
         let url = environment.url(for: requestType, platform: platform)
         let timeout = environment.timeout(for: requestType) ?? requestConfig.defaultTimeout ?? 60
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208717418466383/task/1210249767398976?focus=true

### Description

MaliciousSiteProtection Apple APIClient contains an unused AuthToken that needs to be removed because, even if used, wouldn't work with AuthV2

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)