### PR TITLE
Fix e2e tests after refresh button changes

### DIFF
--- a/.maestro/privacy_tests/09_navigation_with_refresh.yaml
+++ b/.maestro/privacy_tests/09_navigation_with_refresh.yaml
@@ -102,9 +102,8 @@ tags:
     text: "About our Web Tracking Protections"
 - tapOn: "Back"
 - tapOn: "Done"  
-- assertVisible: "Browsing Menu"
-- tapOn: "Browsing Menu"
-- tapOn: "Refresh"
+- assertVisible: "Refresh Page"
+- tapOn: "Refresh Page"
 - assertVisible:
     text: "Pay"
 - tapOn:

--- a/.maestro/release_tests/refresh.yaml
+++ b/.maestro/release_tests/refresh.yaml
@@ -1,13 +1,16 @@
-# bookmarks.yaml
+# refresh.yaml
 appId: com.duckduckgo.mobile.ios
 tags:
     - release
 
 ---
 
-# Set up 
-- runFlow: 
+# Set up
+- runFlow:
     file: ../shared/setup.yaml
+
+# Make Sure there's no refresh button
+- assertNotVisible: "Refresh Page"
 
 # Load Site
 - assertVisible:
@@ -18,9 +21,7 @@ tags:
 - pressKey: Enter
 
 - assertVisible: ".*Privacy Test Pages.*"
- 
+
 # Reload page
-- assertVisible: "Browsing menu"
-- tapOn: "Browsing menu"
-- assertVisible: "Refresh"
-- tapOn: "Refresh"
+- assertVisible: "Refresh Page"
+- tapOn: "Refresh Page"


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1210408665240547?focus=true
Tech Design URL:
CC: @brindy 

### Description

Update for automated tests after bringing back refresh button to the address bar (https://github.com/duckduckgo/apple-browsers/pull/859).

`browsing-menu` test was introduced along with the original refresh button removal, so I renamed it and added a check for it being present in the address bar now instead of browsing menu.

### Testing Steps
1. Make sure E2E tests pass (https://github.com/duckduckgo/apple-browsers/actions/runs/15332458391)

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)