### PR TITLE
fix ai chat usage pixel

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -144,8 +144,8 @@ extension Pixel {
         case browsingMenuReportBrokenSite
         case browsingMenuFireproof
         case browsingMenuAutofill
-        case browsingMenuAIChat
-        case browsingMenuListAIChat
+        case browsingMenuAIChatNewTabPage
+        case browsingMenuAIChatWebPage
 
         case addressBarShare
         case addressBarSettings
@@ -2313,8 +2313,8 @@ extension Pixel.Event {
         case .openAIChatFromWidgetQuickAction: return "m_aichat-widget-quickaction"
         case .openAIChatFromWidgetControlCenter: return "m_aichat-widget-control-center"
         case .openAIChatFromWidgetLockScreenComplication: return "m_aichat-widget-lock-screen-complication"
-        case .browsingMenuAIChat: return "m_aichat_menu_tab_icon"
-        case .browsingMenuListAIChat: return "m_browsing_menu_list_aichat"
+        case .browsingMenuAIChatNewTabPage: return "m_aichat_menu_newtabpage"
+        case .browsingMenuAIChatWebPage: return "m_aichat_menu_webpage"
         case .openAIChatFromIconShortcut: return "m_aichat-icon-shortcut"
         case .openAIChatFromTabManager: return "m_aichat_tabmanager_icon"
         case .aiChatSettingsVoiceTurnedOff: return "m_aichat_settings_voice_turned_off"

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1930,7 +1930,6 @@ class MainViewController: UIViewController {
     }
 
     func openAIChat(_ query: String? = nil, autoSend: Bool = false, payload: Any? = nil) {
-        featureDiscovery.setWasUsedBefore(.aiChat)
         aiChatViewControllerManager.openAIChat(query, payload: payload, autoSend: autoSend, on: self)
     }
 }
@@ -2373,8 +2372,12 @@ extension MainViewController: OmniBarDelegate {
             openAIChat()
         }
 
-        Pixel.fire(pixel: .openAIChatFromAddressBar,
-                   withAdditionalParameters: featureDiscovery.addToParams([:], forFeature: .aiChat))
+        fireAIChatUsagePixelAndSetFeatureUsed(.openAIChatFromAddressBar)
+    }
+
+    private func fireAIChatUsagePixelAndSetFeatureUsed(_ pixel: Pixel.Event) {
+        Pixel.fire(pixel: pixel, withAdditionalParameters: featureDiscovery.addToParams([:], forFeature: .aiChat))
+        featureDiscovery.setWasUsedBefore(.aiChat)
     }
 
     func onAccessoryLongPressed(accessoryType: OmniBarAccessoryType) {
@@ -2686,7 +2689,7 @@ extension MainViewController: TabDelegate {
     }
 
     func tabDidRequestAIChat(tab: TabViewController) {
-        // Pixel fired at point where this is triggered to avoid over firing
+        fireAIChatUsagePixelAndSetFeatureUsed(tab.link == nil ? .browsingMenuAIChatNewTabPage : .browsingMenuAIChatWebPage)
         openAIChat()
     }
 
@@ -2921,8 +2924,7 @@ extension MainViewController: TabSwitcherDelegate {
     }
 
     func tabSwitcherDidRequestAIChat(tabSwitcher: TabSwitcherViewController) {
-        Pixel.fire(pixel: .openAIChatFromTabManager,
-                   withAdditionalParameters: featureDiscovery.addToParams([:], forFeature: .aiChat))
+        fireAIChatUsagePixelAndSetFeatureUsed(.openAIChatFromTabManager)
         self.aiChatViewControllerManager.openAIChat(on: tabSwitcher)
     }
 }

--- a/iOS/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerBrowsingMenuExtension.swift
@@ -143,8 +143,6 @@ extension TabViewController {
         .regular(name: UserText.actionOpenAIChat,
                  image: smallIcon ? DesignSystemImages.Glyphs.Size16.aiChat : DesignSystemImages.Glyphs.Size24.aiChat,
                  action: { [weak self] in
-            Pixel.fire(pixel: smallIcon ? .browsingMenuListAIChat : .browsingMenuAIChat,
-                       withAdditionalParameters: self?.featureDiscovery.addToParams([:], forFeature: .aiChat) ?? [:])
             self?.openAIChat()
         })
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1210592355928739?focus=true
Tech Design URL:
CC:

### Description
Fixes AI chat firing with regards to if AI chat had already been used.

Funnels all firing code for this feature through a single call which fires a different pixel depending on the source.

* Address bar -> `m.aichat.addressbar.icon`
* Menu when on new tab page -> `m.aichat.menu.newtabpage`
* Menu when on web page (inc SERP) -> `m.aichat.menu.webpage`
* Tab switcher -> `m.aichat.tabmanager.icon`

### Testing Steps
1. Clean install.  
2. Tap chat button on address bar and confirm `m.aichat.addressbar.icon` pixel is fired with `"was_used_before": "0"` parameter
3. Tap it again and check that `"was_used_before": "1"` parameter
4. Check pixel is fired for each of above sources and the `was_used_before` parameter is set

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Just internal data

### Quality Considerations
n/a

### Notes to Reviewer
n/a

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)