### PR TITLE
macOS: implement duck ai pro welcome messaging

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "e02f499ad25f439e8a2a36ac6f9b9d88b8a65d56",
-        "version" : "17.2.0"
+        "revision" : "442bf756b54632b4662105fa2faeac5ed2868858",
+        "version" : "17.3.0"
       }
     },
     {

--- a/macOS/DuckDuckGo/Statistics/PrivacyProPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/PrivacyProPixel.swift
@@ -53,6 +53,7 @@ enum PrivacyProPixel: PixelKitEventV2 {
     case privacyProWelcomeAddDevice
     case privacyProWelcomeVPN
     case privacyProWelcomePersonalInformationRemoval
+    case privacyProWelcomeAIChat
     case privacyProWelcomeIdentityRestoration
     case privacyProSubscriptionSettings
     case privacyProVPNSettings
@@ -104,6 +105,8 @@ enum PrivacyProPixel: PixelKitEventV2 {
         case .privacyProWelcomeAddDevice: return "m_mac_\(appDistribution)_privacy-pro_welcome_add-device_click_u"
         case .privacyProWelcomeVPN: return "m_mac_\(appDistribution)_privacy-pro_welcome_vpn_click_u"
         case .privacyProWelcomePersonalInformationRemoval: return "m_mac_\(appDistribution)_privacy-pro_welcome_personal-information-removal_click_u"
+        case .privacyProWelcomeAIChat:
+            return "m_mac_\(appDistribution)_privacy-pro_welcome_ai-chat_click_u"
         case .privacyProWelcomeIdentityRestoration: return "m_mac_\(appDistribution)_privacy-pro_welcome_identity-theft-restoration_click_u"
         case .privacyProSubscriptionSettings: return "m_mac_\(appDistribution)_privacy-pro_settings_screen_impression"
         case .privacyProVPNSettings: return "m_mac_\(appDistribution)_privacy-pro_settings_vpn_click"

--- a/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeature.swift
@@ -385,7 +385,6 @@ final class SubscriptionPagesUseSubscriptionFeature: Subfeature {
             let url = subscriptionManager.url(for: .identityTheftRestoration)
             await uiHandler.showTab(with: .identityTheftRestoration(url))
         case .paidAIChat:
-            // Follow up: Implement paidAIChat selection
             break
         case .unknown:
             break

--- a/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeatureV2.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeatureV2.swift
@@ -395,8 +395,9 @@ final class SubscriptionPagesUseSubscriptionFeatureV2: Subfeature {
             let url = subscriptionManager.url(for: .identityTheftRestoration)
             await uiHandler.showTab(with: .identityTheftRestoration(url))
         case .paidAIChat:
-            // Follow up: Implement paidAIChat selection
-            break
+            PixelKit.fire(PrivacyProPixel.privacyProWelcomeAIChat, frequency: .uniqueByName)
+            let aiChatURL = URL(string: AIChatRemoteSettings.SettingsValue.aiChatURL.defaultValue)!
+            await uiHandler.showTab(with: .aiChat(aiChatURL))
         case .unknown:
             break
         }

--- a/macOS/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureV2Tests.swift
+++ b/macOS/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureV2Tests.swift
@@ -39,6 +39,7 @@ final class SubscriptionPagesUseSubscriptionFeatureV2Tests: XCTestCase {
     private var mockFreemiumDBPExperimentManager: MockFreemiumDBPExperimentManager!
     private var mockPixelHandler: MockFreemiumDBPExperimentPixelHandler!
     private var mockFeatureFlagger: MockFeatureFlagger!
+    private var mockNotificationCenter: NotificationCenter!
 
     private struct Constants {
         static let subscriptionOptions = SubscriptionOptionsV2(platform: SubscriptionPlatformName.macos,
@@ -87,6 +88,7 @@ final class SubscriptionPagesUseSubscriptionFeatureV2Tests: XCTestCase {
         mockFreemiumDBPExperimentManager = MockFreemiumDBPExperimentManager()
         mockPixelHandler = MockFreemiumDBPExperimentPixelHandler()
         mockFeatureFlagger = MockFeatureFlagger()
+        mockNotificationCenter = NotificationCenter()
 
         sut = SubscriptionPagesUseSubscriptionFeatureV2(subscriptionManager: subscriptionManagerV2,
                                                         subscriptionSuccessPixelHandler: subscriptionSuccessPixelHandler,
@@ -95,7 +97,7 @@ final class SubscriptionPagesUseSubscriptionFeatureV2Tests: XCTestCase {
                                                         subscriptionFeatureAvailability: mockSubscriptionFeatureAvailability,
                                                         freemiumDBPUserStateManager: mockFreemiumDBPUserStateManager,
                                                         freemiumDBPPixelExperimentManager: mockFreemiumDBPExperimentManager,
-                                                        notificationCenter: .default,
+                                                        notificationCenter: mockNotificationCenter,
                                                         freemiumDBPExperimentPixelHandler: mockPixelHandler,
                                                         featureFlagger: mockFeatureFlagger)
     }
@@ -199,5 +201,136 @@ final class SubscriptionPagesUseSubscriptionFeatureV2Tests: XCTestCase {
         XCTAssertTrue(featureValue.useUnifiedFeedback)
         XCTAssertTrue(featureValue.useSubscriptionsAuthV2)
         XCTAssertFalse(featureValue.useDuckAiPro)
+    }
+
+    // MARK: - Feature Selection Tests
+
+    @MainActor
+    func testFeatureSelected_NetworkProtection_PostsCorrectNotification() async throws {
+        // Given
+        let params = ["productFeature": "Network Protection"]
+        let expectation = expectation(description: "Network protection notification posted")
+        
+        let observer = mockNotificationCenter.addObserver(forName: .ToggleNetworkProtectionInMainWindow, object: sut, queue: nil) { _ in
+            expectation.fulfill()
+        }
+        defer { mockNotificationCenter.removeObserver(observer) }
+
+        // When
+        let result = try await sut.featureSelected(params: params, original: Constants.mockScriptMessage)
+
+        // Then
+        XCTAssertNil(result)
+        await fulfillment(of: [expectation], timeout: 1.0)
+    }
+
+    @MainActor
+    func testFeatureSelected_DataBrokerProtection_PostsNotificationAndShowsTab() async throws {
+        // Given
+        let params = ["productFeature": "Data Broker Protection"]
+        let dbpNotificationExpectation = expectation(description: "DBP notification posted")
+        let uiHandlerExpectation = expectation(description: "UI handler show tab called")
+        
+        let observer = mockNotificationCenter.addObserver(forName: .openPersonalInformationRemoval, object: sut, queue: nil) { _ in
+            dbpNotificationExpectation.fulfill()
+        }
+        defer { mockNotificationCenter.removeObserver(observer) }
+
+        mockUIHandler.setDidPerformActionCallback { action in
+            if case .didShowTab(.dataBrokerProtection) = action {
+                uiHandlerExpectation.fulfill()
+            }
+        }
+
+        // When
+        let result = try await sut.featureSelected(params: params, original: Constants.mockScriptMessage)
+
+        // Then
+        XCTAssertNil(result)
+        await fulfillment(of: [dbpNotificationExpectation, uiHandlerExpectation], timeout: 1.0)
+    }
+
+    @MainActor
+    func testFeatureSelected_IdentityTheftRestoration_ShowsCorrectTab() async throws {
+        // Given
+        let params = ["productFeature": "Identity Theft Restoration"]
+        let uiHandlerExpectation = expectation(description: "UI handler show tab called")
+
+        mockUIHandler.setDidPerformActionCallback { action in
+            if case .didShowTab(.identityTheftRestoration(let url)) = action {
+                XCTAssertNotNil(url)
+                uiHandlerExpectation.fulfill()
+            }
+        }
+
+        // When
+        let result = try await sut.featureSelected(params: params, original: Constants.mockScriptMessage)
+
+        // Then
+        XCTAssertNil(result)
+        await fulfillment(of: [uiHandlerExpectation], timeout: 1.0)
+    }
+
+    @MainActor
+    func testFeatureSelected_IdentityTheftRestorationGlobal_ShowsCorrectTab() async throws {
+        // Given
+        let params = ["productFeature": "Global Identity Theft Restoration"]
+        let uiHandlerExpectation = expectation(description: "UI handler show tab called")
+
+        mockUIHandler.setDidPerformActionCallback { action in
+            if case .didShowTab(.identityTheftRestoration(let url)) = action {
+                XCTAssertNotNil(url)
+                uiHandlerExpectation.fulfill()
+            }
+        }
+
+        // When
+        let result = try await sut.featureSelected(params: params, original: Constants.mockScriptMessage)
+
+        // Then
+        XCTAssertNil(result)
+        await fulfillment(of: [uiHandlerExpectation], timeout: 1.0)
+    }
+
+    @MainActor
+    func testFeatureSelected_PaidAIChat_ShowsCorrectTab() async throws {
+        // Given
+        let params = ["productFeature": "Duck.ai"]
+        let uiHandlerExpectation = expectation(description: "UI handler show tab called")
+
+        mockUIHandler.setDidPerformActionCallback { action in
+            if case .didShowTab(.aiChat(let url)) = action {
+                XCTAssertNotNil(url)
+                uiHandlerExpectation.fulfill()
+            }
+        }
+
+        // When
+        let result = try await sut.featureSelected(params: params, original: Constants.mockScriptMessage)
+
+        // Then
+        XCTAssertNil(result)
+        await fulfillment(of: [uiHandlerExpectation], timeout: 1.0)
+    }
+
+    @MainActor
+    func testFeatureSelected_UnknownFeature_DoesNothing() async throws {
+        // Given
+        let params = ["productFeature": "unknown"]
+        let uiHandlerExpectation = expectation(description: "UI handler should not be called")
+        uiHandlerExpectation.isInverted = true
+
+        mockUIHandler.setDidPerformActionCallback { action in
+            if case .didShowTab = action {
+                uiHandlerExpectation.fulfill()
+            }
+        }
+
+        // When
+        let result = try await sut.featureSelected(params: params, original: Constants.mockScriptMessage)
+
+        // Then
+        XCTAssertNil(result)
+        await fulfillment(of: [uiHandlerExpectation], timeout: 0.1)
     }
 }

--- a/macOS/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureV2Tests.swift
+++ b/macOS/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureV2Tests.swift
@@ -210,7 +210,7 @@ final class SubscriptionPagesUseSubscriptionFeatureV2Tests: XCTestCase {
         // Given
         let params = ["productFeature": "Network Protection"]
         let expectation = expectation(description: "Network protection notification posted")
-        
+
         let observer = mockNotificationCenter.addObserver(forName: .ToggleNetworkProtectionInMainWindow, object: sut, queue: nil) { _ in
             expectation.fulfill()
         }
@@ -230,7 +230,7 @@ final class SubscriptionPagesUseSubscriptionFeatureV2Tests: XCTestCase {
         let params = ["productFeature": "Data Broker Protection"]
         let dbpNotificationExpectation = expectation(description: "DBP notification posted")
         let uiHandlerExpectation = expectation(description: "UI handler show tab called")
-        
+
         let observer = mockNotificationCenter.addObserver(forName: .openPersonalInformationRemoval, object: sut, queue: nil) { _ in
             dbpNotificationExpectation.fulfill()
         }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1210228242617803

### Description Open Duck ai from welcome page

### Testing Steps
1.  Note that this cannot be fully tested at this stage since the FE is not implemented
2. Go to SubscriptionPagesUseSubscriptionFeatureV2.swift and make feature selection return .paidAIChat (let featureSelection: FeatureSelection = FeatureSelection(productFeature: .paidAIChat))
3. Go through the subscription and/or email flow
4. When you are on the welcome page click on any features and check it opens a duck.ai tab

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!--
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)