### PR TITLE
Rename CI pixels

### DIFF
--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -93,7 +93,7 @@ jobs:
         if: always() && github.ref_name == 'main'
         uses: ./.github/actions/send-pixel
         with:
-          pixel-name: m_ci_apple_bsk_main_unit_tests_macos_${{ steps.run-unit-tests.outcome }}
+          pixel-name: m_ci_apple_status_bsk_main_unit_tests_macos_${{ steps.run-unit-tests.outcome }}
 
       - name: Report job duration
         if: success() || (always() && steps.run-unit-tests.outcome == 'failure')
@@ -255,7 +255,7 @@ jobs:
         if: always() && github.ref_name == 'main'
         uses: ./.github/actions/send-pixel
         with:
-          pixel-name: m_ci_apple_bsk_main_unit_tests_ios_${{ steps.run-unit-tests-ios.outcome }}
+          pixel-name: m_ci_apple_status_bsk_main_unit_tests_ios_${{ steps.run-unit-tests-ios.outcome }}
 
       - name: Upload JUnit XML as artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -101,7 +101,7 @@ jobs:
         with:
           mode: stop
           start-timestamp: ${{ steps.start-duration-macos.outputs.start-timestamp }}
-          pixel-name: m_ci_apple_bsk_unit_tests_macos_duration
+          pixel-name: m_ci_apple_duration_bsk_unit_tests_macos
           pixel-params: |
             runner: ${{ env.RUNS_ON }}
 
@@ -247,7 +247,7 @@ jobs:
         with:
           mode: stop
           start-timestamp: ${{ steps.start-duration-ios.outputs.start-timestamp }}
-          pixel-name: m_ci_apple_bsk_unit_tests_ios_duration
+          pixel-name: m_ci_apple_duration_bsk_unit_tests_ios
           pixel-params: |
             runner: ${{ env.RUNS_ON }}
 

--- a/.github/workflows/dbp_pr_checks.yml
+++ b/.github/workflows/dbp_pr_checks.yml
@@ -102,7 +102,7 @@ jobs:
         if: always() && github.ref_name == 'main'
         uses: ./.github/actions/send-pixel
         with:
-          pixel-name: m_ci_apple_dbp_main_unit_tests_macos_${{ steps.run-unit-tests.outcome }}
+          pixel-name: m_ci_apple_status_dbp_main_unit_tests_macos_${{ steps.run-unit-tests.outcome }}
 
       - name: Update Asana with failed unit tests
         if: always() # always run even if the previous step fails
@@ -228,7 +228,7 @@ jobs:
         if: always() && github.ref_name == 'main'
         uses: ./.github/actions/send-pixel
         with:
-          pixel-name: m_ci_apple_dbp_main_unit_tests_ios_${{ steps.run-unit-tests.outcome }}
+          pixel-name: m_ci_apple_status_dbp_main_unit_tests_ios_${{ steps.run-unit-tests.outcome }}
 
       - name: Update Asana with failed unit tests
         if: always() # always run even if the previous step fails

--- a/.github/workflows/dbp_pr_checks.yml
+++ b/.github/workflows/dbp_pr_checks.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           mode: stop
           start-timestamp: ${{ steps.start-duration-macos.outputs.start-timestamp }}
-          pixel-name: m_ci_apple_dbp_unit_tests_macos_duration
+          pixel-name: m_ci_apple_duration_dbp_unit_tests_macos
           pixel-params: |
             runner: ${{ env.RUNS_ON }}
 
@@ -212,7 +212,7 @@ jobs:
         with:
           mode: stop
           start-timestamp: ${{ steps.start-duration-ios.outputs.start-timestamp }}
-          pixel-name: m_ci_apple_dbp_unit_tests_ios_duration
+          pixel-name: m_ci_apple_duration_dbp_unit_tests_ios
           pixel-params: |
             runner: ${{ env.RUNS_ON }}
 

--- a/.github/workflows/ios_end_to_end.yml
+++ b/.github/workflows/ios_end_to_end.yml
@@ -67,7 +67,7 @@ jobs:
       with:
         mode: stop
         start-timestamp: ${{ steps.start-duration.outputs.start-timestamp }}
-        pixel-name: m_ci_apple_ios_e2e_tests_build_duration
+        pixel-name: m_ci_apple_duration_ios_e2e_tests_build
         pixel-params: |
           runner: ${{ env.RUNS_ON }}
 
@@ -139,7 +139,7 @@ jobs:
       with:
         mode: stop
         start-timestamp: ${{ steps.start-duration.outputs.start-timestamp }}
-        pixel-name: m_ci_apple_ios_e2e_tests_${{ matrix.test-tag }}_duration
+        pixel-name: m_ci_apple_duration_ios_e2e_tests_${{ matrix.test-tag }}
         pixel-params: |
           runner: ${{ env.RUNS_ON }}
 

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -181,7 +181,7 @@ jobs:
       with:
         mode: stop
         start-timestamp: ${{ steps.start-duration-tests.outputs.start-timestamp }}
-        pixel-name: m_ci_apple_ios_unit_tests_duration
+        pixel-name: m_ci_apple_duration_ios_unit_tests
         pixel-params: |
           runner: ${{ env.RUNS_ON }}
 
@@ -287,7 +287,7 @@ jobs:
       with:
         mode: stop
         start-timestamp: ${{ steps.start-duration-release-build.outputs.start-timestamp }}
-        pixel-name: m_ci_apple_ios_release_build_duration
+        pixel-name: m_ci_apple_duration_ios_release_build
         pixel-params: |
           runner: ${{ env.RUNS_ON }}
 

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -189,7 +189,7 @@ jobs:
       if: always() && github.ref_name == 'main'
       uses: ./.github/actions/send-pixel
       with:
-        pixel-name: m_ci_apple_ios_main_unit_tests_${{ steps.run-unit-tests.outcome }}
+        pixel-name: m_ci_apple_status_ios_main_unit_tests_${{ steps.run-unit-tests.outcome }}
 
     - name: Fetch latest commit author
       if: always() && github.ref_name == 'main'

--- a/.github/workflows/ios_sync_end_to_end.yml
+++ b/.github/workflows/ios_sync_end_to_end.yml
@@ -67,7 +67,7 @@ jobs:
       with:
         mode: stop
         start-timestamp: ${{ steps.start-duration.outputs.start-timestamp }}
-        pixel-name: m_ci_apple_ios_sync_tests_build_duration
+        pixel-name: m_ci_apple_duration_ios_sync_tests_build
         pixel-params: |
           runner: ${{ env.RUNS_ON }}
 
@@ -155,7 +155,7 @@ jobs:
       with:
         mode: stop
         start-timestamp: ${{ steps.start-duration.outputs.start-timestamp }}
-        pixel-name: m_ci_apple_ios_${{ matrix.os-version }}_sync_tests_duration
+        pixel-name: m_ci_apple_duration_ios_${{ matrix.os-version }}_sync_tests
         pixel-params: |
           runner: ${{ env.RUNS_ON }}
 

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -171,7 +171,7 @@ jobs:
       with:
         mode: stop
         start-timestamp: ${{ steps.start-duration.outputs.start-timestamp }}
-        pixel-name: m_ci_apple_macos_notarized_build_duration
+        pixel-name: m_ci_apple_duration_macos_notarized_build
         pixel-params: |
           runner: ${{ env.RUNS_ON }}
 
@@ -346,7 +346,7 @@ jobs:
       with:
         mode: stop
         start-timestamp: ${{ steps.start-duration.outputs.start-timestamp }}
-        pixel-name: m_ci_apple_macos_create_dmg_duration
+        pixel-name: m_ci_apple_duration_macos_create_dmg
         pixel-params: |
           runner: ${{ env.RUNS_ON }}
 

--- a/.github/workflows/macos_pir_end_to_end_tests.yml
+++ b/.github/workflows/macos_pir_end_to_end_tests.yml
@@ -141,7 +141,7 @@ jobs:
       with:
         mode: stop
         start-timestamp: ${{ steps.start-duration.outputs.start-timestamp }}
-        pixel-name: m_ci_apple_macos_pir_e2e_tests_duration
+        pixel-name: m_ci_apple_duration_macos_pir_e2e_tests
         pixel-params: |
           runner: ${{ matrix.runner }}
 

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -294,7 +294,7 @@ jobs:
       with:
         mode: stop
         start-timestamp: ${{ steps.start-duration-tests.outputs.start-timestamp }}
-        pixel-name: m_ci_apple_macos_${{ matrix.flavor }}_unit_tests_duration
+        pixel-name: m_ci_apple_duration_macos_${{ matrix.flavor }}_unit_tests
         pixel-params: |
           runner: ${{ matrix.runs-on }}
 
@@ -442,7 +442,7 @@ jobs:
       with:
         mode: stop
         start-timestamp: ${{ steps.start-duration-release-build.outputs.start-timestamp }}
-        pixel-name: m_ci_apple_macos_release_build_duration
+        pixel-name: m_ci_apple_duration_macos_release_build
         pixel-params: |
           runner: ${{ env.RUNS_ON }}
 

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -302,13 +302,13 @@ jobs:
       if: always() && github.ref_name == 'main'
       uses: ./.github/actions/send-pixel
       with:
-        pixel-name: m_ci_apple_mac_main_${{ matrix.flavor }}_unit_tests_${{ steps.run-unit-tests.outcome }}
+        pixel-name: m_ci_apple_status_mac_main_${{ matrix.flavor }}_unit_tests_${{ steps.run-unit-tests.outcome }}
 
     - name: Send Integration Tests Status Pixel
       if: always() && github.ref_name == 'main'
       uses: ./.github/actions/send-pixel
       with:
-        pixel-name: m_ci_apple_mac_main_${{ matrix.flavor }}_integration_tests_${{ steps.run-integration-tests.outcome }}
+        pixel-name: m_ci_apple_status_mac_main_${{ matrix.flavor }}_integration_tests_${{ steps.run-integration-tests.outcome }}
 
     - name: Upload failed unit tests log
       uses: actions/upload-artifact@v4

--- a/.github/workflows/macos_sync_end_to_end.yml
+++ b/.github/workflows/macos_sync_end_to_end.yml
@@ -176,7 +176,7 @@ jobs:
       with:
         mode: stop
         start-timestamp: ${{ steps.start-duration.outputs.start-timestamp }}
-        pixel-name: m_ci_apple_macos_${{ matrix.os-version }}_sync_tests_duration
+        pixel-name: m_ci_apple_duration_macos_${{ matrix.os-version }}_sync_tests
         pixel-params: |
           runner: ${{ matrix.runner }}
 

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -276,7 +276,7 @@ jobs:
       with:
         mode: stop
         start-timestamp: ${{ needs.setup-tests.outputs.start-timestamp }}
-        pixel-name: ${{ (needs.setup-tests.outputs.all-os-versions == true) && 'm_ci_apple_macos_ui_tests_all_duration' || 'm_ci_apple_macos_ui_tests_latest_duration' }}
+        pixel-name: ${{ (needs.setup-tests.outputs.all-os-versions == true) && 'm_ci_apple_duration_macos_ui_tests_all' || 'm_ci_apple_duration_macos_ui_tests_latest' }}
 
   notify-failure:
     name: Notify on failure


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1210519459609108?focus=true

### Description
This change renames CI pixels to prefix duration pixels with m_ci_apple_duration and workflow 
status pixels with m_ci_apple_status.

### Testing Steps
Verify new pixel naming.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)