### PR TITLE
Show logo on new switch omnibar

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -26,6 +26,7 @@ import Persistence
 import History
 import Core
 import Suggestions
+import SwiftUI
 
 struct SuggestionTrayDependencies {
     let favoritesViewModel: FavoritesListInteracting
@@ -46,6 +47,12 @@ protocol OmniBarEditingStateViewControllerDelegate: AnyObject {
 
 /// Later: Inject auto suggestions here.
 final class OmniBarEditingStateViewController: UIViewController {
+
+    private enum ViewVisibility {
+        case visible
+        case hidden
+    }
+
     var textAreaView: UIView {
         switchBarVC.textEntryViewController.textEntryView
     }
@@ -54,6 +61,7 @@ final class OmniBarEditingStateViewController: UIViewController {
     private lazy var switchBarVC = SwitchBarViewController(switchBarHandler: switchBarHandler)
     weak var delegate: OmniBarEditingStateViewControllerDelegate?
     private var suggestionTrayViewController: SuggestionTrayViewController?
+    private var daxLogoHostingController: UIHostingController<NewTabPageDaxLogoView>?
     var expectedStartFrame: CGRect?
     var suggestionTrayDependencies: SuggestionTrayDependencies?
     lazy var isTopBarPosition = AppDependencyProvider.shared.appSettings.currentAddressBarPosition == .top
@@ -73,6 +81,7 @@ final class OmniBarEditingStateViewController: UIViewController {
 
         installSwitchBarVC()
         installSuggestionsTray()
+        installDaxLogoView()
 
         self.view.backgroundColor = .clear
     }
@@ -165,7 +174,9 @@ final class OmniBarEditingStateViewController: UIViewController {
 
     @objc private func dismissButtonTapped(_ sender: UIButton) {
         switchBarVC.unfocusTextField()
-        hideSuggestionTray()
+        setSuggestionTrayVisibility(.hidden)
+        setLogoVisibility(.hidden)
+
         dismissAnimated()
     }
 
@@ -279,7 +290,8 @@ final class OmniBarEditingStateViewController: UIViewController {
                         self.showSuggestionTray(.autocomplete(query: self.switchBarHandler.currentText))
                     }
                 case .aiChat:
-                    self.hideSuggestionTray()
+                    self.setSuggestionTrayVisibility(.hidden)
+                    self.setLogoVisibility(.visible)
                 }
             }
             .store(in: &cancellables)
@@ -302,6 +314,26 @@ final class OmniBarEditingStateViewController: UIViewController {
 
     func selectAllText() {
         switchBarVC.textEntryViewController.selectAllText()
+    }
+
+    private func installDaxLogoView() {
+        let daxLogoView = NewTabPageDaxLogoView()
+        let hostingController = UIHostingController(rootView: daxLogoView)
+        daxLogoHostingController = hostingController
+        
+        hostingController.view.backgroundColor = .clear
+        addChild(hostingController)
+        view.addSubview(hostingController.view)
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            hostingController.view.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            hostingController.view.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: 18),
+        ])
+        
+        hostingController.didMove(toParent: self)
+        
+        view.sendSubviewToBack(hostingController.view)
     }
 }
 
@@ -350,12 +382,22 @@ extension OmniBarEditingStateViewController {
     private func showSuggestionTray(_ type: SuggestionTrayViewController.SuggestionType) {
         guard switchBarHandler.currentToggleState == .search else { return }
 
-        suggestionTrayViewController?.show(for: type)
-        suggestionTrayViewController?.view.isHidden = false
+        let canShowSuggestion = suggestionTrayViewController?.canShow(for: type) == true
+        suggestionTrayViewController?.view.isHidden = !canShowSuggestion
+        daxLogoHostingController?.view.isHidden = canShowSuggestion
+
+        if canShowSuggestion {
+            suggestionTrayViewController?.show(for: type)
+        }
     }
 
-    private func hideSuggestionTray() {
-        suggestionTrayViewController?.view.isHidden = true
+
+    private func setSuggestionTrayVisibility(_ visibility: ViewVisibility) {
+        suggestionTrayViewController?.view.isHidden = visibility == .hidden
+    }
+
+    private func setLogoVisibility(_ visibility: ViewVisibility) {
+        daxLogoHostingController?.view.isHidden = visibility == .hidden
     }
 
     private func installSuggestionsTray() {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -325,10 +325,12 @@ final class OmniBarEditingStateViewController: UIViewController {
         addChild(hostingController)
         view.addSubview(hostingController.view)
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false
-        
+
+        /// Offset so the logo is displayed on the same height as the NTP logo
+        let logoOffset: CGFloat = 18
         NSLayoutConstraint.activate([
             hostingController.view.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            hostingController.view.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: 18),
+            hostingController.view.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: logoOffset),
         ])
         
         hostingController.didMove(toParent: self)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210503995054107?focus=true
Tech Design URL:
CC:

### Description
Show the dax logo

### Testing Steps
1. Enable the new UI (Settings -> Appearance -> Experimental)
2. Enable duck.ai experimental (Settings -> Duck.ai -> Experimental)
3. Without favorites, open the new omnibar, see if we display the dax logo on both search (when empty) and duck.ai mode
4. With favorites, open the new omnbiar, see if we display the dax logo only on duck.ai mode

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Show the logo at the wrong state, for example, above auto-complete results
