### PR TITLE
Connect shortHistoryMenu feature flag to shortHistoryMenu Privacy Feature

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -66,6 +66,7 @@ public enum PrivacyFeature: String {
     case adAttributionReporting
     case forceOldAppDelegate
     case htmlHistoryPage
+    case shortHistoryMenu
     case tabManager
     case webViewStateRestoration
     case experimentalTheming

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -234,7 +234,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .aiChatSidebar:
             return .internalOnly()
         case .shortHistoryMenu:
-            return .disabled
+            return .remoteReleasable(.feature(.shortHistoryMenu))
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1210519540757012?focus=true

### Description
This change defines a new Privacy Config feature flag to control short history menu.

### Testing Steps
1. Launch the app and make sure shortHistoryMenu feature flag override is off.
2. Verify that you see daily history groupings in the history menu.
3. Use this privacy config: https://duckduckgo.github.io/privacy-configuration/pr-3297/v4/macos-config.json
4. Verify that you can’t see daily history groupings in the history menu.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)