### PR TITLE
Fix colors in tab remote message view

### DIFF
--- a/macOS/DuckDuckGo/Assets.xcassets/Colors/TabBarRemoteMessageButtonHover.colorset/Contents.json
+++ b/macOS/DuckDuckGo/Assets.xcassets/Colors/TabBarRemoteMessageButtonHover.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCA",
+          "green" : "0x55",
+          "red" : "0x2B"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCA",
+          "green" : "0x55",
+          "red" : "0x2B"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/macOS/DuckDuckGo/Assets.xcassets/Colors/TabBarRemoteMessageButtonRest.colorset/Contents.json
+++ b/macOS/DuckDuckGo/Assets.xcassets/Colors/TabBarRemoteMessageButtonRest.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEF",
+          "green" : "0x69",
+          "red" : "0x39"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEF",
+          "green" : "0x69",
+          "red" : "0x39"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/macOS/DuckDuckGo/RemoteMessaging/TabBarRemoteMessageView.swift
+++ b/macOS/DuckDuckGo/RemoteMessaging/TabBarRemoteMessageView.swift
@@ -42,8 +42,8 @@ struct TabBarRemoteMessageView: View {
             .padding(.trailing, 6)
             .cornerRadius(8)
             .background(wasViewHovered
-                        ? Color("PrimaryButtonHover")
-                        : Color("PrimaryButtonRest"))
+                        ? Color(.tabBarRemoteMessageButtonHover)
+                        : Color(.tabBarRemoteMessageButtonRest))
             .onTapGesture { onTap(model.surveyURL) }
             .onHover { hovering in
                 wasViewHovered = hovering
@@ -70,8 +70,8 @@ struct TabBarRemoteMessageView: View {
             .padding([.top, .bottom])
             .padding([.leading, .trailing], 4)
             .background(wasCloseButtonHovered
-                        ? Color("PrimaryButtonHover")
-                        : Color("PrimaryButtonRest"))
+                        ? Color(.tabBarRemoteMessageButtonHover)
+                        : Color(.tabBarRemoteMessageButtonRest))
             .cornerRadius(8)
             .onTapGesture {
                 onClose()
@@ -82,8 +82,8 @@ struct TabBarRemoteMessageView: View {
             .frame(maxWidth: .infinity)
         }
         .background(wasCloseButtonHovered || wasViewHovered
-                    ? Color("PrimaryButtonHover")
-                    : Color("PrimaryButtonRest"))
+                    ? Color(.tabBarRemoteMessageButtonHover)
+                    : Color(.tabBarRemoteMessageButtonRest))
         .frame(height: 24)
         .cornerRadius(8)
         .onAppear(perform: { onAppear() })


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210263432294800?focus=true
Tech Design URL:
CC:

### Description
Update the background colors of the tab bar remote message. It appears that the colors being used lost their reference (I am unsure exactly when and why), but let’s correct this issue, and then I can investigate further.

### Testing Steps
To trigger the tab bar remote message you can apply this diff:

```diff --git a/macOS/DuckDuckGo/TabBar/View/TabBarRemoteMessagePresenting.swift b/macOS/DuckDuckGo/TabBar/View/TabBarRemoteMessagePresenting.swift
index 629341b1b..32ef27aec 100644
--- a/macOS/DuckDuckGo/TabBar/View/TabBarRemoteMessagePresenting.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarRemoteMessagePresenting.swift
@@ -56,7 +56,7 @@ extension TabBarRemoteMessagePresenting {
                     }
                 } else {
                     if self.feedbackBarButtonHostingController != nil {
-                        self.removeFeedbackButton()
+                        // self.removeFeedbackButton()
                     }
                 }
             })
@@ -69,7 +69,7 @@ extension TabBarRemoteMessagePresenting {
     /// The view is then inserted into the `rightSideStackView`.
     ///
     /// - Parameter tabBarRemotMessage: The remote message to be displayed.
-    private func showTabBarRemoteMessage(_ tabBarRemotMessage: TabBarRemoteMessage) {
+    func showTabBarRemoteMessage(_ tabBarRemotMessage: TabBarRemoteMessage) {
         let feedbackButtonView = TabBarRemoteMessageView(
             model: tabBarRemotMessage,
             onClose: { [weak self] in
diff --git a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
index 9ab79091d..a82993859 100644
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -175,6 +175,7 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
         setupAddTabButton()
         setupAsBurnerWindowIfNeeded()
         subscribeToPinnedTabsSettingChanged()
+        showTabBarRemoteMessage(TabBarRemoteMessage(buttonTitle: "Help us improve!", popupTitle: “Title", popupSubtitle: “Message", surveyURL: URL("www.duckduckgo.com")!))
     }

     override func viewWillAppear() {
```

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing.

### Quality Considerations
N/A

### Notes to Reviewer
Nothing specific.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)