### PR TITLE
Added missing https to Threat protection link

### DIFF
--- a/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
@@ -410,7 +410,7 @@ extension URL {
     }
 
     static var threatProtectionLearnMore: URL {
-        return URL(string: "duckduckgo.com/duckduckgo-help-pages/threat-protection/")!
+        return URL(string: "https://duckduckgo.com/duckduckgo-help-pages/threat-protection/")!
     }
 
     static var dnsBlocklistLearnMore = URL(string: "https://duckduckgo.com/duckduckgo-help-pages/privacy-pro/vpn/dns-blocklists")!


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210512604856096?focus=true
CC: @SabrinaTardio 

### Description

The threat protection learn more link in settings went out without the https:// schema, causing issues in production.


### Testing Steps

Go to threat protection settings and check all links work

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)