### PR TITLE
Fix issue opening links

### DIFF
--- a/iOS/DuckDuckGo/AIChat/AIChatViewControllerManager.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatViewControllerManager.swift
@@ -202,8 +202,9 @@ extension AIChatViewControllerManager: UserContentControllerDelegate {
 
 extension AIChatViewControllerManager: AIChatViewControllerDelegate {
     func aiChatViewController(_ viewController: AIChatViewController, didRequestToLoad url: URL) {
-        delegate?.aiChatViewControllerManager(self, didRequestToLoad: url)
-        viewController.dismiss(animated: true)
+        viewController.dismiss(animated: true) {
+            self.delegate?.aiChatViewControllerManager(self, didRequestToLoad: url)
+        }
     }
 
     func aiChatViewControllerDidFinish(_ viewController: AIChatViewController) {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3315,7 +3315,16 @@ extension MainViewController: AutofillLoginListViewControllerDelegate {
 // MARK: - AIChatViewControllerManagerDelegate
 extension MainViewController: AIChatViewControllerManagerDelegate {
     func aiChatViewControllerManager(_ manager: AIChatViewControllerManager, didRequestToLoad url: URL) {
-        loadUrlInNewTab(url, inheritedAttribution: nil)
+        if let tabSwitcher = tabSwitcherController {
+            loadUrlInNewTab(url, inheritedAttribution: nil)
+            tabSwitcher.dismiss(animated: true) {
+                if let lastTab = self.tabManager.model.tabs.last {
+                    self.tabManager.selectTab(lastTab)
+                }
+            }
+        } else {
+            loadUrlInNewTab(url, inheritedAttribution: nil)
+        }
     }
 
     func aiChatViewControllerManager(_ manager: AIChatViewControllerManager, didSubmitQuery query: String) {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3317,11 +3317,7 @@ extension MainViewController: AIChatViewControllerManagerDelegate {
     func aiChatViewControllerManager(_ manager: AIChatViewControllerManager, didRequestToLoad url: URL) {
         if let tabSwitcher = tabSwitcherController {
             loadUrlInNewTab(url, inheritedAttribution: nil)
-            tabSwitcher.dismiss(animated: true) {
-                if let lastTab = self.tabManager.model.tabs.last {
-                    self.tabManager.selectTab(lastTab)
-                }
-            }
+            tabSwitcher.dismiss(animated: true)
         } else {
             loadUrlInNewTab(url, inheritedAttribution: nil)
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1210345665934128?focus=true

### Description
Fix issue opening duck.ai links from tab switcher

### Testing Steps
1. Go to the tab switcher
2. Search for “iphone prices"
3. Tap on a link
4. The tab switcher should be dismissed and you see the selected page


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Breaking up some state outside of the tab switcher when tapping on links
