### PR TITLE
Fix auto-closing PR Checks failed Asana tasks

### DIFF
--- a/.github/actions/asana-failed-pr-checks/action.yml
+++ b/.github/actions/asana-failed-pr-checks/action.yml
@@ -25,6 +25,7 @@ runs:
   using: "composite"
   steps:
     - id: get-asana-user-id
+      if: inputs.action == 'create-task'
       uses: duckduckgo/native-github-asana-sync@v1.9
       with:
         action: 'get-asana-user-id'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1210503429415007?focus=true

### Description
This change fixes asana-failed-pr-checks action to only map GitHub user to Asana user ID
when creating Asana task. Closing Asana task doesn’t require any Asana user ID and that
ID has never been passed to the action when closing the task.

### Testing Steps
🤷  trust me

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)