### PR TITLE
PIR iOS UI support 5: Make macOS use EditablePartialProfile 

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/UIWeb/DBPUICommunicationModel.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/UIWeb/DBPUICommunicationModel.swift
@@ -138,7 +138,7 @@ public struct DBPUIUserProfile: Codable {
 }
 
 public extension DBPUIUserProfile {
-    init(fromDataBrokerProtectionProfile profile: DataBrokerProtectionProfile) {
+    init(from profile: DataBrokerProtectionProfile) {
         names = profile.names.map { DBPUIUserProfileName(first: $0.firstName, middle: $0.middleName, last: $0.lastName, suffix: $0.suffix) }
         addresses = profile.addresses.map { DBPUIUserProfileAddress(street: $0.street, city: $0.city, state: $0.state, zipCode: $0.zipCode) }
         birthYear = profile.birthYear

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/UIWeb/DBPUINativeModel.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/UIWeb/DBPUINativeModel.swift
@@ -1,0 +1,114 @@
+//
+//  DBPUINativeModel.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public struct DBPUIEditablePartialProfile {
+    public var names: [DBPUIUserProfileName] = []
+    public var birthYear: DBPUIBirthYear?
+    public var addresses: [DBPUIUserProfileAddress] = []
+
+    public init(names: [DBPUIUserProfileName] = [], birthYear: DBPUIBirthYear? = nil, addresses: [DBPUIUserProfileAddress] = []) {
+        self.names = names
+        self.birthYear = birthYear
+        self.addresses = addresses
+    }
+}
+
+public extension DBPUIEditablePartialProfile {
+
+    init(from profile: DataBrokerProtectionProfile) {
+        let names = profile.names.map { DBPUIUserProfileName(first: $0.firstName, middle: $0.middleName, last: $0.lastName, suffix: $0.suffix) }
+        let addresses = profile.addresses.map { DBPUIUserProfileAddress(street: $0.street, city: $0.city, state: $0.state, zipCode: $0.zipCode) }
+        let birthYear = DBPUIBirthYear(year: profile.birthYear)
+        self.init(names: names, birthYear: birthYear, addresses: addresses)
+    }
+
+    mutating func addName(_ name: DBPUIUserProfileName) -> Bool {
+        guard !name.requiredComponentsAreBlank() else { return false }
+
+        // Duplicates not allowed
+        guard names.firstIndex(where: { $0  == name }) == nil else { return false }
+
+        names.append(name)
+        return true
+    }
+
+    mutating func setNameAtIndex(_ nameAtIndex: DBPUINameAtIndex) -> Bool {
+        guard nameAtIndex.index < names.count else {
+            assertionFailure("Attempted to set name at index \(nameAtIndex.index) but only have \(names.count) names")
+            return false
+        }
+
+        names[nameAtIndex.index] = nameAtIndex.name
+        return true
+    }
+
+    mutating func removeNameAtIndex(_ index: Int) -> Bool {
+        guard index < names.count else {
+            assertionFailure("Attempted to remove name at index \(index) but only have \(names.count) names")
+            return false
+        }
+
+        names.remove(at: index)
+        return true
+    }
+
+    mutating func addAddress(_ address: DBPUIUserProfileAddress) -> Bool {
+        guard !address.requiredComponentsAreBlank() else { return false }
+
+        // Duplicates not allowed
+        guard addresses.firstIndex(of: address) == nil else { return false }
+
+        addresses.append(address)
+        return true
+    }
+
+    mutating func setAddressAtIndex(_ addressAtIndex: DBPUIAddressAtIndex) -> Bool {
+        guard addressAtIndex.index < addresses.count else {
+            assertionFailure("Attempted to set address at index \(addressAtIndex.index) but only have \(addresses.count) addresses")
+            return false
+        }
+
+        addresses[addressAtIndex.index] = addressAtIndex.address
+        return true
+    }
+
+    mutating func removeAddressAtIndex(_ index: Int) -> Bool {
+        guard index < addresses.count else {
+            assertionFailure("Attempted to remove address at index \(index) but only have \(addresses.count) addresses")
+            return false
+        }
+
+        addresses.remove(at: index)
+        return true
+    }
+}
+
+public extension DataBrokerProtectionProfile {
+    init?(from profile: DBPUIEditablePartialProfile) {
+        guard let birthYear = profile.birthYear else {
+            assertionFailure("No birth year specified")
+            return nil
+        }
+
+        let names = profile.names.map { Name(firstName: $0.first, lastName: $0.last, middleName: $0.middle, suffix: $0.suffix) }
+        let addresses = profile.addresses.map { Address(city: $0.city, state: $0.state, street: $0.street, zipCode: $0.zipCode) }
+        self.init(names: names, addresses: addresses, phones: [], birthYear: birthYear.year)
+    }
+}

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/UINative/DBPUIViewModel.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/UINative/DBPUIViewModel.swift
@@ -26,12 +26,6 @@ import os.log
 import DataBrokerProtectionCore
 import Subscription
 
-private struct EditablePartialProfile {
-    var names: [DBPUIUserProfileName] = []
-    var birthYear: DBPUIBirthYear?
-    var addresses: [DBPUIUserProfileAddress] = []
-}
-
 public protocol DBPUIViewModelDelegate: AnyObject {
     func isUserAuthenticated() -> Bool
     func getUserProfile() throws -> DataBrokerProtectionProfile?
@@ -51,7 +45,7 @@ public final class DBPUIViewModel {
     private let webUISettings: DataBrokerProtectionWebUIURLSettingsRepresentable
     private let pixelHandler: EventMapping<DataBrokerProtectionSharedPixels>
 
-    private var editablePartialProfile: EditablePartialProfile
+    private var editablePartialProfile: DBPUIEditablePartialProfile
 
     public init(delegate: DBPUIViewModelDelegate,
                 webUISettings: DataBrokerProtectionWebUIURLSettingsRepresentable,
@@ -95,7 +89,7 @@ extension DBPUIViewModel: DBPUICommunicationDelegate {
     }
     
     public func saveProfile() async throws {
-        guard let profile = DataBrokerProtectionProfile(fromEditablePartialProfile: editablePartialProfile) else {
+        guard let profile = DataBrokerProtectionProfile(from: editablePartialProfile) else {
             assertionFailure("Couldn't save profile")
             return
         }
@@ -107,7 +101,7 @@ extension DBPUIViewModel: DBPUICommunicationDelegate {
             let profile = try delegate?.getUserProfile()
 
             guard let profile = profile else { return nil }
-            return DBPUIUserProfile(fromDataBrokerProtectionProfile: profile)
+            return DBPUIUserProfile(from: profile)
         } catch {
             return nil
         }
@@ -117,7 +111,7 @@ extension DBPUIViewModel: DBPUICommunicationDelegate {
         try delegate?.deleteAllUserProfileData()
 
         // Clear the in memory data
-        editablePartialProfile = EditablePartialProfile()
+        editablePartialProfile = DBPUIEditablePartialProfile()
     }
 
     public func addNameToCurrentUserProfile(_ name: DBPUIUserProfileName) -> Bool {
@@ -212,88 +206,5 @@ extension DBPUIViewModel: DBPUICommunicationDelegate {
 
     public func applyVPNBypassSetting(_ bypass: Bool) async {
         // No op, we don't have a VPN bypass on iOS
-    }
-}
-
-extension EditablePartialProfile {
-
-    init(from profile: DataBrokerProtectionProfile) {
-        let names = profile.names.map { DBPUIUserProfileName(first: $0.firstName, middle: $0.middleName, last: $0.lastName, suffix: $0.suffix) }
-        let addresses = profile.addresses.map { DBPUIUserProfileAddress(street: $0.street, city: $0.city, state: $0.state, zipCode: $0.zipCode) }
-        let birthYear = DBPUIBirthYear(year: profile.birthYear)
-        self.init(names: names, birthYear: birthYear, addresses: addresses)
-    }
-
-    mutating func addName(_ name: DBPUIUserProfileName) -> Bool {
-        guard !name.requiredComponentsAreBlank() else { return false }
-
-        // Duplicates not allowed
-        guard names.firstIndex(where: { $0  == name }) == nil else { return false }
-
-        names.append(name)
-        return true
-    }
-
-    mutating func setNameAtIndex(_ nameAtIndex: DBPUINameAtIndex) -> Bool {
-        guard nameAtIndex.index < names.count else {
-            assertionFailure("Attempted to set name at index \(nameAtIndex.index) but only have \(names.count) names")
-            return false
-        }
-
-        names[nameAtIndex.index] = nameAtIndex.name
-        return true
-    }
-
-    mutating func removeNameAtIndex(_ index: Int) -> Bool {
-        guard index < names.count else {
-            assertionFailure("Attempted to remove name at index \(index) but only have \(names.count) names")
-            return false
-        }
-
-        names.remove(at: index)
-        return true
-    }
-
-    mutating func addAddress(_ address: DBPUIUserProfileAddress) -> Bool {
-        guard !address.requiredComponentsAreBlank() else { return false }
-
-        // Duplicates not allowed
-        guard addresses.firstIndex(of: address) == nil else { return false }
-
-        addresses.append(address)
-        return true
-    }
-
-    mutating func setAddressAtIndex(_ addressAtIndex: DBPUIAddressAtIndex) -> Bool {
-        guard addressAtIndex.index < addresses.count else {
-            assertionFailure("Attempted to set address at index \(addressAtIndex.index) but only have \(addresses.count) addresses")
-            return false
-        }
-
-        addresses[addressAtIndex.index] = addressAtIndex.address
-        return true
-    }
-
-    mutating func removeAddressAtIndex(_ index: Int) -> Bool {
-        guard index < addresses.count else {
-            assertionFailure("Attempted to remove address at index \(index) but only have \(addresses.count) addresses")
-            return false
-        }
-
-        addresses.remove(at: index)
-        return true
-    }
-}
-
-private extension DataBrokerProtectionProfile {
-    init?(fromEditablePartialProfile profile: EditablePartialProfile) {
-        guard let birthYear = profile.birthYear else {
-            assertionFailure("No birth year specified")
-            return nil
-        }
-
-        let names = profile.names.map { Name(firstName: $0.first, lastName: $0.last, middleName: $0.middle, suffix: $0.suffix) }
-        let addresses = profile.addresses.map { Address(city: $0.city, state: $0.state, street: $0.street, zipCode: $0.zipCode) }
-        self.init(names: names, addresses: addresses, phones: [], birthYear: birthYear.year)
     }
 }

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/DataCaching/DataBrokerProtectionDataManager.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/DataCaching/DataBrokerProtectionDataManager.swift
@@ -241,7 +241,21 @@ public protocol UserActionDelegate: AnyObject {
 }
 
 public final class DBPUICommunicator {
-    var profile: DataBrokerProtectionProfile?
+
+    var profile: DataBrokerProtectionProfile? {
+        get {
+            DataBrokerProtectionProfile(from: editablePartialProfile)
+        }
+        set {
+            if let newValue = newValue {
+                editablePartialProfile = DBPUIEditablePartialProfile(from: newValue)
+            } else {
+                editablePartialProfile = DBPUIEditablePartialProfile()
+            }
+        }
+    }
+    private var editablePartialProfile = DBPUIEditablePartialProfile()
+
     var brokerProfileQueryData = [BrokerProfileQueryData]()
     private let debugMetaDataMapper = UIDebugMetadataMapper()
 
@@ -270,37 +284,10 @@ extension DBPUICommunicator: DBPUICommunicationDelegate {
         try await delegate?.saveCachedProfileToDatabase(profile)
     }
 
-    private func indexForName(matching name: DBPUIUserProfileName, in profile: DataBrokerProtectionProfile) -> Int? {
-        if let idx = profile.names.firstIndex(where: { $0.firstName == name.first && $0.lastName == name.last && $0.middleName == name.middle && $0.suffix == name.suffix }) {
-            return idx
-        }
-
-        return nil
-    }
-
-    private func indexForAddress(matching address: DBPUIUserProfileAddress, in profile: DataBrokerProtectionProfile) -> Int? {
-        if let idx = profile.addresses.firstIndex(where: { $0.street == address.street && $0.state == address.state && $0.city == address.city && $0.zipCode == address.zipCode}) {
-            return idx
-        }
-
-        return nil
-    }
-
-    private func isNameEmpty(_ name: DBPUIUserProfileName) -> Bool {
-        return name.first.isBlank || name.last.isBlank
-    }
-
-    private func addressIsEmpty(_ address: DBPUIUserProfileAddress) -> Bool {
-        return address.city.isBlank || address.state.isBlank
-    }
-
     public func getUserProfile() -> DBPUIUserProfile? {
         let profile = profile ?? emptyProfile
 
-        let names = profile.names.map { DBPUIUserProfileName(first: $0.firstName, middle: $0.middleName, last: $0.lastName, suffix: $0.suffix) }
-        let addresses = profile.addresses.map { DBPUIUserProfileAddress(street: $0.street, city: $0.city, state: $0.state, zipCode: $0.zipCode) }
-
-        return DBPUIUserProfile(names: names, birthYear: profile.birthYear, addresses: addresses)
+        return DBPUIUserProfile(from: profile)
     }
 
     public func deleteProfileData() throws {
@@ -309,96 +296,38 @@ extension DBPUICommunicator: DBPUICommunicationDelegate {
     }
 
     public func addNameToCurrentUserProfile(_ name: DBPUIUserProfileName) -> Bool {
-        let profile = profile ?? emptyProfile
-
-        guard !isNameEmpty(name) else { return false }
-
-        // No duplicates
-        guard indexForName(matching: name, in: profile) == nil else { return false }
-
-        var names = profile.names
-        names.append(DataBrokerProtectionProfile.Name(firstName: name.first, lastName: name.last, middleName: name.middle, suffix: name.suffix))
-
-        self.profile = DataBrokerProtectionProfile(names: names, addresses: profile.addresses, phones: profile.phones, birthYear: profile.birthYear)
-
-        return true
+        let success = editablePartialProfile.addName(name)
+        return success
     }
 
     public func setNameAtIndexInCurrentUserProfile(_ payload: DBPUINameAtIndex) -> Bool {
-        let profile = profile ?? emptyProfile
-
-        var names = profile.names
-        if payload.index < names.count {
-            names[payload.index] = DataBrokerProtectionProfile.Name(firstName: payload.name.first, lastName: payload.name.last, middleName: payload.name.middle, suffix: payload.name.suffix)
-            self.profile = DataBrokerProtectionProfile(names: names, addresses: profile.addresses, phones: profile.phones, birthYear: profile.birthYear)
-            return true
-        }
-
-        return false
+        let success = editablePartialProfile.setNameAtIndex(payload)
+        return success
     }
 
     public func removeNameAtIndexFromUserProfile(_ index: DBPUIIndex) -> Bool {
-        let profile = profile ?? emptyProfile
-
-        var names = profile.names
-        if index.index < names.count {
-            names.remove(at: index.index)
-            self.profile = DataBrokerProtectionProfile(names: names, addresses: profile.addresses, phones: profile.phones, birthYear: profile.birthYear)
-            return true
-        }
-
-        return false
+        let success = editablePartialProfile.removeNameAtIndex(index.index)
+        return success
     }
 
     public func setBirthYearForCurrentUserProfile(_ year: DBPUIBirthYear) -> Bool {
-        let profile = profile ?? emptyProfile
-
-        self.profile = DataBrokerProtectionProfile(names: profile.names, addresses: profile.addresses, phones: profile.phones, birthYear: year.year)
-
+        editablePartialProfile.birthYear = year
         return true
     }
 
     public func addAddressToCurrentUserProfile(_ address: DBPUIUserProfileAddress) -> Bool {
-        let profile = profile ?? emptyProfile
-
-        guard !addressIsEmpty(address) else { return false }
-
-        // No duplicates
-        guard indexForAddress(matching: address, in: profile) == nil else { return false }
-
-        var addresses = profile.addresses
-        addresses.append(DataBrokerProtectionProfile.Address(city: address.city, state: address.state, street: address.street, zipCode: address.zipCode))
-
-        self.profile = DataBrokerProtectionProfile(names: profile.names, addresses: addresses, phones: profile.phones, birthYear: profile.birthYear)
-
-        return true
+        let success = editablePartialProfile.addAddress(address)
+        return success
     }
 
     public func setAddressAtIndexInCurrentUserProfile(_ payload: DBPUIAddressAtIndex) -> Bool {
-        let profile = profile ?? emptyProfile
-
-        var addresses = profile.addresses
-        if payload.index < addresses.count {
-            addresses[payload.index] = DataBrokerProtectionProfile.Address(city: payload.address.city, state: payload.address.state,
-                                                                           street: payload.address.street, zipCode: payload.address.zipCode)
-            self.profile = DataBrokerProtectionProfile(names: profile.names, addresses: addresses, phones: profile.phones, birthYear: profile.birthYear)
-            return true
-        }
-
-        return false
+        let success = editablePartialProfile.setAddressAtIndex(payload)
+        return success
     }
 
     public func removeAddressAtIndexFromUserProfile(_ index: DBPUIIndex) -> Bool {
-        let profile = profile ?? emptyProfile
-
-        var addresses = profile.addresses
-        if index.index < addresses.count {
-            addresses.remove(at: index.index)
-            self.profile = DataBrokerProtectionProfile(names: profile.names, addresses: addresses, phones: profile.phones, birthYear: profile.birthYear)
-            return true
-        }
-
-        return false
+        let success = editablePartialProfile.removeAddressAtIndex(index.index)
+        return success
     }
 
     public func startScanAndOptOut() -> Bool {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1205142657210376/task/1210594776494461?focus=true
Tech Design URL:
CC:

### Description
Makes macOS use the new EditablePartialProfile from iOS to remove the duplicated logic when adding addresses etc

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1.
2.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)