### PR TITLE
fix onboarding bug

### DIFF
--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -310,6 +310,7 @@ final class BrowserTabViewController: NSViewController {
                 subscribeToHoveredLink(of: selectedTabViewModel)
                 subscribeToUserDialogs(of: selectedTabViewModel)
 
+                // changing tab is considered equivalent to dismissing the dialog
                 wasContextualOnboardingDialogDismissed = true
 
                 adjustFirstResponder(force: true)
@@ -474,12 +475,14 @@ final class BrowserTabViewController: NSViewController {
             delegate?.dismissViewHighlight()
             return
         }
+        // once a dialog is presented we reset the is dismissed flag
         self.wasContextualOnboardingDialogDismissed = false
 
         var onDismissAction: () -> Void = {}
         if let webViewContainer {
             onDismissAction = { [weak self] in
                 guard let self else { return }
+                // we mark the flag for dialog dismissed
                 wasContextualOnboardingDialogDismissed = true
                 delegate?.dismissViewHighlight()
                 self.removeChild(in: self.containerStackView, webViewContainer: webViewContainer)

--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -310,6 +310,8 @@ final class BrowserTabViewController: NSViewController {
                 subscribeToHoveredLink(of: selectedTabViewModel)
                 subscribeToUserDialogs(of: selectedTabViewModel)
 
+                wasContextualOnboardingDialogDismissed = true
+
                 adjustFirstResponder(force: true)
             }
             .store(in: &cancellables)
@@ -472,6 +474,7 @@ final class BrowserTabViewController: NSViewController {
             delegate?.dismissViewHighlight()
             return
         }
+        self.wasContextualOnboardingDialogDismissed = false
 
         var onDismissAction: () -> Void = {}
         if let webViewContainer {
@@ -654,7 +657,6 @@ final class BrowserTabViewController: NSViewController {
             self.presentContextualOnboarding()
             self.lastURL = self.tabViewModel?.tab.url
             self.lastTab = self.tabViewModel?.tab
-            self.wasContextualOnboardingDialogDismissed = false
         }.store(in: &tabViewModelCancellables)
     }
 
@@ -1171,7 +1173,7 @@ extension BrowserTabViewController: TabDelegate {
         // This helps keep dialogs consistent when moving between Windows
         //  - If the dialog was dismissed it will not reload when leaving and coming back to the Window
         //  - It tells presentContextualOnboarding that should show the lastDialog if possible
-        if !wasContextualOnboardingDialogDismissed {
+        if !wasContextualOnboardingDialogDismissed && onboardingDialogTypeProvider.state != .onboardingCompleted {
             presentContextualOnboarding(showLastDialog: true)
         }
     }

--- a/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
+++ b/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
@@ -189,6 +189,7 @@ final class BrowserTabViewControllerOnboardingTests: XCTestCase {
     }
 
     func testWhenNavigationCompletedAndWindowDidBecomeActiveCorrectDialogCapturedInFactory() throws {
+        dialogProvider.state = .ongoing
         dialogProvider.dialog = .tryFireButton
         tab.navigateFromOnboarding(to: .duckDuckGo)
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210144780372343?focus=true

### Description Fixes a bug when dialogs reappearing under certain circumstances (see task). 

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Go to debug menu -> Reset Data -> Reset Contextual onboarding
2. Go to DuckDuckGo you should see the first dialog
3. Continue until the tracker dialog
4. Open a new tab
5. go back to the original put the app out of focus and on focus again 
6. check the dialog does not reappaer
7. Navigate to another site -> you should see the fire dialog
8. Navigate to another site (so that you see the high five dialog on a site)
9. dismiss the high five dialog
10. Open a new tab
11. Go back to the previous tab
12. move app out and in focus again
13. The dialog should not appear anymore

### Impact and Risks
<!— 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
—>

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)