### PR TITLE
Hidden webView pixel to fire only when error is invisible

### DIFF
--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -628,7 +628,7 @@ class TabViewController: UIViewController {
         if webView.window == nil {
             DailyPixel.fireDailyAndCount(pixel: .debugWebViewNotAttachedToWindow)
         }
-        if webView.isHidden {
+        if webView.isHidden && (errorMessage.text.isNilOrEmpty || error.isHidden) {
             DailyPixel.fireDailyAndCount(pixel: .debugWebViewInVisibleTabHidden)
         }
         if webView.frame == .zero {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1210251291351493?focus=true

### Description

There's a rare bug where the webView appears to be invisible occasionally on navigating to a tab. Some pixels were added to fire from the iOS TabViewController when the webView is hidden, not in the hierarchy etc. After releasing these, I found that there were a few fired when webView.isHidden. However, this may be the case when an error is showing.

Goal
Rule out cases where the tab's error view is showing (with text). Only fire it if:
- The error is invisible
- The error is visible but contains no text

### Testing Steps
- Make sure you're running while plugged into the debugger
- Visit https://privacy-test-pages.site/network-error/drop
- Check that the `m_debug_webview_in_visible_tab_hidden` is NOT fired

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
Worst case: pixel never fires and I'm back to square one.

### Quality Considerations
Just pixels that were already fired but honed in.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)