### PR TITLE
macOS Visual Refresh: Increase pinned tab width

### DIFF
--- a/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
+++ b/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
@@ -249,8 +249,21 @@ struct PinnedTabInnerView: View {
         ZStack {
             Rectangle()
                 .foregroundColor(foregroundColor)
-                .frame(width: shouldApplyNewHoverState ? width - 8 : width, height: shouldApplyNewHoverState ? height - 8 : height)
-                .cornerRadius(shouldApplyNewHoverState ? 6 : PinnedTabView.Const.cornerRadius, corners: shouldApplyNewHoverState ? [.topLeft, .topRight, .bottomLeft, .bottomRight] : [.topLeft, .topRight])
+                .frame(width: shouldApplyNewHoverState ? width - 8 : width,
+                       height: shouldApplyNewHoverState ? height - 8 : height)
+                .cornerRadius(
+                    shouldApplyNewHoverState ? 6 : PinnedTabView.Const.cornerRadius,
+                    corners: shouldApplyNewHoverState ? [.topLeft, .topRight, .bottomLeft, .bottomRight] : [.topLeft, .topRight]
+                )
+                .clipShape(
+                    CustomRoundedCornersShape(
+                        inset: 0,
+                        tl: shouldApplyNewHoverState ? 6 : PinnedTabView.Const.cornerRadius,
+                        tr: shouldApplyNewHoverState ? 6 : PinnedTabView.Const.cornerRadius,
+                        bl: shouldApplyNewHoverState ? 6 : 0,
+                        br: shouldApplyNewHoverState ? 6 : 0
+                    )
+                )
 
             if drawSeparator {
                 GeometryReader { proxy in

--- a/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
+++ b/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
@@ -249,20 +249,11 @@ struct PinnedTabInnerView: View {
         ZStack {
             Rectangle()
                 .foregroundColor(foregroundColor)
-                .frame(width: shouldApplyNewHoverState ? width - 8 : width,
+                .frame(width: shouldApplyNewHoverState ? width - 8 : showSShaped ? width : width-2,
                        height: shouldApplyNewHoverState ? height - 8 : height)
                 .cornerRadius(
                     shouldApplyNewHoverState ? 6 : PinnedTabView.Const.cornerRadius,
                     corners: shouldApplyNewHoverState ? [.topLeft, .topRight, .bottomLeft, .bottomRight] : [.topLeft, .topRight]
-                )
-                .clipShape(
-                    CustomRoundedCornersShape(
-                        inset: 0,
-                        tl: shouldApplyNewHoverState ? 6 : PinnedTabView.Const.cornerRadius,
-                        tr: shouldApplyNewHoverState ? 6 : PinnedTabView.Const.cornerRadius,
-                        bl: shouldApplyNewHoverState ? 6 : 0,
-                        br: shouldApplyNewHoverState ? 6 : 0
-                    )
                 )
 
             if drawSeparator {

--- a/macOS/DuckDuckGo/VisualRefresh/TabStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/TabStyleProviding.swift
@@ -62,7 +62,7 @@ final class NewlineTabStyleProvider: TabStyleProviding {
     let tabsScrollViewHeight: CGFloat = 38
     let pinnedTabsContainerViewHeight: CGFloat = 38
     let standardTabHeight: CGFloat = 38
-    let pinnedTabWidth: CGFloat = 34
+    let pinnedTabWidth: CGFloat = 38
     let pinnedTabHeight: CGFloat = 38
     let shouldShowSShapedTab = true
     let isRoundedBackgroundPresentOnHover = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1210441628866875?focus=true
Tech Design URL:
CC:

### Description
There was some comments about pinned tabs looking weird, we decided to increase the width to make them look different without losing the corner radius.

### Testing Steps
1. Run the application
2. Check pinned tabs are wider than the production visual refresh

| Before | After |
| ------ | ----- |
![Screenshot 2025-06-03 at 9 30 27 AM](https://github.com/user-attachments/assets/44755bc5-2d25-4bb0-9088-9cec530b8d6a)|![Screenshot 2025-06-03 at 9 30 14 AM](https://github.com/user-attachments/assets/b52b8bc7-92a6-421d-a126-647a5dc3c980)


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)