### PR TITLE
Fixes a bug with the bookmarks icon blinking when switching tabs

### DIFF
--- a/macOS/DuckDuckGo/MainWindow/MainView.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainView.swift
@@ -283,12 +283,23 @@ final class MainView: NSView {
     override func updateTrackingAreas() {
         if let mouseAboveWebViewTrackingArea {
             removeTrackingArea(mouseAboveWebViewTrackingArea)
-            isMouseAboveWebView = false
             let trackingArea = makeMouseAboveViewTrackingArea()
             self.mouseAboveWebViewTrackingArea = trackingArea
             addTrackingArea(trackingArea)
+            updateIsMouseAboveWebView(for: trackingArea)
         }
         super.updateTrackingAreas()
+    }
+
+    private func updateIsMouseAboveWebView(for trackingArea: NSTrackingArea) {
+        guard let window else {
+            isMouseAboveWebView = false
+            return
+        }
+
+        let mouseLocation = window.mouseLocationOutsideOfEventStream
+        let viewLocation = convert(mouseLocation, from: nil)
+        isMouseAboveWebView = trackingArea.rect.contains(viewLocation)
     }
 
     override func mouseEntered(with event: NSEvent) {

--- a/macOS/DuckDuckGo/MainWindow/MainView.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainView.swift
@@ -286,20 +286,8 @@ final class MainView: NSView {
             let trackingArea = makeMouseAboveViewTrackingArea()
             self.mouseAboveWebViewTrackingArea = trackingArea
             addTrackingArea(trackingArea)
-            updateIsMouseAboveWebView(for: trackingArea)
         }
         super.updateTrackingAreas()
-    }
-
-    private func updateIsMouseAboveWebView(for trackingArea: NSTrackingArea) {
-        guard let window else {
-            isMouseAboveWebView = false
-            return
-        }
-
-        let mouseLocation = window.mouseLocationOutsideOfEventStream
-        let viewLocation = convert(mouseLocation, from: nil)
-        isMouseAboveWebView = trackingArea.rect.contains(viewLocation)
     }
 
     override func mouseEntered(with event: NSEvent) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210331120635171?focus=true

### Description

Fixes an issue that caused the bookmarks icon to blink when switching tabs.

### Testing Steps

1. Load a site in a tab.
2. Create another tab and switch to it.
3. When going back to the tab with the site loaded you'll see the bookmarks icon blinking.

### Impact and Risks

Low

#### What could go wrong?

I don't think anything should.  But worst thing that could happen is I'm calculating visibility wrong for the icon.

### Quality Considerations

Ensure the icon behaves correctly when moving the mouse into and outside of the address bar area.

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)