### PR TITLE
Fix Bookmarks bar UI test

### DIFF
--- a/macOS/UITests/BookmarksAndFavoritesTests.swift
+++ b/macOS/UITests/BookmarksAndFavoritesTests.swift
@@ -678,9 +678,9 @@ class BookmarksAndFavoritesTests: UITestCase {
         let bookmarkBarBookmarkIconCoordinate = bookmarkBarBookmarkIcon.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
         var deleteContextMenuItemCoordinate: XCUICoordinate
         if #available(macOS 15.0, *) {
-            deleteContextMenuItemCoordinate = bookmarkBarBookmarkIcon.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 8.0))
-        } else {
             deleteContextMenuItemCoordinate = bookmarkBarBookmarkIcon.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 9.0))
+        } else {
+            deleteContextMenuItemCoordinate = bookmarkBarBookmarkIcon.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 10.0))
         }
 
         bookmarkBarBookmarkIconCoordinate.rightClick()

--- a/macOS/UITests/BookmarksAndFavoritesTests.swift
+++ b/macOS/UITests/BookmarksAndFavoritesTests.swift
@@ -680,7 +680,7 @@ class BookmarksAndFavoritesTests: UITestCase {
         if #available(macOS 15.0, *) {
             deleteContextMenuItemCoordinate = bookmarkBarBookmarkIcon.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 9.0))
         } else {
-            deleteContextMenuItemCoordinate = bookmarkBarBookmarkIcon.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 10.0))
+            deleteContextMenuItemCoordinate = bookmarkBarBookmarkIcon.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 10.5))
         }
 
         bookmarkBarBookmarkIconCoordinate.rightClick()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1210384592437146?focus=true

### Description:
This change fixes a UI tests that uses coordinates to find menu items.
It got broken after adding “Open in New Fire Window” menu action.

### Testing Steps
Verify that [this UI tests workflow](https://github.com/duckduckgo/apple-browsers/actions/runs/15286989981) is green.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)