### PR TITLE
Autofill known fields in the Internal Feedback Form

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -1047,6 +1047,10 @@
 		371D00E129D8509400EC8598 /* OpenSSL in Frameworks */ = {isa = PBXBuildFile; productRef = 371D00E029D8509400EC8598 /* OpenSSL */; };
 		371E1D672D0B2E9F00F9205B /* NewTabPageCustomizationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371E1D662D0B2E9F00F9205B /* NewTabPageCustomizationProvider.swift */; };
 		371E1D682D0B2E9F00F9205B /* NewTabPageCustomizationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371E1D662D0B2E9F00F9205B /* NewTabPageCustomizationProvider.swift */; };
+		372042D42DF9B0AD00CE099A /* InternalFeedbackFormTabExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372042D32DF9B0A400CE099A /* InternalFeedbackFormTabExtension.swift */; };
+		372042D52DF9B0AD00CE099A /* InternalFeedbackFormTabExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372042D32DF9B0A400CE099A /* InternalFeedbackFormTabExtension.swift */; };
+		372042E12DF9C04400CE099A /* internal-feedback-autofiller.js in Resources */ = {isa = PBXBuildFile; fileRef = 372042DF2DF9C04400CE099A /* internal-feedback-autofiller.js */; };
+		372042E22DF9C04400CE099A /* internal-feedback-autofiller.js in Resources */ = {isa = PBXBuildFile; fileRef = 372042DF2DF9C04400CE099A /* internal-feedback-autofiller.js */; };
 		372A0FEC2B2379310033BF7F /* SyncMetricsEventsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372A0FEB2B2379310033BF7F /* SyncMetricsEventsHandler.swift */; };
 		372A0FED2B2379310033BF7F /* SyncMetricsEventsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372A0FEB2B2379310033BF7F /* SyncMetricsEventsHandler.swift */; };
 		372BC2A12A4AFA47001D8FD5 /* SyncCredentialsAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372BC2A02A4AFA47001D8FD5 /* SyncCredentialsAdapter.swift */; };
@@ -4076,6 +4080,8 @@
 		371BFF5E2D39360E0075DB87 /* HistoryViewActionsManagerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewActionsManagerExtension.swift; sourceTree = "<group>"; };
 		371C0A2827E33EDC0070591F /* FeedbackPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackPresenter.swift; sourceTree = "<group>"; };
 		371E1D662D0B2E9F00F9205B /* NewTabPageCustomizationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageCustomizationProvider.swift; sourceTree = "<group>"; };
+		372042D32DF9B0A400CE099A /* InternalFeedbackFormTabExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalFeedbackFormTabExtension.swift; sourceTree = "<group>"; };
+		372042DF2DF9C04400CE099A /* internal-feedback-autofiller.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "internal-feedback-autofiller.js"; sourceTree = "<group>"; };
 		3720B7F82D00DA4500D20F23 /* WebKitExtensions */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = WebKitExtensions; sourceTree = "<group>"; };
 		372A0FEB2B2379310033BF7F /* SyncMetricsEventsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncMetricsEventsHandler.swift; sourceTree = "<group>"; };
 		372BC2A02A4AFA47001D8FD5 /* SyncCredentialsAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncCredentialsAdapter.swift; sourceTree = "<group>"; };
@@ -6418,6 +6424,14 @@
 			path = RemoteMessaging;
 			sourceTree = "<group>";
 		};
+		372042E02DF9C04400CE099A /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				372042DF2DF9C04400CE099A /* internal-feedback-autofiller.js */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
 		373A1AA6283ECC8000586521 /* HTML */ = {
 			isa = PBXGroup;
 			children = (
@@ -8725,6 +8739,7 @@
 		AA3863C227A1E1C000749AB5 /* Feedback */ = {
 			isa = PBXGroup;
 			children = (
+				372042E02DF9C04400CE099A /* Resources */,
 				AA3D531827A2F24C00074EC1 /* View */,
 				AA3D531927A2F47100074EC1 /* Model */,
 			);
@@ -9990,6 +10005,7 @@
 		B647EFB32922539400BA628D /* TabExtensions */ = {
 			isa = PBXGroup;
 			children = (
+				372042D32DF9B0A400CE099A /* InternalFeedbackFormTabExtension.swift */,
 				B647EFBA2922584B00BA628D /* AdClickAttributionTabExtension.swift */,
 				3148727D2CC68F6200EEF89B /* AIChatTabExtension.swift */,
 				B6C00ECA292F839D009C73A6 /* AutofillTabExtension.swift */,
@@ -11709,6 +11725,7 @@
 				3706FCCA293F65D500E42796 /* FirePopoverCollectionViewHeader.xib in Resources */,
 				9FBB0C012CB94FC10006B6A6 /* view_highlight.json in Resources */,
 				3706FCCC293F65D500E42796 /* TabBar.storyboard in Resources */,
+				372042E22DF9C04400CE099A /* internal-feedback-autofiller.js in Resources */,
 				3706FCD0293F65D500E42796 /* BookmarksBarCollectionViewItem.xib in Resources */,
 				7B5A23762C46A4A8007213AC /* ExcludedDomains.storyboard in Resources */,
 				BBCB2FCC2DEA1DD800A97A6C /* fire-dark.json in Resources */,
@@ -11932,6 +11949,7 @@
 				AAE246F6270A3D3000BEEAEE /* FirePopoverCollectionViewHeader.xib in Resources */,
 				9FBB0C002CB94FC10006B6A6 /* view_highlight.json in Resources */,
 				AA80EC79256C46AA007083E7 /* TabBar.storyboard in Resources */,
+				372042E12DF9C04400CE099A /* internal-feedback-autofiller.js in Resources */,
 				4BE5336B286912D40019DBFD /* BookmarksBarCollectionViewItem.xib in Resources */,
 				7B5A23752C46A4A8007213AC /* ExcludedDomains.storyboard in Resources */,
 				BBCB2FCB2DEA1DD800A97A6C /* fire-dark.json in Resources */,
@@ -13109,6 +13127,7 @@
 				3706FC21293F65D500E42796 /* UserText+PasswordManager.swift in Sources */,
 				F118EA7E2BEA2B8700F77634 /* DefaultSubscriptionFeatureAvailability+DefaultInitializer.swift in Sources */,
 				3706FC22293F65D500E42796 /* LoadingProgressView.swift in Sources */,
+				372042D52DF9B0AD00CE099A /* InternalFeedbackFormTabExtension.swift in Sources */,
 				3706FC23293F65D500E42796 /* StatisticsStore.swift in Sources */,
 				37F09AD42DDE433500643A1B /* FaviconManagerMock.swift in Sources */,
 				1DDD3EBD2B84DCB9004CBF2B /* WebTrackingProtectionPreferences.swift in Sources */,
@@ -14620,6 +14639,7 @@
 				BD88A83E2C4F3E4300460A26 /* FeedbackCategoryProviding.swift in Sources */,
 				9F56CFB12B843F6C00BB7F11 /* BookmarksDialogViewFactory.swift in Sources */,
 				F1FD5B672C2B0AAA0040FA0D /* SubscriptionPagesUseSubscriptionFeature.swift in Sources */,
+				372042D42DF9B0AD00CE099A /* InternalFeedbackFormTabExtension.swift in Sources */,
 				B645D8F629FA95440024461F /* WKProcessPoolExtension.swift in Sources */,
 				9D9AE86B2AA76CF90026E7DC /* LoginItemsManager.swift in Sources */,
 				C18194642C7DF7D600381092 /* FreemiumDBPPresenter.swift in Sources */,

--- a/macOS/DuckDuckGo/Feedback/Resources/internal-feedback-autofiller.js
+++ b/macOS/DuckDuckGo/Feedback/Resources/internal-feedback-autofiller.js
@@ -1,0 +1,98 @@
+function openDropdown(label) {
+    const dropdown = document.querySelector(`[aria-label^="${label}"]`);
+    if (dropdown) {
+        dropdown.click();
+    } else {
+        console.error(`Dropdown with label "${label}" not found.`);
+    }
+}
+
+function selectOption(optionText) {
+    setTimeout(() => {
+        const option = Array.from(document.querySelectorAll('[role="option"], .dropdown-option, .select-option'))
+            .find(el => el.textContent.trim() === optionText);
+        if (option) {
+            option.click();
+        } else {
+            console.error(`Option "${optionText}" not found in dropdown.`);
+        }
+    }, 100);
+}
+
+function setInputValue(input, value) {
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value'
+    ).set;
+
+    nativeInputValueSetter.call(input, value);
+
+    const inputEvent = new Event('input', { bubbles: true });
+    input.dispatchEvent(inputEvent);
+}
+
+function setInputAfterLabel(tag, labelText, value) {
+    const xpath = `//${tag}[contains(text(), '${labelText}')]/following::input[@type='text'][1]`;
+    const result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+    const input = result.singleNodeValue;
+
+    if (input) {
+        if (value) {
+            setInputValue(input, value);
+        } else {
+            input.focus()
+        }
+    } else {
+        console.error(`${tag} field after label "${labelText}" not found.`);
+    }
+}
+
+function waitForElement(tag, text, timeout = 5000) {
+    return new Promise((resolve, reject) => {
+        const startTime = Date.now();
+
+        const checkForElement = () => {
+            const element = Array.from(document.querySelectorAll(tag))
+                .find(x => x.textContent.trim().startsWith(text));
+
+            if (element) {
+                resolve(element);
+                return;
+            }
+
+            if (Date.now() - startTime >= timeout) {
+                reject(new Error(`Timeout: ${tag} with text "${text}" not found within ${timeout}ms`));
+                return;
+            }
+
+            setTimeout(checkForElement, 100);
+        };
+
+        checkForElement();
+    });
+}
+
+function fillOutForm() {
+    openDropdown('Which product area or team does this issue relate to?');
+    selectOption('Native Apps');
+
+    waitForElement('label', 'Which platform?')
+        .then(() => {
+            openDropdown('Which platform?');
+            selectOption('macOS Browser');
+
+            waitForElement('label', 'Which macOS version?')
+                .then(() => {
+                    setInputAfterLabel('label', 'Which macOS version?', '%OS_VERSION%');
+                    setInputAfterLabel('label', 'Which version of the DuckDuckGo Browser?', '%APP_VERSION%');
+                    // set with no value -> just focus it
+                    setInputAfterLabel('label', 'Asana Task Title');
+                })
+                .catch(error => console.error('"Which macOS version?" label not found:', error));
+        })
+        .catch(error => console.error('"Which platform?" label not found:', error));
+}
+
+waitForElement('h1', 'Internal Product Feedback Form')
+    .then(_ => fillOutForm())
+    .catch(_ => console.error('Internal Product Feedback Form is not loaded after 5s'));

--- a/macOS/DuckDuckGo/Tab/Model/Tab+Navigation.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab+Navigation.swift
@@ -99,6 +99,9 @@ extension Tab: NavigationResponder {
 
             .weak(nullable: self.networkProtection),
 
+            // Internal Feedback Form
+            .weak(nullable: self.internalFeedbackForm),
+
             // should be the last, for Unit Tests navigation events tracking
             .struct(nullable: testsClosureNavigationResponder)
             // !! don‘t add Tab Extensions here !!

--- a/macOS/DuckDuckGo/Tab/TabExtensions/InternalFeedbackFormTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/InternalFeedbackFormTabExtension.swift
@@ -1,0 +1,126 @@
+//
+//  InternalFeedbackFormTabExtension.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import BrowserServicesKit
+import Combine
+import Common
+import Navigation
+import Foundation
+import UserScript
+import WebKit
+
+/**
+ * This is a wrapper class for a hardcoded script evaluated in on the Internal Feedback Form page.
+ *
+ * It's not really using any `UserScript` APIs and it isn't loaded permanently into the webView,
+ * but it only subclasses `UserScript` to be able to use `loadJS` API and provide values for
+ * placeholders.
+ *
+ * The `source` property is used by `InternalFeedbackFormTabExtension`.
+ */
+final class InternalFeedbackFormUserScript: NSObject, UserScript {
+    let messageNames: [String] = []
+    let injectionTime: WKUserScriptInjectionTime = .atDocumentStart
+    let forMainFrameOnly: Bool = true
+    let source: String
+
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {}
+
+    override init() {
+#if APPSTORE
+        let distributionType = "App Store"
+#else
+        let distributionType = "DMG"
+#endif
+        source = Self.loadJS("internal-feedback-autofiller", from: .main, withReplacements: [
+            "%OS_VERSION%": ProcessInfo.processInfo.operatingSystemVersion.description,
+            "%APP_VERSION%": "\(AppVersion().versionAndBuildNumber) (\(distributionType))"
+        ])
+        super.init()
+    }
+}
+
+fileprivate extension URLComponents {
+    /// This is the URL that users land on after going to `go.duckduckgo.com/feedback`.
+    static let internalFeedbackForm = URLComponents(string: "https://form.asana.com/?k=auWnXd_NQejLUySD7egW_Q&d=137249556945")!
+}
+
+/// This tab extension auto-fills Internal Feedback Form with OS version and app version values.
+///
+/// It's only active for internal users and only performs an action on the Internal Feedback Form page.
+///
+final class InternalFeedbackFormTabExtension {
+
+    private let internalUserDecider: InternalUserDecider
+    private weak var webView: WKWebView?
+    private var cancellables = Set<AnyCancellable>()
+
+    init(
+        webViewPublisher: some Publisher<WKWebView, Never>,
+        internalUserDecider: InternalUserDecider
+    ) {
+        self.internalUserDecider = internalUserDecider
+
+        webViewPublisher.sink { [weak self] webView in
+            self?.webView = webView
+        }
+        .store(in: &cancellables)
+    }
+}
+
+extension InternalFeedbackFormTabExtension: NavigationResponder {
+
+    func navigationDidFinish(_ navigation: Navigation) {
+        guard internalUserDecider.isInternalUser, let webView, navigation.navigationAction.isForMainFrame, isInternalFeedbackURL(navigation.url) else {
+            return
+        }
+#if APPSTORE
+        let distributionType = "App Store"
+#else
+        let distributionType = "DMG"
+#endif
+        let script = InternalFeedbackFormUserScript().source
+        webView.evaluateJavaScript(script)
+    }
+
+    /// The URL needs to be matched against the form URL, but there may be additional
+    /// query items in the webView URL that shouldn't be affecting the logic.
+    /// So we're comparing the host, path and that webView URL query items are superset
+    /// of the reference URL query items.
+    private func isInternalFeedbackURL(_ url: URL) -> Bool {
+        guard let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return false
+        }
+        return urlComponents.host == URLComponents.internalFeedbackForm.host &&
+            urlComponents.path == URLComponents.internalFeedbackForm.path &&
+            Set(urlComponents.queryItems ?? []).isSuperset(of: Set(URLComponents.internalFeedbackForm.queryItems ?? []))
+    }
+}
+
+protocol InternalFeedbackFormTabExtensionProtocol: AnyObject, NavigationResponder {
+}
+
+extension InternalFeedbackFormTabExtension: InternalFeedbackFormTabExtensionProtocol, TabExtension {
+    func getPublicProtocol() -> InternalFeedbackFormTabExtensionProtocol { self }
+}
+
+extension TabExtensions {
+    var internalFeedbackForm: InternalFeedbackFormTabExtensionProtocol? {
+        resolve(InternalFeedbackFormTabExtension.self)
+    }
+}

--- a/macOS/DuckDuckGo/Tab/TabExtensions/InternalFeedbackFormTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/InternalFeedbackFormTabExtension.swift
@@ -69,12 +69,14 @@ final class InternalFeedbackFormTabExtension {
     private let internalUserDecider: InternalUserDecider
     private weak var webView: WKWebView?
     private var cancellables = Set<AnyCancellable>()
+    private let scriptSource: String
 
     init(
         webViewPublisher: some Publisher<WKWebView, Never>,
         internalUserDecider: InternalUserDecider
     ) {
         self.internalUserDecider = internalUserDecider
+        self.scriptSource = InternalFeedbackFormUserScript().source
 
         webViewPublisher.sink { [weak self] webView in
             self?.webView = webView
@@ -94,8 +96,7 @@ extension InternalFeedbackFormTabExtension: NavigationResponder {
 #else
         let distributionType = "DMG"
 #endif
-        let script = InternalFeedbackFormUserScript().source
-        webView.evaluateJavaScript(script)
+        webView.evaluateJavaScript(scriptSource)
     }
 
     /// The URL needs to be matched against the form URL, but there may be additional

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
@@ -260,6 +260,13 @@ extension TabExtensionsBuilder {
                 NetworkProtectionControllerTabExtension(tunnelController: tunnelController)
             }
         }
+
+        add {
+            InternalFeedbackFormTabExtension(
+                webViewPublisher: args.webViewFuture,
+                internalUserDecider: dependencies.featureFlagger.internalUserDecider
+            )
+        }
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/42792087274227/task/1210519390344797?focus=true

### Description
This change adds a tab extension that runs small JS script on Internal Feedback Form page
in order to prefill fields like platform, OS version and app version, so that internal users
don’t need to fill them out themselves. The tab extension is only active for internal users
and otherwise is transparent to regular users.

### Testing Steps
1. Launch the app and set internal user state.
2. Open Hamburger menu -> Send Feedback -> Send Browser Feedback. Perform Duo authentication if needed. Verify that you land on Internal Feedback Form page with macOS browser, your OS version and app version prefilled.
3. Repeat the test with the App Store app and verify that you see app version with `(App Store)` suffix.
4. Remove internal user state and go to https://go.duckduckgo.com/feedback. Verify that autofilling does not happen.

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
* Logic leaking to regular users. But internalUserDecider is there.
* Tab extension getting in the way of other tab extensions. This is solved by putting this one as the last in the responder chain.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)