### PR TITLE
Fixes the VPN restart logic for the authv2 migration

### DIFF
--- a/macOS/DuckDuckGoVPN/VPNAppEventsHandler.swift
+++ b/macOS/DuckDuckGoVPN/VPNAppEventsHandler.swift
@@ -51,11 +51,12 @@ final class VPNAppEventsHandler {
 
             if appState.isAuthV2Enabled && !appState.isMigratedToAuthV2 {
                 Task {
-                    guard await !tunnelController.isConnected else {
+                    guard await tunnelController.isConnected else {
                         return
                     }
 
                     await tunnelController.stop()
+                    try await Task.sleep(interval: .seconds(2))
                     await tunnelController.start()
                     appState.isMigratedToAuthV2 = true
                 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207603085593419/task/1210406352665274?focus=true

### Description

Fixes an issue that was causing the VPN to start when it shouldn't, during the AuthV2 migration.

### Testing Steps

1. Enable the VPN on AuthV1.
2. Stop the VPN.
3. Switch to AuthV2
4. Relaunch the app

Ensure the VPN won't connect.

### Impact and Risks

Medium.

#### What could go wrong?

The VPN restart logic is tricky.

### Quality Considerations

NA

### Notes to Reviewer

Just ensure the changes make sense.  We'd like the VPN to restart when already connected and not vice-versa.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)