### PR TITLE
Pass GitHub token to asana-failed-pr-checks action

### DIFF
--- a/.github/actions/asana-failed-pr-checks/action.yml
+++ b/.github/actions/asana-failed-pr-checks/action.yml
@@ -19,7 +19,7 @@ inputs:
     type: string
   github-token:
     description: "GitHub token"
-    required: false
+    required: true
     type: string
 runs:
   using: "composite"

--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -275,6 +275,7 @@ jobs:
           asana-access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-section-id: ${{ vars.APPLE_CI_FAILING_TESTS_BSK_POST_MERGE_SECTION_ID }}
           commit-author: ${{ needs.unit-tests.outputs.commit_author }}
+          github-token: ${{ secrets.GH_RO_PAT }}
 
   close-asana-task:
     name: Close Asana Task
@@ -293,3 +294,4 @@ jobs:
           action: close-task
           asana-access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-section-id: ${{ vars.APPLE_CI_FAILING_TESTS_BSK_POST_MERGE_SECTION_ID }}
+          github-token: ${{ secrets.GH_RO_PAT }}

--- a/.github/workflows/dbp_pr_checks.yml
+++ b/.github/workflows/dbp_pr_checks.yml
@@ -224,6 +224,7 @@ jobs:
           asana-access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-section-id: ${{ vars.APPLE_CI_FAILING_TESTS_BSK_POST_MERGE_SECTION_ID }}
           commit-author: ${{ needs.unit-tests.outputs.commit_author }}
+          github-token: ${{ secrets.GH_RO_PAT }}
 
   close-asana-task:
     name: Close Asana Task
@@ -242,3 +243,4 @@ jobs:
           action: close-task
           asana-access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-section-id: ${{ vars.APPLE_CI_FAILING_TESTS_BSK_POST_MERGE_SECTION_ID }}
+          github-token: ${{ secrets.GH_RO_PAT }}

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -38,6 +38,8 @@ on:
         required: true
       ASANA_ACCESS_TOKEN:
         required: true
+      GH_RO_PAT:
+        required: true
       MATCH_PASSWORD:
         required: true
       SSH_PRIVATE_KEY_FASTLANE_MATCH:
@@ -270,6 +272,7 @@ jobs:
           asana-access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-section-id: ${{ vars.APPLE_CI_FAILING_TESTS_IOS_POST_MERGE_SECTION_ID }}
           commit-author: ${{ needs.unit-tests.outputs.commit_author }}
+          github-token: ${{ secrets.GH_RO_PAT }}
 
   close-asana-task:
     name: Close Asana Task
@@ -288,3 +291,4 @@ jobs:
           action: close-task
           asana-access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-section-id: ${{ vars.APPLE_CI_FAILING_TESTS_IOS_POST_MERGE_SECTION_ID }}
+          github-token: ${{ secrets.GH_RO_PAT }}

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -33,6 +33,8 @@ on:
         required: true
       ASANA_ACCESS_TOKEN:
         required: true
+      GH_RO_PAT:
+        required: true
       MATCH_PASSWORD:
         required: true
       SSH_PRIVATE_KEY_FASTLANE_MATCH:
@@ -454,6 +456,7 @@ jobs:
           asana-access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-section-id: ${{ vars.APPLE_CI_FAILING_TESTS_MACOS_POST_MERGE_SECTION_ID }}
           commit-author: ${{ needs.tests.outputs.commit_author }}
+          github-token: ${{ secrets.GH_RO_PAT }}
 
   close-asana-task:
     name: Close Asana Task
@@ -472,3 +475,4 @@ jobs:
           action: close-task
           asana-access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-section-id: ${{ vars.APPLE_CI_FAILING_TESTS_MACOS_POST_MERGE_SECTION_ID }}
+          github-token: ${{ secrets.GH_RO_PAT }}


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1210472527506627?focus=true

### Description
This change fixes calling asana-failed-pr-checks action by passing the GitHub token as a required parameter.

### Testing Steps
Verify that CI is green.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)