### PR TITLE
Fix WKDownload using originating WebView instead of target WebView

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Navigation/DistributedNavigationDelegate.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Navigation/DistributedNavigationDelegate.swift
@@ -1,7 +1,7 @@
 //
 //  DistributedNavigationDelegate.swift
 //
-//  Copyright © 2022 DuckDuckGo. All rights reserved.
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -466,6 +466,8 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
 
     @MainActor
     private func willStartDownload(with navigationAction: NavigationAction, in webView: WKWebView) {
+        Logger.navigation.log("willStartDownload \(navigationAction.debugDescription) in \(webView.description)")
+
         let responders = (navigationAction.isForMainFrame ? navigationAction.mainFrameNavigation?.navigationResponders : nil) ?? responders
         for responder in responders {
             responder.navigationAction(navigationAction, willBecomeDownloadIn: webView)
@@ -944,6 +946,8 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
 
     @MainActor
     private func willStartDownload(with navigationResponse: NavigationResponse, in webView: WKWebView) {
+        Logger.navigation.log("willStartDownload \(navigationResponse.debugDescription) in \(webView.description)")
+
         let responders = (navigationResponse.isForMainFrame ? navigationResponse.mainFrameNavigation?.navigationResponders : nil) ?? responders
         for responder in responders {
             responder.navigationResponse(navigationResponse, willBecomeDownloadIn: webView)
@@ -976,6 +980,8 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
         }()
         Logger.navigation.log("navigationActionDidBecomeDownload: \(navigationAction.debugDescription)")
 
+        download.targetWebView = webView
+
         let responders = (navigationAction.isForMainFrame ? navigationAction.mainFrameNavigation?.navigationResponders : nil) ?? responders
         for responder in responders {
             responder.navigationAction(navigationAction, didBecome: download)
@@ -1002,6 +1008,8 @@ extension DistributedNavigationDelegate: WKNavigationDelegate {
             return NavigationResponse(navigationResponse: wkNavigationResponse, mainFrameNavigation: startedNavigation)
         }()
         Logger.navigation.log("navigationResponseDidBecomeDownload: \(navigationResponse.debugDescription)")
+
+        download.targetWebView = webView
 
         let responders = (navigationResponse.isForMainFrame ? navigationResponse.mainFrameNavigation?.navigationResponders : nil) ?? responders
         for responder in responders {

--- a/SharedPackages/BrowserServicesKit/Sources/Navigation/Extensions/WKDownloadExtension.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Navigation/Extensions/WKDownloadExtension.swift
@@ -1,0 +1,35 @@
+//
+//  WKDownloadExtension.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import WebKit
+
+extension WKDownload {
+    
+    private struct WebViewRef {
+        weak var webView: WKWebView?
+    }
+    
+    private static let targetWebViewKey = UnsafeRawPointer(bitPattern: "targetWebView".hashValue)!
+    
+    /// The WebView that is loading this download
+    @objc public var targetWebView: WKWebView? {
+        get { (objc_getAssociatedObject(self, Self.targetWebViewKey) as? WebViewRef)?.webView }
+        set { objc_setAssociatedObject(self, Self.targetWebViewKey, WebViewRef(webView: newValue), .OBJC_ASSOCIATION_RETAIN) }
+    }
+    
+} 

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -2275,6 +2275,8 @@
 		845B43372DB69F2E00D46001 /* SwiftObjectRetainCycleBreakerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845B43332DB69F2C00D46001 /* SwiftObjectRetainCycleBreakerTests.swift */; };
 		845B43402DB7689F00D46001 /* OnboardingNavigatingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A054402C22438C007D8FAB /* OnboardingNavigatingTests.swift */; };
 		845B43412DB7689F00D46001 /* OnboardingNavigatingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A054402C22438C007D8FAB /* OnboardingNavigatingTests.swift */; };
+		847873DE2E02A32C00A8CB04 /* Logger+UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B479072CCA7A3900F40329 /* Logger+UnitTests.swift */; };
+		847873DF2E02A32C00A8CB04 /* Logger+UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B479072CCA7A3900F40329 /* Logger+UnitTests.swift */; };
 		848648A12C76F4B20082282D /* BookmarksBarMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848648A02C76F4B20082282D /* BookmarksBarMenuViewController.swift */; };
 		848648A22C76F4B20082282D /* BookmarksBarMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848648A02C76F4B20082282D /* BookmarksBarMenuViewController.swift */; };
 		84A03D2B2DBBE06B00A3685B /* DraggingDestinationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A03D2A2DBBE06700A3685B /* DraggingDestinationView.swift */; };
@@ -13838,6 +13840,7 @@
 				560C6ED92CCA5CE700D411E2 /* FindInView.swift in Sources */,
 				B60C6F8B29B1CAC0007BFAA8 /* FileManagerTempDirReplacement.swift in Sources */,
 				3706FEA4293F662100E42796 /* CoreDataTestUtilities.swift in Sources */,
+				847873DF2E02A32C00A8CB04 /* Logger+UnitTests.swift in Sources */,
 				8434E6BD2DB01633008FFA3D /* MockBookmarkManager.swift in Sources */,
 				84524C092D79E6EF00F723D6 /* WebsiteDataStoreMock.swift in Sources */,
 				B62A234129C41D4400D22475 /* HistoryIntegrationTests.swift in Sources */,
@@ -13914,6 +13917,7 @@
 				845063512DB76F9E00A60B56 /* WindowManagerStateRestorationTests.swift in Sources */,
 				560C6ED82CCA5CE700D411E2 /* FindInView.swift in Sources */,
 				B60C6F8A29B1CABF007BFAA8 /* FileManagerTempDirReplacement.swift in Sources */,
+				847873DE2E02A32C00A8CB04 /* Logger+UnitTests.swift in Sources */,
 				8434E6BC2DB01633008FFA3D /* MockBookmarkManager.swift in Sources */,
 				84524C082D79E6EF00F723D6 /* WebsiteDataStoreMock.swift in Sources */,
 				4B1AD92125FC474E00261379 /* CoreDataEncryptionTesting.xcdatamodeld in Sources */,

--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS Browser App Store.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS Browser App Store.xcscheme
@@ -175,12 +175,6 @@
                   Identifier = "CoreDataEncryptionTests/testSavingIncorrectValueTypes()">
                </Test>
                <Test
-                  Identifier = "DownloadsIntegrationTests/testWhenDownloadIsStartedAfterAppOpensURL_tabIsClosed()">
-               </Test>
-               <Test
-                  Identifier = "DownloadsIntegrationTests/testWhenDownloadIsStartedInNewTab_tabIsClosed()">
-               </Test>
-               <Test
                   Identifier = "EncryptionKeyStoreTests">
                </Test>
                <Test

--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS Browser.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS Browser.xcscheme
@@ -190,12 +190,6 @@
                   Identifier = "CoreDataEncryptionTests/testSavingIncorrectValueTypes()">
                </Test>
                <Test
-                  Identifier = "DownloadsIntegrationTests/testWhenDownloadIsStartedAfterAppOpensURL_tabIsClosed()">
-               </Test>
-               <Test
-                  Identifier = "DownloadsIntegrationTests/testWhenDownloadIsStartedInNewTab_tabIsClosed()">
-               </Test>
-               <Test
                   Identifier = "EncryptionKeyStoreTests">
                </Test>
                <Test
@@ -335,6 +329,18 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "PrefersMallocStackLoggingLite"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "MallocStackLogging"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/macOS/DuckDuckGo/FileDownload/Model/WebKitDownloadTask.swift
+++ b/macOS/DuckDuckGo/FileDownload/Model/WebKitDownloadTask.swift
@@ -123,8 +123,8 @@ final class WebKitDownloadTask: NSObject, ProgressReporting, @unchecked Sendable
     var originalRequest: URLRequest? {
         download.originalRequest
     }
-    var originalWebView: WKWebView? {
-        download.webView
+    var targetWebView: WKWebView? {
+        download.targetWebView
     }
     @MainActor var shouldPromptForLocation: Bool {
         return if case .initial(.prompt) = state { true } else { false }
@@ -597,7 +597,7 @@ final class WebKitDownloadTask: NSObject, ProgressReporting, @unchecked Sendable
 extension WebKitDownloadTask: WKDownloadDelegate {
 
     @MainActor
-    func download(_ download: WKDownload, decideDestinationUsing response: URLResponse, suggestedFilename: String) async -> URL? {
+    func download(_: WKDownload, decideDestinationUsing response: URLResponse, suggestedFilename: String) async -> URL? {
         Logger.fileDownload.debug("decide destination \(self)")
 
         guard let delegate = delegate else {
@@ -649,7 +649,7 @@ extension WebKitDownloadTask: WKDownloadDelegate {
     }
 
     @MainActor
-    func download(_ download: WKDownload,
+    func download(_: WKDownload,
                   willPerformHTTPRedirection response: HTTPURLResponse,
                   newRequest request: URLRequest,
                   decisionHandler: @escaping (WKDownload.RedirectPolicy) -> Void) {
@@ -658,11 +658,11 @@ extension WebKitDownloadTask: WKDownloadDelegate {
     }
 
     @MainActor
-    func download(_ download: WKDownload,
+    func download(_: WKDownload,
                   didReceive challenge: URLAuthenticationChallenge,
                   completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         Logger.fileDownload.debug("did receive challenge \(self): \(challenge)")
-        download.webView?.navigationDelegate?.webView?(download.webView!, didReceive: challenge, completionHandler: completionHandler) ?? {
+        download.targetWebView?.navigationDelegate?.webView?(download.targetWebView!, didReceive: challenge, completionHandler: completionHandler) ?? {
             completionHandler(.performDefaultHandling, nil)
         }()
     }

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="o2v-eH-jTI">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="24093.7" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="o2v-eH-jTI">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24093.7"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -409,13 +409,9 @@
                         <outlet property="goBackButton" destination="kky-0N-Cfd" id="RA9-yE-URS"/>
                         <outlet property="goBackButtonHeightConstraint" destination="0zh-Jn-l2h" id="1Xv-Mt-Vgm"/>
                         <outlet property="goBackButtonWidthConstraint" destination="8sl-Tr-gSd" id="68f-l3-gFj"/>
-                        <outlet property="goBackHeightConstraint" destination="0zh-Jn-l2h" id="39P-rp-d3H"/>
-                        <outlet property="goBackWidthConstraint" destination="8sl-Tr-gSd" id="Akc-23-mbB"/>
                         <outlet property="goForwardButton" destination="mdE-u0-Ei5" id="7wT-nX-Avr"/>
                         <outlet property="goForwardButtonHeightConstraint" destination="VXS-B2-jFA" id="5qt-by-Oq3"/>
                         <outlet property="goForwardButtonWidthConstraint" destination="jYM-So-c8l" id="lUu-R0-dqm"/>
-                        <outlet property="goForwardHeightConstraint" destination="VXS-B2-jFA" id="HEm-hd-UU2"/>
-                        <outlet property="goForwardWidthConstraint" destination="jYM-So-c8l" id="CQM-pJ-Nkf"/>
                         <outlet property="homeButton" destination="s7D-YB-p00" id="sjk-Af-Zl4"/>
                         <outlet property="homeButtonHeightConstraint" destination="AGI-Qn-D1V" id="f7o-Uj-CzW"/>
                         <outlet property="homeButtonSeparator" destination="3o5-MS-AWl" id="mcV-id-0zR"/>

--- a/macOS/DuckDuckGo/Tab/TabExtensions/DownloadsTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/DownloadsTabExtension.swift
@@ -222,8 +222,11 @@ extension DownloadsTabExtension: NavigationResponder {
 
     @MainActor
     func enqueueDownload(_ download: WebKitDownload, withNavigationAction navigationAction: NavigationAction?) {
-        let task = downloadManager.add(download, fireWindowSession: FireWindowSessionRef(window: download.webView?.window), delegate: self, destination: .auto)
-        guard let webView = download.webView else { return }
+        let task = downloadManager.add(download,
+                                       fireWindowSession: FireWindowSessionRef(window: (download.originatingWebView ?? download.targetWebView)?.window),
+                                       delegate: self,
+                                       destination: .auto)
+        guard let webView = download.targetWebView else { return }
 
         var shouldCloseTabOnDownloadStart: Bool {
             guard let navigationAction else {

--- a/macOS/IntegrationTests/Downloads/DownloadsIntegrationTests.swift
+++ b/macOS/IntegrationTests/Downloads/DownloadsIntegrationTests.swift
@@ -18,7 +18,9 @@
 
 import Combine
 import Common
+import os.log
 import XCTest
+
 @testable import DuckDuckGo_Privacy_Browser
 
 @available(macOS 12.0, *)
@@ -66,6 +68,10 @@ class DownloadsIntegrationTests: XCTestCase {
     override func tearDown() async throws {
         window?.close()
         window = nil
+
+        tabCollectionViewModel = nil
+        contentBlockingMock = nil
+        privacyFeaturesMock = nil
     }
 
     // MARK: - Tests
@@ -219,29 +225,33 @@ class DownloadsIntegrationTests: XCTestCase {
             </body>
             </html>
             """.utf8data)
-        let tab = tabViewModel.tab
-        _=await tab.setUrl(pageUrl, source: .link)?.result
+        let tab1 = tabViewModel.tab
+        _=await tab1.setUrl(pageUrl, source: .link)?.result
 
         NSApp.activate(ignoringOtherApps: true)
-        let downloadTaskFuture = FileDownloadManager.shared.downloadsPublisher.timeout(5).first().promise()
+        let downloadTaskFuture = FileDownloadManager.shared.downloadsPublisher.timeout(10).first().promise()
 
         let e1 = expectation(description: "new tab opened")
         var e2: XCTestExpectation!
-        let c = tabCollectionViewModel.$selectedTabViewModel.dropFirst()
-            .receive(on: DispatchQueue.main)
-            .sink { [unowned self] tabViewModel in
-                guard let tabViewModel else { return }
-                print("tabViewModel", tabViewModel.tab, tab)
-                if tabViewModel.tab !== tab {
-                    e1.fulfill()
-                    e2 = expectation(description: "new tab closed")
-                } else {
-                    e2.fulfill()
-                }
+
+        var c: AnyCancellable! = tabCollectionViewModel.tabCollection.$tabs.sink { [unowned self] tabs in
+            Logger.tests.debug("tabs: \(tabs.map { "\($0) (\($0.url?.absoluteString ??? "<nil>"))" }); tab 1: \(tab1) (\(tab1.url?.absoluteString ??? "<nil>"))")
+
+            XCTAssertLessThanOrEqual(tabs.count, 2)
+            XCTAssert(tabs.first === tab1, "tabs: \(tabs.map { "\($0) (\($0.url?.absoluteString ??? "<nil>"))" }); tab1: \(tab1) (\(tab1.url?.absoluteString ??? "<nil>"))")
+            if tabs.count > 1 {
+                e1.fulfill() // download tab opened
+
+                e2 = expectation(description: "download tab closed")
+
+            } else if let e2 {
+                // download tab closed
+                e2.fulfill()
             }
+        }
 
         // click to open a new (download) tab and instantly deactivate it
-        click(tab.webView)
+        click(tab1.webView)
 
         // download should start in the background tab
         _=try await downloadTaskFuture.get()
@@ -249,6 +259,7 @@ class DownloadsIntegrationTests: XCTestCase {
         // expect for the download tab to close
         await fulfillment(of: [e1, e2], timeout: 10)
         withExtendedLifetime(c, {})
+        c = nil
     }
 
     @MainActor
@@ -274,7 +285,7 @@ class DownloadsIntegrationTests: XCTestCase {
             .receive(on: DispatchQueue.main)
             .sink { [unowned self] tabViewModel in
                 guard let tabViewModel else { return }
-                print("tabViewModel", tabViewModel.tab, tab)
+                Logger.tests.debug("selected tabViewModel \(tabViewModel.tab) (\(tabViewModel.tab.url?.absoluteString ??? "<nil>")); tab 1: \(tab) (\(tab.url?.absoluteString ??? "<nil>"))")
                 if tabViewModel.tab !== tab {
                     e1.fulfill()
                     e2 = expectation(description: "new tab closed")
@@ -341,7 +352,7 @@ class DownloadsIntegrationTests: XCTestCase {
             .receive(on: DispatchQueue.main)
             .sink { [unowned self] tabViewModel in
                 guard let tabViewModel else { return }
-                print("tabViewModel", tabViewModel.tab, tab)
+                Logger.tests.debug("selected tabViewModel \(tabViewModel.tab) (\(tabViewModel.tab.url?.absoluteString ??? "<nil>")); tab 1: \(tab) (\(tab.url?.absoluteString ??? "<nil>"))")
                 if tabViewModel.tab !== tab {
                     e1.fulfill()
                     e2 = expectation(description: "new tab closed")
@@ -452,7 +463,7 @@ class DownloadsIntegrationTests: XCTestCase {
                 _=await tab.setUrl(pageUrl, source: .link)?.result
                 ePageLoaded.fulfill()
             }
-            waitForExpectations(timeout: 5)
+            waitForExpectations(timeout: 10)
 
             NSApp.activate(ignoringOtherApps: true)
             let downloadTaskFuture = FileDownloadManager.shared.downloadsPublisher.timeout(5).first().promise()

--- a/macOS/UnitTests/FileDownload/Helpers/WKDownloadMock.swift
+++ b/macOS/UnitTests/FileDownload/Helpers/WKDownloadMock.swift
@@ -21,8 +21,11 @@ import WebKit
 @testable import DuckDuckGo_Privacy_Browser
 
 final class WKDownloadMock: NSObject, WebKitDownload, ProgressReporting {
+    var originatingWebView: WKWebView?
+    var targetWebView: WKWebView?
+    
     var originalRequest: URLRequest?
-    var webView: WKWebView?
+
     var progress = Progress()
     weak var delegate: WKDownloadDelegate?
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1207801149824708?focus=true

### Description
- Fixes bug causing originating WebView `close()` called instead of target one when starting download in a new tab (in the recent WebKit update `WKDownload.webView` now returns the originating WebView instead of the target one)

### Testing Steps
1. Open https://kodi.tv/download/macos/, click Download
2. A new tab is opened and download starts, validate the tab is closed after starting the download
2. Drag a download link (e.g. from Asana) to the Tab Bar, validate the new tab is closed

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)