### PR TITLE
macOS Visual Refresh: Fix rounded corners on add tab button on legacy

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarFooter.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarFooter.swift
@@ -60,7 +60,7 @@ final class TabBarFooter: NSView, NSCollectionViewElement {
         addButton.imagePosition = .imageOnly
         addButton.imageScaling = .scaleNone
         addButton.registerForDraggedTypes([.string])
-        addButton.setCornerRadius(visualStyle.toolbarButtonsCornerRadius)
+        addButton.cornerRadius = visualStyle.toolbarButtonsCornerRadius
         toolTip = UserText.newTabTooltip
 
         addSubview(addButton)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1210462202068006?focus=true
Tech Design URL:
CC:

### Description
Fix corner radius of the add tab button on the legacy UI.

### Testing Steps
1. Run the app
2. Go to Debug -> Feature Flags Override, and select the `visualRefresh` this will set the flag to off
3. Restart the application or open a new window
4. Check the add tab button in the tab bar has rounded corners

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing specific

### Quality Considerations
Nothing specific

### Notes to Reviewer
Nothing specific

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)