### PR TITLE
Move app launch pixel to applicationDidBecomeActive

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -617,12 +617,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         freemiumDBPScanResultPolling = DefaultFreemiumDBPScanResultPolling(dataManager: DataBrokerProtectionManager.shared.dataManager, freemiumDBPUserStateManager: freemiumDBPUserStateManager)
         freemiumDBPScanResultPolling?.startPollingOrObserving()
-
-#if SPARKLE
-        PixelKit.fire(NonStandardEvent(GeneralPixel.launch(isDefault: DefaultBrowserPreferences().isDefault, isAddedToDock: DockCustomizer().isAddedToDock)), frequency: .daily)
-#else
-        PixelKit.fire(NonStandardEvent(GeneralPixel.launch(isDefault: DefaultBrowserPreferences().isDefault, isAddedToDock: nil)), frequency: .daily)
-#endif
     }
 
     private func fireFailedCompilationsPixelIfNeeded() {
@@ -642,6 +636,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidBecomeActive(_ notification: Notification) {
         guard didFinishLaunching else { return }
 
+        fireAppLaunchPixel()
+
         initializeSync()
 
         let freemiumDBPUserStateManager = DefaultFreemiumDBPUserStateManager(userDefaults: .dbp)
@@ -659,6 +655,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task { @MainActor in
             await subscriptionCookieManager.refreshSubscriptionCookie()
         }
+    }
+
+    private func fireAppLaunchPixel() {
+#if SPARKLE
+        PixelKit.fire(NonStandardEvent(GeneralPixel.launch(isDefault: DefaultBrowserPreferences().isDefault, isAddedToDock: DockCustomizer().isAddedToDock)), frequency: .daily)
+#else
+        PixelKit.fire(NonStandardEvent(GeneralPixel.launch(isDefault: DefaultBrowserPreferences().isDefault, isAddedToDock: nil)), frequency: .daily)
+#endif
     }
 
     private func initializeSync() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1210317072100185?focus=true
Tech Design URL:
CC: @ayoy 

### Description

### Testing Steps
1. Launch the app.
2. Ensure that ”m_mac_daily_active_user” pixel is fired in the console log.
3. Put the app in background and foreground it again.
4. Ensure that this time “m_mac_daily_active_user” pixel is skipped in the console log.

### Impact and Risks
Low

#### What could go wrong?
Wrong reporting of app launches

### Quality Considerations
Checked the [following dashboards](https://dub.duckduckgo.com/duckduckgo/grafana-snapshots/search?q=%22m.mac.daily.active.user%22)
- **O-G:** Change is part of this objective.
- **O-J (macOS Pixels and macOS Errors):**:  Dashboards would also benefit from it
- **O-R:** This pixel is misused anyway. Needs a proper “launch” pixel, not a daily pixel as it is used for crash rate. O-R is fine with this change.

More info [here](https://app.asana.com/1/137249556945/task/1210316488794902/comment/1210315773016587?focus=true)


### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)