### PR TITLE
Allows showing the popup-blocked popover many times

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -497,7 +497,6 @@ final class AddressBarButtonsViewController: NSViewController {
             case .geolocation:
                 button = geolocationButton
             case .popups:
-                guard !query.wasShownOnce else { return }
                 button = popupsButton
                 popover = popupBlockedPopoverCreatingIfNeeded()
             case .externalScheme:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210327066524779?focus=true

### Description

Allows showing the popup-blocked popover many times, so users won't miss that their popovers are being blocked.

### Testing Steps

1. Open hotmail.com (or any site where you know a popover will be blocked)
2. Try opening the popup.
3. Each time you try you should see a popover the popup was blocked.

### Impact and Risks

None

#### What could go wrong?

Nothing really from a technical point of view.  People might not like it always coming up.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)