### PR TITLE
Improve Feature Flags override menu

### DIFF
--- a/macOS/DuckDuckGo/InternalUserDecider/FeatureFlagOverridesMenu.swift
+++ b/macOS/DuckDuckGo/InternalUserDecider/FeatureFlagOverridesMenu.swift
@@ -34,8 +34,12 @@ final class FeatureFlagOverridesMenu: NSMenu {
             internalUserStateMenuItem()
             NSMenuItem.separator()
 
-            sectionHeader(title: "Feature Flags")
-            featureFlagMenuItems()
+            sectionHeader(title: "Categorized Feature Flags")
+            categotizedFeatureFlagMenuItems()
+            NSMenuItem.separator()
+
+            sectionHeader(title: "Uncategorized Feature Flags")
+            uncategorizedFeatureFlagMenuItems()
             NSMenuItem.separator()
 
             sectionHeader(title: "Experiments")
@@ -55,9 +59,9 @@ final class FeatureFlagOverridesMenu: NSMenu {
         return setInternalUserStateItem
     }
 
-    private func featureFlagMenuItems() -> [NSMenuItem] {
+    private func uncategorizedFeatureFlagMenuItems() -> [NSMenuItem] {
         return FeatureFlag.allCases
-            .filter { $0.supportsLocalOverriding && $0.cohortType == nil }
+            .filter { $0.supportsLocalOverriding && $0.cohortType == nil && $0.category == .none }
             .sorted(by: { $0.rawValue.caseInsensitiveCompare($1.rawValue) == .orderedAscending })
             .map { flag in
                 NSMenuItem(
@@ -66,6 +70,35 @@ final class FeatureFlagOverridesMenu: NSMenu {
                     target: self,
                     representedObject: flag
                 )
+            }
+    }
+
+    private func categotizedFeatureFlagMenuItems() -> [NSMenuItem] {
+        FeatureFlagCategory.allCases
+            .sorted { $0.rawValue.lowercased() < $1.rawValue.lowercased() }
+            .map { category in
+                let menuItem = NSMenuItem(title: category.rawValue)
+                let submenu = NSMenu(title: category.rawValue)
+                menuItem.submenu = submenu
+
+                let flagItems = FeatureFlag.allCases
+                    .filter {
+                        $0.supportsLocalOverriding
+                        && $0.cohortType == nil
+                        && $0.category == category
+                    }
+                    .sorted { $0.rawValue.lowercased() < $1.rawValue.lowercased() }
+                    .map { flag in
+                        NSMenuItem(
+                            title: menuItemTitle(for: flag),
+                            action: #selector(toggleFeatureFlag(_:)),
+                            target: self,
+                            representedObject: flag
+                        )
+                    }
+
+                submenu.items = flagItems
+                return menuItem
             }
     }
 
@@ -115,6 +148,7 @@ final class FeatureFlagOverridesMenu: NSMenu {
         let override = featureFlagger.localOverrides?.override(for: flag)
         let submenu = NSMenu()
         submenu.addItem(removeOverrideSubmenuItem(for: flag))
+        item.subtitle = "asd"
         item.state = override == true ? .on : .off
         item.submenu = override != nil ? submenu : nil
     }

--- a/macOS/DuckDuckGo/InternalUserDecider/FeatureFlagOverridesMenu.swift
+++ b/macOS/DuckDuckGo/InternalUserDecider/FeatureFlagOverridesMenu.swift
@@ -78,6 +78,7 @@ final class FeatureFlagOverridesMenu: NSMenu {
             .sorted { $0.rawValue.lowercased() < $1.rawValue.lowercased() }
             .map { category in
                 let menuItem = NSMenuItem(title: category.rawValue)
+                menuItem.representedObject = category
                 let submenu = NSMenu(title: category.rawValue)
                 menuItem.submenu = submenu
 
@@ -93,8 +94,7 @@ final class FeatureFlagOverridesMenu: NSMenu {
                             title: menuItemTitle(for: flag),
                             action: #selector(toggleFeatureFlag(_:)),
                             target: self,
-                            representedObject: flag
-                        )
+                            representedObject: flag)
                     }
 
                 submenu.items = flagItems
@@ -107,7 +107,7 @@ final class FeatureFlagOverridesMenu: NSMenu {
             .filter { $0.supportsLocalOverriding && $0.cohortType != nil }
             .map { experiment in
                 let experimentMenuItem = NSMenuItem(
-                    title: menuItemTitle(for: experiment),
+                    title: self.experimentMenuItemTitle(for: experiment),
                     action: nil,
                     target: self,
                     representedObject: experiment
@@ -129,11 +129,22 @@ final class FeatureFlagOverridesMenu: NSMenu {
 
     override func update() {
         super.update()
+        update(items)
+        setInternalUserStateItem.isHidden = featureFlagger.internalUserDecider.isInternalUser
+    }
 
-        items.forEach { item in
-            guard let flag = item.representedObject as? FeatureFlag else { return }
+    private func update(_ items: [NSMenuItem]) {
+        for item in items {
+            if let category = item.representedObject as? FeatureFlagCategory {
+                updateCategoryItem(item, category: category)
+                continue
+            }
+
+            guard let flag = item.representedObject as? FeatureFlag else {
+                continue
+            }
+
             item.isHidden = !featureFlagger.internalUserDecider.isInternalUser
-            item.title = menuItemTitle(for: flag)
 
             if flag.cohortType == nil {
                 updateFeatureFlagItem(item, flag: flag)
@@ -141,22 +152,31 @@ final class FeatureFlagOverridesMenu: NSMenu {
                 updateExperimentFeatureItem(item, flag: flag)
             }
         }
-        setInternalUserStateItem.isHidden = featureFlagger.internalUserDecider.isInternalUser
+    }
+
+    private func updateCategoryItem(_ item: NSMenuItem, category: FeatureFlagCategory) {
+        item.image = icon(for: category)
+
+        if let submenu = item.submenu {
+            update(submenu.items)
+        }
     }
 
     private func updateFeatureFlagItem(_ item: NSMenuItem, flag: FeatureFlag) {
         let override = featureFlagger.localOverrides?.override(for: flag)
         let submenu = NSMenu()
         submenu.addItem(removeOverrideSubmenuItem(for: flag))
-        item.subtitle = "asd"
-        item.state = override == true ? .on : .off
+        //item.state = override == true ? .on : .off
         item.submenu = override != nil ? submenu : nil
+        item.title = menuItemTitle(for: flag)
+        item.image = icon(for: flag)
     }
 
     private func updateExperimentFeatureItem(_ item: NSMenuItem, flag: FeatureFlag) {
         let override = featureFlagger.localOverrides?.experimentOverride(for: flag)
         item.state = override != nil ? .on : .off
         item.submenu = cohortSubmenu(for: flag)
+        item.title = experimentMenuItemTitle(for: flag)
     }
 
     // MARK: - Actions
@@ -184,7 +204,60 @@ final class FeatureFlagOverridesMenu: NSMenu {
     // MARK: - Helpers
 
     private func menuItemTitle(for flag: FeatureFlag) -> String {
-        return "\(flag.rawValue) (default: \(defaultValue(for: flag)), override: \(overrideValue(for: flag)))"
+        return "\(flag.rawValue)"
+    }
+
+    private func experimentMenuItemTitle(for flag: FeatureFlag) -> String {
+        return "\(flag.rawValue) (default: \(defaultExperimentValue(for: flag)), override: \(experimentOverrideValue(for: flag)))"
+    }
+
+    // MARK: - Menu Icons
+
+    private static let iconAlpha = 0.2
+
+    private static var enabledByDefaultIcon = NSImage(systemSymbolName: "checkmark.circle",
+                           accessibilityDescription: "Enabled by default")!
+
+    private static var enabledByUserIcon = NSImage(systemSymbolName: "checkmark.circle.fill",
+                                                   accessibilityDescription: "Enabled by user")!
+
+    private static var disabledByDefaultIcon = NSImage(systemSymbolName: "x.circle",
+                                                       accessibilityDescription: "Disabled by default")!
+
+    private static var disabledByUserIcon = NSImage(systemSymbolName: "x.circle.fill",
+                                                    accessibilityDescription: "Disabled by user")!
+
+    private func icon(for category: FeatureFlagCategory) -> NSImage? {
+        for flag in FeatureFlag.allCases {
+            guard flag.supportsLocalOverriding
+                && flag.cohortType == nil
+                && flag.category == category else {
+
+                continue
+            }
+
+            if overrideValue(for: flag) != nil {
+                return NSImage(systemSymbolName: "flag.fill", accessibilityDescription: "Category has overridden flags")!
+            }
+        }
+
+        return nil
+    }
+
+    private func icon(for flag: FeatureFlag) -> NSImage {
+        if let override = overrideValue(for: flag) {
+            if override {
+                return Self.enabledByUserIcon
+            } else {
+                return Self.disabledByUserIcon
+            }
+        } else {
+            if defaultValue(for: flag) {
+                return Self.enabledByDefaultIcon
+            } else {
+                return Self.disabledByDefaultIcon
+            }
+        }
     }
 
     private func cohortSubmenu(for flag: FeatureFlag) -> NSMenu {
@@ -237,26 +310,27 @@ final class FeatureFlagOverridesMenu: NSMenu {
         return featureFlag.cohortType?.cohorts ?? []
     }
 
-    private func defaultValue(for flag: FeatureFlag) -> String {
-        if flag.cohortType == nil {
-            return featureFlagger.isFeatureOn(for: flag, allowOverride: false) ? "on" : "off"
-        } else {
-            return featureFlagger.localOverrides?.currentExperimentCohort(for: flag)?.rawValue ?? "unassigned"
-        }
+    private func defaultValue(for flag: FeatureFlag) -> Bool {
+        assert(flag.cohortType == nil)
+        return featureFlagger.isFeatureOn(for: flag, allowOverride: false)
     }
 
-    private func overrideValue(for flag: FeatureFlag) -> String {
-        if flag.cohortType == nil {
-            guard let override = featureFlagger.localOverrides?.override(for: flag) else {
-                return "none"
-            }
-            return override ? "on" : "off"
-        } else {
-            guard let override = featureFlagger.localOverrides?.experimentOverride(for: flag) else {
-                return "none"
-            }
-            return override
+    private func defaultExperimentValue(for flag: FeatureFlag) -> String {
+        assert(flag.cohortType != nil)
+        return featureFlagger.localOverrides?.currentExperimentCohort(for: flag)?.rawValue ?? "unassigned"
+    }
+
+    private func overrideValue(for flag: FeatureFlag) -> Bool? {
+        assert(flag.cohortType == nil)
+        return featureFlagger.localOverrides?.override(for: flag)
+    }
+
+    private func experimentOverrideValue(for flag: FeatureFlag) -> String {
+        assert(flag.cohortType != nil)
+        guard let override = featureFlagger.localOverrides?.experimentOverride(for: flag) else {
+            return "none"
         }
+        return override
     }
 
     private func sectionHeader(title: String) -> NSMenuItem {

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlagCategory.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlagCategory.swift
@@ -1,0 +1,41 @@
+//
+//  FeatureFlag.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import BrowserServicesKit
+
+public enum FeatureFlagCategory: String, CaseIterable {
+    case vpn = "DuckDuckGo VPN"
+}
+
+public protocol FeatureFlagCategorization {
+    var category: FeatureFlagCategory? { get }
+}
+
+extension FeatureFlag: FeatureFlagCategorization {
+    public var category: FeatureFlagCategory? {
+        switch self {
+        case .networkProtectionAppStoreSysex,
+                .networkProtectionAppStoreSysexMessage,
+                .networkProtectionRiskyDomainsProtection:
+            return .vpn
+        default:
+            return .none
+        }
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1210496567641327?focus=true

### Description

Improve the Feature Flags override menu.

Changes:
- Show different icons for default-off, default-on, user-enabled and user-disabled.  Remove default checkmark.
- Require FeatureFlags to have a category, and populate this menu using those categories.
- Always show default value for a feature flag in a readable manner - probably just (ON) / (OFF).
- The category menu item will show a white flag if any of its feature flag has been overridden, so it's easier to find the ones you'd want to disable without going into all categories.

### Testing Steps

Just test the menu extensively.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)