### PR TITLE
Draw top and bottom edge for webView

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -422,6 +422,7 @@
 		6F395BBB2CD2C87D00B92FC3 /* BoolFileMarkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F395BB92CD2C84300B92FC3 /* BoolFileMarkerTests.swift */; };
 		6F40D15B2C34423800BF22F0 /* HomePageDisplayDailyPixelBucket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F40D15A2C34423800BF22F0 /* HomePageDisplayDailyPixelBucket.swift */; };
 		6F40D15E2C34436500BF22F0 /* HomePageDisplayDailyPixelBucketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F40D15C2C34436200BF22F0 /* HomePageDisplayDailyPixelBucketTests.swift */; };
+		6F4BFD3E2DE06F1F00E754EB /* TabBorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4BFD3D2DE06F1F00E754EB /* TabBorderView.swift */; };
 		6F5041C92CC11A5100989E48 /* NewTabPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5041C82CC11A5100989E48 /* NewTabPageView.swift */; };
 		6F5345AF2C53F2DE00424A43 /* NewTabPageSettingsPersistentStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5345AE2C53F2DE00424A43 /* NewTabPageSettingsPersistentStorage.swift */; };
 		6F5938982DB1028200C8C068 /* ToolbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5938972DB1028200C8C068 /* ToolbarButton.swift */; };
@@ -2020,6 +2021,7 @@
 		6F395BB92CD2C84300B92FC3 /* BoolFileMarkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolFileMarkerTests.swift; sourceTree = "<group>"; };
 		6F40D15A2C34423800BF22F0 /* HomePageDisplayDailyPixelBucket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePageDisplayDailyPixelBucket.swift; sourceTree = "<group>"; };
 		6F40D15C2C34436200BF22F0 /* HomePageDisplayDailyPixelBucketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePageDisplayDailyPixelBucketTests.swift; sourceTree = "<group>"; };
+		6F4BFD3D2DE06F1F00E754EB /* TabBorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBorderView.swift; sourceTree = "<group>"; };
 		6F5041C82CC11A5100989E48 /* NewTabPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageView.swift; sourceTree = "<group>"; };
 		6F5345AE2C53F2DE00424A43 /* NewTabPageSettingsPersistentStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageSettingsPersistentStorage.swift; sourceTree = "<group>"; };
 		6F5938972DB1028200C8C068 /* ToolbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarButton.swift; sourceTree = "<group>"; };
@@ -7319,6 +7321,7 @@
 				984147C224F026A300362052 /* Tab.storyboard */,
 				F1386BA31E6846C40062FC3C /* TabDelegate.swift */,
 				F159BDA31F0BDB5A00B4A01D /* TabViewController.swift */,
+				6F4BFD3D2DE06F1F00E754EB /* TabBorderView.swift */,
 				CB9C3F6B2D898BE000264725 /* PullToRefreshViewAdapter.swift */,
 				31D4CD4F2D4D3CD600BC27C6 /* Navigatable.swift */,
 				CBC88EE42C8097B500F0F8C5 /* URLCredentialCreator.swift */,
@@ -9564,6 +9567,7 @@
 				9F254AAB2CF47DD50063B308 /* MaliciousSiteProtectionManager.swift in Sources */,
 				310D091D2799F57200DC0060 /* Download.swift in Sources */,
 				65F4CB462D7A0EFF00E89416 /* DuckPlayerWebView.swift in Sources */,
+				6F4BFD3E2DE06F1F00E754EB /* TabBorderView.swift in Sources */,
 				BDE91CDA2C62A70B0005CB74 /* UnifiedMetadataCollector.swift in Sources */,
 				C13F3F6C2B7F88470083BE40 /* AuthConfirmationPromptViewModel.swift in Sources */,
 				1EEF124E2850EADE003DDE57 /* PrivacyIconView.swift in Sources */,
@@ -9904,8 +9908,6 @@
 				4B27FBB12C9252F4007E21A7 /* DefaultPersistentPixelStorageTests.swift in Sources */,
 				564DE45A2C450BE600D23241 /* DaxDialogsNewTabTests.swift in Sources */,
 				C174CE602BD6A6CE00AED2EA /* MockDDGSyncing.swift in Sources */,
-				987DA29E2D936330002E03B7 /* KeyValueFileStoreServiceTests.swift in Sources */,
-				56D5B39A2DD3831800407440 /* ScriptSourceProviderTests.swift in Sources */,
 				9F4CC51F2C48D758006A96EB /* ContextualDaxDialogsFactoryTests.swift in Sources */,
 				8521FDE6238D414B00A44CC3 /* FileStoreTests.swift in Sources */,
 				F14E491F1E391CE900DC037C /* URLExtensionTests.swift in Sources */,

--- a/iOS/DuckDuckGo/TabBorderView.swift
+++ b/iOS/DuckDuckGo/TabBorderView.swift
@@ -1,0 +1,77 @@
+//
+//  TabBorderView.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+import DesignResourcesKit
+
+final class TabBorderView: UIView {
+
+    private let topEdge = UIView()
+    private let bottomEdge = UIView()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setUpSubviews()
+        setUpConstraints()
+        setUpProperties()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setUpSubviews() {
+        addSubview(topEdge)
+        addSubview(bottomEdge)
+    }
+
+    private func setUpConstraints() {
+        topEdge.translatesAutoresizingMaskIntoConstraints = false
+        bottomEdge.translatesAutoresizingMaskIntoConstraints = false
+
+        let height = Metrics.lineWidth
+
+        NSLayoutConstraint.activate([
+            topEdge.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            topEdge.leadingAnchor.constraint(equalTo: leadingAnchor),
+            topEdge.trailingAnchor.constraint(equalTo: trailingAnchor),
+            topEdge.heightAnchor.constraint(equalToConstant: height),
+
+            bottomEdge.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+            bottomEdge.leadingAnchor.constraint(equalTo: leadingAnchor),
+            bottomEdge.trailingAnchor.constraint(equalTo: trailingAnchor),
+            bottomEdge.heightAnchor.constraint(equalToConstant: height)
+        ])
+    }
+
+    private func setUpProperties() {
+        isUserInteractionEnabled = false
+        backgroundColor = .clear
+
+        let edgeColor = UIColor(designSystemColor: .shadowPrimary)
+        topEdge.backgroundColor = edgeColor
+        bottomEdge.backgroundColor = edgeColor
+    }
+
+    private struct Metrics {
+        static let lineWidth = 0.5
+    }
+}


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1210340616083163?focus=true
Tech Design URL:
CC:

### Description

* Adds border to top and bottom edge of the Web View. This helps with marking the web content / bar boundary.
* Design can be found [here](https://www.figma.com/design/triNDLtPcx4by8Hsw9CzYt/🖍%EF%B8%8F-2025-Visual-Design-Update---1-Tap-AI-ChatOS---Android?node-id=7466-72205&p=f&m=dev).


### Testing Steps
1. Enable experimental appearance. Restart the app.
2. Open NTP, make sure borders are not visible.
3. Browse to any URL. Observe top and bottom edges are visible near the bars.
4. Scroll the website. Border should be moving along with the content.
5. Turn off experimental appearance. Restart the app. No border should be visible on website.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)