### PR TITLE
[Release PR] Reload the tab switcher when tabs change

### DIFF
--- a/iOS/DuckDuckGo/TabSwitcherViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController.swift
@@ -28,6 +28,7 @@ import os.log
 import SwiftUI
 import BrowserServicesKit
 import AIChat
+import Combine
 
 class TabSwitcherViewController: UIViewController {
 
@@ -111,6 +112,7 @@ class TabSwitcherViewController: UIViewController {
     }
 
     let barsHandler = TabSwitcherBarsStateHandler()
+    private var tabObserverCancellable: AnyCancellable?
 
     required init?(coder: NSCoder,
                    bookmarksDatabase: CoreDataDatabase,
@@ -158,6 +160,10 @@ class TabSwitcherViewController: UIViewController {
         if !tabSwitcherSettings.hasSeenNewLayout {
             Pixel.fire(pixel: .tabSwitcherNewLayoutSeen)
             tabSwitcherSettings.hasSeenNewLayout = true
+        }
+
+        tabObserverCancellable = tabsModel.$tabs.receive(on: DispatchQueue.main).sink { [weak self] _ in
+            self?.collectionView.reloadData()
         }
     }
 

--- a/iOS/DuckDuckGo/TabsModel.swift
+++ b/iOS/DuckDuckGo/TabsModel.swift
@@ -30,7 +30,7 @@ public class TabsModel: NSObject, NSCoding {
     }
 
     private(set) var currentIndex: Int
-    private(set) var tabs: [Tab]
+    @Published private(set) var tabs: [Tab]
 
     var hasUnread: Bool {
         return tabs.contains(where: { !$0.viewed })


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1210323647312903?focus=true
Tech Design URL:
CC:

### Description

This PR updates the tab switcher to reload its collection view when the list of tabs change. This change is because the tab switcher doesn't do any deliberate reloads otherwise, but URLs can be modified when it's active, so the fix is to reload its data source more proactively.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. See [Asana](https://app.asana.com/1/137249556945/project/1199333091098016/task/1210323647312903?focus=true) for steps
2. Check that tab persistence works as expected, just to make sure that `@Published` didn't have an effect on `NSCoding`

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)