### PR TITLE
Use Swift Tools 5.9 in DesignResourcesKitIcons

### DIFF
--- a/SharedPackages/DesignResourcesKitIcons/Package.swift
+++ b/SharedPackages/DesignResourcesKitIcons/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 //
 //  Package.swift


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1210376606467197?focus=true

### Description
Swift Tools 6.0 are not available on macOS 14 and 13 where UI tests are run in CI.

### Testing Steps
1. Verify that CI is green
2. Verify that [this UI tests workflow](https://github.com/duckduckgo/apple-browsers/actions/runs/15247613708) is green.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)