### PR TITLE
Update address bar clear button to work like Esc key

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -28,7 +28,7 @@ import PixelKit
 
 protocol AddressBarButtonsViewControllerDelegate: AnyObject {
 
-    func addressBarButtonsViewControllerClearButtonClicked(_ addressBarButtonsViewController: AddressBarButtonsViewController)
+    func addressBarButtonsViewControllerCancelButtonClicked(_ addressBarButtonsViewController: AddressBarButtonsViewController)
     func addressBarButtonsViewController(_ controller: AddressBarButtonsViewController, didUpdateAIChatButtonVisibility isVisible: Bool)
     func addressBarButtonsViewControllerHideAIChatButtonClicked(_ addressBarButtonsViewController: AddressBarButtonsViewController)
 }
@@ -69,7 +69,7 @@ final class AddressBarButtonsViewController: NSViewController {
     @IBOutlet weak var bookmarkButton: AddressBarButton!
     @IBOutlet weak var imageButtonWrapper: NSView!
     @IBOutlet weak var imageButton: NSButton!
-    @IBOutlet weak var clearButton: NSButton!
+    @IBOutlet weak var cancelButton: NSButton!
     @IBOutlet private weak var buttonsContainer: NSStackView!
     @IBOutlet weak var aiChatButton: AddressBarMenuButton!
 
@@ -321,8 +321,8 @@ final class AddressBarButtonsViewController: NSViewController {
         openBookmarkPopover(setFavorite: false, accessPoint: .button)
     }
 
-    @IBAction func clearButtonAction(_ sender: Any) {
-        delegate?.addressBarButtonsViewControllerClearButtonClicked(self)
+    @IBAction func cancelButtonAction(_ sender: Any) {
+        delegate?.addressBarButtonsViewControllerCancelButtonClicked(self)
     }
 
     @IBAction func privacyEntryPointButtonAction(_ sender: Any) {
@@ -368,7 +368,7 @@ final class AddressBarButtonsViewController: NSViewController {
     private func setupButtonsCornerRadius() {
         aiChatButton.setCornerRadius(visualStyle.addressBarButtonsCornerRadius)
         bookmarkButton.setCornerRadius(visualStyle.addressBarButtonsCornerRadius)
-        clearButton.setCornerRadius(visualStyle.addressBarButtonsCornerRadius)
+        cancelButton.setCornerRadius(visualStyle.addressBarButtonsCornerRadius)
         permissionButtons.setCornerRadius(visualStyle.addressBarButtonsCornerRadius)
         zoomButton.setCornerRadius(visualStyle.addressBarButtonsCornerRadius)
         privacyEntryPointButton.setCornerRadius(visualStyle.addressBarButtonsCornerRadius)
@@ -391,7 +391,7 @@ final class AddressBarButtonsViewController: NSViewController {
                 }
             }
 
-            return clearButton.isHidden && !hasEmptyAddressBar && (isMouseOverNavigationBar || popovers?.isEditBookmarkPopoverShown == true || isUrlBookmarked)
+            return cancelButton.isHidden && !hasEmptyAddressBar && (isMouseOverNavigationBar || popovers?.isEditBookmarkPopoverShown == true || isUrlBookmarked)
         }
 
         bookmarkButton.isShown = shouldShowBookmarkButton
@@ -450,7 +450,7 @@ final class AddressBarButtonsViewController: NSViewController {
     }
 
     private func updateAIChatDividerVisibility() {
-        let shouldShowDivider = clearButton.isShown || bookmarkButton.isShown
+        let shouldShowDivider = cancelButton.isShown || bookmarkButton.isShown
         aiChatDivider.isHidden = aiChatButton.isHidden || !shouldShowDivider
     }
 
@@ -546,7 +546,7 @@ final class AddressBarButtonsViewController: NSViewController {
     func updateButtons() {
         stopAnimationsAfterFocus()
 
-        clearButton.isShown = isTextFieldEditorFirstResponder && !textFieldValue.isEmpty
+        cancelButton.isShown = isTextFieldEditorFirstResponder && !textFieldValue.isEmpty
 
         updateImageButton()
         updatePrivacyEntryPointButton()

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -659,8 +659,8 @@ extension AddressBarViewController: AddressBarButtonsViewControllerDelegate {
         passiveTextFieldTrailingConstraint.constant = trailingConstant
     }
 
-    func addressBarButtonsViewControllerClearButtonClicked(_ addressBarButtonsViewController: AddressBarButtonsViewController) {
-        addressBarTextField.clearValue()
+    func addressBarButtonsViewControllerCancelButtonClicked(_ addressBarButtonsViewController: AddressBarButtonsViewController) {
+        _ = escapeKeyDown()
     }
 }
 

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="o2v-eH-jTI">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="o2v-eH-jTI">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -753,7 +753,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                                 <connections>
-                                    <action selector="clearButtonAction:" target="mcr-nj-GmC" id="m9h-NY-Ujx"/>
+                                    <action selector="cancelButtonAction:" target="mcr-nj-GmC" id="ead-BN-Oj3"/>
                                 </connections>
                             </button>
                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="2" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="L9C-04-I02" userLabel="Ai Chat Stack View">
@@ -1068,7 +1068,7 @@
                         <outlet property="bookmarkButton" destination="taC-vG-1fV" id="tbQ-qW-71o"/>
                         <outlet property="buttonsContainer" destination="HEu-ro-RSA" id="5r4-Ag-NpA"/>
                         <outlet property="cameraButton" destination="C2L-f9-L3r" id="xua-H5-hAx"/>
-                        <outlet property="clearButton" destination="kRc-0m-oqe" id="2sv-EP-8MW"/>
+                        <outlet property="cancelButton" destination="kRc-0m-oqe" id="iAr-0l-X5i"/>
                         <outlet property="externalSchemeButton" destination="gGA-Yv-pnz" id="Eyj-ms-jcc"/>
                         <outlet property="geolocationButton" destination="CN6-fJ-o2J" id="FP7-Od-wu8"/>
                         <outlet property="imageButton" destination="psi-hX-Kh9" id="gEt-yl-q9m"/>
@@ -1093,7 +1093,7 @@
         <image name="Arrow-Right-12" width="9" height="9"/>
         <image name="Back" width="16" height="16"/>
         <image name="Bookmark" width="16" height="16"/>
-        <image name="Bookmarks" width="24" height="24"/>
+        <image name="Bookmarks" width="16" height="16"/>
         <image name="Camera-Active" width="16" height="12"/>
         <image name="Camera-Icon" width="16" height="12"/>
         <image name="Camera-Tab-Blocked" width="16" height="14"/>


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1209860537312297?focus=true

### Description
This change fixes the behavior of address bar’s 'X' button so that it works exactly like the Esc key
(most importantly resign focus of the address bar rather than clear the text).

### Testing Steps
Verify that the ‘X’ button in the address bar works the same as Esc key when:
1. address bar is activated with a URL,
2. address bar is activated and text was edited.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)