### PR TITLE
Only display 1 about panel at any given time

### DIFF
--- a/SharedPackages/BrowserServicesKit/Package.resolved
+++ b/SharedPackages/BrowserServicesKit/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/DesignResourcesKit",
       "state" : {
-        "revision" : "f07a285c6edb5265b3a256c87124135ebcedee6f",
-        "version" : "4.3.0"
+        "revision" : "e45e56bb3dd891db1f860eb767a22b91e8b5ab3d",
+        "version" : "4.4.0"
       }
     },
     {

--- a/SharedPackages/DataBrokerProtectionCore/Package.resolved
+++ b/SharedPackages/DataBrokerProtectionCore/Package.resolved
@@ -21,10 +21,10 @@
     {
       "identity" : "designresourceskit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/duckduckgo/DesignResourcesKit.git",
+      "location" : "https://github.com/duckduckgo/DesignResourcesKit",
       "state" : {
-        "revision" : "f07a285c6edb5265b3a256c87124135ebcedee6f",
-        "version" : "4.3.0"
+        "revision" : "e45e56bb3dd891db1f860eb767a22b91e8b5ab3d",
+        "version" : "4.4.0"
       }
     },
     {

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/DesignResourcesKit.git",
       "state" : {
-        "revision" : "f07a285c6edb5265b3a256c87124135ebcedee6f",
-        "version" : "4.3.0"
+        "revision" : "e45e56bb3dd891db1f860eb767a22b91e8b5ab3d",
+        "version" : "4.4.0"
       }
     },
     {

--- a/macOS/DuckDuckGo/Application/AboutPanel.swift
+++ b/macOS/DuckDuckGo/Application/AboutPanel.swift
@@ -93,9 +93,9 @@ struct AboutPanelView: View {
 // Controller to display the About panel
 final class AboutPanelController {
 
-    private var panel: NSPanel!
+    private var panel: AboutPanelWindow
 
-    init(internalUserDecider: InternalUserDecider) {
+    private init(internalUserDecider: InternalUserDecider) {
         panel = AboutPanelWindow(
             contentRect: NSRect(x: 0, y: 0, width: 360, height: 300),
             styleMask: [.titled, .closable],
@@ -109,9 +109,17 @@ final class AboutPanelController {
         panel.contentView = hosting.view
     }
 
-    func show() {
-        panel.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+    private func showPanel() {
+        panel.show()
+    }
+
+    static func show(internalUserDecider: InternalUserDecider) {
+        guard let panel = NSApp.windows.first(where: { $0 is AboutPanelWindow }) as? AboutPanelWindow else {
+            let aboutController = AboutPanelController(internalUserDecider: internalUserDecider)
+            aboutController.showPanel()
+            return
+        }
+        panel.show()
     }
 }
 
@@ -130,5 +138,10 @@ private class AboutPanelWindow: NSPanel {
         }
         self.close()
         return true
+    }
+
+    func show() {
+        makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
     }
 }

--- a/macOS/DuckDuckGo/Application/AboutPanel.swift
+++ b/macOS/DuckDuckGo/Application/AboutPanel.swift
@@ -91,6 +91,7 @@ struct AboutPanelView: View {
 }
 
 // Controller to display the About panel
+@MainActor
 final class AboutPanelController {
 
     private var panel: AboutPanelWindow

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -263,8 +263,7 @@ extension AppDelegate {
     }
 
     @objc func openAbout(_ sender: Any?) {
-        let aboutController = AboutPanelController(internalUserDecider: internalUserDecider)
-        aboutController.show()
+        AboutPanelController.show(internalUserDecider: internalUserDecider)
     }
 
     @objc func openImportBrowserDataWindow(_ sender: Any?) {

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -262,6 +262,7 @@ extension AppDelegate {
         }
     }
 
+    @MainActor
     @objc func openAbout(_ sender: Any?) {
         AboutPanelController.show(internalUserDecider: internalUserDecider)
     }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210253905192916?focus=true

### Description
Add a static function to AboutPanelController that’s responsible for finding a panel on screen,
and only create a fresh one if not found.

### Testing Steps
1. Select Main Menu -> DuckDuckGo -> About DuckDuckGo
2. Verify that it presents the “About” panel
3. Don’t close the panel and repeat step 1. Verify that no new panel was created.
4. Don’t close the panel, activate the main app window and repeat step 1. Verify that the about panel was brought to front.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)