### PR TITLE
Disable Onboarding for iPad users running on OS 17.7.7 

### DIFF
--- a/iOS/DuckDuckGoTests/LaunchOptionsHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/LaunchOptionsHandlerTests.swift
@@ -135,4 +135,39 @@ final class LaunchOptionsHandlerTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    // MARK: - iPad 17.7.7 Issue
+
+    func testShouldReturnDeveloperOverriddenCompletedWhenIpadAndOSIs17_7_7() throws {
+        // GIVEN
+        let sut = LaunchOptionsHandler(environment: [:], userDefaults: userDefaults, isIpad: true, systemVersion: "17.7.7")
+
+        // WHEN
+        let result = sut.onboardingStatus
+
+        // THEN
+        XCTAssertEqual(result, .overridden(.developer(completed: true)))
+    }
+
+    func testShouldNotReturnDeveloperOverriddenCompletedWhenIpadAndOSIsNot17_7_7() throws {
+        // GIVEN
+        let sut = LaunchOptionsHandler(environment: [:], userDefaults: userDefaults, isIpad: true, systemVersion: "17.7.6")
+
+        // WHEN
+        let result = sut.onboardingStatus
+
+        // THEN
+        XCTAssertEqual(result, .notOverridden)
+    }
+
+    func testShouldNotReturnDeveloperOverriddenCompletedWhenIsNotIpadAndOSIs17_7_7() {
+        // GIVEN
+        let sut = LaunchOptionsHandler(environment: [:], userDefaults: userDefaults, isIpad: false, systemVersion: "17.7.7")
+
+        // WHEN
+        let result = sut.onboardingStatus
+
+        // THEN
+        XCTAssertEqual(result, .notOverridden)
+    }
+
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1210267814606214

### Description
A recent Apple update (version 17.7.7) affected the persistence layer, particularly the User Defaults, resulting in several issues, including the onboarding process appearing at every app launch.
For more info check [Asana](https://app.asana.com/1/137249556945/project/414709148257752/task/1210267814606214) 

This PR prevents showing the Onboarding for those users to avoid users’ frustration and complaints.

### Testing Steps
1. Check CI is green.
2. In `LaunchOptionsHandler.swift` change `systemVersion == “17.7.7”` to a version you can run on simulator/device.
3. Delete the DDG from simulator/device.
4. Run the app.
5. Ensure the linear onboarding is not presented.
6. Navigate to a web page with trackers e.g. instagram.com
7. Ensure that no Dax Dialogs are shown.   

### Impact and Risks
The feature is already broken for these users.

#### What could go wrong?
Can’t get worse than this.

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)