### PR TITLE
macOS: Attempt crash fix in updateAIChatDividerVisibility

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -534,7 +534,7 @@ final class AddressBarButtonsViewController: NSViewController {
     }
 
     private func updateAIChatDividerVisibility() {
-        // Prevent crash if Combine subscriptions outlive view lifecycle
+        // Prevent crash if Combine subscriptions outlive view lifecycle: https://app.asana.com/1/137249556945/project/1199230911884351/task/1210593147082728
         guard isViewLoaded else { return }
 
         leadingAIChatDivider.isHidden = aiChatButton.isHidden || bookmarkButton.isHidden


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1210593147082728?focus=true

### Description

This is an attempted crash fix for a crash that we haven’t been able to reproduce, but that happens sometime after a new browser window is opened. The crash happens in `AddressBarButtonsViewController.updateAIChatDividerVisibility()` and we suspect that it’s caused when the Combine subscriptions that call this method outlive the view lifecycle.

### Testing Steps

We don’t have steps to confirm the crash fix, but this confirms the browser continues to work as expected:

1. Open a new browser window.
2. Confirm the button(s) on the right side of the address bar (and the divider between them) appear as expected.

### Impact and Risks
Low risk - view lifecycle check

#### What could go wrong?
May not fix crash

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)