### PR TITLE
macOS visual refresh: Increase address bar height when is focused

### DIFF
--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -380,7 +380,7 @@ final class MainViewController: NSViewController {
 
     private func resizeNavigationBar(isHomePage homePage: Bool, animated: Bool) {
         updateDividerColor(isShowingHomePage: homePage)
-        navigationBarViewController.resizeAddressBar(for: homePage ? .homePage : (isInPopUpWindow ? .popUpWindow : .default), animated: animated, focused: true)
+        navigationBarViewController.resizeAddressBar(for: homePage ? .homePage : (isInPopUpWindow ? .popUpWindow : .default), animated: animated)
     }
 
     private var lastTabContent = Tab.TabContent.none

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -380,7 +380,7 @@ final class MainViewController: NSViewController {
 
     private func resizeNavigationBar(isHomePage homePage: Bool, animated: Bool) {
         updateDividerColor(isShowingHomePage: homePage)
-        navigationBarViewController.resizeAddressBar(for: homePage ? .homePage : (isInPopUpWindow ? .popUpWindow : .default), animated: animated)
+        navigationBarViewController.resizeAddressBar(for: homePage ? .homePage : (isInPopUpWindow ? .popUpWindow : .default), animated: animated, focused: true)
     }
 
     private var lastTabContent = Tab.TabContent.none

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -980,16 +980,12 @@ extension AddressBarTextField: NSTextFieldDelegate {
     func controlTextDidEndEditing(_ obj: Notification) {
         suggestionContainerViewModel?.clearUserStringValue()
         hideSuggestionWindow()
+        focusDelegate?.addressBarDidLoseFocus(self)
     }
 
     func controlTextDidChange(_ obj: Notification) {
         handleTextDidChange()
         onboardingDelegate?.measureAddressBarTypedIn()
-    }
-
-    override func textDidEndEditing(_ notification: Notification) {
-        super.textDidEndEditing(notification)
-        focusDelegate?.addressBarDidLoseFocus(self)
     }
 
     private func handleTextDidChange() {

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -26,6 +26,11 @@ import Suggestions
 import Subscription
 import os.log
 
+protocol AddressBarTextFieldFocusDelegate: AnyObject {
+    func addressBarDidFocus(_ addressBarTextField: AddressBarTextField)
+    func addressBarDidLoseFocus(_ addressBarTextField: AddressBarTextField)
+}
+
 final class AddressBarTextField: NSTextField {
 
     var tabCollectionViewModel: TabCollectionViewModel! {
@@ -61,6 +66,7 @@ final class AddressBarTextField: NSTextField {
     private var windowFrameCancellable: AnyCancellable?
 
     weak var onboardingDelegate: OnboardingAddressBarReporting?
+    weak var focusDelegate: AddressBarTextFieldFocusDelegate?
 
     private let searchPreferences: SearchPreferences = SearchPreferences.shared
 
@@ -385,6 +391,14 @@ final class AddressBarTextField: NSTextField {
             // resign first responder if nothing has changed
             self.window?.makeFirstResponder(nil)
         }
+    }
+
+    override func becomeFirstResponder() -> Bool {
+        let result = super.becomeFirstResponder()
+        if result {
+            focusDelegate?.addressBarDidFocus(self)
+        }
+        return result
     }
 
     private func updateTabUrlWithUrl(_ providedUrl: URL, userEnteredValue: String, downloadRequested: Bool, suggestion: Suggestion?) {
@@ -971,6 +985,11 @@ extension AddressBarTextField: NSTextFieldDelegate {
     func controlTextDidChange(_ obj: Notification) {
         handleTextDidChange()
         onboardingDelegate?.measureAddressBarTypedIn()
+    }
+
+    override func textDidEndEditing(_ notification: Notification) {
+        super.textDidEndEditing(notification)
+        focusDelegate?.addressBarDidLoseFocus(self)
     }
 
     private func handleTextDidChange() {

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -22,6 +22,10 @@ import Lottie
 import Common
 import AIChat
 
+protocol AddressBarViewControllerDelegate: AnyObject {
+    func resizeAddressBarForHomePage(_ addressBarViewController: AddressBarViewController, isFocused: Bool)
+}
+
 final class AddressBarViewController: NSViewController {
 
     enum Mode: Equatable {
@@ -109,6 +113,8 @@ final class AddressBarViewController: NSViewController {
     /// save mouse-down position to handle same-place clicks outside of the Address Bar to remove first responder
     private var clickPoint: NSPoint?
 
+    weak var delegate: AddressBarViewControllerDelegate?
+
     // MARK: - View Lifecycle
 
     required init?(coder: NSCoder) {
@@ -169,6 +175,8 @@ final class AddressBarViewController: NSViewController {
 
         // disallow dragging window by the background view
         activeBackgroundView.interceptClickEvents = true
+
+        addressBarTextField.focusDelegate = self
     }
 
     override func viewWillAppear() {
@@ -776,6 +784,16 @@ extension AddressBarViewController: NSDraggingDestination {
             // activate the address bar and replace its string value
             return addressBarTextField.performDragOperation(draggingInfo)
         }
+    }
+}
+
+extension AddressBarViewController: AddressBarTextFieldFocusDelegate {
+    func addressBarDidFocus(_ addressBarTextField: AddressBarTextField) {
+        delegate?.resizeAddressBarForHomePage(self, isFocused: true)
+    }
+
+    func addressBarDidLoseFocus(_ addressBarTextField: AddressBarTextField) {
+        delegate?.resizeAddressBarForHomePage(self, isFocused: false)
     }
 }
 

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -820,7 +820,7 @@ final class NavigationBarViewController: NSViewController {
 
     private var daxFadeInAnimation: DispatchWorkItem?
     private var heightChangeAnimation: DispatchWorkItem?
-    func resizeAddressBar(for sizeClass: AddressBarSizeClass, animated: Bool, focused: Bool = false) {
+    func resizeAddressBar(for sizeClass: AddressBarSizeClass, animated: Bool) {
         daxFadeInAnimation?.cancel()
         heightChangeAnimation?.cancel()
 
@@ -830,8 +830,9 @@ final class NavigationBarViewController: NSViewController {
         let performResize = { [weak self] in
             guard let self else { return }
 
+            let isAddressBarFocused = view.window?.firstResponder == addressBarViewController?.addressBarTextField.currentEditor()
             let height: NSLayoutConstraint = animated ? navigationBarHeightConstraint.animator() : navigationBarHeightConstraint
-            height.constant = visualStyle.addressBarHeight(for: sizeClass, focused: focused)
+            height.constant = visualStyle.addressBarHeight(for: sizeClass, focused: isAddressBarFocused)
 
             let barTop: NSLayoutConstraint = animated ? addressBarTopConstraint.animator() : addressBarTopConstraint
             barTop.constant = visualStyle.addressBarTopPadding(for: sizeClass)
@@ -1667,7 +1668,7 @@ extension NavigationBarViewController: AddressBarViewControllerDelegate {
 
     func resizeAddressBarForHomePage(_ addressBarViewController: AddressBarViewController, isFocused: Bool) {
         let addressBarSizeClass: AddressBarSizeClass = tabCollectionViewModel.selectedTabViewModel?.tab.content == .newtab ? .homePage : .default
-        resizeAddressBar(for: addressBarSizeClass, animated: true, focused: isFocused)
+        resizeAddressBar(for: addressBarSizeClass, animated: true)
     }
 }
 

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -327,6 +327,7 @@ final class NavigationBarViewController: NSViewController {
         }
 
         self.addressBarViewController = addressBarViewController
+        self.addressBarViewController?.delegate = self
         return addressBarViewController
     }
 
@@ -819,7 +820,7 @@ final class NavigationBarViewController: NSViewController {
 
     private var daxFadeInAnimation: DispatchWorkItem?
     private var heightChangeAnimation: DispatchWorkItem?
-    func resizeAddressBar(for sizeClass: AddressBarSizeClass, animated: Bool) {
+    func resizeAddressBar(for sizeClass: AddressBarSizeClass, animated: Bool, focused: Bool = false) {
         daxFadeInAnimation?.cancel()
         heightChangeAnimation?.cancel()
 
@@ -830,7 +831,7 @@ final class NavigationBarViewController: NSViewController {
             guard let self else { return }
 
             let height: NSLayoutConstraint = animated ? navigationBarHeightConstraint.animator() : navigationBarHeightConstraint
-            height.constant = visualStyle.addressBarHeight(for: sizeClass)
+            height.constant = visualStyle.addressBarHeight(for: sizeClass, focused: focused)
 
             let barTop: NSLayoutConstraint = animated ? addressBarTopConstraint.animator() : addressBarTopConstraint
             barTop.constant = visualStyle.addressBarTopPadding(for: sizeClass)
@@ -1660,6 +1661,14 @@ extension NavigationBarViewController: MouseOverButtonDelegate {
         }
     }
 
+}
+
+extension NavigationBarViewController: AddressBarViewControllerDelegate {
+
+    func resizeAddressBarForHomePage(_ addressBarViewController: AddressBarViewController, isFocused: Bool) {
+        let addressBarSizeClass: AddressBarSizeClass = tabCollectionViewModel.selectedTabViewModel?.tab.content == .newtab ? .homePage : .default
+        resizeAddressBar(for: addressBarSizeClass, animated: true, focused: isFocused)
+    }
 }
 
 #if DEBUG || REVIEW

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
@@ -23,7 +23,7 @@ import NetworkProtectionUI
 
 protocol VisualStyleProviding {
     /// Address bar
-    func addressBarHeight(for type: AddressBarSizeClass) -> CGFloat
+    func addressBarHeight(for type: AddressBarSizeClass, focused: Bool) -> CGFloat
     func addressBarTopPadding(for type: AddressBarSizeClass) -> CGFloat
     func addressBarBottomPadding(for type: AddressBarSizeClass) -> CGFloat
     func addressBarStackSpacing(for type: AddressBarSizeClass) -> CGFloat
@@ -96,6 +96,8 @@ struct VisualStyle: VisualStyleProviding {
     private let addressBarBottomPaddingForHomePage: CGFloat
     private let addressBarBottomPaddingForPopUpWindow: CGFloat
     private let alwaysShowAddressBarOutline: Bool
+    private let addressBarHeightWhenFocused: CGFloat
+    private let addressBarHeightForHomePageWhenFocused: CGFloat
 
     let shouldShowLogoinInAddressBar: Bool
     let toolbarButtonsCornerRadius: CGFloat
@@ -126,10 +128,10 @@ struct VisualStyle: VisualStyleProviding {
     let bookmarksBarMenuBookmarkIcon: NSImage
     let bookmarksBarMenuFolderIcon: NSImage
 
-    func addressBarHeight(for type: AddressBarSizeClass) -> CGFloat {
+    func addressBarHeight(for type: AddressBarSizeClass, focused: Bool) -> CGFloat {
         switch type {
-        case .default: return addressBarHeightForDefault
-        case .homePage: return addressBarHeightForHomePage
+        case .default: return focused ? addressBarHeightWhenFocused : addressBarHeightForDefault
+        case .homePage: return focused ? addressBarHeightForHomePageWhenFocused : addressBarHeightForHomePage
         case .popUpWindow: return addressBarHeightForPopUpWindow
         }
     }
@@ -172,6 +174,8 @@ struct VisualStyle: VisualStyleProviding {
                            addressBarBottomPaddingForHomePage: 8,
                            addressBarBottomPaddingForPopUpWindow: 0,
                            alwaysShowAddressBarOutline: false,
+                           addressBarHeightWhenFocused: 48,
+                           addressBarHeightForHomePageWhenFocused: 52,
                            shouldShowLogoinInAddressBar: false,
                            toolbarButtonsCornerRadius: 4,
                            backButtonImage: .back,
@@ -213,6 +217,8 @@ struct VisualStyle: VisualStyleProviding {
                            addressBarBottomPaddingForHomePage: 6,
                            addressBarBottomPaddingForPopUpWindow: 6,
                            alwaysShowAddressBarOutline: true,
+                           addressBarHeightWhenFocused: 56,
+                           addressBarHeightForHomePageWhenFocused: 56,
                            shouldShowLogoinInAddressBar: true,
                            toolbarButtonsCornerRadius: 9,
                            backButtonImage: .backNew,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1210129405457243?focus=true
Tech Design URL:
CC:

### Description
Expand the address bar height when it gets focused. The size should got back to normal when the address bar loses focus.

### Testing Steps
1. Set internal user state
2. Go to Debug -> Feature Flag Overrides, and override the `visualRefresh`
3. Open a new window, and select and unselect the address bar
4. Check the address bar height increases when it is focused, and it is back to normal when it loses focus
5. This should happen for all pages (new tab, home page, default)
6. Remove the feature flag override and check it doesn’t happen

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
My only quality consideration, is that we added a new delegate method that is not behind the feature flag, we call it and resize the address bar with the address bar numbers. Do you think we should add one?

### Notes to Reviewer
Check question in quality considerations.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)