### PR TITLE
Invalid refresh token detected and mitigation pixels improved

### DIFF
--- a/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
@@ -246,14 +246,7 @@ final class AppDependencyProvider: DependencyProvider {
 
             let restoreFlow = DefaultAppStoreRestoreFlowV2(subscriptionManager: subscriptionManager, storePurchaseManager: storePurchaseManager)
             subscriptionManager.tokenRecoveryHandler = {
-                do {
-                    try await DeadTokenRecoverer.attemptRecoveryFromPastPurchase(subscriptionManager: subscriptionManager, restoreFlow: restoreFlow)
-                    DailyPixel.fire(pixel: .privacyProInvalidRefreshTokenRecovered)
-                    Pixel.fire(pixel: .privacyProInvalidRefreshTokenRecovered)
-                } catch {
-                    DailyPixel.fire(pixel: .privacyProInvalidRefreshTokenSignedOut)
-                    Pixel.fire(pixel: .privacyProInvalidRefreshTokenSignedOut)
-                }
+                try await DeadTokenRecoverer.attemptRecoveryFromPastPurchase(subscriptionManager: subscriptionManager, restoreFlow: restoreFlow)
             }
 
             self.subscriptionManagerV2 = subscriptionManager

--- a/iOS/DuckDuckGo/Subscription/AuthV2PixelHandler.swift
+++ b/iOS/DuckDuckGo/Subscription/AuthV2PixelHandler.swift
@@ -59,6 +59,10 @@ public struct AuthV2PixelHandler: SubscriptionPixelHandler {
         case .getTokensError(let policy, let error):
             DailyPixel.fireDailyAndCount(pixel: .privacyProAuthV2GetTokensError, withAdditionalParameters: [Defaults.errorKey: error.localizedDescription,
                                                                                                             Defaults.policyCacheKey: policy.description].merging(sourceParam) { $1 })
+        case .invalidRefreshTokenSignedOut:
+            DailyPixel.fireDailyAndCount(pixel: .privacyProInvalidRefreshTokenSignedOut, withAdditionalParameters: sourceParam)
+        case .invalidRefreshTokenRecovered:
+            DailyPixel.fireDailyAndCount(pixel: .privacyProInvalidRefreshTokenRecovered, withAdditionalParameters: sourceParam)
         }
     }
 

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -432,17 +432,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if #available(iOS 15.0, macOS 12.0, *) {
                 let restoreFlow = DefaultAppStoreRestoreFlowV2(subscriptionManager: subscriptionManager, storePurchaseManager: subscriptionManager.storePurchaseManager())
                 subscriptionManager.tokenRecoveryHandler = {
-                    do {
                         try await DeadTokenRecoverer.attemptRecoveryFromPastPurchase(subscriptionManager: subscriptionManager, restoreFlow: restoreFlow)
-                        PixelKit.fire(PrivacyProPixel.privacyProInvalidRefreshTokenRecovered, frequency: .dailyAndCount)
-                    } catch {
-                        PixelKit.fire(PrivacyProPixel.privacyProInvalidRefreshTokenSignedOut, frequency: .dailyAndCount)
-                    }
                 }
             } else {
                 subscriptionManager.tokenRecoveryHandler = {
                     try await DeadTokenRecoverer.reportDeadRefreshToken()
-                    PixelKit.fire(PrivacyProPixel.privacyProInvalidRefreshTokenSignedOut, frequency: .dailyAndCount)
                 }
             }
 

--- a/macOS/DuckDuckGo/Subscription/AuthV2PixelHandler.swift
+++ b/macOS/DuckDuckGo/Subscription/AuthV2PixelHandler.swift
@@ -56,6 +56,10 @@ public struct AuthV2PixelHandler: SubscriptionPixelHandler {
             PixelKit.fire(PrivacyProPixel.privacyProAuthV2MigrationSucceeded(source), frequency: .dailyAndCount)
         case .getTokensError(let policy, let error):
             PixelKit.fire(PrivacyProPixel.privacyProAuthV2GetTokensError(policy, source, error), frequency: .dailyAndCount)
+        case .invalidRefreshTokenSignedOut:
+            PixelKit.fire(PrivacyProPixel.privacyProInvalidRefreshTokenSignedOut, frequency: .dailyAndCount)
+        case .invalidRefreshTokenRecovered:
+            PixelKit.fire(PrivacyProPixel.privacyProInvalidRefreshTokenRecovered, frequency: .dailyAndCount)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205842942115003/task/1210453926427230

### Description

- now all pixels related to invalid refresh token detected and mitigation are managed by the pixel handler
- in case of an unrecoverable state the logout is performed only after the failed recovery attempt

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)