### PR TITLE
Report tracker's parent entity name for Privacy Stats

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/PrivacyStatsTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PrivacyStatsTabExtension.swift
@@ -21,15 +21,23 @@ import Common
 import ContentBlocking
 import Foundation
 import Navigation
+import NewTabPage
 import PrivacyStats
+import TrackerRadarKit
 
 final class PrivacyStatsTabExtension: NSObject {
 
     let privacyStats: PrivacyStatsCollecting
+    private var trackerData: TrackerData
     private var cancellables = Set<AnyCancellable>()
 
-    init(privacyStats: PrivacyStatsCollecting = NSApp.delegateTyped.privacyStats, trackersPublisher: some Publisher<DetectedTracker, Never>) {
+    init(
+        privacyStats: PrivacyStatsCollecting = NSApp.delegateTyped.privacyStats,
+        trackersPublisher: some Publisher<DetectedTracker, Never>,
+        trackerDataProvider: PrivacyStatsTrackerDataProviding
+    ) {
         self.privacyStats = privacyStats
+        self.trackerData = trackerDataProvider.trackerData
         super.init()
 
         trackersPublisher
@@ -37,10 +45,21 @@ final class PrivacyStatsTabExtension: NSObject {
                 self?.recordDetectedTracker(tracker)
             }
             .store(in: &cancellables)
+
+        trackerDataProvider.trackerDataUpdatesPublisher
+            .sink { [weak self, weak trackerDataProvider] in
+                guard let self, let trackerDataProvider else {
+                    return
+                }
+                trackerData = trackerDataProvider.trackerData
+            }
+            .store(in: &cancellables)
     }
 
     private func recordDetectedTracker(_ tracker: DetectedTracker) {
-        guard tracker.request.isBlocked, let entityName = tracker.request.entityName else {
+        guard tracker.request.isBlocked,
+              let host = tracker.request.url.url?.host,
+              let entityName = trackerData.findParentEntityOrFallback(forHost: host)?.displayName else {
             return
         }
         switch tracker.type {

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
@@ -200,7 +200,10 @@ extension TabExtensionsBuilder {
                                 titlePublisher: args.titlePublisher)
         }
         add {
-            PrivacyStatsTabExtension(trackersPublisher: contentBlocking.trackersPublisher)
+            PrivacyStatsTabExtension(
+                trackersPublisher: contentBlocking.trackersPublisher,
+                trackerDataProvider: PrivacyStatsTrackerDataProvider(contentBlocking: dependencies.privacyFeatures.contentBlocking)
+            )
         }
         add {
             ExternalAppSchemeHandler(workspace: dependencies.workspace, permissionModel: args.permissionModel, contentPublisher: args.contentPublisher)

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/PrivacyStats/PrivacyStatsTrackerDataProviding.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/PrivacyStats/PrivacyStatsTrackerDataProviding.swift
@@ -19,7 +19,7 @@
 import Combine
 import TrackerRadarKit
 
-public protocol PrivacyStatsTrackerDataProviding {
+public protocol PrivacyStatsTrackerDataProviding: AnyObject {
     var trackerData: TrackerData { get }
     var trackerDataUpdatesPublisher: AnyPublisher<Void, Never> { get }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210445074620203?focus=true

### Description
This change updates PrivacyStatsTabExtension to report the entity’s parent company name
for detected trackers, if that exists.

Some blocked trackers missed being attributed to their parent entity, which could cause them to be misclassified in the Privacy Stats report, e.g. in “Other” category, instead of one of the top 100 companies. This change fixes that error by introducing proper mapping to parent company:
<img width="517" alt="Screenshot 2025-06-02 at 23 45 05" src="https://github.com/user-attachments/assets/6d4760d5-1997-44bb-8b31-b329139dc18d" />

### Testing Steps
1. Launch the app from main or release branch. Open some websites (e.g. open all bookmarks from a folder).
2. Take a screenshot of the Privacy Stats widget.
3. Burn data, switch to this PR branch, run the app and open the same set of websites.
4. Compare Privacy Stats widget with the screenshot from step 2. You should see more trackers attributed (and fewer in “Other” category).

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

### Quality Considerations
We’re reusing existing TRK API to look up parent entity so it should be safe to add it.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)