### PR TITLE
Use two reuse pools for OmniBar cells

### DIFF
--- a/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -75,7 +75,8 @@ class SwipeTabsCoordinator: NSObject {
                 
         super.init()
         
-        collectionView.register(OmniBarCell.self, forCellWithReuseIdentifier: "omnibar")
+        collectionView.register(OmniBarCell.self, forCellWithReuseIdentifier: Constant.omniBarReuseIdentifier)
+        collectionView.register(OmniBarCell.self, forCellWithReuseIdentifier: Constant.templateReuseIdentifier)
         collectionView.isPagingEnabled = true
         collectionView.delegate = self
         collectionView.dataSource = self
@@ -167,6 +168,10 @@ class SwipeTabsCoordinator: NSObject {
         }
     }
 
+    private struct Constant {
+        static let omniBarReuseIdentifier = "omniBar"
+        static let templateReuseIdentifier = "template"
+    }
 }
 
 // MARK: UICollectionViewDelegate
@@ -361,11 +366,14 @@ extension SwipeTabsCoordinator: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "omnibar", for: indexPath) as? OmniBarCell else {
+        let isCurrentTab = tabsModel.currentIndex == indexPath.row || !isEnabled
+        let reuseIdentifier = isCurrentTab ? Constant.omniBarReuseIdentifier : Constant.templateReuseIdentifier
+
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath) as? OmniBarCell else {
             fatalError("Not \(OmniBarCell.self)")
         }
 
-        if !isEnabled || tabsModel.currentIndex == indexPath.row {
+        if isCurrentTab {
             cell.omniBar = coordinator.omniBar
         } else {
             // Strong reference while we use the omnibar


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1210229858278888
Tech Design URL:
CC: @amddg44 

### Description

Because "real" OmniBar was removed from the cell it probably meant it got reassigned to another one. This adds another reuse identifier distinguishing between the real and template OmniBars so that cells don't get cross-reused for these two cases.

### Testing Steps

More testing scenarios can be found in the [task](https://app.asana.com/1/137249556945/project/414709148257752/task/1210229858278888).

1. Create more than 3 tabs. Make sure there's no NTP tab at the end.
1. Swipe to the first tab.
1. Swipe to the last tab.
1. Drag more to create a new tab, but don't finish the gesture.
1. Make sure OmniBar is visible all the time.

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Not sure, as this part of the app proved to be troublesome recently.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)