### PR TITLE
macOS Visual refresh: Align fire button with more options menu

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/Base.lproj/TabBar.storyboard
+++ b/macOS/DuckDuckGo/TabBar/View/Base.lproj/TabBar.storyboard
@@ -295,6 +295,8 @@
                         <outlet property="collectionView" destination="OEu-5P-cRF" id="b95-c4-JM0"/>
                         <outlet property="draggingSpace" destination="Ako-KX-AM9" id="yya-hb-te7"/>
                         <outlet property="fireButton" destination="XV4-Ze-5j7" id="ZCC-wX-7hC"/>
+                        <outlet property="fireButtonHeightConstraint" destination="Dea-ni-6y6" id="Kiz-yu-ppN"/>
+                        <outlet property="fireButtonWidthConstraint" destination="9Ii-rC-Eca" id="nke-9d-5t2"/>
                         <outlet property="leftScrollButton" destination="7XG-Qm-Ksx" id="yre-8P-vb9"/>
                         <outlet property="leftShadowImageView" destination="zsA-or-9Xo" id="wVp-jj-2UD"/>
                         <outlet property="leftSideStackLeadingConstraint" destination="qU6-dU-yJw" id="eFI-TI-wxX"/>

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -51,6 +51,8 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
     @IBOutlet weak var windowDraggingViewLeadingConstraint: NSLayoutConstraint!
     @IBOutlet weak var burnerWindowBackgroundView: NSImageView!
 
+    @IBOutlet weak var fireButtonWidthConstraint: NSLayoutConstraint!
+    @IBOutlet weak var fireButtonHeightConstraint: NSLayoutConstraint!
     @IBOutlet weak var addTabButton: MouseOverButton!
 
     private var fireButtonMouseOverCancellable: AnyCancellable?
@@ -272,6 +274,9 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
             .sink(receiveValue: { [weak self] _ in
                 self?.stopFireButtonPulseAnimation()
             })
+
+        fireButtonWidthConstraint.constant = visualStyle.fireButtonSize
+        fireButtonHeightConstraint.constant = visualStyle.fireButtonSize
     }
 
     private func setupAsBurnerWindowIfNeeded() {

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
@@ -59,6 +59,7 @@ protocol VisualStyleProviding {
     var moreOptionsMenuIconsProvider: MoreOptionsMenuIconsProviding { get }
     var tabStyleProvider: TabStyleProviding { get }
     var colorsProvider: ColorsProviding { get }
+    var fireButtonSize: CGFloat { get }
 }
 
 protocol VisualStyleManagerProviding {
@@ -127,6 +128,7 @@ struct VisualStyle: VisualStyleProviding {
     let newTabOrHomePageAddressBarFontSize: CGFloat
     let bookmarksBarMenuBookmarkIcon: NSImage
     let bookmarksBarMenuFolderIcon: NSImage
+    let fireButtonSize: CGFloat
 
     func addressBarHeight(for type: AddressBarSizeClass, focused: Bool) -> CGFloat {
         switch type {
@@ -202,7 +204,8 @@ struct VisualStyle: VisualStyleProviding {
                            defaultAddressBarFontSize: 13,
                            newTabOrHomePageAddressBarFontSize: 15,
                            bookmarksBarMenuBookmarkIcon: .bookmark,
-                           bookmarksBarMenuFolderIcon: .folder16)
+                           bookmarksBarMenuFolderIcon: .folder16,
+                           fireButtonSize: 28)
     }
 
     static var current: VisualStyleProviding {
@@ -245,7 +248,8 @@ struct VisualStyle: VisualStyleProviding {
                            defaultAddressBarFontSize: 13,
                            newTabOrHomePageAddressBarFontSize: 13,
                            bookmarksBarMenuBookmarkIcon: .bookmarkNew,
-                           bookmarksBarMenuFolderIcon: .folderNew)
+                           bookmarksBarMenuFolderIcon: .folderNew,
+                           fireButtonSize: 32)
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1210331228149927?focus=true
Tech Design URL:
CC:

### Description
Increases the size of the fire button to 32x32, to mimic the designs. It also aligns the fire button with the more options button, as shown in the following screenshot.

<img width="561" alt="Screenshot 2025-05-20 at 1 34 42 PM" src="https://github.com/user-attachments/assets/17324d70-29d8-4243-ab9d-28d367a9a58a" />

### Testing Steps
1. Set internal user state
2. Go to Debug -> Feature Flag Overrides, and turn the `visualRefresh` flag on
3. Reset the application
4. Check the fire button is aligned with the more options menu
5. Also, check the hover area of the fire button increases
6. Remove the flag and re-start it again
7. Check that doesn’t happen when the FF is off

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
This goes to production without the FF.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)