### PR TITLE
Update autofill to 18.0.0

### DIFF
--- a/SharedPackages/BrowserServicesKit/Package.resolved
+++ b/SharedPackages/BrowserServicesKit/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "e02f499ad25f439e8a2a36ac6f9b9d88b8a65d56",
-        "version" : "17.2.0"
+        "revision" : "c504edade04adc0535ecf1b4636cbb17e81b78ad",
+        "version" : "18.0.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
         .library(name: "PrivacyStats", targets: ["PrivacyStats"])
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "17.2.0"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "18.0.0"),
         .package(url: "https://github.com/duckduckgo/GRDB.swift.git", exact: "2.4.2"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit.git", exact: "3.0.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.5.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210535155117862
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.0.0
Apple PR: 

## Description
Updates Autofill to version [18.0.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.0.0).

### Autofill 18.0.0 release notes
## What's Changed
* Improve the check-password-resources automation by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/849
* [Release Process] Readme by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/716
* Fix bluesky by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/851
* [iOS] Add credit card support for iOS by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/834
* fix: brctv didn't fill username bug by @borgateo in https://github.com/duckduckgo/duckduckgo-autofill/pull/853
* chore: change 'expires' to 'Expiry' for credit cards by @borgateo in https://github.com/duckduckgo/duckduckgo-autofill/pull/852


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/17.3.0...18.0.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).