### PR TITLE
macOS: Include secure vault error type in error reporting pixels

### DIFF
--- a/macOS/DuckDuckGo/Autofill/AutofillActionExecutor.swift
+++ b/macOS/DuckDuckGo/Autofill/AutofillActionExecutor.swift
@@ -69,7 +69,7 @@ struct AutofillDeleteAllPasswordsExecutor: AutofillActionExecutor {
                 syncService.scheduler.notifyDataChanged()
                 onSuccess?()
             } catch {
-                PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error)))
+                PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error), error: error))
             }
 
             return

--- a/macOS/DuckDuckGo/DataExport/CSVLoginExporter.swift
+++ b/macOS/DuckDuckGo/DataExport/CSVLoginExporter.swift
@@ -50,7 +50,7 @@ final class CSVLoginExporter {
                 }
             }
         } catch {
-            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error)))
+            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error), error: error))
             throw error
         }
 

--- a/macOS/DuckDuckGo/HomePage/Model/DataImportStatusProviding.swift
+++ b/macOS/DuckDuckGo/HomePage/Model/DataImportStatusProviding.swift
@@ -81,7 +81,7 @@ final class BookmarksAndPasswordsImportStatusProvider: DataImportStatusProviding
             let identitiesDates = try secureVault.identities().map(\.created)
             dates.append(contentsOf: identitiesDates)
         } catch {
-            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error)))
+            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error), error: error))
         }
         guard dates.count >= 2 else {
             return false

--- a/macOS/DuckDuckGo/SecureVault/Extensions/NSAlert+PasswordManager.swift
+++ b/macOS/DuckDuckGo/SecureVault/Extensions/NSAlert+PasswordManager.swift
@@ -49,6 +49,16 @@ extension NSAlert {
         return alert
     }
 
+    // Temporary alert to help track down a user issue
+    static func passwordManagerSaveError(errorType: String) -> NSAlert {
+        let alert = NSAlert()
+        alert.messageText = "Error"
+        alert.informativeText = "There was an error saving your changes. \(errorType)"
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: UserText.ok)
+        return alert
+    }
+
     static func passwordManagerConfirmDeleteCard() -> NSAlert {
         let alert = NSAlert()
         alert.messageText = UserText.passwordManagerAlertRemoveCardConfirmation

--- a/macOS/DuckDuckGo/SecureVault/Model/AutofillNeverPromptWebsitesManager.swift
+++ b/macOS/DuckDuckGo/SecureVault/Model/AutofillNeverPromptWebsitesManager.swift
@@ -49,7 +49,7 @@ final class AutofillNeverPromptWebsitesManager {
             fetchNeverPromptWebsites()
             return id
         } catch {
-            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error)))
+            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error), error: error))
             throw error
         }
     }
@@ -65,7 +65,7 @@ final class AutofillNeverPromptWebsitesManager {
             fetchNeverPromptWebsites()
             return true
         } catch {
-            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error)))
+            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error), error: error))
             return false
         }
     }
@@ -78,7 +78,7 @@ final class AutofillNeverPromptWebsitesManager {
         do {
             neverPromptWebsites = try secureVault.neverPromptWebsites()
         } catch {
-            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error)))
+            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error), error: error))
             neverPromptWebsites = []
         }
     }

--- a/macOS/DuckDuckGo/SecureVault/SecureVaultReporter.swift
+++ b/macOS/DuckDuckGo/SecureVault/SecureVaultReporter.swift
@@ -53,9 +53,9 @@ final class SecureVaultReporter: SecureVaultReporting {
 
         switch error {
         case .initFailed, .failedToOpenDatabase:
-            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultInitError(error: error)))
+            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultInitError(error: error), error: error))
         default:
-            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error)))
+            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error), error: error))
         }
     }
 

--- a/macOS/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
+++ b/macOS/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
@@ -589,6 +589,9 @@ final class PasswordManagementViewController: NSViewController {
                 showDuplicateAlert()
             } else {
                 PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error), error: error))
+                if let window = view.window {
+                    NSAlert.passwordManagerSaveError(errorType: error.localizedDescription).beginSheetModal(for: window)
+                }
             }
         }
     }

--- a/macOS/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
+++ b/macOS/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
@@ -588,7 +588,7 @@ final class PasswordManagementViewController: NSViewController {
             if case SecureStorageError.duplicateRecord = error {
                 showDuplicateAlert()
             } else {
-                PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error)))
+                PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error), error: error))
             }
         }
     }
@@ -611,7 +611,7 @@ final class PasswordManagementViewController: NSViewController {
             postChange()
 
         } catch {
-            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error)))
+            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error), error: error))
         }
     }
 
@@ -655,7 +655,7 @@ final class PasswordManagementViewController: NSViewController {
             postChange()
 
         } catch {
-            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error)))
+            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error), error: error))
         }
     }
 
@@ -675,7 +675,7 @@ final class PasswordManagementViewController: NSViewController {
                     self.refreshData()
                     PixelKit.fire(GeneralPixel.autofillManagementDeleteLogin)
                 } catch {
-                    PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error)))
+                    PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error), error: error))
                 }
 
             default:
@@ -698,7 +698,7 @@ final class PasswordManagementViewController: NSViewController {
                     try self.secureVault?.deleteIdentityFor(identityId: id)
                     self.refreshData()
                 } catch {
-                    PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error)))
+                    PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error), error: error))
                 }
 
             default:
@@ -740,7 +740,7 @@ final class PasswordManagementViewController: NSViewController {
                     try self.secureVault?.deleteCreditCardFor(cardId: id)
                     self.refreshData()
                 } catch {
-                    PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error)))
+                    PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error), error: error))
                 }
 
             default:
@@ -793,7 +793,7 @@ final class PasswordManagementViewController: NSViewController {
                         self?.syncModelsOnNote(note)
                     }
                 } catch {
-                    PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error)))
+                    PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error), error: error))
                 }
             }
 
@@ -923,7 +923,7 @@ final class PasswordManagementViewController: NSViewController {
                     items = cards.map(SecureVaultItem.card)
                 }
             } catch {
-                PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error)))
+                PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error), error: error))
             }
 
             DispatchQueue.main.async {

--- a/macOS/DuckDuckGo/SecureVault/View/SaveCredentialsViewController.swift
+++ b/macOS/DuckDuckGo/SecureVault/View/SaveCredentialsViewController.swift
@@ -305,7 +305,7 @@ final class SaveCredentialsViewController: NSViewController {
             }
         } catch {
             Logger.sync.error("failed to store credentials \(error.localizedDescription)")
-            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error)))
+            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error), error: error))
         }
 
         NotificationCenter.default.post(name: .autofillSaveEvent, object: nil, userInfo: nil)

--- a/macOS/DuckDuckGo/SecureVault/View/SaveIdentityViewController.swift
+++ b/macOS/DuckDuckGo/SecureVault/View/SaveIdentityViewController.swift
@@ -76,7 +76,7 @@ final class SaveIdentityViewController: NSViewController {
             PixelKit.fire(GeneralPixel.autofillItemSaved(kind: .identity))
         } catch {
             Logger.general.error("Failed to store identity \(error.localizedDescription)")
-            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error)))
+            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error), error: error))
         }
     }
 

--- a/macOS/DuckDuckGo/SecureVault/View/SavePaymentMethodViewController.swift
+++ b/macOS/DuckDuckGo/SecureVault/View/SavePaymentMethodViewController.swift
@@ -96,7 +96,7 @@ final class SavePaymentMethodViewController: NSViewController {
             try AutofillSecureVaultFactory.makeVault(reporter: SecureVaultReporter.shared).storeCreditCard(paymentMethod)
         } catch {
             Logger.secureVault.error("Failed to store payment method \(error.localizedDescription)")
-            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error)))
+            PixelKit.fire(DebugEvent(GeneralPixel.secureVaultError(error: error), error: error))
         }
     }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1210317997888604?focus=true
Tech Design URL:
CC:

### Description
Update secure vault error reporting pixels on macOS to include the error type

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1.
2.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)