### PR TITLE
Remove spacer from iOS VPN location selector

### DIFF
--- a/iOS/DuckDuckGo/NetworkProtectionUIElements.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionUIElements.swift
@@ -33,7 +33,6 @@ struct NetworkProtectionUIElements {
                 label: {
                     HStack(spacing: 12) {
                         label()
-                        Spacer()
                         Image(systemName: "checkmark")
                             .tint(.init(designSystemColor: .accent))
                             .if(!isSelected) {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1210394502948660?focus=true
Tech Design URL:
CC:

### Description

This PR fixes an issue where the VPN location selector had an extra spacer between the label and checkmark, causing everything to be pushed to the left.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Open the VPN location selection screen
2. Check that the city selector button is right-aligned and doesn't overlap with the checkmark
3. Check that tapping the city selector button opens the city selection modal

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)