### PR TITLE
Improvements in the authv2 cleanup when using authv1

### DIFF
--- a/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
@@ -127,7 +127,7 @@ final class AppDependencyProvider: DependencyProvider {
         var authenticationStateProvider: (any SubscriptionAuthenticationStateProvider)!
 
         let tokenStorageV2 = SubscriptionTokenKeychainStorageV2(keychainType: .dataProtection(.named(subscriptionAppGroup))) { accessType, error in
-
+            Logger.subscription.error("Failed to access keychain, Error: \(error.localizedDescription, privacy: .public)")
             let parameters = [PixelParameters.privacyProKeychainAccessType: accessType.rawValue,
                               PixelParameters.privacyProKeychainError: error.localizedDescription,
                               PixelParameters.source: KeychainErrorSource.browser.rawValue,
@@ -186,8 +186,8 @@ final class AppDependencyProvider: DependencyProvider {
             authenticationStateProvider = subscriptionManager
             subscriptionAuthV1toV2Bridge = subscriptionManager
 
-            let tokenContainer = try? tokenStorageV2.getTokenContainer()
-            if tokenContainer != nil {
+            // Auth V2 cleanup in case of rollback
+            if let tokenContainer = try? tokenStorageV2.getTokenContainer() {
                 Logger.subscription.debug("Cleaning up Auth V2 token")
                 try? tokenStorageV2.saveTokenContainer(nil)
                 subscriptionEndpointService.clearSubscription()

--- a/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -438,6 +438,20 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
 
         var tokenHandler: any SubscriptionTokenHandling
         var entitlementsCheck: (() async -> Result<Bool, Error>)
+
+        // AuthV2 keychain storage
+        let subscriptionAppGroup = Bundle.main.appGroup(bundle: .subs)
+        let tokenStorageV2 = SubscriptionTokenKeychainStorageV2(keychainType: .dataProtection(.named(subscriptionAppGroup))) { accessType, error in
+            Logger.subscription.error("Failed to access keychain, Error: \(error.localizedDescription, privacy: .public)")
+            let parameters = [PixelParameters.privacyProKeychainAccessType: accessType.rawValue,
+                              PixelParameters.privacyProKeychainError: error.localizedDescription,
+                              PixelParameters.source: KeychainErrorSource.vpn.rawValue,
+                              PixelParameters.authVersion: KeychainErrorAuthVersion.v2.rawValue]
+            DailyPixel.fireDailyAndCount(pixel: .privacyProKeychainAccessError,
+                                         pixelNameSuffixes: DailyPixel.Constant.legacyDailyPixelSuffixes,
+                                         withAdditionalParameters: parameters)
+        }
+
         Self.isAuthV2Enabled = settings.isAuthV2Enabled
         if !Self.isAuthV2Enabled {
             // MARK: Subscription V1
@@ -467,6 +481,13 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
             tokenHandler = NetworkProtectionKeychainTokenStore(accessTokenProvider: accessTokenProvider)
             entitlementsCheck = { return await Self.entitlementCheck(accountManager: accountManager) }
             self.subscriptionManager = nil
+
+            // Auth V2 cleanup in case of rollback
+            if let tokenContainer = try? tokenStorageV2.getTokenContainer() {
+                Logger.subscription.debug("Cleaning up Auth V2 token")
+                try? tokenStorageV2.saveTokenContainer(nil)
+                subscriptionEndpointService.clearSubscription()
+            }
         } else {
             // MARK: Subscription V2
             Logger.networkProtection.log("Configure Subscription V2")
@@ -474,19 +495,8 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
             let authService = DefaultOAuthService(baseURL: authEnvironment.url,
                                                   apiService: APIServiceFactory.makeAPIServiceForAuthV2(withUserAgent: DefaultUserAgentManager.duckDuckGoUserAgent))
 
-            // keychain storage
-            let subscriptionAppGroup = Bundle.main.appGroup(bundle: .subs)
-            let tokenStorage = SubscriptionTokenKeychainStorageV2(keychainType: .dataProtection(.named(subscriptionAppGroup))) { accessType, error in
-                let parameters = [PixelParameters.privacyProKeychainAccessType: accessType.rawValue,
-                                  PixelParameters.privacyProKeychainError: error.localizedDescription,
-                                  PixelParameters.source: KeychainErrorSource.vpn.rawValue,
-                                  PixelParameters.authVersion: KeychainErrorAuthVersion.v2.rawValue]
-                DailyPixel.fireDailyAndCount(pixel: .privacyProKeychainAccessError,
-                                             pixelNameSuffixes: DailyPixel.Constant.legacyDailyPixelSuffixes,
-                                             withAdditionalParameters: parameters)
-            }
             let legacyAccountStorage = SubscriptionTokenKeychainStorage(keychainType: .dataProtection(.named(subscriptionAppGroup)))
-            let authClient = DefaultOAuthClient(tokensStorage: tokenStorage,
+            let authClient = DefaultOAuthClient(tokensStorage: tokenStorageV2,
                                                 legacyTokenStorage: legacyAccountStorage,
                                                 authService: authService)
             let subscriptionEndpointService = DefaultSubscriptionEndpointServiceV2(apiService: APIServiceFactory.makeAPIServiceForSubscription(withUserAgent: DefaultUserAgentManager.duckDuckGoUserAgent),

--- a/macOS/DuckDuckGo/Subscription/SubscriptionManager+StandardConfiguration.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionManager+StandardConfiguration.swift
@@ -92,10 +92,14 @@ extension DefaultSubscriptionManager {
         accountManager.delegate = self
 
         // Auth V2 cleanup in case of rollback
-        let tokenStorage = SubscriptionTokenKeychainStorageV2(keychainType: keychainType) { _, error in
+        let tokenStorageV2 = SubscriptionTokenKeychainStorageV2(keychainType: keychainType) { _, error in
             Logger.subscription.error("Failed to remove AuthV2 token container : \(error.localizedDescription, privacy: .public)")
         }
-        try? tokenStorage.saveTokenContainer(nil)
+        if let tokenContainer = try? tokenStorageV2.getTokenContainer() {
+            Logger.subscription.debug("Cleaning up Auth V2 token")
+            try? tokenStorageV2.saveTokenContainer(nil)
+            subscriptionEndpointService.clearSubscription()
+        }
     }
 }
 
@@ -131,6 +135,7 @@ extension DefaultSubscriptionManagerV2 {
         let authService = DefaultOAuthService(baseURL: environment.authEnvironment.url,
                                               apiService: APIServiceFactory.makeAPIServiceForAuthV2(withUserAgent: UserAgent.duckDuckGoUserAgent()))
         let tokenStorage = SubscriptionTokenKeychainStorageV2(keychainType: keychainType) { accessType, error in
+            Logger.subscription.error("Failed to access keychain, Error: \(error.localizedDescription, privacy: .public)")
             PixelKit.fire(PrivacyProErrorPixel.privacyProKeychainAccessError(accessType: accessType,
                                                                              accessError: error,
                                                                              source: KeychainErrorSource.shared,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209882303470922/task/1210318610492466?focus=true
CC: @miasma13 

### Description

Every time AuthV1 is used AuthV2 token container is deleted from the keychain so the migration can happen again when AUthV2 is enabled.
This is a corner case mostly useful for the developers that jump from V1 to V2 during development, but also in case of public roll-back of AuthV2

### Testing Steps
- enable AuthV1
- kill app
- restore subscription
- enable VPN
- enable authv2
- kill app
- enable-disable VPN
- enable authv1
- kill app
- enable-disable VPN

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)