### PR TITLE
Fix + button not being fully tappable

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -640,15 +640,7 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
             return 0
         }
 
-        let insets: NSEdgeInsets
-        let tabsWidth: CGFloat
-        if visualStyle.tabStyleProvider.shouldShowSShapedTab {
-            insets = self.collectionView(self.collectionView, layout: self.collectionView.collectionViewLayout!, insetForSectionAt: 0)
-            tabsWidth = scrollView.bounds.width - footerCurrentWidthDimension - insets.left - insets.right
-        } else {
-            tabsWidth = scrollView.bounds.width - footerCurrentWidthDimension
-        }
-
+        let tabsWidth = scrollView.bounds.width - footerCurrentWidthDimension
         let minimumWidth = selected ? TabBarViewItem.Width.minimumSelected : TabBarViewItem.Width.minimum
 
         if tabMode == .divided {
@@ -1120,7 +1112,7 @@ extension TabBarViewController: NSCollectionViewDelegateFlowLayout {
         if visualStyle.tabStyleProvider.shouldShowSShapedTab {
             let isRightScrollButtonVisible = !rightScrollButton.isHidden
             let isLeftScrollButonVisible = !leftScrollButton.isHidden
-            return NSEdgeInsets(top: 0, left: isLeftScrollButonVisible ? 6 : 12, bottom: 0, right: isRightScrollButtonVisible ? 6 : 0)
+            return NSEdgeInsets(top: 0, left: isLeftScrollButonVisible ? 6 : 12, bottom: 0, right: isRightScrollButtonVisible ? 6 : -12)
         } else if let flowLayout = collectionViewLayout as? NSCollectionViewFlowLayout {
             return flowLayout.sectionInset
         } else {

--- a/macOS/DuckDuckGo/VisualRefresh/AddressBarStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/AddressBarStyleProviding.swift
@@ -143,7 +143,7 @@ final class CurrentAddressBarStyleProvider: AddressBarStyleProviding {
     let shouldAddAddressBarShadowWhenInactive: Bool = true
     let tabBarButtonSize: CGFloat = 28
     let addressBarButtonSize: CGFloat = 28
-    let addTabButtonPadding: CGFloat = 5
+    let addTabButtonPadding: CGFloat = 32 // Takes into account the extra 24pts (12pts for each inset on s-shaped tabs)
     let addressBarActiveBackgroundViewRadius: CGFloat = 15
     let addressBarInactiveBackgroundViewRadius: CGFloat = 12
     let addressBarInnerBorderViewRadius: CGFloat = 15


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1210443911553302?focus=true
Tech Design URL:
CC:

### Description
The new visual refresh added some changes to allow the s-shaped tabs, which introduced a bug that caused the + button to be not fully tappable. This is fixed by calculating the correct width.

### Testing Steps
1. Run the application
2. Check the + button is fully tappable

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
This goes to external users

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)