### PR TITLE
prevent dismiss and search loop appearing on top of each other on iPad

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "e02f499ad25f439e8a2a36ac6f9b9d88b8a65d56",
-        "version" : "17.2.0"
+        "revision" : "442bf756b54632b4662105fa2faeac5ed2868858",
+        "version" : "17.3.0"
       }
     },
     {

--- a/iOS/DuckDuckGo/LargeOmniBarState.swift
+++ b/iOS/DuckDuckGo/LargeOmniBarState.swift
@@ -198,7 +198,7 @@ struct LargeOmniBarState {
         var onEnterPadState: OmniBarState { return self }
         var onEnterPhoneState: OmniBarState { return SmallOmniBarState.BrowsingTextEditingState(dependencies: dependencies, isLoading: isLoading) }
         var onReloadState: OmniBarState { return BrowsingTextEditingState(dependencies: dependencies, isLoading: isLoading) }
-        var showSearchLoupe: Bool { !dependencies.voiceSearchHelper.isVoiceSearchEnabled }
+        var showSearchLoupe: Bool { !dependencies.themingProperties.isExperimentalThemingEnabled && !dependencies.voiceSearchHelper.isVoiceSearchEnabled }
         var showVoiceSearch: Bool { dependencies.voiceSearchHelper.isVoiceSearchEnabled }
 
         let dependencies: OmnibarDependencyProvider

--- a/iOS/DuckDuckGoTests/LargeOmniBarStateTests.swift
+++ b/iOS/DuckDuckGoTests/LargeOmniBarStateTests.swift
@@ -45,6 +45,21 @@ class LargeOmniBarStateTests: XCTestCase {
         super.tearDown()
     }
 
+    func testWhenLargeEditingAndVisualUpdatesThenDontShowSearchLoupe() {
+        mockFeatureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.visualUpdates])
+
+        let testee = LargeOmniBarState.BrowsingTextEditingState(dependencies: MockOmnibarDependency(voiceSearchHelper: enabledVoiceSearchHelper, featureFlagger: mockFeatureFlagger), isLoading: false)
+        XCTAssertFalse(testee.showSearchLoupe)
+    }
+
+    func testWhenLargeEditingAndNotVisualUpdatesThenShowSearchLoupe() {
+        let testee = LargeOmniBarState.BrowsingTextEditingState(dependencies: MockOmnibarDependency(voiceSearchHelper: enabledVoiceSearchHelper, featureFlagger: mockFeatureFlagger), isLoading: false)
+        XCTAssertFalse(testee.showSearchLoupe)
+
+        let testee2 = LargeOmniBarState.BrowsingTextEditingState(dependencies: MockOmnibarDependency(voiceSearchHelper: disabledVoiceSearchHelper, featureFlagger: mockFeatureFlagger), isLoading: false)
+        XCTAssertTrue(testee2.showSearchLoupe)
+    }
+
     func testWhenInHomeEmptyEditingStateWithoutVoiceSearchThenCorrectButtonsAreShown() {
         let testee = LargeOmniBarState.HomeEmptyEditingState(dependencies: MockOmnibarDependency(voiceSearchHelper: disabledVoiceSearchHelper, featureFlagger: mockFeatureFlagger), isLoading: false)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1210556646320677?focus=true
Tech Design URL:
CC:

### Description
Prevents search loupe showing on iPad when in visual updates view.

### Testing Steps
1. Launch on iPad
2. Enable visual updates (internal user + visualUpdates feature flag + restart app)
3. Browse to a web page and focus the address bar
4. Dismiss button should appear to allow keyboard to be hidden

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Some new weird omni bar state.

### Quality Considerations
n/a

### Notes to Reviewer
n/a

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)