### PR TITLE
macOS: Update address bar Duck.ai and "x" button placement

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -68,7 +68,7 @@ final class AddressBarButtonsViewController: NSViewController {
     @IBOutlet weak var bookmarkButton: AddressBarButton!
     @IBOutlet weak var imageButtonWrapper: NSView!
     @IBOutlet weak var imageButton: NSButton!
-    @IBOutlet weak var cancelButton: NSButton!
+    @IBOutlet weak var cancelButton: AddressBarButton!
     @IBOutlet private weak var buttonsContainer: NSStackView!
     @IBOutlet weak var aiChatButton: AddressBarMenuButton!
 
@@ -87,6 +87,8 @@ final class AddressBarButtonsViewController: NSViewController {
     @IBOutlet weak var notificationAnimationView: NavigationBarBadgeAnimationView!
     @IBOutlet weak var bookmarkButtonWidthConstraint: NSLayoutConstraint!
     @IBOutlet weak var bookmarkButtonHeightConstraint: NSLayoutConstraint!
+    @IBOutlet weak var cancelButtonWidthConstraint: NSLayoutConstraint!
+    @IBOutlet weak var cancelButtonHeightConstraint: NSLayoutConstraint!
     @IBOutlet weak var aiChatButtonWidthConstraint: NSLayoutConstraint!
     @IBOutlet weak var aiChatButtonHeightConstraint: NSLayoutConstraint!
     @IBOutlet weak var privacyShieldButtonWidthConstraint: NSLayoutConstraint!
@@ -408,6 +410,8 @@ final class AddressBarButtonsViewController: NSViewController {
     private func setupButtonsSize() {
         bookmarkButtonWidthConstraint.constant = visualStyle.addressBarStyleProvider.addressBarButtonSize
         bookmarkButtonHeightConstraint.constant = visualStyle.addressBarStyleProvider.addressBarButtonSize
+        cancelButtonWidthConstraint.constant = visualStyle.addressBarStyleProvider.addressBarButtonSize
+        cancelButtonHeightConstraint.constant = visualStyle.addressBarStyleProvider.addressBarButtonSize
         aiChatButtonWidthConstraint.constant = visualStyle.addressBarStyleProvider.addressBarButtonSize
         aiChatButtonHeightConstraint.constant = visualStyle.addressBarStyleProvider.addressBarButtonSize
         privacyShieldButtonWidthConstraint.constant = visualStyle.addressBarStyleProvider.addressBarButtonSize
@@ -527,7 +531,8 @@ final class AddressBarButtonsViewController: NSViewController {
     }
 
     private func updateButtonsPosition() {
-        aiChatButton.position = .right
+        cancelButton.position = .right
+        aiChatButton.position = cancelButton.isShown ? .center : .right
         bookmarkButton.position = aiChatButton.isShown ? .center : .right
     }
 

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
@@ -795,16 +795,16 @@
                                         <rect key="frame" x="7" y="0.0" width="5" height="20"/>
                                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" image="AIChat-Divider" id="4ID-09-y9M"/>
                                     </imageView>
-                                    <button hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kRc-0m-oqe" customClass="MouseOverButton" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="-6" width="26" height="26"/>
+                                    <button hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kRc-0m-oqe" customClass="AddressBarButton" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="-12" width="32" height="32"/>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="Clear" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="Qnf-P6-S6w">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                         <color key="contentTintColor" name="ClearButtonColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="26" id="8Ag-uG-RA7"/>
-                                            <constraint firstAttribute="height" constant="26" id="B6E-P0-EL6"/>
+                                            <constraint firstAttribute="width" constant="32" id="8Ag-uG-RA7"/>
+                                            <constraint firstAttribute="height" constant="32" id="B6E-P0-EL6"/>
                                         </constraints>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="color" keyPath="mouseOverColor">
@@ -815,6 +815,12 @@
                                             </userDefinedRuntimeAttribute>
                                             <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
                                                 <real key="value" value="4"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="horizontalPadding">
+                                                <real key="value" value="6"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="verticalPadding">
+                                                <real key="value" value="6"/>
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
@@ -1110,6 +1116,8 @@
                         <outlet property="cameraButton" destination="C2L-f9-L3r" id="xua-H5-hAx"/>
                         <outlet property="cameraButtonHeightConstraint" destination="A7u-wU-pBb" id="0E3-ev-fmb"/>
                         <outlet property="cancelButton" destination="kRc-0m-oqe" id="iAr-0l-X5i"/>
+                        <outlet property="cancelButtonHeightConstraint" destination="B6E-P0-EL6" id="T4M-Ck-MPY"/>
+                        <outlet property="cancelButtonWidthConstraint" destination="8Ag-uG-RA7" id="JfF-9g-kQG"/>
                         <outlet property="externalSchemeButton" destination="gGA-Yv-pnz" id="Eyj-ms-jcc"/>
                         <outlet property="externalSchemeButtonHeightConstraint" destination="QiS-pG-2Ex" id="XPu-Oa-9kk"/>
                         <outlet property="geolocationButton" destination="CN6-fJ-o2J" id="FP7-Od-wu8"/>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1210474744854326?focus=true

### Description

This PR swaps the position of the Duck.ai and “x” (cancel) buttons when the address bar has focus, so the “x” button is on the right and the Duck.ai button is on the left, closer to the address bar text.

#### Changes

1. Storyboard changes:
   * The bookmark, Duck.ai, and “x” buttons are now contained in a single stack view, to more easily reason about their placement in the address bar.
   * There are now two dividers (leading and trailing Duck.ai dividers) to separate the Duck.ai button from the other buttons when needed.
2. `AddressBarButtonsViewController` changes:
   * The “x” (cancel) button is now an `AddressBarButton` so we can set its position in `updateButtonsPosition()` (to control the background shape in its hover state).
   * We set the size of the cancel button in `setupButtonsSize()`, depending on whether the `visualRefresh` feature flag is enabled.
   * The logic for showing the dividers is updated in `updateAIChatDividerVisibility()` to handle each divider based on its related buttons.

### Testing Steps
1. In Settings > Duck.ai, enable the setting “Show Duck.ai shortcut in the address bar."
2. In a new tab, confirm only the Duck.ai button shows on the right side of the address bar.
3. Enter some text in the address bar and confirm the cancel button now shows to the right of the Duck.ai button, with a divider between them.
4. Visit a website that isn’t bookmarked and confirm only the Duck.ai button shows on the right side of the address bar.
5. Hover over the address bar and confirm the bookmark button now shows to the left of the Duck.ai button, with a divider between them.
6. Visit a website that is bookmarked and confirm the bookmark button shows to the left of the Duck.ai button, with a divider between them.
7. Confirm that toggling the focus on the address bar switches between showing the bookmark/Duck.ai button and showing the Duck.ai/cancel buttons in the expected positions.

Additional scenarios:
* Go to Debug > Feature Flag Overrides, disable the `visualRefresh` feature flag, and repeat the steps above to confirm the buttons are in the correct positions with the expected hover states.
* Go to Settings > Duck.ai, disable the setting “Show Duck.ai shortcut in the address bar," and repeat the steps above, confirming the Duck.ai button and dividers are not shown and the bookmark/cancel buttons always appear in the expected position on the right.

### Impact and Risks
Low: Minor visual changes

#### What could go wrong?
* Incorrect size/shape of buttons when `visualRefresh` feature flag is enabled/disabled. (Handled in `AddressBarButtonsViewController` and included in testing steps above.)
* Incorrect position of buttons or dividers when Duck.ai setting is enabled/disabled. (Handled in `AddressBarButtonsViewController` and included in testing steps above.)

### Notes to Reviewer

https://github.com/user-attachments/assets/74d800f1-2536-424a-bce6-0fd24fdd6189

Scenario|Before|After - `visualRefresh` enabled|After - `visualRefresh` disabled
-|-|-|-
New tab (no change)|![Screenshot 2025-06-09 at 13 20 26](https://github.com/user-attachments/assets/b0a073d8-d8e7-46ac-86cc-ca0bbabb2bcb)|![Screenshot 2025-06-09 at 13 14 25](https://github.com/user-attachments/assets/d028031e-721c-4d1a-8953-5be760127748)|![Screenshot 2025-06-09 at 13 18 12](https://github.com/user-attachments/assets/0c4cdf17-248a-4f3c-8d78-87d6a8abd167)
Bookmarked website (no change)|![Screenshot 2025-06-09 at 13 20 32](https://github.com/user-attachments/assets/32255ea8-e6ac-4973-b89b-82fd72f66807)|![Screenshot 2025-06-09 at 13 14 31](https://github.com/user-attachments/assets/946b7793-6794-4f9c-948e-2917bc63ad01)|![Screenshot 2025-06-09 at 13 18 40](https://github.com/user-attachments/assets/8531bb43-56e8-48f4-8516-64875b0fb006)
Address bar focused|![Screenshot 2025-06-09 at 13 20 35](https://github.com/user-attachments/assets/5a6624c5-247d-41a2-99a8-8fb8147a183c)|![Screenshot 2025-06-09 at 13 14 35](https://github.com/user-attachments/assets/6a1fa1e9-5f26-4119-821a-8a44b4bafdd8)|![Screenshot 2025-06-09 at 13 18 44](https://github.com/user-attachments/assets/a42914f9-eddf-4aaa-a975-c3c879024499)
Entering address bar text|![Screenshot 2025-06-09 at 13 20 38](https://github.com/user-attachments/assets/189f3c64-23e7-4023-981a-3816e9dc9b06)|![Screenshot 2025-06-09 at 13 14 44](https://github.com/user-attachments/assets/c34ff1ca-f22f-45f9-bb12-a0a82b1d3e14)|![Screenshot 2025-06-09 at 13 18 55](https://github.com/user-attachments/assets/cee3e026-088d-49ee-8f26-b2e74de8d315)
Cancel button hover state|![Screenshot 2025-06-09 at 13 20 42](https://github.com/user-attachments/assets/fd40956f-70c8-4f65-b5f9-695a2a20a0b3)|![Screenshot 2025-06-09 at 13 14 51](https://github.com/user-attachments/assets/9bb64018-27af-41c7-9c27-e538f1ed4181)|![Screenshot 2025-06-09 at 13 19 11](https://github.com/user-attachments/assets/627fa262-25c4-4bcd-b3c9-789eb79fa7b1)
Bookmarked website, Duck.ai button disabled (no change)|![Screenshot 2025-06-09 at 13 32 53](https://github.com/user-attachments/assets/34a6667d-49b0-439f-96b8-c9636ee45ccb)|![Screenshot 2025-06-09 at 13 34 20](https://github.com/user-attachments/assets/ad59436b-ccb0-4f63-8407-52e1a2409362)|![Screenshot 2025-06-09 at 13 35 12](https://github.com/user-attachments/assets/34b52ce6-25d8-4939-9204-5c475fd5ab47)
Entering address bar text, Duck.ai button disabled|![Screenshot 2025-06-09 at 13 33 03](https://github.com/user-attachments/assets/6db3f699-55df-4331-a34d-036ed852f136)|![Screenshot 2025-06-09 at 13 34 25](https://github.com/user-attachments/assets/887543a4-9320-4d09-b32e-466eea6a4139)|![Screenshot 2025-06-09 at 13 35 22](https://github.com/user-attachments/assets/3b14eada-0055-4d3f-b153-0caea16f1799)





—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)