### PR TITLE
Use BrowserChromeButton for buttons on iPad tabs controller 

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -422,7 +422,7 @@
 		6F40D15E2C34436500BF22F0 /* HomePageDisplayDailyPixelBucketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F40D15C2C34436200BF22F0 /* HomePageDisplayDailyPixelBucketTests.swift */; };
 		6F5041C92CC11A5100989E48 /* NewTabPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5041C82CC11A5100989E48 /* NewTabPageView.swift */; };
 		6F5345AF2C53F2DE00424A43 /* NewTabPageSettingsPersistentStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5345AE2C53F2DE00424A43 /* NewTabPageSettingsPersistentStorage.swift */; };
-		6F5938982DB1028200C8C068 /* ToolbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5938972DB1028200C8C068 /* ToolbarButton.swift */; };
+		6F5938982DB1028200C8C068 /* BrowserChromeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5938972DB1028200C8C068 /* BrowserChromeButton.swift */; };
 		6F5AA3EF2CC1588400685CB4 /* FavoritesListInteractingAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5AA3EE2CC1588400685CB4 /* FavoritesListInteractingAdapterTests.swift */; };
 		6F5CC0812C2AFFE400AFC840 /* ToggleExpandButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5CC0802C2AFFE400AFC840 /* ToggleExpandButtonStyle.swift */; };
 		6F64AA532C47E92600CF4489 /* FavoritesFaviconLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F64AA522C47E92600CF4489 /* FavoritesFaviconLoader.swift */; };
@@ -2017,7 +2017,7 @@
 		6F40D15C2C34436200BF22F0 /* HomePageDisplayDailyPixelBucketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePageDisplayDailyPixelBucketTests.swift; sourceTree = "<group>"; };
 		6F5041C82CC11A5100989E48 /* NewTabPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageView.swift; sourceTree = "<group>"; };
 		6F5345AE2C53F2DE00424A43 /* NewTabPageSettingsPersistentStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageSettingsPersistentStorage.swift; sourceTree = "<group>"; };
-		6F5938972DB1028200C8C068 /* ToolbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarButton.swift; sourceTree = "<group>"; };
+		6F5938972DB1028200C8C068 /* BrowserChromeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserChromeButton.swift; sourceTree = "<group>"; };
 		6F5AA3EE2CC1588400685CB4 /* FavoritesListInteractingAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesListInteractingAdapterTests.swift; sourceTree = "<group>"; };
 		6F5CC0802C2AFFE400AFC840 /* ToggleExpandButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleExpandButtonStyle.swift; sourceTree = "<group>"; };
 		6F64AA522C47E92600CF4489 /* FavoritesFaviconLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesFaviconLoader.swift; sourceTree = "<group>"; };
@@ -4754,7 +4754,7 @@
 		6F5938962DB1027400C8C068 /* ButtonConfigurations */ = {
 			isa = PBXGroup;
 			children = (
-				6F5938972DB1028200C8C068 /* ToolbarButton.swift */,
+				6F5938972DB1028200C8C068 /* BrowserChromeButton.swift */,
 			);
 			path = ButtonConfigurations;
 			sourceTree = "<group>";
@@ -9619,7 +9619,7 @@
 				46DD3D5A2D0A29F600F33D49 /* CrashReportSenderExtensions.swift in Sources */,
 				1DEAADEA2BA4539800E25A97 /* SettingsAppearanceView.swift in Sources */,
 				B623C1C22862CA9E0043013E /* DownloadSession.swift in Sources */,
-				6F5938982DB1028200C8C068 /* ToolbarButton.swift in Sources */,
+				6F5938982DB1028200C8C068 /* BrowserChromeButton.swift in Sources */,
 				7B16810C2D10CF44005EAE24 /* WidgetVPNIntents.swift in Sources */,
 				317CA3432CFF82E100F88848 /* SettingsAIChatView.swift in Sources */,
 				9F7CFF7F2C8A94F70012833E /* OnboardingView+AddressBarPositionContent.swift in Sources */,

--- a/iOS/DuckDuckGo/Base.lproj/TabSwitcher.storyboard
+++ b/iOS/DuckDuckGo/Base.lproj/TabSwitcher.storyboard
@@ -351,8 +351,17 @@
                         <rect key="frame" x="0.0" y="0.0" width="800" height="40"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eRo-Z1-BzV">
+                                <rect key="frame" x="768" y="0.0" width="32" height="40"/>
+                            </view>
+                            <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="aDD-d2-KuN">
+                                <rect key="frame" x="784" y="2" width="0.0" height="36"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" priority="250" id="Frc-XT-onX"/>
+                                </constraints>
+                            </stackView>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" directionalLockEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="1wM-Ln-7ly">
-                                <rect key="frame" x="8" y="0.0" width="618" height="40"/>
+                                <rect key="frame" x="8" y="0.0" width="760" height="40"/>
                                 <color key="backgroundColor" systemColor="systemOrangeColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="4DC-C5-QHY">
                                     <size key="itemSize" width="128" height="128"/>
@@ -456,71 +465,29 @@
                                     </collectionViewCell>
                                 </cells>
                             </collectionView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eRo-Z1-BzV">
-                                <rect key="frame" x="626" y="0.0" width="174" height="40"/>
-                            </view>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="aDD-d2-KuN">
-                                <rect key="frame" x="638" y="-2" width="138" height="44"/>
-                                <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cYd-YU-sSj">
-                                        <rect key="frame" x="0.0" y="0.0" width="30" height="44"/>
-                                        <accessibility key="accessibilityConfiguration" label="Add new tab"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="30" id="nob-CW-zXt"/>
-                                        </constraints>
-                                        <state key="normal" image="Add"/>
-                                        <connections>
-                                            <action selector="onNewTabPressed" destination="LNa-Pc-RyW" eventType="touchUpInside" id="nKg-dF-UQL"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hcx-F2-HgO">
-                                        <rect key="frame" x="54" y="0.0" width="30" height="44"/>
-                                        <accessibility key="accessibilityConfiguration" label="Clear tabs and data"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="30" id="VVN-wr-Trj"/>
-                                        </constraints>
-                                        <state key="normal" image="sharesheet-burndata"/>
-                                        <connections>
-                                            <action selector="onFireButtonPressed" destination="LNa-Pc-RyW" eventType="touchUpInside" id="Sqt-ap-yN7"/>
-                                        </connections>
-                                    </button>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0eS-1F-EgF">
-                                        <rect key="frame" x="108" y="0.0" width="30" height="44"/>
-                                        <accessibility key="accessibilityConfiguration">
-                                            <accessibilityTraits key="traits" button="YES"/>
-                                            <bool key="isElement" value="YES"/>
-                                        </accessibility>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="30" id="hLu-Tm-uj6"/>
-                                            <constraint firstAttribute="height" constant="44" id="hlc-iN-dB9"/>
-                                        </constraints>
-                                    </view>
-                                </subviews>
-                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="xZV-8A-KoM"/>
                         <constraints>
                             <constraint firstItem="1wM-Ln-7ly" firstAttribute="top" secondItem="8BH-do-lHc" secondAttribute="top" id="28V-cD-7Ty"/>
+                            <constraint firstItem="aDD-d2-KuN" firstAttribute="centerY" secondItem="8BH-do-lHc" secondAttribute="centerY" id="8Mp-g2-mVt"/>
                             <constraint firstAttribute="trailing" secondItem="eRo-Z1-BzV" secondAttribute="trailing" id="AXl-ER-GiJ"/>
                             <constraint firstAttribute="bottom" secondItem="1wM-Ln-7ly" secondAttribute="bottom" id="Ign-CF-bTN"/>
+                            <constraint firstItem="aDD-d2-KuN" firstAttribute="top" relation="greaterThanOrEqual" secondItem="8BH-do-lHc" secondAttribute="top" id="MmQ-jI-s9Q"/>
+                            <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="aDD-d2-KuN" secondAttribute="bottom" id="N8j-Q1-GG3"/>
                             <constraint firstItem="1wM-Ln-7ly" firstAttribute="leading" secondItem="8BH-do-lHc" secondAttribute="leading" constant="8" id="RGE-7m-yXx"/>
                             <constraint firstItem="1wM-Ln-7ly" firstAttribute="height" secondItem="8BH-do-lHc" secondAttribute="height" id="c2u-Ow-7wx"/>
                             <constraint firstItem="eRo-Z1-BzV" firstAttribute="top" secondItem="8BH-do-lHc" secondAttribute="top" id="cOB-V5-0Al"/>
-                            <constraint firstAttribute="trailing" secondItem="aDD-d2-KuN" secondAttribute="trailing" constant="24" id="drm-rF-cl7"/>
+                            <constraint firstAttribute="trailing" secondItem="aDD-d2-KuN" secondAttribute="trailing" constant="16" id="drm-rF-cl7"/>
                             <constraint firstAttribute="bottom" secondItem="eRo-Z1-BzV" secondAttribute="bottom" id="ehD-xW-kb9"/>
-                            <constraint firstItem="aDD-d2-KuN" firstAttribute="top" secondItem="8BH-do-lHc" secondAttribute="top" constant="-2" id="gao-OH-EED"/>
                             <constraint firstItem="eRo-Z1-BzV" firstAttribute="leading" secondItem="1wM-Ln-7ly" secondAttribute="trailing" id="owJ-aY-lUW"/>
-                            <constraint firstItem="aDD-d2-KuN" firstAttribute="leading" secondItem="1wM-Ln-7ly" secondAttribute="trailing" constant="12" id="z6F-x8-cQ6"/>
+                            <constraint firstItem="aDD-d2-KuN" firstAttribute="leading" secondItem="1wM-Ln-7ly" secondAttribute="trailing" constant="16" id="z6F-x8-cQ6"/>
                         </constraints>
                     </view>
                     <size key="freeformSize" width="800" height="40"/>
                     <connections>
-                        <outlet property="addTabButton" destination="cYd-YU-sSj" id="Esy-Fe-JSs"/>
                         <outlet property="buttonsBackground" destination="eRo-Z1-BzV" id="X83-Xq-Aup"/>
                         <outlet property="buttonsStack" destination="aDD-d2-KuN" id="5zW-Qb-KIe"/>
                         <outlet property="collectionView" destination="1wM-Ln-7ly" id="cCP-cW-HWP"/>
-                        <outlet property="fireButton" destination="Hcx-F2-HgO" id="JuZ-vT-v3y"/>
-                        <outlet property="tabSwitcherContainer" destination="0eS-1F-EgF" id="YUq-xZ-LsO"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2qS-F2-HbF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -537,12 +504,10 @@
         </scene>
     </scenes>
     <resources>
-        <image name="Add" width="24" height="24"/>
         <image name="Close-24" width="24" height="24"/>
         <image name="GlobeSmall" width="24" height="24"/>
         <image name="Remove" width="24" height="24"/>
         <image name="TabUnread" width="24" height="24"/>
-        <image name="sharesheet-burndata" width="24" height="24"/>
         <namedColor name="icons">
             <color red="0.0" green="0.0" blue="0.0" alpha="0.8399999737739563" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/iOS/DuckDuckGo/Base.lproj/TabSwitcher.storyboard
+++ b/iOS/DuckDuckGo/Base.lproj/TabSwitcher.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="G9p-Sf-e96">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="G9p-Sf-e96">
     <device id="retina4_7" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -511,10 +511,12 @@ class MainViewController: UIViewController {
         let controller: TabsBarViewController = storyboard.instantiateViewController(identifier: "TabsBar") { coder in
             TabsBarViewController(coder: coder, featureFlagger: self.featureFlagger)
         }
+        controller.willMove(toParent: self)
         controller.view.frame = viewCoordinator.tabBarContainer.bounds
         controller.delegate = self
         viewCoordinator.tabBarContainer.addSubview(controller.view)
         tabsBarController = controller
+        addChild(controller)
     }
 
     func startAddFavoriteFlow() {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -508,7 +508,9 @@ class MainViewController: UIViewController {
         guard isPad else { return }
 
         let storyboard = UIStoryboard(name: "TabSwitcher", bundle: nil)
-        let controller: TabsBarViewController = storyboard.instantiateViewController(identifier: "TabsBar")
+        let controller: TabsBarViewController = storyboard.instantiateViewController(identifier: "TabsBar") { coder in
+            TabsBarViewController(coder: coder, featureFlagger: self.featureFlagger)
+        }
         controller.view.frame = viewCoordinator.tabBarContainer.bounds
         controller.delegate = self
         viewCoordinator.tabBarContainer.addSubview(controller.view)

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -511,12 +511,12 @@ class MainViewController: UIViewController {
         let controller: TabsBarViewController = storyboard.instantiateViewController(identifier: "TabsBar") { coder in
             TabsBarViewController(coder: coder, featureFlagger: self.featureFlagger)
         }
-        controller.willMove(toParent: self)
+        addChild(controller)
         controller.view.frame = viewCoordinator.tabBarContainer.bounds
         controller.delegate = self
         viewCoordinator.tabBarContainer.addSubview(controller.view)
         tabsBarController = controller
-        addChild(controller)
+        controller.didMove(toParent: self)
     }
 
     func startAddFavoriteFlow() {

--- a/iOS/DuckDuckGo/Refactoring/Updated/ButtonConfigurations/BrowserChromeButton.swift
+++ b/iOS/DuckDuckGo/Refactoring/Updated/ButtonConfigurations/BrowserChromeButton.swift
@@ -1,5 +1,5 @@
 //
-//  ToolbarButton.swift
+//  BrowserChromeButton.swift
 //  DuckDuckGo
 //
 //  Copyright © 2025 DuckDuckGo. All rights reserved.
@@ -20,7 +20,7 @@
 import UIKit
 import DesignResourcesKit
 
-class ToolbarButton: UIButton {
+class BrowserChromeButton: UIButton {
 
     enum ButtonType {
         case primary
@@ -68,7 +68,7 @@ class ToolbarButton: UIButton {
     }
 }
 
-private extension ToolbarButton.ButtonType {
+private extension BrowserChromeButton.ButtonType {
 
     func backgroundColor(for state: UIButton.State) -> UIColor {
 

--- a/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarSearchView.swift
+++ b/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarSearchView.swift
@@ -32,7 +32,7 @@ final class UpdatedOmniBarSearchView: UIView {
 
     let loupeIconView = UIImageView()
     let customIconView = UIImageView()
-    let dismissButtonView = ToolbarButton()
+    let dismissButtonView = BrowserChromeButton()
 
     let leftIconContainer = UIView()
     let textField = TextFieldWithInsets()
@@ -42,13 +42,13 @@ final class UpdatedOmniBarSearchView: UIView {
 
     let separatorView = URLSeparatorView()
 
-    let reloadButton = ToolbarButton()
-    let clearButton = ToolbarButton(.secondary)
+    let reloadButton = BrowserChromeButton()
+    let clearButton = BrowserChromeButton(.secondary)
 
-    let shareButton = ToolbarButton()
-    let cancelButton = ToolbarButton(.secondary)
-    let voiceSearchButton = ToolbarButton()
-    let accessoryButton = ToolbarButton()
+    let shareButton = BrowserChromeButton()
+    let cancelButton = BrowserChromeButton(.secondary)
+    let voiceSearchButton = BrowserChromeButton()
+    let accessoryButton = BrowserChromeButton()
 
     private let mainStackView = UIStackView()
 

--- a/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarView.swift
+++ b/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarView.swift
@@ -212,11 +212,11 @@ final class UpdatedOmniBarView: UIView, OmniBarView {
         set { forwardButton.menu = newValue }
     }
 
-    let settingsButtonView = ToolbarButton()
-    let bookmarksButtonView = ToolbarButton()
-    let menuButtonView = ToolbarButton()
-    let forwardButtonView = ToolbarButton()
-    let backButtonView = ToolbarButton()
+    let settingsButtonView = BrowserChromeButton()
+    let bookmarksButtonView = BrowserChromeButton()
+    let menuButtonView = BrowserChromeButton()
+    let forwardButtonView = BrowserChromeButton()
+    let backButtonView = BrowserChromeButton()
 
     var menuButtonContent: MenuButton = MenuButton()
 

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -256,7 +256,7 @@ class TabsBarViewController: UIViewController {
     private func createButton(resource: ImageResource) -> UIButton {
         let image = UIImage(resource: resource)
         if isExperimentalThemingEnabled {
-            let button = ToolbarButton()
+            let button = BrowserChromeButton()
             button.setImage(image)
             return button
         } else {

--- a/iOS/DuckDuckGo/ToolbarButtons/FireButton.swift
+++ b/iOS/DuckDuckGo/ToolbarButtons/FireButton.swift
@@ -20,7 +20,7 @@
 import UIKit
 import DesignResourcesKit
 
-class FireButton: ToolbarButton {
+class FireButton: BrowserChromeButton {
     convenience init() {
         self.init(.fire)
 

--- a/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherAnimatedButton.swift
+++ b/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherAnimatedButton.swift
@@ -50,6 +50,7 @@ class TabSwitcherAnimatedButton: UIView, TabSwitcherButton {
 
     let anim = LottieAnimationView(name: "new_tab")
     let label = UILabel()
+    var pointer: UIView? { pointerView }
     let pointerView: UIView = UIView(frame: CGRect(x: 0,
                                                    y: 0,
                                                    width: Constants.pointerViewWidth,

--- a/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherButton.swift
+++ b/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherButton.swift
@@ -22,6 +22,8 @@ import UIKit
 protocol TabSwitcherButton: UIView {
     var delegate: TabSwitcherButtonDelegate? { get set }
 
+    var pointer: UIView? { get }
+
     var tabCount: Int { get set }
     var hasUnread: Bool { get set }
 

--- a/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherStaticButton.swift
+++ b/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherStaticButton.swift
@@ -28,6 +28,9 @@ final class TabSwitcherStaticButton: ToolbarButton, TabSwitcherButton {
         tabSwitcherView.label.text
     }
 
+    // Just to satisfy protocol requirement
+    let pointer: UIView? = nil
+
     init() {
         super.init()
         self.frame = CGRect(x: 0, y: 0, width: 34, height: 44)
@@ -44,6 +47,7 @@ final class TabSwitcherStaticButton: ToolbarButton, TabSwitcherButton {
         addGestureRecognizer(longPressRecognizer)
 
         setUpSubviews()
+        self.isPointerInteractionEnabled = true
     }
 
     @available(*, unavailable)
@@ -56,6 +60,7 @@ final class TabSwitcherStaticButton: ToolbarButton, TabSwitcherButton {
 
         tabSwitcherView.frame = bounds
         tabSwitcherView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        tabSwitcherView.isUserInteractionEnabled = false
 
         // This is needed so the ToolbarButton is resized appropriately.
         setImage(.fake(size: CGSize(width: 24, height: 24)))

--- a/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherStaticButton.swift
+++ b/iOS/DuckDuckGo/ToolbarButtons/TabSwitcherStaticButton.swift
@@ -19,7 +19,7 @@
 
 import UIKit
 
-final class TabSwitcherStaticButton: ToolbarButton, TabSwitcherButton {
+final class TabSwitcherStaticButton: BrowserChromeButton, TabSwitcherButton {
 
     private let tabSwitcherView = TabSwitcherStaticView()
     weak var delegate: TabSwitcherButtonDelegate?
@@ -62,7 +62,7 @@ final class TabSwitcherStaticButton: ToolbarButton, TabSwitcherButton {
         tabSwitcherView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         tabSwitcherView.isUserInteractionEnabled = false
 
-        // This is needed so the ToolbarButton is resized appropriately.
+        // This is needed so the BrowserChromeButton is resized appropriately.
         setImage(.fake(size: CGSize(width: 24, height: 24)))
     }
 

--- a/iOS/DuckDuckGo/ToolbarStateHandling.swift
+++ b/iOS/DuckDuckGo/ToolbarStateHandling.swift
@@ -129,7 +129,7 @@ final class ToolbarHandler: ToolbarStateHandling {
 
     private func createBarButtonItem(title: String, imageResource: ImageResource) -> UIBarButtonItem {
         if self.isExperimentalThemingEnabled {
-            let button = ToolbarButton(.primary)
+            let button = BrowserChromeButton(.primary)
             button.setImage(UIImage(resource: imageResource))
             button.frame = CGRect(x: 0, y: 0, width: 34, height: 44)
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210350800763731
Tech Design URL:
CC:

### Description

* Updated the TabsBarViewController to use the same tab switcher button instance as main view.
* Updated all buttons to have similar appearance on iPad when experimental appearance is enabled.
* Renamed `ToolbarButton` to `BrowserChromeButton`.

### Testing Steps
1. Enable experimental appearance. Restart the app.
2. Check the updated tab switcher button is visible and updates properly when tabs count is changing.
3. Verify opening tab switcher and long press to open a new tab works as expected.
4. On iPad enable pointer simulation and verify all three buttons highlight when hovering over it.
5. Check fire and + button work as expected.

### Impact and Risks
Medium: Could disrupt specific features or user flows

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)