### PR TITLE
Diego/publish update improvements

### DIFF
--- a/macOS/DuckDuckGo/Updates/UpdateController.swift
+++ b/macOS/DuckDuckGo/Updates/UpdateController.swift
@@ -291,8 +291,8 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
     // Due to frequent releases (weekly public, daily internal), the downloaded update
     // may become obsolete if the user doesn't relaunch the app for an extended period.
     var shouldForceUpdateCheck: Bool {
-        let thresholdInDays = internalUserDecider.isInternalUser ? 1 : 7
-        guard let userDriver, userDriver.daysSinceLastUpdateCheck > thresholdInDays else { return false }
+        let thresholdInHours = internalUserDecider.isInternalUser ? 1 : 24
+        guard let userDriver, userDriver.hoursSinceLastUpdateCheck > thresholdInHours else { return false }
 
         // This workaround is for internal users for now
         guard internalUserDecider.isInternalUser else { return false }

--- a/macOS/DuckDuckGo/Updates/UpdateUserDriver.swift
+++ b/macOS/DuckDuckGo/Updates/UpdateUserDriver.swift
@@ -124,8 +124,8 @@ final class UpdateUserDriver: NSObject, SPUUserDriver {
         pendingUpdateSince = Date()
     }
 
-    var daysSinceLastUpdateCheck: Int {
-        Calendar.current.dateComponents([.day], from: pendingUpdateSince, to: Date()).day ?? Int.max
+    var hoursSinceLastUpdateCheck: Int {
+        Calendar.current.dateComponents([.hour], from: pendingUpdateSince, to: Date()).hour ?? Int.max
     }
 
     // Dismiss the current update for the time being but keep the downloaded file around

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -198,7 +198,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .autoUpdateInDEBUG:
             return .disabled
         case .updatesWontAutomaticallyRestartApp:
-            return .internalOnly()
+            return .enabled
         case .autofillPartialFormSaves:
             return .remoteReleasable(.subfeature(AutofillSubfeature.partialFormSaves))
         case .autocompleteTabs:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1210222474357762?focus=true

### Description

This PR:
- Fixed a bug with the expiration logic that was causing downloads to be interrupted.
- Reduce the time for a build to expire (1 hour for internal users, 24 hours for public users).

### Testing Steps

1. Modify BuildNumber.xcconfig to set a low build number like `CURRENT_PROJECT_VERSION = 400`
2. Launch the app
3. [OPTIONAL] If you want to test automatic updates, make sure you enable feature flag Updates > `autoUpdateInDEBUG`
4. Go to Settings > About and ensure you see an update available.  Feel free to install it if you're on manual updates, but don't click "Restart to Update"
5. Make sure you're an internal user
6. Once the update is downloaded, go to System Settings > Date & Time, and move the time forward 45 minutes.
7. Go back to the app, alt+tab a few times, and make sure you are still shown the same update.
8. Go to System Settings > Date & Time, and move the time forward 61 minutes.
9. Go back to the app, alt+tab a few times, and make sure the update is expired / re-offered / re-downloaded.

Re-test as an external user but using 24 hours as the threshold.

### Impact and Risks

Low

#### What could go wrong?

The time expiration logic could be off and cause trouble, but it's easy to test with the provided steps.

### Quality Considerations

Worst case scenario we can turn this off making a hotfix, but to be honest this has been live internally for a while and we haven't seen any issues.

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)