### PR TITLE
Fix assertion in debug when playing Fire animation on macOS

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -188,11 +188,11 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
         // https://app.asana.com/0/1177771139624306/1202033879471339
         addMouseMonitors()
         addTabBarRemoteMessageListener()
-        subscribeToChildWindows()
     }
 
     override func viewDidAppear() {
         enableScrollButtons()
+        subscribeToChildWindows()
     }
 
     override func viewWillDisappear() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1210156034682808?focus=true

### Description
This change ensures that TabBarViewController subscribes to child windows always when its view has a window,
by moving the subscription from viewWillAppear to viewDidAppear.

### Testing Steps
1. Verify that using fire button and closing Fire Window doesn’t stop at an assertion when the app is run from Xcode.
2. Verify that this change doesn’t break the fix introduced in https://github.com/duckduckgo/apple-browsers/pull/483

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)