### PR TITLE
fire correct pixel depending on position in menu

### DIFF
--- a/iOS/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
@@ -134,7 +134,7 @@ extension TabViewController {
                  accessibilityLabel: UserText.actionPrintSite,
                  image: smallIcon ? DesignSystemImages.Glyphs.Size16.print : DesignSystemImages.Glyphs.Size24.print,
                  action: { [weak self] in
-            Pixel.fire(pixel: .browsingMenuListPrint)
+            Pixel.fire(pixel: smallIcon ? .browsingMenuListPrint : .browsingMenuPrint)
             self?.print()
         })
     }
@@ -143,7 +143,7 @@ extension TabViewController {
         .regular(name: UserText.actionOpenAIChat,
                  image: smallIcon ? DesignSystemImages.Glyphs.Size16.aiChat : DesignSystemImages.Glyphs.Size24.aiChat,
                  action: { [weak self] in
-            Pixel.fire(pixel: .browsingMenuAIChat,
+            Pixel.fire(pixel: smallIcon ? .browsingMenuListAIChat : .browsingMenuAIChat,
                        withAdditionalParameters: self?.featureDiscovery.addToParams([:], forFeature: .aiChat) ?? [:])
             self?.openAIChat()
         })


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1210542035830049
Tech Design URL:
CC:

### Description
Fire the correct pixel for Duck.ai and Print depending on menu position.

### Testing Steps
1. New tab page
2. Open menu and choose AI Chat -> should fire `m.browsing.menu.list.aichat`
1. Load a web page
3. Go to the browsing menu and choose AI Chat -> should fire `m.aichat.menu.tab.icon`
4. Go to the browsing menu and choose Print -> should fire `m.browsing.menu.list.print`
5. Disable Duck.ai (Settings > Duck.ai > Enable Duck.ai (toggle off)
6. Go back to browsing menu
7. AI Chat should be gone
8. Print should now be in the menu header, tap it -> should fire `mb.br`

### Impact and Risks
Low: Just firing the correct pixel

#### What could go wrong?
Fire the wrong pixel

### Quality Considerations
n/a

### Notes to Reviewer
n/a

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)