### PR TITLE
Update RMF design for visual updates

### DIFF
--- a/iOS/DuckDuckGo/HomeMessageView.swift
+++ b/iOS/DuckDuckGo/HomeMessageView.swift
@@ -81,12 +81,18 @@ struct HomeMessageView: View {
                     dimension[.top]
                 }
         }
-        .background(RoundedRectangle(cornerRadius: Const.Radius.corner)
-                        .fill(Color.background)
-                        .shadow(color: Color.shadow,
-                                radius: Const.Radius.shadow,
-                                x: 0,
-                                y: Const.Offset.shadowVertical))
+        .background(RoundedRectangle(cornerRadius: viewModel.isExperimentalThemingEnabled ? Const.Radius.cornerLarge : Const.Radius.corner)
+            .fill(Color.background)
+            .if(viewModel.isExperimentalThemingEnabled) {
+                $0.shadow(color: Color.updatedShadow, radius: Const.Radius.updatedShadow1, x: 0, y: Const.Offset.updatedShadow1Vertical)
+                    .shadow(color: Color.updatedShadow, radius: Const.Radius.updatedShadow2, x: 0, y: Const.Offset.updatedShadow2Vertical)
+            }
+            .if(!viewModel.isExperimentalThemingEnabled) {
+                $0.shadow(color: Color.shadow,
+                          radius: Const.Radius.shadow,
+                          x: 0,
+                          y: Const.Offset.shadowVertical)
+            })
         .onAppear {
             viewModel.onDidAppear()
         }
@@ -240,6 +246,7 @@ private extension Color {
     static let cancelButtonForeground = Color(designSystemColor: .buttonsSecondaryFillText)
     static let background = Color(designSystemColor: .surface)
     static let shadow = Color.shade(0.1)
+    static let updatedShadow = Color(designSystemColor: .shadowPrimary)
 }
 
 private extension Image {
@@ -256,7 +263,10 @@ private enum Const {
     
     enum Radius {
         static let shadow: CGFloat = 3
+        static let updatedShadow1: CGFloat = 12
+        static let updatedShadow2: CGFloat = 48
         static let corner: CGFloat = 8
+        static let cornerLarge: CGFloat = 16
     }
     
     enum Padding {
@@ -280,6 +290,8 @@ private enum Const {
     
     enum Offset {
         static let shadowVertical: CGFloat = 2
+        static let updatedShadow1Vertical: CGFloat = 4
+        static let updatedShadow2Vertical: CGFloat = 16
     }
 }
 
@@ -322,30 +334,35 @@ struct HomeMessageView_Previews: PreviewProvider {
                                                             sendPixels: false,
                                                             modelType: small,
                                                             navigator: DefaultMessageNavigator(delegate: nil),
+                                                            isExperimentalThemingEnabled: false,
                                                             onDidClose: { _ in }, onDidAppear: {}, onAttachAdditionalParameters: { _, params in params }))
 
             HomeMessageView(viewModel: HomeMessageViewModel(messageId: "Critical",
                                                             sendPixels: false,
                                                             modelType: critical,
                                                             navigator: DefaultMessageNavigator(delegate: nil),
+                                                            isExperimentalThemingEnabled: false,
                                                             onDidClose: { _ in }, onDidAppear: {}, onAttachAdditionalParameters: { _, params in params }))
 
             HomeMessageView(viewModel: HomeMessageViewModel(messageId: "Big Single",
                                                             sendPixels: false,
                                                             modelType: bigSingle,
                                                             navigator: DefaultMessageNavigator(delegate: nil),
+                                                            isExperimentalThemingEnabled: false,
                                                             onDidClose: { _ in }, onDidAppear: {}, onAttachAdditionalParameters: { _, params in params }))
 
             HomeMessageView(viewModel: HomeMessageViewModel(messageId: "Big Two",
                                                             sendPixels: false,
                                                             modelType: bigTwo,
                                                             navigator: DefaultMessageNavigator(delegate: nil),
+                                                            isExperimentalThemingEnabled: false,
                                                             onDidClose: { _ in }, onDidAppear: {}, onAttachAdditionalParameters: { _, params in params }))
 
             HomeMessageView(viewModel: HomeMessageViewModel(messageId: "Promo",
                                                             sendPixels: false,
                                                             modelType: promo,
                                                             navigator: DefaultMessageNavigator(delegate: nil),
+                                                            isExperimentalThemingEnabled: false,
                                                             onDidClose: { _ in }, onDidAppear: {}, onAttachAdditionalParameters: { _, params in params }))
         }
         .frame(height: 200)

--- a/iOS/DuckDuckGo/HomeMessageViewModel.swift
+++ b/iOS/DuckDuckGo/HomeMessageViewModel.swift
@@ -35,6 +35,7 @@ struct HomeMessageViewModel {
     let sendPixels: Bool
     let modelType: RemoteMessageModelType
     let navigator: MessageNavigator
+    let isExperimentalThemingEnabled: Bool
 
     var image: String? {
         switch modelType {

--- a/iOS/DuckDuckGo/HomeMessageViewModelBuilder.swift
+++ b/iOS/DuckDuckGo/HomeMessageViewModelBuilder.swift
@@ -35,6 +35,7 @@ struct HomeMessageViewModelBuilder {
     static func build(for remoteMessage: RemoteMessageModel,
                       with privacyProDataReporter: PrivacyProDataReporting?,
                       navigator: MessageNavigator,
+                      isExperimentalThemingEnabled: Bool,
                       onDidClose: @escaping (HomeMessageViewModel.ButtonAction?) async -> Void,
                       onDidAppear: @escaping () -> Void) -> HomeMessageViewModel? {
             guard let content = remoteMessage.content else { return nil }
@@ -44,6 +45,7 @@ struct HomeMessageViewModelBuilder {
             sendPixels: remoteMessage.isMetricsEnabled,
             modelType: content,
             navigator: navigator,
+            isExperimentalThemingEnabled: isExperimentalThemingEnabled,
             onDidClose: onDidClose,
             onDidAppear: onDidAppear,
             onAttachAdditionalParameters: { useCase, params in

--- a/iOS/DuckDuckGo/NewTabPageMessagesModel.swift
+++ b/iOS/DuckDuckGo/NewTabPageMessagesModel.swift
@@ -32,17 +32,20 @@ final class NewTabPageMessagesModel: ObservableObject {
     private let pixelFiring: PixelFiring.Type
     private let privacyProDataReporter: PrivacyProDataReporting?
     private let navigator: MessageNavigator
+    private let isExperimentalThemingEnabled: Bool
 
     init(homePageMessagesConfiguration: HomePageMessagesConfiguration,
          notificationCenter: NotificationCenter = .default,
          pixelFiring: PixelFiring.Type = Pixel.self,
          privacyProDataReporter: PrivacyProDataReporting? = nil,
-         navigator: MessageNavigator) {
+         navigator: MessageNavigator,
+         isExperimentalThemingEnabled: Bool = false) {
         self.homePageMessagesConfiguration = homePageMessagesConfiguration
         self.notificationCenter = notificationCenter
         self.pixelFiring = pixelFiring
         self.privacyProDataReporter = privacyProDataReporter
         self.navigator = navigator
+        self.isExperimentalThemingEnabled = isExperimentalThemingEnabled
     }
 
     func load() {
@@ -80,7 +83,11 @@ final class NewTabPageMessagesModel: ObservableObject {
     private func homeMessageViewModel(for message: HomeMessage) -> HomeMessageViewModel? {
         switch message {
         case .placeholder:
-            return HomeMessageViewModel(messageId: "", sendPixels: false, modelType: .small(titleText: "", descriptionText: ""), navigator: navigator) { [weak self] _ in
+            return HomeMessageViewModel(messageId: "",
+                                        sendPixels: false,
+                                        modelType: .small(titleText: "", descriptionText: ""),
+                                        navigator: navigator,
+                                        isExperimentalThemingEnabled: isExperimentalThemingEnabled) { [weak self] _ in
                 await self?.dismissHomeMessage(message)
             } onDidAppear: {
                 // no-op
@@ -93,7 +100,10 @@ final class NewTabPageMessagesModel: ObservableObject {
             // as a result of refreshing a config while the user was on a new tab page already.
             didAppear(message)
 
-            return HomeMessageViewModelBuilder.build(for: remoteMessage, with: privacyProDataReporter, navigator: navigator) { @MainActor [weak self] action in
+            return HomeMessageViewModelBuilder.build(for: remoteMessage,
+                                                     with: privacyProDataReporter,
+                                                     navigator: navigator,
+                                                     isExperimentalThemingEnabled: isExperimentalThemingEnabled) { @MainActor [weak self] action in
                 guard let action,
                       let self else { return }
 

--- a/iOS/DuckDuckGo/NewTabPageView.swift
+++ b/iOS/DuckDuckGo/NewTabPageView.swift
@@ -86,7 +86,10 @@ private extension NewTabPageView {
                     
                     messagesSectionView
                         .padding(.top, Metrics.nonGridSectionTopPadding)
-                    
+                        .if(viewModel.isExperimentalAppearanceEnabled) {
+                            $0.padding(.horizontal, Metrics.updatedNonGridSectionHorizontalPadding)
+                        }
+
                     favoritesSectionView(proxy: proxy)
                 }
                 .padding(sectionsViewPadding(in: proxy))
@@ -106,6 +109,9 @@ private extension NewTabPageView {
             VStack(spacing: Metrics.sectionSpacing) {
                 messagesSectionView
                     .padding(.top, Metrics.nonGridSectionTopPadding)
+                    .if(viewModel.isExperimentalAppearanceEnabled) {
+                        $0.padding(.horizontal, Metrics.updatedNonGridSectionHorizontalPadding)
+                    }
                     .frame(maxHeight: .infinity, alignment: .top)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -149,6 +155,7 @@ private struct Metrics {
     static let regularPadding = 24.0
     static let sectionSpacing = 32.0
     static let nonGridSectionTopPadding = -8.0
+    static let updatedNonGridSectionHorizontalPadding = -8.0
 
     static let messageMaximumWidth: CGFloat = 380
     static let messageMaximumWidthPad: CGFloat = 455

--- a/iOS/DuckDuckGo/NewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewController.swift
@@ -76,7 +76,8 @@ final class NewTabPageViewController: UIHostingController<AnyView>, NewTabPage {
         shortcutsModel = ShortcutsModel()
         messagesModel = NewTabPageMessagesModel(homePageMessagesConfiguration: homePageMessagesConfiguration,
                                                 privacyProDataReporter: privacyProDataReporting,
-                                                navigator: DefaultMessageNavigator(delegate: messageNavigationDelegate))
+                                                navigator: DefaultMessageNavigator(delegate: messageNavigationDelegate),
+                                                isExperimentalThemingEnabled: isExperimentalAppearanceEnabled)
 
         if isNewTabPageCustomizationEnabled {
             super.init(rootView: AnyView(CustomizableNewTabPageView(viewModel: self.newTabPageViewModel,


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1210368065427216?focus=true
Tech Design URL:
CC:

### Description

This adjusts how Remote Message looks on NewTabPage when experimental appearance is on:
* Adjusted shadow parameters ([figma](https://www.figma.com/design/3W4vi0zX8hrpQc7zInQQB6/%F0%9F%8E%A8-Global-Colors---Styles?node-id=6152-21378&m=dev))
* Adjusted padding
* Adjusted corner radius

### Testing Steps
1. Set endpoint of RemoteMessagingClient to custom model (e.g. http://www.jsonblob.com/api/1377309266414854144)
2. To make testing of different cases easier disable marking message as seen by commenting out `homePageMessagesConfiguration.didAppear(homeMessage)` in `NewTabPageMessagesModel.viewDidAppear`
3. Make sure there's no difference when experimental updates are disabled
4. Turn on experimental appearance in Appearance Settings (internal user flag must be set). Restart the app.
5. Confirm the message looks like defined in the linked task.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)