### PR TITLE
Changes the action for the restart-to-update button

### DIFF
--- a/macOS/DuckDuckGo/Preferences/Model/AboutPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AboutPreferences.swift
@@ -98,9 +98,7 @@ final class AboutPreferences: ObservableObject, PreferencesTabOpening {
             if isAtRestartCheckpoint {
                 return UpdateButtonConfiguration(
                     title: UserText.restartToUpdate,
-                    action: { [weak self] in
-                        self?.checkForUpdate(userInitiated: true)
-                    },
+                    action: runUpdate,
                     enabled: true)
             } else if hasPendingUpdate {
                 return UpdateButtonConfiguration(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1210386545302221?focus=true

### Description

Ensure "Restart to Update" works well again.

### Testing Steps

1. Decrease the build number in `BuildNumber.xcconfig`
2. Run the app
3. You'll need to enable `autoUpdateInDEBUG` for debug builds
4. Check for updates, and when "Restart to Update" comes up, ensure it restarts the app.  Please be advised that the restart can appear to be a crash when running the App in Xcode.

### Impact and Risks

Low.

#### What could go wrong?

Nothing I can think of with this specific change.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)