### PR TITLE
Don't display history groupings in History Menu

### DIFF
--- a/macOS/DuckDuckGo/Menus/HistoryMenu.swift
+++ b/macOS/DuckDuckGo/Menus/HistoryMenu.swift
@@ -117,7 +117,9 @@ final class HistoryMenu: NSMenu {
 
         clearOldVariableMenuItems()
         addRecentlyVisited()
-        addHistoryGroupings()
+        if !featureFlagger.isFeatureOn(.shortHistoryMenu) {
+            addHistoryGroupings()
+        }
         addClearAllAndShowHistoryOnTheBottom()
         clearAllHistoryMenuItem.title = featureFlagger.isFeatureOn(.historyView) ? UserText.mainMenuHistoryDeleteAllHistory : UserText.mainMenuHistoryClearAllHistory
     }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -98,6 +98,9 @@ public enum FeatureFlag: String, CaseIterable {
 
     /// https://app.asana.com/1/137249556945/project/1209671977594486/task/1210410403692636?focus=true
     case aiChatSidebar
+
+    /// https://app.asana.com/1/137249556945/project/1201048563534612/task/1210493210455717?focus=true
+    case shortHistoryMenu
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -142,7 +145,8 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .exchangeKeysToSyncWithAnotherDevice,
                 .canScanUrlBasedSyncSetupBarcodes,
                 .removeWWWInCanonicalizationInThreatProtection,
-                .aiChatSidebar:
+                .aiChatSidebar,
+                .shortHistoryMenu:
             return true
         case .debugMenu,
                 .sslCertificatesBypass,
@@ -225,6 +229,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(MaliciousSiteProtectionSubfeature.removeWWWInCanonicalization))
         case .aiChatSidebar:
             return .internalOnly()
+        case .shortHistoryMenu:
+            return .disabled
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210493210455717?focus=true

### Description
This change removes history groupings from History Menu (both via Main Menu and More Options Menu).
It’s currently behind an off-by-default feature flag called `shortHistoryMenu`.

### Testing Steps
1. Launch the app and populate history via Main Menu -> Debug -> History -> Add 10 history visits each day 
2. Enter History menu. Verify that you can see submenus with date groupings for past 7 days.
3. Enable `shortHistoryMenu` feature flag via overrides menu.
4. Enter History menu. Verify that you don’t see submenus with date groupings.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)