### PR TITLE
[iOS] hide logo if there are remote messages to show

### DIFF
--- a/iOS/DuckDuckGo/NewTabPageView.swift
+++ b/iOS/DuckDuckGo/NewTabPageView.swift
@@ -96,7 +96,9 @@ private extension NewTabPageView {
     @ViewBuilder
     private var emptyStateView: some View {
         ZStack {
-            NewTabPageDaxLogoView()
+            if messagesModel.homeMessageViewModels.isEmpty {
+                NewTabPageDaxLogoView()
+            }
 
             VStack(spacing: Metrics.sectionSpacing) {
                 messagesSectionView


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1209992335398534?focus=true
Tech Design URL:
CC:

### Description
Hides the logo if there are no messages to show.

### Testing Steps
1. Trigger an RMF message (right now you can do this by editing the RemoteMessageClient to point at the prod JSON and turning on the visual updates flag)
2. Ensure logo does not show when message is visible
3. Dismiss message ensure logo shows
4. Open and close tabs, browse to sites, etc
5. Repeat with favorites, should be no logo in either case.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Incorrect hide logo - unlikely

### Quality Considerations
n/a

### Notes to Reviewer
n/a

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)