### PR TITLE
macOS Visual Refresh: Increase suggestion row size from 28 to 32

### DIFF
--- a/macOS/DuckDuckGo/VisualRefresh/AddressBarStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/AddressBarStyleProviding.swift
@@ -189,6 +189,6 @@ final class CurrentAddressBarStyleProvider: AddressBarStyleProviding {
     }
 
     func sizeForSuggestionRow(isHomePage: Bool) -> CGFloat {
-        return 28
+        return 32
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1210467121144321?focus=true
Tech Design URL:
CC:

### Description
We want to increase the size of the suggestions rows from `28` to `32`.

### Testing Steps
1. Run the app
2. Type something into the address bar
3. Check the size of the suggestion table view
4. Compare it with the production app
5. Check this one is taller

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing

### Quality Considerations
Nothing

### Notes to Reviewer
Nothing specific.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)