### PR TITLE
macOS Visual Refresh: Send internal users to internal feedback form

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -461,7 +461,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             subscriptionFeatureAvailability: DefaultSubscriptionFeatureAvailability(
                 privacyConfigurationManager: privacyConfigurationManager,
                 purchasePlatform: subscriptionAuthV1toV2Bridge.currentEnvironment.purchasePlatform
-            )
+            ),
+            internalUserDecider: internalUserDecider
         )
         self.windowControllersManager = windowControllersManager
 

--- a/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
+++ b/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
@@ -82,9 +82,11 @@ final class WindowControllersManager: WindowControllersManagerProtocol {
     }
 
     init(pinnedTabsManagerProvider: PinnedTabsManagerProviding,
-         subscriptionFeatureAvailability: SubscriptionFeatureAvailability) {
+         subscriptionFeatureAvailability: SubscriptionFeatureAvailability,
+         internalUserDecider: InternalUserDecider) {
         self.pinnedTabsManagerProvider = pinnedTabsManagerProvider
         self.subscriptionFeatureAvailability = subscriptionFeatureAvailability
+        self.internalUserDecider = internalUserDecider
     }
 
     /**
@@ -94,6 +96,7 @@ final class WindowControllersManager: WindowControllersManagerProtocol {
     @Published private(set) var mainWindowControllers = [MainWindowController]()
     private(set) var pinnedTabsManagerProvider: PinnedTabsManagerProviding
     private let subscriptionFeatureAvailability: SubscriptionFeatureAvailability
+    private let internalUserDecider: InternalUserDecider
 
     weak var lastKeyMainWindowController: MainWindowController? {
         didSet {
@@ -417,9 +420,8 @@ extension WindowControllersManager {
 
     /// Shows the non-privacy pro feedback modal
     func showFeedbackModal(preselectedFormOption: FeedbackViewController.FormOption? = nil) {
-        let internalUserDecider = NSApp.delegateTyped.internalUserDecider
         if internalUserDecider.isInternalUser {
-            Application.appDelegate.windowControllersManager.showTab(with: .url(.internalFeedbackForm, source: .ui))
+            showTab(with: .url(.internalFeedbackForm, source: .ui))
         } else {
             FeedbackPresenter.presentFeedbackForm(preselectedFormOption: preselectedFormOption)
         }

--- a/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
+++ b/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
@@ -417,7 +417,12 @@ extension WindowControllersManager {
 
     /// Shows the non-privacy pro feedback modal
     func showFeedbackModal(preselectedFormOption: FeedbackViewController.FormOption? = nil) {
-        FeedbackPresenter.presentFeedbackForm(preselectedFormOption: preselectedFormOption)
+        let internalUserDecider = NSApp.delegateTyped.internalUserDecider
+        if internalUserDecider.isInternalUser {
+            Application.appDelegate.windowControllersManager.showTab(with: .url(.internalFeedbackForm, source: .ui))
+        } else {
+            FeedbackPresenter.presentFeedbackForm(preselectedFormOption: preselectedFormOption)
+        }
     }
 
     /// Shows the Privacy Pro feedback modal


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210535371053608?focus=true
Tech Design URL:
CC:

### Description
We added a new navigation from RMF to show the feedback dialog. We want to ensure that internal users are still redirected to the internal feedback form.

### Testing Steps
1. Go to `RemoteMessagingClient` line `51` and replace the URL with `https://jsonblob.com/api/1380594945500569600`
2. Make sure the internal state is set to on
3. Go to Debug -> Remote Messaging Framework -> Reset Remote Messages
4. Go to Debug -> Remote Messaging Framework -> Refresh Config (if the blue Help Us Improve! RMF appears, close it and do another Refresh Config)
5. Open a new tab page
6. The ‘DuckDuckGo got a refresh` message should appear.
7. Tap on `Share feedback` it should take you to the internal feedback form
8. Remove internal user state (Debug -> Remove Internal State)
9. Follow steps 3 to 7
10. Now the feedback dialog with `General feedback` option should appear.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing specifc this change is for internal users only

### Quality Considerations
Nothing specifc this change is for internal users only

### Notes to Reviewer
Nothing specific.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)