### PR TITLE
Set due date to Today on all Asana tasks created by release automation

### DIFF
--- a/iOS/Gemfile.lock
+++ b/iOS/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: ac3a20d7287a52ffa6be08f302b86be903611489
-  tag: 2.4.2
+  revision: aa00532b3e4dbb844a8ab89c936b49d194c68f9e
+  tag: 2.5.0
   specs:
-    fastlane-plugin-ddg_apple_automation (2.4.2)
+    fastlane-plugin-ddg_apple_automation (2.5.0)
       asana
       climate_control
       httpparty
@@ -27,22 +27,22 @@ GEM
       oauth2 (>= 1.4, < 3)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1111.0)
-    aws-sdk-core (3.225.0)
+    aws-partitions (1.1116.0)
+    aws-sdk-core (3.225.2)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
       base64
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.102.0)
+    aws-sdk-kms (1.104.0)
       aws-sdk-core (~> 3, >= 3.225.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.189.0)
+    aws-sdk-s3 (1.189.1)
       aws-sdk-core (~> 3, >= 3.225.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
-    aws-sigv4 (1.12.0)
+    aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     base64 (0.3.0)
@@ -199,7 +199,7 @@ GEM
     multipart-post (2.4.1)
     mutex_m (0.3.0)
     nanaimo (0.4.0)
-    naturally (2.2.1)
+    naturally (2.3.0)
     nkf (0.2.0)
     oauth2 (2.0.12)
       faraday (>= 0.17.3, < 4.0)

--- a/iOS/fastlane/Pluginfile
+++ b/iOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '2.4.2'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '2.5.0'

--- a/macOS/Gemfile.lock
+++ b/macOS/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: ac3a20d7287a52ffa6be08f302b86be903611489
-  tag: 2.4.2
+  revision: aa00532b3e4dbb844a8ab89c936b49d194c68f9e
+  tag: 2.5.0
   specs:
-    fastlane-plugin-ddg_apple_automation (2.4.2)
+    fastlane-plugin-ddg_apple_automation (2.5.0)
       asana
       climate_control
       httpparty
@@ -27,22 +27,22 @@ GEM
       oauth2 (>= 1.4, < 3)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1111.0)
-    aws-sdk-core (3.225.0)
+    aws-partitions (1.1116.0)
+    aws-sdk-core (3.225.2)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
       base64
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.102.0)
+    aws-sdk-kms (1.104.0)
       aws-sdk-core (~> 3, >= 3.225.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.189.0)
+    aws-sdk-s3 (1.189.1)
       aws-sdk-core (~> 3, >= 3.225.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
-    aws-sigv4 (1.12.0)
+    aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     base64 (0.3.0)
@@ -199,7 +199,7 @@ GEM
     multipart-post (2.4.1)
     mutex_m (0.3.0)
     nanaimo (0.4.0)
-    naturally (2.2.1)
+    naturally (2.3.0)
     nkf (0.2.0)
     oauth2 (2.0.12)
       faraday (>= 0.17.3, < 4.0)

--- a/macOS/fastlane/Pluginfile
+++ b/macOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '2.4.2'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '2.5.0'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1210526856673084?focus=true

### Description
This change updates fastlane plugin to a version which supports setting due date on tasks
created by release automation and sets it to “Today” for all created tasks.
This is supposed to help increase visibility of tasks created by release automation.

### Testing Steps
No testing steps at this time.

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Release workflows may break, but I’m here to help fix it, and also my plan is to bump both iOS and macOS releases once this is merged.

### Quality Considerations
I’ve tested the action locally (from the macOS project) by passing it a due date and not passing it a due date, with positive results in both cases.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)