### PR TITLE
macOS: Remove additional step to cancel address bar editing

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -383,14 +383,10 @@ final class AddressBarTextField: NSTextField {
         }
 
         // reset to actual value
-        let oldValue = value
         clearValue()
         updateValue(selectedTabViewModel: nil, addressBarString: nil)
 
-        if oldValue == value {
-            // resign first responder if nothing has changed
-            self.window?.makeFirstResponder(nil)
-        }
+        self.window?.makeFirstResponder(nil)
     }
 
     override func becomeFirstResponder() -> Bool {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210520513333452?focus=true

### Description

This updates the “x” (cancel) button and escape key behavior, so it immediately clears the address bar text changes and resigns first responder at once (instead of first clearing the text and then resigning first responder with two clicks).

![image](https://github.com/user-attachments/assets/2586a15b-3a39-4131-81ea-df81370063b6)


### Testing Steps
1. Enter some text in the browser address bar.
2. Click the “x” (cancel) button or press the escape key, and confirm the suggestions window is closed but your entered text is still visible.
3. Click the “x” (cancel) button or press the escape key again, and confirm the entered text is cleared (the address bar text is reset to its previous value) and the address bar is no longer in focus.

### Impact and Risks
Low: small bug fixes

#### What could go wrong?
Wrong text should be shown when cancel button is clicked.

### Notes to Reviewer

https://github.com/user-attachments/assets/04a1b575-6b41-4877-a19d-432deea71001




—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)