### PR TITLE
Add voice search button in the new Switch Bar

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -42,6 +42,7 @@ protocol OmniBarEditingStateViewControllerDelegate: AnyObject {
     func onPromptSubmitted(_ query: String)
     func onSelectFavorite(_ favorite: BookmarkEntity)
     func onSelectSuggestion(_ suggestion: Suggestion)
+    func onVoiceSearchRequested(from mode: TextEntryMode)
 }
 
 /// Later: Inject auto suggestions here.
@@ -298,6 +299,17 @@ final class OmniBarEditingStateViewController: UIViewController {
             }
             .store(in: &cancellables)
 
+        switchBarHandler.microphoneButtonTappedPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                self?.handleMicrophoneButtonTapped()
+            }
+            .store(in: &cancellables)
+
+    }
+
+    private func handleMicrophoneButtonTapped() {
+        delegate?.onVoiceSearchRequested(from: switchBarHandler.currentToggleState)
     }
 
     func selectAllText() {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
@@ -37,12 +37,14 @@ protocol SwitchBarHandling: AnyObject {
     var currentTextPublisher: AnyPublisher<String, Never> { get }
     var toggleStatePublisher: AnyPublisher<TextEntryMode, Never> { get }
     var textSubmissionPublisher: AnyPublisher<(text: String, mode: TextEntryMode), Never> { get }
+    var microphoneButtonTappedPublisher: AnyPublisher<Void, Never> { get }
 
     // MARK: - Methods
     func updateCurrentText(_ text: String)
     func submitText(_ text: String)
     func setToggleState(_ state: TextEntryMode)
     func clearText()
+    func microphoneButtonTapped()
 }
 
 // MARK: - SwitchBarHandler Implementation
@@ -71,7 +73,12 @@ final class SwitchBarHandler: SwitchBarHandling {
         textSubmissionSubject.eraseToAnyPublisher()
     }
 
+    var microphoneButtonTappedPublisher: AnyPublisher<Void, Never> {
+        microphoneButtonTappedSubject.eraseToAnyPublisher()
+    }
+
     private let textSubmissionSubject = PassthroughSubject<(text: String, mode: TextEntryMode), Never>()
+    private let microphoneButtonTappedSubject = PassthroughSubject<Void, Never>()
 
     init(voiceSearchHelper: VoiceSearchHelperProtocol) {
         self.voiceSearchHelper = voiceSearchHelper
@@ -93,5 +100,9 @@ final class SwitchBarHandler: SwitchBarHandling {
 
     func clearText() {
         updateCurrentText("")
+    }
+
+    func microphoneButtonTapped() {
+        microphoneButtonTappedSubject.send(())
     }
 }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
@@ -32,6 +32,7 @@ protocol SwitchBarHandling: AnyObject {
     // MARK: - Published Properties
     var currentText: String { get }
     var currentToggleState: TextEntryMode { get }
+    var isVoiceSearchEnabled: Bool { get }
 
     var currentTextPublisher: AnyPublisher<String, Never> { get }
     var toggleStatePublisher: AnyPublisher<TextEntryMode, Never> { get }
@@ -47,9 +48,16 @@ protocol SwitchBarHandling: AnyObject {
 // MARK: - SwitchBarHandler Implementation
 final class SwitchBarHandler: SwitchBarHandling {
 
+    // MARK: - Dependencies
+    private let voiceSearchHelper: VoiceSearchHelperProtocol
+
     // MARK: - Published Properties
     @Published private(set) var currentText: String = ""
     @Published private(set) var currentToggleState: TextEntryMode = .search
+
+    var isVoiceSearchEnabled: Bool {
+        voiceSearchHelper.isVoiceSearchEnabled
+    }
 
     var currentTextPublisher: AnyPublisher<String, Never> {
         $currentText.eraseToAnyPublisher()
@@ -65,7 +73,9 @@ final class SwitchBarHandler: SwitchBarHandling {
 
     private let textSubmissionSubject = PassthroughSubject<(text: String, mode: TextEntryMode), Never>()
 
-    init() { }
+    init(voiceSearchHelper: VoiceSearchHelperProtocol) {
+        self.voiceSearchHelper = voiceSearchHelper
+    }
 
     // MARK: - SwitchBarHandling Implementation
     func updateCurrentText(_ text: String) {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -49,6 +49,7 @@ class SwitchBarTextEntryView: UIView {
     private let textView = UITextView()
     private let placeholderLabel = UILabel()
     private let clearButton = UIButton(type: .system)
+    private let microphoneButton = UIButton(type: .system)
 
     private var currentMode: TextEntryMode {
         handler.currentToggleState
@@ -56,7 +57,6 @@ class SwitchBarTextEntryView: UIView {
     private var cancellables = Set<AnyCancellable>()
 
     private var heightConstraint: NSLayoutConstraint?
-    private var textViewTrailingConstraint: NSLayoutConstraint?
     private var textViewTrailingConstraintWithButton: NSLayoutConstraint?
 
     // MARK: - Initialization
@@ -92,19 +92,26 @@ class SwitchBarTextEntryView: UIView {
         clearButton.isHidden = true
         clearButton.addTarget(self, action: #selector(clearButtonTapped), for: .touchUpInside)
 
+        // Setup microphone button
+        microphoneButton.setImage(UIImage(systemName: "mic.fill"), for: .normal)
+        microphoneButton.tintColor = UIColor.systemGray
+        microphoneButton.isHidden = false  // Initially visible when no text
+        microphoneButton.addTarget(self, action: #selector(microphoneButtonTapped), for: .touchUpInside)
+
         addSubview(textView)
         addSubview(placeholderLabel)
         addSubview(clearButton)
+        addSubview(microphoneButton)
 
         textView.translatesAutoresizingMaskIntoConstraints = false
         placeholderLabel.translatesAutoresizingMaskIntoConstraints = false
         clearButton.translatesAutoresizingMaskIntoConstraints = false
+        microphoneButton.translatesAutoresizingMaskIntoConstraints = false
 
         heightConstraint = heightAnchor.constraint(equalToConstant: Constants.minHeight)
         heightConstraint?.isActive = true
 
-        // Create both trailing constraints for textView
-        textViewTrailingConstraint = textView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        // Create trailing constraint for textView with button space (since we always have one button visible)
         textViewTrailingConstraintWithButton = textView.trailingAnchor.constraint(equalTo: clearButton.leadingAnchor, constant: Constants.clearButtonSpacing)
 
         NSLayoutConstraint.activate([
@@ -119,20 +126,33 @@ class SwitchBarTextEntryView: UIView {
             clearButton.centerYAnchor.constraint(equalTo: placeholderLabel.centerYAnchor),
             clearButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: Constants.clearButtonTrailingOffset),
             clearButton.widthAnchor.constraint(equalToConstant: Constants.clearButtonSize),
-            clearButton.heightAnchor.constraint(equalToConstant: Constants.clearButtonSize)
+            clearButton.heightAnchor.constraint(equalToConstant: Constants.clearButtonSize),
+
+            microphoneButton.centerYAnchor.constraint(equalTo: placeholderLabel.centerYAnchor),
+            microphoneButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: Constants.clearButtonTrailingOffset),
+            microphoneButton.widthAnchor.constraint(equalToConstant: Constants.clearButtonSize),
+            microphoneButton.heightAnchor.constraint(equalToConstant: Constants.clearButtonSize)
         ])
 
-        // Initially activate the constraint without button
-        textViewTrailingConstraint?.isActive = true
+        // Activate the text view constraint (always accounts for button space)
+        textViewTrailingConstraintWithButton?.isActive = true
 
         updateForCurrentMode()
         updateTextViewHeight()
     }
 
+    // MARK: - Button Actions
+    
     @objc private func clearButtonTapped() {
         handler.clearText()
     }
 
+    @objc private func microphoneButtonTapped() {
+        print("potato")
+    }
+
+    // MARK: - UI Updates
+    
     private func updateForCurrentMode() {
         switch currentMode {
         case .search:
@@ -147,7 +167,7 @@ class SwitchBarTextEntryView: UIView {
         }
         textView.reloadInputViews()
         updatePlaceholderVisibility()
-        updateClearButtonVisibility()
+        updateActionButtonsVisibility()
         updateTextViewHeight()
     }
 
@@ -155,21 +175,19 @@ class SwitchBarTextEntryView: UIView {
         placeholderLabel.isHidden = !textView.text.isEmpty
     }
 
-    private func updateClearButtonVisibility() {
-        let shouldShowClearButton = !textView.text.isEmpty
-
+    /// Updates visibility of action buttons (clear/microphone) - they are mutually exclusive
+    /// - Clear button shows when there's text
+    /// - Microphone button shows when there's no text
+    private func updateActionButtonsVisibility() {
+        let hasText = !textView.text.isEmpty
+        
         UIView.animate(withDuration: Constants.animationDuration) {
-            self.clearButton.isHidden = !shouldShowClearButton
+            self.clearButton.isHidden = !hasText
+            self.microphoneButton.isHidden = hasText
         }
-
-        // Update text view constraints based on clear button visibility
-        if shouldShowClearButton {
-            textViewTrailingConstraint?.isActive = false
-            textViewTrailingConstraintWithButton?.isActive = true
-        } else {
-            textViewTrailingConstraintWithButton?.isActive = false
-            textViewTrailingConstraint?.isActive = true
-        }
+        
+        // Note: No need to update constraints since we always have one button visible
+        // and the text view is already constrained to account for button space
     }
 
     private func updateTextViewHeight() {
@@ -204,7 +222,7 @@ class SwitchBarTextEntryView: UIView {
                 if self.textView.text != text {
                     self.textView.text = text
                     self.updatePlaceholderVisibility()
-                    self.updateClearButtonVisibility()
+                    self.updateActionButtonsVisibility()
                     self.updateTextViewHeight()
                 }
             }
@@ -230,7 +248,7 @@ extension SwitchBarTextEntryView: UITextViewDelegate {
 
     func textViewDidChange(_ textView: UITextView) {
         updatePlaceholderVisibility()
-        updateClearButtonVisibility()
+        updateActionButtonsVisibility()
         updateTextViewHeight()
         handler.updateCurrentText(textView.text ?? "")
     }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -150,7 +150,7 @@ class SwitchBarTextEntryView: UIView {
     }
 
     @objc private func microphoneButtonTapped() {
-        print("potato")
+        handler.microphoneButtonTapped()
     }
 
     // MARK: - UI Updates

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -57,6 +57,7 @@ class SwitchBarTextEntryView: UIView {
     private var cancellables = Set<AnyCancellable>()
 
     private var heightConstraint: NSLayoutConstraint?
+    private var textViewTrailingConstraint: NSLayoutConstraint?
     private var textViewTrailingConstraintWithButton: NSLayoutConstraint?
 
     // MARK: - Initialization
@@ -95,7 +96,7 @@ class SwitchBarTextEntryView: UIView {
         // Setup microphone button
         microphoneButton.setImage(UIImage(systemName: "mic.fill"), for: .normal)
         microphoneButton.tintColor = UIColor.systemGray
-        microphoneButton.isHidden = false  // Initially visible when no text
+        microphoneButton.isHidden = !handler.isVoiceSearchEnabled  // Initially visible when no text and voice search is enabled
         microphoneButton.addTarget(self, action: #selector(microphoneButtonTapped), for: .touchUpInside)
 
         addSubview(textView)
@@ -111,7 +112,8 @@ class SwitchBarTextEntryView: UIView {
         heightConstraint = heightAnchor.constraint(equalToConstant: Constants.minHeight)
         heightConstraint?.isActive = true
 
-        // Create trailing constraint for textView with button space (since we always have one button visible)
+        // Create both trailing constraints for textView
+        textViewTrailingConstraint = textView.trailingAnchor.constraint(equalTo: trailingAnchor)
         textViewTrailingConstraintWithButton = textView.trailingAnchor.constraint(equalTo: clearButton.leadingAnchor, constant: Constants.clearButtonSpacing)
 
         NSLayoutConstraint.activate([
@@ -134,8 +136,8 @@ class SwitchBarTextEntryView: UIView {
             microphoneButton.heightAnchor.constraint(equalToConstant: Constants.clearButtonSize)
         ])
 
-        // Activate the text view constraint (always accounts for button space)
-        textViewTrailingConstraintWithButton?.isActive = true
+        // Initially determine which constraint to activate based on initial state
+        updateConstraintsForButtonVisibility()
 
         updateForCurrentMode()
         updateTextViewHeight()
@@ -177,17 +179,31 @@ class SwitchBarTextEntryView: UIView {
 
     /// Updates visibility of action buttons (clear/microphone) - they are mutually exclusive
     /// - Clear button shows when there's text
-    /// - Microphone button shows when there's no text
+    /// - Microphone button shows when there's no text and voice search is enabled
     private func updateActionButtonsVisibility() {
         let hasText = !textView.text.isEmpty
+        let shouldShowMicrophoneButton = !hasText && handler.isVoiceSearchEnabled
         
         UIView.animate(withDuration: Constants.animationDuration) {
             self.clearButton.isHidden = !hasText
-            self.microphoneButton.isHidden = hasText
+            self.microphoneButton.isHidden = !shouldShowMicrophoneButton
         }
         
-        // Note: No need to update constraints since we always have one button visible
-        // and the text view is already constrained to account for button space
+        updateConstraintsForButtonVisibility()
+    }
+
+    private func updateConstraintsForButtonVisibility() {
+        let hasText = !textView.text.isEmpty
+        let shouldShowMicrophoneButton = !hasText && handler.isVoiceSearchEnabled
+        let anyButtonVisible = hasText || shouldShowMicrophoneButton
+        
+        if anyButtonVisible {
+            textViewTrailingConstraint?.isActive = false
+            textViewTrailingConstraintWithButton?.isActive = true
+        } else {
+            textViewTrailingConstraintWithButton?.isActive = false
+            textViewTrailingConstraint?.isActive = true
+        }
     }
 
     private func updateTextViewHeight() {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -19,6 +19,7 @@
 
 import UIKit
 import Combine
+import DesignResourcesKitIcons
 
 class SwitchBarTextEntryView: UIView {
 
@@ -88,13 +89,13 @@ class SwitchBarTextEntryView: UIView {
         placeholderLabel.numberOfLines = 0
 
         // Setup clear button
-        clearButton.setImage(UIImage(systemName: "xmark.circle.fill"), for: .normal)
+        clearButton.setImage(DesignSystemImages.Glyphs.Size24.clear, for: .normal)
         clearButton.tintColor = UIColor.systemGray
         clearButton.isHidden = true
         clearButton.addTarget(self, action: #selector(clearButtonTapped), for: .touchUpInside)
 
         // Setup microphone button
-        microphoneButton.setImage(UIImage(systemName: "mic.fill"), for: .normal)
+        microphoneButton.setImage(DesignSystemImages.Glyphs.Size24.microphone, for: .normal)
         microphoneButton.tintColor = UIColor.systemGray
         microphoneButton.isHidden = !handler.isVoiceSearchEnabled  // Initially visible when no text and voice search is enabled
         microphoneButton.addTarget(self, action: #selector(microphoneButtonTapped), for: .touchUpInside)

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1664,7 +1664,8 @@ class MainViewController: UIViewController {
     }
 
     private func handleVoiceSearchOpenRequest(preferredTarget: VoiceSearchTarget? = nil) {
-        SpeechRecognizer.requestMicAccess { permission in
+        SpeechRecognizer.requestMicAccess { [weak self] permission in
+            guard let self = self else { return }
             if permission {
                 if let target = preferredTarget {
                     self.showVoiceSearch(preferredTarget: target)
@@ -1676,6 +1677,7 @@ class MainViewController: UIViewController {
             }
         }
     }
+
     private func showVoiceSearch(preferredTarget: VoiceSearchTarget? = nil) {
         // https://app.asana.com/0/0/1201408131067987
         UIMenuController.shared.hideMenu()

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1662,14 +1662,27 @@ class MainViewController: UIViewController {
         // hide toolbar on iPhone
         viewCoordinator.toolbar.accessibilityElementsHidden = !AppWidthObserver.shared.isLargeWidth
     }
-    
-    private func showVoiceSearch() {
+
+    private func handleVoiceSearchOpenRequest(preferredTarget: VoiceSearchTarget? = nil) {
+        SpeechRecognizer.requestMicAccess { permission in
+            if permission {
+                if let target = preferredTarget {
+                    self.showVoiceSearch(preferredTarget: target)
+                } else {
+                    self.showVoiceSearch()
+                }
+            } else {
+                self.showNoMicrophonePermissionAlert()
+            }
+        }
+    }
+    private func showVoiceSearch(preferredTarget: VoiceSearchTarget? = nil) {
         // https://app.asana.com/0/0/1201408131067987
         UIMenuController.shared.hideMenu()
         viewCoordinator.omniBar.removeTextSelection()
         
         Pixel.fire(pixel: .openVoiceSearch)
-        let voiceSearchController = VoiceSearchViewController()
+        let voiceSearchController = VoiceSearchViewController(preferredTarget: preferredTarget)
         voiceSearchController.delegate = self
         voiceSearchController.modalTransitionStyle = .crossDissolve
         voiceSearchController.modalPresentationStyle = .overFullScreen
@@ -2143,7 +2156,6 @@ extension MainViewController: BrowserChromeDelegate {
 
 // MARK: - OmniBarDelegate Methods
 extension MainViewController: OmniBarDelegate {
-
     func onSelectFavorite(_ favorite: BookmarkEntity) {
         handleFavoriteSelected(favorite)
     }
@@ -2453,13 +2465,11 @@ extension MainViewController: OmniBarDelegate {
     }
 
     func onVoiceSearchPressed() {
-        SpeechRecognizer.requestMicAccess { permission in
-            if permission {
-                self.showVoiceSearch()
-            } else {
-                self.showNoMicrophonePermissionAlert()
-            }
-        }
+        handleVoiceSearchOpenRequest()
+    }
+
+    func onVoiceSearchPressed(preferredTarget: VoiceSearchTarget) {
+        handleVoiceSearchOpenRequest(preferredTarget: preferredTarget)
     }
 
     /// We always want to show the AI Chat button if the keyboard is on focus

--- a/iOS/DuckDuckGo/OmniBarDelegate.swift
+++ b/iOS/DuckDuckGo/OmniBarDelegate.swift
@@ -74,6 +74,8 @@ protocol OmniBarDelegate: AnyObject {
     func selectedSuggestion() -> Suggestion?
     
     func onVoiceSearchPressed()
+    
+    func onVoiceSearchPressed(preferredTarget: VoiceSearchTarget)
 
     func onDidBeginEditing()
 
@@ -144,4 +146,7 @@ extension OmniBarDelegate {
     func onForwardPressed() {
     }
     
+    func onVoiceSearchPressed(preferredTarget: VoiceSearchTarget) {
+        onVoiceSearchPressed()
+    }
 }

--- a/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarViewController.swift
@@ -184,7 +184,8 @@ extension UpdatedOmniBarViewController: OmniBarEditingStateViewControllerDelegat
     }
 
     func onPromptSubmitted(_ query: String) {
-        editingStateViewController?.dismissAnimated {
+        editingStateViewController?.dismissAnimated { [weak self] in
+            guard let self else { return }
             self.omniDelegate?.onOmniPromptSubmitted(query)
         }
     }
@@ -197,5 +198,14 @@ extension UpdatedOmniBarViewController: OmniBarEditingStateViewControllerDelegat
     func onSelectSuggestion(_ suggestion: Suggestion) {
         omniDelegate?.onOmniSuggestionSelected(suggestion)
         editingStateViewController?.dismissAnimated()
+    }
+
+    func onVoiceSearchRequested(from mode: TextEntryMode) {
+        editingStateViewController?.dismissAnimated { [weak self] in
+            guard let self else { return }
+
+            let voiceSearchTarget: VoiceSearchTarget = (mode == .aiChat) ? .AIChat : .SERP
+            self.omniDelegate?.onVoiceSearchPressed(preferredTarget: voiceSearchTarget)
+        }
     }
 }

--- a/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarViewController.swift
@@ -151,7 +151,7 @@ final class UpdatedOmniBarViewController: OmniBarViewController {
     }
 
     private func createSwitchBarHandler(for textField: UITextField) -> SwitchBarHandler {
-        let switchBarHandler = SwitchBarHandler()
+        let switchBarHandler = SwitchBarHandler(voiceSearchHelper: dependencies.voiceSearchHelper)
 
         guard let currentText = omniBarView.text else {
             return switchBarHandler

--- a/iOS/DuckDuckGo/VoiceSearchFeedbackViewModel.swift
+++ b/iOS/DuckDuckGo/VoiceSearchFeedbackViewModel.swift
@@ -74,11 +74,13 @@ class VoiceSearchFeedbackViewModel: ObservableObject {
         aiChatSettings.isAIChatVoiceSearchUserSettingsEnabled
     }
 
-    internal init(speechRecognizer: SpeechRecognizerProtocol, aiChatSettings: AIChatSettingsProvider) {
+    internal init(speechRecognizer: SpeechRecognizerProtocol, aiChatSettings: AIChatSettingsProvider, preferredTarget: VoiceSearchTarget? = nil) {
         self.speechRecognizer = speechRecognizer
         self.aiChatSettings = aiChatSettings
 
-        if aiChatSettings.isAIChatVoiceSearchUserSettingsEnabled {
+        if let preferredTarget = preferredTarget {
+            searchTarget = preferredTarget
+        } else if aiChatSettings.isAIChatVoiceSearchUserSettingsEnabled {
             searchTarget = VoiceSearchTarget(rawValue: self.storedSearchTarget) ?? .SERP
         } else {
             searchTarget = .SERP

--- a/iOS/DuckDuckGo/VoiceSearchViewController.swift
+++ b/iOS/DuckDuckGo/VoiceSearchViewController.swift
@@ -27,10 +27,21 @@ protocol VoiceSearchViewControllerDelegate: AnyObject {
 class VoiceSearchViewController: UIViewController {
     weak var delegate: VoiceSearchViewControllerDelegate?
     private let speechRecognizer = SpeechRecognizer()
+    private let preferredTarget: VoiceSearchTarget?
+    
     private lazy var blurView: UIVisualEffectView = {
         let effectView = UIVisualEffectView(effect: UIBlurEffect(style: .regular))
         return effectView
     }()
+
+    init(preferredTarget: VoiceSearchTarget? = nil) {
+        self.preferredTarget = preferredTarget
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     private func setupConstraints() {
         blurView.translatesAutoresizingMaskIntoConstraints = false
@@ -52,7 +63,7 @@ class VoiceSearchViewController: UIViewController {
     }
     
     private func installSpeechView() {
-        let model = VoiceSearchFeedbackViewModel(speechRecognizer: speechRecognizer, aiChatSettings: AIChatSettings())
+        let model = VoiceSearchFeedbackViewModel(speechRecognizer: speechRecognizer, aiChatSettings: AIChatSettings(), preferredTarget: preferredTarget)
         model.delegate = self
         let speechView = VoiceSearchFeedbackView(speechModel: model)
         let controller = UIHostingController(rootView: speechView)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210503995054108?focus=true

### Description
Add the voice search button on the new switch bar with duck.ai

### Testing Steps
1. Enable the new UI (Settings -> Appearance -> Experimental)
2. Enable duck.ai experimental (Settings -> Duck.ai -> Experimental)
3. Enable Voice-search (Settings -> Accessibility)
4. Make sure voice-search button still works for the unfocused omnibar
5. Select the omnibar see if the voice-search button appears when there's no text
6. Tap on it from the search mode, it should open voice-search with search selected
7. Tap on it from the duck.ai mode, it should open voice-search with duck.ai selected

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Regressions on the old omnibar

### Quality Considerations
Animations are still a bit messy, as expected at this phase. 