### PR TITLE
Fixes an issue with the tab bar width calculation

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -603,7 +603,7 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
             if dividedWidth < TabBarViewItem.Width.minimumSelected {
                 dividedWidth = (tabsWidth - TabBarViewItem.Width.minimumSelected) / (numberOfItems - 1)
             }
-            return min(TabBarViewItem.Width.maximum, max(minimumWidth, dividedWidth)).rounded()
+            return floor(min(TabBarViewItem.Width.maximum, max(minimumWidth, dividedWidth)))
         } else {
             return minimumWidth
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210323142455264?focus=true

### Description

Fixes an issue where the tab bar's width was miscalculated and causing some horizontal scrolling to happen.

### Testing Steps

See the video in [this task](https://app.asana.com/1/137249556945/project/1201048563534612/task/1210323142455264?focus=true).

1. Add tabs until they fill the tab bar width.
2. Try shift + wheel scrolling and see if the tab bar moves horizontally.

### Impact and Risks

Low

#### What could go wrong?

Could slightly affect tab bar width, but for no more than 1 pixel.

### Quality Considerations

NA

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)