### PR TITLE
[iOS] Onboarding - Set Default Browser Picture In Picture Video Experiment Setup  

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -293,8 +293,9 @@ public enum SetAsDefaultAndAddToDockSubfeature: String, PrivacySubfeature {
 public enum OnboardingSubfeature: String, PrivacySubfeature {
     public var parent: PrivacyFeature { .extendedOnboarding }
 
-    case setAsDefaultBrowserExperiment
     case showSettingsCompleteSetupSection
+    /// https://app.asana.com/1/137249556945/project/1108686900785972/task/1210454186090900?focus=true
+    case setAsDefaultBrowserPiPVideoExperiment
 }
 
 public enum ExperimentalThemingSubfeature: String, PrivacySubfeature {

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -282,7 +282,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .privacyProAuthV2:
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.privacyProAuthV2))
         case .onboardingSetAsDefaultBrowserPiPVideo:
-            return .remoteDevelopment(.subfeature(OnboardingSubfeature.setAsDefaultBrowserPiPVideoExperiment))
+            return .remoteReleasable(.subfeature(OnboardingSubfeature.setAsDefaultBrowserPiPVideoExperiment))
         case .failsafeExampleCrossPlatformFeature:
             return .remoteReleasable(.feature(.intentionallyLocalOnlyFeatureForTests))
         case .failsafeExamplePlatformSpecificSubfeature:

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -93,8 +93,8 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/0/72649045549333/1207991044706236/f
     case privacyProAuthV2
 
-    /// https://app.asana.com/0/1206329551987282/1209130794450271
-    case onboardingSetAsDefaultBrowser
+    /// https://app.asana.com/1/137249556945/project/1108686900785972/task/1209304767941984?focus=true
+    case onboardingSetAsDefaultBrowserPiPVideo
 
     // Demonstrative cases for default value. Remove once a real-world feature/subfeature is added
     case failsafeExampleCrossPlatformFeature
@@ -151,8 +151,8 @@ extension FeatureFlag: FeatureFlagDescribing {
         switch self {
         case .privacyProFreeTrialJan25:
             PrivacyProFreeTrialExperimentCohort.self
-        case .onboardingSetAsDefaultBrowser:
-            OnboardingSetAsDefaultBrowserCohort.self
+        case .onboardingSetAsDefaultBrowserPiPVideo:
+            OnboardingSetAsDefaultBrowserPiPVideoCohort.self
         default:
             nil
         }
@@ -188,8 +188,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             } else {
                 return false
             }
-        case .onboardingSetAsDefaultBrowser:
-            if #available(iOS 18.3, *) {
+        case .onboardingSetAsDefaultBrowserPiPVideo:
+            if #available(iOS 18.2, *) {
                 return true
             } else {
                 return false
@@ -281,8 +281,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(ExperimentalThemingSubfeature.visualUpdates))
         case .privacyProAuthV2:
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.privacyProAuthV2))
-        case .onboardingSetAsDefaultBrowser:
-            return .remoteReleasable(.subfeature(OnboardingSubfeature.setAsDefaultBrowserExperiment))
+        case .onboardingSetAsDefaultBrowserPiPVideo:
+            return .remoteDevelopment(.subfeature(OnboardingSubfeature.setAsDefaultBrowserPiPVideoExperiment))
         case .failsafeExampleCrossPlatformFeature:
             return .remoteReleasable(.feature(.intentionallyLocalOnlyFeatureForTests))
         case .failsafeExamplePlatformSpecificSubfeature:
@@ -330,7 +330,7 @@ public enum PrivacyProFreeTrialExperimentCohort: String, FeatureFlagCohortDescri
     case treatment
 }
 
-public enum OnboardingSetAsDefaultBrowserCohort: String, FeatureFlagCohortDescribing {
+public enum OnboardingSetAsDefaultBrowserPiPVideoCohort: String, FeatureFlagCohortDescribing {
     /// Control cohort with no changes applied.
     case control
     /// Treatment cohort where the experiment modifications are applied.

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1175,7 +1175,7 @@
 		9F0949A72D389F1E0079291B /* MaliciousSiteProtectionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0949A62D389F180079291B /* MaliciousSiteProtectionAPI.swift */; };
 		9F16230B2CA0F0190093C4FC /* DebouncerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F16230A2CA0F0190093C4FC /* DebouncerTests.swift */; };
 		9F1798572CD2443F0073018B /* AddToDockPromoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F1798562CD2443F0073018B /* AddToDockPromoViewModelTests.swift */; };
-		9F1C69212D7FEA5C0072F97D /* OnboardingManager+SetDefaultBrowserExperimentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F1C69202D7FEA5C0072F97D /* OnboardingManager+SetDefaultBrowserExperimentTests.swift */; };
+		9F1C69212D7FEA5C0072F97D /* OnboardingManager+SetDefaultBrowserPipVideoExperimentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F1C69202D7FEA5C0072F97D /* OnboardingManager+SetDefaultBrowserPipVideoExperimentTests.swift */; };
 		9F23B8012C2BC94400950875 /* OnboardingBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23B8002C2BC94400950875 /* OnboardingBackground.swift */; };
 		9F23B8032C2BCD0000950875 /* DaxDialogStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23B8022C2BCD0000950875 /* DaxDialogStyles.swift */; };
 		9F23B8062C2BE22700950875 /* OnboardingIntroViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23B8052C2BE22700950875 /* OnboardingIntroViewModelTests.swift */; };
@@ -3287,7 +3287,7 @@
 		9F0949A62D389F180079291B /* MaliciousSiteProtectionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionAPI.swift; sourceTree = "<group>"; };
 		9F16230A2CA0F0190093C4FC /* DebouncerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebouncerTests.swift; sourceTree = "<group>"; };
 		9F1798562CD2443F0073018B /* AddToDockPromoViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddToDockPromoViewModelTests.swift; sourceTree = "<group>"; };
-		9F1C69202D7FEA5C0072F97D /* OnboardingManager+SetDefaultBrowserExperimentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingManager+SetDefaultBrowserExperimentTests.swift"; sourceTree = "<group>"; };
+		9F1C69202D7FEA5C0072F97D /* OnboardingManager+SetDefaultBrowserPipVideoExperimentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingManager+SetDefaultBrowserPipVideoExperimentTests.swift"; sourceTree = "<group>"; };
 		9F23B8002C2BC94400950875 /* OnboardingBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingBackground.swift; sourceTree = "<group>"; };
 		9F23B8022C2BCD0000950875 /* DaxDialogStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaxDialogStyles.swift; sourceTree = "<group>"; };
 		9F23B8052C2BE22700950875 /* OnboardingIntroViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingIntroViewModelTests.swift; sourceTree = "<group>"; };
@@ -6339,7 +6339,7 @@
 				9FE05CEF2C3642F900D9046B /* OnboardingPixelReporterTests.swift */,
 				9F5E5AB12C3E606D00165F54 /* ContextualOnboardingPresenterTests.swift */,
 				9F4CC5162C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift */,
-				9F1C69202D7FEA5C0072F97D /* OnboardingManager+SetDefaultBrowserExperimentTests.swift */,
+				9F1C69202D7FEA5C0072F97D /* OnboardingManager+SetDefaultBrowserPipVideoExperimentTests.swift */,
 				9F7CFF7C2C89B69A0012833E /* AppIconPickerViewModelTests.swift */,
 				9FDEC7B32C8FD62F00C7A692 /* OnboardingAddressBarPositionPickerViewModelTests.swift */,
 				9FDEC7B92C9006E000C7A692 /* BrowserComparisonModelTests.swift */,
@@ -10306,7 +10306,7 @@
 				5694372B2BE3F2D900C0881B /* SyncErrorHandlerTests.swift in Sources */,
 				4B27FBB52C927435007E21A7 /* PersistentPixelTests.swift in Sources */,
 				987130C7294AAB9F00AB05E0 /* MenuBookmarksViewModelTests.swift in Sources */,
-				9F1C69212D7FEA5C0072F97D /* OnboardingManager+SetDefaultBrowserExperimentTests.swift in Sources */,
+				9F1C69212D7FEA5C0072F97D /* OnboardingManager+SetDefaultBrowserPipVideoExperimentTests.swift in Sources */,
 				9FFDA83D2DFA8F6F007923F7 /* MockAudioSessionManager.swift in Sources */,
 				858650D32469BFAD00C36F8A /* DaxDialogTests.swift in Sources */,
 				31C138B227A4097800FFD4B2 /* DownloadTestsHelper.swift in Sources */,

--- a/iOS/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
@@ -158,7 +158,7 @@ extension OnboardingManager: OnboardingStepsProvider {
 
 protocol OnboardingSetAsDefaultExperimentManaging: AnyObject {
     var isEnrolledInSetAsDefaultBrowserExperiment: Bool { get }
-    func resolveSetAsDefaultBrowserExperimentCohort() -> OnboardingSetAsDefaultBrowserCohort?
+    func resolveSetAsDefaultBrowserExperimentCohort() -> OnboardingSetAsDefaultBrowserPiPVideoCohort?
 }
 
 extension OnboardingManager: OnboardingSetAsDefaultExperimentManaging {
@@ -167,11 +167,11 @@ extension OnboardingManager: OnboardingSetAsDefaultExperimentManaging {
         resolveSetAsDefaultBrowserExperimentCohort() != nil
     }
 
-    func resolveSetAsDefaultBrowserExperimentCohort() -> OnboardingSetAsDefaultBrowserCohort? {
+    func resolveSetAsDefaultBrowserExperimentCohort() -> OnboardingSetAsDefaultBrowserPiPVideoCohort? {
         // The experiment runs only for users on iOS 18.3+ and for non returning users
         guard #available(iOS 18.3, *), isNewUser else { return nil }
 
-        return featureFlagger.resolveCohort(for: FeatureFlag.onboardingSetAsDefaultBrowser) as? OnboardingSetAsDefaultBrowserCohort
+        return featureFlagger.resolveCohort(for: FeatureFlag.onboardingSetAsDefaultBrowserPiPVideo) as? OnboardingSetAsDefaultBrowserPiPVideoCohort
     }
 
 }

--- a/iOS/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
@@ -164,7 +164,7 @@ protocol OnboardingSetAsDefaultBrowserPiPVideoExperimentManaging: AnyObject {
 
 extension OnboardingSetAsDefaultBrowserPiPVideoExperimentManaging {
 
-    func resolveSetAsDefaultBrowserPipVideoExperimentCohort()  -> OnboardingSetAsDefaultBrowserPiPVideoCohort? {
+    func resolveSetAsDefaultBrowserPipVideoExperimentCohort() -> OnboardingSetAsDefaultBrowserPiPVideoCohort? {
         resolveSetAsDefaultBrowserPipVideoExperimentCohort(isPictureInPictureSupported: AVPictureInPictureController.isPictureInPictureSupported())
     }
 

--- a/iOS/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
@@ -17,6 +17,7 @@
 //  limitations under the License.
 //
 
+import AVKit
 import BrowserServicesKit
 import Core
 
@@ -37,7 +38,7 @@ enum OnboardingUserType: String, Equatable, CaseIterable, CustomStringConvertibl
     }
 }
 
-typealias OnboardingIntroExperimentManaging = OnboardingSetAsDefaultExperimentManaging
+typealias OnboardingIntroExperimentManaging = OnboardingSetAsDefaultBrowserPiPVideoExperimentManaging
 typealias OnboardingManaging = OnboardingSettingsURLProvider & OnboardingStepsProvider & OnboardingIntroExperimentManaging
 
 final class OnboardingManager {
@@ -154,52 +155,38 @@ extension OnboardingManager: OnboardingStepsProvider {
 
 }
 
-// MARK: - Set Default Browser Experiment
+// MARK: - Set Default Browser  PiP Experiment
 
-protocol OnboardingSetAsDefaultExperimentManaging: AnyObject {
-    var isEnrolledInSetAsDefaultBrowserExperiment: Bool { get }
-    func resolveSetAsDefaultBrowserExperimentCohort() -> OnboardingSetAsDefaultBrowserPiPVideoCohort?
+protocol OnboardingSetAsDefaultBrowserPiPVideoExperimentManaging: AnyObject {
+    var isEnrolledInSetAsDefaultBrowserPipVideoExperiment: Bool { get }
+    func resolveSetAsDefaultBrowserPipVideoExperimentCohort(isPictureInPictureSupported: Bool) -> OnboardingSetAsDefaultBrowserPiPVideoCohort?
 }
 
-extension OnboardingManager: OnboardingSetAsDefaultExperimentManaging {
+extension OnboardingSetAsDefaultBrowserPiPVideoExperimentManaging {
 
-    var isEnrolledInSetAsDefaultBrowserExperiment: Bool {
-        resolveSetAsDefaultBrowserExperimentCohort() != nil
+    func resolveSetAsDefaultBrowserPipVideoExperimentCohort()  -> OnboardingSetAsDefaultBrowserPiPVideoCohort? {
+        resolveSetAsDefaultBrowserPipVideoExperimentCohort(isPictureInPictureSupported: AVPictureInPictureController.isPictureInPictureSupported())
     }
 
-    func resolveSetAsDefaultBrowserExperimentCohort() -> OnboardingSetAsDefaultBrowserPiPVideoCohort? {
-        // The experiment runs only for users on iOS 18.3+ and for non returning users
-        guard #available(iOS 18.3, *), isNewUser else { return nil }
+}
+
+extension OnboardingManager: OnboardingSetAsDefaultBrowserPiPVideoExperimentManaging {
+
+    var isEnrolledInSetAsDefaultBrowserPipVideoExperiment: Bool {
+        resolveSetAsDefaultBrowserPipVideoExperimentCohort() != nil
+    }
+
+    func resolveSetAsDefaultBrowserPipVideoExperimentCohort(isPictureInPictureSupported: Bool) -> OnboardingSetAsDefaultBrowserPiPVideoCohort? {
+        // The experiment runs only for users on iOS 18.2+ and for non returning users
+        guard
+            isPictureInPictureSupported,
+            #available(iOS 18.2, *),
+            isNewUser
+        else {
+            return nil
+        }
 
         return featureFlagger.resolveCohort(for: FeatureFlag.onboardingSetAsDefaultBrowserPiPVideo) as? OnboardingSetAsDefaultBrowserPiPVideoCohort
-    }
-
-}
-
-// MARK: - Settings URL Provider + Set As Default Browser Experiment
-
-extension OnboardingSettingsURLProvider where Self: OnboardingSetAsDefaultExperimentManaging {
-
-    // If running iOS 18.3 check if the user should be enrolled in the SetAsDefaultBrowser experiment.
-    // If the user is enrolled in the control group or SetAsDefaultBrowser is not running, deep link to DDG custom settings in the Settings app.
-    // If the user is enrolled in the treatment group, deep link to the Settings app for default app selection.
-    var settingsURLPath: String {
-        if #available(iOS 18.3, *) {
-            switch resolveSetAsDefaultBrowserExperimentCohort() {
-            case .none:
-                Logger.onboarding.debug("SetAsDefaultBrowser experiment not running")
-                return UIApplication.openSettingsURLString
-            case .control:
-                Logger.onboarding.debug("User enrolled in the control group of the SetAsDefaultBrowser experiment")
-                return UIApplication.openSettingsURLString
-            case .treatment:
-                Logger.onboarding.debug("User enrolled in the treatment group of the SetAsDefaultBrowser experiment")
-                return UIApplication.openDefaultApplicationsSettingsURLString
-            }
-        } else {
-            Logger.onboarding.debug("User running an iOS version lower than iOS 18.3. Returning DDG’s custom settings url in the Settings app.")
-            return UIApplication.openSettingsURLString
-        }
     }
 
 }

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
@@ -154,7 +154,9 @@ final class OnboardingIntroViewModel: ObservableObject {
         }
         pixelReporter.measureChooseBrowserCTAAction()
 
-        // makeNextViewState()
+        guard !shouldShowSetDefaultBrowserTutorialVideo() else { return }
+
+        makeNextViewState()
     }
 
     func completedSetDefaultBrowserAction() {
@@ -229,7 +231,7 @@ private extension OnboardingIntroViewModel {
         case .introDialog(let isReturningUser):
             OnboardingView.ViewState.onboarding(.init(type: .startOnboardingDialog(canSkipTutorial: isReturningUser), step: .hidden))
         case .browserComparison:
-            OnboardingView.ViewState.onboarding(.init(type: .browsersComparisonDialog, step: stepInfo()))
+            OnboardingView.ViewState.onboarding(.init(type: .browsersComparisonDialog(shouldShowSetDefaultBrowserTutorialVideo: shouldShowSetDefaultBrowserTutorialVideo()), step: stepInfo()))
         case .addToDockPromo:
             OnboardingView.ViewState.onboarding(.init(type: .addToDockPromoDialog, step: stepInfo()))
         case .appIconSelection:
@@ -264,7 +266,7 @@ private extension OnboardingIntroViewModel {
     }
 
     func measureDDGDefaultBrowserIfNeeded() {
-        guard onboardingManager.isEnrolledInSetAsDefaultBrowserExperiment else { return }
+        guard onboardingManager.isEnrolledInSetAsDefaultBrowserPipVideoExperiment else { return }
 
         defaultBrowserManager.defaultBrowserInfo()
             .onNewValue { newInfo in
@@ -290,6 +292,10 @@ private extension OnboardingIntroViewModel {
         case .chooseAddressBarPositionDialog:
             pixelReporter.measureAddressBarPositionSelectionImpression()
         }
+    }
+
+    func shouldShowSetDefaultBrowserTutorialVideo() -> Bool {
+        onboardingManager.resolveSetAsDefaultBrowserPipVideoExperimentCohort() == .treatment ? true : false
     }
 
 }

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingIntroViewModel.swift
@@ -146,14 +146,21 @@ final class OnboardingIntroViewModel: ObservableObject {
         onCompletingOnboardingIntro?()
     }
 
+    func enrollUserInPiPVideoExperimentAndCheckIfShouldShowVideoTutorial() -> Bool {
+        pixelReporter.measureChooseBrowserCTAAction()
+
+        return shouldShowSetDefaultBrowserTutorialVideo()
+    }
+
     func setDefaultBrowserAction() {
         let urlPath = onboardingManager.settingsURLPath
 
         if let url = URL(string: urlPath) {
             urlOpener.open(url)
         }
-        pixelReporter.measureChooseBrowserCTAAction()
 
+        // If the user is in the treatment group do not transition to the next step as it will interrupt PiP.
+        // Manually stopping PiP on willEnterForeground event doesn't seem to work fine. Stopping it on didBecomeActive shows a UI glitch as the player tries to go back in place first.
         guard !shouldShowSetDefaultBrowserTutorialVideo() else { return }
 
         makeNextViewState()
@@ -231,7 +238,7 @@ private extension OnboardingIntroViewModel {
         case .introDialog(let isReturningUser):
             OnboardingView.ViewState.onboarding(.init(type: .startOnboardingDialog(canSkipTutorial: isReturningUser), step: .hidden))
         case .browserComparison:
-            OnboardingView.ViewState.onboarding(.init(type: .browsersComparisonDialog(shouldShowSetDefaultBrowserTutorialVideo: shouldShowSetDefaultBrowserTutorialVideo()), step: stepInfo()))
+            OnboardingView.ViewState.onboarding(.init(type: .browsersComparisonDialog, step: stepInfo()))
         case .addToDockPromo:
             OnboardingView.ViewState.onboarding(.init(type: .addToDockPromoDialog, step: stepInfo()))
         case .appIconSelection:

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
@@ -161,7 +161,9 @@ struct OnboardingView: View {
             showContent: $model.browserComparisonState.showComparisonButton,
             isSkipped: $model.isSkipped,
             setAsDefaultBrowserAction: {
-                if model.state.shouldShowSetDefaultBrowserTutorialVideo {
+                if model.enrollUserInPiPVideoExperimentAndCheckIfShouldShowVideoTutorial() {
+                    // Play video first and then deeplink to the settings.
+                    // Once the video starts playing sending the app to the background will start PiP automatically.
                     isPlayingSetAsDefaultVideo = true
                 } else {
                     model.setDefaultBrowserAction()
@@ -224,7 +226,8 @@ struct OnboardingView: View {
     private var setDefaultBrowserTutorialView: some View {
         // Position the 'Set Default Browser' video tutorial behind the onboarding background.
         // When we want to show the PiP video to the user we will start playing and then deeplink into the settings.
-        if model.state.shouldShowSetDefaultBrowserTutorialVideo {
+        // We explicitly not call the associated function associated with `.browsersComparisonDialog` because it will enrol the user in the experiment. We want to enrol the user in the experiment when they tap the CTA button.
+        if case .browsersComparisonDialog = model.state.intro?.type {
             setAsDefaultTutorialVideoView
                 .frame(width: 300, height: 100) // Fixed size prevents stretching in ZStack and smooths PiP transition. PiP size is auto-determined by OS.
         } else {
@@ -257,6 +260,7 @@ struct OnboardingView: View {
             }
         }
     }
+
 }
 
 // MARK: - View State
@@ -273,15 +277,6 @@ extension OnboardingView {
                 return nil
             case let .onboarding(intro):
                 return intro
-            }
-        }
-
-        var shouldShowSetDefaultBrowserTutorialVideo: Bool {
-            switch intro?.type {
-            case let .browsersComparisonDialog(shouldShowSetDefaultBrowserTutorialVideo):
-                return shouldShowSetDefaultBrowserTutorialVideo
-            default:
-                return false
             }
         }
     }
@@ -301,7 +296,7 @@ extension OnboardingView.ViewState.Intro {
 
     enum IntroType: Equatable {
         case startOnboardingDialog(canSkipTutorial: Bool)
-        case browsersComparisonDialog(shouldShowSetDefaultBrowserTutorialVideo: Bool)
+        case browsersComparisonDialog
         case addToDockPromoDialog
         case chooseAppIconDialog
         case chooseAddressBarPositionDialog

--- a/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/OnboardingIntro/OnboardingView.swift
@@ -42,10 +42,7 @@ struct OnboardingView: View {
         ZStack(alignment: .topTrailing) {
             // Position the 'Set Default Browser' video tutorial behind the onboarding background.
             // When we want to show the PiP video to the user we will start playing and then deeplink into the settings.
-            if model.state.intro?.type == .browsersComparisonDialog {
-                setAsDefaultTutorialVideoView
-                    .frame(width: 300, height: 100) // Fixed size prevents stretching in ZStack and smooths PiP transition. PiP size is auto-determined by OS.
-            }
+            setDefaultBrowserTutorialView
 
             OnboardingBackground()
 
@@ -164,8 +161,11 @@ struct OnboardingView: View {
             showContent: $model.browserComparisonState.showComparisonButton,
             isSkipped: $model.isSkipped,
             setAsDefaultBrowserAction: {
-                // Check if should play video or not depending on experiment
-                isPlayingSetAsDefaultVideo = true
+                if model.state.shouldShowSetDefaultBrowserTutorialVideo {
+                    isPlayingSetAsDefaultVideo = true
+                } else {
+                    model.setDefaultBrowserAction()
+                }
             },
             cancelAction: {
                 model.cancelSetDefaultBrowserAction()
@@ -213,10 +213,22 @@ struct OnboardingView: View {
             model.setDefaultBrowserAction()
         })
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
-            Logger.videoPlayer.debug("[Video Player] - Will Enter Foreground - Is Playing Video:  \(isPlayingSetAsDefaultVideo)")
+            Logger.onboarding.debug("[Onboarding] - Will Enter Foreground. Is Playing Set Default Tutorial Video:  \(isPlayingSetAsDefaultVideo)")
             if isPlayingSetAsDefaultVideo {
                 model.completedSetDefaultBrowserAction()
             }
+        }
+    }
+
+    @ViewBuilder
+    private var setDefaultBrowserTutorialView: some View {
+        // Position the 'Set Default Browser' video tutorial behind the onboarding background.
+        // When we want to show the PiP video to the user we will start playing and then deeplink into the settings.
+        if model.state.shouldShowSetDefaultBrowserTutorialVideo {
+            setAsDefaultTutorialVideoView
+                .frame(width: 300, height: 100) // Fixed size prevents stretching in ZStack and smooths PiP transition. PiP size is auto-determined by OS.
+        } else {
+            EmptyView()
         }
     }
 
@@ -263,6 +275,15 @@ extension OnboardingView {
                 return intro
             }
         }
+
+        var shouldShowSetDefaultBrowserTutorialVideo: Bool {
+            switch intro?.type {
+            case let .browsersComparisonDialog(shouldShowSetDefaultBrowserTutorialVideo):
+                return shouldShowSetDefaultBrowserTutorialVideo
+            default:
+                return false
+            }
+        }
     }
     
 }
@@ -280,7 +301,7 @@ extension OnboardingView.ViewState.Intro {
 
     enum IntroType: Equatable {
         case startOnboardingDialog(canSkipTutorial: Bool)
-        case browsersComparisonDialog
+        case browsersComparisonDialog(shouldShowSetDefaultBrowserTutorialVideo: Bool)
         case addToDockPromoDialog
         case chooseAppIconDialog
         case chooseAddressBarPositionDialog

--- a/iOS/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/Pixels/OnboardingPixelReporter.swift
@@ -343,9 +343,9 @@ extension OnboardingPixelReporter: OnboardingAddToDockReporting {
 
 extension OnboardingPixelReporter: OnboardingSetAsDefaultBrowserExperimentReporting {
 
-    enum SetAsDefaultExperimentMetrics {
+    enum SetAsDefaultBrowserPipVideoExperimentMetrics {
         /// Unique identifier for the subfeature being tested.
-        static let subfeatureIdentifier = OnboardingSubfeature.setAsDefaultBrowserExperiment.rawValue
+        static let subfeatureIdentifier = OnboardingSubfeature.setAsDefaultBrowserPiPVideoExperiment.rawValue
 
         /// Metric identifiers for various user actions during the experiment.
         static let metricDefaultBrowserSet = "setAsDefaultBrowser"
@@ -357,18 +357,18 @@ extension OnboardingPixelReporter: OnboardingSetAsDefaultBrowserExperimentReport
 
     func measureDidSetDDGAsDefaultBrowser() {
         experimentPixel.fireExperimentPixel(
-            for: SetAsDefaultExperimentMetrics.subfeatureIdentifier,
-            metric: SetAsDefaultExperimentMetrics.metricDefaultBrowserSet,
-            conversionWindowDays: SetAsDefaultExperimentMetrics.conversionWindowDays,
+            for: SetAsDefaultBrowserPipVideoExperimentMetrics.subfeatureIdentifier,
+            metric: SetAsDefaultBrowserPipVideoExperimentMetrics.metricDefaultBrowserSet,
+            conversionWindowDays: SetAsDefaultBrowserPipVideoExperimentMetrics.conversionWindowDays,
             value: "1"
         )
     }
 
     func measureDidNotSetDDGAsDefaultBrowser() {
         experimentPixel.fireExperimentPixel(
-            for: SetAsDefaultExperimentMetrics.subfeatureIdentifier,
-            metric: SetAsDefaultExperimentMetrics.metricDefaultBrowserNotSet,
-            conversionWindowDays: SetAsDefaultExperimentMetrics.conversionWindowDays,
+            for: SetAsDefaultBrowserPipVideoExperimentMetrics.subfeatureIdentifier,
+            metric: SetAsDefaultBrowserPipVideoExperimentMetrics.metricDefaultBrowserNotSet,
+            conversionWindowDays: SetAsDefaultBrowserPipVideoExperimentMetrics.conversionWindowDays,
             value: "1"
         )
     }

--- a/iOS/DuckDuckGo/OnboardingExperiment/VideoPlayer/VideoPlayerCoordinator.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/VideoPlayer/VideoPlayerCoordinator.swift
@@ -46,8 +46,6 @@ final class VideoPlayerCoordinator: ObservableObject {
 
     @Published private var pictureInPictureController: PictureInPictureControlling
     private var pictureInPictureActiveCancellable: AnyCancellable?
-    private var lifecycleCancellable: AnyCancellable?
-
 
     let url: URL
     private let audioSessionManager: AudioSessionManaging
@@ -124,7 +122,18 @@ private extension VideoPlayerCoordinator {
             .handleEvents(receiveOutput: { event in
                 Logger.videoPlayer.debug("[Video Player] - Received Picture In Picture Event: \(event.debugDescription)")
             })
-            .compactMap { $0 == .didStartPictureInPicture }
+            .compactMap { event in
+                switch event {
+                case .willStartPictureInPicture:
+                    nil
+                case .didStartPictureInPicture:
+                    true
+                case .willStopPictureInPicture:
+                    nil
+                case.didStopPictureInPicture, .failedToStartPictureInPicture:
+                    false
+                }
+            }
             .assign(to: \.isPictureInPictureActive, onWeaklyHeld: self)
     }
 

--- a/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -597,7 +597,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     func testWhenAppIconPickerContinueActionIsCalledAndSetAsDefaultBrowserEnabledThenCheckIfBrowserIsDefault() {
         // GIVEN
-        onboardingManagerMock.isEnrolledInSetAsDefaultBrowserExperiment = true
+        onboardingManagerMock.isEnrolledInSetAsDefaultBrowserPipVideoExperiment = true
         let sut = makeSUT()
         XCTAssertFalse(defaultBrowserManagerMock.didCallDefaultBrowserInfo)
 
@@ -610,7 +610,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     func testWhenAppIconPickerContinueActionIsCalledAndSetAsDefaultBrowserDisabledThenDoNotCheckIfBrowserIsDefault() {
         // GIVEN
-        onboardingManagerMock.isEnrolledInSetAsDefaultBrowserExperiment = false
+        onboardingManagerMock.isEnrolledInSetAsDefaultBrowserPipVideoExperiment = false
         let sut = makeSUT()
         XCTAssertFalse(defaultBrowserManagerMock.didCallDefaultBrowserInfo)
 
@@ -623,7 +623,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     func testWhenDefaultBrowserInfoIsSuccessfulResult_AndIsDefaultBrowserIsTrue_ThenFireDidSetDefaultBrowserPixel() {
         // GIVEN
-        onboardingManagerMock.isEnrolledInSetAsDefaultBrowserExperiment = true
+        onboardingManagerMock.isEnrolledInSetAsDefaultBrowserPipVideoExperiment = true
         defaultBrowserManagerMock.resultToReturn = .successful(isDefaultBrowser: true)
         let sut = makeSUT()
         XCTAssertFalse(pixelReporterMock.didCallMeasureDidSetDDGAsDefaultBrowser)
@@ -639,7 +639,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     func testWhenDefaultBrowserInfoIsSuccessfulResult_AndIsDefaultBrowserIsFalse_ThenFireDidNotSetDefaultBrowserPixel() {
         // GIVEN
-        onboardingManagerMock.isEnrolledInSetAsDefaultBrowserExperiment = true
+        onboardingManagerMock.isEnrolledInSetAsDefaultBrowserPipVideoExperiment = true
         defaultBrowserManagerMock.resultToReturn = .successful(isDefaultBrowser: false)
         let sut = makeSUT()
         XCTAssertFalse(pixelReporterMock.didCallMeasureDidSetDDGAsDefaultBrowser)
@@ -655,7 +655,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     func testWhenDefaultBrowserInfoIsFailureResult_AndFailureIsRateLimited_ThenDoNotFireSetDefaultBrowserPixels() {
         // GIVEN
-        onboardingManagerMock.isEnrolledInSetAsDefaultBrowserExperiment = true
+        onboardingManagerMock.isEnrolledInSetAsDefaultBrowserPipVideoExperiment = true
         defaultBrowserManagerMock.resultToReturn = .failed(reason: .rateLimitReached(updatedStoredInfo: nil))
         let sut = makeSUT()
         XCTAssertFalse(pixelReporterMock.didCallMeasureDidSetDDGAsDefaultBrowser)
@@ -671,7 +671,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     func testWhenDefaultBrowserInfoIsFailureResult_AndFailureIsUnkownError_ThenDoNotFireSetDefaultBrowserPixels() {
         // GIVEN
-        onboardingManagerMock.isEnrolledInSetAsDefaultBrowserExperiment = true
+        onboardingManagerMock.isEnrolledInSetAsDefaultBrowserPipVideoExperiment = true
         defaultBrowserManagerMock.resultToReturn = .failed(reason: .unknownError(NSError(domain: #function, code: 0)))
         let sut = makeSUT()
         XCTAssertFalse(pixelReporterMock.didCallMeasureDidSetDDGAsDefaultBrowser)
@@ -687,7 +687,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     func testWhenDefaultBrowserInfoIsFailureResult_AndFailureIsNotSupportedOnCurrentOSVersion_ThenDoNotFireSetDefaultBrowserPixels() {
         // GIVEN
-        onboardingManagerMock.isEnrolledInSetAsDefaultBrowserExperiment = true
+        onboardingManagerMock.isEnrolledInSetAsDefaultBrowserPipVideoExperiment = true
         defaultBrowserManagerMock.resultToReturn = .failed(reason: .notSupportedOnCurrentOSVersion)
         let sut = makeSUT()
         XCTAssertFalse(pixelReporterMock.didCallMeasureDidSetDDGAsDefaultBrowser)

--- a/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -147,7 +147,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         sut.startOnboardingAction(isResumingOnboarding: true)
 
         // THEN
-        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog, step: .init(currentStep: 1, totalSteps: 4))))
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog(shouldShowSetDefaultBrowserTutorialVideo: false), step: .init(currentStep: 1, totalSteps: 4))))
     }
 
     func testWhenConfirmSkipOnboarding_andIsIphoneFlow_ThenDismissOnboardingAndDisableDaxDialogs() throws {
@@ -286,7 +286,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         sut.startOnboardingAction(isResumingOnboarding: true)
 
         // THEN
-        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog, step: .init(currentStep: 1, totalSteps: 2))))
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog(shouldShowSetDefaultBrowserTutorialVideo: false), step: .init(currentStep: 1, totalSteps: 2))))
     }
 
     func testWhenConfirmSkipOnboarding_andIsIpadFlow_ThenDismissOnboardingAndDisableDaxDialogs() throws {
@@ -318,7 +318,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         sut.startOnboardingAction()
 
         // THEN
-        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog, step: .init(currentStep: 1, totalSteps: 2))))
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog(shouldShowSetDefaultBrowserTutorialVideo: false), step: .init(currentStep: 1, totalSteps: 2))))
     }
 
     func testWhenSetDefaultBrowserActionIsCalledAndIsIpadFlowThenViewStateChangesToChooseAppIconDialogAndProgressIs2Of3() {
@@ -699,6 +699,100 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         // THEN
         XCTAssertFalse(pixelReporterMock.didCallMeasureDidSetDDGAsDefaultBrowser)
         XCTAssertFalse(pixelReporterMock.didCallMeasureDidNotSetDDGAsDefaultBrowser)
+    }
+
+    // MARK: - Set As Default Browser PiP Experiment
+
+    func testWhenStartOnboardingActionIsCalled_AndUserIsInControlGroup_ThenViewStateShouldBeBrowserComparison_AndShouldNotShowSetDefaultBrowserVideoTutorial() throws {
+        // GIVEN
+        onboardingManagerMock.cohortToReturn = .control
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: true)
+        let currentStep = try XCTUnwrap(onboardingManagerMock.onboardingSteps.first)
+        let sut = makeSUT(currentOnboardingStep: currentStep)
+
+        // WHEN
+        sut.startOnboardingAction(isResumingOnboarding: false)
+
+        // THEN
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog(shouldShowSetDefaultBrowserTutorialVideo: false), step: .init(currentStep: 1, totalSteps: 4))))
+    }
+
+    func testWhenStartOnboardingActionIsCalled_AndUserIsNotEnrolledInExperiment_ThenViewStateShouldBeBrowserComparison_AndShouldNotShowSetDefaultBrowserVideoTutorial() throws {
+        // GIVEN
+        onboardingManagerMock.cohortToReturn = nil
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: true)
+        let currentStep = try XCTUnwrap(onboardingManagerMock.onboardingSteps.first)
+        let sut = makeSUT(currentOnboardingStep: currentStep)
+
+        // WHEN
+        sut.startOnboardingAction(isResumingOnboarding: false)
+
+        // THEN
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog(shouldShowSetDefaultBrowserTutorialVideo: false), step: .init(currentStep: 1, totalSteps: 4))))
+    }
+
+    func testWhenStartOnboardingActionIsCalled_AndUserIsInTreatmentGroup_ThenViewStateShouldBeBrowserComparison_AndShouldShowSetDefaultBrowserVideoTutorial() throws {
+        // GIVEN
+        onboardingManagerMock.cohortToReturn = .treatment
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: true)
+        let currentStep = try XCTUnwrap(onboardingManagerMock.onboardingSteps.first)
+        let sut = makeSUT(currentOnboardingStep: currentStep)
+
+        // WHEN
+        sut.startOnboardingAction(isResumingOnboarding: false)
+
+        // THEN
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog(shouldShowSetDefaultBrowserTutorialVideo: true), step: .init(currentStep: 1, totalSteps: 4))))
+    }
+
+    func testWhenSetDefaultBrowserActionIsCalled_AndUserIsInControlGroup_ThenMakeNextViewState() {
+        // GIVEN
+        onboardingManagerMock.cohortToReturn = .control
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: true)
+        let sut = makeSUT(currentOnboardingStep: .browserComparison)
+
+        // WHEN
+        sut.setDefaultBrowserAction()
+
+        // THEN
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .addToDockPromoDialog, step: .init(currentStep: 2, totalSteps: 4))))
+    }
+
+    func testWhenSetDefaultBrowserActionIsCalled_AndUserNotEnrolledInPiPExperiment_ThenMakeNextViewState() {
+        // GIVEN
+        onboardingManagerMock.cohortToReturn = nil
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: true)
+        let sut = makeSUT(currentOnboardingStep: .browserComparison)
+
+        // WHEN
+        sut.setDefaultBrowserAction()
+
+        // THEN
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .addToDockPromoDialog, step: .init(currentStep: 2, totalSteps: 4))))
+    }
+
+    func testWhenSetDefaultBrowserActionIsCalled_AndUserIsInTreatmentGroup_ThenDoNotMakeNextViewState() {
+        // GIVEN
+        onboardingManagerMock.cohortToReturn = .treatment
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: true)
+        let sut = makeSUT(currentOnboardingStep: .browserComparison)
+
+        // WHEN
+        sut.setDefaultBrowserAction()
+
+        // THEN
+        XCTAssertNotEqual(sut.state, .onboarding(.init(type: .addToDockPromoDialog, step: .init(currentStep: 2, totalSteps: 4))))
+    }
+
+    func testWhenCompletedSetDefaultBrowserActionIsCalled_ThenMakeNextViewState() {
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: true)
+        let sut = makeSUT(currentOnboardingStep: .browserComparison)
+
+        // WHEN
+        sut.completedSetDefaultBrowserAction()
+
+        // THEN
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .addToDockPromoDialog, step: .init(currentStep: 2, totalSteps: 4))))
     }
 
 }

--- a/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -147,7 +147,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         sut.startOnboardingAction(isResumingOnboarding: true)
 
         // THEN
-        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog(shouldShowSetDefaultBrowserTutorialVideo: false), step: .init(currentStep: 1, totalSteps: 4))))
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog, step: .init(currentStep: 1, totalSteps: 4))))
     }
 
     func testWhenConfirmSkipOnboarding_andIsIphoneFlow_ThenDismissOnboardingAndDisableDaxDialogs() throws {
@@ -286,7 +286,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         sut.startOnboardingAction(isResumingOnboarding: true)
 
         // THEN
-        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog(shouldShowSetDefaultBrowserTutorialVideo: false), step: .init(currentStep: 1, totalSteps: 2))))
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog, step: .init(currentStep: 1, totalSteps: 2))))
     }
 
     func testWhenConfirmSkipOnboarding_andIsIpadFlow_ThenDismissOnboardingAndDisableDaxDialogs() throws {
@@ -318,7 +318,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         sut.startOnboardingAction()
 
         // THEN
-        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog(shouldShowSetDefaultBrowserTutorialVideo: false), step: .init(currentStep: 1, totalSteps: 2))))
+        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog, step: .init(currentStep: 1, totalSteps: 2))))
     }
 
     func testWhenSetDefaultBrowserActionIsCalledAndIsIpadFlowThenViewStateChangesToChooseAppIconDialogAndProgressIs2Of3() {
@@ -386,18 +386,6 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
         // THEN
         XCTAssertTrue(pixelReporterMock.didCallMeasureBrowserComparisonImpression)
-    }
-
-    func testWhenChooseBrowserIsCalledThenPixelReporterTrackChooseBrowserCTAAction() {
-        // GIVEN
-        let sut = makeSUT()
-        XCTAssertFalse(pixelReporterMock.didCallMeasureChooseBrowserCTAAction)
-
-        // WHEN
-        sut.setDefaultBrowserAction()
-
-        // THEN
-        XCTAssertTrue(pixelReporterMock.didCallMeasureChooseBrowserCTAAction)
     }
 
     func testWhenAppIconScreenPresentedThenPixelReporterTrackAppIconImpression() {
@@ -703,46 +691,55 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
     // MARK: - Set As Default Browser PiP Experiment
 
-    func testWhenStartOnboardingActionIsCalled_AndUserIsInControlGroup_ThenViewStateShouldBeBrowserComparison_AndShouldNotShowSetDefaultBrowserVideoTutorial() throws {
-        // GIVEN
-        onboardingManagerMock.cohortToReturn = .control
-        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: true)
-        let currentStep = try XCTUnwrap(onboardingManagerMock.onboardingSteps.first)
-        let sut = makeSUT(currentOnboardingStep: currentStep)
-
-        // WHEN
-        sut.startOnboardingAction(isResumingOnboarding: false)
-
-        // THEN
-        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog(shouldShowSetDefaultBrowserTutorialVideo: false), step: .init(currentStep: 1, totalSteps: 4))))
-    }
-
-    func testWhenStartOnboardingActionIsCalled_AndUserIsNotEnrolledInExperiment_ThenViewStateShouldBeBrowserComparison_AndShouldNotShowSetDefaultBrowserVideoTutorial() throws {
+    func testWhenEnrollUserInPiPVideoExperimentAndCheckIfShouldShowVideoTutorial_AndUserIsNotEnrolledInExperiment_ThenDoNotShowVideoTutorial() {
         // GIVEN
         onboardingManagerMock.cohortToReturn = nil
         onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: true)
-        let currentStep = try XCTUnwrap(onboardingManagerMock.onboardingSteps.first)
-        let sut = makeSUT(currentOnboardingStep: currentStep)
+        let sut = makeSUT()
 
         // WHEN
-        sut.startOnboardingAction(isResumingOnboarding: false)
+        let result = sut.enrollUserInPiPVideoExperimentAndCheckIfShouldShowVideoTutorial()
 
         // THEN
-        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog(shouldShowSetDefaultBrowserTutorialVideo: false), step: .init(currentStep: 1, totalSteps: 4))))
+        XCTAssertFalse(result)
     }
 
-    func testWhenStartOnboardingActionIsCalled_AndUserIsInTreatmentGroup_ThenViewStateShouldBeBrowserComparison_AndShouldShowSetDefaultBrowserVideoTutorial() throws {
+    func testWhenEnrollUserInPiPVideoExperimentAndCheckIfShouldShowVideoTutorial_AndUserIsInControlGroup_ThenDoNotShowVideoTutorial() {
+        // GIVEN
+        onboardingManagerMock.cohortToReturn = .control
+        onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: true)
+        let sut = makeSUT()
+
+        // WHEN
+        let result = sut.enrollUserInPiPVideoExperimentAndCheckIfShouldShowVideoTutorial()
+
+        // THEN
+        XCTAssertFalse(result)
+    }
+
+    func testWhenEnrollUserInPiPVideoExperimentAndCheckIfShouldShowVideoTutorial_AndUserIsInTreatmentGroup_ThenShowVideoTutorial() {
         // GIVEN
         onboardingManagerMock.cohortToReturn = .treatment
         onboardingManagerMock.onboardingSteps = OnboardingIntroStep.newUserSteps(isIphone: true)
-        let currentStep = try XCTUnwrap(onboardingManagerMock.onboardingSteps.first)
-        let sut = makeSUT(currentOnboardingStep: currentStep)
+        let sut = makeSUT()
 
         // WHEN
-        sut.startOnboardingAction(isResumingOnboarding: false)
+        let result = sut.enrollUserInPiPVideoExperimentAndCheckIfShouldShowVideoTutorial()
 
         // THEN
-        XCTAssertEqual(sut.state, .onboarding(.init(type: .browsersComparisonDialog(shouldShowSetDefaultBrowserTutorialVideo: true), step: .init(currentStep: 1, totalSteps: 4))))
+        XCTAssertTrue(result)
+    }
+
+    func testWhenEnrollUserInPiPVideoExperimentAndCheckIfShouldShowVideoTutorial_ThenPixelReporterTrackChooseBrowserCTAAction() {
+        // GIVEN
+        let sut = makeSUT()
+        XCTAssertFalse(pixelReporterMock.didCallMeasureChooseBrowserCTAAction)
+
+        // WHEN
+        _ = sut.enrollUserInPiPVideoExperimentAndCheckIfShouldShowVideoTutorial()
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallMeasureChooseBrowserCTAAction)
     }
 
     func testWhenSetDefaultBrowserActionIsCalled_AndUserIsInControlGroup_ThenMakeNextViewState() {

--- a/iOS/DuckDuckGoTests/OnboardingManagerTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingManagerTests.swift
@@ -130,4 +130,21 @@ struct OnboardingManagerTests {
 
     }
 
+    struct URLSettingsProvider {
+
+        @Test("Check Right Settings URL is returned")
+        func checkCorrectSettingsURLIsReturned() {
+            // GIVEN
+            let sut = OnboardingManager(appDefaults: AppSettingsMock(), featureFlagger: MockFeatureFlagger(), variantManager: MockVariantManager())
+            let expectedSettingsURL = UIApplication.openSettingsURLString
+
+            // WHEN
+            let result = sut.settingsURLPath
+
+            // THEN
+            #expect(result == expectedSettingsURL)
+        }
+
+    }
+
 }

--- a/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
@@ -696,7 +696,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         // THEN
         XCTAssertEqual(OnboardingExperimentPixelFireMock.firedMetrics.count, 1)
         let firedPixel = try XCTUnwrap(OnboardingExperimentPixelFireMock.firedMetrics.first)
-        XCTAssertEqual(firedPixel.subfeatureID, OnboardingPixelReporter.SetAsDefaultExperimentMetrics.subfeatureIdentifier)
+        XCTAssertEqual(firedPixel.subfeatureID, OnboardingPixelReporter.SetAsDefaultBrowserPipVideoExperimentMetrics.subfeatureIdentifier)
         XCTAssertEqual(firedPixel.metric, "setAsDefaultBrowser")
         XCTAssertEqual(firedPixel.conversionWindow, 0...0)
         XCTAssertEqual(firedPixel.value, "1")
@@ -712,7 +712,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         // THEN
         XCTAssertEqual(OnboardingExperimentPixelFireMock.firedMetrics.count, 1)
         let firedPixel = try XCTUnwrap(OnboardingExperimentPixelFireMock.firedMetrics.first)
-        XCTAssertEqual(firedPixel.subfeatureID, OnboardingPixelReporter.SetAsDefaultExperimentMetrics.subfeatureIdentifier)
+        XCTAssertEqual(firedPixel.subfeatureID, OnboardingPixelReporter.SetAsDefaultBrowserPipVideoExperimentMetrics.subfeatureIdentifier)
         XCTAssertEqual(firedPixel.metric, "rejectSetAsDefaultBrowser")
         XCTAssertEqual(firedPixel.conversionWindow, 0...0)
         XCTAssertEqual(firedPixel.value, "1")

--- a/iOS/DuckDuckGoTests/VideoPlayer/VideoPlayerCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/VideoPlayer/VideoPlayerCoordinatorTests.swift
@@ -196,8 +196,15 @@ final class VideoPlayerCoordinatorTests {
         #expect(mockAudioSessionManager.didCallSetPlaybackSessionInactive)
     }
 
-    @Test("Check Picture In Picture Is Active Event Is Published when Picture In Picture Starts")
-    func whenPictureInPictureStartsThenPictureInPictureIsActiveEventIsPublished() {
+    @Test(
+        "Check Picture In Picture Is Active Event Is Published when Picture In Picture Starts",
+        arguments: [
+            (PictureInPictureEvent.didStartPictureInPicture, true),
+            (.didStopPictureInPicture, false),
+            (.failedToStartPictureInPicture, false)
+        ]
+    )
+    func whenPictureInPictureStartsThenPictureInPictureIsActiveEventIsPublished(context: (event: PictureInPictureEvent, expectedResult: Bool)) {
         // GIVEN
         let sut = makeSUT(url: fakeURL, configuration: .init(loopVideo: false, allowsPictureInPicturePlayback: true))
         var capturedIsActive: Bool = false
@@ -207,10 +214,10 @@ final class VideoPlayerCoordinatorTests {
             }
 
         // WHEN
-        mockPictureInPictureController.send(.didStartPictureInPicture)
+        mockPictureInPictureController.send(context.event)
 
         // THEN
         withExtendedLifetime(c){}
-        #expect(capturedIsActive)
+        #expect(capturedIsActive == context.expectedResult)
     }
 }

--- a/iOS/SharedTestUtils/Mocks/OnboardingManagerMock.swift
+++ b/iOS/SharedTestUtils/Mocks/OnboardingManagerMock.swift
@@ -21,11 +21,12 @@ import Foundation
 import Core
 @testable import DuckDuckGo
 
-final class OnboardingManagerMock: OnboardingSetAsDefaultExperimentManaging, OnboardingSettingsURLProvider, OnboardingStepsProvider {
+final class OnboardingManagerMock: OnboardingIntroExperimentManaging, OnboardingSettingsURLProvider, OnboardingStepsProvider {
     private(set) var didCallSettingsURLPath = false
+    var cohortToReturn: OnboardingSetAsDefaultBrowserPiPVideoCohort?
 
     var onboardingSteps: [DuckDuckGo.OnboardingIntroStep] = OnboardingIntroStep.newUserSteps(isIphone: true)
-    var isEnrolledInSetAsDefaultBrowserExperiment: Bool = false
+    var isEnrolledInSetAsDefaultBrowserPipVideoExperiment: Bool = false
 
     var settingsURLPathToReturn: String = "www.example.com"
     var settingsURLPath: String {
@@ -38,7 +39,7 @@ final class OnboardingManagerMock: OnboardingSetAsDefaultExperimentManaging, Onb
         }
     }
 
-    func resolveSetAsDefaultBrowserExperimentCohort() -> OnboardingSetAsDefaultBrowserCohort? {
-        nil
+    func resolveSetAsDefaultBrowserPipVideoExperimentCohort(isPictureInPictureSupported: Bool) -> OnboardingSetAsDefaultBrowserPiPVideoCohort? {
+        cohortToReturn
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210454186090910?focus=true
Tech Design URL:
CC:

### Description

- Setup the Set Default Browser PiP Experiment.
- Implement the logic to show the Set Default Browser PiP video to the treatment group.

### Testing Steps

**Prerequisites:**
- PiP can only be tested on a real device.
- Ensure the device runs a version of iOS >= 18.2 to enroll in the experiment.

**Scenario 1 - Flow Control Group**
1. Ensure that 'Internal User’ is on in the Debug Menu and device OS version is >= 18.2+.
2. Tap the the 'Feature Flags’ menu item and in ‘Experiments’ ‘onboardingSetAsDefaultBrowserPiPVideo’ select the `control` cohort.
3. Go back to the `Debug Menu`, tap the `Onboarding` item and select ’New User'.
4. Tap the ‘Preview Onboarding’ button.
5. Get to the browser comparisons screen.
6. Tap the "Choose Your Browser” button.
7. Ensure the app deeplinks into the settings no video tutorial is presented to the user.
8. Go back to the App. 
9. Ensure that the “Add to Dock” screen is visible

**Scenario 2 - Flow Experiment Group**
1. Ensure that 'Internal User’ is on in the Debug Menu and device OS version is >= 18.2+.
2. Tap the the 'Feature Flags’ menu item and in ‘Experiments’ ‘onboardingSetAsDefaultBrowserPiPVideo’ select the `treatment` cohort.
3. Go back to the `Debug Menu`, tap the `Onboarding` item and select ’New User'.
4. Tap the ‘Preview Onboarding’ button.
5. Get to the browser comparisons screen.
6. Tap the "Choose Your Browser” button.
7. Ensure the app deeplinks into the settings and a Picture in Picture video tutorial is presented on screen and it loops.
8. Go back to the App. 
9. Ensure that both the <- DuckDuckGo button and the PIP button on the video launch the app and the “Add to Dock” onboarding screen is presented (iPhone).

**Scenario 3 - Pixels Control Group**
1. Edit the Privacy Config https://www.jsonblob.com/1384080685115039744 and set the weight of `setAsDefaultBrowserPiPVideoExperiment` treatment group to 0.
2. Delete the App.
3. Launche the App.
4. Skip Onboarding.
5. Override Privacy Config URL with https://www.jsonblob.com/api/1384080685115039744 and set 
6. Open the Debug menu.
7. Ensure the Internal User State toggle is on.
8. Tap the Feature Flags item.
9. Tap ‘onboardingSetAsDefaultBrowserPiPVideo’.
10. Choose the control cohort.
11. Go back to the main debug menu.
12. Tap Onboarding.
13. Select ’New User’ type.
14. Tap 'Preview Onboarding Intro’.
15. Wait for the onboarding to appear and tap the Let’s do it! button.
16. Wait for the Protections activated! screen to appear.
17. Tap the 'Choose Your Browser’ button.
18. Ensure pixel experiment enrollment `experiment_enroll_setAsDefaultBrowserPiPVideoExperiment_control_ios_phone ` is fired.
19. Ensure that the DuckDuckGo settings in the System settings open.
20. Select DDG as default browser
21. Go back to the App.
22. The ‘Add to Dock’ screen should be visible
23. Tap Skip button.
24. Tap Chose App Icon color Continue CTA.
25. Ensure that Experiment pixel  `experiment_metrics_setAsDefaultBrowserPiPVideoExperiment_control_ios_phone ["conversionWindowDays": "0", "metric": “setAsDefaultBrowser", "enrollmentDate": "2025-06-17", "value": “1", "pixelSource": "phone”]` is fired.

Repeat experiment without setting DDG as default browser and ensure “metric” value in `experiment_metrics_setAsDefaultBrowserPiPVideoExperiment_control_ios_phone`  is `rejectedsetAsDefaultBrowser`

**Scenario 4 - Pixels Treatment Group**
1. Edit the Privacy Config https://www.jsonblob.com/1384080685115039744 and set the weight of `setAsDefaultBrowserPiPVideoExperiment` control group to 0.
2. Delete the App.
3. Launche the App.
4. Skip Onboarding.
5. Override Privacy Config URL with https://www.jsonblob.com/api/1384080685115039744 and set 
6. Open the Debug menu.
7. Ensure the Internal User State toggle is on.
8. Tap the Feature Flags item.
9. Tap ‘onboardingSetAsDefaultBrowserPiPVideo’.
10. Choose the control cohort.
11. Go back to the main debug menu.
12. Tap Onboarding.
13. Select ’New User’ type.
14. Tap 'Preview Onboarding Intro’.
15. Wait for the onboarding to appear and tap the Let’s do it! button.
16. Wait for the Protections activated! screen to appear.
17. Tap the 'Choose Your Browser’ button.
18. Ensure pixel experiment enrollment `experiment_enroll_setAsDefaultBrowserPiPVideoExperiment_treatment_ios_phone` is fired.
19. Ensure that the DuckDuckGo settings in the System settings open and PiP video displays on screen.
20. Select DDG as default browser
21. Go back to the App.
22.The ‘Add to Dock’ screen should be visible
22. Tap Skip button.
23. Tap Chose App Icon color Continue CTA.
24. Ensure that Experiment pixel  `experiment_metrics_setAsDefaultBrowserPiPVideoExperiment_treatment_ios_phone  ["conversionWindowDays": "0", "metric": “setAsDefaultBrowser", "enrollmentDate": "2025-06-17", "value": “1", "pixelSource": "phone”]` is fired.

Repeat experiment without setting DDG as default browser and ensure “metric” value in `experiment_metrics_setAsDefaultBrowserPiPVideoExperiment_treatment_ios_phone`  is `rejectedsetAsDefaultBrowser`

### Impact and Risks
Low: Merging into a feature branch

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)