### PR TITLE
Update autofill to 17.2.0

### DIFF
--- a/SharedPackages/BrowserServicesKit/Package.resolved
+++ b/SharedPackages/BrowserServicesKit/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "90541ed7d3a69733fc37e9c51bd92f21e0d56a57",
-        "version" : "17.1.0"
+        "revision" : "e02f499ad25f439e8a2a36ac6f9b9d88b8a65d56",
+        "version" : "17.2.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
         .library(name: "PrivacyStats", targets: ["PrivacyStats"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "17.1.0"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "17.2.0"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.4.2"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit.git", exact: "3.0.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.5.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210272268839653
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/17.2.0
Apple PR: 

## Description
Updates Autofill to version [17.2.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/17.2.0).

### Autofill 17.2.0 release notes
## What's Changed
* Update password-related json files (2025-04-15) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/797
* [SiteSpecificFixes] Add support for input types by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/795
* [SiteSpecificFeature] Add readme for site-specific-feature by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/799
* build: add missing precompile-regexes step by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/807
* build: exclude generated regex folder from watch by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/808
* Update password-related json files (2025-05-05) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/806
* Update password-related json files (2025-05-06) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/810
* Add credit card and identity for Windows by @borgateo in https://github.com/duckduckgo/duckduckgo-autofill/pull/796
* Ema/cc forms fixes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/809
* Recategorize password variant by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/818
* Update password-related json files (2025-05-16) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/822


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/17.1.0...17.2.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).