### PR TITLE
macOS Visual Refresh: Update address bar radius for new style

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -425,6 +425,14 @@ final class AddressBarViewController: NSViewController {
         activeBackgroundView.borderColor = isBurner ? NSColor.burnerAccent.withAlphaComponent(0.2) : visualStyle.colorsProvider.accentPrimaryColor
 
         setupAddressBarPlaceHolder()
+        setupAddressBarCornerRadius()
+    }
+
+    private func setupAddressBarCornerRadius() {
+        activeBackgroundView.setCornerRadius(visualStyle.addressBarActiveBackgroundViewRadius)
+        inactiveBackgroundView.setCornerRadius(visualStyle.addressBarInactiveBackgroundViewRadius)
+        innerBorderView.setCornerRadius(visualStyle.addressBarInnerBorderViewRadius)
+        activeOuterBorderView.setCornerRadius(visualStyle.addressBarActiveOuterBorderViewRadius)
     }
 
     private func setupAddressBarPlaceHolder() {

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
@@ -60,6 +60,11 @@ protocol VisualStyleProviding {
     var tabStyleProvider: TabStyleProviding { get }
     var colorsProvider: ColorsProviding { get }
     var fireButtonSize: CGFloat { get }
+
+    var addressBarActiveBackgroundViewRadius: CGFloat { get }
+    var addressBarInactiveBackgroundViewRadius: CGFloat { get }
+    var addressBarInnerBorderViewRadius: CGFloat { get }
+    var addressBarActiveOuterBorderViewRadius: CGFloat { get }
 }
 
 protocol VisualStyleManagerProviding {
@@ -129,6 +134,10 @@ struct VisualStyle: VisualStyleProviding {
     let bookmarksBarMenuBookmarkIcon: NSImage
     let bookmarksBarMenuFolderIcon: NSImage
     let fireButtonSize: CGFloat
+    let addressBarActiveBackgroundViewRadius: CGFloat
+    let addressBarInactiveBackgroundViewRadius: CGFloat
+    let addressBarInnerBorderViewRadius: CGFloat
+    let addressBarActiveOuterBorderViewRadius: CGFloat
 
     func addressBarHeight(for type: AddressBarSizeClass, focused: Bool) -> CGFloat {
         switch type {
@@ -205,7 +214,11 @@ struct VisualStyle: VisualStyleProviding {
                            newTabOrHomePageAddressBarFontSize: 15,
                            bookmarksBarMenuBookmarkIcon: .bookmark,
                            bookmarksBarMenuFolderIcon: .folder16,
-                           fireButtonSize: 28)
+                           fireButtonSize: 28,
+                           addressBarActiveBackgroundViewRadius: 8,
+                           addressBarInactiveBackgroundViewRadius: 6,
+                           addressBarInnerBorderViewRadius: 8,
+                           addressBarActiveOuterBorderViewRadius: 10)
     }
 
     static var current: VisualStyleProviding {
@@ -249,7 +262,11 @@ struct VisualStyle: VisualStyleProviding {
                            newTabOrHomePageAddressBarFontSize: 13,
                            bookmarksBarMenuBookmarkIcon: .bookmarkNew,
                            bookmarksBarMenuFolderIcon: .folderNew,
-                           fireButtonSize: 32)
+                           fireButtonSize: 32,
+                           addressBarActiveBackgroundViewRadius: 11,
+                           addressBarInactiveBackgroundViewRadius: 11,
+                           addressBarInnerBorderViewRadius: 11,
+                           addressBarActiveOuterBorderViewRadius: 13)
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1210331228149931?focus=true
Tech Design URL:
CC:

### Description
Updates the corner radius of the address bar to follow the new designs:

<img width="897" alt="Screenshot 2025-05-20 at 2 57 08 PM" src="https://github.com/user-attachments/assets/a5a0ef80-b87b-4be9-ba36-44447386894f" />


### Testing Steps
1. Set internal user state
2. Go to Debug -> Feature Flag Overrides, and override the `visualRefresh` flag.
3. Reset the application
4. Check the address bar have more curved corner radius and it fits better with the privacy shield and ai chat buttons
5. Remove the override flag, and restart the application
6. Check the address bar size is back to normal

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The change goes to production without the FF.

### Quality Considerations
Nothing specific

### Notes to Reviewer
Nothing specific

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)