### PR TITLE
Subscription is now fetched earlier in the restore flow

### DIFF
--- a/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
@@ -713,6 +713,7 @@ final class DefaultSubscriptionPagesUseSubscriptionFeatureV2: SubscriptionPagesU
 
         do {
             try await subscriptionManager.adopt(accessToken: subscriptionValues.accessToken, refreshToken: subscriptionValues.refreshToken)
+            try await subscriptionManager.getSubscription(cachePolicy: .remoteFirst)
             Logger.subscription.log("Subscription retrieved")
         } catch {
             Logger.subscription.error("Failed to adopt V2 tokens: \(error, privacy: .public)")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205842942115003/task/1210612873879174?focus=true

### Description

When restoring a subscription in iOS the new Subscription is fetched only when the settings page is opened and this introduces a delay and possible UI flashing when on slow connections. In macOS the subscription is fetched immediately after restoration.
Apply the same approach to iOS.

### Testing Steps
**iOS**
1. Restore subscription
2. Navigate back to settings, the subscription should load faster

### Impact and Risks

very low

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)