### PR TITLE
Don't send pixel on qr code scan fail

### DIFF
--- a/iOS/DuckDuckGo/SyncErrorMessage.swift
+++ b/iOS/DuckDuckGo/SyncErrorMessage.swift
@@ -56,4 +56,13 @@ enum SyncErrorMessage {
             return UserText.unableToRecognizeCode
         }
     }
+
+    var shouldSendPixel: Bool {
+        switch self {
+        case .unableToRecognizeCode:
+            return false
+        default:
+            return true
+        }
+    }
 }

--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -157,8 +157,10 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
     }
 
     @MainActor
-    func handleError(_ type: SyncErrorMessage, error: Error?, event: Pixel.Event) {
-        firePixelIfNeededFor(event: event, error: error)
+    func handleError(_ type: SyncErrorMessage, error: Error?, event: Pixel.Event?) {
+        if type.shouldSendPixel, let event = event {
+            firePixelIfNeededFor(event: event, error: error)
+        }
         let alertController = UIAlertController(
             title: type.title,
             message: [type.description, error?.localizedDescription].compactMap({ $0 }).joined(separator: "\n"),

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -508,7 +508,7 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
     func controllerDidError(_ error: SyncConnectionError, underlyingError: (any Error)?) {
         switch error {
         case .unableToRecognizeCode:
-            handleError(.unableToRecognizeCode, error: underlyingError, event: .syncSignupError)
+            handleError(.unableToRecognizeCode, error: underlyingError, event: nil)
         case .failedToFetchPublicKey, .failedToTransmitExchangeRecoveryKey, .failedToFetchConnectRecoveryKey, .failedToLogIn, .failedToTransmitExchangeKey, .failedToFetchExchangeRecoveryKey, .failedToTransmitConnectRecoveryKey:
             handleError(.unableToSyncWithDevice, error: underlyingError, event: .syncLoginError)
         case .failedToCreateAccount:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1210378006250997?focus=true

### Description

A pixel is being erroneously sent when a non-valid QR code is scanned. This stops it from being sent when there's a QR code scan failure.

### Testing Steps
1. Find any random QR code (e.g from [this Figma file](https://www.figma.com/design/PDXa8Yl808Im6NWJTeqKQ2/Sync-QR-from-Phone?node-id=409-125478&m=dev))
2. Go to Settings -> Sync and Backup
3. Tap "Sync with another device"
4. Scan the QR code
5. Ensure no pixel is sent in this case.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)