### PR TITLE
Fix DuckPlayer constraint crash by removing force unwraps

### DIFF
--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/DuckPlayerNativeUIPresenter.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/DuckPlayerNativeUIPresenter.swift
@@ -195,10 +195,14 @@ final class DuckPlayerNativeUIPresenter {
     @objc func handleOmnibarDidLayout(_ notification: Notification) {
         guard let height = notification.object as? CGFloat else { return }
         omniBarHeight = height
-        guard let bottomConstraint = bottomConstraint else { return }
-        // To be replaced with AppUserDefaults.Notifications.addressBarPositionChanged after release
-        // https://app.asana.com/1/137249556945/project/1207252092703676/task/1210323588862346?focus=true
-        bottomConstraint.constant = appSettings.currentAddressBarPosition == .bottom ? -height : 0
+        
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self,
+                  let bottomConstraint = self.bottomConstraint else { return }
+            // To be replaced with AppUserDefaults.Notifications.addressBarPositionChanged after release
+            // https://app.asana.com/1/137249556945/project/1207252092703676/task/1210323588862346?focus=true
+            bottomConstraint.constant = self.appSettings.currentAddressBarPosition == .bottom ? -height : 0
+        }
     }
 
         /// Updates the UI based on Ombibar Notification
@@ -232,11 +236,12 @@ final class DuckPlayerNativeUIPresenter {
                     self?.dismissPill(programatic: programatic)
                 },
                 onPresentDuckPlayer: { [weak self] in
-                    guard let self = self else { return }
+                    guard let self = self,
+                          let hostView = self.hostView else { return }
                     _ = self.presentDuckPlayer(
                         videoID: videoID,
                         source: .youtube,
-                        in: self.hostView!,
+                        in: hostView,
                         title: nil,
                         timestamp: timestamp
                     )
@@ -258,11 +263,12 @@ final class DuckPlayerNativeUIPresenter {
                     self?.dismissPill(programatic: programatic)
                 },
                 onPresentDuckPlayer: { [weak self] in
-                    guard let self = self else { return }
+                    guard let self = self,
+                          let hostView = self.hostView else { return }
                     _ = self.presentDuckPlayer(
                         videoID: videoID,
                         source: .youtube,
-                        in: self.hostView!,
+                        in: hostView,
                         title: nil,
                         timestamp: timestamp
                     )
@@ -287,11 +293,12 @@ final class DuckPlayerNativeUIPresenter {
                     self?.dismissPill(programatic: programatic)
                 },
                 onPresentDuckPlayer: { [weak self] in
-                    guard let self = self else { return }
+                    guard let self = self,
+                          let hostView = self.hostView else { return }
                     _ = self.presentDuckPlayer(
                         videoID: videoID,
                         source: .youtube,
-                        in: self.hostView!,
+                        in: hostView,
                         title: nil,
                         timestamp: timestamp
                     )
@@ -305,6 +312,7 @@ final class DuckPlayerNativeUIPresenter {
     /// Updates the webView constraint based on the current pill height
     @MainActor
     private func updateWebViewConstraintForPillHeight() {
+        guard hostView != nil else { return }
         constraintUpdatePublisher.send(.showPill(height: self.pillHeight))
     }
 
@@ -328,12 +336,20 @@ final class DuckPlayerNativeUIPresenter {
     /// Resets the webView constraint to its default value
     @MainActor
     private func resetWebViewConstraint() {
+        guard hostView != nil else { return }
         constraintUpdatePublisher.send(.reset)
     }
 
     /// Removes the pill controller
     @MainActor
     private func removePillContainer() {
+        // Cancel all subscriptions first
+        containerCancellables.removeAll()
+        
+        // Remove constraints before removing from superview
+        bottomConstraint?.isActive = false
+        bottomConstraint = nil
+        
         // First remove from superview
         containerViewController?.view.removeFromSuperview()
 
@@ -341,16 +357,29 @@ final class DuckPlayerNativeUIPresenter {
         containerViewController = nil
         containerViewModel = nil
         presentedPillType = nil
-        containerCancellables.removeAll()
 
         // Finally ensure constraints are reset
         resetWebViewConstraint()
     }
 
     deinit {
-        cleanupPlayer()
+        // Cancel all subscriptions
+        cancellables.removeAll()
         containerCancellables.removeAll()
+        playerCancellables.removeAll()
+        
+        // Clean up player
+        cleanupPlayer()
+        
+        // Remove notification observers
         NotificationCenter.default.removeObserver(self)
+        
+        // Clean up any remaining UI elements
+        bottomConstraint?.isActive = false
+        bottomConstraint = nil
+        containerViewController?.view.removeFromSuperview()
+        containerViewController = nil
+        containerViewModel = nil
     }
     
     private func cleanupPlayer() {
@@ -545,33 +574,39 @@ extension DuckPlayerNativeUIPresenter: DuckPlayerNativeUIPresenting {
 
         // Calculate bottom constraints based on URL Bar position
         // If at the bottom, the Container should be placed above it
-        bottomConstraint =
+        let newBottomConstraint =
             appSettings.currentAddressBarPosition == .bottom
             ? hostingController.view.bottomAnchor.constraint(equalTo: hostView.view.bottomAnchor, constant: -omniBarHeight)
             : hostingController.view.bottomAnchor.constraint(equalTo: hostView.view.bottomAnchor)
+        
+        bottomConstraint = newBottomConstraint
 
         NSLayoutConstraint.activate([
             hostingController.view.leadingAnchor.constraint(equalTo: hostView.view.leadingAnchor),
             hostingController.view.trailingAnchor.constraint(equalTo: hostView.view.trailingAnchor),
-            bottomConstraint!
+            newBottomConstraint
         ])
 
         // Store reference to the hosting controller
         containerViewController = hostingController
 
         // Subscribe to the sheet animation completed event
-        containerViewModel.$sheetAnimationCompleted.sink { [weak self] completed in
-            if completed && containerViewModel.sheetVisible {
-                self?.updateWebViewConstraintForPillHeight()
-            }
+        containerViewModel.$sheetAnimationCompleted.sink { [weak self, weak containerViewModel] completed in
+            guard let self = self,
+                  let containerViewModel = containerViewModel,
+                  completed && containerViewModel.sheetVisible else { return }
+            self.updateWebViewConstraintForPillHeight()
         }.store(in: &containerCancellables)
 
         // Subscribe to dragging state changes
-        containerViewModel.$isDragging.sink { [weak self] isDragging in
+        containerViewModel.$isDragging.sink { [weak self, weak containerViewModel] isDragging in
+            guard let self = self,
+                  let containerViewModel = containerViewModel else { return }
+            
             if isDragging {
-                self?.resetWebViewConstraint()
+                self.resetWebViewConstraint()
             } else if containerViewModel.sheetVisible {
-                self?.updateWebViewConstraintForPillHeight()
+                self.updateWebViewConstraintForPillHeight()
             }
         }.store(in: &containerCancellables)
 

--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/DuckPlayerNativeUIPresenter.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/DuckPlayerNativeUIPresenter.swift
@@ -502,6 +502,7 @@ extension DuckPlayerNativeUIPresenter: DuckPlayerNativeUIPresenting {
     ///   - videoID: The YouTube video ID to be played
     ///   - timestamp: The timestamp of the video
     @MainActor
+    // swiftlint:disable:next cyclomatic_complexity
     func presentPill(for videoID: String, in hostViewController: DuckPlayerHosting, timestamp: TimeInterval?) {
         
         if duckPlayerSettings.nativeUIYoutubeMode == .never {

--- a/iOS/DuckDuckGoTests/DuckPlayer/DuckPlayerNativeUIPresenterTests.swift
+++ b/iOS/DuckDuckGoTests/DuckPlayer/DuckPlayerNativeUIPresenterTests.swift
@@ -825,6 +825,13 @@ final class DuckPlayerNativeUIPresenterTests: XCTestCase {
         let notification = Notification(name: DefaultOmniBarView.didLayoutNotification, object: omnibarHeight)
         sut.handleOmnibarDidLayout(notification)
         
+        // Wait for async constraint update
+        let expectation = expectation(description: "Constraint update")
+        DispatchQueue.main.async {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+        
         // Then
         XCTAssertEqual(sut.bottomConstraint?.constant, 0, "Bottom constraint should be 0 for top address bar")
     }
@@ -842,6 +849,13 @@ final class DuckPlayerNativeUIPresenterTests: XCTestCase {
         // When
         let notification = Notification(name: DefaultOmniBarView.didLayoutNotification, object: omnibarHeight)
         sut.handleOmnibarDidLayout(notification)
+        
+        // Wait for async constraint update
+        let expectation = expectation(description: "Constraint update")
+        DispatchQueue.main.async {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
         
         // Then
         XCTAssertEqual(sut.bottomConstraint?.constant, -omnibarHeight, "Bottom constraint should be negative omnibar height for bottom address bar")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1210613997565723?focus=true
Tech Design URL: N/A
CC: N/A

### Description

Fixes a background crash in DuckPlayer's constraint handling. Crash was occurring during Auto Layout constraint processing

**Key Changes:**
- Remove all force unwrapping (`\!`) from constraint-related code
- Add proper nil checks and guard statements for weak references
- Send UI updates in `DispatchQueue.main.async`
- Improve cleanup in `deinit` and `removePillContainer()` methods
- Add weak captures in sink closures to prevent retain cycles

### Testing Steps
1. Navigate to a YouTube video page
2. Confirm DuckPlayer pill presentation
3. Go to Settings > Appeareance and Change Address bar position
4. Confirm DuckPlayer Pill properly attaches to Toolbar or Omnibar

![CleanShot 2025-06-23 at 12 48 10@2x](https://github.com/user-attachments/assets/e7d9385a-8330-460b-af88-064774616c16)


### Impact and Risks
![CleanShot 2025-06-23 at 12 48 26@2x](https://github.com/user-attachments/assets/7a14c385-1907-4e17-83be-e9469a33bef6)


#### What could go wrong?
N/A

**Mitigation:**
- All changes are defensive

### Quality Considerations
The crash was reproduced in Testflight buid with the stack trace showing `objc_msgSend` failures during constraint processing. 
