### PR TITLE
macOS Visual Refresh: Only check for the FF once at AppDelegate.init

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -3234,6 +3234,8 @@
 		BB80DDD32D75EEAC00ED1FFF /* ApplicationBuildType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB80DDD12D75EEA100ED1FFF /* ApplicationBuildType.swift */; };
 		BB80DDDB2D761EC700ED1FFF /* DefaultBrowserAndDockPromptPresentingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB80DDDA2D761EC400ED1FFF /* DefaultBrowserAndDockPromptPresentingTests.swift */; };
 		BB80DDDC2D761EC700ED1FFF /* DefaultBrowserAndDockPromptPresentingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB80DDDA2D761EC400ED1FFF /* DefaultBrowserAndDockPromptPresentingTests.swift */; };
+		BB8D1FD72DF9C0EE007F2834 /* RemoteMessagingConfigMatcherProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8D1FD62DF9C0E4007F2834 /* RemoteMessagingConfigMatcherProviderTests.swift */; };
+		BB8D1FD82DF9C0EE007F2834 /* RemoteMessagingConfigMatcherProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8D1FD62DF9C0E4007F2834 /* RemoteMessagingConfigMatcherProviderTests.swift */; };
 		BB960BCD2DD77A0B002C46DD /* SettingsIconsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB960BCC2DD77A02002C46DD /* SettingsIconsProviding.swift */; };
 		BB960BCE2DD77A0B002C46DD /* SettingsIconsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB960BCC2DD77A02002C46DD /* SettingsIconsProviding.swift */; };
 		BB960BD32DD7890B002C46DD /* BookmarksIconsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB960BD22DD788FD002C46DD /* BookmarksIconsProviding.swift */; };
@@ -5404,6 +5406,7 @@
 		BB80DDCE2D75E94A00ED1FFF /* DefaultBrowserAndDockPromptCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserAndDockPromptCoordinatorTests.swift; sourceTree = "<group>"; };
 		BB80DDD12D75EEA100ED1FFF /* ApplicationBuildType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBuildType.swift; sourceTree = "<group>"; };
 		BB80DDDA2D761EC400ED1FFF /* DefaultBrowserAndDockPromptPresentingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserAndDockPromptPresentingTests.swift; sourceTree = "<group>"; };
+		BB8D1FD62DF9C0E4007F2834 /* RemoteMessagingConfigMatcherProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteMessagingConfigMatcherProviderTests.swift; sourceTree = "<group>"; };
 		BB960BCC2DD77A02002C46DD /* SettingsIconsProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsIconsProviding.swift; sourceTree = "<group>"; };
 		BB960BD22DD788FD002C46DD /* BookmarksIconsProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksIconsProviding.swift; sourceTree = "<group>"; };
 		BB9BA21F2D10BC6B009229F3 /* TabBarRemoteMessageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarRemoteMessageViewModelTests.swift; sourceTree = "<group>"; };
@@ -6445,6 +6448,7 @@
 		373B2F7F2C384DD20013A94B /* RemoteMessaging */ = {
 			isa = PBXGroup;
 			children = (
+				BB8D1FD62DF9C0E4007F2834 /* RemoteMessagingConfigMatcherProviderTests.swift */,
 				373B2F802C384DEB0013A94B /* ActiveRemoteMessageModelTests.swift */,
 				37DB56EE2C3B31CD0093D4DC /* MockRemoteMessagingAvailabilityProvider.swift */,
 				37DB56F12C3B36B80093D4DC /* RemoteMessagingClientTests.swift */,
@@ -13660,6 +13664,7 @@
 				560C6ECA2CCA381A00D411E2 /* OnboardingPixelReporterTests.swift in Sources */,
 				3706FE62293F661700E42796 /* PasswordManagementListSectionTests.swift in Sources */,
 				37A756EE2DD610930003C8C9 /* NewTabPageCoordinatorTests.swift in Sources */,
+				BB8D1FD82DF9C0EE007F2834 /* RemoteMessagingConfigMatcherProviderTests.swift in Sources */,
 				3706FE63293F661700E42796 /* RecentlyClosedCoordinatorMock.swift in Sources */,
 				1D638D622C44F2BA00530DD5 /* ApplicationUpdateDetectorTests.swift in Sources */,
 				1D6D04202D953E20005BC23F /* FullscreenControllerTests.swift in Sources */,
@@ -15484,6 +15489,7 @@
 				CD89DD612C89E08D0080F9AF /* MaliciousSiteProtectionTests.swift in Sources */,
 				310E79BF294A19A8007C49E8 /* FireproofingReferenceTests.swift in Sources */,
 				B6BBF1722744CE36004F850E /* FireproofDomainsStoreMock.swift in Sources */,
+				BB8D1FD72DF9C0EE007F2834 /* RemoteMessagingConfigMatcherProviderTests.swift in Sources */,
 				4BA1A6D9258C0CB300F6F690 /* DataEncryptionTests.swift in Sources */,
 				BB80DDD02D75E94D00ED1FFF /* DefaultBrowserAndDockPromptCoordinatorTests.swift in Sources */,
 				3798580D2D730E32008773F6 /* HistoryQueryKindExtensionTests.swift in Sources */,

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -152,7 +152,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let defaultBrowserAndDockPromptPresenter: DefaultBrowserAndDockPromptPresenter
     let defaultBrowserAndDockPromptKeyValueStore: DefaultBrowserAndDockPromptStorage
     let defaultBrowserAndDockPromptFeatureFlagger: DefaultBrowserAndDockPromptFeatureFlagger
-    let visualStyleManager: VisualStyleManagerProviding
+    let visualStyle: VisualStyleProviding
 
     let isAuthV2Enabled: Bool
     var subscriptionAuthV1toV2Bridge: any SubscriptionAuthV1toV2Bridge
@@ -464,7 +464,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         self.windowControllersManager = windowControllersManager
 
-        visualStyleManager = VisualStyleManager(featureFlagger: featureFlagger, internalUserDecider: internalUserDecider)
+        let visualStyleManager = VisualStyleManager(featureFlagger: featureFlagger, internalUserDecider: internalUserDecider)
+        visualStyle = visualStyleManager.style
 
 #if DEBUG
         if AppVersion.runType.requiresEnvironment {
@@ -488,7 +489,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             pixelFiring: PixelKit.shared
         )
         startupPreferences = StartupPreferences(appearancePreferences: appearancePreferences, dataClearingPreferences: dataClearingPreferences)
-        newTabPageCustomizationModel = NewTabPageCustomizationModel(visualStyleManager: visualStyleManager, appearancePreferences: appearancePreferences)
+        newTabPageCustomizationModel = NewTabPageCustomizationModel(visualStyle: visualStyle, appearancePreferences: appearancePreferences)
 
 #if DEBUG
         if AppVersion.runType.requiresEnvironment {

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -585,7 +585,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     privacyConfigurationManager: privacyConfigurationManager
                 ),
                 subscriptionManager: subscriptionAuthV1toV2Bridge,
-                featureFlagger: self.featureFlagger
+                featureFlagger: self.featureFlagger,
+                visualStyle: self.visualStyle
             )
             activeRemoteMessageModel = ActiveRemoteMessageModel(remoteMessagingClient: remoteMessagingClient, openURLHandler: { url in
                 windowControllersManager.showTab(with: .contentFromURL(url, source: .appOpenUrl))

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -464,8 +464,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         self.windowControllersManager = windowControllersManager
 
-        let visualStyleManager = VisualStyleManager(featureFlagger: featureFlagger, internalUserDecider: internalUserDecider)
-        visualStyle = visualStyleManager.style
+        let visualStyleDecider = DefaultVisualStyleDecider(featureFlagger: featureFlagger, internalUserDecider: internalUserDecider)
+        visualStyle = visualStyleDecider.style
 
 #if DEBUG
         if AppVersion.runType.requiresEnvironment {

--- a/macOS/DuckDuckGo/Bookmarks/Model/BookmarkOutlineViewDataSource.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Model/BookmarkOutlineViewDataSource.swift
@@ -91,7 +91,7 @@ final class BookmarkOutlineViewDataSource: NSObject, BookmarksOutlineViewDataSou
         dragDropManager: BookmarkDragDropManager,
         sortMode: BookmarksSortMode,
         presentFaviconsFetcherOnboarding: (() -> Void)? = nil,
-        visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager
+        visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle
     ) {
         self.contentMode = contentMode
         self.bookmarkManager = bookmarkManager
@@ -99,7 +99,7 @@ final class BookmarkOutlineViewDataSource: NSObject, BookmarksOutlineViewDataSou
         self.treeController = treeController
         self.presentFaviconsFetcherOnboarding = presentFaviconsFetcherOnboarding
         self.sortMode = sortMode
-        self.visualStyle = visualStyleManager.style
+        self.visualStyle = visualStyle
 
         super.init()
     }

--- a/macOS/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
+++ b/macOS/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
@@ -150,7 +150,7 @@ final class BookmarkListViewController: NSViewController {
     init(bookmarkManager: BookmarkManager,
          dragDropManager: BookmarkDragDropManager,
          metrics: BookmarksSearchAndSortMetrics = BookmarksSearchAndSortMetrics(),
-         visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager) {
+         visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle) {
         self.bookmarkManager = bookmarkManager
         self.dragDropManager = dragDropManager
         self.treeControllerDataSource = BookmarkListTreeControllerDataSource(bookmarkManager: bookmarkManager)
@@ -161,7 +161,7 @@ final class BookmarkListViewController: NSViewController {
                                                      sortMode: sortBookmarksViewModel.selectedSortMode,
                                                      searchDataSource: treeControllerSearchDataSource,
                                                      isBookmarksBarMenu: false)
-        self.visualStyle = visualStyleManager.style
+        self.visualStyle = visualStyle
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/macOS/DuckDuckGo/Bookmarks/View/BookmarkManagementDetailViewController.swift
+++ b/macOS/DuckDuckGo/Bookmarks/View/BookmarkManagementDetailViewController.swift
@@ -119,13 +119,13 @@ final class BookmarkManagementDetailViewController: NSViewController, NSMenuItem
 
     init(bookmarkManager: BookmarkManager,
          dragDropManager: BookmarkDragDropManager,
-         visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager) {
+         visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle) {
         self.bookmarkManager = bookmarkManager
         self.dragDropManager = dragDropManager
         let metrics = BookmarksSearchAndSortMetrics()
         let sortViewModel = SortBookmarksViewModel(manager: bookmarkManager, metrics: metrics, origin: .manager)
         self.sortBookmarksViewModel = sortViewModel
-        self.visualStyle = visualStyleManager.style
+        self.visualStyle = visualStyle
         self.managementDetailViewModel = BookmarkManagementDetailViewModel(bookmarkManager: bookmarkManager,
                                                                            metrics: metrics,
                                                                            mode: bookmarkManager.sortMode)

--- a/macOS/DuckDuckGo/Bookmarks/View/BookmarkManagementSidebarViewController.swift
+++ b/macOS/DuckDuckGo/Bookmarks/View/BookmarkManagementSidebarViewController.swift
@@ -73,11 +73,11 @@ final class BookmarkManagementSidebarViewController: NSViewController {
 
     init(bookmarkManager: BookmarkManager,
          dragDropManager: BookmarkDragDropManager,
-         visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager) {
+         visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle) {
         self.bookmarkManager = bookmarkManager
         self.dragDropManager = dragDropManager
         self.selectedSortMode = bookmarkManager.sortMode
-        self.visualStyle = visualStyleManager.style
+        self.visualStyle = visualStyle
         treeControllerDataSource = .init(bookmarkManager: bookmarkManager)
         super.init(nibName: nil, bundle: nil)
     }

--- a/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarMenuViewController.swift
+++ b/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarMenuViewController.swift
@@ -93,7 +93,7 @@ final class BookmarksBarMenuViewController: NSViewController {
     init(bookmarkManager: BookmarkManager,
          dragDropManager: BookmarkDragDropManager,
          rootFolder: BookmarkFolder? = nil,
-         visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager) {
+         visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle) {
         self.bookmarkManager = bookmarkManager
         self.dragDropManager = dragDropManager
         self.treeControllerDataSource = BookmarkListTreeControllerDataSource(bookmarkManager: bookmarkManager)
@@ -101,7 +101,7 @@ final class BookmarksBarMenuViewController: NSViewController {
                                                      sortMode: .manual,
                                                      rootFolder: rootFolder,
                                                      isBookmarksBarMenu: true)
-        self.visualStyle = visualStyleManager.style
+        self.visualStyle = visualStyle
         super.init(nibName: nil, bundle: nil)
         self.representedObject = rootFolder
     }

--- a/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarViewController.swift
+++ b/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarViewController.swift
@@ -40,7 +40,7 @@ final class BookmarksBarViewController: NSViewController {
     private let viewModel: BookmarksBarViewModel
     private let tabCollectionViewModel: TabCollectionViewModel
     private let appereancePreferences: AppearancePreferencesPersistor
-    private let visualStyleManager: VisualStyleManagerProviding
+    private let visualStyle: VisualStyleProviding
 
     private var cancellables = Set<AnyCancellable>()
 
@@ -67,18 +67,18 @@ final class BookmarksBarViewController: NSViewController {
           bookmarkManager: BookmarkManager,
           dragDropManager: BookmarkDragDropManager,
           appereancePreferences: AppearancePreferencesPersistor = AppearancePreferencesUserDefaultsPersistor(keyValueStore: NSApp.delegateTyped.keyValueStore),
-          visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager
+          visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle
     ) {
         self.bookmarkManager = bookmarkManager
         self.dragDropManager = dragDropManager
         self.appereancePreferences = appereancePreferences
-        self.visualStyleManager = visualStyleManager
+        self.visualStyle = visualStyle
 
         self.tabCollectionViewModel = tabCollectionViewModel
         self.viewModel = BookmarksBarViewModel(bookmarkManager: bookmarkManager,
                                                dragDropManager: dragDropManager,
                                                tabCollectionViewModel: tabCollectionViewModel,
-                                               visualStyleManager: visualStyleManager)
+                                               visualStyle: visualStyle)
 
         super.init(coder: coder)
     }
@@ -98,7 +98,7 @@ final class BookmarksBarViewController: NSViewController {
 
         viewModel.delegate = self
 
-        backgroundColorView.backgroundColor = visualStyleManager.style.colorsProvider.navigationBackgroundColor
+        backgroundColorView.backgroundColor = visualStyle.colorsProvider.navigationBackgroundColor
 
         let nib = NSNib(nibNamed: "BookmarksBarCollectionViewItem", bundle: .main)
         bookmarksBarCollectionView.setDraggingSourceOperationMask([.copy, .move], forLocal: true)
@@ -106,7 +106,7 @@ final class BookmarksBarViewController: NSViewController {
         bookmarksBarCollectionView.allowsMultipleSelection = false
 
         bookmarksBarCollectionView.registerForDraggedTypes(BookmarkDragDropManager.draggedTypes)
-        bookmarksBarCollectionView.backgroundColors = [visualStyleManager.style.colorsProvider.navigationBackgroundColor]
+        bookmarksBarCollectionView.backgroundColors = [visualStyle.colorsProvider.navigationBackgroundColor]
         bookmarksBarCollectionView.setAccessibilityIdentifier("BookmarksBarViewController.bookmarksBarCollectionView")
 
         clippedItemsIndicator.registerForDraggedTypes(BookmarkDragDropManager.draggedTypes)

--- a/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarViewModel.swift
+++ b/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarViewModel.swift
@@ -113,11 +113,11 @@ final class BookmarksBarViewModel: NSObject {
     init(bookmarkManager: BookmarkManager,
          dragDropManager: BookmarkDragDropManager,
          tabCollectionViewModel: TabCollectionViewModel,
-         visualStyleManager: VisualStyleManagerProviding) {
+         visualStyle: VisualStyleProviding) {
         self.bookmarkManager = bookmarkManager
         self.dragDropManager = dragDropManager
         self.tabCollectionViewModel = tabCollectionViewModel
-        self.visualStyle = visualStyleManager.style
+        self.visualStyle = visualStyle
         super.init()
         subscribeToBookmarks()
     }

--- a/macOS/DuckDuckGo/Common/View/SwiftUI/BannerView.swift
+++ b/macOS/DuckDuckGo/Common/View/SwiftUI/BannerView.swift
@@ -25,7 +25,7 @@ struct TitledButtonAction {
 }
 
 final class BannerMessageViewController: NSHostingController<BannerView> {
-    private var visualStyle: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager
+    private var visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle
     let viewModel: BannerViewModel
 
     init(message: String,
@@ -35,7 +35,7 @@ final class BannerMessageViewController: NSHostingController<BannerView> {
          closeAction: @escaping () -> Void) {
         self.viewModel = .init(message: message,
                                image: image,
-                               backgroundColor: visualStyle.style.colorsProvider.bannerBackgroundColor,
+                               backgroundColor: visualStyle.colorsProvider.bannerBackgroundColor,
                                primaryAction: primaryAction,
                                secondaryAction: secondaryAction,
                                closeAction: closeAction)

--- a/macOS/DuckDuckGo/FileDownload/View/DownloadsViewController.swift
+++ b/macOS/DuckDuckGo/FileDownload/View/DownloadsViewController.swift
@@ -50,9 +50,9 @@ final class DownloadsViewController: NSViewController {
     private var errorBannerHostingView: NSHostingView<DownloadsErrorBannerView>?
 
     init(viewModel: DownloadListViewModel,
-         visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager) {
+         visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle) {
         self.viewModel = viewModel
-        self.visualStyle = visualStyleManager.style
+        self.visualStyle = visualStyle
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -88,7 +88,7 @@ final class MainViewController: NSViewController {
          brokenSitePromptLimiter: BrokenSitePromptLimiter = NSApp.delegateTyped.brokenSitePromptLimiter,
          featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
          defaultBrowserAndDockPromptPresenting: DefaultBrowserAndDockPromptPresenting = NSApp.delegateTyped.defaultBrowserAndDockPromptPresenter,
-         visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager
+         visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle
     ) {
 
         self.aiChatMenuConfig = aiChatMenuConfig
@@ -100,7 +100,7 @@ final class MainViewController: NSViewController {
         self.isBurner = tabCollectionViewModel.isBurner
         self.featureFlagger = featureFlagger
         self.defaultBrowserAndDockPromptPresenting = defaultBrowserAndDockPromptPresenting
-        self.visualStyle = visualStyleManager.style
+        self.visualStyle = visualStyle
 
         tabBarViewController = TabBarViewController.create(
             tabCollectionViewModel: tabCollectionViewModel,

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -213,7 +213,7 @@ final class AddressBarButtonsViewController: NSViewController {
           aiChatTabOpener: AIChatTabOpening,
           aiChatMenuConfig: AIChatMenuVisibilityConfigurable,
           aiChatSidebarPresenter: AIChatSidebarPresenting,
-          visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager,
+          visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle,
           featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger) {
         self.tabCollectionViewModel = tabCollectionViewModel
         self.bookmarkManager = bookmarkManager
@@ -223,7 +223,7 @@ final class AddressBarButtonsViewController: NSViewController {
         self.aiChatTabOpener = aiChatTabOpener
         self.aiChatMenuConfig = aiChatMenuConfig
         self.aiChatSidebarPresenter = aiChatSidebarPresenter
-        self.visualStyle = visualStyleManager.style
+        self.visualStyle = visualStyle
         self.featureFlagger = featureFlagger
         self.privacyConfigurationManager = privacyConfigurationManager
         super.init(coder: coder)

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -56,7 +56,7 @@ final class AddressBarTextField: NSTextField {
         tabCollectionViewModel.isBurner
     }
 
-    var visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyleManager.style
+    var visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle
 
     private var suggestionResultCancellable: AnyCancellable?
     private var selectedSuggestionViewModelCancellable: AnyCancellable?

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -140,7 +140,7 @@ final class AddressBarViewController: NSViewController {
           popovers: NavigationBarPopovers?,
           onboardingPixelReporter: OnboardingAddressBarReporting = OnboardingPixelReporter(),
           aiChatSettings: AIChatPreferencesStorage = DefaultAIChatPreferencesStorage(),
-          visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager,
+          visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle,
           aiChatSidebarPresenter: AIChatSidebarPresenting) {
         self.tabCollectionViewModel = tabCollectionViewModel
         self.bookmarkManager = bookmarkManager
@@ -155,12 +155,12 @@ final class AddressBarViewController: NSViewController {
                 burnerMode: burnerMode,
                 isUrlIgnored: { _ in false }
             ),
-            visualStyle: visualStyleManager.style
+            visualStyle: visualStyle
         )
         self.isBurner = burnerMode.isBurner
         self.onboardingPixelReporter = onboardingPixelReporter
         self.aiChatSettings = aiChatSettings
-        self.visualStyle = visualStyleManager.style
+        self.visualStyle = visualStyle
         self.aiChatSidebarPresenter = aiChatSidebarPresenter
 
         super.init(coder: coder)

--- a/macOS/DuckDuckGo/NavigationBar/View/Animations/BadgeAnimations/CookieManaged/CookieNotificationAnimationModel.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/Animations/BadgeAnimations/CookieManaged/CookieNotificationAnimationModel.swift
@@ -33,11 +33,11 @@ final class CookieNotificationAnimationModel: ObservableObject {
     let addressBarIconsProvider: AddressBarCookiesIconsProviding
 
     init(duration: CGFloat = AnimationDefaultConsts.totalDuration,
-         visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager) {
+         visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle) {
         self.duration = duration
         self.halfDuration = duration / 2.0
         self.secondPhaseDelay = self.halfDuration
-        self.addressBarIconsProvider = visualStyleManager.style.iconsProvider.addressBarCookiesIconsProvider
+        self.addressBarIconsProvider = visualStyle.iconsProvider.addressBarCookiesIconsProvider
     }
 }
 

--- a/macOS/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
@@ -112,7 +112,7 @@ final class MoreOptionsMenu: NSMenu, NSMenuDelegate {
          featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
          freemiumDBPExperimentPixelHandler: EventMapping<FreemiumDBPExperimentPixel> = FreemiumDBPExperimentPixelHandler(),
          aiChatMenuConfiguration: AIChatMenuVisibilityConfigurable = AIChatMenuConfiguration(),
-         visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager) {
+         visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle) {
 
         self.tabCollectionViewModel = tabCollectionViewModel
         self.bookmarkManager = bookmarkManager
@@ -134,7 +134,7 @@ final class MoreOptionsMenu: NSMenu, NSMenuDelegate {
         self.freemiumDBPExperimentPixelHandler = freemiumDBPExperimentPixelHandler
         self.aiChatMenuConfiguration = aiChatMenuConfiguration
         self.featureFlagger = featureFlagger
-        self.moreOptionsMenuIconsProvider = visualStyleManager.style.iconsProvider.moreOptionsMenuIconsProvider
+        self.moreOptionsMenuIconsProvider = visualStyle.iconsProvider.moreOptionsMenuIconsProvider
 
         super.init(title: "")
 

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -168,7 +168,7 @@ final class NavigationBarViewController: NSViewController {
                        autofillPopoverPresenter: AutofillPopoverPresenter,
                        brokenSitePromptLimiter: BrokenSitePromptLimiter,
                        featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
-                       visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager,
+                       visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle,
                        aiChatSidebarPresenter: AIChatSidebarPresenting
     ) -> NavigationBarViewController {
         NSStoryboard(name: "NavigationBar", bundle: nil).instantiateInitialController { coder in
@@ -186,7 +186,7 @@ final class NavigationBarViewController: NSViewController {
                 autofillPopoverPresenter: autofillPopoverPresenter,
                 brokenSitePromptLimiter: brokenSitePromptLimiter,
                 featureFlagger: featureFlagger,
-                visualStyle: visualStyleManager.style,
+                visualStyle: visualStyle,
                 aiChatSidebarPresenter: aiChatSidebarPresenter
             )
         }!

--- a/macOS/DuckDuckGo/NewTabPage/Features/Customization/NewTabPageCustomizationModel.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/Customization/NewTabPageCustomizationModel.swift
@@ -50,7 +50,7 @@ final class NewTabPageCustomizationModel: ObservableObject {
     private var availableCustomImagesCancellable: AnyCancellable?
     private var customBackgroundPixelCancellable: AnyCancellable?
 
-    convenience init(visualStyleManager: VisualStyleManagerProviding, appearancePreferences: AppearancePreferences) {
+    convenience init(visualStyle: VisualStyleProviding, appearancePreferences: AppearancePreferences) {
         self.init(
             appearancePreferences: appearancePreferences,
             userBackgroundImagesManager: UserBackgroundImagesManager(
@@ -71,7 +71,7 @@ final class NewTabPageCustomizationModel: ObservableObject {
                 let alert = NSAlert.cannotReadImageAlert()
                 alert.runModal()
             },
-            visualStyle: visualStyleManager.style
+            visualStyle: visualStyle
         )
     }
 

--- a/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabsView.swift
+++ b/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabsView.swift
@@ -19,7 +19,7 @@
 import SwiftUI
 
 struct PinnedTabsView: View {
-    private let tabStyleProvider: TabStyleProviding = NSApp.delegateTyped.visualStyleManager.style.tabStyleProvider
+    private let tabStyleProvider: TabStyleProviding = NSApp.delegateTyped.visualStyle.tabStyleProvider
 
     @ObservedObject var model: PinnedTabsViewModel
     @State private var draggedTab: Tab?

--- a/macOS/DuckDuckGo/Preferences/Model/PreferencesSidebarModel.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/PreferencesSidebarModel.swift
@@ -77,7 +77,7 @@ final class PreferencesSidebarModel: ObservableObject {
         vpnTunnelIPCClient: VPNControllerXPCClient = .shared,
         subscriptionManager: any SubscriptionAuthV1toV2Bridge,
         notificationCenter: NotificationCenter = .default,
-        settingsIconProvider: SettingsIconsProviding = NSApp.delegateTyped.visualStyleManager.style.iconsProvider.settingsIconProvider,
+        settingsIconProvider: SettingsIconsProviding = NSApp.delegateTyped.visualStyle.iconsProvider.settingsIconProvider,
         pixelFiring: PixelFiring?
     ) {
         self.loadSections = loadSections

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesRootView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesRootView.swift
@@ -59,11 +59,11 @@ enum Preferences {
         init(model: PreferencesSidebarModel,
              subscriptionManager: SubscriptionManager,
              subscriptionUIHandler: SubscriptionUIHandling,
-             visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager) {
+             visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle) {
             self.model = model
             self.subscriptionManager = subscriptionManager
             self.subscriptionUIHandler = subscriptionUIHandler
-            self.visualStyle = visualStyleManager.style
+            self.visualStyle = visualStyle
             self.purchaseSubscriptionModel = makePurchaseSubscriptionViewModel()
             self.personalInformationRemovalModel = makePersonalInformationRemovalViewModel()
             self.identityTheftRestorationModel = makeIdentityTheftRestorationViewModel()
@@ -286,12 +286,12 @@ enum Preferences {
             model: PreferencesSidebarModel,
             subscriptionManager: SubscriptionManagerV2,
             subscriptionUIHandler: SubscriptionUIHandling,
-            visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager
+            visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle
         ) {
             self.model = model
             self.subscriptionManager = subscriptionManager
             self.subscriptionUIHandler = subscriptionUIHandler
-            self.visualStyle = visualStyleManager.style
+            self.visualStyle = visualStyle
             self.purchaseSubscriptionModel = makePurchaseSubscriptionViewModel()
             self.personalInformationRemovalModel = makePersonalInformationRemovalViewModel()
             self.identityTheftRestorationModel = makeIdentityTheftRestorationViewModel()

--- a/macOS/DuckDuckGo/RemoteMessaging/RemoteMessagingClient.swift
+++ b/macOS/DuckDuckGo/RemoteMessaging/RemoteMessagingClient.swift
@@ -48,7 +48,7 @@ final class RemoteMessagingClient: RemoteMessagingProcessing {
         static let minimumConfigurationRefreshInterval: TimeInterval = 60 * 30
         static let endpoint: URL = {
 #if DEBUG
-            URL(string: "https://raw.githubusercontent.com/duckduckgo/remote-messaging-config/main/samples/ios/sample1.json")!
+            URL(string: "https://jsonblob.com/api/1380594945500569600")!
 #else
             URL(string: "https://staticcdn.duckduckgo.com/remotemessaging/config/v1/macos-config.json")!
 #endif
@@ -73,7 +73,8 @@ final class RemoteMessagingClient: RemoteMessagingProcessing {
         remoteMessagingAvailabilityProvider: RemoteMessagingAvailabilityProviding,
         remoteMessagingStoreProvider: RemoteMessagingStoreProviding = DefaultRemoteMessagingStoreProvider(),
         subscriptionManager: any SubscriptionAuthV1toV2Bridge,
-        featureFlagger: FeatureFlagger
+        featureFlagger: FeatureFlagger,
+        visualStyle: VisualStyleProviding
     ) {
         let provider = RemoteMessagingConfigMatcherProvider(
             database: database,
@@ -82,7 +83,8 @@ final class RemoteMessagingClient: RemoteMessagingProcessing {
             pinnedTabsManagerProvider: pinnedTabsManagerProvider,
             internalUserDecider: internalUserDecider,
             subscriptionManager: subscriptionManager,
-            featureFlagger: featureFlagger
+            featureFlagger: featureFlagger,
+            visualStyle: visualStyle
         )
         self.init(
             remoteMessagingDatabase: remoteMessagingDatabase,

--- a/macOS/DuckDuckGo/RemoteMessaging/RemoteMessagingClient.swift
+++ b/macOS/DuckDuckGo/RemoteMessaging/RemoteMessagingClient.swift
@@ -48,7 +48,7 @@ final class RemoteMessagingClient: RemoteMessagingProcessing {
         static let minimumConfigurationRefreshInterval: TimeInterval = 60 * 30
         static let endpoint: URL = {
 #if DEBUG
-            URL(string: "https://jsonblob.com/api/1380594945500569600")!
+            URL(string: "https://raw.githubusercontent.com/duckduckgo/remote-messaging-config/main/samples/ios/sample1.json")!
 #else
             URL(string: "https://staticcdn.duckduckgo.com/remotemessaging/config/v1/macos-config.json")!
 #endif

--- a/macOS/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
+++ b/macOS/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
@@ -167,7 +167,7 @@ final class PasswordManagementViewController: NSViewController {
     private let urlMatcher = AutofillDomainNameUrlMatcher()
     private let tld = NSApp.delegateTyped.tld
     private let urlSort = AutofillDomainNameUrlSort()
-    private let visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyleManager.style
+    private let visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/macOS/DuckDuckGo/TabBar/View/TabBarFooter.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarFooter.swift
@@ -22,7 +22,7 @@ final class TabBarFooter: NSView, NSCollectionViewElement {
 
     static let identifier = NSUserInterfaceItemIdentifier(rawValue: "TabBarFooter")
 
-    private let visualStyle = NSApp.delegateTyped.visualStyleManager.style
+    private let visualStyle = NSApp.delegateTyped.visualStyle
 
     let addButton = MouseOverButton(image: .add, target: nil, action: #selector(TabBarViewController.addButtonAction))
 

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -165,14 +165,14 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
           bookmarkManager: BookmarkManager,
           fireproofDomains: FireproofDomains,
           activeRemoteMessageModel: ActiveRemoteMessageModel,
-          visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager) {
+          visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle) {
         self.tabCollectionViewModel = tabCollectionViewModel
         self.bookmarkManager = bookmarkManager
         self.fireproofDomains = fireproofDomains
         let tabBarActiveRemoteMessageModel = TabBarActiveRemoteMessage(activeRemoteMessageModel: activeRemoteMessageModel)
         self.tabBarRemoteMessageViewModel = TabBarRemoteMessageViewModel(activeRemoteMessageModel: tabBarActiveRemoteMessageModel,
                                                                          isFireWindow: tabCollectionViewModel.isBurner)
-        self.visualStyle = visualStyleManager.style
+        self.visualStyle = visualStyle
         if !tabCollectionViewModel.isBurner, let pinnedTabCollection = tabCollectionViewModel.pinnedTabsManager?.tabCollection {
             let pinnedTabsViewModel = PinnedTabsViewModel(collection: pinnedTabCollection, fireproofDomains: fireproofDomains, bookmarkManager: bookmarkManager)
             let pinnedTabsView = PinnedTabsView(model: pinnedTabsViewModel)
@@ -185,7 +185,7 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
             self.pinnedTabsHostingView = nil
         }
 
-        standardTabHeight = visualStyleManager.style.tabStyleProvider.standardTabHeight
+        standardTabHeight = visualStyle.tabStyleProvider.standardTabHeight
 
         super.init(coder: coder)
     }

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -119,7 +119,7 @@ final class TabBarItemCellView: NSView {
         static let trailingSpaceWithPermissionAndButton: CGFloat = 40
     }
 
-    private var visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyleManager.style
+    private var visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle
 
     fileprivate let faviconImageView = {
         let faviconImageView = NSImageView()
@@ -485,7 +485,7 @@ final class TabBarViewItem: NSCollectionViewItem {
     private var currentURL: URL?
     private var cancellables = Set<AnyCancellable>()
 
-    private let tabVisualProvider: TabStyleProviding = NSApp.delegateTyped.visualStyleManager.style.tabStyleProvider
+    private let visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle
 
     weak var delegate: TabBarViewItemDelegate?
     var tabViewModel: TabBarViewModel? {
@@ -496,8 +496,6 @@ final class TabBarViewItem: NSCollectionViewItem {
         }
         return tabViewModel
     }
-
-    private var visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyleManager.style
 
     private(set) var isMouseOver = false
 
@@ -756,7 +754,7 @@ final class TabBarViewItem: NSCollectionViewItem {
                 cell.mouseOverView.mouseOverColor = nil
                 cell.mouseOverView.backgroundColor = visualStyle.colorsProvider.navigationBackgroundColor
             } else {
-                if tabVisualProvider.isRoundedBackgroundPresentOnHover {
+                if visualStyle.tabStyleProvider.isRoundedBackgroundPresentOnHover {
                     cell.mouseOverView.mouseOverColor = nil
                     cell.mouseOverView.backgroundColor = visualStyle.colorsProvider.baseBackgroundColor
                     cell.roundedBackgroundColorView.backgroundColor = visualStyle.colorsProvider.navigationBackgroundColor
@@ -813,9 +811,9 @@ final class TabBarViewItem: NSCollectionViewItem {
     }
 
     private func updateSeparatorView() {
-        let shouldHideForHover = tabVisualProvider.isRoundedBackgroundPresentOnHover && isMouseOver
+        let shouldHideForHover = visualStyle.tabStyleProvider.isRoundedBackgroundPresentOnHover && isMouseOver
         let rightItemIsHovered: Bool = {
-            guard tabVisualProvider.isRoundedBackgroundPresentOnHover,
+            guard visualStyle.tabStyleProvider.isRoundedBackgroundPresentOnHover,
                   let indexPath = collectionView?.indexPath(for: self),
                   let rightItem = collectionView?.item(at: IndexPath(item: indexPath.item + 1, section: indexPath.section)) as? TabBarViewItem
             else { return false }
@@ -1053,7 +1051,7 @@ extension TabBarViewItem: MouseClickViewDelegate {
         } : nil
 
         // Notify the tab to the left to update its separator when this tab is hovered/unhovered
-        if tabVisualProvider.isRoundedBackgroundPresentOnHover {
+        if visualStyle.tabStyleProvider.isRoundedBackgroundPresentOnHover {
             if let indexPath = collectionView?.indexPath(for: self),
                indexPath.item > 0,
                let leftItem = collectionView?.item(at: IndexPath(item: indexPath.item - 1, section: indexPath.section)) as? TabBarViewItem {
@@ -1238,9 +1236,9 @@ extension TabBarViewItem {
         var collectionViews = [NSCollectionView]()
 
         init(sections: [[TabBarViewModelMock]],
-             visualStyleManager: VisualStyleManagerProviding = NSApp.delegateTyped.visualStyleManager) {
+             visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle) {
             self.sections = sections
-            self.tabVisualProvider = visualStyleManager.style.tabStyleProvider
+            self.tabVisualProvider = visualStyle.tabStyleProvider
             super.init(nibName: nil, bundle: nil)
         }
 

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
@@ -35,6 +35,8 @@ protocol VisualStyleProviding {
     var tabStyleProvider: TabStyleProviding { get }
     var colorsProvider: ColorsProviding { get }
     var iconsProvider: IconsProviding { get }
+
+    var isNewStyle: Bool { get }
 }
 
 protocol VisualStyleDecider {
@@ -74,6 +76,7 @@ struct VisualStyle: VisualStyleProviding {
     let navigationToolbarButtonsSpacing: CGFloat
     let tabBarButtonSize: CGFloat
     let addToolbarShadow: Bool
+    let isNewStyle: Bool
 
     static var legacy: VisualStyleProviding {
         return VisualStyle(toolbarButtonsCornerRadius: 4,
@@ -86,7 +89,8 @@ struct VisualStyle: VisualStyleProviding {
                            fireButtonSize: 28,
                            navigationToolbarButtonsSpacing: 0,
                            tabBarButtonSize: 28,
-                           addToolbarShadow: false)
+                           addToolbarShadow: false,
+                           isNewStyle: false)
     }
 
     static var current: VisualStyleProviding {
@@ -101,7 +105,8 @@ struct VisualStyle: VisualStyleProviding {
                            fireButtonSize: 32,
                            navigationToolbarButtonsSpacing: 2,
                            tabBarButtonSize: 28,
-                           addToolbarShadow: true)
+                           addToolbarShadow: true,
+                           isNewStyle: true)
     }
 }
 

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
@@ -37,7 +37,7 @@ protocol VisualStyleProviding {
     var iconsProvider: IconsProviding { get }
 }
 
-protocol VisualStyleManagerProviding {
+protocol VisualStyleDecider {
     var style: any VisualStyleProviding { get }
 }
 
@@ -105,7 +105,7 @@ struct VisualStyle: VisualStyleProviding {
     }
 }
 
-final class VisualStyleManager: VisualStyleManagerProviding {
+final class DefaultVisualStyleDecider: VisualStyleDecider {
     private let featureFlagger: FeatureFlagger
     private let internalUserDecider: InternalUserDecider
 

--- a/macOS/IntegrationTests/BookmarksBar/ViewModel/BookmarksBarViewModelTests.swift
+++ b/macOS/IntegrationTests/BookmarksBar/ViewModel/BookmarksBarViewModelTests.swift
@@ -28,7 +28,7 @@ class BookmarksBarViewModelTests: XCTestCase {
             bookmarkManager: manager,
             dragDropManager: .init(bookmarkManager: manager),
             tabCollectionViewModel: .mock(),
-            visualStyleManager: MockVisualStyleManager()
+            visualStyle: VisualStyle.current
         )
 
         let clipped = bookmarksBarViewModel.clipLastBarItem()
@@ -47,7 +47,7 @@ class BookmarksBarViewModelTests: XCTestCase {
             bookmarkManager: manager,
             dragDropManager: .init(bookmarkManager: manager),
             tabCollectionViewModel: .mock(),
-            visualStyleManager: MockVisualStyleManager()
+            visualStyle: VisualStyle.current
         )
         bookmarksBarViewModel.update(from: bookmarks, containerWidth: 200)
 
@@ -67,7 +67,7 @@ class BookmarksBarViewModelTests: XCTestCase {
             bookmarkManager: manager,
             dragDropManager: .init(bookmarkManager: manager),
             tabCollectionViewModel: .mock(),
-            visualStyleManager: MockVisualStyleManager()
+            visualStyle: VisualStyle.current
         )
         bookmarksBarViewModel.update(from: bookmarks, containerWidth: 200)
 
@@ -92,7 +92,7 @@ class BookmarksBarViewModelTests: XCTestCase {
             bookmarkManager: manager,
             dragDropManager: .init(bookmarkManager: manager),
             tabCollectionViewModel: .mock(),
-            visualStyleManager: MockVisualStyleManager()
+            visualStyle: VisualStyle.current
         )
         bookmarksBarViewModel.update(from: bookmarks, containerWidth: 0)
 
@@ -109,7 +109,7 @@ class BookmarksBarViewModelTests: XCTestCase {
             bookmarkManager: manager,
             dragDropManager: .init(bookmarkManager: manager),
             tabCollectionViewModel: .mock(),
-            visualStyleManager: MockVisualStyleManager()
+            visualStyle: VisualStyle.current
         )
         bookmarksBarViewModel.update(from: bookmarks, containerWidth: 200)
 
@@ -122,7 +122,7 @@ class BookmarksBarViewModelTests: XCTestCase {
     func testWhenItemFiresClickedActionThenDelegateReceivesClickItemActionAndPreventClickIsFalse() {
         // GIVEN
         let manager = createMockBookmarksManager()
-        let sut = BookmarksBarViewModel(bookmarkManager: manager, dragDropManager: .init(bookmarkManager: manager), tabCollectionViewModel: .mock(), visualStyleManager: MockVisualStyleManager())
+        let sut = BookmarksBarViewModel(bookmarkManager: manager, dragDropManager: .init(bookmarkManager: manager), tabCollectionViewModel: .mock(), visualStyle: VisualStyle.current)
         let collectionViewItem = BookmarksBarCollectionViewItem()
         let delegateMock = BookmarksBarViewModelDelegateMock()
         sut.delegate = delegateMock
@@ -185,8 +185,4 @@ private extension Bookmark {
                                          title: "Title",
                                          isFavorite: false)
 
-}
-
-final class MockVisualStyleManager: VisualStyleManagerProviding {
-    var style: VisualStyleProviding = VisualStyle.current
 }

--- a/macOS/UnitTests/RemoteMessaging/RemoteMessagingClientTests.swift
+++ b/macOS/UnitTests/RemoteMessaging/RemoteMessagingClientTests.swift
@@ -133,7 +133,8 @@ final class RemoteMessagingClientTests: XCTestCase {
                 statisticsStore: MockStatisticsStore(),
                 variantManager: MockVariantManager(),
                 subscriptionManager: subscriptionAuthV1toV2Bridge,
-                featureFlagger: MockFeatureFlagger()
+                featureFlagger: MockFeatureFlagger(),
+                visualStyle: VisualStyle.current
             ),
             remoteMessagingAvailabilityProvider: availabilityProvider
         )

--- a/macOS/UnitTests/RemoteMessaging/RemoteMessagingConfigMatcherProviderTests.swift
+++ b/macOS/UnitTests/RemoteMessaging/RemoteMessagingConfigMatcherProviderTests.swift
@@ -1,0 +1,151 @@
+//
+//  RemoteMessagingConfigMatcherProviderTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import XCTest
+import RemoteMessaging
+import BrowserServicesKit
+import Persistence
+import Bookmarks
+import NetworkProtection
+import Subscription
+import Freemium
+import FeatureFlags
+import Common
+@testable import RemoteMessaging
+@testable import DuckDuckGo_Privacy_Browser
+
+final class RemoteMessagingConfigMatcherProviderTests: XCTestCase {
+    // Test: Feature flag is on, but visualStyle.isNewStyle is false → should NOT return the message
+    func testVisualUpdatesFeatureFlag_WhenFeatureFlagOnButVisualStyleNotNew_ShouldNotBeInEnabledFlags() async {
+        // Given
+        let featureFlagger = VisualStyleManagerTests.MockFeatureFlagger()
+        let visualStyle: VisualStyleProviding = VisualStyle.legacy
+        featureFlagger.enabledFeatureFlags = [FeatureFlag.visualUpdates]
+
+        let remoteConfig = provideRemoteStoreWithVisualUpdateMessage()
+        let provider = createProvider(featureFlagger: featureFlagger, visualStyle: visualStyle)
+
+        // When
+        let configMatcher = await provider.refreshConfigMatcher(using: MockRemoteMessagingStore())
+
+        // Then
+        XCTAssertNil(configMatcher.evaluate(remoteConfig: remoteConfig))
+    }
+
+    // Test: Feature flag is off → should NOT return the message
+    func testVisualUpdatesFeatureFlag_WhenFeatureFlagOff_ShouldNotBeInEnabledFlags() async {
+        // Given
+        let featureFlagger = VisualStyleManagerTests.MockFeatureFlagger()
+        let visualStyle: VisualStyleProviding = VisualStyle.legacy
+        featureFlagger.enabledFeatureFlags = []
+
+        let remoteConfig = provideRemoteStoreWithVisualUpdateMessage()
+        let provider = createProvider(featureFlagger: featureFlagger, visualStyle: visualStyle)
+
+        // When
+        let configMatcher = await provider.refreshConfigMatcher(using: MockRemoteMessagingStore())
+
+        // Then
+        XCTAssertNil(configMatcher.evaluate(remoteConfig: remoteConfig))
+    }
+
+    // Test: Feature flag is on and visualStyle.isNewStyle is true → should return the message
+    func testVisualUpdatesFeatureFlag_WhenFeatureFlagOnAndVisualStyleNew_ShouldBeInEnabledFlags() async {
+        // Given
+        let featureFlagger = VisualStyleManagerTests.MockFeatureFlagger()
+        let visualStyle: VisualStyleProviding = VisualStyle.current
+        featureFlagger.enabledFeatureFlags = [FeatureFlag.visualUpdates]
+
+        let remoteConfig = provideRemoteStoreWithVisualUpdateMessage()
+        let provider = createProvider(featureFlagger: featureFlagger, visualStyle: visualStyle)
+
+        // When
+        let configMatcher = await provider.refreshConfigMatcher(using: MockRemoteMessagingStore())
+
+        // Then
+        XCTAssertNotNil(configMatcher.evaluate(remoteConfig: remoteConfig))
+    }
+
+    // MARK: - Helper Methods
+
+    private func provideRemoteStoreWithVisualUpdateMessage() -> RemoteConfigModel {
+        let remoteMessage = RemoteMessageModel(id: "1",
+                                               content: .bigSingleAction(titleText: "DuckDuckGo got a refresh!",
+                                                                         descriptionText: "New icons, fresh styles, and the same world-class protection.",
+                                                                         placeholder: .announce,
+                                                                         primaryActionText: "Share Feedback",
+                                                                         primaryAction: .navigation(value: .feedback)),
+                                               matchingRules: [23],
+                                               exclusionRules: [],
+                                               isMetricsEnabled: false)
+        let matchingAttributes: [MatchingAttribute] = [
+            AppVersionMatchingAttribute(min: "1.143.0", fallback: false),
+            AllFeatureFlagsEnabledMatchingAttribute(value: ["visualUpdates"])
+        ]
+        let remoteRuleModel = RemoteConfigRule(id: 23, targetPercentile: nil, attributes: matchingAttributes)
+
+        return RemoteConfigModel(messages: [remoteMessage], rules: [remoteRuleModel])
+    }
+
+    private func createProvider(featureFlagger: FeatureFlagger, visualStyle: VisualStyleProviding) -> RemoteMessagingConfigMatcherProvider {
+        let bookmarksDB = CoreDataDatabase.bookmarksMock
+        return RemoteMessagingConfigMatcherProvider(
+            bookmarksDatabase: bookmarksDB,
+            appearancePreferences: .mock,
+            startupPreferencesPersistor: StartupPreferencesPersistorMock(launchToCustomHomePage: false, customHomePageURL: ""),
+            duckPlayerPreferencesPersistor: DuckPlayerPreferencesPersistorMock(),
+            pinnedTabsManagerProvider: PinnedTabsManagerProvidingMock(),
+            internalUserDecider: VisualStyleManagerTests.MockInternalUserDecider(),
+            statisticsStore: MockStatisticsStore(),
+            variantManager: MockVariantManager(),
+            subscriptionManager: DefaultSubscriptionManager(),
+            featureFlagger: featureFlagger,
+            visualStyle: visualStyle
+        )
+    }
+}
+
+// MARK: - Mocks
+
+extension CoreDataDatabase {
+
+    static func tempDBDir() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    }
+
+    static func mock(
+        bundle: Bundle,
+        modelName: String,
+        dbName: String = "Test",
+        containerLocation: URL = MockBookmarksDatabase.tempDBDir()
+    ) -> CoreDataDatabase {
+        let model = CoreDataDatabase.loadModel(from: bundle, named: modelName)!
+        let db = CoreDataDatabase(name: "Test", containerLocation: tempDBDir(), model: model)
+        db.loadStore()
+        return db
+    }
+
+}
+extension CoreDataDatabase {
+
+    static var bookmarksMock: CoreDataDatabase {
+        mock(bundle: Bookmarks.bundle, modelName: "BookmarksModel")
+    }
+
+}

--- a/macOS/UnitTests/RemoteMessaging/RemoteMessagingConfigMatcherProviderTests.swift
+++ b/macOS/UnitTests/RemoteMessaging/RemoteMessagingConfigMatcherProviderTests.swift
@@ -18,15 +18,11 @@
 
 import Foundation
 import XCTest
-import RemoteMessaging
 import BrowserServicesKit
 import Persistence
 import Bookmarks
-import NetworkProtection
 import Subscription
-import Freemium
 import FeatureFlags
-import Common
 @testable import RemoteMessaging
 @testable import DuckDuckGo_Privacy_Browser
 

--- a/macOS/UnitTests/VisualRefresh/VisualStyleManagerTests.swift
+++ b/macOS/UnitTests/VisualRefresh/VisualStyleManagerTests.swift
@@ -28,14 +28,14 @@ class VisualStyleManagerTests: XCTestCase {
 
     private var mockInternalUserDecider: MockInternalUserDecider!
     private var mockFeatureFlagger: MockFeatureFlagger!
-    var visualStyleManager: VisualStyleManager!
+    var visualStyleDecider: VisualStyleDecider!
 
     override func setUp() {
         super.setUp()
         mockInternalUserDecider = MockInternalUserDecider()
         mockFeatureFlagger = MockFeatureFlagger(internalUserDecider: mockInternalUserDecider)
 
-        visualStyleManager = VisualStyleManager(
+        visualStyleDecider = DefaultVisualStyleDecider(
             featureFlagger: mockFeatureFlagger,
             internalUserDecider: mockInternalUserDecider
         )
@@ -44,7 +44,7 @@ class VisualStyleManagerTests: XCTestCase {
     override func tearDown() {
         mockInternalUserDecider = nil
         mockFeatureFlagger = nil
-        visualStyleManager = nil
+        visualStyleDecider = nil
         super.tearDown()
     }
 
@@ -56,7 +56,7 @@ class VisualStyleManagerTests: XCTestCase {
         mockFeatureFlagger.enabledFeatureFlags = []
 
         // When
-        let style = visualStyleManager.style
+        let style = visualStyleDecider.style
 
         // Then
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0, "Should return legacy corner radius")
@@ -71,7 +71,7 @@ class VisualStyleManagerTests: XCTestCase {
         mockFeatureFlagger.enabledFeatureFlags = [.visualUpdates]
 
         // When
-        let style = visualStyleManager.style
+        let style = visualStyleDecider.style
 
         // Then
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 9.0, "Should return current corner radius")
@@ -88,7 +88,7 @@ class VisualStyleManagerTests: XCTestCase {
         mockFeatureFlagger.enabledFeatureFlags = [] // No feature flags enabled
 
         // When
-        let style = visualStyleManager.style
+        let style = visualStyleDecider.style
 
         // Then
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0, "Internal users should get legacy style when visualUpdatesInternalOnly is disabled")
@@ -103,7 +103,7 @@ class VisualStyleManagerTests: XCTestCase {
         mockFeatureFlagger.enabledFeatureFlags = [.visualUpdatesInternalOnly]
 
         // When
-        let style = visualStyleManager.style
+        let style = visualStyleDecider.style
 
         // Then
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 9.0, "Internal users should get current style when visualUpdatesInternalOnly is enabled")
@@ -118,7 +118,7 @@ class VisualStyleManagerTests: XCTestCase {
         mockFeatureFlagger.enabledFeatureFlags = [.visualUpdates] // Regular feature flag enabled
 
         // When
-        let style = visualStyleManager.style
+        let style = visualStyleDecider.style
 
         // Then - Should return legacy style (internal users ignore .visualUpdates flag)
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0, "Internal users should ignore .visualUpdates flag and only respond to .visualUpdatesInternalOnly")
@@ -135,7 +135,7 @@ class VisualStyleManagerTests: XCTestCase {
         mockFeatureFlagger.enabledFeatureFlags = []
 
         // When
-        let style = visualStyleManager.style
+        let style = visualStyleDecider.style
 
         // Then
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0)
@@ -158,7 +158,7 @@ class VisualStyleManagerTests: XCTestCase {
         mockFeatureFlagger.enabledFeatureFlags = [.visualUpdates]
 
         // When
-        let style = visualStyleManager.style
+        let style = visualStyleDecider.style
 
         // Then
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 9.0)
@@ -183,7 +183,7 @@ class VisualStyleManagerTests: XCTestCase {
         mockFeatureFlagger.enabledFeatureFlags = [.visualUpdates]
 
         // When
-        let style = visualStyleManager.style
+        let style = visualStyleDecider.style
 
         // Then - Should return legacy style (internal users ignore .visualUpdates)
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0, "Internal users should ignore .visualUpdates flag")
@@ -192,7 +192,7 @@ class VisualStyleManagerTests: XCTestCase {
         mockFeatureFlagger.enabledFeatureFlags = [.visualUpdatesInternalOnly]
 
         // When
-        let styleWithInternalFlag = visualStyleManager.style
+        let styleWithInternalFlag = visualStyleDecider.style
 
         // Then - Should return current style
         XCTAssertEqual(styleWithInternalFlag.toolbarButtonsCornerRadius, 9.0, "Internal users should respond to .visualUpdatesInternalOnly flag")
@@ -204,7 +204,7 @@ class VisualStyleManagerTests: XCTestCase {
         mockFeatureFlagger.enabledFeatureFlags = [.visualUpdatesInternalOnly]
 
         // When
-        let style = visualStyleManager.style
+        let style = visualStyleDecider.style
 
         // Then - Should return legacy style (non-internal users ignore .visualUpdatesInternalOnly)
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0, "Non-internal users should ignore .visualUpdatesInternalOnly flag")
@@ -213,7 +213,7 @@ class VisualStyleManagerTests: XCTestCase {
         mockFeatureFlagger.enabledFeatureFlags = [.visualUpdates]
 
         // When
-        let styleWithVisualUpdates = visualStyleManager.style
+        let styleWithVisualUpdates = visualStyleDecider.style
 
         // Then - Should return current style
         XCTAssertEqual(styleWithVisualUpdates.toolbarButtonsCornerRadius, 9.0, "Non-internal users should respond to .visualUpdates flag")
@@ -225,7 +225,7 @@ class VisualStyleManagerTests: XCTestCase {
         mockFeatureFlagger.enabledFeatureFlags = [.visualUpdates, .visualUpdatesInternalOnly]
 
         // When
-        let style = visualStyleManager.style
+        let style = visualStyleDecider.style
 
         // Then - Should return current style (both flags enabled, internal user uses internal-only flag)
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 9.0, "Internal users should use .visualUpdatesInternalOnly when both flags are enabled")
@@ -237,7 +237,7 @@ class VisualStyleManagerTests: XCTestCase {
         mockFeatureFlagger.enabledFeatureFlags = [.visualUpdates, .visualUpdatesInternalOnly]
 
         // When
-        let style = visualStyleManager.style
+        let style = visualStyleDecider.style
 
         // Then - Should return current style (both flags enabled, non-internal user uses .visualUpdates flag)
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 9.0, "Non-internal users should use .visualUpdates when both flags are enabled")
@@ -251,21 +251,21 @@ class VisualStyleManagerTests: XCTestCase {
         mockFeatureFlagger.enabledFeatureFlags = []
 
         // When/Then - Should return legacy style
-        var style = visualStyleManager.style
+        var style = visualStyleDecider.style
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0)
 
         // Given - Change to internal user (still no feature flags)
         mockInternalUserDecider.isInternalUser = true
 
         // When/Then - Should still return legacy style (internal users need .visualUpdatesInternalOnly)
-        style = visualStyleManager.style
+        style = visualStyleDecider.style
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0)
 
         // Given - Enable internal-only feature flag
         mockFeatureFlagger.enabledFeatureFlags = [.visualUpdatesInternalOnly]
 
         // When/Then - Should now return current style
-        style = visualStyleManager.style
+        style = visualStyleDecider.style
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 9.0)
     }
 
@@ -275,14 +275,14 @@ class VisualStyleManagerTests: XCTestCase {
         mockFeatureFlagger.enabledFeatureFlags = []
 
         // When/Then - Should return legacy style
-        var style = visualStyleManager.style
+        var style = visualStyleDecider.style
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0)
 
         // Given - Enable the feature for non-internal users
         mockFeatureFlagger.enabledFeatureFlags = [.visualUpdates]
 
         // When/Then - Should return current style
-        style = visualStyleManager.style
+        style = visualStyleDecider.style
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 9.0)
     }
 
@@ -292,34 +292,34 @@ class VisualStyleManagerTests: XCTestCase {
         mockFeatureFlagger.enabledFeatureFlags = []
 
         // When/Then - Should return legacy style
-        var style = visualStyleManager.style
+        var style = visualStyleDecider.style
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0)
 
         // Given - Enable regular visualUpdates (should be ignored by internal users)
         mockFeatureFlagger.enabledFeatureFlags = [.visualUpdates]
 
         // When/Then - Should still return legacy style
-        style = visualStyleManager.style
+        style = visualStyleDecider.style
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0)
 
         // Given - Enable internal-only feature
         mockFeatureFlagger.enabledFeatureFlags = [.visualUpdatesInternalOnly]
 
         // When/Then - Should return current style
-        style = visualStyleManager.style
+        style = visualStyleDecider.style
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 9.0)
 
         // Given - Disable internal-only feature
         mockFeatureFlagger.enabledFeatureFlags = []
 
         // When/Then - Should return legacy style again
-        style = visualStyleManager.style
+        style = visualStyleDecider.style
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0)
     }
 
     // MARK: - Mock Classes
 
-    private class MockInternalUserDecider: InternalUserDecider {
+    class MockInternalUserDecider: InternalUserDecider {
         var isInternalUser: Bool = false
         var isInternalUserPublisher: AnyPublisher<Bool, Never> {
             isInternalUserSubject.eraseToAnyPublisher()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1210516955340220
Tech Design URL:
CC:

### Description
This PR optimizes the visual refresh feature implementation by improving performance and adding proper filtering for remote messages. The changes ensure that visual style checks are performed only at launch time instead of repeatedly throughout the app lifecycle, and that remote messages are only displayed to users who are actually seeing the new visual style.

**Key Changes:**
- **Performance Optimization**: Visual style is now determined once at launch rather than being checked repeatedly across all UI components
- **Remote Messaging Filtering**: Added logic to ensure remote messages related to visual updates are only shown to users with the new visual style enabled
- **Code Clarity**: Renamed `VisualStyleManager` to `VisualStyleDecider` for better semantic clarity
- **Testing**: Added comprehensive unit tests for the new remote messaging filtering logic

### Testing Steps

**Check the  Visual Updates are only applied at app launch**
1. You can add a breakpoint to the `DefaultVisualStyleDecider` line 129
2. Run the application, verify it gets called once from the `AppDelete.init`
3. Go to Debug -> Feature Flag Overrides -> and override the `visualUpdatesInternalOnly` and the `visualUpdates`
4. Open new windows, new tabs and play with the app. You should still see the current theme.
5. Close the app and re-open it.
6. Verify the new changes are applied.

**Verify the remote message is not shown if the FF is enabled but the user is seeing the legacy visuals**
1. Before running the application, change the `RemoteMessageClientConfiguration`, to return this in the DEBUG mode: `https://jsonblob.com/api/1380594945500569600`
2.Run the application
3. Go to Debug -> Feature Flag Overrides -> and override the `visualUpdatesInternalOnly` to false 
4. Restart the app to see the legacy view.
5. Go to Debug -> Feature Flag Overrides -> and override the `visualUpdates` to true
6. Go to Debug -> Remote Messaging Framework -> Reset Remote Messages
7. Go to Debug -> Remote Messaging Framework -> Refresh Config
5. You should not see the new RMF in the New Tab Page
8. Go to Debug -> Feature Flag Overrides -> and override the `visualUpdatesInternalOnly` to true again.
9. Restart the application, you should see the new theme
10. Follow steps 6 and 7
11.  You should see the remote message on NTP

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
1. **Visual inconsistencies**: If the style determination logic fails, some UI components might show mixed visual styles
   - *Mitigation*: The refactored code maintains the same decision logic, just moves the evaluation point to launch time. Extensive testing across all UI components has been done.

2. **Remote messages not showing**: The new filtering logic might be too restrictive and prevent legitimate messages from appearing
   - *Mitigation*: Added comprehensive unit tests to verify the filtering logic works correctly. The logic only affects visual-refresh-related messages.

3. **Performance regression**: Changes to the style checking mechanism could potentially impact performance
   - *Mitigation*: This is actually a performance improvement - checking style once at launch instead of repeatedly should reduce CPU usage.

### Quality Considerations
- **Performance Impact**: Positive - reduces repeated style checks throughout the app lifecycle by determining visual style once at launch
- **Edge Cases**: 
  - Internal users vs external users (handled by existing `InternalUserDecider`)
  - Feature flag state changes (requires app restart, which is expected behavior)
  - Mixed visual styles across components (prevented by centralized style determination)
- **Testing**: Added unit tests specifically for `RemoteMessagingConfigMatcherProvider` to verify the new filtering logic
- **Monitoring**: No additional monitoring needed - existing remote messaging analytics will capture message display metrics
- **Privacy/Security**: No impact - this is purely a UI optimization and filtering enhancement

### Notes to Reviewer
- Pay special attention to the remote messaging filtering logic in `RemoteMessagingConfigMatcherProvider.swift` (lines ~184-190)
- The performance improvement comes from replacing multiple `visualStyleManager.style` checks throughout the codebase with a single determination at launch
- The rename from `VisualStyleManager` to `VisualStyleDecider` better reflects that this class decides/determines style rather than manages it
- New unit tests provide good coverage of the edge cases for the remote messaging filtering

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943) 
