### PR TITLE
Fix outer border color in address bar and flickering on dax logo on NTP

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -422,7 +422,7 @@ final class AddressBarViewController: NSViewController {
 
         activeOuterBorderView.alphaValue = isKey && isFirstResponder && visualStyle.shouldShowOutlineBorder(isHomePage: isHomePage) ? 1 : 0
         activeOuterBorderView.backgroundColor = isBurner ? NSColor.burnerAccent.withAlphaComponent(0.2) : visualStyle.colorsProvider.addressBarOutlineShadow
-        activeBackgroundView.borderColor = isBurner ? NSColor.burnerAccent.withAlphaComponent(0.2) : visualStyle.colorsProvider.accentPrimaryColor
+        activeBackgroundView.borderColor = isBurner ? NSColor.burnerAccent.withAlphaComponent(0.8) : visualStyle.colorsProvider.accentPrimaryColor
 
         setupAddressBarPlaceHolder()
         setupAddressBarCornerRadius()

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -1671,7 +1671,10 @@ extension NavigationBarViewController: AddressBarViewControllerDelegate {
 
     func resizeAddressBarForHomePage(_ addressBarViewController: AddressBarViewController, isFocused: Bool) {
         let addressBarSizeClass: AddressBarSizeClass = tabCollectionViewModel.selectedTabViewModel?.tab.content == .newtab ? .homePage : .default
-        resizeAddressBar(for: addressBarSizeClass, animated: true)
+
+        if visualStyle.shouldShowLogoinInAddressBar {
+            resizeAddressBar(for: addressBarSizeClass, animated: true)
+        }
     }
 }
 

--- a/macOS/DuckDuckGo/VisualRefresh/ColorsProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/ColorsProviding.swift
@@ -46,8 +46,8 @@ final class LegacyColorsProviding: ColorsProviding {
     var textPrimaryColor: NSColor { .labelColor }
     var textSecondaryColor: NSColor { .secondaryLabelColor }
     var backgroundTertiaryColor: NSColor { .inactiveSearchBarBackground }
-    var accentPrimaryColor: NSColor { .controlAccentColor.withAlphaComponent(0.8) }
-    var addressBarOutlineShadow: NSColor { .controlColor.withAlphaComponent(0.2) }
+    var accentPrimaryColor: NSColor { .globalAccent.withAlphaComponent(0.8) }
+    var addressBarOutlineShadow: NSColor { .globalAccent.withAlphaComponent(0.2) }
     var iconsColor: NSColor { .button }
     var buttonMouseOverColor: NSColor { .buttonMouseOver }
     var addressBarSuffixTextColor: NSColor { .addressBarSuffix }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1210355890591502?focus=true
Tech Design URL:
CC:

### Description

### Testing Steps
1. Set internal state
2. Be sure that the `visualRefresh` flag override is not turned on by going to Debug -> Feature Flag Overrides.
3. Open a New Tab, check that the address bar has the outline border
4. Open a Fire Window, check that the address bar has the outline border
5. On a new tab or home, focus and remove focus from the address bar, the Dax logo to the left of the address bar should not flicker.

![Screenshot 2025-05-22 at 1 50 01 PM](https://github.com/user-attachments/assets/87fe0caf-cc48-47db-b69b-fb370e6e6c76)
![Screenshot 2025-05-22 at 1 50 31 PM](https://github.com/user-attachments/assets/600a0cfe-f821-4020-9a20-6410a5eedb25)


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
This gets shipped to users.

### Quality Considerations
Nothing in particular

### Notes to Reviewer
Nothing in particular

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)