### PR TITLE
macOS Visual Refresh: Hide adjacent separators when hovering pinned tabs

### DIFF
--- a/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
+++ b/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
@@ -50,7 +50,7 @@ struct PinnedTabView: View, DropDelegate {
                     foregroundColor: foregroundColor,
                     separatorColor: Color(tabStyleProvider.separatorColor),
                     separatorHeight: tabStyleProvider.separatorHeight,
-                    drawSeparator: !collectionModel.itemsWithoutSeparator.contains(model),
+                    drawSeparator: shouldDrawSeparator,
                     showSShaped: tabStyleProvider.shouldShowSShapedTab,
                     applyTabShadow: tabStyleProvider.applyTabShadow,
                     roundedHover: tabStyleProvider.isRoundedBackgroundPresentOnHover
@@ -76,6 +76,15 @@ struct PinnedTabView: View, DropDelegate {
         if controlActiveState == .key {
             stack.onHover { [weak collectionModel, weak model] isHovered in
                 collectionModel?.hoveredItem = isHovered ? model : nil
+                // Notify adjacent tabs to update their separators
+                if let model = model, let index = collectionModel?.items.firstIndex(of: model) {
+                    if index > 0 {
+                        collectionModel?.items[index - 1].needsSeparatorUpdate = true
+                    }
+                    if index < (collectionModel?.items.count ?? 0) - 1 {
+                        collectionModel?.items[index + 1].needsSeparatorUpdate = true
+                    }
+                }
             }
         } else {
             stack
@@ -108,6 +117,22 @@ struct PinnedTabView: View, DropDelegate {
         }
         let isHovered = collectionModel.hoveredItem == model
         return showsHover && isHovered ? Color(tabStyleProvider.selectedTabColor) : Color.clear
+    }
+
+    private var shouldDrawSeparator: Bool {
+        let isHovered = collectionModel.hoveredItem == model
+        let rightItemIsHovered: Bool = {
+            guard let index = collectionModel.items.firstIndex(of: model),
+                  index < collectionModel.items.count - 1
+            else { return false }
+            return collectionModel.hoveredItem == collectionModel.items[index + 1]
+        }()
+
+        if tabStyleProvider.isRoundedBackgroundPresentOnHover && (isHovered || rightItemIsHovered) {
+            return false
+        }
+
+        return !isSelected && !collectionModel.itemsWithoutSeparator.contains(model)
     }
 
     @ViewBuilder

--- a/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
+++ b/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
@@ -116,7 +116,7 @@ struct PinnedTabView: View, DropDelegate {
             return Color(tabStyleProvider.selectedTabColor)
         }
         let isHovered = collectionModel.hoveredItem == model
-        return showsHover && isHovered ? Color(tabStyleProvider.selectedTabColor) : Color.clear
+        return showsHover && isHovered ? Color(tabStyleProvider.hoverTabColor) : Color.clear
     }
 
     private var shouldDrawSeparator: Bool {

--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -507,6 +507,9 @@ protocol NewWindowPolicyDecisionMaker {
         }
     }
 
+    /// Used to trigger a separator update in the PinnedTabsViewModel
+    @Published var needsSeparatorUpdate: Bool = false
+
     /// Currently committed page security origin (protocol, host, port).
     ///
     /// Set to the opener location security origin for popup Tabs.

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -199,7 +199,6 @@ final class TabBarItemCellView: NSView {
 
     fileprivate let mouseOverView = {
         let mouseOverView = MouseOverView()
-        mouseOverView.mouseOverColor = .tabMouseOver
         return mouseOverView
     }()
 
@@ -274,6 +273,7 @@ final class TabBarItemCellView: NSView {
             .layerMinXMaxYCorner,
             .layerMaxXMaxYCorner
         ]
+        mouseOverView.mouseOverColor = visualStyle.tabStyleProvider.hoverTabColor
 
         if visualStyle.tabStyleProvider.shouldShowSShapedTab {
             addSubview(leftRampView)

--- a/macOS/DuckDuckGo/VisualRefresh/TabStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/TabStyleProviding.swift
@@ -28,6 +28,7 @@ protocol TabStyleProviding {
 
     var shouldShowSShapedTab: Bool { get }
     var selectedTabColor: NSColor { get }
+    var hoverTabColor: NSColor { get }
     var isRoundedBackgroundPresentOnHover: Bool { get }
     var tabSpacing: CGFloat { get }
     var applyTabShadow: Bool { get }
@@ -45,6 +46,7 @@ final class LegacyTabStyleProvider: TabStyleProviding {
     let pinnedTabHeight: CGFloat = 34
     let shouldShowSShapedTab = false
     let selectedTabColor: NSColor = .navigationBarBackground
+    let hoverTabColor: NSColor = .tabMouseOver
     let isRoundedBackgroundPresentOnHover = false
     let tabSpacing: CGFloat = 0
     let applyTabShadow: Bool = false
@@ -57,6 +59,7 @@ final class NewlineTabStyleProvider: TabStyleProviding {
 
     var separatorColor: NSColor { palette.decorationTertiary }
     var selectedTabColor: NSColor { palette.surfacePrimary }
+    var hoverTabColor: NSColor { palette.controlsFillPrimary }
 
     let separatorHeight: CGFloat = 16
     let tabsScrollViewHeight: CGFloat = 38


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1210438924680753?focus=true
Tech Design URL:
CC:

### Description
In the Ship Review, we added some logic to hide adjacent separators when hoving a standard tab. Now, we are adding the same for pinned tabs.

https://github.com/user-attachments/assets/c82f9e67-3162-4e28-b692-4ab8869be6f7


### Testing Steps
1. Run the app
2. Pin some tabs
3. Hover the pinned tabs, check that adjacent separators are hidden when hovering.
4. Turn the visual refresh flag off (Debug -> Feature Flags Overrides, visualRefresh)
5. Check that adjacent separators are always visible on legacy UI

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
This goes to production.

### Quality Considerations
Nothing specific

### Notes to Reviewer
Nothing specific

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)