### PR TITLE
Skip Navigation tests in BSK tests

### DIFF
--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -68,7 +68,11 @@ jobs:
 
       - name: Run tests
         id: run-unit-tests
-        run: set -o pipefail && swift test | tee -a build-log.txt | xcbeautify --report junit --report-path . --junit-report-filename package-tests.xml
+        run: |
+          # temporarily skip Navigation tests - https://app.asana.com/1/137249556945/project/1201037661562251/task/1210416915595210?focus=true
+          set -o pipefail && swift test --skip Navigation \
+            | tee -a build-log.txt \
+            | xcbeautify --report junit --report-path . --junit-report-filename package-tests.xml
         
       - name: Send Unit Tests Status Pixel
         if: always() && github.ref_name == 'main'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210416942590080?focus=true

### Description
This change disabled Navigation tests in BSK PR Checks workflow to unblock running it while
we’re working on fixing Navigation regression on macOS 15.5

### Testing Steps
Verify that CI is green.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)