### PR TITLE
macOS Duck.ai Sidebar: 3. Duck.ai chat context handoff from SERP to sidebar (or new tab)

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
@@ -24,6 +24,9 @@ protocol AIChatTabOpening {
 
     @MainActor
     func openAIChatTab(_ value: AddressBarTextField.Value, target: AIChatTabOpenerTarget)
+
+    @MainActor
+    func openNewAIChatTab(withPayload payload: AIChatPayload)
 }
 
 extension AIChatTabOpening {
@@ -77,5 +80,15 @@ struct AIChatTabOpener: AIChatTabOpening {
             promptHandler.setData(.queryPrompt(query, autoSubmit: autoSubmit))
         }
         Application.appDelegate.windowControllersManager.openAIChat(aiChatRemoteSettings.aiChatURL, target: target, hasPrompt: query != nil)
+    }
+
+    @MainActor
+    func openNewAIChatTab(withPayload payload: AIChatPayload) {
+        guard let tabCollectionViewModel = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel else { return }
+
+        let newAIChatTab = Tab(content: .url(aiChatRemoteSettings.aiChatURL, source: .ui))
+        newAIChatTab.aiChat?.setAIChatNativeHandoffData(payload: payload)
+
+        tabCollectionViewModel.insertOrAppend(tab: newAIChatTab, selected: true)
     }
 }

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
@@ -21,7 +21,7 @@ import UserScript
 import AIChat
 
 final class AIChatUserScript: NSObject, Subfeature {
-    private let handler: AIChatUserScriptHandling
+    public let handler: AIChatUserScriptHandling
     public let featureName: String = "aiChat"
     weak var broker: UserScriptMessageBroker?
     private(set) var messageOriginPolicy: MessageOriginPolicy
@@ -53,6 +53,10 @@ final class AIChatUserScript: NSObject, Subfeature {
             return handler.closeAIChat
         case .getAIChatNativePrompt:
             return handler.getAIChatNativePrompt
+        case .openAIChat:
+            return handler.openAIChat
+        case .getAIChatNativeHandoffData:
+            return handler.getAIChatNativeHandoffData
         default:
             return nil
         }

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -24,16 +24,24 @@ protocol AIChatUserScriptHandling {
     func getAIChatNativeConfigValues(params: Any, message: UserScriptMessage) async -> Encodable?
     func closeAIChat(params: Any, message: UserScriptMessage) async -> Encodable?
     func getAIChatNativePrompt(params: Any, message: UserScriptMessage) async -> Encodable?
+    func openAIChat(params: Any, message: UserScriptMessage) async -> Encodable?
+    func getAIChatNativeHandoffData(params: Any, message: UserScriptMessage) -> Encodable?
+
+    var messageHandling: AIChatMessageHandling { get }
 }
 
 struct AIChatUserScriptHandler: AIChatUserScriptHandling {
-    private let messageHandling: AIChatMessageHandling
+    public let messageHandling: AIChatMessageHandling
     private let storage: AIChatPreferencesStorage
 
     init(storage: AIChatPreferencesStorage,
          messageHandling: AIChatMessageHandling = AIChatMessageHandler()) {
         self.storage = storage
         self.messageHandling = messageHandling
+    }
+
+    enum AIChatKeys {
+        static let aiChatPayload = "aiChatPayload"
     }
 
     @MainActor public func openAIChatSettings(params: Any, message: UserScriptMessage) async -> Encodable? {
@@ -53,4 +61,25 @@ struct AIChatUserScriptHandler: AIChatUserScriptHandling {
     func getAIChatNativePrompt(params: Any, message: UserScriptMessage) async -> Encodable? {
         messageHandling.getDataForMessageType(.nativePrompt)
     }
+
+    @MainActor
+    func openAIChat(params: Any, message: UserScriptMessage) async -> Encodable? {
+        var payload: AIChatPayload?
+        if let paramsDict = params as? AIChatPayload {
+            payload = paramsDict[AIChatKeys.aiChatPayload] as? AIChatPayload
+        }
+
+        NotificationCenter.default.post(name: .aiChatNativeHandoffData,
+                                        object: payload,
+                                        userInfo: nil)
+        return nil
+    }
+
+    public func getAIChatNativeHandoffData(params: Any, message: UserScriptMessage) -> Encodable? {
+        messageHandling.getDataForMessageType(.nativeHandoffData)
+    }
+}
+
+extension NSNotification.Name {
+    static let aiChatNativeHandoffData: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.notification.aiChatNativeHandoffData")
 }

--- a/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarPresenter.swift
+++ b/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarPresenter.swift
@@ -19,6 +19,7 @@
 import Foundation
 import BrowserServicesKit
 import Combine
+import AIChat
 
 /// Represents an event of hiding or showing an AI Chat tab sidebar.
 ///
@@ -53,6 +54,8 @@ final class AIChatSidebarPresenter: AIChatSidebarPresenting {
     private let featureFlagger: FeatureFlagger
     private let sidebarPresenceWillChangeSubject = PassthroughSubject<AIChatSidebarPresenceChange, Never>()
 
+    private var cancellables = Set<AnyCancellable>()
+
     init(sidebarHost: AIChatSidebarHosting,
          sidebarProvider: AIChatSidebarProviding = AIChatSidebarProvider(),
          featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger) {
@@ -62,6 +65,15 @@ final class AIChatSidebarPresenter: AIChatSidebarPresenting {
 
         sidebarPresenceWillChangePublisher = sidebarPresenceWillChangeSubject.eraseToAnyPublisher()
         self.sidebarHost.aiChatSidebarHostingDelegate = self
+
+        NotificationCenter.default.publisher(for: .aiChatNativeHandoffData)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                if let payload = notification.object as? AIChatPayload {
+                    self?.handleAIChatHandoff(with: payload)
+                }
+            }
+            .store(in: &cancellables)
     }
 
     func toggleSidebar() {
@@ -70,7 +82,6 @@ final class AIChatSidebarPresenter: AIChatSidebarPresenting {
 
         let willShowSidebar = !sidebarProvider.isShowingSidebar(for: currentTabID)
 
-        sidebarPresenceWillChangeSubject.send(.init(tabID: currentTabID, isShown: willShowSidebar))
         updateSidebarConstraints(for: currentTabID, isShowingSidebar: willShowSidebar, withAnimation: true)
     }
 
@@ -81,6 +92,8 @@ final class AIChatSidebarPresenter: AIChatSidebarPresenting {
     }
 
     private func updateSidebarConstraints(for tabID: TabIdentifier, isShowingSidebar: Bool, withAnimation: Bool) {
+        sidebarPresenceWillChangeSubject.send(.init(tabID: tabID, isShown: isShowingSidebar))
+
         if isShowingSidebar {
             let sidebarViewController = sidebarProvider.sidebar(for: tabID).sidebarViewController
             sidebarViewController.delegate = self
@@ -107,6 +120,26 @@ final class AIChatSidebarPresenter: AIChatSidebarPresenting {
 
             if let tabID = sidebarHost.currentTabID, !isShowingSidebar {
                 sidebarProvider.handleSidebarDidClose(for: tabID)
+            }
+        }
+    }
+
+    private func handleAIChatHandoff(with payload: AIChatPayload) {
+        guard featureFlagger.isFeatureOn(.aiChatSidebar) else { return }
+        guard let currentTabID = sidebarHost.currentTabID else { return }
+
+        let isShowingSidebar = sidebarProvider.isShowingSidebar(for: currentTabID)
+
+        if !isShowingSidebar {
+            // If not showing the sidebar open it with the payload received
+            let sidebarViewController = sidebarProvider.sidebar(for: currentTabID).sidebarViewController
+            sidebarViewController.aiChatPayload = payload
+            updateSidebarConstraints(for: currentTabID, isShowingSidebar: true, withAnimation: true)
+        } else {
+            // If sidebar is open then pass the payload to a new AIChat tab
+            Task { @MainActor in
+                // TODO:
+                NSApp.delegateTyped.aiChatTabOpener.openAIChatTab(nil, target: .newTabSelected)
             }
         }
     }

--- a/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarPresenter.swift
+++ b/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarPresenter.swift
@@ -138,8 +138,7 @@ final class AIChatSidebarPresenter: AIChatSidebarPresenting {
         } else {
             // If sidebar is open then pass the payload to a new AIChat tab
             Task { @MainActor in
-                // TODO:
-                NSApp.delegateTyped.aiChatTabOpener.openAIChatTab(nil, target: .newTabSelected)
+                NSApp.delegateTyped.aiChatTabOpener.openNewAIChatTab(withPayload: payload)
             }
         }
     }

--- a/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarViewController.swift
+++ b/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarViewController.swift
@@ -18,7 +18,6 @@
 
 import AppKit
 import BrowserServicesKit
-import Combine
 import AIChat
 
 /// A delegate protocol that handles user interactions with the AI Chat sidebar view controller.

--- a/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarViewController.swift
+++ b/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarViewController.swift
@@ -18,6 +18,8 @@
 
 import AppKit
 import BrowserServicesKit
+import Combine
+import AIChat
 
 /// A delegate protocol that handles user interactions with the AI Chat sidebar view controller.
 /// This protocol defines methods for responding to navigation and UI events in the sidebar.
@@ -48,6 +50,7 @@ final class AIChatSidebarViewController: NSViewController {
     }
 
     weak var delegate: AIChatSidebarViewControllerDelegate?
+    public var aiChatPayload: AIChatPayload?
 
     private var openInNewTabButton: MouseOverButton!
     private var closeButton: MouseOverButton!
@@ -69,6 +72,10 @@ final class AIChatSidebarViewController: NSViewController {
         let container = NSView()
         container.wantsLayer = true
         container.layer?.backgroundColor = NSColor.navigationBarBackground.cgColor
+
+        if let aiChatPayload {
+            aiTab.aiChat?.setAIChatNativeHandoffData(payload: aiChatPayload)
+        }
 
         createAndSetupSeparator(in: container)
         createAndSetupTopBar(in: container)

--- a/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
@@ -67,9 +67,38 @@ final class AIChatUserScriptTests: XCTestCase {
         XCTAssertTrue(mockHandler.didGetPrompt, "getAIChatNativePrompt should be called")
         XCTAssertNil(result, "Expected result to be nil")
     }
+
+    @MainActor func testOpenAIChat() async throws {
+        let handler = try XCTUnwrap(userScript.handler(forMethodNamed: AIChatUserScriptMessages.openAIChat.rawValue))
+        let result = try await handler([""], WKScriptMessage())
+
+        XCTAssertTrue(mockHandler.didOpenChat, "openAIChat should be called")
+        XCTAssertNil(result, "Expected result to be nil")
+    }
+
+    @MainActor func testGetAIChatNativeHandoffData() async throws {
+        let handler = try XCTUnwrap(userScript.handler(forMethodNamed: AIChatUserScriptMessages.getAIChatNativeHandoffData.rawValue))
+        let result = try await handler([""], WKScriptMessage())
+
+        XCTAssertTrue(mockHandler.didGetHandoffData, "getAIChatNativeHandoffData should be called")
+        XCTAssertNil(result, "Expected result to be nil")
+    }
 }
 
 final class MockAIChatUserScriptHandler: AIChatUserScriptHandling {
+    var didOpenSettings = false
+    var didGetConfigValues = false
+    var didCloseChat = false
+    var didGetPrompt = false
+    var didOpenChat = false
+    var didGetHandoffData = false
+
+    var messageHandling: any DuckDuckGo_Privacy_Browser.AIChatMessageHandling
+
+    init(messageHandling: any AIChatMessageHandling = MockAIChatMessageHandling()) {
+        self.messageHandling = messageHandling
+    }
+
     func openAIChatSettings(params: Any, message: UserScriptMessage) async -> (any Encodable)? {
         didOpenSettings = true
         return nil
@@ -90,14 +119,31 @@ final class MockAIChatUserScriptHandler: AIChatUserScriptHandling {
         return nil
     }
 
-    var didOpenSettings = false
-    var didGetConfigValues = false
-    var didCloseChat = false
-    var didGetPrompt = false
+    func openAIChat(params: Any, message: any UserScriptMessage) async -> (any Encodable)? {
+        didOpenChat = true
+        return nil
+    }
+
+    func getAIChatNativeHandoffData(params: Any, message: any UserScriptMessage) -> (any Encodable)? {
+        didGetHandoffData = true
+        return nil
+    }
 }
 
 private final class AIChatMockDebugSettings: AIChatDebugURLSettingsRepresentable {
     var customURLHostname: String?
     var customURL: String?
     func reset() { }
+}
+
+private final class MockAIChatMessageHandling: AIChatMessageHandling {
+    var payloadHandler: AIChat.AIChatPayloadHandler
+
+    init(payloadHandler: AIChat.AIChatPayloadHandler = AIChatPayloadHandler()) {
+        self.payloadHandler = payloadHandler
+    }
+
+    func getDataForMessageType(_ type: DuckDuckGo_Privacy_Browser.AIChatMessageType) -> (any Encodable)? {
+        nil
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209671977594486/task/1210012482760771?focus=true
Tech Design URL:
CC: @ayoy 

### Description
Add support for Duck.ai chat context handoff to sidebar or new tab when clicking chat button on SERP results.

### Testing Steps
**Handoff from SERP to sidebar**
1. Use search query that shows Duck.ai Assist enhanced results e.g. "star wars movies ranked"
2. Make sure that on current tab the Duck.ai sidebar is collapsed
3. Click Duck.ai "Chat" button on SERP
4. 
**Expected:** The Duck.ai sidebar is open and the query context is passed into it 

--

**Handoff from SERP to a new tab** 
5. Make sure that on current tab the Duck.ai sidebar is open
5. Use search query that shows Duck.ai Assist enhanced results
6. Click Duck.ai "Chat" button on SERP

**Expected:** The Duck.ai sidebar stays open, a new tab is open and the query context is passed into Duck.ai in the new tab.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing. Both Duck.ai sidebar functionality and handoff support is gated behind the feature flag.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)