### PR TITLE
macOS Visual Refresh: Implement new feature flag logic

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -3249,6 +3249,8 @@
 		BBBB65402C77BB9400E69AC6 /* BookmarkSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB653F2C77BB9400E69AC6 /* BookmarkSearchTests.swift */; };
 		BBBEE1BF2C4FF63600035ABA /* SortBookmarksViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBEE1BE2C4FF63600035ABA /* SortBookmarksViewModelTests.swift */; };
 		BBBEE1C02C4FF63600035ABA /* SortBookmarksViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBEE1BE2C4FF63600035ABA /* SortBookmarksViewModelTests.swift */; };
+		BBC0001E2DF743DE0003E9F5 /* VisualStyleManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC0001D2DF743D20003E9F5 /* VisualStyleManagerTests.swift */; };
+		BBC0001F2DF743DE0003E9F5 /* VisualStyleManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC0001D2DF743D20003E9F5 /* VisualStyleManagerTests.swift */; };
 		BBC063E82C5A9E4B007BDC18 /* BookmarkManagementDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC063E72C5A9E4B007BDC18 /* BookmarkManagementDetailViewModelTests.swift */; };
 		BBC063E92C5A9E4B007BDC18 /* BookmarkManagementDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC063E72C5A9E4B007BDC18 /* BookmarkManagementDetailViewModelTests.swift */; };
 		BBC114652D89E859007A82D8 /* TabCollectionViewModelCloseTabLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC114642D89E859007A82D8 /* TabCollectionViewModelCloseTabLogicTests.swift */; };
@@ -5406,6 +5408,7 @@
 		BBB891E52DAEC1B6001A42DF /* MoreOptionsMenuIconsProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreOptionsMenuIconsProviding.swift; sourceTree = "<group>"; };
 		BBBB653F2C77BB9400E69AC6 /* BookmarkSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkSearchTests.swift; sourceTree = "<group>"; };
 		BBBEE1BE2C4FF63600035ABA /* SortBookmarksViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortBookmarksViewModelTests.swift; sourceTree = "<group>"; };
+		BBC0001D2DF743D20003E9F5 /* VisualStyleManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualStyleManagerTests.swift; sourceTree = "<group>"; };
 		BBC063E72C5A9E4B007BDC18 /* BookmarkManagementDetailViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkManagementDetailViewModelTests.swift; sourceTree = "<group>"; };
 		BBC114642D89E859007A82D8 /* TabCollectionViewModelCloseTabLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabCollectionViewModelCloseTabLogicTests.swift; sourceTree = "<group>"; };
 		BBC386822DE5E6E70004583A /* SuggestionsIconsProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionsIconsProviding.swift; sourceTree = "<group>"; };
@@ -8923,6 +8926,7 @@
 		AA585D93248FD31400E9A3E2 /* UnitTests */ = {
 			isa = PBXGroup;
 			children = (
+				BBC0001C2DF743CC0003E9F5 /* VisualRefresh */,
 				56EA40272DB782D500B5061E /* Localization */,
 				31F25EFD2CC3C9F9002F9084 /* AIChat */,
 				B6A5A28C25B962CB00AA7ADA /* App */,
@@ -10399,6 +10403,14 @@
 				9FB4AF522DED8BFF00BE416F /* DefaultBrowserAndDockPromptPixelEventTests.swift */,
 			);
 			path = DefaultBrowserAndAddToDockPrompts;
+			sourceTree = "<group>";
+		};
+		BBC0001C2DF743CC0003E9F5 /* VisualRefresh */ = {
+			isa = PBXGroup;
+			children = (
+				BBC0001D2DF743D20003E9F5 /* VisualStyleManagerTests.swift */,
+			);
+			path = VisualRefresh;
 			sourceTree = "<group>";
 		};
 		BBDE001A2D6DE66100109F88 /* DefaultBrowserAndAddToDockPrompts */ = {
@@ -13555,6 +13567,7 @@
 				37EC314C2D8C02C00026C348 /* FaviconTests.swift in Sources */,
 				C17CA7B32B9B5317008EC3C1 /* MockAutofillPopoverPresenter.swift in Sources */,
 				3706FE3F293F661700E42796 /* FileStoreMock.swift in Sources */,
+				BBC0001E2DF743DE0003E9F5 /* VisualStyleManagerTests.swift in Sources */,
 				B6619F042B17123200CD9186 /* DataImportViewModelTests.swift in Sources */,
 				1D8C2FE62B70F4C4005E4BBD /* TabSnapshotExtensionTests.swift in Sources */,
 				3706FE40293F661700E42796 /* BWResponseTests.swift in Sources */,
@@ -15396,6 +15409,7 @@
 				9F872DA02B90644800138637 /* ContextualMenuTests.swift in Sources */,
 				4B9292BE2667103100AD2C21 /* PasteboardFolderTests.swift in Sources */,
 				BBBEE1BF2C4FF63600035ABA /* SortBookmarksViewModelTests.swift in Sources */,
+				BBC0001F2DF743DE0003E9F5 /* VisualStyleManagerTests.swift in Sources */,
 				4B9292C52667104B00AD2C21 /* CoreDataTestUtilities.swift in Sources */,
 				37A0BA2D2D747C5C00130447 /* CapturingHistoryViewBookmarksHandler.swift in Sources */,
 				567A23DE2C89980A0010F66C /* OnboardingNavigationDelegateTests.swift in Sources */,

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -463,7 +463,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             )
         )
 
-        visualStyleManager = VisualStyleManager(featureFlagger: featureFlagger)
+        visualStyleManager = VisualStyleManager(featureFlagger: featureFlagger, internalUserDecider: internalUserDecider)
 
 #if DEBUG
         if AppVersion.runType.requiresEnvironment {

--- a/macOS/DuckDuckGo/RemoteMessaging/RemoteMessagingClient.swift
+++ b/macOS/DuckDuckGo/RemoteMessaging/RemoteMessagingClient.swift
@@ -48,7 +48,7 @@ final class RemoteMessagingClient: RemoteMessagingProcessing {
         static let minimumConfigurationRefreshInterval: TimeInterval = 60 * 30
         static let endpoint: URL = {
 #if DEBUG
-            URL(string: "https://raw.githubusercontent.com/duckduckgo/remote-messaging-config/main/samples/ios/sample1.json")!
+            URL(string: "https://jsonblob.com/api/1380594945500569600")!
 #else
             URL(string: "https://staticcdn.duckduckgo.com/remotemessaging/config/v1/macos-config.json")!
 #endif

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
@@ -107,30 +107,28 @@ struct VisualStyle: VisualStyleProviding {
 
 final class VisualStyleManager: VisualStyleManagerProviding {
     private let featureFlagger: FeatureFlagger
+    private let internalUserDecider: InternalUserDecider
 
     private var cancellables: Set<AnyCancellable> = []
 
-    init(featureFlagger: FeatureFlagger) {
+    init(featureFlagger: FeatureFlagger, internalUserDecider: InternalUserDecider) {
         self.featureFlagger = featureFlagger
-
-        subscribeToLocalOverride()
+        self.internalUserDecider = internalUserDecider
     }
 
     var style: any VisualStyleProviding {
-        return featureFlagger.isFeatureOn(.visualRefresh) ? VisualStyle.current : VisualStyle.legacy
-    }
-
-    private func subscribeToLocalOverride() {
-        guard let overridesHandler = featureFlagger.localOverrides?.actionHandler as? FeatureFlagOverridesPublishingHandler<FeatureFlag> else {
-            return
-        }
-
-        overridesHandler.flagDidChangePublisher
-            .filter { $0.0 == .visualRefresh }
-            .sink { (_, enabled) in
-                /// Here I need to apply the visual changes. The easier way should be to restart the app.
-                print("Visual refresh feature flag changed to \(enabled ? "enabled" : "disabled")")
+        if internalUserDecider.isInternalUser {
+            guard let localOverrides = featureFlagger.localOverrides else {
+                return VisualStyle.legacy
             }
-            .store(in: &cancellables)
+
+            if localOverrides.override(for: FeatureFlag.visualUpdatesInternalOnly) == false {
+                return VisualStyle.legacy
+            } else {
+                return VisualStyle.current
+            }
+        } else {
+            return featureFlagger.isFeatureOn(.visualUpdates) ? VisualStyle.current : VisualStyle.legacy
+        }
     }
 }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -70,7 +70,8 @@ public enum FeatureFlag: String, CaseIterable {
     case failsafeExamplePlatformSpecificSubfeature
 
     /// https://app.asana.com/0/72649045549333/1209793701087222/f
-    case visualRefresh
+    case visualUpdates
+    case visualUpdatesInternalOnly
 
     /// https://app.asana.com/1/137249556945/project/72649045549333/task/1209227311680179?focus=true
     case tabCrashDebugging
@@ -106,7 +107,7 @@ public enum FeatureFlag: String, CaseIterable {
 extension FeatureFlag: FeatureFlagDescribing {
     public var defaultValue: Bool {
         switch self {
-        case .failsafeExampleCrossPlatformFeature, .failsafeExamplePlatformSpecificSubfeature, .removeWWWInCanonicalizationInThreatProtection:
+        case .failsafeExampleCrossPlatformFeature, .failsafeExamplePlatformSpecificSubfeature, .removeWWWInCanonicalizationInThreatProtection, .visualUpdatesInternalOnly:
             true
         default:
             false
@@ -136,7 +137,8 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .scamSiteProtection,
                 .failsafeExampleCrossPlatformFeature,
                 .failsafeExamplePlatformSpecificSubfeature,
-                .visualRefresh,
+                .visualUpdates,
+                .visualUpdatesInternalOnly,
                 .tabCrashDebugging,
                 .tabCrashRecovery,
                 .maliciousSiteProtection,
@@ -209,7 +211,9 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.feature(.intentionallyLocalOnlyFeatureForTests))
         case .failsafeExamplePlatformSpecificSubfeature:
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.intentionallyLocalOnlySubfeatureForTests))
-        case .visualRefresh:
+        case .visualUpdates:
+            return .remoteReleasable(.subfeature(ExperimentalThemingSubfeature.visualUpdates))
+        case .visualUpdatesInternalOnly:
             return .internalOnly()
         case .tabCrashDebugging:
             return .disabled

--- a/macOS/UnitTests/VisualRefresh/VisualStyleManagerTests.swift
+++ b/macOS/UnitTests/VisualRefresh/VisualStyleManagerTests.swift
@@ -1,0 +1,390 @@
+//
+//  VisualStyleManagerTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Combine
+import BrowserServicesKit
+import FeatureFlags
+@testable import DuckDuckGo_Privacy_Browser
+
+// MARK: - Tests
+
+class VisualStyleManagerTests: XCTestCase {
+
+    private var mockInternalUserDecider: MockInternalUserDecider!
+    private var mockLocalOverrides: MockFeatureFlagLocalOverriding!
+    private var mockFeatureFlagger: MockFeatureFlagger!
+    var visualStyleManager: VisualStyleManager!
+
+    override func setUp() {
+        super.setUp()
+        mockInternalUserDecider = MockInternalUserDecider()
+        mockLocalOverrides = MockFeatureFlagLocalOverriding()
+        mockFeatureFlagger = MockFeatureFlagger(internalUserDecider: mockInternalUserDecider)
+        mockFeatureFlagger.localOverrides = mockLocalOverrides
+
+        visualStyleManager = VisualStyleManager(
+            featureFlagger: mockFeatureFlagger,
+            internalUserDecider: mockInternalUserDecider
+        )
+    }
+
+    override func tearDown() {
+        mockInternalUserDecider = nil
+        mockLocalOverrides = nil
+        mockFeatureFlagger = nil
+        visualStyleManager = nil
+        super.tearDown()
+    }
+
+    // MARK: - Non-Internal User Tests
+
+    func testNonInternalUser_FeatureDisabled_ReturnsLegacyStyle() {
+        // Given
+        mockInternalUserDecider.isInternalUser = false
+        mockFeatureFlagger.enabledFeatures = []
+
+        // When
+        let style = visualStyleManager.style
+
+        // Then
+        XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0, "Should return legacy corner radius")
+        XCTAssertEqual(style.fireButtonSize, 28.0, "Should return legacy fire button size")
+        XCTAssertFalse(style.areNavigationBarCornersRound, "Should not have round navigation bar corners")
+        XCTAssertFalse(style.addToolbarShadow, "Should not add toolbar shadow")
+    }
+
+    func testNonInternalUser_FeatureEnabled_ReturnsCurrentStyle() {
+        // Given
+        mockInternalUserDecider.isInternalUser = false
+        mockFeatureFlagger.enabledFeatures = [.visualUpdates]
+
+        // When
+        let style = visualStyleManager.style
+
+        // Then
+        XCTAssertEqual(style.toolbarButtonsCornerRadius, 9.0, "Should return current corner radius")
+        XCTAssertEqual(style.fireButtonSize, 32.0, "Should return current fire button size")
+        XCTAssertTrue(style.areNavigationBarCornersRound, "Should have round navigation bar corners")
+        XCTAssertTrue(style.addToolbarShadow, "Should add toolbar shadow")
+    }
+
+    // MARK: - Internal User Tests
+
+    func testInternalUser_NoLocalOverrides_ReturnsLegacyStyle() {
+        // Given
+        mockInternalUserDecider.isInternalUser = true
+        mockFeatureFlagger.localOverrides = nil
+
+        // When
+        let style = visualStyleManager.style
+
+        // Then
+        XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0, "Should return legacy corner radius when no local overrides")
+    }
+
+    func testInternalUser_LocalOverrideDisabled_ReturnsLegacyStyle() {
+        // Given
+        mockInternalUserDecider.isInternalUser = true
+        mockLocalOverrides.setOverride(for: .visualUpdatesInternalOnly, value: false)
+
+        // When
+        let style = visualStyleManager.style
+
+        // Then
+        XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0, "Should return legacy corner radius when override is false")
+        XCTAssertEqual(style.fireButtonSize, 28.0, "Should return legacy fire button size")
+        XCTAssertFalse(style.areNavigationBarCornersRound, "Should not have round navigation bar corners")
+        XCTAssertFalse(style.addToolbarShadow, "Should not add toolbar shadow")
+    }
+
+    func testInternalUser_LocalOverrideEnabled_ReturnsCurrentStyle() {
+        // Given
+        mockInternalUserDecider.isInternalUser = true
+        mockLocalOverrides.setOverride(for: .visualUpdatesInternalOnly, value: true)
+
+        // When
+        let style = visualStyleManager.style
+
+        // Then
+        XCTAssertEqual(style.toolbarButtonsCornerRadius, 9.0, "Should return current corner radius when override is true")
+        XCTAssertEqual(style.fireButtonSize, 32.0, "Should return current fire button size")
+        XCTAssertTrue(style.areNavigationBarCornersRound, "Should have round navigation bar corners")
+        XCTAssertTrue(style.addToolbarShadow, "Should add toolbar shadow")
+    }
+
+    func testInternalUser_NoLocalOverrideSet_ReturnsCurrentStyle() {
+        // Given
+        mockInternalUserDecider.isInternalUser = true
+        // No override set (nil)
+
+        // When
+        let style = visualStyleManager.style
+
+        // Then
+        XCTAssertEqual(style.toolbarButtonsCornerRadius, 9.0, "Should return current corner radius when no override is set")
+        XCTAssertEqual(style.fireButtonSize, 32.0, "Should return current fire button size")
+        XCTAssertTrue(style.areNavigationBarCornersRound, "Should have round navigation bar corners")
+        XCTAssertTrue(style.addToolbarShadow, "Should add toolbar shadow")
+    }
+
+    // MARK: - Style Properties Tests
+
+    func testLegacyStyleProperties() {
+        // Given
+        mockInternalUserDecider.isInternalUser = false
+        mockFeatureFlagger.enabledFeatures = []
+
+        // When
+        let style = visualStyleManager.style
+
+        // Then
+        XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0)
+        XCTAssertEqual(style.fireButtonSize, 28.0)
+        XCTAssertEqual(style.navigationToolbarButtonsSpacing, 0.0)
+        XCTAssertEqual(style.tabBarButtonSize, 28.0)
+        XCTAssertFalse(style.areNavigationBarCornersRound)
+        XCTAssertFalse(style.addToolbarShadow)
+
+        // Verify style providers are legacy types
+        XCTAssertTrue(style.addressBarStyleProvider is LegacyAddressBarStyleProvider)
+        XCTAssertTrue(style.tabStyleProvider is LegacyTabStyleProvider)
+        XCTAssertTrue(style.colorsProvider is LegacyColorsProviding)
+        XCTAssertTrue(style.iconsProvider is LegacyIconsProvider)
+    }
+
+    func testCurrentStyleProperties() {
+        // Given
+        mockInternalUserDecider.isInternalUser = false
+        mockFeatureFlagger.enabledFeatures = [.visualUpdates]
+
+        // When
+        let style = visualStyleManager.style
+
+        // Then
+        XCTAssertEqual(style.toolbarButtonsCornerRadius, 9.0)
+        XCTAssertEqual(style.fireButtonSize, 32.0)
+        XCTAssertEqual(style.navigationToolbarButtonsSpacing, 2.0)
+        XCTAssertEqual(style.tabBarButtonSize, 28.0)
+        XCTAssertTrue(style.areNavigationBarCornersRound)
+        XCTAssertTrue(style.addToolbarShadow)
+
+        // Verify style providers are current types
+        XCTAssertTrue(style.addressBarStyleProvider is CurrentAddressBarStyleProvider)
+        XCTAssertTrue(style.tabStyleProvider is NewlineTabStyleProvider)
+        XCTAssertTrue(style.colorsProvider is NewColorsProviding)
+        XCTAssertTrue(style.iconsProvider is CurrentIconsProvider)
+    }
+
+    // MARK: - Feature Flag Separation Tests
+
+    func testInternalUser_IgnoresExternalFeatureFlag() {
+        // Given - Internal user with external feature enabled but no local override
+        mockInternalUserDecider.isInternalUser = true
+        mockFeatureFlagger.enabledFeatures = [.visualUpdates] // External feature flag
+        // No local override set for internal feature
+
+        // When
+        let style = visualStyleManager.style
+
+        // Then - Should return current style (default behavior for internal users when no override)
+        XCTAssertEqual(style.toolbarButtonsCornerRadius, 9.0, "Internal users should ignore external feature flag")
+    }
+
+    func testNonInternalUser_IgnoresInternalFeatureOverride() {
+        // Given - Non-internal user with internal feature override set but external feature disabled
+        mockInternalUserDecider.isInternalUser = false
+        mockFeatureFlagger.enabledFeatures = [] // External feature disabled
+        mockLocalOverrides.setOverride(for: .visualUpdatesInternalOnly, value: true) // Internal override
+
+        // When
+        let style = visualStyleManager.style
+
+        // Then - Should return legacy style (following external feature flag)
+        XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0, "Non-internal users should ignore internal feature overrides")
+    }
+
+    func testInternalUser_OverridesTakesPrecedenceOverExternalFlag() {
+        // Given - Internal user with external feature enabled and internal override disabled
+        mockInternalUserDecider.isInternalUser = true
+        mockFeatureFlagger.enabledFeatures = [.visualUpdates] // External feature enabled
+        mockLocalOverrides.setOverride(for: .visualUpdatesInternalOnly, value: false) // Internal override disabled
+
+        // When
+        let style = visualStyleManager.style
+
+        // Then - Should return legacy style (following internal override, not external flag)
+        XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0, "Internal overrides should take precedence over external feature flags")
+    }
+
+    // MARK: - Dynamic Behavior Tests
+
+    func testStyleChangesWithInternalUserStatus() {
+        // Given - Start as non-internal user with visualUpdates feature disabled
+        mockInternalUserDecider.isInternalUser = false
+        mockFeatureFlagger.enabledFeatures = []
+
+        // When/Then - Should return legacy style
+        var style = visualStyleManager.style
+        XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0)
+
+        // Given - Change to internal user with internal feature override enabled
+        mockInternalUserDecider.isInternalUser = true
+        mockLocalOverrides.setOverride(for: .visualUpdatesInternalOnly, value: true)
+
+        // When/Then - Should return current style
+        style = visualStyleManager.style
+        XCTAssertEqual(style.toolbarButtonsCornerRadius, 9.0)
+    }
+
+    func testStyleChangesWithFeatureToggle() {
+        // Given - Non-internal user with feature disabled
+        mockInternalUserDecider.isInternalUser = false
+        mockFeatureFlagger.enabledFeatures = []
+
+        // When/Then - Should return legacy style
+        var style = visualStyleManager.style
+        XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0)
+
+        // Given - Enable the feature for non-internal users
+        mockFeatureFlagger.enabledFeatures = [.visualUpdates]
+
+        // When/Then - Should return current style
+        style = visualStyleManager.style
+        XCTAssertEqual(style.toolbarButtonsCornerRadius, 9.0)
+    }
+
+    func testStyleChangesWithLocalOverride() {
+        // Given - Internal user with no override
+        mockInternalUserDecider.isInternalUser = true
+
+        // When/Then - Should return current style (default behavior)
+        var style = visualStyleManager.style
+        XCTAssertEqual(style.toolbarButtonsCornerRadius, 9.0)
+
+        // Given - Set override to disable
+        mockLocalOverrides.setOverride(for: .visualUpdatesInternalOnly, value: false)
+
+        // When/Then - Should return legacy style
+        style = visualStyleManager.style
+        XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0)
+
+        // Given - Set override to enable
+        mockLocalOverrides.setOverride(for: .visualUpdatesInternalOnly, value: true)
+
+        // When/Then - Should return current style
+        style = visualStyleManager.style
+        XCTAssertEqual(style.toolbarButtonsCornerRadius, 9.0)
+    }
+
+    // MARK: - Mock Classes
+
+    private class MockInternalUserDecider: InternalUserDecider {
+        var isInternalUser: Bool = false
+        var isInternalUserPublisher: AnyPublisher<Bool, Never> {
+            isInternalUserSubject.eraseToAnyPublisher()
+        }
+
+        private let isInternalUserSubject = PassthroughSubject<Bool, Never>()
+
+        func markUserAsInternalIfNeeded(forUrl url: URL?, response: HTTPURLResponse?) -> Bool {
+            return false
+        }
+    }
+
+    private class MockFeatureFlagger: FeatureFlagger {
+        var internalUserDecider: InternalUserDecider
+        var localOverrides: FeatureFlagLocalOverriding?
+        var enabledFeatures: Set<FeatureFlag> = []
+
+        init(internalUserDecider: InternalUserDecider) {
+            self.internalUserDecider = internalUserDecider
+        }
+
+        func isFeatureOn<Flag: FeatureFlagDescribing>(for featureFlag: Flag, allowOverride: Bool) -> Bool {
+            guard let flag = featureFlag as? FeatureFlag else { return false }
+            return enabledFeatures.contains(flag)
+        }
+
+        func resolveCohort<Flag>(for featureFlag: Flag, allowOverride: Bool) -> (any FeatureFlagCohortDescribing)? where Flag: FeatureFlagDescribing {
+            return nil
+        }
+
+        var allActiveExperiments: Experiments { [:] }
+    }
+
+    private class MockFeatureFlagLocalOverriding: FeatureFlagLocalOverriding {
+        var featureFlagger: (any BrowserServicesKit.FeatureFlagger)? = nil
+        var actionHandler: any BrowserServicesKit.FeatureFlagLocalOverridesHandling = MockFeatureFlagLocalOverridesHandling()
+
+        private var overrides: [String: Bool] = [:]
+
+        func setOverride(for flag: FeatureFlag, value: Bool?) {
+            if let value = value {
+                overrides[flag.rawValue] = value
+            } else {
+                overrides.removeValue(forKey: flag.rawValue)
+            }
+        }
+
+        func override<Flag>(for featureFlag: Flag) -> Bool? where Flag : BrowserServicesKit.FeatureFlagDescribing {
+            return overrides[featureFlag.rawValue]
+        }
+
+        func experimentOverride<Flag>(for featureFlag: Flag) -> BrowserServicesKit.CohortID? where Flag : BrowserServicesKit.FeatureFlagDescribing {
+            return nil
+        }
+
+        func toggleOverride<Flag>(for featureFlag: Flag) where Flag : BrowserServicesKit.FeatureFlagDescribing {
+            let currentValue = override(for: featureFlag)
+            setOverride(for: featureFlag as! FeatureFlag, value: currentValue == nil ? true : !currentValue!)
+        }
+
+        func setExperimentCohortOverride<Flag>(for featureFlag: Flag, cohort: BrowserServicesKit.CohortID) where Flag : BrowserServicesKit.FeatureFlagDescribing {
+            // Not needed for visual updates tests
+        }
+
+        func clearOverride<Flag>(for featureFlag: Flag) where Flag : BrowserServicesKit.FeatureFlagDescribing {
+            // Not needed for visual updates tests
+        }
+
+        func currentValue<Flag>(for featureFlag: Flag) -> Bool? where Flag : BrowserServicesKit.FeatureFlagDescribing {
+            return nil
+        }
+
+        func currentExperimentCohort<Flag>(for featureFlag: Flag) -> (any BrowserServicesKit.FeatureFlagCohortDescribing)? where Flag : BrowserServicesKit.FeatureFlagDescribing {
+            return nil
+        }
+
+        func clearAllOverrides<Flag>(for flagType: Flag.Type) where Flag : BrowserServicesKit.FeatureFlagDescribing {
+            // Not needed for visual updates tests
+        }
+
+        // MARK: - Mocks
+
+        class MockFeatureFlagLocalOverridesHandling: FeatureFlagLocalOverridesHandling {
+            func flagDidChange<Flag>(_ featureFlag: Flag, isEnabled: Bool) where Flag : BrowserServicesKit.FeatureFlagDescribing {
+                // Not needed for visual updates tests
+            }
+
+            func experimentFlagDidChange<Flag>(_ featureFlag: Flag, cohort: BrowserServicesKit.CohortID) where Flag : BrowserServicesKit.FeatureFlagDescribing {
+                // Not needed for visual updates tests
+            }
+        }
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1210464341341436?focus=true
Tech Design URL:
CC:

### Description
- Replaces the feature flag name with the one that the different platforms will use. It also sets the feature flag to be remote releasable
- Creates a new feature flag called `visualUpdatesIntenalOnly`. The reason is that we want for internal users to have the new UI by default, but with the possibility for them to turn it off.

### Testing Steps

**Removing Internal State**
1. Remove Internal state from the Debug menu
2. Restart or open a new window
3. You would always see the legacy UI (unless you override the `visualUpdates` flag)
4. Check the state of `visualUpdatesInternalOnly` does not get into account on this flag

**As internal user, default state**
1. Set internal user state
2. Restart or open a new window
3. You should see the new UI
4. If you go to Debug -> Feature Flag Overrides, and check the `visualUpdatesInternalOnly`, it should be on by default.
5. Set the flag as off (in the override menu)
6. Open a new window or restart the app
7. You should see the old UI

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The feature flags are incorrect and get release when they shouldn’t.

### Quality Considerations
I’ve added unit tests

### Notes to Reviewer
Nothing specific.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)