### PR TITLE
[iOS][Set as Default] Setup feature flag for scheduling prompts

### DIFF
--- a/DuckDuckGo.xcworkspace/contents.xcworkspacedata
+++ b/DuckDuckGo.xcworkspace/contents.xcworkspacedata
@@ -32,4 +32,7 @@
    <FileRef
       location = "group:macOS/DuckDuckGo-macOS.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:iOS/LocalPackages/SetDefaultBrowser/Tests/SetDefaultBrowserCore.xctestplan">
+   </FileRef>
 </Workspace>

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -135,6 +135,9 @@ public enum FeatureFlag: String {
 
     /// https://app.asana.com/1/137249556945/project/72649045549333/task/1210410396636449?focus=true
     case showSettingsCompleteSetupSection
+
+    /// https://app.asana.com/1/137249556945/project/72649045549333/task/1209304767941984?focus=true
+    case scheduledSetDefaultBrowserPrompts
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -313,6 +316,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(AIChatSubfeature.keepSession))
         case .showSettingsCompleteSetupSection:
             return .remoteReleasable(.subfeature(OnboardingSubfeature.showSettingsCompleteSetupSection))
+        case .scheduledSetDefaultBrowserPrompts:
+            return .internalOnly()
         }
     }
 }

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1201,7 +1201,7 @@
 		9F3C7FE22D7990E50061FA72 /* DefaultBrowserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3C7FE12D7990DE0061FA72 /* DefaultBrowserManager.swift */; };
 		9F3DF7902D7EACAD00857D06 /* CheckDefaultBrowserServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3DF78F2D7EACAD00857D06 /* CheckDefaultBrowserServiceTests.swift */; };
 		9F454D1A2E051CC800B8CC5A /* DefaultBrowserPromptFeatureFlagAdapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F454D192E051CBE00B8CC5A /* DefaultBrowserPromptFeatureFlagAdapters.swift */; };
-		9F454D222E0540B100B8CC5A /* SetDefaultBrowserCore in Frameworks */ = {isa = PBXBuildFile; productRef = 9F454D212E0540B100B8CC5A /* SetDefaultBrowserCore */; };
+		9F454D242E05489200B8CC5A /* SetDefaultBrowserCore in Frameworks */ = {isa = PBXBuildFile; productRef = 9F454D232E05489200B8CC5A /* SetDefaultBrowserCore */; };
 		9F465E1E2D3F5C2E00490109 /* Logger+MaliciousSiteProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F465E1D2D3F5C2700490109 /* Logger+MaliciousSiteProtection.swift */; };
 		9F465E2A2D41B61900490109 /* MaliciousSiteProtectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F465E292D41B61300490109 /* MaliciousSiteProtectionService.swift */; };
 		9F46BEF82CD8D7490092E0EF /* OnboardingView+AddToDockContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F46BEF72CD8D7490092E0EF /* OnboardingView+AddToDockContent.swift */; };
@@ -3999,7 +3999,6 @@
 				4BC95E7D2D7416B2002FAB32 /* Onboarding in Frameworks */,
 				853273B624FFE0BB00E3C778 /* WidgetKit.framework in Frameworks */,
 				0238E44F29C0FAA100615E30 /* FindInPageIOSJSSupport in Frameworks */,
-				9F454D222E0540B100B8CC5A /* SetDefaultBrowserCore in Frameworks */,
 				56D7792C2CFF476800B619EF /* StoreKit.framework in Frameworks */,
 				3760DFED299315EF0045A446 /* Waitlist in Frameworks */,
 				BB631D162DE0D9020099977D /* DesignResourcesKitIcons in Frameworks */,
@@ -4012,6 +4011,7 @@
 				4BC95E7F2D7416C1002FAB32 /* PrivacyDashboard in Frameworks */,
 				31E69A63280F4CB600478327 /* DuckUI in Frameworks */,
 				F42D541D29DCA40B004C4FF1 /* DesignResourcesKit in Frameworks */,
+				9F454D242E05489200B8CC5A /* SetDefaultBrowserCore in Frameworks */,
 				9FDD72052D895D8C0016246B /* CombineSchedulers in Frameworks */,
 				9F254AF12CF8D5250063B308 /* MaliciousSiteProtection in Frameworks */,
 				F4D7F634298C00C3006C3AE9 /* FindInPageIOSJSSupport in Frameworks */,
@@ -8624,7 +8624,7 @@
 				316AC7862DC28DD1003D9770 /* UIComponents */,
 				BB631D152DE0D9020099977D /* DesignResourcesKitIcons */,
 				7BC26C9F2DFC0CAC00E52480 /* VPN */,
-				9F454D212E0540B100B8CC5A /* SetDefaultBrowserCore */,
+				9F454D232E05489200B8CC5A /* SetDefaultBrowserCore */,
 			);
 			productName = DuckDuckGo;
 			productReference = 84E341921E2F7EFB00BDBA6F /* DuckDuckGo.app */;
@@ -14554,6 +14554,10 @@
 		9F254AF02CF8D5250063B308 /* MaliciousSiteProtection */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = MaliciousSiteProtection;
+		};
+		9F454D232E05489200B8CC5A /* SetDefaultBrowserCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SetDefaultBrowserCore;
 		};
 		9F8FE9482BAE50E50071E372 /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1200,6 +1200,8 @@
 		9F3C7FE02D7990740061FA72 /* DefaultBrowserInfoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3C7FDF2D7990710061FA72 /* DefaultBrowserInfoStore.swift */; };
 		9F3C7FE22D7990E50061FA72 /* DefaultBrowserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3C7FE12D7990DE0061FA72 /* DefaultBrowserManager.swift */; };
 		9F3DF7902D7EACAD00857D06 /* CheckDefaultBrowserServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3DF78F2D7EACAD00857D06 /* CheckDefaultBrowserServiceTests.swift */; };
+		9F454D1A2E051CC800B8CC5A /* DefaultBrowserPromptFeatureFlagAdapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F454D192E051CBE00B8CC5A /* DefaultBrowserPromptFeatureFlagAdapters.swift */; };
+		9F454D222E0540B100B8CC5A /* SetDefaultBrowserCore in Frameworks */ = {isa = PBXBuildFile; productRef = 9F454D212E0540B100B8CC5A /* SetDefaultBrowserCore */; };
 		9F465E1E2D3F5C2E00490109 /* Logger+MaliciousSiteProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F465E1D2D3F5C2700490109 /* Logger+MaliciousSiteProtection.swift */; };
 		9F465E2A2D41B61900490109 /* MaliciousSiteProtectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F465E292D41B61300490109 /* MaliciousSiteProtectionService.swift */; };
 		9F46BEF82CD8D7490092E0EF /* OnboardingView+AddToDockContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F46BEF72CD8D7490092E0EF /* OnboardingView+AddToDockContent.swift */; };
@@ -3322,6 +3324,8 @@
 		9F3C7FDF2D7990710061FA72 /* DefaultBrowserInfoStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserInfoStore.swift; sourceTree = "<group>"; };
 		9F3C7FE12D7990DE0061FA72 /* DefaultBrowserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserManager.swift; sourceTree = "<group>"; };
 		9F3DF78F2D7EACAD00857D06 /* CheckDefaultBrowserServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckDefaultBrowserServiceTests.swift; sourceTree = "<group>"; };
+		9F454D192E051CBE00B8CC5A /* DefaultBrowserPromptFeatureFlagAdapters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserPromptFeatureFlagAdapters.swift; sourceTree = "<group>"; };
+		9F454D202E052D1E00B8CC5A /* SetDefaultBrowser */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = SetDefaultBrowser; sourceTree = "<group>"; };
 		9F465E1D2D3F5C2700490109 /* Logger+MaliciousSiteProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+MaliciousSiteProtection.swift"; sourceTree = "<group>"; };
 		9F465E292D41B61300490109 /* MaliciousSiteProtectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaliciousSiteProtectionService.swift; sourceTree = "<group>"; };
 		9F46BEF72CD8D7490092E0EF /* OnboardingView+AddToDockContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingView+AddToDockContent.swift"; sourceTree = "<group>"; };
@@ -3995,6 +3999,7 @@
 				4BC95E7D2D7416B2002FAB32 /* Onboarding in Frameworks */,
 				853273B624FFE0BB00E3C778 /* WidgetKit.framework in Frameworks */,
 				0238E44F29C0FAA100615E30 /* FindInPageIOSJSSupport in Frameworks */,
+				9F454D222E0540B100B8CC5A /* SetDefaultBrowserCore in Frameworks */,
 				56D7792C2CFF476800B619EF /* StoreKit.framework in Frameworks */,
 				3760DFED299315EF0045A446 /* Waitlist in Frameworks */,
 				BB631D162DE0D9020099977D /* DesignResourcesKitIcons in Frameworks */,
@@ -4754,6 +4759,7 @@
 		31E69A60280F4BAD00478327 /* LocalPackages */ = {
 			isa = PBXGroup;
 			children = (
+				9F454D202E052D1E00B8CC5A /* SetDefaultBrowser */,
 				85B6ABB62DE5E4CC009C85C7 /* Onboarding */,
 				4BE4D0BB2D8D2DFC00D63840 /* BrowserServicesKit */,
 				9D87088B2DAD5075007E22D4 /* DataBrokerProtectionCore */,
@@ -5623,6 +5629,7 @@
 				F1DF09502B039E6E008CC908 /* PrivacyDashboard */,
 				02ECEC602A965074009F0654 /* PrivacyInfo.xcprivacy */,
 				C1B7B51D28941F160098FD6A /* RemoteMessaging */,
+				9F454D182E051CA000B8CC5A /* SetDefaultBrowser */,
 				F1AB2B401E3F75A000868554 /* Settings */,
 				0A6CC0EE23904D5400E4F627 /* Settings.bundle */,
 				7B4F87E82D0738D20010B18F /* Siri */,
@@ -6451,6 +6458,14 @@
 				9F63BABC2D7ECFD800BD31F4 /* DefaultBrowserManagerTesting.swift */,
 			);
 			path = CheckDefaultBrowser;
+			sourceTree = "<group>";
+		};
+		9F454D182E051CA000B8CC5A /* SetDefaultBrowser */ = {
+			isa = PBXGroup;
+			children = (
+				9F454D192E051CBE00B8CC5A /* DefaultBrowserPromptFeatureFlagAdapters.swift */,
+			);
+			path = SetDefaultBrowser;
 			sourceTree = "<group>";
 		};
 		9F4CC5252C4E22F9006A96EB /* ContextualOnboarding */ = {
@@ -8609,6 +8624,7 @@
 				316AC7862DC28DD1003D9770 /* UIComponents */,
 				BB631D152DE0D9020099977D /* DesignResourcesKitIcons */,
 				7BC26C9F2DFC0CAC00E52480 /* VPN */,
+				9F454D212E0540B100B8CC5A /* SetDefaultBrowserCore */,
 			);
 			productName = DuckDuckGo;
 			productReference = 84E341921E2F7EFB00BDBA6F /* DuckDuckGo.app */;
@@ -9739,6 +9755,7 @@
 				9F0949A72D389F1E0079291B /* MaliciousSiteProtectionAPI.swift in Sources */,
 				31B524572715BB23002225AB /* WebJSAlert.swift in Sources */,
 				D652E24E2DDE8B3B00BCD978 /* DuckPlayerPixelFiring.swift in Sources */,
+				9F454D1A2E051CC800B8CC5A /* DefaultBrowserPromptFeatureFlagAdapters.swift in Sources */,
 				C1641EB32BC2F53C0012607A /* ImportPasswordsViaSyncViewModel.swift in Sources */,
 				9FDEC7BF2C91264C00C7A692 /* OnboardingAddressBarPositionPicker.swift in Sources */,
 				65EBA0B42D7F489700E34997 /* NativeDuckPlayerNavigationHandler.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/xcshareddata/xcschemes/iOS Browser.xcscheme
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/xcshareddata/xcschemes/iOS Browser.xcscheme
@@ -156,6 +156,16 @@
                ReferencedContainer = "container:../SharedPackages/AIChat">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SetDefaultBrowserTests"
+               BuildableName = "SetDefaultBrowserTests"
+               BlueprintName = "SetDefaultBrowserTests"
+               ReferencedContainer = "container:LocalPackages/SetDefaultBrowser">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/iOS/DuckDuckGo/SetDefaultBrowser/DefaultBrowserPromptFeatureFlagAdapters.swift
+++ b/iOS/DuckDuckGo/SetDefaultBrowser/DefaultBrowserPromptFeatureFlagAdapters.swift
@@ -1,0 +1,39 @@
+//
+//  DefaultBrowserPromptFeatureFlagger.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Core
+import BrowserServicesKit
+import SetDefaultBrowserCore
+
+extension DefaultFeatureFlagger: @retroactive DefaultBrowserPromptFeatureFlagProvider {
+
+    public var isDefaultBrowserPromptsFeatureEnabled: Bool {
+        isFeatureOn(FeatureFlag.scheduledSetDefaultBrowserPrompts)
+    }
+
+}
+
+extension PrivacyConfigurationManager: @retroactive DefaultBrowserPromptFeatureFlagSettingsProvider {
+
+    public var featureSettings: [String: Any] {
+        privacyConfig.settings(for: .setAsDefaultAndAddToDock)
+    }
+
+}

--- a/iOS/LocalPackages/SetDefaultBrowser/.gitignore
+++ b/iOS/LocalPackages/SetDefaultBrowser/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/iOS/LocalPackages/SetDefaultBrowser/Package.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SetDefaultBrowser",
+    platforms: [
+        .iOS("15.0")
+    ],
+    products: [
+        .library(
+            name: "SetDefaultBrowserCore",
+            targets: ["SetDefaultBrowserCore"]
+        ),
+        .library(
+            name: "SetDefaultBrowserTestSupport",
+            targets: ["SetDefaultBrowserTestSupport"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "SetDefaultBrowserCore"
+        ),
+        .target(
+            name: "SetDefaultBrowserTestSupport",
+            dependencies: [
+                "SetDefaultBrowserCore"
+            ]
+        ),
+        .testTarget(
+            name: "SetDefaultBrowserTests",
+            dependencies: [
+                "SetDefaultBrowserCore",
+                "SetDefaultBrowserTestSupport",
+            ]
+        ),
+    ]
+)

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserCore/DefaultBrowserPromptFeatureFlagger.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserCore/DefaultBrowserPromptFeatureFlagger.swift
@@ -1,0 +1,94 @@
+//
+//  DefaultBrowserPromptFeatureFlagger.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public protocol DefaultBrowserPromptFeatureFlagProvider {
+    /// A Boolean value indicating whether Set Default Browser Prompts are enabled.
+    /// - Returns: `true` if the feature is enabled; otherwise, `false`.
+    var isDefaultBrowserPromptsFeatureEnabled: Bool { get }
+}
+
+public protocol DefaultBrowserPromptFeatureFlagSettingsProvider {
+    // A dictionary representing the settings for the feature.
+    var featureSettings: [String: Any] { get }
+}
+
+/// An enum representing the different settings for Set Default Browser Prompts feature flag.
+enum DefaultBrowserPromptFeatureSettings: String {
+    /// The setting for the number of days to wait after app installation before showing the first modal. Default to 1 day..
+    case firstModalDelayDays
+    /// The setting for the number of days to wait after the popover has been shown before displaying the banner. Default to 14 days.
+    case secondModalDelayDays
+    /// The settings for the number of days between subsequent displays of the banner. Default to 14 days.
+    case subsequentModalRepeatIntervalDays
+
+    var defaultValue: Int {
+        switch self {
+        case .firstModalDelayDays: return 1
+        case .secondModalDelayDays: return 4
+        case .subsequentModalRepeatIntervalDays: return 14
+        }
+    }
+}
+
+public protocol DefaultBrowserPromptFeatureFlagger: DefaultBrowserPromptFeatureFlagProvider {
+    /// The number of active days to wait after app installation before showing the first modal. Default is 1.
+    var firstModalDelayDays: Int { get }
+    /// The number of active days to wait after the first modal has been shown before displaying the second modal. Default is 4.
+    var secondModalDelayDays: Int { get }
+    /// The number of active days between subsequent displays of the modal. Default is 14.
+    var subsequentModalRepeatIntervalDays: Int { get }
+}
+
+public final class DefaultBrowserPromptFeatureFlag {
+    private let settingsProvider: DefaultBrowserPromptFeatureFlagSettingsProvider
+    private let featureFlagProvider: DefaultBrowserPromptFeatureFlagProvider
+
+    public init(settingsProvider: DefaultBrowserPromptFeatureFlagSettingsProvider, featureFlagProvider: DefaultBrowserPromptFeatureFlagProvider) {
+        self.settingsProvider = settingsProvider
+        self.featureFlagProvider = featureFlagProvider
+    }
+}
+
+// MARK: - DefaultBrowserPromptFeatureFlagger
+
+extension DefaultBrowserPromptFeatureFlag: DefaultBrowserPromptFeatureFlagger {
+
+    public var isDefaultBrowserPromptsFeatureEnabled: Bool {
+        featureFlagProvider.isDefaultBrowserPromptsFeatureEnabled
+    }
+
+    public var firstModalDelayDays: Int {
+        getSettings(.firstModalDelayDays)
+    }
+
+    public var secondModalDelayDays: Int {
+        getSettings(.secondModalDelayDays)
+    }
+
+    public var subsequentModalRepeatIntervalDays: Int {
+        getSettings(.subsequentModalRepeatIntervalDays)
+    }
+
+    private func getSettings(_ value: DefaultBrowserPromptFeatureSettings) -> Int {
+        settingsProvider.featureSettings[value.rawValue] as? Int ?? value.defaultValue
+    }
+
+}

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserTestSupport/MockDefaultBrowserPromptFeatureFlag.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserTestSupport/MockDefaultBrowserPromptFeatureFlag.swift
@@ -1,0 +1,45 @@
+//
+//  MockDefaultBrowserPromptFeatureFlagProvider.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import SetDefaultBrowserCore
+
+public final class MockDefaultBrowserPromptFeatureFlag: DefaultBrowserPromptFeatureFlagger {
+    public init() {}
+
+    public var isDefaultBrowserPromptsFeatureEnabled: Bool = true
+
+    public var firstModalDelayDays: Int = 1
+
+    public var secondModalDelayDays: Int = 2
+
+    public var subsequentModalRepeatIntervalDays: Int = 3
+}
+
+package final class MockDefaultBrowserPromptFeatureFlagProvider: DefaultBrowserPromptFeatureFlagProvider {
+    package var isDefaultBrowserPromptsFeatureEnabled: Bool = true
+
+    package init() {}
+}
+
+package final class MockDefaultBrowserPromptFeatureFlagsSettingsProvider: DefaultBrowserPromptFeatureFlagSettingsProvider {
+    package var featureSettings: [String : Any] = [:]
+
+    package init() {}
+}

--- a/iOS/LocalPackages/SetDefaultBrowser/Tests/SetDefaultBrowserCore.xctestplan
+++ b/iOS/LocalPackages/SetDefaultBrowser/Tests/SetDefaultBrowserCore.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "53BCFC96-6941-47D0-BCEB-80C9A0EE9569",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "SetDefaultBrowserTests",
+        "name" : "SetDefaultBrowserTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/iOS/LocalPackages/SetDefaultBrowser/Tests/SetDefaultBrowserTests/DefaultBrowserPromptFeatureFlaggerTests.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Tests/SetDefaultBrowserTests/DefaultBrowserPromptFeatureFlaggerTests.swift
@@ -1,0 +1,82 @@
+//
+//  DefaultBrowserAndDockPromptFeatureFlaggerTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Testing
+import SetDefaultBrowserTestSupport
+@testable import SetDefaultBrowserCore
+
+@Suite("Set Default Browser - Prompt Feature Flag")
+struct DefaultBrowserAndDockPromptFeatureFlaggerTests {
+    let mockFeatureFlagSettingsProvider = MockDefaultBrowserPromptFeatureFlagsSettingsProvider()
+    let mockFeatureFlagProvider = MockDefaultBrowserPromptFeatureFlagProvider()
+
+    @Test("Check Feature Flag Returns The Correct Value", arguments: [true, false])
+    func isDefaultBrowserAndDockPromptFeatureEnabledThenReturnTheCorrectValue(_ isEnabled: Bool) {
+        // GIVEN
+        mockFeatureFlagProvider.isDefaultBrowserPromptsFeatureEnabled = isEnabled
+        let sut = DefaultBrowserPromptFeatureFlag(settingsProvider: mockFeatureFlagSettingsProvider, featureFlagProvider: mockFeatureFlagProvider)
+
+        // WHEN
+        let result = sut.isDefaultBrowserPromptsFeatureEnabled
+
+        // THEN
+        #expect(result == isEnabled)
+    }
+
+    @Test("Check Remote Subfeature Settings Are Returned Correctly")
+    func checkRemoteSettingsAreReturnedCorrectly() throws {
+        // GIVEN
+        mockFeatureFlagSettingsProvider.featureSettings = [
+            DefaultBrowserPromptFeatureSettings.firstModalDelayDays.rawValue: 2,
+            DefaultBrowserPromptFeatureSettings.secondModalDelayDays.rawValue: 4,
+            DefaultBrowserPromptFeatureSettings.subsequentModalRepeatIntervalDays.rawValue: 6
+        ]
+        let sut = DefaultBrowserPromptFeatureFlag(settingsProvider: mockFeatureFlagSettingsProvider, featureFlagProvider: mockFeatureFlagProvider)
+
+        // WHEN
+        let firstModalDelayDays = sut.firstModalDelayDays
+        let secondModalDelayDays = sut.secondModalDelayDays
+        let subsequentModalRepeatIntervalDays = sut.subsequentModalRepeatIntervalDays
+
+        // THEN
+        #expect(firstModalDelayDays == 2)
+        #expect(secondModalDelayDays == 4)
+        #expect(subsequentModalRepeatIntervalDays == 6)
+    }
+
+    @Test("Check Subfeature Settings Default Value Are Returned When Remote Settings Not Set")
+    func checkDefaultSettingsAreReturnedWhenRemoteSettingsAreNotSet() throws {
+        // GIVEN
+        mockFeatureFlagSettingsProvider.featureSettings = [:]
+        let sut = DefaultBrowserPromptFeatureFlag(settingsProvider: mockFeatureFlagSettingsProvider, featureFlagProvider: mockFeatureFlagProvider)
+
+        // WHEN
+        let firstModalDelayDays = sut.firstModalDelayDays
+        let secondModalDelayDays = sut.secondModalDelayDays
+        let subsequentModalRepeatIntervalDays = sut.subsequentModalRepeatIntervalDays
+
+        // THEN
+        #expect(firstModalDelayDays == 1)
+        #expect(secondModalDelayDays == 4)
+        #expect(subsequentModalRepeatIntervalDays == 14)
+    }
+
+}
+


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210580348981351?focus=true
Tech Design URL:
CC:

### Description

This PR adds a feature flag for the ’Set Default’ browser prompts feature.
It also adds a local iOS package to encapsulate the feature.

### Testing Steps
Ensure CI is green.

### Impact and Risks
None, the feature is not plugged in.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)