### PR TITLE
Prevent showing remote message before visual updates are applied in runtime

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -501,6 +501,8 @@
 		6FE127432C204DF700EB5724 /* FavoriteItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE127422C204DF700EB5724 /* FavoriteItemView.swift */; };
 		6FE127462C2054A900EB5724 /* NewTabPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE127452C2054A900EB5724 /* NewTabPageViewController.swift */; };
 		6FE1274B2C20943500EB5724 /* ShortcutItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE1274A2C20943500EB5724 /* ShortcutItemView.swift */; };
+		6FE23A862DF193CF00E44664 /* RemoteMessagingConfigMatcherProviderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE23A852DF193CF00E44664 /* RemoteMessagingConfigMatcherProviderTest.swift */; };
+		6FE23A892DF1945000E44664 /* MockInternalUserDecider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE23A882DF1944800E44664 /* MockInternalUserDecider.swift */; };
 		6FE3AEFB2D9D8933001AE6B8 /* trackers-2-new.json in Resources */ = {isa = PBXBuildFile; fileRef = 6FE3AEF92D9D8933001AE6B8 /* trackers-2-new.json */; };
 		6FE3AEFC2D9D8933001AE6B8 /* dark-trackers-3-new.json in Resources */ = {isa = PBXBuildFile; fileRef = 6FE3AEF62D9D8933001AE6B8 /* dark-trackers-3-new.json */; };
 		6FE3AEFD2D9D8933001AE6B8 /* dark-shield-new.json in Resources */ = {isa = PBXBuildFile; fileRef = 6FE3AEF32D9D8933001AE6B8 /* dark-shield-new.json */; };
@@ -2104,6 +2106,8 @@
 		6FE127422C204DF700EB5724 /* FavoriteItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteItemView.swift; sourceTree = "<group>"; };
 		6FE127452C2054A900EB5724 /* NewTabPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageViewController.swift; sourceTree = "<group>"; };
 		6FE1274A2C20943500EB5724 /* ShortcutItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutItemView.swift; sourceTree = "<group>"; };
+		6FE23A852DF193CF00E44664 /* RemoteMessagingConfigMatcherProviderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteMessagingConfigMatcherProviderTest.swift; sourceTree = "<group>"; };
+		6FE23A882DF1944800E44664 /* MockInternalUserDecider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInternalUserDecider.swift; sourceTree = "<group>"; };
 		6FE3AEF32D9D8933001AE6B8 /* dark-shield-new.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "dark-shield-new.json"; sourceTree = "<group>"; };
 		6FE3AEF42D9D8933001AE6B8 /* dark-trackers-1-new.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "dark-trackers-1-new.json"; sourceTree = "<group>"; };
 		6FE3AEF52D9D8933001AE6B8 /* dark-trackers-2-new.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "dark-trackers-2-new.json"; sourceTree = "<group>"; };
@@ -4950,6 +4954,14 @@
 			name = Shortcuts;
 			sourceTree = "<group>";
 		};
+		6FE23A842DF193BE00E44664 /* RemoteMessage */ = {
+			isa = PBXGroup;
+			children = (
+				6FE23A852DF193CF00E44664 /* RemoteMessagingConfigMatcherProviderTest.swift */,
+			);
+			path = RemoteMessage;
+			sourceTree = "<group>";
+		};
 		6FE3AEF22D9D8901001AE6B8 /* New */ = {
 			isa = PBXGroup;
 			children = (
@@ -7222,6 +7234,7 @@
 		F12D98401F266B30003C2EE3 /* DuckDuckGo */ = {
 			isa = PBXGroup;
 			children = (
+				6FE23A842DF193BE00E44664 /* RemoteMessage */,
 				56CA25EC2DB7ABAC00BE4226 /* Localization */,
 				6FF9157F2B88E04F0042AC87 /* AdAttribution */,
 				F17669A21E411D63003D3222 /* Application */,
@@ -7517,6 +7530,7 @@
 		F17669A91E412A17003D3222 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				6FE23A882DF1944800E44664 /* MockInternalUserDecider.swift */,
 				31CE145F2D552EBB0027F11D /* MockAIChatSettingsProvider.swift */,
 				C14882E927F20DD000D59F0C /* MockBookmarksCoreDataStorage.swift */,
 				CBDD5DE029A6741300832877 /* MockBundle.swift */,
@@ -9744,6 +9758,7 @@
 				31CE14602D552EBB0027F11D /* MockAIChatSettingsProvider.swift in Sources */,
 				85C29708247BDD060063A335 /* DaxDialogsBrowsingSpecTests.swift in Sources */,
 				9FE05CF12C36468A00D9046B /* OnboardingPixelReporterTests.swift in Sources */,
+				6FE23A862DF193CF00E44664 /* RemoteMessagingConfigMatcherProviderTest.swift in Sources */,
 				9FDEC7B42C8FD62F00C7A692 /* OnboardingAddressBarPositionPickerViewModelTests.swift in Sources */,
 				85BA58581F34F72F00C6E8CA /* AppUserDefaultsTests.swift in Sources */,
 				F1134EBC1F40D45700B73467 /* MockStatisticsStore.swift in Sources */,
@@ -9949,6 +9964,7 @@
 				22CB1ED8203DDD2C00D2C724 /* AppDeepLinksTests.swift in Sources */,
 				9847C00527A41A0A00DB07AA /* WebViewTestHelper.swift in Sources */,
 				6F7235412D3F974600710C07 /* MockTabInteractionStateSource.swift in Sources */,
+				6FE23A892DF1945000E44664 /* MockInternalUserDecider.swift in Sources */,
 				3170048227A9504F00C03F35 /* DownloadMocks.swift in Sources */,
 				317045C02858C6B90016ED1F /* AutofillInterfaceEmailTruncatorTests.swift in Sources */,
 				6FD3AEE32B8F4EEB0060FCCC /* AdAttributionPixelReporterTests.swift in Sources */,

--- a/iOS/DuckDuckGo/RemoteMessagingConfigMatcherProvider.swift
+++ b/iOS/DuckDuckGo/RemoteMessagingConfigMatcherProvider.swift
@@ -115,7 +115,21 @@ final class RemoteMessagingConfigMatcherProvider: RemoteMessagingConfigMatcherPr
         let shownMessageIds = store.fetchShownRemoteMessageIDs()
 
         let enabledFeatureFlags: [String] = FeatureFlag.allCases.filter { flag in
-            flag.cohortType == nil && featureFlagger.isFeatureOn(for: flag)
+            guard flag.cohortType == nil else { return false }
+
+            let isFlagEnabled: Bool
+            switch flag {
+            case .visualUpdates:
+                // Use value established at launch instead of live feature flag.
+                // This prevents showing remote message that's based on this flag prematurely,
+                // i.e. before `visualUpdates` flag becomes effective after restart.
+                // See https://app.asana.com/1/137249556945/project/1206226850447395/task/1210454132810101
+                isFlagEnabled = ThemeManager.shared.properties.isExperimentalThemingEnabled
+            default:
+                isFlagEnabled = featureFlagger.isFeatureOn(for: flag)
+            }
+
+            return isFlagEnabled
         }.map(\.rawValue)
 
         return RemoteMessagingConfigMatcher(

--- a/iOS/DuckDuckGo/RemoteMessagingConfigMatcherProvider.swift
+++ b/iOS/DuckDuckGo/RemoteMessagingConfigMatcherProvider.swift
@@ -36,13 +36,15 @@ final class RemoteMessagingConfigMatcherProvider: RemoteMessagingConfigMatcherPr
         appSettings: AppSettings,
         internalUserDecider: InternalUserDecider,
         duckPlayerStorage: DuckPlayerStorage,
-        featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger
+        featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
+        themeManager: ThemeManaging = ThemeManager.shared
     ) {
         self.bookmarksDatabase = bookmarksDatabase
         self.appSettings = appSettings
         self.internalUserDecider = internalUserDecider
         self.duckPlayerStorage = duckPlayerStorage
         self.featureFlagger = featureFlagger
+        self.themeManager = themeManager
     }
 
     let bookmarksDatabase: CoreDataDatabase
@@ -50,6 +52,7 @@ final class RemoteMessagingConfigMatcherProvider: RemoteMessagingConfigMatcherPr
     let duckPlayerStorage: DuckPlayerStorage
     let internalUserDecider: InternalUserDecider
     let featureFlagger: FeatureFlagger
+    let themeManager: ThemeManaging
 
     func refreshConfigMatcher(using store: RemoteMessagingStoring) async -> RemoteMessagingConfigMatcher {
 
@@ -124,7 +127,7 @@ final class RemoteMessagingConfigMatcherProvider: RemoteMessagingConfigMatcherPr
                 // This prevents showing remote message that's based on this flag prematurely,
                 // i.e. before `visualUpdates` flag becomes effective after restart.
                 // See https://app.asana.com/1/137249556945/project/1206226850447395/task/1210454132810101
-                isFlagEnabled = ThemeManager.shared.properties.isExperimentalThemingEnabled
+                isFlagEnabled = themeManager.properties.isExperimentalThemingEnabled
             default:
                 isFlagEnabled = featureFlagger.isFeatureOn(for: flag)
             }

--- a/iOS/DuckDuckGoTests/MockInternalUserDecider.swift
+++ b/iOS/DuckDuckGoTests/MockInternalUserDecider.swift
@@ -1,0 +1,34 @@
+//
+//  MockInternalUserDecider.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import BrowserServicesKit
+import Foundation
+import Combine
+
+final class MockInternalUserDecider: InternalUserDecider {
+    var isInternalUser: Bool = false
+
+    var isInternalUserPublisher: AnyPublisher<Bool, Never> {
+        Just(false).eraseToAnyPublisher()
+    }
+
+    func markUserAsInternalIfNeeded(forUrl url: URL?, response: HTTPURLResponse?) -> Bool {
+        return false
+    }
+}

--- a/iOS/DuckDuckGoTests/RemoteMessage/RemoteMessagingConfigMatcherProviderTest.swift
+++ b/iOS/DuckDuckGoTests/RemoteMessage/RemoteMessagingConfigMatcherProviderTest.swift
@@ -1,0 +1,101 @@
+//
+//  RemoteMessagingConfigMatcherProviderTest.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Foundation
+import Persistence
+import CoreData
+import Bookmarks
+import Core
+
+@testable import RemoteMessaging
+@testable import DuckDuckGo
+
+final class RemoteMessagingConfigMatcherProviderTest: XCTestCase {
+    var remoteMessagingConfigMatcherProvider: RemoteMessagingConfigMatcherProvider!
+    var themeManager: MockThemeManager!
+    var featureFlagger: MockFeatureFlagger!
+
+    override func setUp() {
+
+        themeManager = MockThemeManager()
+        featureFlagger = MockFeatureFlagger()
+
+        let bookmarksDB = CoreDataDatabase.bookmarksMock
+
+        remoteMessagingConfigMatcherProvider = RemoteMessagingConfigMatcherProvider(
+            bookmarksDatabase: bookmarksDB,
+            appSettings: AppSettingsMock(),
+            internalUserDecider: MockInternalUserDecider(),
+            duckPlayerStorage: MockDuckPlayerStorage(),
+            featureFlagger: featureFlagger,
+            themeManager: themeManager)
+    }
+
+    func testMatchesFeatureFlagAttributeForVisualUpdatesWhenEnabledInThemeManager() async {
+        themeManager.properties = .init(isExperimentalThemingEnabled: true)
+        featureFlagger.enabledFeatureFlags = []
+
+        let matcher = await remoteMessagingConfigMatcherProvider.refreshConfigMatcher(using: EmptyRemoteMessagingStore())
+        let matchingArray = AllFeatureFlagsEnabledMatchingAttribute(value: ["visualUpdates"])
+        let result = matcher.evaluateAttribute(matchingAttribute: matchingArray)
+
+        XCTAssertEqual(result, .match)
+    }
+
+    func testFailsMatchOfFeatureFlagAttributeForVisualUpdatesWhenDisabledInThemeManager() async {
+        themeManager.properties = .init(isExperimentalThemingEnabled: false)
+        featureFlagger.enabledFeatureFlags = [.visualUpdates]
+
+        let matcher = await remoteMessagingConfigMatcherProvider.refreshConfigMatcher(using: EmptyRemoteMessagingStore())
+        let matchingArray = AllFeatureFlagsEnabledMatchingAttribute(value: ["visualUpdates"])
+        let result = matcher.evaluateAttribute(matchingAttribute: matchingArray)
+
+        XCTAssertEqual(result, .fail)
+    }
+
+    override func tearDown() {
+        remoteMessagingConfigMatcherProvider = nil
+    }
+
+    private func setUpValidBookmarksDatabase() -> CoreDataDatabase? {
+        let location = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+
+        let bundle = Bookmarks.bundle
+        guard let model = CoreDataDatabase.loadModel(from: bundle, named: "BookmarksModel") else {
+            XCTFail("Failed to load model")
+            return nil
+        }
+        return CoreDataDatabase(name: type(of: self).description(),
+                                containerLocation: location,
+                                model: model)
+    }
+}
+
+private class EmptyRemoteMessagingStore: RemoteMessagingStoring {
+    func saveProcessedResult(_ processorResult: RemoteMessaging.RemoteMessagingConfigProcessor.ProcessorResult) async { }
+    func fetchRemoteMessagingConfig() -> RemoteMessaging.RemoteMessagingConfig? { nil }
+    func fetchScheduledRemoteMessage() -> RemoteMessaging.RemoteMessageModel? { nil }
+    func hasShownRemoteMessage(withID id: String) -> Bool { true }
+    func fetchShownRemoteMessageIDs() -> [String] { [] }
+    func dismissRemoteMessage(withID id: String) async { }
+    func fetchDismissedRemoteMessageIDs() -> [String] { [] }
+    func updateRemoteMessage(withID id: String, asShown shown: Bool) async { }
+    func resetRemoteMessages() async { }
+}

--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionFeatureFlagMappingTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionFeatureFlagMappingTests.swift
@@ -109,15 +109,3 @@ final class SubscriptionFeatureFlagMappingTests: XCTestCase {
         XCTAssertFalse(subscriptionFeatureFlagMapping.isFeatureOn(.usePrivacyProROWRegionOverride))
     }
 }
-
-final class MockInternalUserDecider: InternalUserDecider {
-    var isInternalUser: Bool = false
-
-    var isInternalUserPublisher: AnyPublisher<Bool, Never> {
-        Just(false).eraseToAnyPublisher()
-    }
-
-    func markUserAsInternalIfNeeded(forUrl url: URL?, response: HTTPURLResponse?) -> Bool {
-        return false
-    }
-}


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1210454132810101
Tech Design URL:
CC: @amddg44 

### Description

Uses value established at launch instead of live feature flag. This prevents prematurely showing visual updates remote message that's based on `visualUpdates` subfeature, in case when the visual updates are not yet applied at runtime (app was not relaunched).

### Testing Steps
1. Run the app, override the remote config with `https://www.jsonblob.com/api/1379474116607926272` (visualUpdates flag enabled)
2. In Debug -> Remote Messaging reset all to start with a clean state.
3. Override RMF config to https://staticcdn.duckduckgo.com/remotemessaging/config/staging/pre/ios-config.json (visual updates message from https://github.com/duckduckgo/remote-messaging-config/pull/189)
4. In Debug -> Remote Messaging there should only be duck.ai message logged.
5. Go to Home Screen and dismiss the duck.ai message if you haven't done it already.
6. Restart the app
7. New UI should be enabled and message visible on New Tab Page.

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
RMF could be affected by filtering. For tests I used config with another Remote Message so that this can be validated.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)