### PR TITLE
macOS: The history page can no longer be bookmarked

### DIFF
--- a/macOS/DuckDuckGo/Tab/Model/TabContent.swift
+++ b/macOS/DuckDuckGo/Tab/Model/TabContent.swift
@@ -338,9 +338,9 @@ extension TabContent {
 
     var canBeBookmarked: Bool {
         switch self {
-        case .newtab, .onboarding, .bookmarks, .settings, .none:
+        case .history, .newtab, .onboarding, .bookmarks, .settings, .none:
             return false
-        case .url, .history, .subscription, .identityTheftRestoration, .dataBrokerProtection, .releaseNotes, .webExtensionUrl:
+        case .url, .subscription, .identityTheftRestoration, .dataBrokerProtection, .releaseNotes, .webExtensionUrl:
             return true
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210345697829702?focus=true

### Description

The history page can no longer be bookmarked in macOS

### Testing Steps

Try bookmarking the history page and make sure you can't.

### Impact and Risks

Low

#### What could go wrong?

Nothing really - the change follow what we use for other similar cases.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)