### PR TITLE
Use SwiftUI ScrollView instead of UIScrollView on NewTabPage

### DIFF
--- a/iOS/DuckDuckGo/NewTabPageView.swift
+++ b/iOS/DuckDuckGo/NewTabPageView.swift
@@ -73,15 +73,7 @@ private extension NewTabPageView {
     @ViewBuilder
     private var sectionsView: some View {
         GeometryReader { proxy in
-            let shadowColor = viewModel.isExperimentalAppearanceEnabled ? Color(designSystemColor: .shadowPrimary) : .clear
-            NewTabPageShadowScrollView(shadowColor: shadowColor, setUpScrollView: {
-                // This setting prevents from going into redraw loop for the hosted SUI view when opening a keyboard covering part of the hosted content.
-                $0.contentInsetAdjustmentBehavior = .never
-                
-                $0.backgroundColor = UIColor(designSystemColor: .background)
-                $0.alwaysBounceVertical = true
-                $0.keyboardDismissMode = .onDrag
-            }) {
+            ScrollView {
                 VStack(spacing: Metrics.sectionSpacing) {
                     
                     messagesSectionView


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210379416433601/task/1210482721397279?focus=true
Tech Design URL:
CC:

### Description

This reverses the performance issue caused by using UIKit's UIScrollView inside a SwiftUI stack.

### Testing Steps
1. Add many (> 500 favorites) 
2. Open tab switcher and go back to new tab page. Make sure there's no noticeable delay.
3. 

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
The performance issue may still be there, but manifesting in a different way, but that's unlikely since the previous implementation was live for a long time on production and didn't show any kinds of performance issues.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)