### PR TITLE
macOS Visual Refresh: Add unique pixel

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -153,6 +153,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let defaultBrowserAndDockPromptKeyValueStore: DefaultBrowserAndDockPromptStorage
     let defaultBrowserAndDockPromptFeatureFlagger: DefaultBrowserAndDockPromptFeatureFlagger
     let visualStyle: VisualStyleProviding
+    private let visualStyleDecider: VisualStyleDecider
 
     let isAuthV2Enabled: Bool
     var subscriptionAuthV1toV2Bridge: any SubscriptionAuthV1toV2Bridge
@@ -464,7 +465,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         self.windowControllersManager = windowControllersManager
 
-        let visualStyleDecider = DefaultVisualStyleDecider(featureFlagger: featureFlagger, internalUserDecider: internalUserDecider)
+        self.visualStyleDecider = DefaultVisualStyleDecider(featureFlagger: featureFlagger, internalUserDecider: internalUserDecider)
         visualStyle = visualStyleDecider.style
 
 #if DEBUG
@@ -793,6 +794,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 #else
         crashReporter.checkForNewReports()
 #endif
+
+        if visualStyleDecider.shouldFirePixel(style: visualStyle) {
+            PixelKit.fire(VisualStylePixel.visualUpdatesEnabled, frequency: .uniqueByName)
+        }
 
         urlEventHandler.applicationDidFinishLaunching()
 

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
@@ -21,6 +21,7 @@ import BrowserServicesKit
 import FeatureFlags
 import NetworkProtectionUI
 import DesignResourcesKit
+import PixelKit
 
 protocol VisualStyleProviding {
     var toolbarButtonsCornerRadius: CGFloat { get }
@@ -41,6 +42,8 @@ protocol VisualStyleProviding {
 
 protocol VisualStyleDecider {
     var style: any VisualStyleProviding { get }
+
+    func shouldFirePixel(style: VisualStyleProviding) -> Bool
 }
 
 enum AddressBarSizeClass {
@@ -127,5 +130,33 @@ final class DefaultVisualStyleDecider: VisualStyleDecider {
         }
 
         return isVisualRefreshEnabled ? VisualStyle.current : VisualStyle.legacy
+    }
+
+    func shouldFirePixel(style: any VisualStyleProviding) -> Bool {
+        return !internalUserDecider.isInternalUser && style.isNewStyle
+    }
+}
+
+/// This enum keeps pixels related to the Visual Refresh
+/// > Related links:
+/// [Pixel Triage](https://app.asana.com/1/137249556945/project/69071770703008/task/1210516955340232)
+enum VisualStylePixel: PixelKitEventV2 {
+
+    /// This pixel will be fired once time per user. The logic will be fired at app launch if the user has the new UI enabled and it is not an internal user.
+    case visualUpdatesEnabled
+
+    var name: String {
+        switch self {
+        case .visualUpdatesEnabled:
+            return "visual_update_enabled_u"
+        }
+    }
+
+    var parameters: [String: String]? {
+        nil
+    }
+
+    var error: (any Error)? {
+        nil
     }
 }

--- a/macOS/UITests/BrowsingHistoryTests.swift
+++ b/macOS/UITests/BrowsingHistoryTests.swift
@@ -99,7 +99,7 @@ class BrowsingHistoryTests: UITestCase {
     func test_history_showsVisitedSiteAfterClosingAndReopeningWindow() throws {
         let historyPageTitleExpectedToBeFirstInTodayHistory = UITests.randomPageTitle(length: lengthForRandomPageTitle)
         let url = UITests.simpleServedPage(titled: historyPageTitleExpectedToBeFirstInTodayHistory)
-        let firstSiteInHistory = app.menuItems["HistoryMenu.historyMenuItem.Today.0"]
+        let siteInRecentlyVisitedSection = app.menuItems[historyPageTitleExpectedToBeFirstInTodayHistory]
         XCTAssertTrue(
             addressBarTextField.waitForExistence(timeout: UITests.Timeouts.elementExistence),
             "The address bar text field didn't become available in a reasonable timeframe."
@@ -118,11 +118,9 @@ class BrowsingHistoryTests: UITestCase {
         )
         historyMenuBarItem.click() // The visited sites identifiers will not be available until after the History menu has been accessed.
         XCTAssertTrue(
-            firstSiteInHistory.waitForExistence(timeout: UITests.Timeouts.elementExistence),
+            siteInRecentlyVisitedSection.waitForExistence(timeout: UITests.Timeouts.elementExistence),
             "The first site in the recently visited section didn't appear in a reasonable timeframe."
         )
-
-        XCTAssertEqual(historyPageTitleExpectedToBeFirstInTodayHistory, firstSiteInHistory.title)
     }
 
     func test_reopenLastClosedWindowMenuItem_canReopenTabsOfLastClosedWindow() throws {

--- a/macOS/UnitTests/VisualRefresh/VisualStyleManagerTests.swift
+++ b/macOS/UnitTests/VisualRefresh/VisualStyleManagerTests.swift
@@ -317,6 +317,23 @@ class VisualStyleManagerTests: XCTestCase {
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0)
     }
 
+    // MARK: - Should Send Pixel Tests
+
+    func testWhenNotInternalUserAndNewStyleThenPixelShouldBeSent() {
+        mockInternalUserDecider.isInternalUser = false
+        XCTAssertTrue(visualStyleDecider.shouldFirePixel(style: VisualStyle.current))
+    }
+
+    func testWhenInternalUserAndNewStyleThenPixelShouldNotBeSent() {
+        mockInternalUserDecider.isInternalUser = true
+        XCTAssertFalse(visualStyleDecider.shouldFirePixel(style: VisualStyle.current))
+    }
+
+    func testWhenNotInternalUserAndLegacyStyleThenPixelShouldNotBeSent() {
+        mockInternalUserDecider.isInternalUser = false
+        XCTAssertFalse(visualStyleDecider.shouldFirePixel(style: VisualStyle.legacy))
+    }
+
     // MARK: - Mock Classes
 
     class MockInternalUserDecider: InternalUserDecider {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1210516955340230?focus=true
Privacy Triage: https://app.asana.com/1/137249556945/project/69071770703008/task/1210516955340232

### Description
Adds a pixel that will get fired once per user when the user sees the new visual updates. The purpose of this pixel is to gain a better understanding of how many users are seeing the refresh; given that users might have the feature flag on, but they will not see the UI until they do an app restart.

### Testing Steps
1. Start the application
2. Check the logs for the `m_mac_visual_update_enabled_u`
3. Run the app again
4. You should not see the `m_mac_visual_update_enabled_u`

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)