### PR TITLE
AuthV2 - isUserAuthenticated and entitlements check improvements

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionAuthV1toV2Bridge.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionAuthV1toV2Bridge.swift
@@ -23,7 +23,13 @@ import Networking
 /// Temporary bridge between auth v1 and v2, this is implemented by SubscriptionManager V1 and V2
 public protocol SubscriptionAuthV1toV2Bridge: SubscriptionTokenProvider, SubscriptionAuthenticationStateProvider {
 
-    func isEnabled(feature: Entitlement.ProductName, cachePolicy: APICachePolicy) async throws -> Bool
+    /// If the feature is enabled in the app, based on Subscription entitlements
+    /// This is mostly used by the UI for showing features and their state
+    func isFeatureAvailableAndEnabled(feature: Entitlement.ProductName, cachePolicy: APICachePolicy) async throws -> Bool
+    /// If the user is allowed to use the feature, base on the TokenContainer entitlements
+    /// This is used by VPN and PIR
+    func isFeatureEnabledForUser(feature: Entitlement.ProductName) async -> Bool
+
     func currentSubscriptionFeatures() async -> [Entitlement.ProductName]
     func signOut(notifyUI: Bool) async
     var canPurchase: Bool { get }
@@ -38,7 +44,7 @@ public protocol SubscriptionAuthV1toV2Bridge: SubscriptionTokenProvider, Subscri
 extension SubscriptionAuthV1toV2Bridge {
 
     public func isEnabled(feature: Entitlement.ProductName) async throws -> Bool {
-        try await isEnabled(feature: feature, cachePolicy: .returnCacheDataElseLoad)
+        try await isFeatureAvailableAndEnabled(feature: feature, cachePolicy: .returnCacheDataElseLoad)
     }
 }
 
@@ -80,7 +86,17 @@ extension SubscriptionEntitlement {
 
 extension DefaultSubscriptionManager: SubscriptionAuthV1toV2Bridge {
 
-    public func isEnabled(feature: Entitlement.ProductName, cachePolicy: APICachePolicy) async throws -> Bool {
+    public func isFeatureEnabledForUser(feature: Entitlement.ProductName) async -> Bool {
+        let result = await accountManager.hasEntitlement(forProductName: feature, cachePolicy: .returnCacheDataDontLoad)
+        switch result {
+        case .success(let hasEntitlements):
+            return hasEntitlements
+        case .failure:
+            return false
+        }
+    }
+
+    public func isFeatureAvailableAndEnabled(feature: Entitlement.ProductName, cachePolicy: APICachePolicy) async throws -> Bool {
 
         let result = await accountManager.hasEntitlement(forProductName: feature, cachePolicy: cachePolicy)
         switch result {
@@ -119,8 +135,20 @@ extension DefaultSubscriptionManager: SubscriptionAuthV1toV2Bridge {
 
 extension DefaultSubscriptionManagerV2: SubscriptionAuthV1toV2Bridge {
 
-    public func isEnabled(feature: Entitlement.ProductName, cachePolicy: APICachePolicy) async throws -> Bool {
-        return try await isFeatureAvailableForUser(feature.subscriptionEntitlement)
+    public func isFeatureEnabledForUser(feature: Entitlement.ProductName) async -> Bool {
+        do {
+            guard let tokenContainer = try self.oAuthClient.currentTokenContainer() else {
+                return false
+            }
+            return tokenContainer.decodedAccessToken.subscriptionEntitlements.contains(where: { $0.product == feature })
+        } catch {
+            // Fallback to the cached user entitlements in case of keychain reading error
+            return self.cachedUserEntitlements.contains(where: { $0.product == feature })
+        }
+    }
+
+    public func isFeatureAvailableAndEnabled(feature: Entitlement.ProductName, cachePolicy: APICachePolicy) async throws -> Bool {
+        return try await isSubscriptionFeatureEnabled(feature.subscriptionEntitlement)
     }
 
     public func currentSubscriptionFeatures() async -> [Entitlement.ProductName] {

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManager.swift
@@ -207,10 +207,6 @@ extension DefaultSubscriptionManager: SubscriptionTokenProvider {
         }
         return token
     }
-
-    public func removeAccessToken() {
-        try? accountManager.removeAccessToken()
-    }
 }
 
 extension DefaultSubscriptionManager: SubscriptionAuthenticationStateProvider {

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
@@ -585,8 +585,6 @@ extension SubscriptionEntitlement {
             return Entitlement(product: .identityTheftRestoration)
         case .identityTheftRestorationGlobal:
             return Entitlement(product: .identityTheftRestorationGlobal)
-        case .paidAIChat:
-            return Entitlement(product: .paidAIChat)
         case .unknown:
             return Entitlement(product: .unknown)
         }

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
@@ -126,8 +126,8 @@ public protocol SubscriptionManagerV2: SubscriptionTokenProvider, SubscriptionAu
     /// A user cant have an entitlement without the feature, if a user is missing an entitlement the feature is disabled
     func currentSubscriptionFeatures(forceRefresh: Bool) async throws -> [SubscriptionFeatureV2]
 
-    /// True if the feature can be used by the user, false otherwise
-    func isFeatureAvailableForUser(_ entitlement: SubscriptionEntitlement) async throws -> Bool
+    /// True if the feature is available in the subscription and can be used by the user, false otherwise
+    func isSubscriptionFeatureEnabled(_ entitlement: SubscriptionEntitlement) async throws -> Bool
 
     // MARK: - Token Management
 
@@ -164,9 +164,11 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
     public let currentEnvironment: SubscriptionEnvironment
     private let isInternalUserEnabled: () -> Bool
     private let legacyAccountStorage: AccountKeychainStorage?
+    private let userDefaults: UserDefaults
 
     public init(storePurchaseManager: StorePurchaseManagerV2? = nil,
                 oAuthClient: any OAuthClient,
+                userDefaults: UserDefaults,
                 subscriptionEndpointService: SubscriptionEndpointServiceV2,
                 subscriptionEnvironment: SubscriptionEnvironment,
                 pixelHandler: SubscriptionPixelHandler,
@@ -176,6 +178,7 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
                 isInternalUserEnabled: @escaping () -> Bool =  { false }) {
         self._storePurchaseManager = storePurchaseManager
         self.oAuthClient = oAuthClient
+        self.userDefaults = userDefaults
         self.subscriptionEndpointService = subscriptionEndpointService
         self.currentEnvironment = subscriptionEnvironment
         self.pixelHandler = pixelHandler
@@ -271,7 +274,7 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
 
     @discardableResult
     public func getSubscription(cachePolicy: SubscriptionCachePolicy) async throws -> PrivacyProSubscription {
-        guard await isUserAuthenticated() else {
+        guard isUserAuthenticated else {
             throw SubscriptionEndpointServiceError.noData
         }
 
@@ -351,7 +354,7 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
     }
 
     public func getCustomerPortalURL() async throws -> URL {
-        guard await isUserAuthenticated() else {
+        guard isUserAuthenticated else {
             throw SubscriptionEndpointServiceError.noData
         }
 
@@ -366,16 +369,20 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
 
     // MARK: - User
     public var isUserAuthenticated: Bool {
-        return (try? oAuthClient.currentTokenContainer())?.accessToken != nil
-    }
-
-    private func isUserAuthenticated() async -> Bool {
-        let tokenContainer = try? await getTokenContainer(policy: .local)
-        return tokenContainer != nil
+        userDefaults.isUserAuthenticated
     }
 
     public var userEmail: String? {
         return (try? oAuthClient.currentTokenContainer())?.decodedAccessToken.email
+    }
+
+    public var cachedUserEntitlements: [SubscriptionEntitlement] {
+        get {
+            userDefaults.userEntitlements ?? []
+        }
+        set {
+            userDefaults.userEntitlements = newValue
+        }
     }
 
     // MARK: -
@@ -391,11 +398,12 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
 
             let resultTokenContainer = try await oAuthClient.getTokens(policy: policy)
             let newEntitlements = resultTokenContainer.decodedAccessToken.subscriptionEntitlements
+            cachedUserEntitlements = newEntitlements
 
             // Send "accountDidSignIn" notification when login changes
             if currentCachedTokenContainer == nil {
                 Logger.subscription.debug("New login detected")
-                NotificationCenter.default.post(name: .accountDidSignIn, object: self, userInfo: nil)
+                accountDidChange(isAuthenticated: true)
             }
 
             // Send notification when entitlements change
@@ -410,6 +418,7 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
             return resultTokenContainer
         } catch OAuthClientError.missingTokenContainer {
             // Expected when no tokens are available
+            cachedUserEntitlements = []
             throw SubscriptionManagerError.tokenUnavailable(error: OAuthClientError.missingTokenContainer)
         } catch {
             pixelHandler.handle(pixelType: .getTokensError(policy, error))
@@ -454,7 +463,7 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
 
     public func exchange(tokenV1: String) async throws -> TokenContainer {
         let tokenContainer = try await oAuthClient.exchange(accessTokenV1: tokenV1)
-        NotificationCenter.default.post(name: .accountDidSignIn, object: self, userInfo: nil)
+        accountDidChange(isAuthenticated: true)
         return tokenContainer
     }
 
@@ -470,11 +479,21 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
         // It’s important to force refresh the token to immediately branch from the one received.
         // See discussion https://app.asana.com/0/1199230911884351/1208785842165508/f
         _ = try await oAuthClient.getTokens(policy: .localForceRefresh)
-        NotificationCenter.default.post(name: .accountDidSignIn, object: self, userInfo: nil)
+        accountDidChange(isAuthenticated: true)
+    }
+
+    private func accountDidChange(isAuthenticated: Bool) {
+        userDefaults.isUserAuthenticated = isAuthenticated
+        if isAuthenticated {
+            NotificationCenter.default.post(name: .accountDidSignIn, object: self, userInfo: nil)
+        } else {
+            NotificationCenter.default.post(name: .accountDidSignOut, object: self, userInfo: nil)
+        }
     }
 
     public func removeLocalAccount() {
         Logger.subscription.log("Removing local account")
+        accountDidChange(isAuthenticated: false)
         oAuthClient.removeLocalAccount()
     }
 
@@ -484,7 +503,9 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
         clearSubscriptionCache()
         if notifyUI {
             Logger.subscription.log("SignOut: Notifying the UI")
-            NotificationCenter.default.post(name: .accountDidSignOut, object: self, userInfo: nil)
+            accountDidChange(isAuthenticated: false)
+        } else {
+            userDefaults.isUserAuthenticated = false
         }
         Logger.subscription.log("Removing V1 Account")
         try? legacyAccountStorage?.clearAuthenticationState()
@@ -507,7 +528,7 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
     /// - Parameter forceRefresh: ignore subscription and token cache and re-download everything
     /// - Returns: An Array of SubscriptionFeature where each feature is enabled or disabled based on the user entitlements
     public func currentSubscriptionFeatures(forceRefresh: Bool) async throws -> [SubscriptionFeatureV2] {
-        guard await isUserAuthenticated() else { return [] }
+        guard isUserAuthenticated else { return [] }
 
         var userEntitlements: [SubscriptionEntitlement]
         var availableFeatures: [SubscriptionEntitlement]
@@ -536,8 +557,8 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
         return result
     }
 
-    public func isFeatureAvailableForUser(_ entitlement: SubscriptionEntitlement) async throws -> Bool {
-        guard await isUserAuthenticated() else { return false }
+    public func isSubscriptionFeatureEnabled(_ entitlement: SubscriptionEntitlement) async throws -> Bool {
+        guard isUserAuthenticated else { return false }
 
         let currentFeatures = try await currentSubscriptionFeatures(forceRefresh: false)
         return currentFeatures.contains { feature in
@@ -549,10 +570,6 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
 extension DefaultSubscriptionManagerV2: SubscriptionTokenProvider {
     public func getAccessToken() async throws -> String {
         try await getTokenContainer(policy: .localValid).accessToken
-    }
-
-    public func removeAccessToken() {
-        removeLocalAccount()
     }
 }
 
@@ -568,8 +585,46 @@ extension SubscriptionEntitlement {
             return Entitlement(product: .identityTheftRestoration)
         case .identityTheftRestorationGlobal:
             return Entitlement(product: .identityTheftRestorationGlobal)
+        case .paidAIChat:
+            return Entitlement(product: .paidAIChat)
         case .unknown:
             return Entitlement(product: .unknown)
+        }
+    }
+}
+
+fileprivate extension UserDefaults {
+
+    static let isUserAuthenticatedKey = "com.duckduckgo.subscription.isUserAuthenticated"
+    var isUserAuthenticated: Bool {
+        get {
+            return bool(forKey: Self.isUserAuthenticatedKey)
+        }
+        set {
+            set(newValue, forKey: Self.isUserAuthenticatedKey)
+            if newValue == false {
+                userEntitlements = nil
+            }
+        }
+    }
+
+    static let userEntitlementsKey = "com.duckduckgo.subscription.userEntitlements"
+    var userEntitlements: [SubscriptionEntitlement]? {
+        get {
+            guard let data = data(forKey: Self.userEntitlementsKey) else {
+                return nil
+            }
+            return (try? JSONDecoder().decode([SubscriptionEntitlement].self, from: data))
+        }
+        set {
+            guard let newValue else {
+                removeObject(forKey: Self.userEntitlementsKey)
+                return
+            }
+
+            if let data = try? JSONEncoder().encode(newValue) {
+                set(data, forKey: Self.userEntitlementsKey)
+            }
         }
     }
 }

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
@@ -376,7 +376,7 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
         return (try? oAuthClient.currentTokenContainer())?.decodedAccessToken.email
     }
 
-    public var cachedUserEntitlements: [SubscriptionEntitlement] {
+    var cachedUserEntitlements: [SubscriptionEntitlement] {
         get {
             userDefaults.userEntitlements ?? []
         }

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
@@ -478,7 +478,8 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
         oAuthClient.adopt(tokenContainer: tokenContainer)
         // It’s important to force refresh the token to immediately branch from the one received.
         // See discussion https://app.asana.com/0/1199230911884351/1208785842165508/f
-        _ = try await oAuthClient.getTokens(policy: .localForceRefresh)
+        let refreshedTokenContainer = try await oAuthClient.getTokens(policy: .localForceRefresh)
+        cachedUserEntitlements = refreshedTokenContainer.decodedAccessToken.subscriptionEntitlements
         accountDidChange(isAuthenticated: true)
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionTokenProvider.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionTokenProvider.swift
@@ -24,7 +24,4 @@ public protocol SubscriptionTokenProvider {
 
     /// Get a valid access token
     func getAccessToken() async throws -> String
-
-    /// Remove the access token
-    func removeAccessToken()
 }

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
@@ -104,11 +104,6 @@ extension SubscriptionUserScript {
         struct HandshakeResponse: Codable, Equatable {
             let availableMessages: [SubscriptionUserScript.MessageName]
             let platform: Platform
-
-            init(availableMessages: [SubscriptionUserScript.MessageName], platform: Platform) {
-                self.availableMessages = availableMessages
-                self.platform = platform
-            }
         }
 
         /// This struct is returned in response to the `subscriptionDetails` message

--- a/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionAuthV1toV2BridgeMock.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionAuthV1toV2BridgeMock.swift
@@ -25,7 +25,10 @@ public final class SubscriptionAuthV1toV2BridgeMock: SubscriptionAuthV1toV2Bridg
     public init() {}
 
     public var enabledFeatures: [Subscription.Entitlement.ProductName] = []
-    public func isEnabled(feature: Subscription.Entitlement.ProductName, cachePolicy: Subscription.APICachePolicy) async throws -> Bool {
+    public func isFeatureAvailableAndEnabled(feature: Subscription.Entitlement.ProductName, cachePolicy: Subscription.APICachePolicy) async throws -> Bool {
+        enabledFeatures.contains(feature)
+    }
+    public func isFeatureEnabledForUser(feature: Subscription.Entitlement.ProductName) async -> Bool {
         enabledFeatures.contains(feature)
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionManagerMock.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionManagerMock.swift
@@ -21,7 +21,6 @@ import Common
 @testable import Subscription
 
 public final class SubscriptionManagerMock: SubscriptionManager {
-
     public var email: String?
 
     public var accountManager: AccountManager
@@ -117,7 +116,14 @@ public final class SubscriptionManagerMock: SubscriptionManager {
         accountManager.isUserAuthenticated
     }
 
-    public func isEnabled(feature: Entitlement.ProductName, cachePolicy: APICachePolicy) async throws -> Bool {
+    public func isFeatureEnabledForUser(feature: Subscription.Entitlement.ProductName) async -> Bool {
+        guard let hasEntitlement = try? await isFeatureAvailableAndEnabled(feature: feature, cachePolicy: .returnCacheDataElseLoad) else {
+            return false
+        }
+        return hasEntitlement
+    }
+
+    public func isFeatureAvailableAndEnabled(feature: Entitlement.ProductName, cachePolicy: APICachePolicy) async throws -> Bool {
 
         let result = await accountManager.hasEntitlement(forProductName: .networkProtection, cachePolicy: cachePolicy)
         switch result {

--- a/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionManagerMockV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionManagerMockV2.swift
@@ -203,8 +203,6 @@ public final class SubscriptionManagerMockV2: SubscriptionManagerV2 {
             return await isFeatureEnabledForUser(feature:.identityTheftRestoration)
         case .identityTheftRestorationGlobal:
             return await isFeatureEnabledForUser(feature:.identityTheftRestorationGlobal)
-        case .paidAIChat:
-            return await isFeatureEnabledForUser(feature:.paidAIChat)
         case .unknown:
             return false
         }
@@ -221,8 +219,6 @@ public final class SubscriptionManagerMockV2: SubscriptionManagerV2 {
                 return .identityTheftRestoration
             case .identityTheftRestorationGlobal:
                 return .identityTheftRestorationGlobal
-            case .paidAIChat:
-                return .paidAIChat
             case .unknown:
                 return nil
             }

--- a/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionManagerMockV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionManagerMockV2.swift
@@ -23,7 +23,6 @@ import Common
 import NetworkingTestingUtils
 
 public final class SubscriptionManagerMockV2: SubscriptionManagerV2 {
-
     public var email: String?
 
     public init() {}
@@ -169,8 +168,16 @@ public final class SubscriptionManagerMockV2: SubscriptionManagerV2 {
         resultFeatures
     }
 
-    public func isFeatureAvailableForUser(_ entitlement: Networking.SubscriptionEntitlement) async -> Bool {
+    public func isSubscriptionFeatureEnabled(_ entitlement: Networking.SubscriptionEntitlement) async throws -> Bool {
         resultFeatures.contains { $0.entitlement == entitlement }
+    }
+
+    public func isFeatureAvailableAndEnabled(feature: Subscription.Entitlement.ProductName, cachePolicy: Subscription.APICachePolicy) async throws -> Bool {
+        resultFeatures.contains { $0.entitlement == feature.subscriptionEntitlement }
+    }
+
+    public func isFeatureEnabledForUser(feature: Subscription.Entitlement.ProductName) async -> Bool {
+        resultFeatures.contains { $0.entitlement == feature.subscriptionEntitlement }
     }
 
     // MARK: - Subscription Token Provider
@@ -189,13 +196,15 @@ public final class SubscriptionManagerMockV2: SubscriptionManagerV2 {
     public func isEnabled(feature: Subscription.Entitlement.ProductName, cachePolicy: Subscription.APICachePolicy) async throws -> Bool {
         switch feature {
         case .networkProtection:
-            return await isFeatureAvailableForUser(.networkProtection)
+            return await isFeatureEnabledForUser(feature:.networkProtection)
         case .dataBrokerProtection:
-            return await isFeatureAvailableForUser(.dataBrokerProtection)
+            return await isFeatureEnabledForUser(feature:.dataBrokerProtection)
         case .identityTheftRestoration:
-            return await isFeatureAvailableForUser(.identityTheftRestoration)
+            return await isFeatureEnabledForUser(feature:.identityTheftRestoration)
         case .identityTheftRestorationGlobal:
-            return await isFeatureAvailableForUser(.identityTheftRestorationGlobal)
+            return await isFeatureEnabledForUser(feature:.identityTheftRestorationGlobal)
+        case .paidAIChat:
+            return await isFeatureEnabledForUser(feature:.paidAIChat)
         case .unknown:
             return false
         }
@@ -212,6 +221,8 @@ public final class SubscriptionManagerMockV2: SubscriptionManagerV2 {
                 return .identityTheftRestoration
             case .identityTheftRestorationGlobal:
                 return .identityTheftRestorationGlobal
+            case .paidAIChat:
+                return .paidAIChat
             case .unknown:
                 return nil
             }

--- a/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionManagerMockV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionManagerMockV2.swift
@@ -196,13 +196,13 @@ public final class SubscriptionManagerMockV2: SubscriptionManagerV2 {
     public func isEnabled(feature: Subscription.Entitlement.ProductName, cachePolicy: Subscription.APICachePolicy) async throws -> Bool {
         switch feature {
         case .networkProtection:
-            return await isFeatureEnabledForUser(feature:.networkProtection)
+            return await isFeatureEnabledForUser(feature: .networkProtection)
         case .dataBrokerProtection:
-            return await isFeatureEnabledForUser(feature:.dataBrokerProtection)
+            return await isFeatureEnabledForUser(feature: .dataBrokerProtection)
         case .identityTheftRestoration:
-            return await isFeatureEnabledForUser(feature:.identityTheftRestoration)
+            return await isFeatureEnabledForUser(feature: .identityTheftRestoration)
         case .identityTheftRestorationGlobal:
-            return await isFeatureEnabledForUser(feature:.identityTheftRestorationGlobal)
+            return await isFeatureEnabledForUser(feature: .identityTheftRestorationGlobal)
         case .unknown:
             return false
         }

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests+CustomURL.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests+CustomURL.swift
@@ -31,10 +31,11 @@ extension SubscriptionManagerV2Tests {
         let subscriptionEnvironment = SubscriptionEnvironment(serviceEnvironment: .production,
                                                               purchasePlatform: .appStore,
                                                               customBaseSubscriptionURL: customBaseSubscriptionURL)
-
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.\(#function)")!
         let subscriptionManager = DefaultSubscriptionManagerV2(
             storePurchaseManager: mockStorePurchaseManager,
             oAuthClient: mockOAuthClient,
+            userDefaults: userDefaults,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: subscriptionEnvironment,
             pixelHandler: MockPixelHandler(),
@@ -56,10 +57,11 @@ extension SubscriptionManagerV2Tests {
         let subscriptionEnvironment = SubscriptionEnvironment(serviceEnvironment: .production,
                                                               purchasePlatform: .appStore,
                                                               customBaseSubscriptionURL: customBaseSubscriptionURL)
-
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.\(#function)")!
         let subscriptionManager = DefaultSubscriptionManagerV2(
             storePurchaseManager: mockStorePurchaseManager,
             oAuthClient: mockOAuthClient,
+            userDefaults: userDefaults,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: subscriptionEnvironment,
             pixelHandler: MockPixelHandler(),
@@ -79,10 +81,11 @@ extension SubscriptionManagerV2Tests {
 
         let subscriptionEnvironment = SubscriptionEnvironment(serviceEnvironment: .production,
                                                               purchasePlatform: .appStore)
-
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.\(#function)")!
         let subscriptionManager = DefaultSubscriptionManagerV2(
             storePurchaseManager: mockStorePurchaseManager,
             oAuthClient: mockOAuthClient,
+            userDefaults: userDefaults,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: subscriptionEnvironment,
             pixelHandler: MockPixelHandler(),

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests+Redirect.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests+Redirect.swift
@@ -52,10 +52,11 @@ extension SubscriptionManagerV2Tests {
         let redirectURLComponents = try XCTUnwrap(URLComponents(string: "https://www.duckduckgo.com/pro?origin=test"))
 
         let stagingEnvironment = SubscriptionEnvironment(serviceEnvironment: .staging, purchasePlatform: .appStore)
-
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.\(#function)")!
         let stagingSubscriptionManager = DefaultSubscriptionManagerV2(
             storePurchaseManager: mockStorePurchaseManager,
             oAuthClient: mockOAuthClient,
+            userDefaults: userDefaults,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: stagingEnvironment,
             pixelHandler: MockPixelHandler(),

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests.swift
@@ -43,10 +43,11 @@ class SubscriptionManagerV2Tests: XCTestCase {
         mockSubscriptionEndpointService = SubscriptionEndpointServiceMockV2()
         mockStorePurchaseManager = StorePurchaseManagerMockV2()
         mockAppStoreRestoreFlowV2 = AppStoreRestoreFlowMockV2()
-
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.SubscriptionManagerV2Tests")!
         subscriptionManager = DefaultSubscriptionManagerV2(
             storePurchaseManager: mockStorePurchaseManager,
             oAuthClient: mockOAuthClient,
+            userDefaults: userDefaults,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: SubscriptionEnvironment(serviceEnvironment: .production, purchasePlatform: .appStore),
             pixelHandler: MockPixelHandler()
@@ -133,9 +134,11 @@ class SubscriptionManagerV2Tests: XCTestCase {
 
     func testURLGeneration_ForSubscriptionTypes() {
         let environment = SubscriptionEnvironment(serviceEnvironment: .production, purchasePlatform: .appStore)
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.\(#function)")!
         subscriptionManager = DefaultSubscriptionManagerV2(
             storePurchaseManager: mockStorePurchaseManager,
             oAuthClient: mockOAuthClient,
+            userDefaults: userDefaults,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: environment,
             pixelHandler: MockPixelHandler()
@@ -190,10 +193,11 @@ class SubscriptionManagerV2Tests: XCTestCase {
     func testForProductionURL() throws {
         // Given
         let productionEnvironment = SubscriptionEnvironment(serviceEnvironment: .production, purchasePlatform: .appStore)
-
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.\(#function)")!
         let productionSubscriptionManager = DefaultSubscriptionManagerV2(
             storePurchaseManager: mockStorePurchaseManager,
             oAuthClient: mockOAuthClient,
+            userDefaults: userDefaults,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: productionEnvironment,
             pixelHandler: MockPixelHandler()
@@ -209,10 +213,11 @@ class SubscriptionManagerV2Tests: XCTestCase {
     func testForStagingURL() throws {
         // Given
         let stagingEnvironment = SubscriptionEnvironment(serviceEnvironment: .staging, purchasePlatform: .appStore)
-
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.\(#function)")!
         let stagingSubscriptionManager = DefaultSubscriptionManagerV2(
             storePurchaseManager: mockStorePurchaseManager,
             oAuthClient: mockOAuthClient,
+            userDefaults: userDefaults,
             subscriptionEndpointService: mockSubscriptionEndpointService,
             subscriptionEnvironment: stagingEnvironment,
             pixelHandler: MockPixelHandler()

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/PrivacyProSubscriptionV2IntegrationTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/PrivacyProSubscriptionV2IntegrationTests.swift
@@ -55,9 +55,10 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
         let subscriptionEndpointService = DefaultSubscriptionEndpointServiceV2(apiService: apiService,
                                                                                baseURL: subscriptionEnvironment.serviceEnvironment.url)
         subscriptionFeatureFlagger = FeatureFlaggerMapping<SubscriptionFeatureFlags>(mapping: { $0.defaultState })
-
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.PrivacyProSubscriptionV2IntegrationTests")!
         subscriptionManager = DefaultSubscriptionManagerV2(storePurchaseManager: storePurchaseManager,
                                                            oAuthClient: authClient,
+                                                           userDefaults: userDefaults,
                                                            subscriptionEndpointService: subscriptionEndpointService,
                                                            subscriptionEnvironment: subscriptionEnvironment,
                                                            pixelHandler: MockPixelHandler())

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Authentication/DataBrokerProtectionSubscriptionManaging.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Authentication/DataBrokerProtectionSubscriptionManaging.swift
@@ -41,7 +41,7 @@ public final class DataBrokerProtectionSubscriptionManager: DataBrokerProtection
             if !isAuthV2Enabled {
                 tokenKey = "PRIVACYPRO_STAGING_TOKEN"
             } else {
-                tokenKey = "PRIVACYPRO_STAGING_TOKEN_V2"
+                tokenKey = "PRIVACYPRO_STAGING_ACCESS_TOKEN_V2"
             }
 
             if let token = ProcessInfo.processInfo.environment[tokenKey] {
@@ -58,7 +58,11 @@ public final class DataBrokerProtectionSubscriptionManager: DataBrokerProtection
     }
 
     public func hasValidEntitlement() async throws -> Bool {
-        try await subscriptionManager.isEnabled(feature: .dataBrokerProtection)
+        if runTypeProvider.runType == .integrationTests {
+            return true // real entitlements check are not possible here in AuthV2 because the SubscriptionManager has no token
+        } else {
+            return await subscriptionManager.isFeatureEnabledForUser(feature: .dataBrokerProtection)
+        }
     }
 }
 

--- a/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
@@ -236,6 +236,7 @@ final class AppDependencyProvider: DependencyProvider {
             let pixelHandler = AuthV2PixelHandler(source: .mainApp)
             let subscriptionManager = DefaultSubscriptionManagerV2(storePurchaseManager: storePurchaseManager,
                                                                    oAuthClient: authClient,
+                                                                   userDefaults: subscriptionUserDefaults,
                                                                    subscriptionEndpointService: subscriptionEndpointService,
                                                                    subscriptionEnvironment: subscriptionEnvironment,
                                                                    pixelHandler: pixelHandler,

--- a/iOS/DuckDuckGo/AppServices/DBPService.swift
+++ b/iOS/DuckDuckGo/AppServices/DBPService.swift
@@ -30,9 +30,10 @@ final class DBPService: NSObject {
 
     init(appDependencies: DependencyProvider) {
 #if DEBUG || ALPHA
-        let dbpSubscriptionManager = DataBrokerProtectionSubscriptionManager(subscriptionManager: AppDependencyProvider.shared.subscriptionAuthV1toV2Bridge,
-                                                                          runTypeProvider: appDependencies.dbpSettings,
-                                                                          isAuthV2Enabled: appDependencies.isAuthV2Enabled)
+        let dbpSubscriptionManager = DataBrokerProtectionSubscriptionManager(
+            subscriptionManager: AppDependencyProvider.shared.subscriptionAuthV1toV2Bridge,
+            runTypeProvider: appDependencies.dbpSettings,
+            isAuthV2Enabled: appDependencies.isAuthV2Enabled)
         let authManager = DataBrokerProtectionAuthenticationManager(subscriptionManager: dbpSubscriptionManager)
         let featureFlagger = DBPFeatureFlagger(appDependencies: appDependencies)
 

--- a/iOS/DuckDuckGo/AppServices/VPNService.swift
+++ b/iOS/DuckDuckGo/AppServices/VPNService.swift
@@ -114,7 +114,7 @@ final class VPNService: NSObject {
     @MainActor
     private func refreshVPNShortcuts() async {
         guard await vpnFeatureVisibility.shouldShowVPNShortcut(),
-              let hasEntitlement = try? await subscriptionManager.isEnabled(feature: .networkProtection,
+              let hasEntitlement = try? await subscriptionManager.isFeatureAvailableAndEnabled(feature: .networkProtection,
                                                                             cachePolicy: .returnCacheDataDontLoad),
               hasEntitlement
         else {

--- a/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -495,6 +495,7 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
             let pixelHandler = AuthV2PixelHandler(source: .systemExtension)
             let subscriptionManager = DefaultSubscriptionManagerV2(storePurchaseManager: storePurchaseManager,
                                                                    oAuthClient: authClient,
+                                                                   userDefaults: UserDefaults.standard,
                                                                    subscriptionEndpointService: subscriptionEndpointService,
                                                                    subscriptionEnvironment: subscriptionEnvironment,
                                                                    pixelHandler: pixelHandler,

--- a/macOS/DuckDuckGo/DBP/DataBrokerProtectionFeatureGatekeeper.swift
+++ b/macOS/DuckDuckGo/DBP/DataBrokerProtectionFeatureGatekeeper.swift
@@ -91,11 +91,8 @@ struct DefaultDataBrokerProtectionFeatureGatekeeper: DataBrokerProtectionFeature
         if !isAuthenticated && freemiumDBPUserStateManager.didActivate { return true }
 
         // NOTE: This check In AuthV1 this can fail in case of bad network, in AuthV2 works as expected in any network condition
-        let hasEntitlements = (try? await subscriptionManager.isEnabled(feature: .dataBrokerProtection,
-                                                                        cachePolicy: .reloadIgnoringLocalCacheData)) ?? false
-
+        let hasEntitlements = await subscriptionManager.isFeatureEnabledForUser(feature: .dataBrokerProtection)
         firePrerequisitePixelsAndLogIfNecessary(hasEntitlements: hasEntitlements, isAuthenticatedResult: isAuthenticated)
-
         return hasEntitlements && isAuthenticated
     }
 }

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/NetworkProtectionSubscriptionEventHandler.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/NetworkProtectionSubscriptionEventHandler.swift
@@ -46,11 +46,9 @@ final class NetworkProtectionSubscriptionEventHandler {
 
     private func subscribeToEntitlementChanges() {
         Task {
-
-            if let hasEntitlements = try? await subscriptionManager.isEnabled(feature: .networkProtection) {
-                Task {
-                    await handleEntitlementsChange(hasEntitlements: hasEntitlements)
-                }
+            let hasEntitlement = await subscriptionManager.isFeatureEnabledForUser(feature: .networkProtection)
+            Task {
+                await handleEntitlementsChange(hasEntitlements: hasEntitlement)
             }
 
             NotificationCenter.default

--- a/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
@@ -465,6 +465,7 @@ final class MacPacketTunnelProvider: PacketTunnelProvider {
                                                                                  baseURL: subscriptionEnvironment.serviceEnvironment.url)
         let pixelHandler = AuthV2PixelHandler(source: .systemExtension)
         let subscriptionManager = DefaultSubscriptionManagerV2(oAuthClient: authClient,
+                                                               userDefaults: subscriptionUserDefaults,
                                                                subscriptionEndpointService: subscriptionEndpointServiceV2,
                                                                subscriptionEnvironment: subscriptionEnvironment,
                                                                pixelHandler: pixelHandler,

--- a/macOS/DuckDuckGo/Subscription/SubscriptionManager+StandardConfiguration.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionManager+StandardConfiguration.swift
@@ -186,6 +186,7 @@ extension DefaultSubscriptionManagerV2 {
             self.init(storePurchaseManager: DefaultStorePurchaseManagerV2(subscriptionFeatureMappingCache: subscriptionEndpointService,
                                                                           subscriptionFeatureFlagger: subscriptionFeatureFlagger),
                       oAuthClient: authClient,
+                      userDefaults: userDefaults,
                       subscriptionEndpointService: subscriptionEndpointService,
                       subscriptionEnvironment: environment,
                       pixelHandler: pixelHandler,
@@ -193,6 +194,7 @@ extension DefaultSubscriptionManagerV2 {
                       isInternalUserEnabled: isInternalUserEnabled)
         } else {
             self.init(oAuthClient: authClient,
+                      userDefaults: userDefaults,
                       subscriptionEndpointService: subscriptionEndpointService,
                       subscriptionEnvironment: environment,
                       pixelHandler: pixelHandler,

--- a/macOS/DuckDuckGo/Waitlist/VPNFeatureGatekeeper.swift
+++ b/macOS/DuckDuckGo/Waitlist/VPNFeatureGatekeeper.swift
@@ -59,13 +59,7 @@ struct DefaultVPNFeatureGatekeeper: VPNFeatureGatekeeper {
     /// For subscription users this means they have entitlements.
     ///
     func canStartVPN() async throws -> Bool {
-        do {
-            return try await subscriptionManager.isEnabled(feature: .networkProtection)
-        } catch DefaultAccountManager.EntitlementsError.noAccessToken {
-            return false
-        } catch {
-            throw error
-        }
+        return await subscriptionManager.isFeatureEnabledForUser(feature: .networkProtection)
     }
 
     /// Whether the user can see the VPN entry points in the UI.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205842942115003/task/1210449733678950
CC: @miasma13 

### Description

- `isUserAuthenticated` now relies on cached (UserDefaults) values and can't fail
- `func isFeatureEnabledForUser(feature: Entitlement.ProductName)` The entitlements check used by the VPN, is now relying on cached user entitlements and can't fail

### Testing Steps

Subscription + VPN functioning as expected

### Impact and Risks

High, the subscription and VPN could be impacted

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)