### PR TITLE
Update fastlane to 2.228.0 that fixes iOS AdHoc builds code signing

### DIFF
--- a/iOS/DuckDuckGo/DuckDuckGoAlpha.entitlements
+++ b/iOS/DuckDuckGo/DuckDuckGoAlpha.entitlements
@@ -10,18 +10,16 @@
 	</array>
 	<key>com.apple.developer.siri</key>
 	<true/>
-	<key>com.apple.developer.web-browser</key>
-	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.duckduckgo.alpha.app-configuration</string>
+		<string>group.com.duckduckgo.alpha.autofill</string>
 		<string>group.com.duckduckgo.alpha.bookmarks</string>
 		<string>group.com.duckduckgo.alpha.contentblocker</string>
 		<string>group.com.duckduckgo.alpha.database</string>
 		<string>group.com.duckduckgo.alpha.netp</string>
 		<string>group.com.duckduckgo.alpha.statistics</string>
 		<string>group.com.duckduckgo.alpha.vault</string>
-		<string>group.com.duckduckgo.alpha.autofill</string>
 	</array>
 	<key>keychain-access-groups</key>
 	<array>

--- a/iOS/Gemfile
+++ b/iOS/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'fastlane', '2.227.2'
+gem 'fastlane', '2.228.0'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/iOS/Gemfile.lock
+++ b/iOS/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
       faraday_middleware
       multi_json
     fastimage (2.4.0)
-    fastlane (2.227.2)
+    fastlane (2.228.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -272,7 +272,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane (= 2.227.2)
+  fastlane (= 2.228.0)
   fastlane-plugin-ddg_apple_automation!
 
 BUNDLED WITH

--- a/iOS/fastlane/Fastfile
+++ b/iOS/fastlane/Fastfile
@@ -17,7 +17,7 @@ platform :ios do
 
   desc 'Fetches and updates certificates and provisioning profiles for Ad-Hoc distribution'
   lane :sync_signing_adhoc do |options|
-    do_sync_signing(options.merge(readonly: true))
+    do_sync_signing(options)
   end
 
   desc 'Fetches and updates certificates and provisioning profiles for Alpha distribution'
@@ -27,7 +27,7 @@ platform :ios do
 
   desc 'Fetches and updates certificates and provisioning profiles for Ad-Hoc distribution'
   lane :sync_signing_alpha_adhoc do |options|
-    do_sync_signing(options.merge(readonly: true))
+    do_sync_signing(options)
   end
 
   desc 'Makes Ad-Hoc build with a specified name and alpha bundle ID in a given directory'
@@ -349,9 +349,7 @@ platform :ios do
     sync_code_signing(
       api_key: get_api_key,
       username: get_username(options),
-      # TODO: remove readonly once we have a way to manage certificates in CI
-      # https://github.com/fastlane/fastlane/issues/29499
-      readonly: options[:readonly] || !is_ci
+      readonly: !is_ci
     )
   end
 

--- a/iOS/fastlane/Matchfile
+++ b/iOS/fastlane/Matchfile
@@ -16,35 +16,29 @@ for_lane :sync_signing_alpha_adhoc do
     type "adhoc"
     app_identifier ["com.duckduckgo.mobile.ios.alpha", "com.duckduckgo.mobile.ios.alpha.ShareExtension", "com.duckduckgo.mobile.ios.alpha.OpenAction2", "com.duckduckgo.mobile.ios.alpha.Widgets", "com.duckduckgo.mobile.ios.alpha.NetworkExtension", "com.duckduckgo.mobile.ios.alpha.CredentialExtension"]
     force_for_new_devices true
-    template_name "Default Web Browser iOS (Dist)"
 end
 
 for_lane :adhoc do
     type "adhoc"
     app_identifier ["com.duckduckgo.mobile.ios.alpha", "com.duckduckgo.mobile.ios.alpha.ShareExtension", "com.duckduckgo.mobile.ios.alpha.OpenAction2", "com.duckduckgo.mobile.ios.alpha.Widgets", "com.duckduckgo.mobile.ios.alpha.NetworkExtension", "com.duckduckgo.mobile.ios.alpha.CredentialExtension"]
     force_for_new_devices true
-    template_name "Default Web Browser iOS (Dist)"
 end
 
 for_lane :release_adhoc do
     type "adhoc"
     force_for_new_devices true
-    template_name "Default Web Browser iOS (Dist)"
 end
 
 for_lane :alpha_adhoc do
     type "adhoc"
     app_identifier ["com.duckduckgo.mobile.ios.alpha", "com.duckduckgo.mobile.ios.alpha.ShareExtension", "com.duckduckgo.mobile.ios.alpha.OpenAction2", "com.duckduckgo.mobile.ios.alpha.Widgets", "com.duckduckgo.mobile.ios.alpha.NetworkExtension", "com.duckduckgo.mobile.ios.alpha.CredentialExtension"]
     force_for_new_devices true
-    template_name "Default Web Browser iOS (Dist)"
 end
 
 for_lane :sync_signing_alpha do
     app_identifier ["com.duckduckgo.mobile.ios.alpha", "com.duckduckgo.mobile.ios.alpha.ShareExtension", "com.duckduckgo.mobile.ios.alpha.OpenAction2", "com.duckduckgo.mobile.ios.alpha.Widgets", "com.duckduckgo.mobile.ios.alpha.NetworkExtension", "com.duckduckgo.mobile.ios.alpha.CredentialExtension"]
-    template_name "Default Web Browser iOS (Dist)"
 end
 
 for_lane :release_alpha do
     app_identifier ["com.duckduckgo.mobile.ios.alpha", "com.duckduckgo.mobile.ios.alpha.ShareExtension", "com.duckduckgo.mobile.ios.alpha.OpenAction2", "com.duckduckgo.mobile.ios.alpha.Widgets", "com.duckduckgo.mobile.ios.alpha.NetworkExtension", "com.duckduckgo.mobile.ios.alpha.CredentialExtension"]
-    template_name "Default Web Browser iOS (Dist)"
 end

--- a/macOS/Gemfile
+++ b/macOS/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'fastlane', '2.227.2'
+gem 'fastlane', '2.228.0'
 gem 'httparty'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')

--- a/macOS/Gemfile.lock
+++ b/macOS/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
       faraday_middleware
       multi_json
     fastimage (2.4.0)
-    fastlane (2.227.2)
+    fastlane (2.228.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -272,7 +272,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane (= 2.227.2)
+  fastlane (= 2.228.0)
   fastlane-plugin-ddg_apple_automation!
   httparty
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1210473120077094?focus=true

### Description
This change updates fastlane to a version containing a fix for iOS AdHoc builds code signing:
https://github.com/fastlane/fastlane/issues/29499
It also reverts a workaround forcing read-only mode in CI, and removes template_name parameter
from the Matchfile, as it’s no longer supported and custom entitlements are enabled via settings
in the App Identifier in Developer Portal (already in place for the iOS app bundle ID).

### Testing Steps
Verify that the [iOS AdHoc Alpha workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/15606980631) and [iOS AdHoc Release workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/15606119933) work fine.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)