### PR TITLE
Fix for crashing actionSheet presentation in Subscription debug menu on iPad

### DIFF
--- a/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
+++ b/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
@@ -349,7 +349,7 @@ final class SubscriptionDebugViewController: UITableViewController {
                     """
         let alertController = UIAlertController(title: "⚠️ App restart required! The changes are persistent",
                                                 message: message,
-                                                preferredStyle: .actionSheet)
+                                                preferredStyle: UIDevice.current.userInterfaceIdiom == .pad ? .alert : .actionSheet)
         alertController.addAction(UIAlertAction(title: "Yes", style: .destructive) { [weak self] _ in
             Task {
                 switch envRows {
@@ -720,7 +720,7 @@ final class SubscriptionDebugViewController: UITableViewController {
                     """
         let alertController = UIAlertController(title: "⚠️ App restart required! The changes are persistent",
                                                 message: message,
-                                                preferredStyle: .actionSheet)
+                                                preferredStyle: UIDevice.current.userInterfaceIdiom == .pad ? .alert : .actionSheet)
         alertController.addAction(UIAlertAction(title: "Yes", style: .destructive) { [weak self] _ in
             self?.setCustomBaseSubscriptionURL(url)
             // Close the app


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209882303470922/task/1210548294316839?focus=true
Tech Design URL:
CC:

### Description
The action sheet presentation on iPad requires a setup of origin view, and without it, it produces a crash. This fix alters the presentation in subscription debug menu for the subscription environment and custom URL actions sheets to alert.

### Testing Steps
**Subscription Environment (Use iPad for testing)**
1. Open Settings -> All debug options -> Subscription 
2. Attempt changing environment
3. Alert requiring confirmation to restart should appear
4. Check after restart if the environment was persisted

**Custom base subscription URL(Use iPad for testing)**
1. Open Settings -> All debug options -> Subscription 
2. Attempt changing custom base subscription URL
3. Alert requiring confirmation to restart should appear
4. Check after restart if the custom base subscription URL was persisted

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
None, change to alert presentation in the debug menu.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)