### PR TITLE
Remove WindowControllersManager.shared

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
@@ -76,6 +76,6 @@ struct AIChatTabOpener: AIChatTabOpening {
         if let query = query {
             promptHandler.setData(.queryPrompt(query, autoSubmit: autoSubmit))
         }
-        WindowControllersManager.shared.openAIChat(aiChatRemoteSettings.aiChatURL, target: target, hasPrompt: query != nil)
+        Application.appDelegate.windowControllersManager.openAIChat(aiChatRemoteSettings.aiChatURL, target: target, hasPrompt: query != nil)
     }
 }

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -37,7 +37,7 @@ struct AIChatUserScriptHandler: AIChatUserScriptHandling {
     }
 
     @MainActor public func openAIChatSettings(params: Any, message: UserScriptMessage) async -> Encodable? {
-        WindowControllersManager.shared.showTab(with: .settings(pane: .aiChat))
+        Application.appDelegate.windowControllersManager.showTab(with: .settings(pane: .aiChat))
         return nil
     }
 
@@ -46,7 +46,7 @@ struct AIChatUserScriptHandler: AIChatUserScriptHandling {
     }
 
     func closeAIChat(params: Any, message: UserScriptMessage) async -> Encodable? {
-        await WindowControllersManager.shared.mainWindowController?.mainViewController.closeTab(nil)
+        await Application.appDelegate.windowControllersManager.mainWindowController?.mainViewController.closeTab(nil)
         return nil
     }
 

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -383,7 +383,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // MARK: - Subscription configuration
 
         subscriptionUIHandler = SubscriptionUIHandler(windowControllersManagerProvider: {
-            return WindowControllersManager.shared
+            return Application.appDelegate.windowControllersManager
         })
 
         self.isAuthV2Enabled = featureFlagger.isFeatureOn(.privacyProAuthV2)
@@ -533,7 +533,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 featureFlagger: self.featureFlagger
             )
             activeRemoteMessageModel = ActiveRemoteMessageModel(remoteMessagingClient: remoteMessagingClient, openURLHandler: { url in
-                WindowControllersManager.shared.showTab(with: .contentFromURL(url, source: .appOpenUrl))
+                Application.appDelegate.windowControllersManager.showTab(with: .contentFromURL(url, source: .appOpenUrl))
             })
         } else {
             // As long as remoteMessagingClient is private to App Delegate and activeRemoteMessageModel
@@ -879,7 +879,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        if WindowControllersManager.shared.mainWindowControllers.isEmpty,
+        if Application.appDelegate.windowControllersManager.mainWindowControllers.isEmpty,
            case .normal = AppVersion.runType {
             WindowsManager.openNewWindow()
             return true
@@ -1017,7 +1017,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     case .alertSecondButtonReturn:
                         alert.window.sheetParent?.endSheet(alert.window)
                         DispatchQueue.main.async {
-                            WindowControllersManager.shared.showPreferencesTab(withSelectedPane: .sync)
+                            Application.appDelegate.windowControllersManager.showPreferencesTab(withSelectedPane: .sync)
                         }
                     default:
                         break

--- a/macOS/DuckDuckGo/Application/URLEventHandler.swift
+++ b/macOS/DuckDuckGo/Application/URLEventHandler.swift
@@ -124,7 +124,7 @@ final class URLEventHandler {
         DispatchQueue.main.async {
             if url.isFileURL && url.pathExtension == WebKitDownloadTask.downloadExtension {
                 guard let mainViewController = {
-                    if let mainWindowController = WindowControllersManager.shared.lastKeyMainWindowController {
+                    if let mainWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController {
                         return mainWindowController.mainViewController
                     }
                     return WindowsManager.openNewWindow(with: .newtab, source: .ui, isBurner: false)?.contentViewController as? MainViewController
@@ -138,7 +138,7 @@ final class URLEventHandler {
             }
 
             if url.scheme?.isNetworkProtectionScheme == false && url.scheme?.isDataBrokerProtectionScheme == false {
-                WindowControllersManager.shared.show(url: url, source: .appOpenUrl, newTab: true)
+                Application.appDelegate.windowControllersManager.show(url: url, source: .appOpenUrl, newTab: true)
             }
         }
     }
@@ -150,7 +150,7 @@ final class URLEventHandler {
         case DataBrokerProtectionNotificationCommand.showDashboard.url:
             NotificationCenter.default.post(name: DataBrokerProtectionNotifications.shouldReloadUI, object: nil)
             DispatchQueue.main.async {
-                WindowControllersManager.shared.showTab(with: .dataBrokerProtection)
+                Application.appDelegate.windowControllersManager.showTab(with: .dataBrokerProtection)
             }
         default:
             return

--- a/macOS/DuckDuckGo/Autofill/AutofillActionPresenter.swift
+++ b/macOS/DuckDuckGo/Autofill/AutofillActionPresenter.swift
@@ -58,6 +58,6 @@ private extension DefaultAutofillActionPresenter {
 
     @MainActor
     var window: NSWindow? {
-        WindowControllersManager.shared.lastKeyMainWindowController?.window
+        Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.window
     }
 }

--- a/macOS/DuckDuckGo/Bookmarks/Services/BookmarksContextMenu.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Services/BookmarksContextMenu.swift
@@ -45,7 +45,7 @@ final class BookmarksContextMenu: NSMenu {
     @MainActor
     init(bookmarkManager: BookmarkManager? = nil, windowControllersManager: WindowControllersManagerProtocol? = nil, delegate: BookmarksContextMenuDelegate) {
         self.bookmarkManager = bookmarkManager ?? NSApp.delegateTyped.bookmarkManager
-        self.windowControllersManager = windowControllersManager ?? WindowControllersManager.shared
+        self.windowControllersManager = windowControllersManager ?? Application.appDelegate.windowControllersManager
         super.init(title: "")
         self.delegate = delegate
         self.autoenablesItems = false

--- a/macOS/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
+++ b/macOS/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
@@ -723,7 +723,7 @@ final class BookmarkListViewController: NSViewController {
             bookmarkMetrics.fireSearchResultClicked(origin: .panel)
         }
 
-        WindowControllersManager.shared.open(bookmark, with: NSApp.currentEvent)
+        Application.appDelegate.windowControllersManager.open(bookmark, with: NSApp.currentEvent)
     }
 
     private func handleItemClickWhenNotInSearchMode(item: Any?) {
@@ -739,7 +739,7 @@ final class BookmarkListViewController: NSViewController {
     }
 
     private func showManageBookmarks() {
-        WindowControllersManager.shared.showBookmarksTab()
+        Application.appDelegate.windowControllersManager.showBookmarksTab()
         delegate?.closeBookmarksPopover(self)
     }
 

--- a/macOS/DuckDuckGo/Bookmarks/View/BookmarkManagementDetailViewController.swift
+++ b/macOS/DuckDuckGo/Bookmarks/View/BookmarkManagementDetailViewController.swift
@@ -464,7 +464,7 @@ final class BookmarkManagementDetailViewController: NSViewController, NSMenuItem
         managementDetailViewModel.onBookmarkTapped()
 
         if let bookmark = entity as? Bookmark {
-            WindowControllersManager.shared.open(bookmark, with: NSApp.currentEvent)
+            Application.appDelegate.windowControllersManager.open(bookmark, with: NSApp.currentEvent)
         } else if let folder = entity as? BookmarkFolder {
             clearSearch()
             resetSelections()
@@ -477,7 +477,7 @@ final class BookmarkManagementDetailViewController: NSViewController, NSMenuItem
               let row = tableView.withMouseLocationInViewCoordinates(event.locationInWindow, convert: tableView.row(at:)), row != -1,
               let bookmark = fetchEntity(at: row) as? Bookmark else { return }
 
-        WindowControllersManager.shared.open(bookmark, with: NSApp.currentEvent)
+        Application.appDelegate.windowControllersManager.open(bookmark, with: NSApp.currentEvent)
     }
 
     @objc func presentAddBookmarkModal(_ sender: Any) {
@@ -697,7 +697,7 @@ extension BookmarkManagementDetailViewController: NSTableViewDelegate, NSTableVi
     }
 
     fileprivate func openBookmarksInNewTabs(_ bookmarks: [Bookmark]) {
-        guard let tabCollection = WindowControllersManager.shared.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel else {
+        guard let tabCollection = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel else {
             assertionFailure("Cannot open in new tabs")
             return
         }

--- a/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarMenuViewController.swift
+++ b/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarMenuViewController.swift
@@ -690,7 +690,7 @@ final class BookmarksBarMenuViewController: NSViewController {
 
         switch node.representedObject {
         case let bookmark as Bookmark:
-            WindowControllersManager.shared.open(bookmark, with: NSApp.currentEvent)
+            Application.appDelegate.windowControllersManager.open(bookmark, with: NSApp.currentEvent)
             delegate?.closeBookmarksPopovers(self)
 
         case let menuItem as MenuItemNode:
@@ -712,11 +712,11 @@ final class BookmarksBarMenuViewController: NSViewController {
               let node = item as? BookmarkNode,
               let bookmark = node.representedObject as? Bookmark else { return }
 
-        WindowControllersManager.shared.open(bookmark, with: NSApp.currentEvent)
+        Application.appDelegate.windowControllersManager.open(bookmark, with: NSApp.currentEvent)
     }
 
     private func openAllInNewTabs() {
-        guard let tabCollection = WindowControllersManager.shared.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel,
+        guard let tabCollection = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel,
               let folder = self.treeController.rootNode.representedObject as? BookmarkFolder else {
             assertionFailure("Cannot open all in new tabs")
             return

--- a/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarViewController.swift
+++ b/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarViewController.swift
@@ -302,7 +302,7 @@ extension BookmarksBarViewController: BookmarksBarViewModelDelegate {
 
         switch entity {
         case let bookmark as Bookmark:
-            WindowControllersManager.shared.open(bookmark, with: NSApp.currentEvent)
+            Application.appDelegate.windowControllersManager.open(bookmark, with: NSApp.currentEvent)
         case let folder as BookmarkFolder:
             showSubmenu(for: folder, from: item.view)
         default:
@@ -458,7 +458,7 @@ private extension BookmarksBarViewController {
     }
 
     @objc func manageBookmarks() {
-        WindowControllersManager.shared.showBookmarksTab()
+        Application.appDelegate.windowControllersManager.showBookmarksTab()
     }
 
     @objc func addFolder(sender: NSMenuItem) {

--- a/macOS/DuckDuckGo/Common/Extensions/NSViewControllerExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/NSViewControllerExtension.swift
@@ -54,7 +54,7 @@ extension NSViewController {
     func beginSheetFromMainWindow(_ viewController: NSViewController) {
         let newWindowController = viewController.wrappedInWindowController()
         guard let newWindow = newWindowController.window,
-              let parentWindowController = WindowControllersManager.shared.lastKeyMainWindowController
+              let parentWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController
         else {
             assertionFailure("Failed to present \(viewController)")
             return

--- a/macOS/DuckDuckGo/Common/View/SwiftUI/ModalView.swift
+++ b/macOS/DuckDuckGo/Common/View/SwiftUI/ModalView.swift
@@ -25,7 +25,7 @@ extension ModalView {
     @MainActor
     func show(in window: NSWindow? = nil, completion: (() -> Void)? = nil) {
 
-        guard let window = window ?? WindowControllersManager.shared.lastKeyMainWindowController?.window else {
+        guard let window = window ?? Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.window else {
             assertionFailure("No parent window to display in. Displaying app-wide modal windows not implemented")
             completion?()
             return

--- a/macOS/DuckDuckGo/DBP/DBPHomeViewController.swift
+++ b/macOS/DuckDuckGo/DBP/DBPHomeViewController.swift
@@ -74,7 +74,7 @@ final class DBPHomeViewController: NSViewController {
             prefs: prefs,
             webUISettings: DataBrokerProtectionWebUIURLSettings(.dbp),
             openURLHandler: { url in
-                WindowControllersManager.shared.show(url: url, source: .link, newTab: true)
+                Application.appDelegate.windowControllersManager.show(url: url, source: .link, newTab: true)
             })
     }()
 

--- a/macOS/DuckDuckGo/Feedback/View/FeedbackPresenter.swift
+++ b/macOS/DuckDuckGo/Feedback/View/FeedbackPresenter.swift
@@ -26,7 +26,7 @@ enum FeedbackPresenter {
         let windowController = NSStoryboard.feedback.instantiateController(withIdentifier: "FeedbackWindowController") as! NSWindowController
 
         guard let feedbackWindow = windowController.window as? FeedbackWindow,
-              let parentWindowController = WindowControllersManager.shared.lastKeyMainWindowController else {
+              let parentWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController else {
             assertionFailure("FeedbackPresenter: Failed to present FeedbackWindow")
             return
         }

--- a/macOS/DuckDuckGo/FileDownload/Services/DownloadListCoordinator.swift
+++ b/macOS/DuckDuckGo/FileDownload/Services/DownloadListCoordinator.swift
@@ -25,7 +25,7 @@ import os.log
 
 @MainActor
 private func getFirstAvailableWebView() -> WKWebView? {
-    let wcm = WindowControllersManager.shared
+    let wcm = Application.appDelegate.windowControllersManager
     if wcm.lastKeyMainWindowController?.mainViewController.browserTabViewController == nil {
         WindowsManager.openNewWindow()
     }

--- a/macOS/DuckDuckGo/FileDownload/View/DownloadsViewController.swift
+++ b/macOS/DuckDuckGo/FileDownload/View/DownloadsViewController.swift
@@ -403,7 +403,7 @@ final class DownloadsViewController: NSViewController {
         else { return }
 
         self.dismiss()
-        WindowControllersManager.shared.show(url: url, source: .historyEntry, newTab: true)
+        Application.appDelegate.windowControllersManager.show(url: url, source: .historyEntry, newTab: true)
     }
 
     @objc func doubleClickAction(_ sender: Any) {
@@ -549,7 +549,7 @@ enum DownloadsErrorViewType {
         switch self {
         case .openHelpURL:
             let updateHelpURL = URL(string: "https://support.apple.com/guide/mac-help/get-macos-updates-and-apps-mh35618/mac")!
-            WindowControllersManager.shared.show(url: updateHelpURL, source: .ui, newTab: true)
+            Application.appDelegate.windowControllersManager.show(url: updateHelpURL, source: .ui, newTab: true)
         case .openSystemSettings:
             let softwareUpdateURL = URL(string: "x-apple.systempreferences:com.apple.Software-Update-Settings.extension")!
             NSWorkspace.shared.open(softwareUpdateURL)

--- a/macOS/DuckDuckGo/Fire/Model/Fire.swift
+++ b/macOS/DuckDuckGo/Fire/Model/Fire.swift
@@ -115,7 +115,7 @@ final class Fire {
         self.permissionManager = permissionManager
         self.savedZoomLevelsCoordinating = savedZoomLevelsCoordinating
         self.downloadListCoordinator = downloadListCoordinator
-        self.windowControllerManager = windowControllerManager ?? WindowControllersManager.shared
+        self.windowControllerManager = windowControllerManager ?? Application.appDelegate.windowControllersManager
         self.faviconManagement = faviconManagement ?? NSApp.delegateTyped.faviconManager
         self.recentlyClosedCoordinator = recentlyClosedCoordinator ?? RecentlyClosedCoordinator.shared
         self.pinnedTabsManagerProvider = pinnedTabsManagerProvider ?? Application.appDelegate.pinnedTabsManagerProvider

--- a/macOS/DuckDuckGo/Fire/View/FireCoordinator.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireCoordinator.swift
@@ -29,7 +29,7 @@ final class FireCoordinator {
         let burningWindow: NSWindow
         let waitForOpening: Bool
 
-        if let lastKeyWindow = WindowControllersManager.shared.lastKeyMainWindowController?.window,
+        if let lastKeyWindow = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.window,
            lastKeyWindow.isVisible {
             burningWindow = lastKeyWindow
             burningWindow.makeKeyAndOrderFront(nil)

--- a/macOS/DuckDuckGo/Fire/View/FirePopoverViewController.swift
+++ b/macOS/DuckDuckGo/Fire/View/FirePopoverViewController.swift
@@ -155,7 +155,7 @@ final class FirePopoverViewController: NSViewController {
     }
 
     @IBAction func closeBurnerWindowButtonAction(_ sender: Any) {
-        let windowControllersManager = WindowControllersManager.shared
+        let windowControllersManager = Application.appDelegate.windowControllersManager
         guard let tabCollectionViewModel = firePopoverViewModel.tabCollectionViewModel,
               let windowController = windowControllersManager.windowController(for: tabCollectionViewModel) else {
             assertionFailure("No TabCollectionViewModel or MainWindowController")
@@ -192,7 +192,7 @@ final class FirePopoverViewController: NSViewController {
         let sites = firePopoverViewModel.selected.count
         switch firePopoverViewModel.clearingOption {
         case .allData:
-            let tabs = WindowControllersManager.shared.allTabViewModels.count
+            let tabs = Application.appDelegate.windowControllersManager.allTabViewModels.count
             infoLabel.stringValue = UserText.activeTabsInfo(tabs: tabs, sites: sites)
         case .currentWindow:
             let tabs = firePopoverViewModel.tabCollectionViewModel?.tabs.count ?? 0

--- a/macOS/DuckDuckGo/Fire/View/FireViewController.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireViewController.swift
@@ -184,7 +184,7 @@ final class FireViewController: NSViewController {
         var playFireAnimation = true
 
         // Animate just on the active window
-        let lastKeyWindowController = WindowControllersManager.shared.lastKeyMainWindowController
+        let lastKeyWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController
         if view.window?.windowController !== lastKeyWindowController {
             playFireAnimation = false
         }

--- a/macOS/DuckDuckGo/Fire/ViewModel/FirePopoverViewModel.swift
+++ b/macOS/DuckDuckGo/Fire/ViewModel/FirePopoverViewModel.swift
@@ -223,7 +223,7 @@ final class FirePopoverViewModel {
 
         case (.allData, false):
             PixelKit.fire(GeneralPixel.fireButton(option: .allSites))
-            fireViewModel.fire.burnEntity(entity: .allWindows(mainWindowControllers: WindowControllersManager.shared.mainWindowControllers,
+            fireViewModel.fire.burnEntity(entity: .allWindows(mainWindowControllers: Application.appDelegate.windowControllersManager.mainWindowControllers,
                                                               selectedDomains: selectedDomains,
                                                               customURLToOpen: nil))
         }

--- a/macOS/DuckDuckGo/Freemium/DBP/FreemiumDBPPresenter.swift
+++ b/macOS/DuckDuckGo/Freemium/DBP/FreemiumDBPPresenter.swift
@@ -38,7 +38,7 @@ final class DefaultFreemiumDBPPresenter: FreemiumDBPPresenter {
     /// Displays Freemium DBP
     func showFreemiumDBPAndSetActivated(windowControllerManager: WindowControllersManagerProtocol? = nil) {
 
-        let windowControllerManager = windowControllerManager ?? WindowControllersManager.shared
+        let windowControllerManager = windowControllerManager ?? Application.appDelegate.windowControllersManager
         freemiumDBPStateManager.didActivate = true
         windowControllerManager.showTab(with: .dataBrokerProtection)
     }

--- a/macOS/DuckDuckGo/Freemium/DBP/FreemiumDBPPromotionViewCoordinator.swift
+++ b/macOS/DuckDuckGo/Freemium/DBP/FreemiumDBPPromotionViewCoordinator.swift
@@ -131,7 +131,7 @@ private extension FreemiumDBPPromotionViewCoordinator {
     /// Shows the Freemium DBP user interface via the presenter.
     @MainActor
     func showFreemiumDBP() {
-        freemiumDBPPresenter.showFreemiumDBPAndSetActivated(windowControllerManager: WindowControllersManager.shared)
+        freemiumDBPPresenter.showFreemiumDBPAndSetActivated(windowControllerManager: Application.appDelegate.windowControllersManager)
     }
 
     /// Dismisses the home page promotion and updates the user state to reflect this.

--- a/macOS/DuckDuckGo/History/Services/HistoryDebugMenu.swift
+++ b/macOS/DuckDuckGo/History/Services/HistoryDebugMenu.swift
@@ -115,7 +115,7 @@ final class HistoryDebugMenu: NSMenu {
     @MainActor
     @objc func showHistoryViewOnboarding() {
         resetHistoryViewOnboarding()
-        WindowControllersManager.shared.lastKeyMainWindowController?
+        Application.appDelegate.windowControllersManager.lastKeyMainWindowController?
             .mainViewController
             .navigationBarViewController
             .presentHistoryViewOnboardingIfNeeded(force: true)

--- a/macOS/DuckDuckGo/History/View/Dialogs/DefaultHistoryViewDialogPresenter.swift
+++ b/macOS/DuckDuckGo/History/View/Dialogs/DefaultHistoryViewDialogPresenter.swift
@@ -31,7 +31,7 @@ final class DefaultHistoryViewDialogPresenter: HistoryViewDialogPresenting {
     @MainActor
     func showMultipleTabsDialog(for itemsCount: Int, in window: NSWindow?) async -> OpenMultipleTabsWarningDialogModel.Response {
         await withCheckedContinuation { continuation in
-            let parentWindow = window ?? WindowControllersManager.shared.lastKeyMainWindowController?.window
+            let parentWindow = window ?? Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.window
             let model = OpenMultipleTabsWarningDialogModel(count: itemsCount)
             let dialog = OpenMultipleTabsWarningDialog(model: model)
             dialog.show(in: parentWindow) {
@@ -43,7 +43,7 @@ final class DefaultHistoryViewDialogPresenter: HistoryViewDialogPresenting {
     @MainActor
     func showDeleteDialog(for itemsCount: Int, deleteMode: HistoryViewDeleteDialogModel.DeleteMode, in window: NSWindow?) async -> HistoryViewDeleteDialogModel.Response {
         await withCheckedContinuation { continuation in
-            let parentWindow = window ?? WindowControllersManager.shared.lastKeyMainWindowController?.window
+            let parentWindow = window ?? Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.window
             let model = HistoryViewDeleteDialogModel(entriesCount: itemsCount, mode: deleteMode)
             let dialog = HistoryViewDeleteDialog(model: model)
             dialog.show(in: parentWindow) {

--- a/macOS/DuckDuckGo/History/View/HistoryViewTabOpening.swift
+++ b/macOS/DuckDuckGo/History/View/HistoryViewTabOpening.swift
@@ -57,7 +57,7 @@ final class DefaultHistoryViewTabOpener: HistoryViewTabOpening {
     let urlOpener: @MainActor () -> URLOpening
 
     init(urlOpener: (@MainActor () -> URLOpening)? = nil) {
-        self.urlOpener = urlOpener ?? { WindowControllersManager.shared }
+        self.urlOpener = urlOpener ?? { Application.appDelegate.windowControllersManager }
     }
 
     @MainActor func open(_ url: URL, window: NSWindow?) {

--- a/macOS/DuckDuckGo/InfoViews/PopoverInfoViewController.swift
+++ b/macOS/DuckDuckGo/InfoViews/PopoverInfoViewController.swift
@@ -131,9 +131,9 @@ struct InfoView: View {
         Text(.init(info))
             .onURLTap { url in
                 if let pane = PreferencePaneIdentifier(url: url) {
-                    WindowControllersManager.shared.showPreferencesTab(withSelectedPane: pane)
+                    Application.appDelegate.windowControllersManager.showPreferencesTab(withSelectedPane: pane)
                 } else {
-                    WindowControllersManager.shared.showTab(with: .url(url, source: .link))
+                    Application.appDelegate.windowControllersManager.showTab(with: .url(url, source: .link))
                 }
             }
             .padding(16)

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -116,7 +116,7 @@ final class MainViewController: NSViewController {
             return NetworkProtectionNavBarPopoverManager(
                 ipcClient: vpnXPCClient,
                 vpnUninstaller: vpnUninstaller,
-                vpnUIPresenting: WindowControllersManager.shared)
+                vpnUIPresenting: Application.appDelegate.windowControllersManager)
         }()
         let networkProtectionStatusReporter: NetworkProtectionStatusReporter = {
             var connectivityIssuesObserver: ConnectivityIssueObserver!
@@ -747,7 +747,7 @@ extension MainViewController: BrowserTabViewControllerDelegate {
         }
 
         lazy var areOtherWindowsWithPinnedTabsAvailable: Bool = {
-            WindowControllersManager.shared.mainWindowControllers
+            Application.appDelegate.windowControllersManager.mainWindowControllers
                 .contains { mainWindowController -> Bool in
                     mainWindowController.mainViewController !== self
                     && mainWindowController.mainViewController.isBurner == false

--- a/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -257,7 +257,7 @@ final class MainWindowController: NSWindowController {
     }
 
     func orderWindowBack(_ sender: Any?) {
-        if let lastKeyWindow = WindowControllersManager.shared.lastKeyMainWindowController?.window {
+        if let lastKeyWindow = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.window {
             window?.order(.below, relativeTo: lastKeyWindow.windowNumber)
         } else {
             window?.orderFront(sender)
@@ -266,7 +266,7 @@ final class MainWindowController: NSWindowController {
     }
 
     private func register() {
-        WindowControllersManager.shared.register(self)
+        Application.appDelegate.windowControllersManager.register(self)
     }
 
 }
@@ -281,7 +281,7 @@ extension MainWindowController: NSWindowDelegate {
         mainViewController.windowDidBecomeKey()
 
         if !mainWindow.isPopUpWindow {
-            WindowControllersManager.shared.lastKeyMainWindowController = self
+            Application.appDelegate.windowControllersManager.lastKeyMainWindowController = self
         }
 
 #if !APPSTORE && WEB_EXTENSIONS_ENABLED
@@ -402,7 +402,7 @@ extension MainWindowController: NSWindowDelegate {
         // Because it's also the delegate, deinit within this method caused crash
         // Push the Window Controller into current autorelease pool so it‘s released when the event loop pass ends
         _=Unmanaged.passRetained(self).autorelease()
-        WindowControllersManager.shared.unregister(self)
+        Application.appDelegate.windowControllersManager.unregister(self)
 
 #if !APPSTORE && WEB_EXTENSIONS_ENABLED
         if #available(macOS 15.4, *) {

--- a/macOS/DuckDuckGo/MainWindow/PDFSearchTextMenuItemHandler.swift
+++ b/macOS/DuckDuckGo/MainWindow/PDFSearchTextMenuItemHandler.swift
@@ -52,7 +52,7 @@ final class PDFSearchTextMenuItemHandler: NSObject {
               let url = URL.makeURL(from: selectedText)
         else { return }
 
-        WindowControllersManager.shared.show(url: url, source: .link, newTab: true)
+        Application.appDelegate.windowControllersManager.show(url: url, source: .link, newTab: true)
     }
 
 }

--- a/macOS/DuckDuckGo/Menus/HistoryMenu.swift
+++ b/macOS/DuckDuckGo/Menus/HistoryMenu.swift
@@ -348,7 +348,7 @@ extension HistoryMenu {
 
         @MainActor
         convenience init() {
-            self.init(isInInitialStatePublisher: WindowControllersManager.shared.$isInInitialState, canRestoreLastSessionState: NSApp.canRestoreLastSessionState)
+            self.init(isInInitialStatePublisher: Application.appDelegate.windowControllersManager.$isInInitialState, canRestoreLastSessionState: NSApp.canRestoreLastSessionState)
         }
 
         private weak var currentlyAssignedMenuItem: NSMenuItem?

--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -629,7 +629,7 @@ final class MainMenu: NSMenu {
     @MainActor
     @objc
     private func toggleBookmarksBarFromMenu(_ sender: Any) {
-        guard let mainVC = WindowControllersManager.shared.lastKeyMainWindowController?.mainViewController else { return }
+        guard let mainVC = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.mainViewController else { return }
         mainVC.toggleBookmarksBarFromMenu(sender)
     }
 
@@ -770,8 +770,8 @@ final class MainMenu: NSMenu {
                                   updateServiceEnvironment: updateServiceEnvironment,
                                   updatePurchasingPlatform: updatePurchasingPlatform,
                                   updateCustomBaseSubscriptionURL: updateCustomBaseSubscriptionURL,
-                                  currentViewController: { WindowControllersManager.shared.lastKeyMainWindowController?.mainViewController },
-                                  openSubscriptionTab: { WindowControllersManager.shared.showTab(with: .subscription($0)) },
+                                  currentViewController: { Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.mainViewController },
+                                  openSubscriptionTab: { Application.appDelegate.windowControllersManager.showTab(with: .subscription($0)) },
                                   subscriptionAuthV1toV2Bridge: Application.appDelegate.subscriptionAuthV1toV2Bridge,
                                   subscriptionManagerV1: Application.appDelegate.subscriptionManagerV1,
                                   subscriptionManagerV2: Application.appDelegate.subscriptionManagerV2,

--- a/macOS/DuckDuckGo/Menus/MainMenuActions+VanillaBrowser.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions+VanillaBrowser.swift
@@ -24,7 +24,7 @@ extension MainViewController: BareBonesBrowserUIDelegate {
 
     fileprivate static let ddgURL = URL(string: "https://duckduckgo.com/")!
     @objc func openVanillaBrowser(_ sender: Any?) {
-        let currentURL = WindowControllersManager.shared.selectedTab?.url ?? MainViewController.ddgURL
+        let currentURL = Application.appDelegate.windowControllersManager.selectedTab?.url ?? MainViewController.ddgURL
         openVanillaBrowser(url: currentURL)
     }
 

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -157,7 +157,7 @@ extension AppDelegate {
 
     @MainActor
     @objc func showAbout(_ sender: Any?) {
-        WindowControllersManager.shared.showTab(with: .settings(pane: .about))
+        Application.appDelegate.windowControllersManager.showTab(with: .settings(pane: .about))
     }
 
     @MainActor
@@ -174,12 +174,12 @@ extension AppDelegate {
 
     @MainActor
     @objc func showReleaseNotes(_ sender: Any?) {
-        WindowControllersManager.shared.showTab(with: .releaseNotes)
+        Application.appDelegate.windowControllersManager.showTab(with: .releaseNotes)
     }
 
     @MainActor
     @objc func showWhatIsNew(_ sender: Any?) {
-        WindowControllersManager.shared.showTab(with: .url(.updates, source: .ui))
+        Application.appDelegate.windowControllersManager.showTab(with: .url(.updates, source: .ui))
     }
 
 #if FEEDBACK
@@ -187,7 +187,7 @@ extension AppDelegate {
     @objc func openFeedback(_ sender: Any?) {
         DispatchQueue.main.async {
             if self.internalUserDecider.isInternalUser {
-                WindowControllersManager.shared.showTab(with: .url(.internalFeedbackForm, source: .ui))
+                Application.appDelegate.windowControllersManager.showTab(with: .url(.internalFeedbackForm, source: .ui))
             } else {
                 FeedbackPresenter.presentFeedbackForm()
             }
@@ -206,7 +206,7 @@ extension AppDelegate {
         privacyDashboardWindow = window
 
         DispatchQueue.main.async {
-            guard let parentWindowController = WindowControllersManager.shared.lastKeyMainWindowController,
+            guard let parentWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController,
                   let tabModel = parentWindowController.mainViewController.tabCollectionViewModel.selectedTabViewModel else {
                 assertionFailure("AppDelegate: Failed to present PrivacyDashboard")
                 return
@@ -218,7 +218,7 @@ extension AppDelegate {
 
     @MainActor
     @objc func openPProFeedback(_ sender: Any?) {
-        WindowControllersManager.shared.showShareFeedbackModal(source: .settings)
+        Application.appDelegate.windowControllersManager.showShareFeedbackModal(source: .settings)
     }
 
     @MainActor
@@ -275,7 +275,7 @@ extension AppDelegate {
 
     @MainActor
     @objc func openExportLogins(_ sender: Any?) {
-        guard let windowController = WindowControllersManager.shared.lastKeyMainWindowController,
+        guard let windowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController,
               let window = windowController.window else { return }
 
         DeviceAuthenticator.shared.authenticateUser(reason: .exportLogins) { authenticationResult in
@@ -315,7 +315,7 @@ extension AppDelegate {
 
     @MainActor
     @objc func openExportBookmarks(_ sender: Any?) {
-        guard let windowController = WindowControllersManager.shared.lastKeyMainWindowController,
+        guard let windowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController,
               let window = windowController.window,
               let list = bookmarkManager.list else { return }
 
@@ -362,8 +362,8 @@ extension AppDelegate {
         UserDefaults.standard.set(true, forKey: UserDefaultsWrapper<Bool>.Key.onboardingFinished.rawValue)
         Application.appDelegate.onboardingContextualDialogsManager.state = .onboardingCompleted
         OnboardingActionsManager.isOnboardingFinished = true
-        WindowControllersManager.shared.updatePreventUserInteraction(prevent: false)
-        WindowControllersManager.shared.replaceTabWith(Tab(content: .newtab))
+        Application.appDelegate.windowControllersManager.updatePreventUserInteraction(prevent: false)
+        Application.appDelegate.windowControllersManager.replaceTabWith(Tab(content: .newtab))
     }
 
     @objc func resetRemoteMessages(_ sender: Any?) {
@@ -622,7 +622,7 @@ extension MainViewController {
                let tab = mainWindowController.activeTab {
                 return tab
             }
-            return WindowControllersManager.shared.lastKeyMainWindowController?.activeTab
+            return Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.activeTab
         }
         guard let tab else {
             assertionFailure("Could not get currently active Tab")
@@ -730,11 +730,11 @@ extension MainViewController {
     @objc func toggleDownloads(_ sender: Any) {
         var navigationBarViewController = self.navigationBarViewController
         if view.window?.isPopUpWindow == true {
-            if let vc = WindowControllersManager.shared.lastKeyMainWindowController?.mainViewController.navigationBarViewController {
+            if let vc = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.mainViewController.navigationBarViewController {
                 navigationBarViewController = vc
             } else {
                 WindowsManager.openNewWindow(with: Tab(content: .newtab))
-                guard let wc = WindowControllersManager.shared.mainWindowControllers.first(where: { $0.window?.isPopUpWindow == false }) else {
+                guard let wc = Application.appDelegate.windowControllersManager.mainWindowControllers.first(where: { $0.window?.isPopUpWindow == false }) else {
                     return
                 }
                 navigationBarViewController = wc.mainViewController.navigationBarViewController
@@ -747,7 +747,7 @@ extension MainViewController {
     @objc func toggleBookmarksBarFromMenu(_ sender: Any) {
         // Leaving this keyboard shortcut in place.  When toggled on it will use the previously set appearence which defaults to "always".
         //  If the user sets it to "new tabs only" somewhere (e.g. preferences), then it'll be that.
-        guard let mainVC = WindowControllersManager.shared.lastKeyMainWindowController?.mainViewController else { return }
+        guard let mainVC = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.mainViewController else { return }
 
         let prefs = NSApp.delegateTyped.appearancePreferences
         if prefs.showBookmarksBar && prefs.bookmarksBarAppearance == .newTabOnly {
@@ -806,7 +806,7 @@ extension MainViewController {
 
         makeKeyIfNeeded()
 
-        WindowControllersManager.shared.open(historyEntry, with: NSApp.currentEvent)
+        Application.appDelegate.windowControllersManager.open(historyEntry, with: NSApp.currentEvent)
     }
 
     @objc func clearAllHistory(_ sender: NSMenuItem) {
@@ -927,7 +927,7 @@ extension MainViewController {
         guard let bookmark = menuItem.representedObject as? Bookmark else { return }
         makeKeyIfNeeded()
 
-        WindowControllersManager.shared.open(bookmark, with: NSApp.currentEvent)
+        Application.appDelegate.windowControllersManager.open(bookmark, with: NSApp.currentEvent)
     }
 
     @objc func openAllInTabs(_ sender: Any?) {
@@ -1031,13 +1031,13 @@ extension MainViewController {
     }
 
     @objc func mergeAllWindows(_ sender: Any?) {
-        guard let mainWindowController = WindowControllersManager.shared.lastKeyMainWindowController else { return }
+        guard let mainWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController else { return }
         assert(!self.isBurner)
 
-        let otherWindowControllers = WindowControllersManager.shared.mainWindowControllers.filter {
+        let otherWindowControllers = Application.appDelegate.windowControllersManager.mainWindowControllers.filter {
             $0 !== mainWindowController && $0.mainViewController.isBurner == false
         }
-        let excludedWindowControllers = WindowControllersManager.shared.mainWindowControllers.filter {
+        let excludedWindowControllers = Application.appDelegate.windowControllersManager.mainWindowControllers.filter {
             $0 === mainWindowController || $0.mainViewController.isBurner == true
         }
 
@@ -1262,7 +1262,7 @@ extension MainViewController: NSMenuItemValidation {
 
         // Merge all windows
         case #selector(MainViewController.mergeAllWindows(_:)):
-            return WindowControllersManager.shared.mainWindowControllers.filter({ !$0.mainViewController.isBurner }).count > 1 && !self.isBurner
+            return Application.appDelegate.windowControllersManager.mainWindowControllers.filter({ !$0.mainViewController.isBurner }).count > 1 && !self.isBurner
 
         // Move Tab to New Window, Select Next/Prev Tab
         case #selector(MainViewController.moveTabToNewWindow(_:)):
@@ -1302,7 +1302,7 @@ extension AppDelegate: NSMenuItemValidation {
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         switch menuItem.action {
         case #selector(AppDelegate.closeAllWindows(_:)):
-            return !WindowControllersManager.shared.mainWindowControllers.isEmpty
+            return !Application.appDelegate.windowControllersManager.mainWindowControllers.isEmpty
 
         // Reopen Last Removed Tab
         case #selector(AppDelegate.reopenLastClosedTab(_:)):
@@ -1321,7 +1321,7 @@ extension AppDelegate: NSMenuItemValidation {
             return areTherePasswords
 
         case #selector(AppDelegate.openReportBrokenSite(_:)):
-            return WindowControllersManager.shared.selectedTab?.canReload ?? false
+            return Application.appDelegate.windowControllersManager.selectedTab?.canReload ?? false
 
         default:
             return true

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -414,7 +414,7 @@ final class AddressBarTextField: NSTextField {
             NSAlert.cannotOpenFileAlert().beginSheetModal(for: window) { response in
                 switch response {
                 case .alertSecondButtonReturn:
-                    WindowControllersManager.shared.show(url: URL.ddgLearnMore, source: .ui, newTab: false)
+                    Application.appDelegate.windowControllersManager.show(url: URL.ddgLearnMore, source: .ui, newTab: false)
                     return
                 default:
                     window.makeFirstResponder(self)
@@ -492,7 +492,7 @@ final class AddressBarTextField: NSTextField {
     private func switchTo(_ tab: OpenTab) {
         // reset value so it‘s not restored next time we come back to the tab
         value = .text("", userTyped: false)
-        WindowControllersManager.shared.show(url: tab.url, tabId: tab.tabId, source: .switchToOpenTab, newTab: true /* in case not found */)
+        Application.appDelegate.windowControllersManager.show(url: tab.url, tabId: tab.tabId, source: .switchToOpenTab, newTab: true /* in case not found */)
     }
 
     private func makeUrl(suggestion: Suggestion?, stringValueWithoutSuffix: String, completion: @escaping (URL?, String, Bool) -> Void) {

--- a/macOS/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
@@ -381,7 +381,7 @@ final class MoreOptionsMenu: NSMenu, NSMenuDelegate {
             freemiumDBPExperimentPixelHandler.fire(FreemiumDBPExperimentPixel.overFlowScan)
         }
 
-        freemiumDBPPresenter.showFreemiumDBPAndSetActivated(windowControllerManager: WindowControllersManager.shared)
+        freemiumDBPPresenter.showFreemiumDBPAndSetActivated(windowControllerManager: Application.appDelegate.windowControllersManager)
         notificationCenter.post(name: .freemiumDBPEntryPointActivated, object: nil)
     }
 

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -635,7 +635,7 @@ final class NavigationBarViewController: NSViewController {
     func listenToFeedbackFormNotifications() {
         feedbackFormCancellable = NotificationCenter.default.publisher(for: .OpenUnifiedFeedbackForm).receive(on: DispatchQueue.main).sink { notification in
             let source = UnifiedFeedbackSource(userInfo: notification.userInfo)
-            WindowControllersManager.shared.showShareFeedbackModal(source: source)
+            Application.appDelegate.windowControllersManager.showShareFeedbackModal(source: source)
         }
     }
 
@@ -1011,7 +1011,7 @@ final class NavigationBarViewController: NSViewController {
             .sink { [weak self] _ in
                 guard let self, !self.isDownloadsPopoverShown,
                       DownloadsPreferences.shared.shouldOpenPopupOnCompletion,
-                      WindowControllersManager.shared.lastKeyMainWindowController?.window === downloadsButton.window else { return }
+                      Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.window === downloadsButton.window else { return }
 
                 self.popovers.showDownloadsPopoverAndAutoHide(from: downloadsButton, popoverDelegate: self, downloadsDelegate: self)
             }
@@ -1626,7 +1626,7 @@ extension NavigationBarViewController: NSMenuDelegate {
 extension NavigationBarViewController: OptionsButtonMenuDelegate {
 
     func optionsButtonMenuRequestedDataBrokerProtection(_ menu: NSMenu) {
-        WindowControllersManager.shared.showDataBrokerProtectionTab()
+        Application.appDelegate.windowControllersManager.showDataBrokerProtectionTab()
     }
 
     func optionsButtonMenuRequestedOpenExternalPasswordManager(_ menu: NSMenu) {
@@ -1649,7 +1649,7 @@ extension NavigationBarViewController: OptionsButtonMenuDelegate {
     }
 
     func optionsButtonMenuRequestedBookmarkManagementInterface(_ menu: NSMenu) {
-        WindowControllersManager.shared.showBookmarksTab()
+        Application.appDelegate.windowControllersManager.showBookmarksTab()
     }
 
     func optionsButtonMenuRequestedBookmarkImportInterface(_ menu: NSMenu) {
@@ -1673,34 +1673,34 @@ extension NavigationBarViewController: OptionsButtonMenuDelegate {
     }
 
     func optionsButtonMenuRequestedPrint(_ menu: NSMenu) {
-        WindowControllersManager.shared.lastKeyMainWindowController?.mainViewController.printWebView(self)
+        Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.mainViewController.printWebView(self)
     }
 
     func optionsButtonMenuRequestedPreferences(_ menu: NSMenu) {
-        WindowControllersManager.shared.showPreferencesTab()
+        Application.appDelegate.windowControllersManager.showPreferencesTab()
     }
 
     func optionsButtonMenuRequestedAppearancePreferences(_ menu: NSMenu) {
-        WindowControllersManager.shared.showPreferencesTab(withSelectedPane: .appearance)
+        Application.appDelegate.windowControllersManager.showPreferencesTab(withSelectedPane: .appearance)
     }
 
     func optionsButtonMenuRequestedAccessibilityPreferences(_ menu: NSMenu) {
-        WindowControllersManager.shared.showPreferencesTab(withSelectedPane: .accessibility)
+        Application.appDelegate.windowControllersManager.showPreferencesTab(withSelectedPane: .accessibility)
     }
 
     func optionsButtonMenuRequestedSubscriptionPurchasePage(_ menu: NSMenu) {
         let url = subscriptionManager.url(for: .purchase)
-        WindowControllersManager.shared.showTab(with: .subscription(url.appendingParameter(name: AttributionParameter.origin, value: SubscriptionFunnelOrigin.appMenu.rawValue)))
+        Application.appDelegate.windowControllersManager.showTab(with: .subscription(url.appendingParameter(name: AttributionParameter.origin, value: SubscriptionFunnelOrigin.appMenu.rawValue)))
         PixelKit.fire(PrivacyProPixel.privacyProOfferScreenImpression)
     }
 
     func optionsButtonMenuRequestedSubscriptionPreferences(_ menu: NSMenu) {
-        WindowControllersManager.shared.showPreferencesTab(withSelectedPane: .subscriptionSettings)
+        Application.appDelegate.windowControllersManager.showPreferencesTab(withSelectedPane: .subscriptionSettings)
     }
 
     func optionsButtonMenuRequestedIdentityTheftRestoration(_ menu: NSMenu) {
         let url = subscriptionManager.url(for: .identityTheftRestoration)
-        WindowControllersManager.shared.showTab(with: .identityTheftRestoration(url))
+        Application.appDelegate.windowControllersManager.showTab(with: .identityTheftRestoration(url))
     }
 }
 

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionNavBarPopoverManager.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionNavBarPopoverManager.swift
@@ -76,7 +76,7 @@ final class NetworkProtectionNavBarPopoverManager: NetPPopoverManager {
         self.vpnUIPresenting = vpnUIPresenting
         self.proxySettings = proxySettings
 
-        let activeDomainPublisher = ActiveDomainPublisher(windowControllersManager: .shared)
+        let activeDomainPublisher = ActiveDomainPublisher(windowControllersManager: Application.appDelegate.windowControllersManager)
 
         activeSitePublisher = ActiveSiteInfoPublisher(
             activeDomainPublisher: activeDomainPublisher.eraseToAnyPublisher(),

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUIActionHandler.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUIActionHandler.swift
@@ -56,7 +56,7 @@ final class VPNUIActionHandler {
 
     @MainActor
     private var windowControllerManager: WindowControllersManager {
-        WindowControllersManager.shared
+        Application.appDelegate.windowControllersManager
     }
 }
 
@@ -123,7 +123,7 @@ extension VPNUIActionHandler: VPNUIActionHandling {
         case .stopVPN:
             return true
         case .excludeApp:
-            WindowControllersManager.shared.showVPNAppExclusions(addApp: true)
+            Application.appDelegate.windowControllersManager.showVPNAppExclusions(addApp: true)
             return false
         case .excludeWebsite:
             let domain = windowControllerManager.activeDomain ?? ""

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUIPresenting.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUIPresenting.swift
@@ -44,9 +44,7 @@ extension WindowControllersManager: VPNUIPresenting {
         let viewController = ExcludedAppsViewController.create()
         let windowController = viewController.wrappedInWindowController()
 
-        guard let window = windowController.window,
-              let parentWindowController = Self.shared.lastKeyMainWindowController
-        else {
+        guard let window = windowController.window, let parentWindowController = lastKeyMainWindowController else {
             assertionFailure("Failed to present ExcludedAppsViewController")
             return
         }
@@ -69,9 +67,7 @@ extension WindowControllersManager: VPNUIPresenting {
         let viewController = ExcludedDomainsViewController.create()
         let windowController = viewController.wrappedInWindowController()
 
-        guard let window = windowController.window,
-              let parentWindowController = Self.shared.lastKeyMainWindowController
-        else {
+        guard let window = windowController.window, let parentWindowController = lastKeyMainWindowController else {
             assertionFailure("Failed to present ExcludedDomainsViewController")
             return
         }

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNURLEventHandler.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNURLEventHandler.swift
@@ -26,7 +26,7 @@ final class VPNURLEventHandler {
     private let windowControllerManager: WindowControllersManager
 
     init(windowControllerManager: WindowControllersManager? = nil) {
-        self.windowControllerManager = windowControllerManager ?? .shared
+        self.windowControllerManager = windowControllerManager ?? Application.appDelegate.windowControllersManager
     }
 
     /// Handles VPN event URLs

--- a/macOS/DuckDuckGo/NetworkProtection/ExcludedDomains/ExcludedDomainsModel.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/ExcludedDomains/ExcludedDomainsModel.swift
@@ -61,7 +61,7 @@ extension DefaultExcludedDomainsViewModel: ExcludedDomainsViewModel {
 
     @MainActor
     func askUserToReportIssues(withDomain domain: String, in window: NSWindow? = nil) async {
-        let parentWindow = window ?? WindowControllersManager.shared.lastKeyMainWindowController?.window
+        let parentWindow = window ?? Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.window
         await ReportSiteIssuesPresenter(userDefaults: .netP).show(withDomain: domain, in: parentWindow)
     }
 }

--- a/macOS/DuckDuckGo/NewTabPage/Features/NewTabPageLinkOpener.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NewTabPageLinkOpener.swift
@@ -23,7 +23,7 @@ struct NewTabPageLinkOpener: NewTabPageLinkOpening {
     @MainActor
     static func open(_ url: URL, source: Tab.Content.URLSource, setBurner: Bool? = nil, sender: LinkOpenSender, target: LinkOpenTarget, sourceWindow: NSWindow?) {
         var tabCollectionViewModel: TabCollectionViewModel? {
-            WindowControllersManager.shared.mainWindowController(for: sourceWindow)?.mainViewController.tabCollectionViewModel
+            Application.appDelegate.windowControllersManager.mainWindowController(for: sourceWindow)?.mainViewController.tabCollectionViewModel
         }
         let linkOpenBehavior: LinkOpenBehavior = {
             switch sender {
@@ -46,9 +46,9 @@ struct NewTabPageLinkOpener: NewTabPageLinkOpening {
                 }
             }
         }()
-        let targetWindowController = WindowControllersManager.shared.mainWindowController(for: sourceWindow ?? NSApp.currentEvent?.window)
+        let targetWindowController = Application.appDelegate.windowControllersManager.mainWindowController(for: sourceWindow ?? NSApp.currentEvent?.window)
 
-        WindowControllersManager.shared.open(url, with: linkOpenBehavior, setBurner: setBurner, source: source, target: targetWindowController)
+        Application.appDelegate.windowControllersManager.open(url, with: linkOpenBehavior, setBurner: setBurner, source: source, target: targetWindowController)
     }
 
     func openLink(_ target: NewTabPageDataModel.OpenAction.Target) async {
@@ -60,7 +60,7 @@ struct NewTabPageLinkOpener: NewTabPageLinkOpening {
 
     private func openAppearanceSettings() {
         Task.detached { @MainActor in
-            WindowControllersManager.shared.showPreferencesTab(withSelectedPane: .appearance)
+            Application.appDelegate.windowControllersManager.showPreferencesTab(withSelectedPane: .appearance)
         }
     }
 }

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
@@ -93,6 +93,6 @@ extension NewTabPageActionsManager {
 struct NewTabPageTabOpener: ContinueSetUpModelTabOpening {
     @MainActor
     func openTab(_ tab: Tab) {
-        WindowControllersManager.shared.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel.insertOrAppend(tab: tab, selected: true)
+        Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel.insertOrAppend(tab: tab, selected: true)
     }
 }

--- a/macOS/DuckDuckGo/PasswordManager/PasswordManagerCoordinator.swift
+++ b/macOS/DuckDuckGo/PasswordManager/PasswordManagerCoordinator.swift
@@ -95,7 +95,7 @@ final class PasswordManagerCoordinator: PasswordManagerCoordinating {
         switch bitwardenManagement.status {
         case .disabled, .notInstalled, .oldVersion, .incompatible, .missingHandshake, .handshakeNotApproved, .error, .accessToContainersNotApproved:
             Task {
-                await WindowControllersManager.shared.showPreferencesTab(withSelectedPane: .autofill)
+                await Application.appDelegate.windowControllersManager.showPreferencesTab(withSelectedPane: .autofill)
             }
             return
         default:

--- a/macOS/DuckDuckGo/Permissions/View/PermissionAuthorizationViewController.swift
+++ b/macOS/DuckDuckGo/Permissions/View/PermissionAuthorizationViewController.swift
@@ -141,6 +141,6 @@ final class PermissionAuthorizationViewController: NSViewController {
     }
 
     @IBAction func learnMoreAction(_ sender: NSButton) {
-        WindowControllersManager.shared.show(url: "https://help.duckduckgo.com/privacy/device-location-services".url, source: .ui, newTab: true)
+        Application.appDelegate.windowControllersManager.show(url: "https://help.duckduckgo.com/privacy/device-location-services".url, source: .ui, newTab: true)
     }
 }

--- a/macOS/DuckDuckGo/PinnedTabs/Model/PinnedTabsManagerProvider.swift
+++ b/macOS/DuckDuckGo/PinnedTabs/Model/PinnedTabsManagerProvider.swift
@@ -72,7 +72,7 @@ final class PinnedTabsManagerProvider: @preconcurrency PinnedTabsManagerProvidin
 
     @MainActor
     private var windowControllerManager: WindowControllersManagerProtocol {
-        WindowControllersManager.shared
+        Application.appDelegate.windowControllersManager
     }
 
     @MainActor

--- a/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
@@ -63,7 +63,7 @@ final class AIChatPreferences: ObservableObject {
     }
 
     @MainActor func openLearnMoreLink() {
-        WindowControllersManager.shared.show(url: learnMoreURL, source: .ui, newTab: true)
+        Application.appDelegate.windowControllersManager.show(url: learnMoreURL, source: .ui, newTab: true)
     }
 
     @MainActor func openAIChatLink() {

--- a/macOS/DuckDuckGo/Preferences/Model/AppearancePreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AppearancePreferences.swift
@@ -143,9 +143,9 @@ protocol NewTabPageNavigator {
 final class DefaultNewTabPageNavigator: NewTabPageNavigator {
     func openNewTabPageBackgroundCustomizationSettings() {
         Task { @MainActor in
-            WindowControllersManager.shared.showTab(with: .newtab)
+            Application.appDelegate.windowControllersManager.showTab(with: .newtab)
             try? await Task.sleep(interval: 0.2)
-            if let window = WindowControllersManager.shared.lastKeyMainWindowController {
+            if let window = Application.appDelegate.windowControllersManager.lastKeyMainWindowController {
                 let newTabPageViewModel = window.mainViewController.browserTabViewController.newTabPageWebViewModel
                 NSApp.delegateTyped.newTabPageCustomizationModel.customizerOpener.openSettings(for: newTabPageViewModel.webView)
             }

--- a/macOS/DuckDuckGo/Preferences/Model/AutofillPreferencesModel.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AutofillPreferencesModel.swift
@@ -130,7 +130,7 @@ final class AutofillPreferencesModel: ObservableObject {
 
     @MainActor
     func showAutofillPopover(_ selectedCategory: SecureVaultSorting.Category = .allItems, source: PasswordManagementSource) {
-        guard let parentWindowController = WindowControllersManager.shared.lastKeyMainWindowController else { return }
+        guard let parentWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController else { return }
         let navigationViewController = parentWindowController.mainViewController.navigationBarViewController
         navigationViewController.showPasswordManagerPopover(selectedCategory: selectedCategory, source: source)
     }
@@ -193,7 +193,7 @@ final class AutofillPreferencesModel: ObservableObject {
         }
 
         guard let connectBitwardenWindow = connectBitwardenWindowController.window,
-              let parentWindowController = WindowControllersManager.shared.lastKeyMainWindowController
+              let parentWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController
         else {
             assertionFailure("Privacy Preferences: Failed to present ConnectBitwardenViewController")
             return

--- a/macOS/DuckDuckGo/Preferences/Model/DataClearingPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/DataClearingPreferences.swift
@@ -55,7 +55,7 @@ final class DataClearingPreferences: ObservableObject, PreferencesTabOpening {
         let fireproofDomainsWindowController = FireproofDomainsViewController.create().wrappedInWindowController()
 
         guard let fireproofDomainsWindow = fireproofDomainsWindowController.window,
-              let parentWindowController = WindowControllersManager.shared.lastKeyMainWindowController
+              let parentWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController
         else {
             assertionFailure("DataClearingPreferences: Failed to present FireproofDomainsViewController")
             return

--- a/macOS/DuckDuckGo/Preferences/Model/DuckPlayerPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/DuckPlayerPreferences.swift
@@ -129,7 +129,7 @@ final class DuckPlayerPreferences: ObservableObject {
     func openLearnMoreContingencyURL() {
         guard let url = duckPlayerContingencyHandler.learnMoreURL else { return }
         PixelKit.fire(NonStandardEvent(GeneralPixel.duckPlayerContingencyLearnMoreClicked))
-        WindowControllersManager.shared.show(url: url, source: .ui, newTab: true)
+        Application.appDelegate.windowControllersManager.show(url: url, source: .ui, newTab: true)
     }
 
     init(persistor: DuckPlayerPreferencesPersistor = DuckPlayerPreferencesUserDefaultsPersistor(),

--- a/macOS/DuckDuckGo/Preferences/Model/PreferencesSidebarModel.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/PreferencesSidebarModel.swift
@@ -378,7 +378,7 @@ final class PreferencesSidebarModel: ObservableObject {
         // Open a new tab in case of special panes
         if identifier.rawValue.hasPrefix(URL.NavigationalScheme.https.rawValue),
             let url = URL(string: identifier.rawValue) {
-            WindowControllersManager.shared.show(url: url,
+            Application.appDelegate.windowControllersManager.show(url: url,
                                                  source: .ui,
                                                  newTab: true)
         }

--- a/macOS/DuckDuckGo/Preferences/Model/SearchPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/SearchPreferences.swift
@@ -60,12 +60,12 @@ extension PreferencesTabOpening {
 
     @MainActor
     func openNewTab(with url: URL) {
-        WindowControllersManager.shared.show(url: url, source: .ui, newTab: true)
+        Application.appDelegate.windowControllersManager.show(url: url, source: .ui, newTab: true)
     }
 
     @MainActor
     func show(url: URL) {
-        WindowControllersManager.shared.show(url: url, source: .ui, newTab: false)
+        Application.appDelegate.windowControllersManager.show(url: url, source: .ui, newTab: false)
     }
 
 }

--- a/macOS/DuckDuckGo/Preferences/Model/SyncPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/SyncPreferences.swift
@@ -314,13 +314,13 @@ final class SyncPreferences: ObservableObject, SyncUI_macOS.ManagementViewModel 
 
     @MainActor
     func manageBookmarks() {
-        guard let mainVC = WindowControllersManager.shared.lastKeyMainWindowController?.mainViewController else { return }
+        guard let mainVC = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.mainViewController else { return }
         mainVC.showManageBookmarks(self)
     }
 
     @MainActor
     func manageLogins() {
-        guard let parentWindowController = WindowControllersManager.shared.lastKeyMainWindowController else { return }
+        guard let parentWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController else { return }
         let navigationViewController = parentWindowController.mainViewController.navigationBarViewController
         navigationViewController.showPasswordManagerPopover(selectedCategory: .allItems, source: .sync)
     }
@@ -417,7 +417,7 @@ final class SyncPreferences: ObservableObject, SyncUI_macOS.ManagementViewModel 
         let syncWindowController = syncViewController.wrappedInWindowController()
 
         guard let syncWindow = syncWindowController.window,
-              let parentWindowController = WindowControllersManager.shared.lastKeyMainWindowController
+              let parentWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController
         else {
             assertionFailure("Sync: Failed to present SyncManagementDialogViewController")
             return

--- a/macOS/DuckDuckGo/Preferences/Model/VPNPreferencesModel.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/VPNPreferencesModel.swift
@@ -322,17 +322,17 @@ final class VPNPreferencesModel: ObservableObject {
 
     @MainActor
     func manageExcludedApps() {
-        WindowControllersManager.shared.showVPNAppExclusions()
+        Application.appDelegate.windowControllersManager.showVPNAppExclusions()
     }
 
     @MainActor
     func manageExcludedSites() {
-        WindowControllersManager.shared.showVPNDomainExclusions()
+        Application.appDelegate.windowControllersManager.showVPNDomainExclusions()
     }
 
     @MainActor
     func openNewTab(with url: URL) {
-        WindowControllersManager.shared.show(url: url, source: .ui, newTab: true)
+        Application.appDelegate.windowControllersManager.show(url: url, source: .ui, newTab: true)
     }
 
     private func updateDNSSettings() {

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesRootView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesRootView.swift
@@ -165,7 +165,7 @@ enum Preferences {
             let sheetActionHandler = SubscriptionAccessActionHandlers(
                 openActivateViaEmailURL: {
                     let url = subscriptionManager.url(for: .activationFlow)
-                    WindowControllersManager.shared.showTab(with: .subscription(url))
+                    Application.appDelegate.windowControllersManager.showTab(with: .subscription(url))
                     PixelKit.fire(PrivacyProPixel.privacyProRestorePurchaseEmailStart, frequency: .legacyDailyAndCount)
                 }, restorePurchases: {
                     if #available(macOS 12.0, *) {
@@ -196,7 +196,7 @@ enum Preferences {
                     switch event {
                     case .openPIR:
                         PixelKit.fire(PrivacyProPixel.privacyProPersonalInformationRemovalSettings)
-                        WindowControllersManager.shared.showTab(with: .dataBrokerProtection)
+                        Application.appDelegate.windowControllersManager.showTab(with: .dataBrokerProtection)
                     case .openURL(let url):
                         openURL(subscriptionURL: url)
                     case .didOpenPIRPreferencePane:
@@ -216,7 +216,7 @@ enum Preferences {
                     case .openITR:
                         PixelKit.fire(PrivacyProPixel.privacyProIdentityRestorationSettings)
                         let url = subscriptionManager.url(for: .identityTheftRestoration)
-                        WindowControllersManager.shared.showTab(with: .identityTheftRestoration(url))
+                        Application.appDelegate.windowControllersManager.showTab(with: .identityTheftRestoration(url))
                     case .openURL(let url):
                         openURL(subscriptionURL: url)
                     case .didOpenITRPreferencePane:
@@ -242,7 +242,7 @@ enum Preferences {
                     case .openManageSubscriptionsInAppStore:
                         NSWorkspace.shared.open(subscriptionManager.url(for: .manageSubscriptionsInAppStore))
                     case .openCustomerPortalURL(let url):
-                        WindowControllersManager.shared.showTab(with: .url(url, source: .ui))
+                        Application.appDelegate.windowControllersManager.showTab(with: .url(url, source: .ui))
                     case .didClickManageEmail:
                         PixelKit.fire(PrivacyProPixel.privacyProSubscriptionManagementEmail, frequency: .legacyDailyAndCount)
                     case .didOpenSubscriptionSettings:
@@ -265,7 +265,7 @@ enum Preferences {
                 let url = subscriptionManager.url(for: subscriptionURL)
                     .appendingParameter(name: AttributionParameter.origin,
                                         value: SubscriptionFunnelOrigin.appSettings.rawValue)
-                WindowControllersManager.shared.showTab(with: .subscription(url))
+                Application.appDelegate.windowControllersManager.showTab(with: .subscription(url))
             }
         }
     }
@@ -393,7 +393,7 @@ enum Preferences {
             let sheetActionHandler = SubscriptionAccessActionHandlers(
                 openActivateViaEmailURL: {
                     let url = subscriptionManager.url(for: .activationFlow)
-                    WindowControllersManager.shared.showTab(with: .subscription(url))
+                    Application.appDelegate.windowControllersManager.showTab(with: .subscription(url))
                     PixelKit.fire(PrivacyProPixel.privacyProRestorePurchaseEmailStart, frequency: .legacyDailyAndCount)
                 }, restorePurchases: {
                     if #available(macOS 12.0, *) {
@@ -421,7 +421,7 @@ enum Preferences {
                     switch event {
                     case .openPIR:
                         PixelKit.fire(PrivacyProPixel.privacyProPersonalInformationRemovalSettings)
-                        WindowControllersManager.shared.showTab(with: .dataBrokerProtection)
+                        Application.appDelegate.windowControllersManager.showTab(with: .dataBrokerProtection)
                     case .openURL(let url):
                         openURL(subscriptionURL: url)
                     case .didOpenPIRPreferencePane:
@@ -441,7 +441,7 @@ enum Preferences {
                     case .openITR:
                         PixelKit.fire(PrivacyProPixel.privacyProIdentityRestorationSettings)
                         let url = subscriptionManager.url(for: .identityTheftRestoration)
-                        WindowControllersManager.shared.showTab(with: .identityTheftRestoration(url))
+                        Application.appDelegate.windowControllersManager.showTab(with: .identityTheftRestoration(url))
                     case .openURL(let url):
                         openURL(subscriptionURL: url)
                     case .didOpenITRPreferencePane:
@@ -467,7 +467,7 @@ enum Preferences {
                     case .openManageSubscriptionsInAppStore:
                         NSWorkspace.shared.open(subscriptionManager.url(for: .manageSubscriptionsInAppStore))
                     case .openCustomerPortalURL(let url):
-                        WindowControllersManager.shared.showTab(with: .url(url, source: .ui))
+                        Application.appDelegate.windowControllersManager.showTab(with: .url(url, source: .ui))
                     case .didClickManageEmail:
                         PixelKit.fire(PrivacyProPixel.privacyProSubscriptionManagementEmail, frequency: .legacyDailyAndCount)
                     case .didOpenSubscriptionSettings:
@@ -490,7 +490,7 @@ enum Preferences {
                 let url = subscriptionManager.url(for: subscriptionURL)
                     .appendingParameter(name: AttributionParameter.origin,
                                         value: SubscriptionFunnelOrigin.appSettings.rawValue)
-                WindowControllersManager.shared.showTab(with: .subscription(url))
+                Application.appDelegate.windowControllersManager.showTab(with: .subscription(url))
             }
         }
     }

--- a/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
+++ b/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
@@ -212,7 +212,7 @@ extension PrivacyDashboardViewController: PrivacyDashboardControllerDelegate {
     }
 
     func privacyDashboardController(_ privacyDashboardController: PrivacyDashboardController, didRequestOpenUrlInNewTab url: URL) {
-        guard let tabCollection = WindowControllersManager.shared.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel
+        guard let tabCollection = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel
         else {
             assertionFailure("could not access shared tabCollectionViewModel")
             return
@@ -222,7 +222,7 @@ extension PrivacyDashboardViewController: PrivacyDashboardControllerDelegate {
 
     func privacyDashboardController(_ privacyDashboardController: PrivacyDashboardController,
                                     didRequestOpenSettings target: PrivacyDashboardOpenSettingsTarget) {
-        guard let tabCollection = WindowControllersManager.shared.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel
+        guard let tabCollection = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel
         else {
             assertionFailure("could not access shared tabCollectionViewModel")
             return

--- a/macOS/DuckDuckGo/RecentlyClosed/Model/RecentlyClosedCoordinator.swift
+++ b/macOS/DuckDuckGo/RecentlyClosed/Model/RecentlyClosedCoordinator.swift
@@ -33,7 +33,7 @@ protocol RecentlyClosedCoordinating: AnyObject {
 @MainActor
 final class RecentlyClosedCoordinator: RecentlyClosedCoordinating {
 
-    static let shared = RecentlyClosedCoordinator(windowControllerManager: WindowControllersManager.shared,
+    static let shared = RecentlyClosedCoordinator(windowControllerManager: Application.appDelegate.windowControllersManager,
                                                   pinnedTabsManagerProvider: Application.appDelegate.pinnedTabsManagerProvider)
 
     var windowControllerManager: WindowControllersManagerProtocol
@@ -171,13 +171,13 @@ final class RecentlyClosedCoordinator: RecentlyClosedCoordinating {
         let tabCollectionViewModel: TabCollectionViewModel
         let tabIndex: Int
         if let originalTabCollection = recentlyClosedTab.originalTabCollection,
-           let lastKeyMainWindowController = WindowControllersManager.shared.lastKeyMainWindowController,
+           let lastKeyMainWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController,
            originalTabCollection == lastKeyMainWindowController.mainViewController.tabCollectionViewModel.tabCollection {
             // Original window still exists and it is key
             tabCollectionViewModel = lastKeyMainWindowController.mainViewController.tabCollectionViewModel
             tabIndex = min(recentlyClosedTab.index.item, tabCollectionViewModel.tabCollection.tabs.count)
 
-        } else if let lastKeyMainWindowController = WindowControllersManager.shared.lastKeyMainWindowController {
+        } else if let lastKeyMainWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController {
             // Original window is closed, reopen the tab in the current window
             tabCollectionViewModel = lastKeyMainWindowController.mainViewController.tabCollectionViewModel
             tabIndex = tabCollectionViewModel.tabCollection.tabs.count
@@ -194,11 +194,11 @@ final class RecentlyClosedCoordinator: RecentlyClosedCoordinating {
     }
 
     private func reopenPinnedTab(_ recentlyClosedTab: RecentlyClosedTab) {
-        var lastKeyMainWindowController = WindowControllersManager.shared.lastKeyMainWindowController
+        var lastKeyMainWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController
         if lastKeyMainWindowController == nil {
             // Create a new window if none exists
             WindowsManager.openNewWindow(with: Tab(content: .newtab, shouldLoadInBackground: true))
-            lastKeyMainWindowController = WindowControllersManager.shared.lastKeyMainWindowController
+            lastKeyMainWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController
         }
 
         guard let tabCollectionViewModel = lastKeyMainWindowController?.mainViewController.tabCollectionViewModel else {

--- a/macOS/DuckDuckGo/RemoteMessaging/RemoteMessagingDebugMenu.swift
+++ b/macOS/DuckDuckGo/RemoteMessaging/RemoteMessagingDebugMenu.swift
@@ -117,7 +117,7 @@ final class RemoteMessagingDebugMenu: NSMenu {
 
     @objc func openRemoteMessagesConfig() {
         Task { @MainActor in
-            WindowControllersManager.shared.showTab(with: .contentFromURL(RemoteMessagingClient.Constants.endpoint, source: .appOpenUrl))
+            Application.appDelegate.windowControllersManager.showTab(with: .contentFromURL(RemoteMessagingClient.Constants.endpoint, source: .appOpenUrl))
         }
     }
 

--- a/macOS/DuckDuckGo/SecureVault/Model/PasswordManagementLoginModel.swift
+++ b/macOS/DuckDuckGo/SecureVault/Model/PasswordManagementLoginModel.swift
@@ -209,7 +209,7 @@ final class PasswordManagementLoginModel: ObservableObject, PasswordManagementIt
 
     @MainActor
     func openURL(_ url: URL) {
-        WindowControllersManager.shared.show(url: url, source: .bookmark, newTab: true)
+        Application.appDelegate.windowControllersManager.show(url: url, source: .bookmark, newTab: true)
     }
 
     func togglePrivateEmailStatus() {

--- a/macOS/DuckDuckGo/SecureVault/View/PasswordManagementBitwardenItemView.swift
+++ b/macOS/DuckDuckGo/SecureVault/View/PasswordManagementBitwardenItemView.swift
@@ -31,7 +31,7 @@ struct PasswordManagementBitwardenItemView: View {
                 HStack(spacing: 3) {
                     Text(UserText.passwordManagerPopoverChangeInSettingsLabel)
                     Button {
-                        WindowControllersManager.shared.showPreferencesTab(withSelectedPane: .autofill)
+                        Application.appDelegate.windowControllersManager.showPreferencesTab(withSelectedPane: .autofill)
                         didFinish()
                     } label: {
                         Text(UserText.passwordManagerPopoverSettingsButton)

--- a/macOS/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
+++ b/macOS/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
@@ -321,7 +321,7 @@ final class PasswordManagementViewController: NSViewController {
     }
 
     @IBAction func openAutofillPreferences(_ sender: Any) {
-        WindowControllersManager.shared.showPreferencesTab(withSelectedPane: .autofill)
+        Application.appDelegate.windowControllersManager.showPreferencesTab(withSelectedPane: .autofill)
         self.dismiss()
     }
 
@@ -1114,9 +1114,9 @@ extension PasswordManagementViewController: NSTextViewDelegate {
     func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {
         if let link = link as? URL {
             if let pane = PreferencePaneIdentifier(url: link) {
-                WindowControllersManager.shared.showPreferencesTab(withSelectedPane: pane)
+                Application.appDelegate.windowControllersManager.showPreferencesTab(withSelectedPane: pane)
             } else {
-                WindowControllersManager.shared.showTab(with: .url(link, source: .link))
+                Application.appDelegate.windowControllersManager.showTab(with: .url(link, source: .link))
             }
             self.dismiss()
         }

--- a/macOS/DuckDuckGo/SecureVault/View/SaveIdentityViewController.swift
+++ b/macOS/DuckDuckGo/SecureVault/View/SaveIdentityViewController.swift
@@ -81,7 +81,7 @@ final class SaveIdentityViewController: NSViewController {
     }
 
     @IBAction func onOpenPreferencesClicked(sender: NSButton) {
-        WindowControllersManager.shared.showPreferencesTab()
+        Application.appDelegate.windowControllersManager.showPreferencesTab()
         self.delegate?.shouldCloseSaveIdentityViewController(self)
     }
 

--- a/macOS/DuckDuckGo/SecureVault/View/SavePaymentMethodViewController.swift
+++ b/macOS/DuckDuckGo/SecureVault/View/SavePaymentMethodViewController.swift
@@ -101,7 +101,7 @@ final class SavePaymentMethodViewController: NSViewController {
     }
 
     @IBAction func onOpenPreferencesClicked(sender: NSButton) {
-        WindowControllersManager.shared.showPreferencesTab()
+        Application.appDelegate.windowControllersManager.showPreferencesTab()
         self.delegate?.shouldCloseSavePaymentMethodViewController(self)
     }
 

--- a/macOS/DuckDuckGo/Sharing/SharingMenu.swift
+++ b/macOS/DuckDuckGo/Sharing/SharingMenu.swift
@@ -46,7 +46,7 @@ final class SharingMenu: NSMenu {
     typealias SharingData = (title: String?, items: [Any])
     @MainActor
     private func sharingData() -> SharingData? {
-        guard let tabViewModel = WindowControllersManager.shared.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel.selectedTabViewModel,
+        guard let tabViewModel = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel.selectedTabViewModel,
               tabViewModel.canReload,
               !tabViewModel.isShowingErrorPage,
               let url = tabViewModel.tab.content.userEditableUrl else { return nil }

--- a/macOS/DuckDuckGo/StateRestoration/AppStateRestorationManager.swift
+++ b/macOS/DuckDuckGo/StateRestoration/AppStateRestorationManager.swift
@@ -107,7 +107,7 @@ final class AppStateRestorationManager: NSObject {
         readLastSessionState(restoreWindows: !service.isAppStateFileStale || isRelaunchingAutomatically, restoreRegularTabs: shouldRestoreRegularTabs)
 
         stateChangedCancellable = Publishers.Merge(
-                WindowControllersManager.shared.stateChanged,
+                Application.appDelegate.windowControllersManager.stateChanged,
                 pinnedTabsManagerProvider.settingChangedPublisher
             )
             .debounce(for: .seconds(1), scheduler: RunLoop.main)
@@ -120,7 +120,7 @@ final class AppStateRestorationManager: NSObject {
 
     func applicationWillTerminate() {
         stateChangedCancellable?.cancel()
-        if WindowControllersManager.shared.isInInitialState {
+        if Application.appDelegate.windowControllersManager.isInInitialState {
             service.clearState(sync: true)
         } else {
             persistAppState(sync: true)
@@ -137,7 +137,7 @@ final class AppStateRestorationManager: NSObject {
             restorePinnedTabs()
             cleanTabSnapshots()
         }
-        WindowControllersManager.shared.updateIsInInitialState()
+        Application.appDelegate.windowControllersManager.updateIsInInitialState()
     }
 
     @MainActor
@@ -156,7 +156,7 @@ final class AppStateRestorationManager: NSObject {
 
     @MainActor
     private func persistAppState(sync: Bool = false) {
-        service.persistState(using: WindowControllersManager.shared.encodeState(with:), sync: sync)
+        service.persistState(using: Application.appDelegate.windowControllersManager.encodeState(with:), sync: sync)
     }
 
     private func migratePinnedTabsSettingIfNecessary() {

--- a/macOS/DuckDuckGo/StateRestoration/WindowManager+StateRestoration.swift
+++ b/macOS/DuckDuckGo/StateRestoration/WindowManager+StateRestoration.swift
@@ -30,7 +30,7 @@ extension WindowsManager {
 
         TabsPreferences.shared.migratePinnedTabsSettingIfNecessary(state.applicationPinnedTabs)
         if let pinnedTabsCollection = state.applicationPinnedTabs {
-            WindowControllersManager.shared.restorePinnedTabs(pinnedTabsCollection)
+            Application.appDelegate.windowControllersManager.restorePinnedTabs(pinnedTabsCollection)
         }
         if includeWindows {
             restoreWindows(from: state, includeRegularTabs: includeRegularTabs)

--- a/macOS/DuckDuckGo/Sync/FaviconsFetcherOnboarding.swift
+++ b/macOS/DuckDuckGo/Sync/FaviconsFetcherOnboarding.swift
@@ -44,7 +44,7 @@ final class FaviconsFetcherOnboarding {
         let windowController = viewController.wrappedInWindowController()
 
         guard let window = windowController.window,
-              let parentWindow = targetWindow ?? WindowControllersManager.shared.lastKeyMainWindowController?.window
+              let parentWindow = targetWindow ?? Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.window
         else {
             assertionFailure("Failed to present FaviconsFetcherOnboardingViewController")
             return

--- a/macOS/DuckDuckGo/Sync/Promotion/SyncPromoManager.swift
+++ b/macOS/DuckDuckGo/Sync/Promotion/SyncPromoManager.swift
@@ -88,7 +88,7 @@ final class SyncPromoManager: SyncPromoManaging {
     }
 
     @MainActor func goToSyncSettings(for touchpoint: Touchpoint) {
-        WindowControllersManager.shared.showPreferencesTab(withSelectedPane: .sync)
+        Application.appDelegate.windowControllersManager.showPreferencesTab(withSelectedPane: .sync)
 
         var source: String
         switch touchpoint {

--- a/macOS/DuckDuckGo/Sync/SyncErrorHandler.swift
+++ b/macOS/DuckDuckGo/Sync/SyncErrorHandler.swift
@@ -442,13 +442,13 @@ extension SyncErrorHandler: SyncErrorHandling {
 
     @MainActor
     private func manageBookmarks() {
-        guard let mainVC = WindowControllersManager.shared.lastKeyMainWindowController?.mainViewController else { return }
+        guard let mainVC = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.mainViewController else { return }
         mainVC.showManageBookmarks(self)
     }
 
     @MainActor
     private func manageLogins() {
-        guard let parentWindowController = WindowControllersManager.shared.lastKeyMainWindowController else { return }
+        guard let parentWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController else { return }
         let navigationViewController = parentWindowController.mainViewController.navigationBarViewController
         navigationViewController.showPasswordManagerPopover(selectedCategory: .allItems, source: .sync)
     }

--- a/macOS/DuckDuckGo/Sync/Utilities/SyncAlertsPresenter.swift
+++ b/macOS/DuckDuckGo/Sync/Utilities/SyncAlertsPresenter.swift
@@ -32,7 +32,7 @@ public struct SyncAlertsPresenter: SyncAlertsPresenting {
                 switch response {
                 case .alertSecondButtonReturn:
                     alert.window.sheetParent?.endSheet(alert.window)
-                    WindowControllersManager.shared.showPreferencesTab(withSelectedPane: .sync)
+                    Application.appDelegate.windowControllersManager.showPreferencesTab(withSelectedPane: .sync)
                 default:
                     break
                 }

--- a/macOS/DuckDuckGo/Tab/UserScripts/SpecialPagesUserScriptExtension.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/SpecialPagesUserScriptExtension.swift
@@ -55,7 +55,7 @@ extension SpecialPagesUserScript {
     @MainActor
     private func buildOnboardingActionsManager() -> OnboardingActionsManaging {
         return OnboardingActionsManager(
-            navigationDelegate: WindowControllersManager.shared,
+            navigationDelegate: Application.appDelegate.windowControllersManager,
             dockCustomization: DockCustomizer(),
             defaultBrowserProvider: SystemDefaultBrowserProvider(),
             appearancePreferences: NSApp.delegateTyped.appearancePreferences,

--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -198,7 +198,7 @@ final class BrowserTabViewController: NSViewController {
 
     @objc
     private func onDuckDuckGoEmailIncontextSignup(_ notification: Notification) {
-        guard WindowControllersManager.shared.lastKeyMainWindowController === self.view.window?.windowController else { return }
+        guard Application.appDelegate.windowControllersManager.lastKeyMainWindowController === self.view.window?.windowController else { return }
 
         self.previouslySelectedTab = tabCollectionViewModel.selectedTab
         let tab = Tab(content: .url(EmailUrls().emailProtectionInContextSignupLink, source: .ui), shouldLoadInBackground: true, burnerMode: tabCollectionViewModel.burnerMode)
@@ -207,7 +207,7 @@ final class BrowserTabViewController: NSViewController {
 
     @objc
     private func onCloseDuckDuckGoEmailProtection(_ notification: Notification) {
-        guard WindowControllersManager.shared.lastKeyMainWindowController === self.view.window?.windowController,
+        guard Application.appDelegate.windowControllersManager.lastKeyMainWindowController === self.view.window?.windowController,
               let previouslySelectedTab else { return }
 
         if let activeTab = tabViewModel?.tab,
@@ -226,7 +226,7 @@ final class BrowserTabViewController: NSViewController {
     private func onPasswordImportFlowFinish(_ notification: Notification) {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            guard WindowControllersManager.shared.lastKeyMainWindowController === self.view.window?.windowController else { return }
+            guard Application.appDelegate.windowControllersManager.lastKeyMainWindowController === self.view.window?.windowController else { return }
             if let previouslySelectedTab {
                 tabCollectionViewModel.select(tab: previouslySelectedTab)
                 previouslySelectedTab.webView.evaluateJavaScript("window.credentialsImportFinished()", in: nil, in: WKContentWorld.defaultClient)
@@ -259,7 +259,7 @@ final class BrowserTabViewController: NSViewController {
 
     @objc
     private func onDataBrokerWaitlistGetStartedPressedByUser(_ notification: Notification) {
-        WindowControllersManager.shared.showDataBrokerProtectionTab()
+        Application.appDelegate.windowControllersManager.showDataBrokerProtectionTab()
     }
 
     @objc
@@ -805,7 +805,7 @@ final class BrowserTabViewController: NSViewController {
         // shouldn't open New Tabs in PopUp window
         if view.window?.isPopUpWindow ?? true {
             // Prefer Tab's Parent
-            WindowControllersManager.shared.showTab(with: content)
+            Application.appDelegate.windowControllersManager.showTab(with: content)
             return nil
         }
 
@@ -1031,7 +1031,7 @@ final class BrowserTabViewController: NSViewController {
         return contentOverlayPopover ?? {
             let overlayPopover = ContentOverlayPopover(currentTabView: self.view)
             self.contentOverlayPopover = overlayPopover
-            WindowControllersManager.shared.stateChanged
+            Application.appDelegate.windowControllersManager.stateChanged
                 .sink { [weak overlayPopover] _ in
                     overlayPopover?.viewController.closeContentOverlayPopover()
                 }.store(in: &self.cancellables)
@@ -1462,9 +1462,9 @@ extension BrowserTabViewController {
 extension BrowserTabViewController {
 
     private func subscribeToTabSelectedInCurrentKeyWindow() {
-        let lastKeyWindowOtherThanOurs = WindowControllersManager.shared.didChangeKeyWindowController
+        let lastKeyWindowOtherThanOurs = Application.appDelegate.windowControllersManager.didChangeKeyWindowController
             .map { $0 }
-            .prepend(WindowControllersManager.shared.lastKeyMainWindowController)
+            .prepend(Application.appDelegate.windowControllersManager.lastKeyMainWindowController)
             .compactMap { $0 }
             .filter { [weak self] in $0.window !== self?.view.window }
 

--- a/macOS/DuckDuckGo/TabBar/View/TabBarRemoteMessagePresenting.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarRemoteMessagePresenting.swift
@@ -82,7 +82,7 @@ extension TabBarRemoteMessagePresenting {
                 guard let self = self else { return }
 
                 DispatchQueue.main.async {
-                    WindowControllersManager.shared.showTab(with: .contentFromURL(surveyURL, source: .appOpenUrl))
+                    Application.appDelegate.windowControllersManager.showTab(with: .contentFromURL(surveyURL, source: .appOpenUrl))
                 }
                 self.tabBarRemoteMessageViewModel.onSurveyOpened()
                 self.removeFeedbackButton()

--- a/macOS/DuckDuckGo/Updates/UpdateNotificationPresenter.swift
+++ b/macOS/DuckDuckGo/Updates/UpdateNotificationPresenter.swift
@@ -29,7 +29,7 @@ final class UpdateNotificationPresenter {
         Logger.updates.log("Notification presented: \(text, privacy: .public)")
 
         DispatchQueue.main.async {
-            guard let windowController = WindowControllersManager.shared.lastKeyMainWindowController ?? WindowControllersManager.shared.mainWindowControllers.last,
+            guard let windowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController ?? Application.appDelegate.windowControllersManager.mainWindowControllers.last,
                   let button = windowController.mainViewController.navigationBarViewController.optionsButton else {
                 return
             }
@@ -61,7 +61,7 @@ final class UpdateNotificationPresenter {
 
     func openUpdatesPage() {
         DispatchQueue.main.async {
-            WindowControllersManager.shared.showTab(with: .releaseNotes)
+            Application.appDelegate.windowControllersManager.showTab(with: .releaseNotes)
         }
     }
 }

--- a/macOS/DuckDuckGo/WebExtensions/WKWebExtensionTab.swift
+++ b/macOS/DuckDuckGo/WebExtensions/WKWebExtensionTab.swift
@@ -32,7 +32,7 @@ extension Tab: WKWebExtensionTab {
     }
 
     private var tabCollectionViewModel: TabCollectionViewModel? {
-        let mainWindowController = WindowControllersManager.shared.windowController(for: self)
+        let mainWindowController = Application.appDelegate.windowControllersManager.windowController(for: self)
         let mainViewController = mainWindowController?.mainViewController
         return mainViewController?.tabCollectionViewModel
     }

--- a/macOS/DuckDuckGo/WebExtensions/WebExtensionInternalSiteNavigationDelegate.swift
+++ b/macOS/DuckDuckGo/WebExtensions/WebExtensionInternalSiteNavigationDelegate.swift
@@ -29,7 +29,7 @@ final class WebExtensionInternalSiteNavigationDelegate: NSObject, WKNavigationDe
             return .allow
         }
 
-        guard let tabCollectionViewModel = WindowControllersManager.shared.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel,
+        guard let tabCollectionViewModel = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel,
               let tab = tabCollectionViewModel.selectedTab else {
             assertionFailure("No current tab")
             return .allow

--- a/macOS/DuckDuckGo/WebExtensions/WebExtensionManager.swift
+++ b/macOS/DuckDuckGo/WebExtensions/WebExtensionManager.swift
@@ -255,7 +255,7 @@ final class WebExtensionManager: NSObject, WebExtensionManaging {
             return nil
         }
 
-        guard let mainWindowController = WindowControllersManager.shared.lastKeyMainWindowController else {
+        guard let mainWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController else {
             assertionFailure("No main window controller")
             return nil
         }
@@ -275,8 +275,8 @@ extension WebExtensionManager: WKWebExtensionControllerDelegate {
     }
 
     func webExtensionController(_ controller: WKWebExtensionController, openWindowsFor extensionContext: WKWebExtensionContext) -> [any WKWebExtensionWindow] {
-        var windows = WindowControllersManager.shared.mainWindowControllers
-        if let focusedWindow = WindowControllersManager.shared.lastKeyMainWindowController {
+        var windows = Application.appDelegate.windowControllersManager.mainWindowControllers
+        if let focusedWindow = Application.appDelegate.windowControllersManager.lastKeyMainWindowController {
             // Ensure focusedWindow is the first item
             windows.removeAll { $0 === focusedWindow }
             windows.insert(focusedWindow, at: 0)
@@ -285,7 +285,7 @@ extension WebExtensionManager: WKWebExtensionControllerDelegate {
     }
 
     func webExtensionController(_ controller: WKWebExtensionController, focusedWindowFor extensionContext: WKWebExtensionContext) -> (any WKWebExtensionWindow)? {
-        return WindowControllersManager.shared.lastKeyMainWindowController
+        return Application.appDelegate.windowControllersManager.lastKeyMainWindowController
     }
 
     func webExtensionController(_ controller: WKWebExtensionController, openNewWindowUsing configuration: WKWebExtension.WindowConfiguration, for extensionContext: WKWebExtensionContext) async throws -> (any WKWebExtensionWindow)? {
@@ -299,7 +299,7 @@ extension WebExtensionManager: WKWebExtensionControllerDelegate {
         )
 
         // Create new window
-        let mainWindow = WindowControllersManager.shared.openNewWindow(
+        let mainWindow = Application.appDelegate.windowControllersManager.openNewWindow(
             with: tabCollectionViewModel,
             burnerMode: burnerMode,
             droppingPoint: configuration.frame.origin,
@@ -324,7 +324,7 @@ extension WebExtensionManager: WKWebExtensionControllerDelegate {
         for existingTab in existingTabs {
             guard
                 let tab = existingTab as? Tab,
-                let sourceViewModel = WindowControllersManager.shared.windowController(for: tab)?
+                let sourceViewModel = Application.appDelegate.windowControllersManager.windowController(for: tab)?
                     .mainViewController.tabCollectionViewModel,
                 let currentIndex = sourceViewModel.tabCollection.tabs.firstIndex(of: tab)
             else {
@@ -337,7 +337,7 @@ extension WebExtensionManager: WKWebExtensionControllerDelegate {
     }
 
     func webExtensionController(_ controller: WKWebExtensionController, openNewTabUsing configuration: WKWebExtension.TabConfiguration, for extensionContext: WKWebExtensionContext) async throws -> (any WKWebExtensionTab)? {
-        if let tabCollectionViewModel = WindowControllersManager.shared.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel,
+        if let tabCollectionViewModel = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel,
            let url = configuration.url {
 
             let content = TabContent.contentFromURL(url, source: .ui)

--- a/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
+++ b/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
@@ -75,10 +75,6 @@ extension WindowControllersManagerProtocol {
 @MainActor
 final class WindowControllersManager: WindowControllersManagerProtocol {
 
-    static var shared: WindowControllersManager {
-        Application.appDelegate.windowControllersManager
-    }
-
     var activeViewController: MainViewController? {
         lastKeyMainWindowController?.mainViewController
     }
@@ -426,7 +422,7 @@ extension WindowControllersManager {
             return
         }
 
-        if let parentWindowController = WindowControllersManager.shared.lastKeyMainWindowController {
+        if let parentWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController {
             parentWindowController.window?.beginSheet(feedbackFormWindow)
         } else {
             let tabCollection = TabCollection(tabs: [])
@@ -437,7 +433,7 @@ extension WindowControllersManager {
     }
 
     func showMainWindow() {
-        guard WindowControllersManager.shared.lastKeyMainWindowController == nil else { return }
+        guard Application.appDelegate.windowControllersManager.lastKeyMainWindowController == nil else { return }
         let tabCollection = TabCollection(tabs: [])
         let tabCollectionViewModel = TabCollectionViewModel(tabCollection: tabCollection)
         _ = WindowsManager.openNewWindow(with: tabCollectionViewModel)
@@ -448,7 +444,7 @@ extension WindowControllersManager {
         let locationsWindowController = locationsViewController.wrappedInWindowController()
 
         guard let locationsFormWindow = locationsWindowController.window,
-              let parentWindowController = WindowControllersManager.shared.lastKeyMainWindowController else {
+              let parentWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController else {
             assertionFailure("Failed to present native VPN feedback form")
             return
         }

--- a/macOS/DuckDuckGo/Windows/View/WindowsManager.swift
+++ b/macOS/DuckDuckGo/Windows/View/WindowsManager.swift
@@ -34,7 +34,7 @@ final class WindowsManager {
     private static let autofillPopoverPresenter: AutofillPopoverPresenter = DefaultAutofillPopoverPresenter()
 
     class func closeWindows(except windows: [NSWindow] = []) {
-        for controller in WindowControllersManager.shared.mainWindowControllers {
+        for controller in Application.appDelegate.windowControllersManager.mainWindowControllers {
             guard let window = controller.window, !windows.contains(window) else { continue }
             controller.close()
         }
@@ -43,7 +43,7 @@ final class WindowsManager {
     /// finds window to position newly opened (or popup) windows against
     private class func findPositioningSourceWindow(for tab: Tab?) -> NSWindow? {
         if let parentTab = tab?.parentTab,
-           let sourceWindowController = WindowControllersManager.shared.mainWindowControllers.first(where: {
+           let sourceWindowController = Application.appDelegate.windowControllersManager.mainWindowControllers.first(where: {
                $0.mainViewController.tabCollectionViewModel.tabs.contains(parentTab)
            }) {
             // window that initiated the new window opening
@@ -51,7 +51,7 @@ final class WindowsManager {
         }
 
         // fallback to last known main window
-        return WindowControllersManager.shared.lastKeyMainWindowController?.window
+        return Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.window
     }
 
     @discardableResult
@@ -153,7 +153,7 @@ final class WindowsManager {
     private static let defaultPopUpHeight: CGFloat = 752
 
     class func openPopUpWindow(with tab: Tab, origin: NSPoint?, contentSize: NSSize?) {
-        if let mainWindowController = WindowControllersManager.shared.lastKeyMainWindowController,
+        if let mainWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController,
            mainWindowController.window?.styleMask.contains(.fullScreen) == true,
            mainWindowController.window?.isPopUpWindow == false {
 
@@ -189,7 +189,7 @@ final class WindowsManager {
         let mainViewController = MainViewController(tabCollectionViewModel: tabCollectionViewModel ?? TabCollectionViewModel(burnerMode: burnerMode), autofillPopoverPresenter: autofillPopoverPresenter)
 
         let fireWindowSession = if case .burner = burnerMode {
-            WindowControllersManager.shared.mainWindowControllers.first(where: {
+            Application.appDelegate.windowControllersManager.mainWindowControllers.first(where: {
                 $0.mainViewController.tabCollectionViewModel.burnerMode == burnerMode
             })?.fireWindowSession ?? FireWindowSession()
         } else { FireWindowSession?.none }

--- a/macOS/IntegrationTests/App/AppStateChangePublisherTests.swift
+++ b/macOS/IntegrationTests/App/AppStateChangePublisherTests.swift
@@ -26,15 +26,15 @@ final class AppStateChangePublisherTests: XCTestCase {
 
     @MainActor
     override func setUp() {
-        assert(WindowControllersManager.shared.mainWindowControllers.isEmpty)
+        assert(Application.appDelegate.windowControllersManager.mainWindowControllers.isEmpty)
     }
 
     @MainActor
     override func tearDown() {
         cancellables.removeAll()
         WindowsManager.closeWindows()
-        for controller in WindowControllersManager.shared.mainWindowControllers {
-            WindowControllersManager.shared.unregister(controller)
+        for controller in Application.appDelegate.windowControllersManager.mainWindowControllers {
+            Application.appDelegate.windowControllersManager.unregister(controller)
         }
     }
 
@@ -50,7 +50,7 @@ final class AppStateChangePublisherTests: XCTestCase {
     func testWhenWindowIsOpenedThenStateChangePublished() {
         let e = expectation(description: "Window Opened fires State change")
 
-        WindowControllersManager.shared.stateChanged
+        Application.appDelegate.windowControllersManager.stateChanged
             .sink { _ in
                 e.fulfill()
             }.store(in: &cancellables)
@@ -66,7 +66,7 @@ final class AppStateChangePublisherTests: XCTestCase {
         let n = 7
         let e = expect(description: "Windows Opened fire State change", events: n)
 
-        WindowControllersManager.shared.stateChanged
+        Application.appDelegate.windowControllersManager.stateChanged
             .sink { _ in
                 e.fulfill()
             }.store(in: &cancellables)
@@ -85,7 +85,7 @@ final class AppStateChangePublisherTests: XCTestCase {
 
         let e = expectation(description: "Window Closed fires State changes")
 
-        WindowControllersManager.shared.stateChanged
+        Application.appDelegate.windowControllersManager.stateChanged
             .sink { _ in
                 e.fulfill()
             }.store(in: &cancellables)
@@ -100,7 +100,7 @@ final class AppStateChangePublisherTests: XCTestCase {
 
         let e = expectation(description: "Window setFrameOrigin fires State changes")
 
-        WindowControllersManager.shared.stateChanged
+        Application.appDelegate.windowControllersManager.stateChanged
             .sink { _ in
                 e.fulfill()
             }.store(in: &cancellables)
@@ -116,7 +116,7 @@ final class AppStateChangePublisherTests: XCTestCase {
 
         let e = expectation(description: "Window setContentSize fires State changes")
 
-        WindowControllersManager.shared.stateChanged
+        Application.appDelegate.windowControllersManager.stateChanged
             .sink { _ in
                 e.fulfill()
             }.store(in: &cancellables)
@@ -129,17 +129,17 @@ final class AppStateChangePublisherTests: XCTestCase {
     @MainActor
     func testWhenNewTabIsOpenedThenStateChangePublished() {
         WindowsManager.openNewWindow(with: Tab(content: .none))
-        WindowControllersManager.shared.mainWindowControllers[0].mainViewController.tabCollectionViewModel
+        Application.appDelegate.windowControllersManager.mainWindowControllers[0].mainViewController.tabCollectionViewModel
             .append(tab: Tab(content: .none))
 
         // 2 events should be fired (one for tab appending, one for selectionIndex change)
         let e = expect(description: "Append new tab fires State changes", events: 2)
-        WindowControllersManager.shared.stateChanged
+        Application.appDelegate.windowControllersManager.stateChanged
             .sink { _ in
                 e.fulfill()
             }.store(in: &cancellables)
 
-        WindowControllersManager.shared.mainWindowControllers[0].mainViewController.tabCollectionViewModel
+        Application.appDelegate.windowControllersManager.mainWindowControllers[0].mainViewController.tabCollectionViewModel
             .append(tab: Tab(content: .none))
 
         waitForExpectations(timeout: 0.3, handler: nil)
@@ -149,21 +149,21 @@ final class AppStateChangePublisherTests: XCTestCase {
     func testWhenTabIsClosedThenStateChangePublished() {
         WindowsManager.openNewWindow(with: Tab(content: .none))
         WindowsManager.openNewWindow(with: Tab(content: .none))
-        WindowControllersManager.shared.mainWindowControllers[0].mainViewController.tabCollectionViewModel
+        Application.appDelegate.windowControllersManager.mainWindowControllers[0].mainViewController.tabCollectionViewModel
             .append(tab: Tab(content: .none))
-        WindowControllersManager.shared.mainWindowControllers[1].mainViewController.tabCollectionViewModel
+        Application.appDelegate.windowControllersManager.mainWindowControllers[1].mainViewController.tabCollectionViewModel
             .append(tab: Tab(content: .none))
 
         // 4 events should be fired (2 for tabs removal, 2 for selectionIndex change)
         let e = expect(description: "Close tabs fire State Changee", events: 4)
-        WindowControllersManager.shared.stateChanged
+        Application.appDelegate.windowControllersManager.stateChanged
             .sink { _ in
                 e.fulfill()
             }.store(in: &cancellables)
 
-        WindowControllersManager.shared.mainWindowControllers[0].mainViewController.tabCollectionViewModel
+        Application.appDelegate.windowControllersManager.mainWindowControllers[0].mainViewController.tabCollectionViewModel
             .remove(at: .unpinned(0))
-        WindowControllersManager.shared.mainWindowControllers[1].mainViewController.tabCollectionViewModel
+        Application.appDelegate.windowControllersManager.mainWindowControllers[1].mainViewController.tabCollectionViewModel
             .remove(at: .unpinned(1))
 
         waitForExpectations(timeout: 0.3, handler: nil)
@@ -172,21 +172,21 @@ final class AppStateChangePublisherTests: XCTestCase {
     @MainActor
     func testWhenAllTabsExceptOneClosedThenStateChangePublished() {
         WindowsManager.openNewWindow(with: Tab(content: .none))
-        WindowControllersManager.shared.mainWindowControllers[0].mainViewController.tabCollectionViewModel
+        Application.appDelegate.windowControllersManager.mainWindowControllers[0].mainViewController.tabCollectionViewModel
             .append(tab: Tab(content: .none))
-        WindowControllersManager.shared.mainWindowControllers[0].mainViewController.tabCollectionViewModel
+        Application.appDelegate.windowControllersManager.mainWindowControllers[0].mainViewController.tabCollectionViewModel
             .append(tab: Tab(content: .none))
-        WindowControllersManager.shared.mainWindowControllers[0].mainViewController.tabCollectionViewModel
+        Application.appDelegate.windowControllersManager.mainWindowControllers[0].mainViewController.tabCollectionViewModel
             .append(tab: Tab(content: .none))
 
         // 2 events should be fired (one for tab removal, one for selectionIndex change)
         let e = expect(description: "Close tabs fires State changes", events: 2)
-        WindowControllersManager.shared.stateChanged
+        Application.appDelegate.windowControllersManager.stateChanged
             .sink { _ in
                 e.fulfill()
             }.store(in: &cancellables)
 
-        WindowControllersManager.shared.mainWindowControllers[0].mainViewController.tabCollectionViewModel
+        Application.appDelegate.windowControllersManager.mainWindowControllers[0].mainViewController.tabCollectionViewModel
             .removeAllTabs(except: 1)
 
         waitForExpectations(timeout: 0.3, handler: nil)
@@ -195,21 +195,21 @@ final class AppStateChangePublisherTests: XCTestCase {
     @MainActor
     func testWhenTabsReorderedThenStateChangePublished() {
         WindowsManager.openNewWindow(with: Tab(content: .none))
-        WindowControllersManager.shared.mainWindowControllers[0].mainViewController.tabCollectionViewModel
+        Application.appDelegate.windowControllersManager.mainWindowControllers[0].mainViewController.tabCollectionViewModel
             .append(tab: Tab(content: .none))
-        WindowControllersManager.shared.mainWindowControllers[0].mainViewController.tabCollectionViewModel
+        Application.appDelegate.windowControllersManager.mainWindowControllers[0].mainViewController.tabCollectionViewModel
             .append(tab: Tab(content: .none))
-        WindowControllersManager.shared.mainWindowControllers[0].mainViewController.tabCollectionViewModel
+        Application.appDelegate.windowControllersManager.mainWindowControllers[0].mainViewController.tabCollectionViewModel
             .append(tab: Tab(content: .none))
 
         // 2 events should be fired: 1 for tabs reordering, 1 for selectionIndex change
         let e = expect(description: "Reordering tabs fires State changes", events: 2)
-        WindowControllersManager.shared.stateChanged
+        Application.appDelegate.windowControllersManager.stateChanged
             .sink { _ in
                 e.fulfill()
             }.store(in: &cancellables)
 
-        WindowControllersManager.shared.mainWindowControllers[0].mainViewController.tabCollectionViewModel
+        Application.appDelegate.windowControllersManager.mainWindowControllers[0].mainViewController.tabCollectionViewModel
             .moveTab(at: 2, to: 0)
 
         waitForExpectations(timeout: 0.3, handler: nil)
@@ -220,13 +220,13 @@ final class AppStateChangePublisherTests: XCTestCase {
         WindowsManager.openNewWindow(with: Tab(content: .none))
 
         var e: XCTestExpectation? = expectation(description: "Reordering tabs fires State changes")
-        WindowControllersManager.shared.stateChanged
+        Application.appDelegate.windowControllersManager.stateChanged
             .sink { _ in
                 e?.fulfill()
                 e = nil
             }.store(in: &cancellables)
 
-        WindowControllersManager.shared.mainWindowControllers[0].mainViewController.tabCollectionViewModel
+        Application.appDelegate.windowControllersManager.mainWindowControllers[0].mainViewController.tabCollectionViewModel
             .tabViewModel(at: 0)!.tab.setContent(.url(URL(string: "https://duckduckgo.com")!, source: .link))
 
         waitForExpectations(timeout: 0.3, handler: nil)
@@ -237,12 +237,12 @@ final class AppStateChangePublisherTests: XCTestCase {
         WindowsManager.openNewWindow(with: Tab(content: .none))
 
         let e = expectation(description: "Reordering tabs fires State changes")
-        WindowControllersManager.shared.stateChanged
+        Application.appDelegate.windowControllersManager.stateChanged
             .sink { _ in
                 e.fulfill()
             }.store(in: &cancellables)
 
-        WindowControllersManager.shared.mainWindowControllers[0].mainViewController.tabCollectionViewModel
+        Application.appDelegate.windowControllersManager.mainWindowControllers[0].mainViewController.tabCollectionViewModel
             .tabViewModel(at: 0)!.tab.favicon = NSImage()
 
         waitForExpectations(timeout: 0.3, handler: nil)

--- a/macOS/IntegrationTests/App/DeallocationTests.swift
+++ b/macOS/IntegrationTests/App/DeallocationTests.swift
@@ -26,7 +26,7 @@ final class DeallocationTests: XCTestCase {
 
     @MainActor
     override func setUp() {
-        assert(WindowControllersManager.shared.mainWindowControllers.isEmpty)
+        assert(Application.appDelegate.windowControllersManager.mainWindowControllers.isEmpty)
         animationDuration = NSAnimationContext.current.duration
         NSAnimationContext.current.duration = 0
     }
@@ -34,8 +34,8 @@ final class DeallocationTests: XCTestCase {
     @MainActor
     override func tearDown() {
         WindowsManager.closeWindows()
-        for controller in WindowControllersManager.shared.mainWindowControllers {
-            WindowControllersManager.shared.unregister(controller)
+        for controller in Application.appDelegate.windowControllersManager.mainWindowControllers {
+            Application.appDelegate.windowControllersManager.unregister(controller)
         }
         NSAnimationContext.current.duration = animationDuration
     }
@@ -67,34 +67,34 @@ final class DeallocationTests: XCTestCase {
             WindowsManager.openNewWindow(with: .duckDuckGo, source: .ui, isBurner: false)
             WindowsManager.openNewWindow(with: .duckDuckGo, source: .ui, isBurner: true)
 
-            for i in 0..<WindowControllersManager.shared.mainWindowControllers.count {
-                WindowControllersManager.shared.mainWindowControllers[i].mainViewController.tabCollectionViewModel
+            for i in 0..<Application.appDelegate.windowControllersManager.mainWindowControllers.count {
+                Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController.tabCollectionViewModel
                     .appendNewTab()
 
-                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i])
-                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].window!)
-                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController)
+                expectDeallocation(of: Application.appDelegate.windowControllersManager.mainWindowControllers[i])
+                expectDeallocation(of: Application.appDelegate.windowControllersManager.mainWindowControllers[i].window!)
+                expectDeallocation(of: Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController)
 
-                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.tabBarViewController)
-                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.navigationBarViewController)
-                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.browserTabViewController)
-                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.findInPageViewController)
-                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.fireViewController)
+                expectDeallocation(of: Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController.tabBarViewController)
+                expectDeallocation(of: Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController.navigationBarViewController)
+                expectDeallocation(of: Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController.browserTabViewController)
+                expectDeallocation(of: Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController.findInPageViewController)
+                expectDeallocation(of: Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController.fireViewController)
 
-                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.tabCollectionViewModel)
-                for tab in WindowControllersManager.shared.mainWindowControllers[i].mainViewController.tabCollectionViewModel.tabCollection.tabs {
+                expectDeallocation(of: Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController.tabCollectionViewModel)
+                for tab in Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController.tabCollectionViewModel.tabCollection.tabs {
                     expectDeallocation(of: tab)
                     expectDeallocation(of: tab.webView)
                 }
             }
 
-            for wc in WindowControllersManager.shared.mainWindowControllers {
+            for wc in Application.appDelegate.windowControllersManager.mainWindowControllers {
                 wc.window!.close()
             }
 
             repeat {
                 RunLoop.main.run(until: Date() + 0.1)
-            } while WindowControllersManager.shared.mainWindowControllers.contains(where: { $0.window?.isVisible == true })
+            } while Application.appDelegate.windowControllersManager.mainWindowControllers.contains(where: { $0.window?.isVisible == true })
         }
         waitForExpectations(timeout: 5, handler: nil)
     }
@@ -108,36 +108,36 @@ final class DeallocationTests: XCTestCase {
             WindowsManager.openNewWindow(with: .duckDuckGo, source: .ui, isBurner: false)
             WindowsManager.openNewWindow(with: .duckDuckGo, source: .ui, isBurner: true)
 
-            for i in 0..<WindowControllersManager.shared.mainWindowControllers.count {
-                WindowControllersManager.shared.mainWindowControllers[i].mainViewController.tabCollectionViewModel
+            for i in 0..<Application.appDelegate.windowControllersManager.mainWindowControllers.count {
+                Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController.tabCollectionViewModel
                     .appendNewTab()
 
-                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i])
-                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].window!)
-                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController)
+                expectDeallocation(of: Application.appDelegate.windowControllersManager.mainWindowControllers[i])
+                expectDeallocation(of: Application.appDelegate.windowControllersManager.mainWindowControllers[i].window!)
+                expectDeallocation(of: Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController)
 
-                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.tabBarViewController)
-                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.navigationBarViewController)
-                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.browserTabViewController)
-                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.findInPageViewController)
-                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.fireViewController)
+                expectDeallocation(of: Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController.tabBarViewController)
+                expectDeallocation(of: Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController.navigationBarViewController)
+                expectDeallocation(of: Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController.browserTabViewController)
+                expectDeallocation(of: Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController.findInPageViewController)
+                expectDeallocation(of: Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController.fireViewController)
 
-                expectDeallocation(of: WindowControllersManager.shared.mainWindowControllers[i].mainViewController.tabCollectionViewModel)
-                for tab in WindowControllersManager.shared.mainWindowControllers[i].mainViewController.tabCollectionViewModel.tabCollection.tabs {
+                expectDeallocation(of: Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController.tabCollectionViewModel)
+                for tab in Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController.tabCollectionViewModel.tabCollection.tabs {
                     expectDeallocation(of: tab)
                     expectDeallocation(of: tab.webView)
                 }
             }
 
-            for i in (0..<WindowControllersManager.shared.mainWindowControllers.count).reversed() {
-                for _ in 0..<WindowControllersManager.shared.mainWindowControllers[i].mainViewController.tabCollectionViewModel.tabCollection.tabs.count {
-                    WindowControllersManager.shared.mainWindowControllers[i].mainViewController.closeTab(self)
+            for i in (0..<Application.appDelegate.windowControllersManager.mainWindowControllers.count).reversed() {
+                for _ in 0..<Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController.tabCollectionViewModel.tabCollection.tabs.count {
+                    Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController.closeTab(self)
                 }
             }
 
             repeat {
                 RunLoop.main.run(until: Date() + 0.1)
-            } while WindowControllersManager.shared.mainWindowControllers.contains(where: { $0.window?.isVisible == true })
+            } while Application.appDelegate.windowControllersManager.mainWindowControllers.contains(where: { $0.window?.isVisible == true })
         }
         waitForExpectations(timeout: 5, handler: nil)
     }

--- a/macOS/IntegrationTests/Fire/FireTests.swift
+++ b/macOS/IntegrationTests/Fire/FireTests.swift
@@ -30,8 +30,8 @@ final class FireTests: XCTestCase {
     @MainActor
     override func tearDown() {
         WindowsManager.closeWindows()
-        for controller in WindowControllersManager.shared.mainWindowControllers {
-            WindowControllersManager.shared.unregister(controller)
+        for controller in Application.appDelegate.windowControllersManager.mainWindowControllers {
+            Application.appDelegate.windowControllersManager.unregister(controller)
         }
     }
 
@@ -45,7 +45,7 @@ final class FireTests: XCTestCase {
         let fire = Fire(cacheManager: manager,
                         historyCoordinating: historyCoordinator,
                         permissionManager: permissionManager,
-                        windowControllerManager: WindowControllersManager.shared,
+                        windowControllerManager: Application.appDelegate.windowControllersManager,
                         faviconManagement: faviconManager,
                         tld: ContentBlocking.shared.tld)
 
@@ -83,7 +83,7 @@ final class FireTests: XCTestCase {
         let fire = Fire(cacheManager: manager,
                         historyCoordinating: historyCoordinator,
                         permissionManager: permissionManager,
-                        windowControllerManager: WindowControllersManager.shared,
+                        windowControllerManager: Application.appDelegate.windowControllersManager,
                         faviconManagement: faviconManager,
                         pinnedTabsManagerProvider: pinnedTabsManagerProvider,
                         tld: ContentBlocking.shared.tld)
@@ -115,7 +115,7 @@ final class FireTests: XCTestCase {
                         historyCoordinating: historyCoordinator,
                         permissionManager: permissionManager,
                         savedZoomLevelsCoordinating: zoomLevelsCoordinator,
-                        windowControllerManager: WindowControllersManager.shared,
+                        windowControllerManager: Application.appDelegate.windowControllersManager,
                         faviconManagement: faviconManager,
                         recentlyClosedCoordinator: recentlyClosedCoordinator,
                         tld: ContentBlocking.shared.tld,
@@ -231,7 +231,7 @@ final class FireTests: XCTestCase {
         let fire = Fire(cacheManager: manager,
                         historyCoordinating: historyCoordinator,
                         permissionManager: permissionManager,
-                        windowControllerManager: WindowControllersManager.shared,
+                        windowControllerManager: Application.appDelegate.windowControllersManager,
                         faviconManagement: faviconManager,
                         recentlyClosedCoordinator: recentlyClosedCoordinator,
                         tld: ContentBlocking.shared.tld,
@@ -271,7 +271,7 @@ final class FireTests: XCTestCase {
         let fire = Fire(cacheManager: manager,
                         historyCoordinating: historyCoordinator,
                         permissionManager: permissionManager,
-                        windowControllerManager: WindowControllersManager.shared,
+                        windowControllerManager: Application.appDelegate.windowControllersManager,
                         faviconManagement: faviconManager,
                         recentlyClosedCoordinator: recentlyClosedCoordinator,
                         tld: ContentBlocking.shared.tld,
@@ -328,7 +328,7 @@ fileprivate extension TabCollectionViewModel {
     @MainActor
     static func makeTabCollectionViewModel(with pinnedTabsManagerProvider: PinnedTabsManagerProviding? = nil) -> TabCollectionViewModel {
 
-        let tabCollectionViewModel = TabCollectionViewModel(tabCollection: .init(), pinnedTabsManagerProvider: pinnedTabsManagerProvider ?? WindowControllersManager.shared.pinnedTabsManagerProvider)
+        let tabCollectionViewModel = TabCollectionViewModel(tabCollection: .init(), pinnedTabsManagerProvider: pinnedTabsManagerProvider ?? Application.appDelegate.windowControllersManager.pinnedTabsManagerProvider)
         tabCollectionViewModel.append(tab: Tab(content: .none))
         tabCollectionViewModel.append(tab: Tab(content: .none))
         return tabCollectionViewModel

--- a/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
+++ b/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
@@ -336,7 +336,7 @@ final class BrowserTabViewControllerOnboardingTests: XCTestCase {
         window.isVisible = false
         let mainWindowController = MainWindowController(window: window, mainViewController: mainViewController, popUp: false)
         mainWindowController.window = window
-        WindowControllersManager.shared.lastKeyMainWindowController = mainWindowController
+        Application.appDelegate.windowControllersManager.lastKeyMainWindowController = mainWindowController
 
         // WHEN
         window.isVisible = true

--- a/macOS/IntegrationTests/Onboarding/ContextualDaxDialogFactoryIntegrationTests.swift
+++ b/macOS/IntegrationTests/Onboarding/ContextualDaxDialogFactoryIntegrationTests.swift
@@ -57,7 +57,7 @@ final class ContextualDaxDialogFactoryIntegrationTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for FirePopover to appear")
         self.waitForPopoverToAppear(expectation: expectation)
         wait(for: [expectation], timeout: 3.0)
-        WindowControllersManager.shared.lastKeyMainWindowController?.window?.close()
+        Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.window?.close()
     }
 
     @MainActor private func waitForPopoverToAppear(expectation: XCTestExpectation) {

--- a/macOS/IntegrationTests/Onboarding/OnboardingNavigatingTests.swift
+++ b/macOS/IntegrationTests/Onboarding/OnboardingNavigatingTests.swift
@@ -26,14 +26,14 @@ final class OnboardingNavigatingTests: XCTestCase {
     @MainActor
     override func setUp() {
         super.setUp()
-        onboardingNavigation = WindowControllersManager.shared
-        assert(WindowControllersManager.shared.mainWindowControllers.isEmpty)
+        onboardingNavigation = Application.appDelegate.windowControllersManager
+        assert(Application.appDelegate.windowControllersManager.mainWindowControllers.isEmpty)
     }
 
     @MainActor
     override func tearDown() {
         onboardingNavigation = nil
-        WindowControllersManager.shared.lastKeyMainWindowController = nil
+        Application.appDelegate.windowControllersManager.lastKeyMainWindowController = nil
         super.tearDown()
     }
 
@@ -43,7 +43,7 @@ final class OnboardingNavigatingTests: XCTestCase {
         let mockWindow = MockWindow(isVisible: false)
         let mvc = MainWindowController(window: mockWindow, mainViewController: MainViewController(autofillPopoverPresenter: DefaultAutofillPopoverPresenter()), popUp: false)
         mvc.window = mockWindow
-        WindowControllersManager.shared.lastKeyMainWindowController = mvc
+        Application.appDelegate.windowControllersManager.lastKeyMainWindowController = mvc
 
         // When
         onboardingNavigation.showImportDataView()
@@ -58,13 +58,13 @@ final class OnboardingNavigatingTests: XCTestCase {
         let mockWindow = MockWindow(isVisible: false)
         let mvc = MainWindowController(window: mockWindow, mainViewController: MainViewController(autofillPopoverPresenter: DefaultAutofillPopoverPresenter()), popUp: false)
         mvc.window = mockWindow
-        WindowControllersManager.shared.lastKeyMainWindowController = mvc
+        Application.appDelegate.windowControllersManager.lastKeyMainWindowController = mvc
 
         // When
         onboardingNavigation.focusOnAddressBar()
 
         // Then
-        let mainVC = try XCTUnwrap(WindowControllersManager.shared.lastKeyMainWindowController?.mainViewController)
+        let mainVC = try XCTUnwrap(Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.mainViewController)
         XCTAssertTrue(mainVC.navigationBarViewController.addressBarViewController?.addressBarTextField.stringValue.isEmpty ?? false)
         XCTAssertTrue(mainVC.navigationBarViewController.addressBarViewController?.addressBarTextField.isFirstResponder ?? false)
     }

--- a/macOS/IntegrationTests/PinnedTabs/PinnedTabsManagerProviderTests.swift
+++ b/macOS/IntegrationTests/PinnedTabs/PinnedTabsManagerProviderTests.swift
@@ -45,7 +45,7 @@ final class PinnedTabsManagerProviderTests: XCTestCase {
         tabsPreferences = nil
         cancellables.removeAll()
 
-        WindowControllersManager.shared.mainWindowControllers.forEach { $0.close() }
+        Application.appDelegate.windowControllersManager.mainWindowControllers.forEach { $0.close() }
         super.tearDown()
     }
 

--- a/macOS/UnitTests/Fire/FirePopoverViewModelTests.swift
+++ b/macOS/UnitTests/Fire/FirePopoverViewModelTests.swift
@@ -33,7 +33,7 @@ final class FirePopoverViewModelTests: XCTestCase {
         let fire = Fire(cacheManager: manager,
                         historyCoordinating: historyCoordinator,
                         permissionManager: permissionManager,
-                        windowControllerManager: WindowControllersManager.shared,
+                        windowControllerManager: Application.appDelegate.windowControllersManager,
                         faviconManagement: faviconManager,
                         tld: ContentBlocking.shared.tld)
         return FirePopoverViewModel(

--- a/macOS/UnitTests/Onboarding/ContextualOnboarding/ContextualDaxDialogsFactoryTests.swift
+++ b/macOS/UnitTests/Onboarding/ContextualOnboarding/ContextualDaxDialogsFactoryTests.swift
@@ -35,7 +35,7 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         factory = nil
         delegate = nil
         reporter = nil
-        WindowControllersManager.shared.lastKeyMainWindowController = nil
+        Application.appDelegate.windowControllersManager.lastKeyMainWindowController = nil
     }
 
     func testWhenMakeViewForTryASearchThenOnboardingTrySearchDialogViewCreatedAndOnActionExpectedSearchOccurs() throws {
@@ -240,7 +240,7 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         let window = MockWindow(isVisible: false)
         let mainWindowController = MainWindowController(window: window, mainViewController: mainViewController, popUp: false)
         mainWindowController.window = window
-        WindowControllersManager.shared.lastKeyMainWindowController = mainWindowController
+        Application.appDelegate.windowControllersManager.lastKeyMainWindowController = mainWindowController
 
         // WHEN
         let result = factory.makeView(for: dialogType, delegate: delegate, onDismiss: onDismiss, onGotItPressed: {}, onFireButtonPressed: onFireButtonPressed)

--- a/macOS/UnitTests/Onboarding/ContextualOnboarding/OnboardingFireButtonDialogViewModelTests.swift
+++ b/macOS/UnitTests/Onboarding/ContextualOnboarding/OnboardingFireButtonDialogViewModelTests.swift
@@ -48,7 +48,7 @@ final class OnboardingFireButtonDialogViewModelTests: XCTestCase {
     override func tearDownWithError() throws {
         reporter = nil
         viewModel = nil
-        WindowControllersManager.shared.lastKeyMainWindowController = nil
+        Application.appDelegate.windowControllersManager.lastKeyMainWindowController = nil
     }
 
     func testWhenHighFiveThenOnGotItAndOnDismissPressed() throws {
@@ -64,7 +64,7 @@ final class OnboardingFireButtonDialogViewModelTests: XCTestCase {
         let window = MockWindow(isVisible: false)
         let mainWindowController = MainWindowController(window: window, mainViewController: mainViewController, popUp: false)
         mainWindowController.window = window
-        WindowControllersManager.shared.lastKeyMainWindowController = mainWindowController
+        Application.appDelegate.windowControllersManager.lastKeyMainWindowController = mainWindowController
 
         window.isVisible = true
         viewModel.tryFireButton()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1210462150349743?focus=true

### Description
This is a clean-up after removing the singleton. This change removes the computed `.shared` property
and replaces it with AppDelegate property.

### Testing Steps
Verify that CI is green.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)