### PR TITLE
Improving Subscription behaviour when the device is offline

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "23aacaa55eb0191c01b71dc30e5f521527bee8bf",
-        "version" : "9.5.0"
+        "revision" : "3e754f8dd56ca00d169c84628135d7e5dd22a6ee",
+        "version" : "9.9.0"
       }
     },
     {

--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "3e754f8dd56ca00d169c84628135d7e5dd22a6ee",
-        "version" : "9.9.0"
+        "revision" : "23aacaa55eb0191c01b71dc30e5f521527bee8bf",
+        "version" : "9.5.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -653,6 +653,7 @@ let package = Package(
             dependencies: [
                 "SecureStorage",
                 "SecureStorageTestsUtils",
+                "PixelKit"
             ]
         ),
         .testTarget(

--- a/SharedPackages/BrowserServicesKit/Sources/NetworkingTestingUtils/MockOAuthClient.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/NetworkingTestingUtils/MockOAuthClient.swift
@@ -22,14 +22,16 @@ import Networking
 public class MockOAuthClient: OAuthClient {
 
     public init() {}
-    public var isUserAuthenticated: Bool = false
-    var internalcurrentTokenContainer: Networking.TokenContainer?
+    public var isUserAuthenticated: Bool {
+        internalCurrentTokenContainer != nil
+    }
+    public var internalCurrentTokenContainer: Networking.TokenContainer?
     public func currentTokenContainer() throws -> TokenContainer? {
-        internalcurrentTokenContainer
+        internalCurrentTokenContainer
     }
 
     public func setCurrentTokenContainer(_ tokenContainer: TokenContainer?) throws {
-        internalcurrentTokenContainer = tokenContainer
+        internalCurrentTokenContainer = tokenContainer
     }
 
     public var getTokensResponse: Result<Networking.TokenContainer, Error>!
@@ -50,7 +52,7 @@ public class MockOAuthClient: OAuthClient {
     }
 
     public func adopt(tokenContainer: Networking.TokenContainer) {
-        internalcurrentTokenContainer = tokenContainer
+        internalCurrentTokenContainer = tokenContainer
     }
 
     public var createAccountResponse: Result<Networking.TokenContainer, Error>!

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/API/SubscriptionAPIService.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/API/SubscriptionAPIService.swift
@@ -65,11 +65,11 @@ public enum APICachePolicy {
     public var subscriptionCachePolicy: SubscriptionCachePolicy {
         switch self {
         case .reloadIgnoringLocalCacheData:
-            return .reloadIgnoringLocalCacheData
+            return .remoteFirst
         case .returnCacheDataElseLoad:
-            return .returnCacheDataElseLoad
+            return .cacheFirst
         case .returnCacheDataDontLoad:
-            return .returnCacheDataDontLoad
+            return .cacheOnly
         }
     }
 }

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/API/SubscriptionEndpointServiceV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/API/SubscriptionEndpointServiceV2.swift
@@ -213,6 +213,8 @@ New: \(subscription.debugDescription, privacy: .public)
             do {
                 let subscription = try await getRemoteSubscription(accessToken: accessToken)
                 return subscription
+            } catch SubscriptionEndpointServiceError.noData {
+                throw SubscriptionEndpointServiceError.noData
             } catch {
                 return try await getSubscription(accessToken: accessToken, cachePolicy: .cacheOnly)
             }

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/API/SubscriptionEndpointServiceV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/API/SubscriptionEndpointServiceV2.swift
@@ -48,7 +48,7 @@ public enum SubscriptionEndpointServiceError: Error, Equatable {
     case invalidResponseCode(HTTPStatusCode)
 }
 
-/// Defines the caching strategy used when retrieving a `Subscription`.
+/// Defines the caching strategy used when retrieving a `PrivacyProSubscription`.
 public enum SubscriptionCachePolicy {
 
     /// Always attempts to fetch the subscription from the remote source.

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/API/SubscriptionEndpointServiceV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/API/SubscriptionEndpointServiceV2.swift
@@ -48,18 +48,26 @@ public enum SubscriptionEndpointServiceError: Error, Equatable {
     case invalidResponseCode(HTTPStatusCode)
 }
 
+/// Defines the caching strategy used when retrieving a `Subscription`.
 public enum SubscriptionCachePolicy {
-    case reloadIgnoringLocalCacheData
-    case returnCacheDataElseLoad
-    case returnCacheDataDontLoad
+
+    /// Always attempts to fetch the subscription from the remote source.
+    /// If the remote fetch or keychain access fails, falls back to the cached subscription if available.
+    case remoteFirst
+
+    /// Returns the cached subscription if it exists; otherwise, attempts to fetch from the remote source.
+    case cacheFirst
+
+    /// Returns only the cached subscription. No remote fetch is attempted.
+    case cacheOnly
 
     public var apiCachePolicy: APICachePolicy {
         switch self {
-        case .reloadIgnoringLocalCacheData:
+        case .remoteFirst:
             return .reloadIgnoringLocalCacheData
-        case .returnCacheDataElseLoad:
+        case .cacheFirst:
             return .returnCacheDataElseLoad
-        case .returnCacheDataDontLoad:
+        case .cacheOnly:
             return .returnCacheDataDontLoad
         }
     }
@@ -67,7 +75,7 @@ public enum SubscriptionCachePolicy {
 
 public protocol SubscriptionEndpointServiceV2 {
     func ingestSubscription(_ subscription: PrivacyProSubscription) async throws
-    func getSubscription(accessToken: String, cachePolicy: SubscriptionCachePolicy) async throws -> PrivacyProSubscription
+    func getSubscription(accessToken: String?, cachePolicy: SubscriptionCachePolicy) async throws -> PrivacyProSubscription
     func getCachedSubscription() -> PrivacyProSubscription?
     func clearSubscription()
     func getProducts() async throws -> [GetProductsItem]
@@ -90,7 +98,7 @@ public protocol SubscriptionEndpointServiceV2 {
 extension SubscriptionEndpointServiceV2 {
 
     public func getSubscription(accessToken: String) async throws -> PrivacyProSubscription {
-        try await getSubscription(accessToken: accessToken, cachePolicy: SubscriptionCachePolicy.returnCacheDataElseLoad)
+        try await getSubscription(accessToken: accessToken, cachePolicy: SubscriptionCachePolicy.cacheFirst)
     }
 }
 
@@ -190,19 +198,33 @@ New: \(subscription.debugDescription, privacy: .public)
         try await storeAndAddFeaturesIfNeededTo(subscription: subscription)
     }
 
-    public func getSubscription(accessToken: String, cachePolicy: SubscriptionCachePolicy = .returnCacheDataElseLoad) async throws -> PrivacyProSubscription {
-        switch cachePolicy {
-        case .reloadIgnoringLocalCacheData:
-            return try await getRemoteSubscription(accessToken: accessToken)
+    public func getSubscription(accessToken: String?, cachePolicy: SubscriptionCachePolicy = .cacheFirst) async throws -> PrivacyProSubscription {
 
-        case .returnCacheDataElseLoad:
+        guard let accessToken else {
+            if let subscription = getCachedSubscription() {
+                return subscription
+            } else {
+                throw SubscriptionEndpointServiceError.noData
+            }
+        }
+
+        switch cachePolicy {
+        case .remoteFirst:
+            do {
+                let subscription = try await getRemoteSubscription(accessToken: accessToken)
+                return subscription
+            } catch {
+                return try await getSubscription(accessToken: accessToken, cachePolicy: .cacheOnly)
+            }
+
+        case .cacheFirst:
             if let cachedSubscription = getCachedSubscription() {
                 return cachedSubscription
             } else {
                 return try await getRemoteSubscription(accessToken: accessToken)
             }
 
-        case .returnCacheDataDontLoad:
+        case .cacheOnly:
             if let cachedSubscription = getCachedSubscription() {
                 return cachedSubscription
             } else {

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlowV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlowV2.swift
@@ -179,7 +179,7 @@ public final class DefaultAppStorePurchaseFlowV2: AppStorePurchaseFlowV2 {
 
     private func getExpiredSubscriptionID() async -> String? {
         do {
-            let subscription = try await subscriptionManager.getSubscription(cachePolicy: .reloadIgnoringLocalCacheData)
+            let subscription = try await subscriptionManager.getSubscription(cachePolicy: .remoteFirst)
             // Only return an externalID if the subscription is expired so to prevent creating multiple subscriptions in the same account
             if !subscription.isActive,
                subscription.platform != .apple {

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Flows/Stripe/StripePurchaseFlowV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Flows/Stripe/StripePurchaseFlowV2.swift
@@ -99,7 +99,7 @@ public final class DefaultStripePurchaseFlowV2: StripePurchaseFlowV2 {
     }
 
     private func isSubscriptionExpired() async -> Bool? {
-        guard let subscription = try? await subscriptionManager.getSubscription(cachePolicy: .reloadIgnoringLocalCacheData) else {
+        guard let subscription = try? await subscriptionManager.getSubscription(cachePolicy: .remoteFirst) else {
             return nil
         }
         return !subscription.isActive

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
@@ -265,7 +265,7 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
     public func loadInitialData() async {
         Logger.subscription.log("Loading initial data...")
         do {
-            let subscription = try await getSubscription(cachePolicy: .reloadIgnoringLocalCacheData)
+            let subscription = try await getSubscription(cachePolicy: .remoteFirst)
             Logger.subscription.log("Subscription is \(subscription.isActive ? "active" : "not active", privacy: .public)")
         } catch SubscriptionEndpointServiceError.noData {
             Logger.subscription.log("No Subscription available")
@@ -281,24 +281,9 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
             throw SubscriptionEndpointServiceError.noData
         }
 
-        var subscription: PrivacyProSubscription
-        // NOTE: This is ugly, the subscription cache will be moved from the endpoint service to here and handled properly https://app.asana.com/0/0/1209015691872191
-        switch cachePolicy {
-        case .reloadIgnoringLocalCacheData:
-            let tokenContainer = try await getTokenContainer(policy: .localValid)
-            subscription = try await subscriptionEndpointService.getSubscription(accessToken: tokenContainer.accessToken,
+        let tokenContainer = try? await getTokenContainer(policy: .localValid)
+        let subscription = try await subscriptionEndpointService.getSubscription(accessToken: tokenContainer?.accessToken,
                                                                                  cachePolicy: cachePolicy)
-        case .returnCacheDataElseLoad:
-            if let tokenContainer = try? await getTokenContainer(policy: .localValid) {
-                subscription = try await subscriptionEndpointService.getSubscription(accessToken: tokenContainer.accessToken,
-                                                                                     cachePolicy: .returnCacheDataElseLoad)
-            } else {
-                subscription = try await getSubscription(cachePolicy: .returnCacheDataDontLoad)
-            }
-        case .returnCacheDataDontLoad:
-            subscription = try await subscriptionEndpointService.getSubscription(accessToken: "",
-                                                                                 cachePolicy: .returnCacheDataDontLoad)
-        }
 
         if subscription.isActive {
             pixelHandler.handle(pixelType: .subscriptionIsActive)
@@ -313,7 +298,7 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
     public func getSubscriptionFrom(lastTransactionJWSRepresentation: String) async throws -> PrivacyProSubscription? {
         do {
             let tokenContainer = try await oAuthClient.activate(withPlatformSignature: lastTransactionJWSRepresentation)
-            return try await subscriptionEndpointService.getSubscription(accessToken: tokenContainer.accessToken, cachePolicy: .reloadIgnoringLocalCacheData)
+            return try await subscriptionEndpointService.getSubscription(accessToken: tokenContainer.accessToken, cachePolicy: .remoteFirst)
         } catch SubscriptionEndpointServiceError.noData {
             return nil
         } catch {
@@ -543,11 +528,11 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
         var availableFeatures: [SubscriptionEntitlement]
         if forceRefresh {
             let tokenContainer = try await getTokenContainer(policy: .localForceRefresh) // Refresh entitlements if requested
-            let currentSubscription = try await getSubscription(cachePolicy: .reloadIgnoringLocalCacheData)
+            let currentSubscription = try await getSubscription(cachePolicy: .remoteFirst)
             userEntitlements = tokenContainer.decodedAccessToken.subscriptionEntitlements // What the user has access to
             availableFeatures = currentSubscription.features ?? [] // what the subscription is capable to provide
         } else {
-            let currentSubscription = try? await getSubscription(cachePolicy: .returnCacheDataElseLoad)
+            let currentSubscription = try? await getSubscription(cachePolicy: .cacheFirst)
             let tokenContainer = try? await getTokenContainer(policy: .local)
             userEntitlements = tokenContainer?.decodedAccessToken.subscriptionEntitlements ?? []
             availableFeatures = currentSubscription?.features ?? []

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
@@ -278,24 +278,40 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
     @discardableResult
     public func getSubscription(cachePolicy: SubscriptionCachePolicy) async throws -> PrivacyProSubscription {
 
+        // NOTE: This is ugly, the subscription cache will be moved from the endpoint service to here and handled properly https://app.asana.com/0/0/1209015691872191
+
         guard isUserAuthenticated else {
             throw SubscriptionEndpointServiceError.noData
         }
 
-        var tokenContainer: TokenContainer
-        do {
-            tokenContainer = try await getTokenContainer(policy: .localValid)
-        } catch SubscriptionManagerError.noTokenAvailable {
-            throw SubscriptionEndpointServiceError.noData
-        } catch {
-            if let subscription = subscriptionEndpointService.getCachedSubscription() {
-                return subscription
-            } else {
-                throw SubscriptionEndpointServiceError.noData
+        var subscription: PrivacyProSubscription
+
+        switch cachePolicy {
+
+        case .remoteFirst, .cacheFirst:
+
+            if cachePolicy == .cacheFirst {
+                // We skip ahead and try to get the cached subscription, useful with slow/no connections where we don't want to wait for a get token timeout
+                do {
+                    subscription = try await subscriptionEndpointService.getSubscription(accessToken: nil, cachePolicy: cachePolicy)
+                    break
+                } catch {}
             }
+
+            var tokenContainer: TokenContainer
+            do {
+                tokenContainer = try await getTokenContainer(policy: .localValid)
+            } catch SubscriptionManagerError.noTokenAvailable {
+                throw SubscriptionEndpointServiceError.noData
+            } catch {
+                // Failed to get a valid token, fall back on cache
+                subscription = try await subscriptionEndpointService.getSubscription(accessToken: nil, cachePolicy: .cacheOnly)
+                break
+            }
+            subscription = try await subscriptionEndpointService.getSubscription(accessToken: tokenContainer.accessToken, cachePolicy: cachePolicy)
+        case .cacheOnly:
+            subscription = try await subscriptionEndpointService.getSubscription(accessToken: nil, cachePolicy: cachePolicy)
         }
-        let subscription = try await subscriptionEndpointService.getSubscription(accessToken: tokenContainer.accessToken,
-                                                                                 cachePolicy: cachePolicy)
 
         if subscription.isActive {
             pixelHandler.handle(pixelType: .subscriptionIsActive)

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
@@ -277,12 +277,24 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
 
     @discardableResult
     public func getSubscription(cachePolicy: SubscriptionCachePolicy) async throws -> PrivacyProSubscription {
+
         guard isUserAuthenticated else {
             throw SubscriptionEndpointServiceError.noData
         }
 
-        let tokenContainer = try? await getTokenContainer(policy: .localValid)
-        let subscription = try await subscriptionEndpointService.getSubscription(accessToken: tokenContainer?.accessToken,
+        var tokenContainer: TokenContainer
+        do {
+            tokenContainer = try await getTokenContainer(policy: .localValid)
+        } catch SubscriptionManagerError.noTokenAvailable {
+            throw SubscriptionEndpointServiceError.noData
+        } catch {
+            if let subscription = subscriptionEndpointService.getCachedSubscription() {
+                return subscription
+            } else {
+                throw SubscriptionEndpointServiceError.noData
+            }
+        }
+        let subscription = try await subscriptionEndpointService.getSubscription(accessToken: tokenContainer.accessToken,
                                                                                  cachePolicy: cachePolicy)
 
         if subscription.isActive {

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
@@ -48,7 +48,7 @@ final class SubscriptionUserScriptHandler: SubscriptionUserScriptHandling {
     }
 
     func subscriptionDetails(params: Any, message: any UserScriptMessage) async throws -> DataModel.SubscriptionDetails {
-        guard let subscription = try? await subscriptionManager.getSubscription(cachePolicy: .returnCacheDataElseLoad) else {
+        guard let subscription = try? await subscriptionManager.getSubscription(cachePolicy: .cacheFirst) else {
             return .notSubscribed
         }
         return .init(subscription)

--- a/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/APIs/SubscriptionEndpointServiceMockV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/APIs/SubscriptionEndpointServiceMockV2.swift
@@ -45,9 +45,9 @@ public final class SubscriptionEndpointServiceMockV2: SubscriptionEndpointServic
     }
 
     public var getSubscriptionCalled: Bool = false
-    public var onGetSubscription: ((String, SubscriptionCachePolicy) -> Void)?
+    public var onGetSubscription: ((String?, SubscriptionCachePolicy) -> Void)?
     public var getSubscriptionResult: Result<PrivacyProSubscription, SubscriptionEndpointServiceError>?
-    public func getSubscription(accessToken: String, cachePolicy: Subscription.SubscriptionCachePolicy) async throws -> Subscription.PrivacyProSubscription {
+    public func getSubscription(accessToken: String?, cachePolicy: Subscription.SubscriptionCachePolicy) async throws -> Subscription.PrivacyProSubscription {
         getSubscriptionCalled = true
         onGetSubscription?(accessToken, cachePolicy)
         switch getSubscriptionResult! {

--- a/SharedPackages/BrowserServicesKit/Tests/CrashesTests/CrashLogMessageExtractorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/CrashesTests/CrashLogMessageExtractorTests.swift
@@ -77,7 +77,8 @@ final class CrashLogMessageExtractorTests: XCTestCase {
 
     func testCrashDiagnosticWritingAndReading() throws {
         let fm = FileManager.default
-        let date = formatter.string(from: Date())
+        let referenceDate = Date()
+        let date = formatter.string(from: referenceDate)
         let fileName = "\(date)-\(ProcessInfo().processIdentifier).log"
         let dir = fm.temporaryDirectory
         let url = dir.appendingPathComponent(fileName)
@@ -92,7 +93,7 @@ final class CrashLogMessageExtractorTests: XCTestCase {
 
         try extractor.writeDiagnostic(for: exception)
 
-        guard let diag = extractor.crashDiagnostic(for: Date(), pid: ProcessInfo().processIdentifier) else {
+        guard let diag = extractor.crashDiagnostic(for: referenceDate, pid: ProcessInfo().processIdentifier) else {
             XCTFail("could not find crash diagnostic")
             return
         }

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/API/SubscriptionEndpointServiceV2Tests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/API/SubscriptionEndpointServiceV2Tests.swift
@@ -53,7 +53,7 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func createSubscriptionResponseData() -> Data {
+    private func createSubscriptionResponseData() throws -> Data {
         let date = Date(timeIntervalSince1970: 123456789)
         let subscription = PrivacyProSubscription(
             productId: "prod123",
@@ -65,7 +65,7 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
             status: .autoRenewable,
             activeOffers: []
         )
-        return try! encoder.encode(subscription)
+        return try encoder.encode(subscription)
     }
 
     private func createAPIResponse(statusCode: Int, data: Data?) -> APIResponseV2 {
@@ -100,7 +100,7 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
 
     func testGetSubscriptionFetchesRemoteSubscriptionWhenNoCache() async throws {
         // mock subscription response
-        let subscriptionData = createSubscriptionResponseData()
+        let subscriptionData = try createSubscriptionResponseData()
         let apiResponse = createAPIResponse(statusCode: 200, data: subscriptionData)
         let request = SubscriptionRequest.getSubscription(baseURL: baseURL, accessToken: "token")!.apiRequest
 

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/API/SubscriptionEndpointServiceV2Tests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/API/SubscriptionEndpointServiceV2Tests.swift
@@ -94,7 +94,7 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
         )
         endpointService.updateCache(with: cachedSubscription)
 
-        let subscription = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .returnCacheDataDontLoad)
+        let subscription = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .cacheOnly)
         XCTAssertEqual(subscription, cachedSubscription)
     }
 
@@ -109,7 +109,7 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
 
         apiService.set(response: apiResponse, forRequest: request)
 
-        let subscription = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .returnCacheDataElseLoad)
+        let subscription = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .cacheFirst)
         XCTAssertEqual(subscription.productId, "prod123")
         XCTAssertEqual(subscription.name, "Pro Plan")
         XCTAssertEqual(subscription.billingPeriod, .yearly)
@@ -119,7 +119,7 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
 
     func testGetSubscriptionThrowsNoDataWhenNoCacheAndFetchFails() async {
         do {
-            _ = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .returnCacheDataDontLoad)
+            _ = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .cacheOnly)
             XCTFail("Expected noData error")
         } catch SubscriptionEndpointServiceError.noData {
             // Success
@@ -229,7 +229,7 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
         )
         endpointService.updateCache(with: subscription)
 
-        let cachedSubscription = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .returnCacheDataDontLoad)
+        let cachedSubscription = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .cacheOnly)
         XCTAssertEqual(cachedSubscription, subscription)
     }
 
@@ -249,7 +249,7 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
 
         endpointService.clearSubscription()
         do {
-            _ = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .returnCacheDataDontLoad)
+            _ = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .cacheOnly)
         } catch SubscriptionEndpointServiceError.noData {
             // Success
         } catch {

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests+CustomURL.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests+CustomURL.swift
@@ -31,7 +31,7 @@ extension SubscriptionManagerV2Tests {
         let subscriptionEnvironment = SubscriptionEnvironment(serviceEnvironment: .production,
                                                               purchasePlatform: .appStore,
                                                               customBaseSubscriptionURL: customBaseSubscriptionURL)
-        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.\(#function)")!
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.subscriptionUnitTests.\(UUID().uuidString)")!
         let subscriptionManager = DefaultSubscriptionManagerV2(
             storePurchaseManager: mockStorePurchaseManager,
             oAuthClient: mockOAuthClient,
@@ -81,7 +81,7 @@ extension SubscriptionManagerV2Tests {
 
         let subscriptionEnvironment = SubscriptionEnvironment(serviceEnvironment: .production,
                                                               purchasePlatform: .appStore)
-        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.\(#function)")!
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.subscriptionUnitTests.\(UUID().uuidString)")!
         let subscriptionManager = DefaultSubscriptionManagerV2(
             storePurchaseManager: mockStorePurchaseManager,
             oAuthClient: mockOAuthClient,

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests+Redirect.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests+Redirect.swift
@@ -52,7 +52,7 @@ extension SubscriptionManagerV2Tests {
         let redirectURLComponents = try XCTUnwrap(URLComponents(string: "https://www.duckduckgo.com/pro?origin=test"))
 
         let stagingEnvironment = SubscriptionEnvironment(serviceEnvironment: .staging, purchasePlatform: .appStore)
-        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.\(#function)")!
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.subscriptionUnitTests.\(UUID().uuidString)")!
         let stagingSubscriptionManager = DefaultSubscriptionManagerV2(
             storePurchaseManager: mockStorePurchaseManager,
             oAuthClient: mockOAuthClient,

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests.swift
@@ -43,7 +43,7 @@ class SubscriptionManagerV2Tests: XCTestCase {
         mockSubscriptionEndpointService = SubscriptionEndpointServiceMockV2()
         mockStorePurchaseManager = StorePurchaseManagerMockV2()
         mockAppStoreRestoreFlowV2 = AppStoreRestoreFlowMockV2()
-        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.SubscriptionManagerV2Tests")!
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.subscriptionUnitTests.\(UUID().uuidString)")!
         subscriptionManager = DefaultSubscriptionManagerV2(
             storePurchaseManager: mockStorePurchaseManager,
             oAuthClient: mockOAuthClient,
@@ -81,22 +81,23 @@ class SubscriptionManagerV2Tests: XCTestCase {
 
     // MARK: - Subscription Status Tests
 
-    func testRefreshCachedSubscription_ActiveSubscription() async {
+    func testRefreshCachedSubscription_ActiveSubscription() async throws {
         let activeSubscription = PrivacyProSubscription(
             productId: "testProduct",
             name: "Test Subscription",
             billingPeriod: .monthly,
-            startedAt: Date(),
-            expiresOrRenewsAt: Date().addingTimeInterval(30 * 24 * 60 * 60), // 30 days from now
+            startedAt: Date().addingTimeInterval(.minutes(-5)),
+            expiresOrRenewsAt: Date().addingTimeInterval(.days(30)),
             platform: .stripe,
             status: .autoRenewable,
             activeOffers: []
         )
         mockSubscriptionEndpointService.getSubscriptionResult = .success(activeSubscription)
-        mockOAuthClient.getTokensResponse = .success(OAuthTokensFactory.makeValidTokenContainer())
-        mockOAuthClient.isUserAuthenticated = true
+        let tokenContainer = OAuthTokensFactory.makeValidTokenContainer()
+        mockOAuthClient.getTokensResponse = .success(tokenContainer)
+        mockOAuthClient.internalCurrentTokenContainer = tokenContainer
 
-        let subscription = try! await subscriptionManager.getSubscription(cachePolicy: .remoteFirst)
+        let subscription = try await subscriptionManager.getSubscription(cachePolicy: .remoteFirst)
         XCTAssertTrue(subscription.isActive)
     }
 
@@ -123,8 +124,10 @@ class SubscriptionManagerV2Tests: XCTestCase {
     // MARK: - URL Generation Tests
 
     func testURLGeneration_ForCustomerPortal() async throws {
-        mockOAuthClient.isUserAuthenticated = true
-        mockOAuthClient.getTokensResponse = .success(OAuthTokensFactory.makeValidTokenContainer())
+
+        let tokenContainer = OAuthTokensFactory.makeValidTokenContainer()
+        mockOAuthClient.internalCurrentTokenContainer = tokenContainer
+        mockOAuthClient.getTokensResponse = .success(tokenContainer)
         let customerPortalURLString = "https://example.com/customer-portal"
         mockSubscriptionEndpointService.getCustomerPortalURLResult = .success(GetCustomerPortalURLResponse(customerPortalUrl: customerPortalURLString))
 
@@ -134,7 +137,7 @@ class SubscriptionManagerV2Tests: XCTestCase {
 
     func testURLGeneration_ForSubscriptionTypes() {
         let environment = SubscriptionEnvironment(serviceEnvironment: .production, purchasePlatform: .appStore)
-        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.\(#function)")!
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.subscriptionUnitTests.\(UUID().uuidString)")!
         subscriptionManager = DefaultSubscriptionManagerV2(
             storePurchaseManager: mockStorePurchaseManager,
             oAuthClient: mockOAuthClient,
@@ -193,7 +196,7 @@ class SubscriptionManagerV2Tests: XCTestCase {
     func testForProductionURL() throws {
         // Given
         let productionEnvironment = SubscriptionEnvironment(serviceEnvironment: .production, purchasePlatform: .appStore)
-        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.\(#function)")!
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.subscriptionUnitTests.\(UUID().uuidString)")!
         let productionSubscriptionManager = DefaultSubscriptionManagerV2(
             storePurchaseManager: mockStorePurchaseManager,
             oAuthClient: mockOAuthClient,
@@ -213,7 +216,7 @@ class SubscriptionManagerV2Tests: XCTestCase {
     func testForStagingURL() throws {
         // Given
         let stagingEnvironment = SubscriptionEnvironment(serviceEnvironment: .staging, purchasePlatform: .appStore)
-        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.\(#function)")!
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.subscriptionUnitTests.\(UUID().uuidString)")!
         let stagingSubscriptionManager = DefaultSubscriptionManagerV2(
             storePurchaseManager: mockStorePurchaseManager,
             oAuthClient: mockOAuthClient,
@@ -285,7 +288,7 @@ class SubscriptionManagerV2Tests: XCTestCase {
         // Given
         mockStorePurchaseManager.isEligibleForFreeTrialResult = true
         let stripeEnvironment = SubscriptionEnvironment(serviceEnvironment: .production, purchasePlatform: .stripe)
-        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.\(#function)")!
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.subscriptionUnitTests.\(UUID().uuidString)")!
         let sut = DefaultSubscriptionManagerV2(
             storePurchaseManager: mockStorePurchaseManager,
             oAuthClient: mockOAuthClient,
@@ -306,7 +309,7 @@ class SubscriptionManagerV2Tests: XCTestCase {
         // Given
         mockStorePurchaseManager.isEligibleForFreeTrialResult = true
         let appStoreEnvironment = SubscriptionEnvironment(serviceEnvironment: .production, purchasePlatform: .appStore)
-        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.\(#function)")!
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.subscriptionUnitTests.\(UUID().uuidString)")!
         let sut = DefaultSubscriptionManagerV2(
             storePurchaseManager: mockStorePurchaseManager,
             oAuthClient: mockOAuthClient,
@@ -327,7 +330,7 @@ class SubscriptionManagerV2Tests: XCTestCase {
         // Given
         mockStorePurchaseManager.isEligibleForFreeTrialResult = false
         let appStoreEnvironment = SubscriptionEnvironment(serviceEnvironment: .production, purchasePlatform: .appStore)
-        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.\(#function)")!
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.subscriptionUnitTests.\(UUID().uuidString)")!
         let sut = DefaultSubscriptionManagerV2(
             storePurchaseManager: mockStorePurchaseManager,
             oAuthClient: mockOAuthClient,

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerV2Tests.swift
@@ -96,7 +96,7 @@ class SubscriptionManagerV2Tests: XCTestCase {
         mockOAuthClient.getTokensResponse = .success(OAuthTokensFactory.makeValidTokenContainer())
         mockOAuthClient.isUserAuthenticated = true
 
-        let subscription = try! await subscriptionManager.getSubscription(cachePolicy: .reloadIgnoringLocalCacheData)
+        let subscription = try! await subscriptionManager.getSubscription(cachePolicy: .remoteFirst)
         XCTAssertTrue(subscription.isActive)
     }
 
@@ -114,7 +114,7 @@ class SubscriptionManagerV2Tests: XCTestCase {
         mockSubscriptionEndpointService.getSubscriptionResult = .success(expiredSubscription)
         mockOAuthClient.getTokensResponse = .success(OAuthTokensFactory.makeValidTokenContainer())
         do {
-            try await subscriptionManager.getSubscription(cachePolicy: .reloadIgnoringLocalCacheData)
+            try await subscriptionManager.getSubscription(cachePolicy: .remoteFirst)
         } catch {
             XCTAssertEqual(error.localizedDescription, SubscriptionEndpointServiceError.noData.localizedDescription)
         }

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/PrivacyProSubscriptionV2IntegrationTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/PrivacyProSubscriptionV2IntegrationTests.swift
@@ -55,7 +55,7 @@ final class PrivacyProSubscriptionV2IntegrationTests: XCTestCase {
         let subscriptionEndpointService = DefaultSubscriptionEndpointServiceV2(apiService: apiService,
                                                                                baseURL: subscriptionEnvironment.serviceEnvironment.url)
         subscriptionFeatureFlagger = FeatureFlaggerMapping<SubscriptionFeatureFlags>(mapping: { $0.defaultState })
-        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.PrivacyProSubscriptionV2IntegrationTests")!
+        let userDefaults = UserDefaults(suiteName: "com.duckduckgo.subscriptionUnitTests.\(UUID().uuidString)")!
         subscriptionManager = DefaultSubscriptionManagerV2(storePurchaseManager: storePurchaseManager,
                                                            oAuthClient: authClient,
                                                            userDefaults: userDefaults,

--- a/iOS/DuckDuckGo/RemoteMessagingConfigMatcherProvider.swift
+++ b/iOS/DuckDuckGo/RemoteMessagingConfigMatcherProvider.swift
@@ -89,7 +89,7 @@ final class RemoteMessagingConfigMatcherProvider: RemoteMessagingConfigMatcherPr
         
         let surveyActionMapper: DefaultRemoteMessagingSurveyURLBuilder
 
-        if let subscription = try? await subscriptionManager.getSubscription(cachePolicy: .returnCacheDataElseLoad) {
+        if let subscription = try? await subscriptionManager.getSubscription(cachePolicy: .cacheFirst) {
             privacyProDaysSinceSubscribed = Calendar.current.numberOfDaysBetween(subscription.startedAt, and: Date()) ?? -1
             privacyProDaysUntilExpiry = Calendar.current.numberOfDaysBetween(Date(), and: subscription.expiresOrRenewsAt) ?? -1
             privacyProPurchasePlatform = subscription.platform.rawValue

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -1022,7 +1022,7 @@ extension SettingsViewModel {
         }
         
         do {
-            let subscription = try await subscriptionAuthV1toV2Bridge.getSubscription(cachePolicy: .returnCacheDataElseLoad)
+            let subscription = try await subscriptionAuthV1toV2Bridge.getSubscription(cachePolicy: .cacheFirst)
             state.subscription.platform = subscription.platform
             state.subscription.hasSubscription = true
             state.subscription.hasActiveSubscription = subscription.isActive

--- a/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModelV2.swift
+++ b/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModelV2.swift
@@ -92,14 +92,14 @@ final class SubscriptionSettingsViewModelV2: ObservableObject {
     func onFirstAppear() {
         Task {
             // Load initial state from the cache
-            async let loadedEmailFromCache = await self.fetchAndUpdateAccountEmail(cachePolicy: .returnCacheDataDontLoad)
-            async let loadedSubscriptionFromCache = await self.fetchAndUpdateSubscriptionDetails(cachePolicy: .returnCacheDataDontLoad,
+            async let loadedEmailFromCache = await self.fetchAndUpdateAccountEmail(cachePolicy: .cacheOnly)
+            async let loadedSubscriptionFromCache = await self.fetchAndUpdateSubscriptionDetails(cachePolicy: .cacheOnly,
                                                                                                  loadingIndicator: false)
             let (hasLoadedEmailFromCache, hasLoadedSubscriptionFromCache) = await (loadedEmailFromCache, loadedSubscriptionFromCache)
 
             // Reload remote subscription and email state
-            async let reloadedEmail = await self.fetchAndUpdateAccountEmail(cachePolicy: .reloadIgnoringLocalCacheData)
-            async let reloadedSubscription = await self.fetchAndUpdateSubscriptionDetails(cachePolicy: .reloadIgnoringLocalCacheData,
+            async let reloadedEmail = await self.fetchAndUpdateAccountEmail(cachePolicy: .remoteFirst)
+            async let reloadedSubscription = await self.fetchAndUpdateSubscriptionDetails(cachePolicy: .remoteFirst,
                                                                                           loadingIndicator: !hasLoadedSubscriptionFromCache)
             let (hasReloadedEmail, hasReloadedSubscription) = await (reloadedEmail, reloadedSubscription)
         }
@@ -131,17 +131,17 @@ final class SubscriptionSettingsViewModelV2: ObservableObject {
         }
     }
 
-    func fetchAndUpdateAccountEmail(cachePolicy: SubscriptionCachePolicy = .returnCacheDataElseLoad) async -> Bool {
+    func fetchAndUpdateAccountEmail(cachePolicy: SubscriptionCachePolicy = .cacheFirst) async -> Bool {
         Logger.subscription.log("Fetch and update account email")
         guard subscriptionManager.isUserAuthenticated else { return false }
 
         var tokensPolicy: AuthTokensCachePolicy = .local
         switch cachePolicy {
-        case .reloadIgnoringLocalCacheData:
+        case .remoteFirst:
             tokensPolicy = .localForceRefresh
-        case .returnCacheDataElseLoad:
+        case .cacheFirst:
             tokensPolicy = .localValid
-        case .returnCacheDataDontLoad:
+        case .cacheOnly:
             tokensPolicy = .local
         }
 

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
@@ -490,7 +490,7 @@ struct SubscriptionSettingsViewV2: View {
                     emailFlow: .manageEmailFlow,
                     onDisappear: {
                         Task {
-                            await viewModel.fetchAndUpdateAccountEmail(cachePolicy: .reloadIgnoringLocalCacheData)
+                            await viewModel.fetchAndUpdateAccountEmail(cachePolicy: .remoteFirst)
                         }
                     }),
                                isActive: $isShowingManageEmailView) {
@@ -507,7 +507,7 @@ struct SubscriptionSettingsViewV2: View {
                 emailFlow: .activationFlow,
                 onDisappear: {
                     Task {
-                        await viewModel.fetchAndUpdateAccountEmail(cachePolicy: .reloadIgnoringLocalCacheData)
+                        await viewModel.fetchAndUpdateAccountEmail(cachePolicy: .remoteFirst)
                     }
                 }),
                            isActive: $isShowingActivationView) {

--- a/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
+++ b/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
@@ -574,7 +574,7 @@ final class SubscriptionDebugViewController: UITableViewController {
     private func getSubscriptionDetailsV2() {
         Task {
             do {
-                let subscription = try await subscriptionManagerV2.getSubscription(cachePolicy: .reloadIgnoringLocalCacheData)
+                let subscription = try await subscriptionManagerV2.getSubscription(cachePolicy: .remoteFirst)
                 showAlert(title: "Subscription info", message: subscription.debugDescription)
             } catch {
                 showAlert(title: "Subscription info", message: "\(error)")

--- a/macOS/DuckDuckGo/RemoteMessaging/RemoteMessagingConfigMatcherProvider.swift
+++ b/macOS/DuckDuckGo/RemoteMessaging/RemoteMessagingConfigMatcherProvider.swift
@@ -122,7 +122,7 @@ final class RemoteMessagingConfigMatcherProvider: RemoteMessagingConfigMatcherPr
         let statisticsStore = self.statisticsStore()
 
         do {
-            let subscription = try await subscriptionManager.getSubscription(cachePolicy: .returnCacheDataElseLoad)
+            let subscription = try await subscriptionManager.getSubscription(cachePolicy: .cacheFirst)
             privacyProDaysSinceSubscribed = Calendar.current.numberOfDaysBetween(subscription.startedAt, and: Date()) ?? -1
             privacyProDaysUntilExpiry = Calendar.current.numberOfDaysBetween(Date(), and: subscription.expiresOrRenewsAt) ?? -1
             privacyProPurchasePlatform = subscription.platform.rawValue

--- a/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeatureV2.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeatureV2.swift
@@ -170,7 +170,7 @@ final class SubscriptionPagesUseSubscriptionFeatureV2: Subfeature {
 
         do {
             try await subscriptionManager.adopt(accessToken: subscriptionValues.accessToken, refreshToken: subscriptionValues.refreshToken)
-            try await subscriptionManager.getSubscription(cachePolicy: .reloadIgnoringLocalCacheData)
+            try await subscriptionManager.getSubscription(cachePolicy: .remoteFirst)
             Logger.subscription.log("Subscription retrieved")
         } catch {
             Logger.subscription.error("Failed to adopt V2 tokens: \(error, privacy: .public)")

--- a/macOS/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/DebugMenu/SubscriptionDebugMenu.swift
+++ b/macOS/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/DebugMenu/SubscriptionDebugMenu.swift
@@ -373,7 +373,7 @@ public final class SubscriptionDebugMenu: NSMenuItem {
     func getSubscriptionDetailsV2() {
         Task {
             do {
-                let subscription = try await subscriptionManagerV2.getSubscription(cachePolicy: .reloadIgnoringLocalCacheData)
+                let subscription = try await subscriptionManagerV2.getSubscription(cachePolicy: .remoteFirst)
                 showAlert(title: "Subscription info", message: subscription.debugDescription)
             } catch {
                 showAlert(title: "Subscription info", message: "\(error)")

--- a/macOS/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/Preferences/PreferencesSubscriptionSettingsModelV2.swift
+++ b/macOS/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/Preferences/PreferencesSubscriptionSettingsModelV2.swift
@@ -66,7 +66,7 @@ public final class PreferencesSubscriptionSettingsModelV2: ObservableObject {
         self.userEventHandler = userEventHandler
 
         Task {
-            await self.updateSubscription(cachePolicy: .returnCacheDataElseLoad)
+            await self.updateSubscription(cachePolicy: .cacheFirst)
         }
 
         self.email = subscriptionManager.userEmail
@@ -80,7 +80,7 @@ public final class PreferencesSubscriptionSettingsModelV2: ObservableObject {
                 }
 
                 await self?.fetchEmail()
-                await self?.updateSubscription(cachePolicy: .returnCacheDataDontLoad)
+                await self?.updateSubscription(cachePolicy: .cacheOnly)
             }
         }
 
@@ -269,7 +269,7 @@ hasAnyEntitlement: \(hasAnyEntitlement)
             }
 
             await self?.fetchEmail()
-            await self?.updateSubscription(cachePolicy: .reloadIgnoringLocalCacheData)
+            await self?.updateSubscription(cachePolicy: .remoteFirst)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200019156869587/task/1209608044788440?focus=true

### Description

**iOS and macOS**
These changes fix the issue where the subscription can become unavailable when the device is offline.

### How to reproduce

1. kill the app
2. Enable "Network Link Conditioner" to 100% loss
3. open settings
4. No subscription is available, this could be ok
5. go online (disable "Network Link Conditioner")
6. subscription is never available, the app needs to be killed.

### Testing Steps

1. kill the app
2. Enable "Network Link Conditioner" to 100% loss
3. open settings
4. No subscription is available, this could be ok
5. go online (disable "Network Link Conditioner")
6. subscription must be visible

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)