### PR TITLE
add “Advanced” pixels

### DIFF
--- a/macOS/DuckDuckGo/Common/Extensions/NSWindowExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/NSWindowExtension.swift
@@ -65,4 +65,22 @@ extension NSWindow {
         }
     }
 
+    /// Determines if the window is approximately half the width of the screen
+    /// with some tolerance for system margins (useful for detecting split screen in fullscreen mode)
+    var isApproximatelyHalfScreenWide: Bool {
+        guard let screen = screen else { return false }
+
+        let windowWidth = frame.width
+        let screenWidth = screen.frame.width
+        let windowHeight = frame.height
+        let screenHeight = screen.frame.height
+
+        // Check if window width is approximately half screen width
+        // Allow some tolerance for system margins (e.g., 1278 of 1280 for 2560 screen)
+        let isApproximatelyHalfWidth = abs(windowWidth - screenWidth / 2) < 20 // Allow 20px tolerance
+        let isSignificantHeight = windowHeight > screenHeight * 0.8 // Height should be at least 80% of screen
+
+        return isApproximatelyHalfWidth && isSignificantHeight
+    }
+
 }

--- a/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -19,6 +19,7 @@
 import Cocoa
 import Combine
 import Common
+import PixelKit
 
 @MainActor
 final class MainWindowController: NSWindowController {
@@ -350,6 +351,17 @@ extension MainWindowController: NSWindowDelegate {
     }
 
     func windowDidEnterFullScreen(_ notification: Notification) {
+        guard let window = self.window else { return }
+
+        // Detect split screen vs regular fullscreen mode
+        if window.isApproximatelyHalfScreenWide {
+            // Fire pixel for split screen usage
+            PixelKit.fire(GeneralPixel.windowSplitScreen, frequency: .dailyAndCount)
+        } else {
+            // Fire pixel for regular fullscreen usage
+            PixelKit.fire(GeneralPixel.windowFullscreen, frequency: .dailyAndCount)
+        }
+
         // fix NSToolbarFullScreenWindow occurring beneath the MainWindow
         // https://app.asana.com/0/1177771139624306/1203853030672990/f
         // NSApp should be active at the moment of window ordering otherwise toolbar would disappear on activation

--- a/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -30,7 +30,6 @@ enum GeneralPixel: PixelKitEventV2 {
     case crashReportingSubmissionFailed
     case crashReportCRCIDMissing
     case compileRulesWait(onboardingShown: OnboardingShown, waitTime: CompileRulesWaitTime, result: WaitResult)
-    case launchInitial(cohort: String)
     case launch(isDefault: Bool, isAddedToDock: Bool?)
 
     case serp
@@ -258,6 +257,52 @@ enum GeneralPixel: PixelKitEventV2 {
 
     // Onboarding
     case onboardingExceptionReported(message: String, id: String)
+
+    // MARK: - Advanced Usage
+    
+    /**
+     * Event Trigger: User enters regular fullscreen mode (not split screen).
+     *
+     * > Note: This is a daily pixel.
+     *
+     * Anomaly Investigation:
+     * - May indicate changes in user interface preferences or usage patterns.
+     * - Increase could suggest users prefer immersive browsing experience.
+     */
+    case windowFullscreen
+    
+    /**
+     * Event Trigger: User enters split screen mode (window approximately half screen width in fullscreen).
+     *
+     * > Note: This is a daily pixel.
+     *
+     * Anomaly Investigation:
+     * - May indicate multitasking behavior changes or macOS split screen adoption.
+     * - Useful for understanding productivity workflows.
+     */
+    case windowSplitScreen
+    
+    /**
+     * Event Trigger: User activates Picture-in-Picture mode for video playback.
+     *
+     * > Note: This is a daily pixel.
+     *
+     * Anomaly Investigation:
+     * - May indicate video consumption patterns and multitasking preferences.
+     * - Increase could suggest growing use of video content while browsing.
+     */
+    case pictureInPictureVideoPlayback
+    
+    /**
+     * Event Trigger: User opens developer tools (via any method: menu, context menu, keyboard shortcuts).
+     *
+     * > Note: This is a daily pixel.
+     *
+     * Anomaly Investigation:
+     * - May indicate changes in developer user base or debugging needs.
+     * - Could suggest technical issues requiring inspection or developer activity.
+     */
+    case developerToolsOpened
 
     // MARK: - Debug
 
@@ -708,8 +753,6 @@ enum GeneralPixel: PixelKitEventV2 {
         case .dashboardProtectionAllowlistRemove:
             return "mp_wlr"
 
-        case .launchInitial:
-            return "m_mac_first-launch"
         case .serpInitial:
             return "m_mac_navigation_first-search_u"
 
@@ -835,6 +878,14 @@ enum GeneralPixel: PixelKitEventV2 {
 
             // Onboarding
         case .onboardingExceptionReported: return "m_mac_onboarding_exception-reported"
+
+         // “Advanced” usage
+         case .windowFullscreen: return "m_mac_window_fullscreen"
+         case .windowSplitScreen: return "m_mac_window_split_screen"
+
+         case .pictureInPictureVideoPlayback: return "m_mac_pip_video_playback"
+
+         case .developerToolsOpened: return "m_mac_dev_tools_opened"
 
             // DEBUG
         case .assertionFailure:
@@ -1201,9 +1252,6 @@ enum GeneralPixel: PixelKitEventV2 {
                 params[PixelKit.Parameters.sourceBrowserVersion] = version
             }
             return params
-
-        case .launchInitial(let cohort):
-            return [PixelKit.Parameters.experimentCohort: cohort]
 
         case .dailyOsVersionCounter:
             return [PixelKit.Parameters.osMajorVersion: "\(ProcessInfo.processInfo.operatingSystemVersion.majorVersion)"]

--- a/macOS/DuckDuckGo/Tab/Model/Tab+UIDelegate.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab+UIDelegate.swift
@@ -20,6 +20,7 @@ import Combine
 import Common
 import Foundation
 import Navigation
+import PixelKit
 import UniformTypeIdentifiers
 import WebKit
 import PDFKit
@@ -411,5 +412,20 @@ extension Tab: WKInspectorDelegate {
                       burnerMode: BurnerMode(isBurner: burnerMode.isBurner),
                       webViewSize: webView.superview?.bounds.size ?? .zero)
         delegate?.tab(self, createdChild: tab, of: .window(active: true, burner: burnerMode.isBurner))
+    }
+
+    // Private WebKit delegate method to detect when developer tools inspector is attached
+    @objc(_webView:didAttachLocalInspector:)
+    func webView(_ webView: WKWebView, didAttachLocalInspector inspector: NSObject) {
+        // Fire pixel when developer tools are opened
+        PixelKit.fire(GeneralPixel.developerToolsOpened, frequency: .dailyAndCount)
+    }
+
+    @objc(_webView:hasVideoInPictureInPictureDidChange:)
+    func webView(_ webView: WKWebView, hasVideoInPictureInPictureDidChange hasVideoInPictureInPicture: Bool) {
+        if hasVideoInPictureInPicture {
+            // Fire pixel when Picture-in-Picture is activated
+            PixelKit.fire(GeneralPixel.pictureInPictureVideoPlayback, frequency: .dailyAndCount)
+        }
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1210462714210332?focus=true

### Description
- adds "Advanced" daily pixels to measure full/split usage, PiP and dev tools

### Testing Steps
1. Open a video (youtube.com), right-click the video twice, choose Picture-in-picture, validate the daily pixel is fired
2. Open dev tools from different entry points (context menu; view -> developer -> …), validate the daily pixel is fired
3. Enter full screen; Split screen (hold mouse over the Green button, choose Full Screen -> Left (Right) of the screen), validate the daily pixel is fired

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)