### PR TITLE
Update visuals in Autocomplete list

### DIFF
--- a/iOS/DuckDuckGo/AutocompleteView.swift
+++ b/iOS/DuckDuckGo/AutocompleteView.swift
@@ -331,7 +331,7 @@ private struct SuggestionListItem: View {
                         .lineLimit(1)
                 }
             }
-            .padding(.leading, Metrics.spacing)
+            .padding(.leading, Metrics.verticalSpacing)
             .padding(.trailing, autocompleteModel.isExperimentalThemingEnabled ? 0 : Metrics.indicatorLeadingPadding)
 
             if autocompleteModel.isExperimentalThemingEnabled && indicator == nil {
@@ -354,7 +354,7 @@ private struct SuggestionListItem: View {
 
     private struct Metrics {
         static let iconSize: CGFloat = 24
-        static let spacing: CGFloat = 8
+        static let verticalSpacing: CGFloat = 10
         static let subtitleSpacing: CGFloat = 2
         static let trailingPadding: CGFloat = 20
         static let indicatorLeadingPadding: CGFloat = 4

--- a/iOS/DuckDuckGo/AutocompleteView.swift
+++ b/iOS/DuckDuckGo/AutocompleteView.swift
@@ -304,10 +304,6 @@ private struct SuggestionListItem: View {
                 .frame(width: Metrics.iconSize, height: Metrics.iconSize)
                 .tintIfAvailable(Color(designSystemColor: .icons))
 
-            if autocompleteModel.isExperimentalThemingEnabled {
-                Spacer().frame(width: Metrics.spacing)
-            }
-
             VStack(alignment: .leading, spacing: Metrics.subtitleSpacing) {
 
                 Group {
@@ -335,7 +331,7 @@ private struct SuggestionListItem: View {
                         .lineLimit(1)
                 }
             }
-            .padding(.leading, autocompleteModel.isExperimentalThemingEnabled ? 0 : Metrics.spacing)
+            .padding(.leading, Metrics.spacing)
             .padding(.trailing, autocompleteModel.isExperimentalThemingEnabled ? 0 : Metrics.indicatorLeadingPadding)
 
             if autocompleteModel.isExperimentalThemingEnabled && indicator == nil {

--- a/iOS/DuckDuckGo/AutocompleteView.swift
+++ b/iOS/DuckDuckGo/AutocompleteView.swift
@@ -331,8 +331,7 @@ private struct SuggestionListItem: View {
                         .lineLimit(1)
                 }
             }
-            .padding(.leading, Metrics.verticalSpacing)
-            .padding(.trailing, autocompleteModel.isExperimentalThemingEnabled ? 0 : Metrics.indicatorLeadingPadding)
+            .padding(.leading, autocompleteModel.isExperimentalThemingEnabled ? Metrics.verticalSpacing : 0)
 
             if autocompleteModel.isExperimentalThemingEnabled && indicator == nil {
                 // No indicator means we want to preserve the room for icon,
@@ -348,6 +347,7 @@ private struct SuggestionListItem: View {
                         onTapIndicator?()
                     })
                     .tintIfAvailable(Color.init(designSystemColor: .iconsSecondary))
+                    .padding(.leading, autocompleteModel.isExperimentalThemingEnabled ? Metrics.indicatorLeadingPadding : 0)
             }
         }
     }

--- a/iOS/DuckDuckGo/AutocompleteView.swift
+++ b/iOS/DuckDuckGo/AutocompleteView.swift
@@ -159,6 +159,10 @@ private struct SuggestionsSection: View {
     let selectedColor = Color(designSystemColor: .accent)
     let unselectedColor = Color(designSystemColor: .surface)
 
+    private struct Metrics {
+        static let rowInsets = EdgeInsets(top: 10, leading: 10, bottom: 8, trailing: 14)
+    }
+
     var body: some View {
         Section {
             ForEach(suggestions.indices, id: \.self) { index in
@@ -168,6 +172,10 @@ private struct SuggestionsSection: View {
                     SuggestionView(model: suggestions[index], query: query)
                  }
                  .listRowBackground(autocompleteViewModel.selection == suggestions[index] ? selectedColor : unselectedColor)
+                 .listRowSeparatorTint(Color(designSystemColor: .lines), edges: [.bottom])
+                 .if(autocompleteViewModel.isExperimentalThemingEnabled) {
+                     $0.listRowInsets(Metrics.rowInsets)
+                 }
                  .modifier(SwipeDeleteHistoryModifier(suggestion: suggestions[index], onSuggestionDeleted: onSuggestionDeleted))
             }
         }
@@ -265,6 +273,8 @@ private struct SuggestionView: View {
 
 private struct SuggestionListItem: View {
 
+    @EnvironmentObject var autocompleteModel: AutocompleteViewModel
+
     let icon: Image
     let title: String
     let subtitle: String?
@@ -288,14 +298,17 @@ private struct SuggestionListItem: View {
     }
 
     var body: some View {
-
-        HStack {
+        HStack(spacing: autocompleteModel.isExperimentalThemingEnabled ? 0 : nil) {
             icon
                 .resizable()
-                .frame(width: 24, height: 24)
+                .frame(width: Metrics.iconSize, height: Metrics.iconSize)
                 .tintIfAvailable(Color(designSystemColor: .icons))
 
-            VStack(alignment: .leading, spacing: 2) {
+            if autocompleteModel.isExperimentalThemingEnabled {
+                Spacer().frame(width: Metrics.spacing)
+            }
+
+            VStack(alignment: .leading, spacing: Metrics.subtitleSpacing) {
 
                 Group {
                     // Can't use dax modifiers because they are not typed for Text
@@ -322,17 +335,35 @@ private struct SuggestionListItem: View {
                         .lineLimit(1)
                 }
             }
+            .padding(.leading, autocompleteModel.isExperimentalThemingEnabled ? 0 : Metrics.spacing)
+            .padding(.trailing, autocompleteModel.isExperimentalThemingEnabled ? 0 : Metrics.indicatorLeadingPadding)
+
+            if autocompleteModel.isExperimentalThemingEnabled && indicator == nil {
+                // No indicator means we want to preserve the room for icon,
+                // so all the titles from other cells are aligned.
+                Spacer(minLength: Metrics.trailingPadding)
+            } else {
+                Spacer()
+            }
 
             if let indicator {
-                Spacer()
                 indicator
                     .highPriorityGesture(TapGesture().onEnded {
                         onTapIndicator?()
                     })
-                    .tintIfAvailable(Color.secondary)
+                    .tintIfAvailable(Color.init(designSystemColor: .iconsSecondary))
             }
         }
     }
+
+    private struct Metrics {
+        static let iconSize: CGFloat = 24
+        static let spacing: CGFloat = 8
+        static let subtitleSpacing: CGFloat = 2
+        static let trailingPadding: CGFloat = 20
+        static let indicatorLeadingPadding: CGFloat = 4
+    }
+
 }
 
 private extension URL {

--- a/iOS/DuckDuckGo/AutocompleteView.swift
+++ b/iOS/DuckDuckGo/AutocompleteView.swift
@@ -172,9 +172,10 @@ private struct SuggestionsSection: View {
                     SuggestionView(model: suggestions[index], query: query)
                  }
                  .listRowBackground(autocompleteViewModel.selection == suggestions[index] ? selectedColor : unselectedColor)
-                 .listRowSeparatorTint(Color(designSystemColor: .lines), edges: [.bottom])
                  .if(autocompleteViewModel.isExperimentalThemingEnabled) {
-                     $0.listRowInsets(Metrics.rowInsets)
+                     $0
+                         .listRowInsets(Metrics.rowInsets)
+                         .listRowSeparatorTint(Color(designSystemColor: .lines), edges: [.bottom])
                  }
                  .modifier(SwipeDeleteHistoryModifier(suggestion: suggestions[index], onSuggestionDeleted: onSuggestionDeleted))
             }

--- a/iOS/DuckDuckGo/AutocompleteViewController.swift
+++ b/iOS/DuckDuckGo/AutocompleteViewController.swift
@@ -85,7 +85,8 @@ class AutocompleteViewController: UIHostingController<AutocompleteView> {
         self.featureFlagger = featureFlagger
 
         self.model = AutocompleteViewModel(isAddressBarAtBottom: appSettings.currentAddressBarPosition == .bottom,
-                                           showMessage: historyManager.isHistoryFeatureEnabled() && historyMessageManager.shouldShow())
+                                           showMessage: historyManager.isHistoryFeatureEnabled() && historyMessageManager.shouldShow(),
+                                           isExperimentalThemingEnabled: ExperimentalThemingManager(featureFlagger: featureFlagger).isExperimentalThemingEnabled)
         super.init(rootView: AutocompleteView(model: model))
         self.model.delegate = self
     }

--- a/iOS/DuckDuckGo/AutocompleteViewModel.swift
+++ b/iOS/DuckDuckGo/AutocompleteViewModel.swift
@@ -52,10 +52,12 @@ class AutocompleteViewModel: ObservableObject {
     weak var delegate: AutocompleteViewModelDelegate?
 
     let isAddressBarAtBottom: Bool
+    let isExperimentalThemingEnabled: Bool
 
-    init(isAddressBarAtBottom: Bool, showMessage: Bool) {
+    init(isAddressBarAtBottom: Bool, showMessage: Bool, isExperimentalThemingEnabled: Bool) {
         self.isAddressBarAtBottom = isAddressBarAtBottom
         self.isMessageVisible = showMessage
+        self.isExperimentalThemingEnabled = isExperimentalThemingEnabled
     }
 
     func updateSuggestions(_ suggestions: SuggestionResult) {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1210109852223178
Tech Design URL:
CC:

### Description

Updates the visual appearance of autocomplete. Note the change of the icon color to secondary is expected for both styles.
For the changes to be fully in-line [icons update](https://app.asana.com/1/137249556945/project/1206226850447395/task/1209809752047351?focus=true) must be done. However current design works with existing icons as well.

### Testing Steps
1. Enable experimental appearance. Restart device.
2. Check if autocomplete looks like on the spec in the [task](https://app.asana.com/1/137249556945/project/1206226850447395/task/1210109852223178?focus=true).
3. Turn off experimental appearance, see if regular appearance is not modified.

⚠️  Note the difference of alignment on a real device vs simulator. Simulator has 20pt List paddings vs 16pt on device. See [this comment](https://app.asana.com/1/137249556945/task/1210109852223178/comment/1210339423486056?focus=true) for details.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)