### PR TITLE
Use read-only mode when syncing signing assets for iOS AdHoc builds

### DIFF
--- a/iOS/fastlane/Fastfile
+++ b/iOS/fastlane/Fastfile
@@ -22,7 +22,7 @@ platform :ios do
 
   desc 'Fetches and updates certificates and provisioning profiles for Alpha distribution'
   lane :sync_signing_alpha do |options|
-    do_sync_signing()
+    do_sync_signing(options)
   end
 
   desc 'Fetches and updates certificates and provisioning profiles for Ad-Hoc distribution'

--- a/iOS/fastlane/Fastfile
+++ b/iOS/fastlane/Fastfile
@@ -17,17 +17,17 @@ platform :ios do
 
   desc 'Fetches and updates certificates and provisioning profiles for Ad-Hoc distribution'
   lane :sync_signing_adhoc do |options|
-    do_sync_signing(options)
+    do_sync_signing(options.merge(readonly: true))
   end
 
   desc 'Fetches and updates certificates and provisioning profiles for Alpha distribution'
   lane :sync_signing_alpha do |options|
-    do_sync_signing(options)
+    do_sync_signing()
   end
 
   desc 'Fetches and updates certificates and provisioning profiles for Ad-Hoc distribution'
   lane :sync_signing_alpha_adhoc do |options|
-    do_sync_signing(options)
+    do_sync_signing(options.merge(readonly: true))
   end
 
   desc 'Makes Ad-Hoc build with a specified name and alpha bundle ID in a given directory'
@@ -349,7 +349,9 @@ platform :ios do
     sync_code_signing(
       api_key: get_api_key,
       username: get_username(options),
-      readonly: !is_ci
+      # TODO: remove readonly once we have a way to manage certificates in CI
+      # https://github.com/fastlane/fastlane/issues/29499
+      readonly: options[:readonly] || !is_ci
     )
   end
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1210498413174262?focus=true

### Description
This change forces read-only mode for fastlane match calls due to the breakage recently
introduced by Apple: https://github.com/fastlane/fastlane/issues/29499

### Testing Steps
Verify that AdHoc build [from `dominik/fastlane-fix` branch](https://github.com/duckduckgo/apple-browsers/actions/runs/15534620889) works.
Verify that AdHoc build [from `main` branch](https://github.com/duckduckgo/apple-browsers/actions/runs/15534616163) fails to build.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)