### PR TITLE
Fix flaky favicon tests

### DIFF
--- a/iOS/DuckDuckGoTests/FaviconsHelperTests.swift
+++ b/iOS/DuckDuckGoTests/FaviconsHelperTests.swift
@@ -26,10 +26,17 @@ class FaviconsHelperTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        Favicons.Constants.tabsCache.clearDiskCache()
+
+        let expectation = expectation(description: "FaviconHelperTests setup")
+        expectation.expectedFulfillmentCount = 2
+
         Favicons.Constants.tabsCache.clearMemoryCache()
-        Favicons.Constants.fireproofCache.clearDiskCache()
         Favicons.Constants.fireproofCache.clearMemoryCache()
+
+        Favicons.Constants.tabsCache.clearDiskCache() { expectation.fulfill() }
+        Favicons.Constants.fireproofCache.clearDiskCache() { expectation.fulfill() }
+
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testLoadFaviconSync_WhenPlayerDomain_ReturnsDuckPlayer() {
@@ -53,7 +60,7 @@ class FaviconsHelperTests: XCTestCase {
     }
     
     func testLoadFaviconSync_WhenMissingFavicon_ReturnsFakeFavicon() {
-        let result = FaviconsHelper.loadFaviconSync(forDomain: "example.com",
+        let result = FaviconsHelper.loadFaviconSync(forDomain: "missingfavicon1.com",
                                                    usingCache: .fireproof,
                                                    useFakeFavicon: true)
         
@@ -63,7 +70,7 @@ class FaviconsHelperTests: XCTestCase {
     
     func testLoadFaviconSync_WhenCachedFavicon_ReturnsFromCache() {
         // Setup
-        let domain = "example.com"
+        let domain = "missingfavicon2.com"
         let cache = Favicons.Constants.caches[.fireproof]!
         let resource = Favicons.shared.defaultResource(forDomain: domain)!
         let testImage = UIImage(named: "Logo")!

--- a/iOS/DuckDuckGoTests/FaviconsHelperTests.swift
+++ b/iOS/DuckDuckGoTests/FaviconsHelperTests.swift
@@ -32,9 +32,14 @@ class FaviconsHelperTests: XCTestCase {
 
         Favicons.Constants.tabsCache.clearMemoryCache()
         Favicons.Constants.fireproofCache.clearMemoryCache()
-
-        Favicons.Constants.tabsCache.clearDiskCache() { expectation.fulfill() }
-        Favicons.Constants.fireproofCache.clearDiskCache() { expectation.fulfill() }
+        
+        Favicons.Constants.tabsCache.clearDiskCache() {
+            expectation.fulfill()
+        }
+        
+        Favicons.Constants.fireproofCache.clearDiskCache() {
+            expectation.fulfill()
+        }
 
         waitForExpectations(timeout: 5, handler: nil)
     }

--- a/iOS/DuckDuckGoTests/FaviconsHelperTests.swift
+++ b/iOS/DuckDuckGoTests/FaviconsHelperTests.swift
@@ -32,14 +32,9 @@ class FaviconsHelperTests: XCTestCase {
 
         Favicons.Constants.tabsCache.clearMemoryCache()
         Favicons.Constants.fireproofCache.clearMemoryCache()
-        
-        Favicons.Constants.tabsCache.clearDiskCache() {
-            expectation.fulfill()
-        }
-        
-        Favicons.Constants.fireproofCache.clearDiskCache() {
-            expectation.fulfill()
-        }
+
+        Favicons.Constants.tabsCache.clearDiskCache { expectation.fulfill() }
+        Favicons.Constants.fireproofCache.clearDiskCache { expectation.fulfill() }
 
         waitForExpectations(timeout: 5, handler: nil)
     }

--- a/iOS/DuckDuckGoTests/FaviconsHelperTests.swift
+++ b/iOS/DuckDuckGoTests/FaviconsHelperTests.swift
@@ -65,7 +65,7 @@ class FaviconsHelperTests: XCTestCase {
     }
     
     func testLoadFaviconSync_WhenMissingFavicon_ReturnsFakeFavicon() {
-        let result = FaviconsHelper.loadFaviconSync(forDomain: "missingfavicon1.com",
+        let result = FaviconsHelper.loadFaviconSync(forDomain: "missingfavicon.com",
                                                    usingCache: .fireproof,
                                                    useFakeFavicon: true)
         
@@ -75,7 +75,7 @@ class FaviconsHelperTests: XCTestCase {
     
     func testLoadFaviconSync_WhenCachedFavicon_ReturnsFromCache() {
         // Setup
-        let domain = "missingfavicon2.com"
+        let domain = "example.com"
         let cache = Favicons.Constants.caches[.fireproof]!
         let resource = Favicons.shared.defaultResource(forDomain: domain)!
         let testImage = UIImage(named: "Logo")!


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1210256798348696?focus=true
Tech Design URL:
CC:

### Description

This PR fixes flaky favicon tests.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI is green
2. Run the test locally many times and check that it always passes - you can do this by right clicking the test indicator and selecting "Run Repeatedly"

You can force this failure with the original code by checking out `main`, commenting out the `clearDiskCache()` functions, and running the test suite. This is what was technically happening before, since `clearDiskCache()` wasn't able to complete in time.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

None, only affects the test suite and the test was already flaky anyway :)

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)