### PR TITLE
macOS Visual Refresh: Update surface dark colors

### DIFF
--- a/macOS/DuckDuckGo/Assets.xcassets/Colors/New-Theme-Colors/SurfaceBackdrop.colorset/Contents.json
+++ b/macOS/DuckDuckGo/Assets.xcassets/Colors/New-Theme-Colors/SurfaceBackdrop.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x0D",
-          "green" : "0x0D",
-          "red" : "0x0D"
+          "blue" : "0x08",
+          "green" : "0x08",
+          "red" : "0x08"
         }
       },
       "idiom" : "universal"

--- a/macOS/DuckDuckGo/Assets.xcassets/Colors/New-Theme-Colors/SurfaceCanvas.colorset/Contents.json
+++ b/macOS/DuckDuckGo/Assets.xcassets/Colors/New-Theme-Colors/SurfaceCanvas.colorset/Contents.json
@@ -22,7 +22,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
+          "alpha" : "0.000",
           "blue" : "0x1F",
           "green" : "0x1F",
           "red" : "0x1F"

--- a/macOS/DuckDuckGo/Assets.xcassets/Colors/New-Theme-Colors/SurfacePrimary.colorset/Contents.json
+++ b/macOS/DuckDuckGo/Assets.xcassets/Colors/New-Theme-Colors/SurfacePrimary.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x26",
-          "green" : "0x26",
-          "red" : "0x26"
+          "blue" : "0x28",
+          "green" : "0x28",
+          "red" : "0x28"
         }
       },
       "idiom" : "universal"

--- a/macOS/DuckDuckGo/Assets.xcassets/Colors/New-Theme-Colors/SurfaceSecondary.colorset/Contents.json
+++ b/macOS/DuckDuckGo/Assets.xcassets/Colors/New-Theme-Colors/SurfaceSecondary.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x33",
-          "green" : "0x33",
-          "red" : "0x33"
+          "blue" : "0x37",
+          "green" : "0x37",
+          "red" : "0x37"
         }
       },
       "idiom" : "universal"

--- a/macOS/DuckDuckGo/Assets.xcassets/Colors/New-Theme-Colors/SurfaceTertiary.colorset/Contents.json
+++ b/macOS/DuckDuckGo/Assets.xcassets/Colors/New-Theme-Colors/SurfaceTertiary.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x40",
-          "green" : "0x40",
-          "red" : "0x40"
+          "blue" : "0x47",
+          "green" : "0x47",
+          "red" : "0x47"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1210438924680754?focus=true
Tech Design URL: 
CC:

### Description
There was some feedback around active tabs were hard to differentiate from non-active. Bryan proposed some new colors for the `surface` palette. This PR adds the new values for those colors.

### Testing Steps
1. Run the app
2. Go to Settings -> Appeareance -> Select Dark mode
3. Open a lot of tabs, the current active tab should be more noticeable than the non-active ones.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing.

### Quality Considerations
Nothing.

### Notes to Reviewer
Nothing.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)