### PR TITLE
'quit without clearing' session restoration with duplicate windows fixed

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -546,6 +546,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             stateRestorationManager.applicationDidFinishLaunching()
         }
 
+        setUpAutoClearHandler()
+
         BWManager.shared.initCommunication()
 
         if WindowsManager.windows.first(where: { $0 is MainWindow }) == nil,
@@ -599,8 +601,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         DataBrokerProtectionAppEvents(featureGatekeeper: pirGatekeeper).applicationDidFinishLaunching()
 
         TipKitAppEventHandler(featureFlagger: featureFlagger).appDidFinishLaunching()
-
-        setUpAutoClearHandler()
 
         setUpAutofillPixelReporter()
 
@@ -954,6 +954,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 NSApplication.shared.reply(toApplicationShouldTerminate: true)
             }
         }
+        self.autoClearHandler.restoreTabsIfNeeded()
     }
 
     private func setUpAutofillPixelReporter() {

--- a/macOS/DuckDuckGo/Application/AutoClearHandler.swift
+++ b/macOS/DuckDuckGo/Application/AutoClearHandler.swift
@@ -36,7 +36,6 @@ final class AutoClearHandler {
     @MainActor
     func handleAppLaunch() {
         burnOnStartIfNeeded()
-        restoreTabsIfNeeded()
         resetTheCorrectTerminationFlag()
     }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1209231185661753?focus=true

### Description
This PR fixes a problem where Quit Without Clearing introduced an extra empty window after the restart of the app.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Navigate to https://github.com/duckduckgo/macos-browser/pull/2600 and execute testing steps.
2. Make sure the session restoration after 'quit without clearing' doesn't contain an extra empty window

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Session restoration

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)