### PR TITLE
Support navigation to feedback dialog from NTP

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -587,6 +587,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             )
             activeRemoteMessageModel = ActiveRemoteMessageModel(remoteMessagingClient: remoteMessagingClient, openURLHandler: { url in
                 Application.appDelegate.windowControllersManager.showTab(with: .contentFromURL(url, source: .appOpenUrl))
+            }, navigateToFeedbackHandler: {
+                Application.appDelegate.windowControllersManager.showShareFeedbackModal(initialReportType: .general)
             })
         } else {
             // As long as remoteMessagingClient is private to App Delegate and activeRemoteMessageModel
@@ -596,7 +598,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             activeRemoteMessageModel = ActiveRemoteMessageModel(
                 remoteMessagingStore: nil,
                 remoteMessagingAvailabilityProvider: nil,
-                openURLHandler: { _ in }
+                openURLHandler: { _ in },
+                navigateToFeedbackHandler: { }
             )
         }
 

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -455,13 +455,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         VPNAppState(defaults: .netP).isAuthV2Enabled = isAuthV2Enabled
 
-        windowControllersManager = WindowControllersManager(
+        let windowControllersManager = WindowControllersManager(
             pinnedTabsManagerProvider: pinnedTabsManagerProvider,
             subscriptionFeatureAvailability: DefaultSubscriptionFeatureAvailability(
                 privacyConfigurationManager: privacyConfigurationManager,
                 purchasePlatform: subscriptionAuthV1toV2Bridge.currentEnvironment.purchasePlatform
             )
         )
+        self.windowControllersManager = windowControllersManager
 
         visualStyleManager = VisualStyleManager(featureFlagger: featureFlagger, internalUserDecider: internalUserDecider)
 
@@ -586,9 +587,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 featureFlagger: self.featureFlagger
             )
             activeRemoteMessageModel = ActiveRemoteMessageModel(remoteMessagingClient: remoteMessagingClient, openURLHandler: { url in
-                Application.appDelegate.windowControllersManager.showTab(with: .contentFromURL(url, source: .appOpenUrl))
+                windowControllersManager.showTab(with: .contentFromURL(url, source: .appOpenUrl))
             }, navigateToFeedbackHandler: {
-                Application.appDelegate.windowControllersManager.showShareFeedbackModal(initialReportType: .general)
+                windowControllersManager.showFeedbackModal(preselectedFormOption: .feedback(feedbackCategory: .other))
             })
         } else {
             // As long as remoteMessagingClient is private to App Delegate and activeRemoteMessageModel

--- a/macOS/DuckDuckGo/Feedback/View/FeedbackPresenter.swift
+++ b/macOS/DuckDuckGo/Feedback/View/FeedbackPresenter.swift
@@ -31,7 +31,6 @@ enum FeedbackPresenter {
             return
         }
 
-
         feedbackWindow.feedbackViewController.preselectedFormOption = preselectedFormOption
         feedbackWindow.feedbackViewController.currentTab =
             parentWindowController.mainViewController.tabCollectionViewModel.selectedTabViewModel?.tab

--- a/macOS/DuckDuckGo/Feedback/View/FeedbackPresenter.swift
+++ b/macOS/DuckDuckGo/Feedback/View/FeedbackPresenter.swift
@@ -21,7 +21,7 @@ import Cocoa
 enum FeedbackPresenter {
 
     @MainActor
-    static func presentFeedbackForm() {
+    static func presentFeedbackForm(preselectedFormOption: FeedbackViewController.FormOption? = nil) {
         // swiftlint:disable:next force_cast
         let windowController = NSStoryboard.feedback.instantiateController(withIdentifier: "FeedbackWindowController") as! NSWindowController
 
@@ -31,6 +31,8 @@ enum FeedbackPresenter {
             return
         }
 
+
+        feedbackWindow.feedbackViewController.preselectedFormOption = preselectedFormOption
         feedbackWindow.feedbackViewController.currentTab =
             parentWindowController.mainViewController.tabCollectionViewModel.selectedTabViewModel?.tab
         parentWindowController.window?.beginSheet(feedbackWindow) { _ in }

--- a/macOS/DuckDuckGo/Feedback/View/FeedbackViewController.swift
+++ b/macOS/DuckDuckGo/Feedback/View/FeedbackViewController.swift
@@ -43,6 +43,19 @@ final class FeedbackViewController: NSViewController {
             default: return nil
             }
         }
+
+        var tag: Int {
+            switch self {
+            case .feedback(let feedbackCategory):
+                switch feedbackCategory {
+                case .bug: return 1
+                case .featureRequest: return 2
+                case .other: return 3
+                case .generalFeedback, .designFeedback, .usability, .dataImport:
+                    return -1 // Unsupported categories
+                }
+            }
+        }
     }
     @IBOutlet weak var titleLabel: NSTextField!
     @IBOutlet weak var okButton: NSButton!
@@ -83,6 +96,13 @@ final class FeedbackViewController: NSViewController {
         return url.trimmingQueryItemsAndFragment()
     }
 
+    /// Optional pre-selected form option to initialize the feedback form with
+    var preselectedFormOption: FormOption? {
+        didSet {
+            setupPreselectedOption()
+        }
+    }
+
     private let feedbackSender = FeedbackSender()
 
     override func viewDidLoad() {
@@ -90,6 +110,7 @@ final class FeedbackViewController: NSViewController {
 
         setContentViewHeight(Constants.defaultContentHeight, animated: false)
         setupTextViews()
+        setupPreselectedOption()
     }
 
     override func viewDidAppear() {
@@ -294,6 +315,20 @@ final class FeedbackViewController: NSViewController {
             unsupportedOsView.isHidden = false
             unsupportedOsChildView = view
         }
+    }
+
+    private func setupPreselectedOption() {
+        guard let preselectedFormOption = preselectedFormOption else {
+            return
+        }
+
+        let tag = preselectedFormOption.tag
+        guard tag >= 0, let menuItem = optionPopUpButton.menu?.item(withTag: tag) else {
+            return
+        }
+
+        optionPopUpButton.select(menuItem)
+        updateViews()
     }
 
 }

--- a/macOS/DuckDuckGo/NewTabPage/Features/ActiveRemoteMessageModel+NewTabPage.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/ActiveRemoteMessageModel+NewTabPage.swift
@@ -46,6 +46,12 @@ extension ActiveRemoteMessageModel: NewTabPageActiveRemoteMessageProviding {
             }
         case .appStore:
             await openURLHandler(.appStore)
+        case .navigation(let value):
+            switch value {
+            case .feedback:
+                await navigateToFeedbackHandler()
+            default: break
+            }
         default:
             break
         }

--- a/macOS/DuckDuckGo/RemoteMessaging/ActiveRemoteMessageModel.swift
+++ b/macOS/DuckDuckGo/RemoteMessaging/ActiveRemoteMessageModel.swift
@@ -54,11 +54,19 @@ final class ActiveRemoteMessageModel: ObservableObject {
      */
     let openURLHandler: (URL) async -> Void
 
-    convenience init(remoteMessagingClient: RemoteMessagingClient, openURLHandler: @escaping (URL) async -> Void) {
+    /**
+     * Handler for opening the user feedback dialog.
+     */
+    let navigateToFeedbackHandler: () async -> Void
+
+    convenience init(remoteMessagingClient: RemoteMessagingClient,
+                     openURLHandler: @escaping (URL) async -> Void,
+                     navigateToFeedbackHandler: @escaping () async -> Void) {
         self.init(
             remoteMessagingStore: remoteMessagingClient.store,
             remoteMessagingAvailabilityProvider: remoteMessagingClient.remoteMessagingAvailabilityProvider,
-            openURLHandler: openURLHandler
+            openURLHandler: openURLHandler,
+            navigateToFeedbackHandler: navigateToFeedbackHandler
         )
     }
 
@@ -68,10 +76,12 @@ final class ActiveRemoteMessageModel: ObservableObject {
     init(
         remoteMessagingStore: @escaping @autoclosure () -> RemoteMessagingStoring?,
         remoteMessagingAvailabilityProvider: RemoteMessagingAvailabilityProviding?,
-        openURLHandler: @escaping (URL) async -> Void
+        openURLHandler: @escaping (URL) async -> Void,
+        navigateToFeedbackHandler: @escaping () async -> Void
     ) {
         self.store = remoteMessagingStore
         self.openURLHandler = openURLHandler
+        self.navigateToFeedbackHandler = navigateToFeedbackHandler
 
         let messagesDidChangePublisher = NotificationCenter.default.publisher(for: RemoteMessagingStore.Notifications.remoteMessagesDidChange)
             .asVoid()

--- a/macOS/DuckDuckGo/UnifiedFeedbackForm/UnifiedFeedbackFormViewController.swift
+++ b/macOS/DuckDuckGo/UnifiedFeedbackForm/UnifiedFeedbackFormViewController.swift
@@ -45,7 +45,8 @@ final class UnifiedFeedbackFormViewController: NSViewController {
     private var cancellables = Set<AnyCancellable>()
 
     init(feedbackSender: UnifiedFeedbackSender = DefaultFeedbackSender(),
-         source: UnifiedFeedbackSource = .default) {
+         source: UnifiedFeedbackSource = .default,
+         initialReportType: UnifiedFeedbackReportType? = nil) {
         self.feedbackSender = feedbackSender
         self.viewModel = UnifiedFeedbackFormViewModel(subscriptionManager: Application.appDelegate.subscriptionAuthV1toV2Bridge,
                                                       apiService: DefaultAPIService(userAgent: UserAgent.duckDuckGoUserAgent()),
@@ -53,6 +54,10 @@ final class UnifiedFeedbackFormViewController: NSViewController {
                                                       dbpMetadataCollector: DefaultDBPMetadataCollector(),
                                                       feedbackSender: feedbackSender,
                                                       source: source)
+
+        if let initialReportType = initialReportType {
+            viewModel.selectedReportType = initialReportType.rawValue
+        }
 
         super.init(nibName: nil, bundle: nil)
         self.viewModel.delegate = self

--- a/macOS/DuckDuckGo/UnifiedFeedbackForm/UnifiedFeedbackFormViewController.swift
+++ b/macOS/DuckDuckGo/UnifiedFeedbackForm/UnifiedFeedbackFormViewController.swift
@@ -45,8 +45,7 @@ final class UnifiedFeedbackFormViewController: NSViewController {
     private var cancellables = Set<AnyCancellable>()
 
     init(feedbackSender: UnifiedFeedbackSender = DefaultFeedbackSender(),
-         source: UnifiedFeedbackSource = .default,
-         initialReportType: UnifiedFeedbackReportType? = nil) {
+         source: UnifiedFeedbackSource = .default) {
         self.feedbackSender = feedbackSender
         self.viewModel = UnifiedFeedbackFormViewModel(subscriptionManager: Application.appDelegate.subscriptionAuthV1toV2Bridge,
                                                       apiService: DefaultAPIService(userAgent: UserAgent.duckDuckGoUserAgent()),
@@ -54,10 +53,6 @@ final class UnifiedFeedbackFormViewController: NSViewController {
                                                       dbpMetadataCollector: DefaultDBPMetadataCollector(),
                                                       feedbackSender: feedbackSender,
                                                       source: source)
-
-        if let initialReportType = initialReportType {
-            viewModel.selectedReportType = initialReportType.rawValue
-        }
 
         super.init(nibName: nil, bundle: nil)
         self.viewModel.delegate = self

--- a/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
+++ b/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
@@ -415,8 +415,8 @@ extension WindowControllersManager {
         windowController.mainViewController.navigationBarViewController.showNetworkProtectionStatus()
     }
 
-    func showShareFeedbackModal(source: UnifiedFeedbackSource = .default) {
-        let feedbackFormViewController = UnifiedFeedbackFormViewController(source: source)
+    func showShareFeedbackModal(source: UnifiedFeedbackSource = .default, initialReportType: UnifiedFeedbackReportType? = nil) {
+        let feedbackFormViewController = UnifiedFeedbackFormViewController(source: source, initialReportType: initialReportType)
         let feedbackFormWindowController = feedbackFormViewController.wrappedInWindowController()
 
         guard let feedbackFormWindow = feedbackFormWindowController.window else {

--- a/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
+++ b/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
@@ -415,8 +415,14 @@ extension WindowControllersManager {
         windowController.mainViewController.navigationBarViewController.showNetworkProtectionStatus()
     }
 
-    func showShareFeedbackModal(source: UnifiedFeedbackSource = .default, initialReportType: UnifiedFeedbackReportType? = nil) {
-        let feedbackFormViewController = UnifiedFeedbackFormViewController(source: source, initialReportType: initialReportType)
+    /// Shows the non-privacy pro feedback modal
+    func showFeedbackModal(preselectedFormOption: FeedbackViewController.FormOption? = nil) {
+        FeedbackPresenter.presentFeedbackForm(preselectedFormOption: preselectedFormOption)
+    }
+
+    /// Shows the Privacy Pro feedback modal
+    func showShareFeedbackModal(source: UnifiedFeedbackSource = .default) {
+        let feedbackFormViewController = UnifiedFeedbackFormViewController(source: source)
         let feedbackFormWindowController = feedbackFormViewController.wrappedInWindowController()
 
         guard let feedbackFormWindow = feedbackFormWindowController.window else {

--- a/macOS/UnitTests/NewTabPage/NewTabPageCoordinatorTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageCoordinatorTests.swift
@@ -74,7 +74,8 @@ final class NewTabPageCoordinatorTests: XCTestCase {
             activeRemoteMessageModel: ActiveRemoteMessageModel(
                 remoteMessagingStore: MockRemoteMessagingStore(),
                 remoteMessagingAvailabilityProvider: MockRemoteMessagingAvailabilityProvider(),
-                openURLHandler: { _ in }
+                openURLHandler: { _ in },
+                navigateToFeedbackHandler: { }
             ),
             historyCoordinator: HistoryCoordinatingMock(),
             contentBlocking: ContentBlockingMock(),

--- a/macOS/UnitTests/RemoteMessaging/ActiveRemoteMessageModelTests.swift
+++ b/macOS/UnitTests/RemoteMessaging/ActiveRemoteMessageModelTests.swift
@@ -40,7 +40,8 @@ final class ActiveRemoteMessageModelTests: XCTestCase {
         model = ActiveRemoteMessageModel(
             remoteMessagingStore: self.store,
             remoteMessagingAvailabilityProvider: MockRemoteMessagingAvailabilityProvider(),
-            openURLHandler: { _ in }
+            openURLHandler: { _ in },
+            navigateToFeedbackHandler: { }
         )
 
         XCTAssertNil(model.newTabPageRemoteMessage)
@@ -51,7 +52,8 @@ final class ActiveRemoteMessageModelTests: XCTestCase {
         model = ActiveRemoteMessageModel(
             remoteMessagingStore: self.store,
             remoteMessagingAvailabilityProvider: MockRemoteMessagingAvailabilityProvider(),
-            openURLHandler: { _ in }
+            openURLHandler: { _ in },
+            navigateToFeedbackHandler: { }
         )
 
         XCTAssertEqual(model.newTabPageRemoteMessage, message)
@@ -62,7 +64,8 @@ final class ActiveRemoteMessageModelTests: XCTestCase {
         model = ActiveRemoteMessageModel(
             remoteMessagingStore: self.store,
             remoteMessagingAvailabilityProvider: MockRemoteMessagingAvailabilityProvider(),
-            openURLHandler: { _ in }
+            openURLHandler: { _ in },
+            navigateToFeedbackHandler: { }
         )
         await model.dismissRemoteMessage(with: .close)
 
@@ -74,7 +77,8 @@ final class ActiveRemoteMessageModelTests: XCTestCase {
         model = ActiveRemoteMessageModel(
             remoteMessagingStore: self.store,
             remoteMessagingAvailabilityProvider: MockRemoteMessagingAvailabilityProvider(),
-            openURLHandler: { _ in }
+            openURLHandler: { _ in },
+            navigateToFeedbackHandler: { }
         )
 
         XCTAssertFalse(store.hasShownRemoteMessage(withID: message.id))
@@ -98,7 +102,8 @@ final class ActiveRemoteMessageModelTests: XCTestCase {
         model = ActiveRemoteMessageModel(
             remoteMessagingStore: self.store,
             remoteMessagingAvailabilityProvider: MockRemoteMessagingAvailabilityProvider(),
-            openURLHandler: { _ in }
+            openURLHandler: { _ in },
+            navigateToFeedbackHandler: { }
         )
 
         XCTAssertNotNil(model.tabBarRemoteMessage)
@@ -110,7 +115,8 @@ final class ActiveRemoteMessageModelTests: XCTestCase {
         model = ActiveRemoteMessageModel(
             remoteMessagingStore: self.store,
             remoteMessagingAvailabilityProvider: MockRemoteMessagingAvailabilityProvider(),
-            openURLHandler: { _ in }
+            openURLHandler: { _ in },
+            navigateToFeedbackHandler: { }
         )
 
         XCTAssertNil(model.tabBarRemoteMessage)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1210510946680683?focus=true
Tech Design URL:
CC:

### Description
We need to support the `navigation` action on macOS for remote messages. The new remote message we will show for the visual updates needs to navigate to the feedback dialog. 

https://github.com/duckduckgo/remote-messaging-config/pull/192/files

We also need to support showing an initial report in the feedback dialog, so that when it is displayed, a category is pre-loaded.

### Testing Steps
1. Go to `RemoteMessagingClient`, and change the DEBUG URL to use `https://jsonblob.com/api/1380594945500569600`. That JSON shows the new remote message for the Visual Updates (it does not add the feature flag parameter to make it easier to test)
2. Start the app
3. Remove internal state
4. Go to Debug -> Remote Messaging Framework -> Refresh Config
5. Check the NTP for the new message
6. Tap the `Share Feedback` button.
7. The feedback dialog should appear with the General Feedback category selected.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
We introudce issues to NTP

### Quality Considerations
Nothing specific.

### Notes to Reviewer
I want to know if I’m following the correct steps here.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)