### PR TITLE
macOS Duck.ai Sidebar: 1. Feature flag, sidebar and trusted indicator

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -225,6 +225,12 @@
 		1E25A4FF2CC9408A0080EFD4 /* SubscriptionCookieManageEventPixelMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E25A4FD2CC937120080EFD4 /* SubscriptionCookieManageEventPixelMapping.swift */; };
 		1E2BEAE42C8B00B5002741A3 /* SubscriptionPagesUseSubscriptionFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E2BEAE32C8B00B5002741A3 /* SubscriptionPagesUseSubscriptionFeatureTests.swift */; };
 		1E2BEAE52C8B00B5002741A3 /* SubscriptionPagesUseSubscriptionFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E2BEAE32C8B00B5002741A3 /* SubscriptionPagesUseSubscriptionFeatureTests.swift */; };
+		1E4EDA282DE9ED2D0019B6E8 /* TabSidebarProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E4EDA272DE9ED2D0019B6E8 /* TabSidebarProvider.swift */; };
+		1E4EDA292DE9ED2D0019B6E8 /* TabSidebarProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E4EDA272DE9ED2D0019B6E8 /* TabSidebarProvider.swift */; };
+		1E4EDA2B2DE9ED4D0019B6E8 /* TabSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E4EDA2A2DE9ED4D0019B6E8 /* TabSidebar.swift */; };
+		1E4EDA2C2DE9ED4D0019B6E8 /* TabSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E4EDA2A2DE9ED4D0019B6E8 /* TabSidebar.swift */; };
+		1E4EDA2E2DE9ED710019B6E8 /* AIChatSidebarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E4EDA2D2DE9ED710019B6E8 /* AIChatSidebarViewController.swift */; };
+		1E4EDA2F2DE9ED710019B6E8 /* AIChatSidebarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E4EDA2D2DE9ED710019B6E8 /* AIChatSidebarViewController.swift */; };
 		1E559BB12BBCA9F1002B4AF6 /* RedirectNavigationResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E559BB02BBCA9F1002B4AF6 /* RedirectNavigationResponder.swift */; };
 		1E559BB22BBCA9F1002B4AF6 /* RedirectNavigationResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E559BB02BBCA9F1002B4AF6 /* RedirectNavigationResponder.swift */; };
 		1E5921BF2CF479E600E15CCA /* FeatureFlags in Frameworks */ = {isa = PBXBuildFile; productRef = 1E5921BE2CF479E600E15CCA /* FeatureFlags */; };
@@ -3950,6 +3956,9 @@
 		1E0C72052ABC63BD00802009 /* SubscriptionPagesUserScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPagesUserScript.swift; sourceTree = "<group>"; };
 		1E25A4FD2CC937120080EFD4 /* SubscriptionCookieManageEventPixelMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionCookieManageEventPixelMapping.swift; sourceTree = "<group>"; };
 		1E2BEAE32C8B00B5002741A3 /* SubscriptionPagesUseSubscriptionFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPagesUseSubscriptionFeatureTests.swift; sourceTree = "<group>"; };
+		1E4EDA272DE9ED2D0019B6E8 /* TabSidebarProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSidebarProvider.swift; sourceTree = "<group>"; };
+		1E4EDA2A2DE9ED4D0019B6E8 /* TabSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSidebar.swift; sourceTree = "<group>"; };
+		1E4EDA2D2DE9ED710019B6E8 /* AIChatSidebarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSidebarViewController.swift; sourceTree = "<group>"; };
 		1E559BB02BBCA9F1002B4AF6 /* RedirectNavigationResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedirectNavigationResponder.swift; sourceTree = "<group>"; };
 		1E7E2E8F29029A2A00C01B54 /* ContentBlockingRulesUpdateObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentBlockingRulesUpdateObserver.swift; sourceTree = "<group>"; };
 		1E7E2E932902AC0E00C01B54 /* PrivacyDashboardPermissionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyDashboardPermissionHandler.swift; sourceTree = "<group>"; };
@@ -6185,6 +6194,16 @@
 				1DC6696F2B6CF0D700AA0645 /* TabSnapshotStore.swift */,
 			);
 			path = Services;
+			sourceTree = "<group>";
+		};
+		1E4EDA262DE9ED1C0019B6E8 /* TabSidebar */ = {
+			isa = PBXGroup;
+			children = (
+				1E4EDA272DE9ED2D0019B6E8 /* TabSidebarProvider.swift */,
+				1E4EDA2A2DE9ED4D0019B6E8 /* TabSidebar.swift */,
+				1E4EDA2D2DE9ED710019B6E8 /* AIChatSidebarViewController.swift */,
+			);
+			path = TabSidebar;
 			sourceTree = "<group>";
 		};
 		31521ABE2CC0139C00248E6F /* AIChat */ = {
@@ -9226,6 +9245,7 @@
 		AA86491B24D837DE001BABEE /* Tab */ = {
 			isa = PBXGroup;
 			children = (
+				1E4EDA262DE9ED1C0019B6E8 /* TabSidebar */,
 				AA86491C24D83868001BABEE /* View */,
 				AA86491D24D83A59001BABEE /* ViewModel */,
 				AA86491E24D83A66001BABEE /* Model */,
@@ -12592,6 +12612,7 @@
 				1DB67F2A2B6FEB17003DF243 /* WebViewSnapshotRenderer.swift in Sources */,
 				3706FB35293F65D500E42796 /* FlatButton.swift in Sources */,
 				3706FB36293F65D500E42796 /* PinnedTabView.swift in Sources */,
+				1E4EDA2B2DE9ED4D0019B6E8 /* TabSidebar.swift in Sources */,
 				7BC641152DD1FBDA00272A9D /* UpdatesDebugMenu.swift in Sources */,
 				3706FB37293F65D500E42796 /* DataEncryption.swift in Sources */,
 				56BA1E762BAAF70F001CF69F /* SpecialErrorPageTabExtension.swift in Sources */,
@@ -12943,6 +12964,7 @@
 				3706FBEC293F65D500E42796 /* EditableTextView.swift in Sources */,
 				3706FBED293F65D500E42796 /* TabCollection.swift in Sources */,
 				B6C0BB6B29AF1C7000AE8E3C /* BrowserTabView.swift in Sources */,
+				1E4EDA282DE9ED2D0019B6E8 /* TabSidebarProvider.swift in Sources */,
 				B62B483A2ADE46FC000DECE5 /* Application.swift in Sources */,
 				3706FBEE293F65D500E42796 /* MainView.swift in Sources */,
 				3706FBEF293F65D500E42796 /* EmailUrlExtensions.swift in Sources */,
@@ -13005,6 +13027,7 @@
 				3706FC0C293F65D500E42796 /* NSAttributedStringExtension.swift in Sources */,
 				C1DAF3B62B9A44860059244F /* AutofillPopoverPresenter.swift in Sources */,
 				3706FC0D293F65D500E42796 /* AnimationView.swift in Sources */,
+				1E4EDA2E2DE9ED710019B6E8 /* AIChatSidebarViewController.swift in Sources */,
 				9FA173DB2B79BD8A00EE4E6E /* BookmarkDialogContainerView.swift in Sources */,
 				3706FC0E293F65D500E42796 /* NSRectExtension.swift in Sources */,
 				370C23122C7747E200A80A3E /* ImageProcessor.swift in Sources */,
@@ -14202,6 +14225,7 @@
 				1D39E5772C2BFD5700757339 /* ReleaseNotesTabExtension.swift in Sources */,
 				379857EB2D720C65008773F6 /* HistoryViewOnboardingDecider.swift in Sources */,
 				987799F12999993C005D8EB6 /* LegacyBookmarkStore.swift in Sources */,
+				1E4EDA292DE9ED2D0019B6E8 /* TabSidebarProvider.swift in Sources */,
 				1D220BF82B86192200F8BBC6 /* PreferencesEmailProtectionView.swift in Sources */,
 				4B8AC93526B3B2FD00879451 /* NSAlert+DataImport.swift in Sources */,
 				AA7412BD24D2BEEE00D22FE0 /* MainWindow.swift in Sources */,
@@ -14327,6 +14351,7 @@
 				4B8A4E0127C8447E005F40E8 /* SaveIdentityPopover.swift in Sources */,
 				B637273B26CBC8AF00C8CB02 /* AuthenticationAlert.swift in Sources */,
 				1DFAB51D2A8982A600A0F7F6 /* SetExtension.swift in Sources */,
+				1E4EDA2C2DE9ED4D0019B6E8 /* TabSidebar.swift in Sources */,
 				EEE11C5E2C7F54AD000ABD7E /* AutofillLoginImportState.swift in Sources */,
 				315AA07028CA5CC800200030 /* YoutubePlayerNavigationHandler.swift in Sources */,
 				56DB9FE92CD24B47001BEC23 /* ContextualOnboardingPixel.swift in Sources */,
@@ -14362,6 +14387,7 @@
 				7B7F5D242C52725A00826256 /* AddExcludedDomainButtonsView.swift in Sources */,
 				B6C0BB6729AEFF8100AE8E3C /* BookmarkExtension.swift in Sources */,
 				4BE6547F271FCD4D008D1D63 /* PasswordManagementCreditCardModel.swift in Sources */,
+				1E4EDA2F2DE9ED710019B6E8 /* AIChatSidebarViewController.swift in Sources */,
 				B68C92C1274E3EF4002AC6B0 /* PopUpWindow.swift in Sources */,
 				3135647B2D9EB8E800BF4B5D /* AIChatAddressBarPromptExtractor.swift in Sources */,
 				AA5FA6A0275F948900DCE9C9 /* Favicons.xcdatamodeld in Sources */,

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -38,6 +38,7 @@ final class AddressBarButtonsViewController: NSViewController {
 
     private let accessibilityPreferences: AccessibilityPreferences
     private let visualStyle: VisualStyleProviding
+    private let featureFlagger: FeatureFlagger
 
     private var permissionAuthorizationPopover: PermissionAuthorizationPopover?
     private func permissionAuthorizationPopoverCreatingIfNeeded() -> PermissionAuthorizationPopover {
@@ -198,7 +199,8 @@ final class AddressBarButtonsViewController: NSViewController {
           onboardingPixelReporter: OnboardingAddressBarReporting = OnboardingPixelReporter(),
           aiChatTabOpener: AIChatTabOpening,
           aiChatMenuConfig: AIChatMenuVisibilityConfigurable,
-          visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager) {
+          visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager,
+          featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger) {
         self.tabCollectionViewModel = tabCollectionViewModel
         self.accessibilityPreferences = accessibilityPreferences
         self.popovers = popovers
@@ -206,6 +208,7 @@ final class AddressBarButtonsViewController: NSViewController {
         self.aiChatTabOpener = aiChatTabOpener
         self.aiChatMenuConfig = aiChatMenuConfig
         self.visualStyle = visualStyleManager.style
+        self.featureFlagger = featureFlagger
         super.init(coder: coder)
     }
 
@@ -355,7 +358,9 @@ final class AddressBarButtonsViewController: NSViewController {
             target = .newTabSelected
         }
 
-        if let value = textFieldValue {
+        if featureFlagger.isFeatureOn(.aiChatSidebar), case .url = tabViewModel?.tabContent, !isTextFieldEditorFirstResponder {
+            WindowControllersManager.shared.mainWindowController?.mainViewController.browserTabViewController.toggleSidebar()
+        } else if let value = textFieldValue {
             aiChatTabOpener.openAIChatTab(value, target: target)
         } else {
             aiChatTabOpener.openAIChatTab(nil, target: target)

--- a/macOS/DuckDuckGo/RecentlyClosed/Model/RecentlyClosedCoordinator.swift
+++ b/macOS/DuckDuckGo/RecentlyClosed/Model/RecentlyClosedCoordinator.swift
@@ -261,7 +261,7 @@ extension Tab.TabContent {
         switch self {
         case .url(let url, credential: let credential, source: _):
             .url(url, credential: credential, source: .pendingStateRestoration)
-        case .newtab, .settings, .bookmarks, .history, .onboarding, .releaseNotes, .none, .dataBrokerProtection, .subscription, .identityTheftRestoration, .webExtensionUrl:
+        case .newtab, .settings, .bookmarks, .history, .onboarding, .releaseNotes, .none, .dataBrokerProtection, .subscription, .identityTheftRestoration, .webExtensionUrl, .aiChat:
             self
         }
     }
@@ -271,7 +271,7 @@ extension Tab.TabContent {
         case .url(let url, credential: let credential, source: let source):
             let newSource: URLSource = source == .pendingStateRestoration ? .loadedByStateRestoration : .reload
             return .url(url, credential: credential, source: newSource)
-        case .newtab, .settings, .bookmarks, .history, .onboarding, .releaseNotes, .none, .dataBrokerProtection, .subscription, .identityTheftRestoration, .webExtensionUrl:
+        case .newtab, .settings, .bookmarks, .history, .onboarding, .releaseNotes, .none, .dataBrokerProtection, .subscription, .identityTheftRestoration, .webExtensionUrl, .aiChat:
             return self
         }
     }

--- a/macOS/DuckDuckGo/RecentlyClosed/View/RecentlyClosedMenu.swift
+++ b/macOS/DuckDuckGo/RecentlyClosed/View/RecentlyClosedMenu.swift
@@ -86,7 +86,7 @@ private extension NSMenuItem {
         case .releaseNotes:
             image = TabViewModel.Favicon.home
             title = UserText.releaseNotesTitle
-        case .url, .subscription, .identityTheftRestoration, .webExtensionUrl:
+        case .url, .subscription, .identityTheftRestoration, .webExtensionUrl, .aiChat:
             image = recentlyClosedTab.favicon
             image?.size = NSSize.faviconSize
             title = recentlyClosedTab.title ?? recentlyClosedTab.tabContent.userEditableUrl?.absoluteString ?? ""

--- a/macOS/DuckDuckGo/StateRestoration/Tab+NSSecureCoding.swift
+++ b/macOS/DuckDuckGo/StateRestoration/Tab+NSSecureCoding.swift
@@ -98,6 +98,7 @@ private extension Tab.TabContent {
         case releaseNotes = 10
         case history = 11
         case webExtensionUrl = 12
+        case aiChat = 13
     }
 
     init?(type: ContentType, url: URL?, videoID: String?, timestamp: String?, preferencePane: PreferencePaneIdentifier?) {
@@ -133,6 +134,9 @@ private extension Tab.TabContent {
             self = .webExtensionUrl(url)
         case .onboardingDeprecated:
             self = .onboarding
+        case .aiChat:
+            guard let url = url else { return nil }
+            self = .aiChat(url)
         }
     }
 
@@ -150,6 +154,7 @@ private extension Tab.TabContent {
         case .identityTheftRestoration: return .identityTheftRestoration
         case .releaseNotes: return .releaseNotes
         case .webExtensionUrl: return .webExtensionUrl
+        case .aiChat: return .aiChat
         }
     }
 

--- a/macOS/DuckDuckGo/Tab/Model/TabContent.swift
+++ b/macOS/DuckDuckGo/Tab/Model/TabContent.swift
@@ -35,6 +35,7 @@ extension Tab {
         case identityTheftRestoration(URL)
         case releaseNotes
         case webExtensionUrl(URL)
+        case aiChat(URL)
     }
     typealias TabContent = Tab.Content
 
@@ -139,6 +140,10 @@ extension TabContent {
             if url.isWebExtensionUrl {
                 return .webExtensionUrl(url)
             }
+            if url.isDuckAIURL,
+               NSApp.delegateTyped.featureFlagger.isFeatureOn(.aiChatSidebar) {
+                    return .aiChat(url)
+            }
 
             let subscriptionManager = Application.appDelegate.subscriptionAuthV1toV2Bridge
             let environment = subscriptionManager.currentEnvironment.serviceEnvironment
@@ -184,7 +189,7 @@ extension TabContent {
 
     var isDisplayable: Bool {
         switch self {
-        case .settings, .bookmarks, .history, .dataBrokerProtection, .subscription, .identityTheftRestoration, .releaseNotes:
+        case .settings, .bookmarks, .history, .dataBrokerProtection, .subscription, .identityTheftRestoration, .releaseNotes, .aiChat:
             return true
         default:
             return false
@@ -221,6 +226,7 @@ extension TabContent {
         case .dataBrokerProtection: return UserText.tabDataBrokerProtectionTitle
         case .releaseNotes: return UserText.releaseNotesTitle
         case .subscription, .identityTheftRestoration: return nil
+        case .aiChat: return nil
         }
     }
 
@@ -260,6 +266,8 @@ extension TabContent {
             return .releaseNotes
         case .subscription(let url), .identityTheftRestoration(let url), .webExtensionUrl(let url):
             return url
+        case .aiChat(let url):
+            return url
         case .none:
             return nil
         }
@@ -270,14 +278,14 @@ extension TabContent {
         case .url(_, _, source: let source):
             return source
         case .newtab, .settings, .bookmarks, .history, .onboarding, .releaseNotes, .dataBrokerProtection,
-                .subscription, .identityTheftRestoration, .webExtensionUrl, .none:
+                .subscription, .identityTheftRestoration, .webExtensionUrl, .none, .aiChat:
             return .ui
         }
     }
 
     var isUrl: Bool {
         switch self {
-        case .url, .subscription, .identityTheftRestoration, .releaseNotes, .history:
+        case .url, .subscription, .identityTheftRestoration, .releaseNotes, .history, .aiChat:
             return true
         default:
             return false
@@ -340,7 +348,7 @@ extension TabContent {
         switch self {
         case .history, .newtab, .onboarding, .bookmarks, .settings, .none:
             return false
-        case .url, .subscription, .identityTheftRestoration, .dataBrokerProtection, .releaseNotes, .webExtensionUrl:
+        case .url, .subscription, .identityTheftRestoration, .dataBrokerProtection, .releaseNotes, .webExtensionUrl, .aiChat:
             return true
         }
     }

--- a/macOS/DuckDuckGo/Tab/TabSidebar/AIChatSidebarViewController.swift
+++ b/macOS/DuckDuckGo/Tab/TabSidebar/AIChatSidebarViewController.swift
@@ -41,10 +41,8 @@ final class AIChatSidebarViewController: NSViewController {
     var aiTab = Tab(content: .url(AIChatRemoteSettings().aiChatURL, source: .ui))
 
     private var buttonTrackingArea: NSTrackingArea?
-    private var id: String
 
-    init(id: String) {
-        self.id = id
+    init() {
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/macOS/DuckDuckGo/Tab/TabSidebar/AIChatSidebarViewController.swift
+++ b/macOS/DuckDuckGo/Tab/TabSidebar/AIChatSidebarViewController.swift
@@ -1,0 +1,223 @@
+//
+//  AIChatSidebarViewController.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+
+final class AIChatSidebarViewController: NSViewController {
+
+    private enum Constants {
+        static let separatorWidth: CGFloat = 1
+        static let topBarHeight: CGFloat = 48
+        static let barButtonHeight: CGFloat = 32
+        static let barButtonWidth: CGFloat = 32
+        static let barButtonMargin: CGFloat = 12
+        static let titleLabelSideMargin: CGFloat = 8
+        static let webViewContainerPadding: CGFloat = 4
+        static let webViewTopCornerRadius: CGFloat = 16
+        static let webViewBottomCornerRadius: CGFloat = 6
+    }
+
+    private var openInNewTabButton: MouseOverButton!
+    private var closeButton: MouseOverButton!
+    private var webViewContainer: WebViewContainerView!
+    private var separator: NSView!
+    private var topBar: NSView!
+
+    var aiTab = Tab(content: .url(AIChatRemoteSettings().aiChatURL, source: .ui))
+
+    private var buttonTrackingArea: NSTrackingArea?
+    private var id: String
+
+    init(id: String) {
+        self.id = id
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        let container = NSView()
+        container.wantsLayer = true
+        container.layer?.backgroundColor = NSColor.navigationBarBackground.cgColor
+
+        createAndSetupSeparator(in: container)
+        createAndSetupTopBar(in: container)
+        createAndSetupWebViewContainer(in: container)
+
+        NSLayoutConstraint.activate([
+            topBar.topAnchor.constraint(equalTo: container.topAnchor),
+            topBar.leadingAnchor.constraint(equalTo: separator.trailingAnchor),
+            topBar.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            topBar.heightAnchor.constraint(equalToConstant: Constants.topBarHeight),
+
+            webViewContainer.topAnchor.constraint(equalTo: topBar.bottomAnchor),
+            webViewContainer.leadingAnchor.constraint(equalTo: separator.trailingAnchor, constant: Constants.webViewContainerPadding),
+            webViewContainer.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -Constants.webViewContainerPadding),
+            webViewContainer.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -Constants.webViewContainerPadding),
+        ])
+
+        self.view = container
+
+        // Initial mask update
+        updateWebViewMask()
+    }
+
+    private func createAndSetupSeparator(in container: NSView) {
+        separator = NSView()
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        separator.wantsLayer = true
+        separator.layer?.backgroundColor = NSColor.separatorColor.cgColor
+        container.addSubview(separator)
+
+        NSLayoutConstraint.activate([
+            separator.topAnchor.constraint(equalTo: container.topAnchor),
+            separator.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            separator.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            separator.widthAnchor.constraint(equalToConstant: Constants.separatorWidth)
+        ])
+    }
+
+    private func createAndSetupTopBar(in container: NSView) {
+        topBar = NSView()
+        topBar.wantsLayer = true
+        topBar.layer?.backgroundColor = NSColor.navigationBarBackground.cgColor
+        topBar.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(topBar)
+
+        openInNewTabButton = MouseOverButton(image: .expand, target: self, action: #selector(openInNewTabButtonClicked))
+        openInNewTabButton.translatesAutoresizingMaskIntoConstraints = false
+        openInNewTabButton.bezelStyle = .shadowlessSquare
+        openInNewTabButton.cornerRadius = 9
+        openInNewTabButton.normalTintColor = .button
+        openInNewTabButton.mouseDownColor = .buttonMouseDown
+        openInNewTabButton.mouseOverColor = .buttonMouseOver
+        openInNewTabButton.isBordered = false
+        topBar.addSubview(openInNewTabButton)
+
+        let titleLabel = NSTextField(labelWithString: "Duck.ai")
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.alignment = .center
+        titleLabel.font = .systemFont(ofSize: 13, weight: .medium)
+        titleLabel.textColor = .labelColor
+        topBar.addSubview(titleLabel)
+
+        closeButton = MouseOverButton(image: .close, target: self, action: #selector(closeButtonClicked))
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        closeButton.bezelStyle = .shadowlessSquare
+        closeButton.cornerRadius = 9
+        closeButton.normalTintColor = .button
+        closeButton.mouseDownColor = .buttonMouseDown
+        closeButton.mouseOverColor = .buttonMouseOver
+        closeButton.isBordered = false
+        topBar.addSubview(closeButton)
+
+        NSLayoutConstraint.activate([
+            openInNewTabButton.leadingAnchor.constraint(equalTo: topBar.leadingAnchor, constant: Constants.barButtonMargin),
+            openInNewTabButton.centerYAnchor.constraint(equalTo: topBar.centerYAnchor),
+            openInNewTabButton.heightAnchor.constraint(equalToConstant: Constants.barButtonHeight),
+            openInNewTabButton.widthAnchor.constraint(equalToConstant: Constants.barButtonWidth),
+
+            titleLabel.centerXAnchor.constraint(equalTo: topBar.centerXAnchor),
+            titleLabel.centerYAnchor.constraint(equalTo: topBar.centerYAnchor),
+            titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: openInNewTabButton.trailingAnchor, constant: Constants.titleLabelSideMargin),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: closeButton.leadingAnchor, constant: -Constants.titleLabelSideMargin),
+
+            closeButton.trailingAnchor.constraint(equalTo: topBar.trailingAnchor, constant: -Constants.barButtonMargin),
+            closeButton.centerYAnchor.constraint(equalTo: topBar.centerYAnchor),
+            closeButton.heightAnchor.constraint(equalToConstant: Constants.barButtonHeight),
+            closeButton.widthAnchor.constraint(equalToConstant: Constants.barButtonWidth),
+        ])
+    }
+
+    private func createAndSetupWebViewContainer(in container: NSView) {
+        webViewContainer = WebViewContainerView(tab: aiTab, webView: aiTab.webView, frame: .zero)
+        webViewContainer.translatesAutoresizingMaskIntoConstraints = false
+        webViewContainer.wantsLayer = true
+        webViewContainer.layer?.masksToBounds = true
+        webViewContainer.layer?.backgroundColor = NSColor.navigationBarBackground.cgColor
+        container.addSubview(webViewContainer)
+
+        // Observe bounds changes to update the mask
+        webViewContainer.postsFrameChangedNotifications = true
+        NotificationCenter.default.addObserver(self,
+                                             selector: #selector(updateWebViewMask),
+                                             name: NSView.frameDidChangeNotification,
+                                             object: webViewContainer)
+    }
+
+    @objc private func updateWebViewMask() {
+        let bounds = webViewContainer.bounds
+
+        let path = CGMutablePath()
+
+        // Bottom left corner
+        path.move(to: CGPoint(x: bounds.minX, y: bounds.minY + Constants.webViewBottomCornerRadius))
+        path.addArc(center: CGPoint(x: bounds.minX + Constants.webViewBottomCornerRadius,
+                                  y: bounds.minY + Constants.webViewBottomCornerRadius),
+                   radius: Constants.webViewBottomCornerRadius,
+                   startAngle: .pi,
+                   endAngle: .pi * 3/2,
+                   clockwise: false)
+
+        // Bottom right corner
+        path.addLine(to: CGPoint(x: bounds.maxX - Constants.webViewBottomCornerRadius, y: bounds.minY))
+        path.addArc(center: CGPoint(x: bounds.maxX - Constants.webViewBottomCornerRadius,
+                                  y: bounds.minY + Constants.webViewBottomCornerRadius),
+                   radius: Constants.webViewBottomCornerRadius,
+                   startAngle: .pi * 3/2,
+                   endAngle: 0,
+                   clockwise: false)
+
+        // Top right corner
+        path.addLine(to: CGPoint(x: bounds.maxX, y: bounds.maxY - Constants.webViewTopCornerRadius))
+        path.addArc(center: CGPoint(x: bounds.maxX - Constants.webViewTopCornerRadius,
+                                  y: bounds.maxY - Constants.webViewTopCornerRadius),
+                   radius: Constants.webViewTopCornerRadius,
+                   startAngle: 0,
+                   endAngle: .pi/2,
+                   clockwise: false)
+
+        // Top left corner
+        path.addLine(to: CGPoint(x: bounds.minX + Constants.webViewTopCornerRadius, y: bounds.maxY))
+        path.addArc(center: CGPoint(x: bounds.minX + Constants.webViewTopCornerRadius,
+                                  y: bounds.maxY - Constants.webViewTopCornerRadius),
+                   radius: Constants.webViewTopCornerRadius,
+                   startAngle: .pi/2,
+                   endAngle: .pi,
+                   clockwise: false)
+
+        path.closeSubpath()
+
+        let shape = CAShapeLayer()
+        shape.path = path
+        webViewContainer.layer?.mask = shape
+    }
+
+    @objc private func openInNewTabButtonClicked() {
+//        WindowControllersManager.shared.lastKeyMainWindowController?.mainViewController.toggleAIChatSidebar()
+//        WindowControllersManager.shared.lastKeyMainWindowController?.mainViewController.browserTabViewController.openNewTab(tab: aiTab)
+        NSApp.delegateTyped.aiChatTabOpener.openAIChatTab(nil, target: .newTabSelected)
+    }
+
+    @objc private func closeButtonClicked() {
+        WindowControllersManager.shared.lastKeyMainWindowController?.mainViewController.browserTabViewController.toggleSidebar()
+    }
+
+}

--- a/macOS/DuckDuckGo/Tab/TabSidebar/TabSidebar.swift
+++ b/macOS/DuckDuckGo/Tab/TabSidebar/TabSidebar.swift
@@ -1,0 +1,32 @@
+//
+//  TabSidebar.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import AppKit
+
+final class TabSidebar {
+    var sidebarViewController: NSViewController
+
+    init(sidebarViewController: NSViewController) {
+        self.sidebarViewController = sidebarViewController
+    }
+
+    static func makeAIChatTabSidebar() -> TabSidebar {
+        return Self.init(sidebarViewController: AIChatSidebarViewController(id: ""))
+    }
+}

--- a/macOS/DuckDuckGo/Tab/TabSidebar/TabSidebar.swift
+++ b/macOS/DuckDuckGo/Tab/TabSidebar/TabSidebar.swift
@@ -27,6 +27,6 @@ final class TabSidebar {
     }
 
     static func makeAIChatTabSidebar() -> TabSidebar {
-        return Self.init(sidebarViewController: AIChatSidebarViewController())
+        return TabSidebar(sidebarViewController: AIChatSidebarViewController())
     }
 }

--- a/macOS/DuckDuckGo/Tab/TabSidebar/TabSidebar.swift
+++ b/macOS/DuckDuckGo/Tab/TabSidebar/TabSidebar.swift
@@ -27,6 +27,6 @@ final class TabSidebar {
     }
 
     static func makeAIChatTabSidebar() -> TabSidebar {
-        return Self.init(sidebarViewController: AIChatSidebarViewController(id: ""))
+        return Self.init(sidebarViewController: AIChatSidebarViewController())
     }
 }

--- a/macOS/DuckDuckGo/Tab/TabSidebar/TabSidebarProvider.swift
+++ b/macOS/DuckDuckGo/Tab/TabSidebar/TabSidebarProvider.swift
@@ -1,0 +1,59 @@
+//
+//  TabSidebarProvider.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+protocol TabSidebarProviding {
+    var sidebarWidth: CGFloat { get }
+
+    func tabSidebar(for tab: Tab) -> TabSidebar
+    func isShowingSidebar(for tab: Tab) -> Bool
+    func handleSidebarDidClose(for tab: Tab)
+}
+
+final class TabSidebarProvider: TabSidebarProviding {
+
+    enum Constants {
+        static let sidebarWidth: CGFloat = 450
+    }
+
+    private var sidebarTabs: NSMapTable = NSMapTable<Tab, TabSidebar>.weakToStrongObjects()
+
+    var sidebarWidth: CGFloat { Constants.sidebarWidth }
+
+    func tabSidebar(for tab: Tab) -> TabSidebar {
+        if let tabSidebar = sidebarTabs.object(forKey: tab) {
+            return tabSidebar
+        } else {
+            let tabSidebar = TabSidebar.makeAIChatTabSidebar()
+            sidebarTabs.setObject(tabSidebar, forKey: tab)
+            return tabSidebar
+        }
+    }
+
+    func isShowingSidebar(for tab: Tab) -> Bool {
+        return sidebarTabs.object(forKey: tab) != nil
+    }
+
+    func handleSidebarDidClose(for tab: Tab) {
+        if let tabSidebar = sidebarTabs.object(forKey: tab) {
+            tabSidebar.sidebarViewController.removeCompletely()
+            sidebarTabs.removeObject(forKey: tab)
+        }
+    }
+}

--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -722,7 +722,7 @@ final class BrowserTabViewController: NSViewController {
              .url(_, _, source: .reload):
             return true
 
-        case .settings, .bookmarks, .history, .dataBrokerProtection, .subscription, .onboarding, .releaseNotes, .identityTheftRestoration, .webExtensionUrl:
+        case .settings, .bookmarks, .history, .dataBrokerProtection, .subscription, .onboarding, .releaseNotes, .identityTheftRestoration, .webExtensionUrl, .aiChat:
             return true
 
         case .none:
@@ -742,7 +742,7 @@ final class BrowserTabViewController: NSViewController {
         case .newtab:
             // don‘t steal focus from the address bar at .newtab page
             return
-        case .url, .subscription, .identityTheftRestoration, .onboarding, .releaseNotes, .history:
+        case .url, .subscription, .identityTheftRestoration, .onboarding, .releaseNotes, .history, .aiChat:
             getView = { [weak self, weak tabViewModel] in
                 guard let self, let tabViewModel else { return nil }
                 return webView(for: tabViewModel, tabContent: tabContent)
@@ -862,7 +862,7 @@ final class BrowserTabViewController: NSViewController {
             removeAllTabContent()
             updateTabIfNeeded(tabViewModel: tabViewModel)
 
-        case .url, .subscription, .identityTheftRestoration:
+        case .url, .subscription, .identityTheftRestoration, .aiChat:
             updateTabIfNeeded(tabViewModel: tabViewModel)
 
         case .newtab:

--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -43,6 +43,7 @@ protocol BrowserTabViewControllerDelegate: AnyObject {
 final class BrowserTabViewController: NSViewController {
 
     private lazy var browserTabView = BrowserTabView(frame: .zero, backgroundColor: .browserTabBackground)
+    private lazy var sidebarContainer = ColorView(frame: .zero, backgroundColor: .browserTabBackground, borderWidth: 0)
     private lazy var hoverLabel = NSTextField(string: URL.duckDuckGo.absoluteString)
     private lazy var hoverLabelContainer = ColorView(frame: .zero, backgroundColor: .browserTabBackground, borderWidth: 0)
 
@@ -95,6 +96,8 @@ final class BrowserTabViewController: NSViewController {
         let modal = DuckPlayerOnboardingModalManager()
         return modal
     }()
+
+    private lazy var tabSidebarProvider: TabSidebarProviding = TabSidebarProvider()
 
     required init?(coder: NSCoder) {
         fatalError("BrowserTabViewController: Bad initializer")
@@ -153,6 +156,19 @@ final class BrowserTabViewController: NSViewController {
         hoverLabel.leadingAnchor.constraint(equalTo: hoverLabelContainer.leadingAnchor, constant: 12).isActive = true
         hoverLabelContainer.trailingAnchor.constraint(equalTo: hoverLabel.trailingAnchor, constant: 8).isActive = true
         hoverLabel.topAnchor.constraint(equalTo: hoverLabelContainer.topAnchor, constant: 6).isActive = true
+
+        if featureFlagger.isFeatureOn(.aiChatSidebar) {
+            view.addSubview(sidebarContainer)
+
+            sidebarContainerLeadingConstraint = sidebarContainer.leadingAnchor.constraint(equalTo: browserTabView.trailingAnchor)
+
+            NSLayoutConstraint.activate([
+                sidebarContainer.topAnchor.constraint(equalTo: browserTabView.topAnchor),
+                sidebarContainer.bottomAnchor.constraint(equalTo: browserTabView.bottomAnchor),
+                sidebarContainerLeadingConstraint!,
+                sidebarContainer.widthAnchor.constraint(equalToConstant: tabSidebarProvider.sidebarWidth)
+            ])
+        }
     }
 
     override func viewDidLoad() {
@@ -305,6 +321,7 @@ final class BrowserTabViewController: NSViewController {
                 generateNativePreviewIfNeeded()
                 tabViewModel = selectedTabViewModel
                 showTabContent(of: selectedTabViewModel)
+                updateSidebar(for: selectedTabViewModel)
 
                 subscribeToTabContent(of: selectedTabViewModel)
                 subscribeToHoveredLink(of: selectedTabViewModel)
@@ -426,6 +443,9 @@ final class BrowserTabViewController: NSViewController {
         }
     }
 
+    private var webContainerTrailingConstraint: NSLayoutConstraint?
+    private var sidebarContainerLeadingConstraint: NSLayoutConstraint?
+
     private func addWebViewToViewHierarchy(_ webView: WebView, tab: Tab) {
         let container = WebViewContainerView(tab: tab, webView: webView, frame: view.bounds)
         self.webViewContainer = container
@@ -438,13 +458,21 @@ final class BrowserTabViewController: NSViewController {
         view.addSubview(containerStackView, positioned: .below, relativeTo: hoverLabelContainer)
 
         containerStackView.translatesAutoresizingMaskIntoConstraints = false
+
+        if webContainerTrailingConstraint == nil {
+            webContainerTrailingConstraint = containerStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        }
+
         NSLayoutConstraint.activate([
             containerStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            containerStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+//            containerStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            webContainerTrailingConstraint!,
             containerStackView.topAnchor.constraint(equalTo: view.topAnchor),
             containerStackView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
         containerStackView.addArrangedSubview(container)
+
+        updateWebContainerAndTabSidebarConstraints(forSidebarRevealed: tabSidebarProvider.isShowingSidebar(for: tab), animated: false)
     }
 
     private func removeExistingDialog() {
@@ -966,6 +994,60 @@ final class BrowserTabViewController: NSViewController {
 
         Task {
             await tabViewModel.tab.tabSnapshots?.renderSnapshot(from: viewForRendering)
+        }
+    }
+
+    // MARK: - Tab sidebar
+
+    func toggleSidebar() {
+        guard featureFlagger.isFeatureOn(.aiChatSidebar) else { return }
+        guard let tab = tabViewModel?.tab else { return }
+
+        let willAnimateSidebarReveal = !tabSidebarProvider.isShowingSidebar(for: tab)
+
+        if willAnimateSidebarReveal {
+            let sidebarViewController = tabSidebarProvider.tabSidebar(for: tab).sidebarViewController
+            addAndLayoutChild(sidebarViewController, into: sidebarContainer)
+            updateWebContainerAndTabSidebarConstraints(forSidebarRevealed: true, animated: true)
+        } else {
+            updateWebContainerAndTabSidebarConstraints(forSidebarRevealed: false, animated: true)
+        }
+    }
+
+    private func updateSidebar(for tabViewModel: TabViewModel?) {
+        guard featureFlagger.isFeatureOn(.aiChatSidebar) else { return }
+        guard let tab = tabViewModel?.tab else { return }
+
+        if tabSidebarProvider.isShowingSidebar(for: tab) {
+            let vc = tabSidebarProvider.tabSidebar(for: tab).sidebarViewController
+            addAndLayoutChild(vc, into: sidebarContainer)
+            updateWebContainerAndTabSidebarConstraints(forSidebarRevealed: true, animated: false)
+        } else {
+            updateWebContainerAndTabSidebarConstraints(forSidebarRevealed: false, animated: false)
+        }
+    }
+
+    private func updateWebContainerAndTabSidebarConstraints(forSidebarRevealed: Bool, animated: Bool) {
+        guard featureFlagger.isFeatureOn(.aiChatSidebar) else { return }
+
+        let newConstraintValue = forSidebarRevealed ? -self.tabSidebarProvider.sidebarWidth : 0.0
+
+        if animated {
+            NSAnimationContext.runAnimationGroup { [weak self] context in
+                guard let self else { return }
+
+                context.duration = 0.25
+                context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+
+                self.sidebarContainerLeadingConstraint?.animator().constant = newConstraintValue
+                self.webContainerTrailingConstraint?.animator().constant = newConstraintValue
+            } completionHandler: { [weak self, tab = tabViewModel?.tab] in
+                guard let self, let tab, !forSidebarRevealed else { return }
+                self.tabSidebarProvider.handleSidebarDidClose(for: tab)
+            }
+        } else {
+            sidebarContainerLeadingConstraint?.constant = newConstraintValue
+            webContainerTrailingConstraint?.constant = newConstraintValue
         }
     }
 

--- a/macOS/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
+++ b/macOS/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
@@ -38,6 +38,7 @@ final class TabViewModel {
         static let dataBrokerProtection = NSImage.personalInformationRemovalMulticolor16
         static let subscription = NSImage.privacyPro
         static let identityTheftRestoration = NSImage.identityTheftRestorationMulticolor16
+        static let aiChat = NSImage.aiChatPreferences
     }
 
     private(set) var tab: Tab
@@ -127,7 +128,7 @@ final class TabViewModel {
         switch tab.content {
         case .url(let url, _, _):
             return !(url.isDuckPlayer || url.isDuckURLScheme)
-        case .subscription, .identityTheftRestoration, .releaseNotes, .webExtensionUrl:
+        case .subscription, .identityTheftRestoration, .releaseNotes, .webExtensionUrl, .aiChat:
             return true
 
         case .newtab, .settings, .bookmarks, .history, .onboarding, .dataBrokerProtection, .none:
@@ -210,7 +211,8 @@ final class TabViewModel {
                      .subscription,
                      .identityTheftRestoration,
                      .releaseNotes,
-                     .webExtensionUrl:
+                     .webExtensionUrl,
+                     .aiChat:
                     // Update the address bar instantly for built-in content types or user-initiated navigations
                     return Just( () ).eraseToAnyPublisher()
                 }
@@ -404,6 +406,8 @@ final class TabViewModel {
                 .emailProtectionTrustedIndicator
         case .url(let url, _, _), .webExtensionUrl(let url):
             NSAttributedString(string: passiveAddressBarString(with: url, showFullURL: showFullURL))
+        case .aiChat:
+                .aiChatTrustedIndicator
         }
     }
 
@@ -453,7 +457,7 @@ final class TabViewModel {
             } else {
                 title = UserText.tabHomeTitle
             }
-        case .url, .none, .subscription, .identityTheftRestoration, .onboarding, .webExtensionUrl:
+        case .url, .none, .subscription, .identityTheftRestoration, .onboarding, .webExtensionUrl, .aiChat:
             if let tabTitle = tab.title?.trimmingWhitespace(), !tabTitle.isEmpty {
                 title = tabTitle
             } else if let host = tab.url?.host?.droppingWwwPrefix() {
@@ -506,6 +510,8 @@ final class TabViewModel {
             Favicon.emailProtection
         case .url, .onboarding, .webExtensionUrl, .none:
             tabFavicon ?? tab.favicon
+        case .aiChat:
+            Favicon.aiChat
         }
     }
 
@@ -644,5 +650,7 @@ private extension NSAttributedString {
                                                                                   title: UserText.emailProtectionPreferences)
     static let releaseNotesTrustedIndicator = trustedIndicatorAttributedString(with: .releaseNotesIndicator,
                                                                                title: UserText.releaseNotesTitle)
+    static let aiChatTrustedIndicator = trustedIndicatorAttributedString(with: .aiChatPreferences,
+                                                                         title: UserText.aiChat)
 
 }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -225,7 +225,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .canScanUrlBasedSyncSetupBarcodes:
             return .remoteReleasable(.subfeature(SyncSubfeature.canScanUrlBasedSyncSetupBarcodes))
         case .aiChatSidebar:
-            return .disabled
+            return .internalOnly()
         }
     }
 }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -91,6 +91,9 @@ public enum FeatureFlag: String, CaseIterable {
 
     /// https://app.asana.com/1/137249556945/project/72649045549333/task/1210081345713964?focus=true
     case canScanUrlBasedSyncSetupBarcodes
+
+    /// https://app.asana.com/1/137249556945/project/1209671977594486/task/1210410403692636?focus=true
+    case aiChatSidebar
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -142,7 +145,8 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .maliciousSiteProtection,
                 .delayedWebviewPresentation,
                 .syncSetupBarcodeIsUrlBased,
-                .canScanUrlBasedSyncSetupBarcodes:
+                .canScanUrlBasedSyncSetupBarcodes,
+                .aiChatSidebar:
             return true
         case .debugMenu,
                 .sslCertificatesBypass,
@@ -220,6 +224,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .disabled
         case .canScanUrlBasedSyncSetupBarcodes:
             return .remoteReleasable(.subfeature(SyncSubfeature.canScanUrlBasedSyncSetupBarcodes))
+        case .aiChatSidebar:
+            return .disabled
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209671977594486/task/1210012482760771?focus=true 
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1210354678311516
CC: @Bunn 

### Description
This PR adds:
1. `.aiChatSidebar` feature flag that is enabled to internal users
2. Preliminary Duck.ai sidebar implementation (gated by the feature flag)
3. Trusted address bar indicator for Duck.ai pages (gated by the feature flag)

### Testing Steps
⚠️ After toggling the feature flag override please restart the app (or at least open a new window)

Ensure that with `aiChatSidebar` feature flag **disabled** no changes are leaking:

**Duck.ai is not using special address bar treatment**
1. Make sure that in "Settings" -> "Duck.ai" option for "Show Duck.ai shortcut in the address bar" is enabled.
2. Navigate to Duck.ai (e.g. using address bar icon)
3. Make sure address bar is not in focus
4. Confirm that  address bar shows URL like for regular website and is not using special treatment like for special pages. and standard DDG favicon is shown on the tab.

**Duck.ai sidebar is not present**
1. Make sure that in "Settings" -> "Duck.ai" option for "Show Duck.ai shortcut in the address bar" is enabled.
2. Navigate to "regular" website
3. Make sure address bar is not in focus
4. Click address bar Duck.ai button
5. Confirm that a new Duck.ai tab is being open


Ensure that with `aiChatSidebar` feature flag **enabled** the new features are available:

**Duck.ai is using special address bar treatment**
1. Make sure that in "Settings" -> "Duck.ai" option for "Show Duck.ai shortcut in the address bar" is enabled.
2. Navigate to Duck.ai (e.g. using address bar icon)
3. Make sure address bar is not in focus
4. Confirm that address bar shows special treatment for Duck.ai displaying "DuckDuckGo > Duck.ai" and using color Duck.ai icon as tab's favicon

**Duck.ai sidebar is present**
1. Make sure that in "Settings" -> "Duck.ai" option for "Show Duck.ai shortcut in the address bar" is enabled.
2. Navigate to "regular" website
3. Make sure address bar is not in focus
4. Click address bar Duck.ai button
5. Confirm that a Duck.ai sidebar is being revealed
6. Click address bar Duck.ai button again
7. Confirm that a Duck.ai sidebar is being closed

### Impact and Risks
High: Could affect user privacy, lose user data, break core functionality

#### What could go wrong?
Broken layout of the tab's webview. 

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)