### PR TITLE
fix autoclear test and update snapshot view

### DIFF
--- a/.maestro/release_tests/autoclear.yaml
+++ b/.maestro/release_tests/autoclear.yaml
@@ -82,6 +82,7 @@ tags:
 
 - tapOn: "DuckDuckGo"
 
+- assertVisible: "Tab Switcher" # wait for the tab switcher to appear so that we don't try and use the blank snapshot view
 - assertNotVisible: "https://example.com/"
 - assertVisible: "Search or enter address"
 - tapOn: "Tab Switcher"

--- a/iOS/DuckDuckGo/BlankSnapshotViewController.swift
+++ b/iOS/DuckDuckGo/BlankSnapshotViewController.swift
@@ -21,6 +21,7 @@ import UIKit
 import Core
 import Suggestions
 import BrowserServicesKit
+import DesignResourcesKitIcons
 
 protocol BlankSnapshotViewRecoveringDelegate: AnyObject {
     
@@ -165,6 +166,7 @@ extension BlankSnapshotViewController: UICollectionViewDataSource {
             fatalError("Not \(OmniBarCell.self)")
         }
         cell.omniBar = viewCoordinator.omniBar
+        cell.omniBar?.barView.accessoryButton.setImage(DesignSystemImages.Glyphs.Size24.aiChat, for: .normal)
         return cell
     }
 
@@ -209,6 +211,10 @@ extension BlankSnapshotViewController {
         viewCoordinator.toolbar.tintColor = theme.barTintColor
 
         viewCoordinator.toolbarTabSwitcherButton.tintColor = theme.barTintColor
+
+        // We don't want this to appear as a real button to users using acessibility devices and our UI tests
+        viewCoordinator.toolbarTabSwitcherButton.isAccessibilityElement = false
+        viewCoordinator.toolbarTabSwitcherButton.accessibilityLabel = nil
 
         viewCoordinator.logoText.tintColor = theme.ddgTextTintColor
      }

--- a/iOS/DuckDuckGo/BlankSnapshotViewController.swift
+++ b/iOS/DuckDuckGo/BlankSnapshotViewController.swift
@@ -96,7 +96,6 @@ class BlankSnapshotViewController: UIViewController {
         decorate()
     }
 
-
     private func addTapInterceptor() {
         let interceptView = UIView(frame: view.bounds)
         interceptView.backgroundColor = .clear


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/392891325557410/task/1210507196399705?focus=true
Tech Design URL:
CC:

### Description
Updates the autoclear test to wait for the tab switcher button instead of asserting against the blank snapshot view and uses correct chat AI icon.

### Testing Steps
1. Check that tests have passed: https://github.com/duckduckgo/apple-browsers/actions/runs/15561761081
2. Turn on autoclear (settings > data clearing > automatically clear data > app exit)
3. Background the app
4. Then view the app in the app switcher - should show the blank snapshot view.  Chat button should be correct icon.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Snapshot view could still be wrong. 

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)