### PR TITLE
macOS: Disable VPN login items on expired subscriptions even if they are manually disabled by the user

### DIFF
--- a/macOS/DuckDuckGo/LoginItems/LoginItemsManager.swift
+++ b/macOS/DuckDuckGo/LoginItems/LoginItemsManager.swift
@@ -29,6 +29,7 @@ protocol LoginItemsManaging {
     func restartLoginItems(_ items: Set<LoginItem>)
 
     func isAnyEnabled(_ items: Set<LoginItem>) -> Bool
+    func isAnyInstalled(_ items: Set<LoginItem>) -> Bool
 }
 
 /// Class to manage the login items for the VPN and DBP
@@ -87,6 +88,12 @@ final class LoginItemsManager: LoginItemsManaging {
     func isAnyEnabled(_ items: Set<LoginItem>) -> Bool {
         return items.contains(where: { item in
             item.status == .enabled
+        })
+    }
+
+    func isAnyInstalled(_ items: Set<LoginItem>) -> Bool {
+        return items.contains(where: { item in
+            item.status.isInstalled
         })
     }
 

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNAppEventsHandler.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNAppEventsHandler.swift
@@ -71,18 +71,14 @@ final class VPNAppEventsHandler {
     ///
     private func loginItemsControlCheckpoint(canRestart: Bool) {
         Task { @MainActor [loginItemsManager] in
-            guard loginItemsManager.isAnyInstalled(LoginItemsManager.vpnLoginItems) else {
-                return
-            }
-
             switch try? await featureGatekeeper.canStartVPN() {
-            case .some(true):
+            case .some(true) where loginItemsManager.isAnyEnabled(LoginItemsManager.vpnLoginItems):
                 if canRestart {
                     restartLoginItem(using: loginItemsManager)
                 }
-            case .some(false):
+            case .some(false) where loginItemsManager.isAnyInstalled(LoginItemsManager.vpnLoginItems):
                 disableLoginItem(using: loginItemsManager)
-            case .none:
+            default:
                 break
             }
         }

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNAppEventsHandler.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNAppEventsHandler.swift
@@ -71,8 +71,7 @@ final class VPNAppEventsHandler {
     ///
     private func loginItemsControlCheckpoint(canRestart: Bool) {
         Task { @MainActor [loginItemsManager] in
-            guard loginItemsManager.isAnyEnabled(LoginItemsManager.vpnLoginItems) else {
-
+            guard loginItemsManager.isAnyInstalled(LoginItemsManager.vpnLoginItems) else {
                 return
             }
 

--- a/macOS/UnitTests/NetworkProtection/Mocks/MockLoginItemsManager.swift
+++ b/macOS/UnitTests/NetworkProtection/Mocks/MockLoginItemsManager.swift
@@ -29,18 +29,21 @@ struct MockLoginItemsManager: LoginItemsManaging {
     private let disableLoginItemsCallback: LoginItemsCallback
     private let restartLoginItemsCallback: LoginItemsCallback
     private let isAnyEnabledCallback: (Set<LoginItems.LoginItem>) -> Bool
+    private let isAnyInstalledCallback: (Set<LoginItems.LoginItem>) -> Bool
 
     init(enableLoginItemsCallback: @escaping LoginItemsCallback = { _ in },
          throwingEnableLoginItemsCallback: @escaping ThrowsLoginItemsCallback = { _ in },
          disableLoginItemsCallback: @escaping LoginItemsCallback = { _ in },
          restartLoginItemsCallback: @escaping LoginItemsCallback = { _ in },
-         isAnyEnabledCallback: @escaping (Set<LoginItems.LoginItem>) -> Bool) {
+         isAnyEnabledCallback: @escaping (Set<LoginItems.LoginItem>) -> Bool,
+         isAnyInstalledCallback: @escaping (Set<LoginItems.LoginItem>) -> Bool) {
 
         self.enableLoginItemsCallback = enableLoginItemsCallback
         self.throwingEnableLoginItemsCallback = throwingEnableLoginItemsCallback
         self.disableLoginItemsCallback = disableLoginItemsCallback
         self.restartLoginItemsCallback = restartLoginItemsCallback
         self.isAnyEnabledCallback = isAnyEnabledCallback
+        self.isAnyInstalledCallback = isAnyInstalledCallback
     }
 
     func enableLoginItems(_ items: Set<LoginItems.LoginItem>) {
@@ -61,5 +64,9 @@ struct MockLoginItemsManager: LoginItemsManaging {
 
     func isAnyEnabled(_ items: Set<LoginItems.LoginItem>) -> Bool {
         isAnyEnabledCallback(items)
+    }
+
+    func isAnyInstalled(_ items: Set<LoginItems.LoginItem>) -> Bool {
+        isAnyInstalledCallback(items)
     }
 }

--- a/macOS/UnitTests/NetworkProtection/VPNAppEventsHandlerTests.swift
+++ b/macOS/UnitTests/NetworkProtection/VPNAppEventsHandlerTests.swift
@@ -42,9 +42,11 @@ final class VPNAppEventsHandlerTests: XCTestCase {
             loginItemsDisabledExpectation.fulfill()
         }, restartLoginItemsCallback: { _ in
             loginItemsRestartedExpectation.fulfill()
-        }) { _ in
+        }, isAnyEnabledCallback: { _ in
             true
-        }
+        }, isAnyInstalledCallback: { _ in
+            true
+        })
 
         let appEventsHandler = VPNAppEventsHandler(
             featureGatekeeper: mockFeatureGatekeeper,
@@ -74,9 +76,11 @@ final class VPNAppEventsHandlerTests: XCTestCase {
             loginItemsDisabledExpectation.fulfill()
         }, restartLoginItemsCallback: { _ in
             loginItemsRestartedExpectation.fulfill()
-        }) { _ in
+        }, isAnyEnabledCallback: { _ in
             true
-        }
+        }, isAnyInstalledCallback: { _ in
+            true
+        })
 
         let appEventsHandler = VPNAppEventsHandler(
             featureGatekeeper: mockFeatureGatekeeper,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1210470416862601?focus=true

### Description

We want to disable the VPN login item when the subscription is expired even if the login item was manually disabled by the user in System Settings.  This helps ensure the VPN menu app won't load when enabled back by the user.

### Testing Steps

1. Connect the VPN so login items are loaded.
2. Disconnect it.
3. Restart the app, ensure the login items are restarted but not disabled.
4. Force [this](https://github.com/duckduckgo/apple-browsers/blob/06a80cdad3e04dc878cc096e4179be5a823a4869/macOS/DuckDuckGo/Waitlist/VPNFeatureGatekeeper.swift#L62) to return false.
5. Go to System Settings > General > Login Items & Extensions, and disable our login item
6. Start the App again
7. Go to System Settings > General > Login Items & Extensions, and enable our login item.
8. Make sure it's not loaded.

### Impact and Risks

Low

#### What could go wrong?

It's unlikely this change could affect anything.  The enabling and  disabling login items is a fairly lightweight process.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)