### PR TITLE
macOS Duck.ai Sidebar: 6. Visual tweaks and fixes

### DIFF
--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -457,6 +457,9 @@ struct UserText {
     static let searchAssistSettings = NSLocalizedString("duckai.search-assist-settings", value: "Search Assist Settings", comment: "The section name in preferences for Search Assist Settings")
     static let searchAssistSettingsDescription = NSLocalizedString("duckai.search-assist-settings.description", value: "Choose how often you want AI-Assisted answers to appear in your searches", comment: "Description of the section in Settings")
     static let searchAssistSettingsLink = NSLocalizedString("duckai.search-assist-settings.link", value: "Open Search Assist Settings", comment: "Button to open the Search Assist Settings")
+    static let aiChatSidebarTitle = NSLocalizedString("aichat.sidebar.title", value: "Duck.ai", comment: "Title for the Duck.ai sidebar")
+    static let aiChatSidebarExpandButtonTooltip = NSLocalizedString("aichat.sidebar.expand-button.tooltip", value: "Expand", comment: "Tooltip for button to open duck.ai chat from sidebar in a full tab")
+    static let aiChatSidebarCloseButtonTooltip = NSLocalizedString("aichat.sidebar.close-button.tooltip", value: "Close", comment: "Tooltip for button to close the sidebar with the duck.ai chat")
 
     // Duck Player Preferences
     static let duckPlayerSettingsTitle = NSLocalizedString("duck-player.title", value: "Duck Player", comment: "Private YouTube Player settings title")

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -1656,6 +1656,42 @@
         }
       }
     },
+    "aichat.sidebar.close-button.tooltip" : {
+      "comment" : "Tooltip for button to close the sidebar with the duck.ai chat",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Close"
+          }
+        }
+      }
+    },
+    "aichat.sidebar.expand-button.tooltip" : {
+      "comment" : "Tooltip for button to open duck.ai chat from sidebar in a full tab",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Expand"
+          }
+        }
+      }
+    },
+    "aichat.sidebar.title" : {
+      "comment" : "Title for the Duck.ai sidebar",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Duck.ai"
+          }
+        }
+      }
+    },
     "alert.sync-bookmarks-bad-data-error-description" : {
       "comment" : "Description for alert shown when sync error occurs because of bad data",
       "extractionState" : "extracted_with_value",

--- a/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarPresenter.swift
+++ b/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarPresenter.swift
@@ -155,15 +155,10 @@ final class AIChatSidebarPresenter: AIChatSidebarPresenting {
 extension AIChatSidebarPresenter: AIChatSidebarHostingDelegate {
 
     func sidebarHostDidSelectTab(with tabID: TabIdentifier) {
-        guard featureFlagger.isFeatureOn(.aiChatSidebar) else { return }
-
-        let isShowingSidebar = sidebarProvider.isShowingSidebar(for: tabID)
-        updateSidebarConstraints(for: tabID, isShowingSidebar: isShowingSidebar, withAnimation: false)
+        updateSidebarConstraints(for: tabID, isShowingSidebar: isSidebarOpen(for: tabID), withAnimation: false)
     }
 
     func sidebarHostDidUpdateTabs() {
-        guard featureFlagger.isFeatureOn(.aiChatSidebar) else { return }
-
         let allPinnedTabIDs = windowControllersManager.pinnedTabsManagerProvider.currentPinnedTabManagers.flatMap { $0.tabViewModels.keys }.map { $0.uuid }
         let allTabIDs = windowControllersManager.allTabCollectionViewModels.flatMap { $0.tabViewModels.keys }.map { $0.uuid }
         sidebarProvider.cleanUp(for: allPinnedTabIDs + allTabIDs)

--- a/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarPresenter.swift
+++ b/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarPresenter.swift
@@ -119,6 +119,7 @@ final class AIChatSidebarPresenter: AIChatSidebarPresenting {
                 guard let self else { return }
 
                 context.duration = 0.25
+                context.allowsImplicitAnimation = true
                 context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
                 sidebarHost.sidebarContainerLeadingConstraint?.animator().constant = newConstraintValue
             } completionHandler: { [weak self, tabID = sidebarHost.currentTabID] in

--- a/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarProvider.swift
+++ b/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarProvider.swift
@@ -86,6 +86,7 @@ final class AIChatSidebarProvider: AIChatSidebarProviding {
         guard let tabSidebar = sidebarsByTab[tabID] else {
             return
         }
+        tabSidebar.sidebarViewController.stopLoading()
         tabSidebar.sidebarViewController.removeCompletely()
         sidebarsByTab.removeValue(forKey: tabID)
     }

--- a/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarViewController.swift
+++ b/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarViewController.swift
@@ -257,6 +257,13 @@ final class AIChatSidebarViewController: NSViewController {
         delegate?.didClickCloseButton()
     }
 
+    func stopLoading() {
+        aiTab.webView.navigationDelegate = nil
+        aiTab.webView.uiDelegate = nil
+
+        aiTab.webView.stopLoading()
+        aiTab.webView.loadHTMLString("", baseURL: nil)
+    }
 }
 
 extension AIChatSidebarViewController: TabDelegate {

--- a/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarViewController.swift
+++ b/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarViewController.swift
@@ -52,6 +52,7 @@ final class AIChatSidebarViewController: NSViewController {
     weak var delegate: AIChatSidebarViewControllerDelegate?
     public var aiChatPayload: AIChatPayload?
     private(set) var currentAIChatURL: URL
+    private let visualStyle: VisualStyleProviding
 
     private var openInNewTabButton: MouseOverButton!
     private var closeButton: MouseOverButton!
@@ -63,8 +64,10 @@ final class AIChatSidebarViewController: NSViewController {
 
     private var cancellables = Set<AnyCancellable>()
 
-    init(currentAIChatURL: URL) {
+    init(currentAIChatURL: URL,
+         visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle) {
         self.currentAIChatURL = currentAIChatURL
+        self.visualStyle = visualStyle
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -73,9 +76,7 @@ final class AIChatSidebarViewController: NSViewController {
     }
 
     override func loadView() {
-        let container = NSView()
-        container.wantsLayer = true
-        container.layer?.backgroundColor = NSColor.navigationBarBackground.cgColor
+        let container = ColorView(frame: .zero, backgroundColor: visualStyle.colorsProvider.navigationBackgroundColor)
 
         if let aiChatPayload {
             aiTab.aiChat?.setAIChatNativeHandoffData(payload: aiChatPayload)
@@ -121,8 +122,6 @@ final class AIChatSidebarViewController: NSViewController {
 
     private func createAndSetupTopBar(in container: NSView) {
         topBar = NSView()
-        topBar.wantsLayer = true
-        topBar.layer?.backgroundColor = NSColor.navigationBarBackground.cgColor
         topBar.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(topBar)
 

--- a/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarViewController.swift
+++ b/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarViewController.swift
@@ -126,6 +126,7 @@ final class AIChatSidebarViewController: NSViewController {
         container.addSubview(topBar)
 
         openInNewTabButton = MouseOverButton(image: .expand, target: self, action: #selector(openInNewTabButtonClicked))
+        openInNewTabButton.toolTip = UserText.aiChatSidebarExpandButtonTooltip
         openInNewTabButton.translatesAutoresizingMaskIntoConstraints = false
         openInNewTabButton.bezelStyle = .shadowlessSquare
         openInNewTabButton.cornerRadius = 9
@@ -135,14 +136,15 @@ final class AIChatSidebarViewController: NSViewController {
         openInNewTabButton.isBordered = false
         topBar.addSubview(openInNewTabButton)
 
-        let titleLabel = NSTextField(labelWithString: "Duck.ai")
+        let titleLabel = NSTextField(labelWithString: UserText.aiChatSidebarTitle)
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.alignment = .center
         titleLabel.font = .systemFont(ofSize: 13, weight: .medium)
         titleLabel.textColor = .labelColor
         topBar.addSubview(titleLabel)
 
-        closeButton = MouseOverButton(image: .close, target: self, action: #selector(closeButtonClicked))
+        closeButton = MouseOverButton(image: .closeLarge, target: self, action: #selector(closeButtonClicked))
+        closeButton.toolTip = UserText.aiChatSidebarCloseButtonTooltip
         closeButton.translatesAutoresizingMaskIntoConstraints = false
         closeButton.bezelStyle = .shadowlessSquare
         closeButton.cornerRadius = 9

--- a/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
@@ -20,6 +20,7 @@ import AppKit
 import Combine
 import Foundation
 import WebKitExtensions
+import BrowserServicesKit
 
 enum NavigationDecision {
     case allow(NewWindowPolicy)
@@ -36,7 +37,8 @@ final class ContextMenuManager: NSObject {
     private var linkURL: String?
 
     private var tabsPreferences: TabsPreferences
-    private var isLoadedInSidebar: Bool
+    private let isLoadedInSidebar: Bool
+    private let internalUserDecider: InternalUserDecider
 
     private var isEmailAddress: Bool {
         guard let linkURL, let url = URL(string: linkURL) else {
@@ -57,9 +59,11 @@ final class ContextMenuManager: NSObject {
     @MainActor
     init(contextMenuScriptPublisher: some Publisher<ContextMenuUserScript?, Never>,
          tabsPreferences: TabsPreferences = TabsPreferences.shared,
-         isLoadedInSidebar: Bool = false) {
+         isLoadedInSidebar: Bool = false,
+         internalUserDecider: InternalUserDecider) {
         self.tabsPreferences = tabsPreferences
         self.isLoadedInSidebar = isLoadedInSidebar
+        self.internalUserDecider = internalUserDecider
         super.init()
 
         userScriptCancellable = contextMenuScriptPublisher.sink { [weak self] contextMenuScript in
@@ -207,7 +211,7 @@ extension ContextMenuManager {
     }
 
     private func handleInspectElementItem(_ item: NSMenuItem, at index: Int, in menu: NSMenu) {
-        guard isLoadedInSidebar else { return }
+        guard isLoadedInSidebar, !internalUserDecider.isInternalUser else { return }
         menu.removeItem(at: index)
     }
 }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
@@ -36,6 +36,7 @@ final class ContextMenuManager: NSObject {
     private var linkURL: String?
 
     private var tabsPreferences: TabsPreferences
+    private var isLoadedInSidebar: Bool
 
     private var isEmailAddress: Bool {
         guard let linkURL, let url = URL(string: linkURL) else {
@@ -55,8 +56,10 @@ final class ContextMenuManager: NSObject {
 
     @MainActor
     init(contextMenuScriptPublisher: some Publisher<ContextMenuUserScript?, Never>,
-         tabsPreferences: TabsPreferences = TabsPreferences.shared) {
+         tabsPreferences: TabsPreferences = TabsPreferences.shared,
+         isLoadedInSidebar: Bool = false) {
         self.tabsPreferences = tabsPreferences
+        self.isLoadedInSidebar = isLoadedInSidebar
         super.init()
 
         userScriptCancellable = contextMenuScriptPublisher.sink { [weak self] contextMenuScript in
@@ -92,7 +95,8 @@ extension ContextMenuManager {
         .downloadImage: handleDownloadImageItem,
         .searchWeb: handleSearchWebItem,
         .reload: handleReloadItem,
-        .openFrameInNewWindow: handleOpenFrameInNewWindowItem
+        .openFrameInNewWindow: handleOpenFrameInNewWindowItem,
+        .inspectElement: handleInspectElementItem
     ]
 
     private var isCurrentWindowBurner: Bool {
@@ -198,7 +202,13 @@ extension ContextMenuManager {
     }
 
     private func handleReloadItem(_ item: NSMenuItem, at index: Int, in menu: NSMenu) {
+        guard !isLoadedInSidebar else { return }
         menu.insertItem(self.bookmarkPageMenuItem(), at: index + 1)
+    }
+
+    private func handleInspectElementItem(_ item: NSMenuItem, at index: Int, in menu: NSMenu) {
+        guard isLoadedInSidebar else { return }
+        menu.removeItem(at: index)
     }
 }
 

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
@@ -174,7 +174,8 @@ extension TabExtensionsBuilder {
                                  isBurner: args.isTabBurner)
         }
         add {
-            ContextMenuManager(contextMenuScriptPublisher: userScripts.map(\.?.contextMenuScript))
+            ContextMenuManager(contextMenuScriptPublisher: userScripts.map(\.?.contextMenuScript),
+                               isLoadedInSidebar: args.isTabLoadedInSidebar)
         }
         add {
             HoveredLinkTabExtension(hoverUserScriptPublisher: userScripts.map(\.?.hoverUserScript))

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
@@ -175,7 +175,8 @@ extension TabExtensionsBuilder {
         }
         add {
             ContextMenuManager(contextMenuScriptPublisher: userScripts.map(\.?.contextMenuScript),
-                               isLoadedInSidebar: args.isTabLoadedInSidebar)
+                               isLoadedInSidebar: args.isTabLoadedInSidebar,
+                               internalUserDecider: dependencies.featureFlagger.internalUserDecider)
         }
         add {
             HoveredLinkTabExtension(hoverUserScriptPublisher: userScripts.map(\.?.hoverUserScript))

--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -170,10 +170,10 @@ final class BrowserTabViewController: NSViewController {
         hoverLabel.topAnchor.constraint(equalTo: hoverLabelContainer.topAnchor, constant: 6).isActive = true
 
         view.addSubview(sidebarContainer)
-        
+
         sidebarContainerLeadingConstraint = sidebarContainer.leadingAnchor.constraint(equalTo: browserTabView.trailingAnchor)
         sidebarContainerWidthConstraint = sidebarContainer.widthAnchor.constraint(equalToConstant: 0)
-        
+
         NSLayoutConstraint.activate([
             sidebarContainer.topAnchor.constraint(equalTo: browserTabView.topAnchor),
             sidebarContainer.bottomAnchor.constraint(equalTo: browserTabView.bottomAnchor),

--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -169,19 +169,17 @@ final class BrowserTabViewController: NSViewController {
         hoverLabelContainer.trailingAnchor.constraint(equalTo: hoverLabel.trailingAnchor, constant: 8).isActive = true
         hoverLabel.topAnchor.constraint(equalTo: hoverLabelContainer.topAnchor, constant: 6).isActive = true
 
-        if featureFlagger.isFeatureOn(.aiChatSidebar) {
-            view.addSubview(sidebarContainer)
-
-            sidebarContainerLeadingConstraint = sidebarContainer.leadingAnchor.constraint(equalTo: browserTabView.trailingAnchor)
-            sidebarContainerWidthConstraint = sidebarContainer.widthAnchor.constraint(equalToConstant: 0)
-
-            NSLayoutConstraint.activate([
-                sidebarContainer.topAnchor.constraint(equalTo: browserTabView.topAnchor),
-                sidebarContainer.bottomAnchor.constraint(equalTo: browserTabView.bottomAnchor),
-                sidebarContainerLeadingConstraint!,
-                sidebarContainerWidthConstraint!
-            ])
-        }
+        view.addSubview(sidebarContainer)
+        
+        sidebarContainerLeadingConstraint = sidebarContainer.leadingAnchor.constraint(equalTo: browserTabView.trailingAnchor)
+        sidebarContainerWidthConstraint = sidebarContainer.widthAnchor.constraint(equalToConstant: 0)
+        
+        NSLayoutConstraint.activate([
+            sidebarContainer.topAnchor.constraint(equalTo: browserTabView.topAnchor),
+            sidebarContainer.bottomAnchor.constraint(equalTo: browserTabView.bottomAnchor),
+            sidebarContainerLeadingConstraint!,
+            sidebarContainerWidthConstraint!
+        ])
     }
 
     override func viewDidLoad() {
@@ -479,12 +477,8 @@ final class BrowserTabViewController: NSViewController {
         NSLayoutConstraint.activate([
             containerStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             containerStackView.topAnchor.constraint(equalTo: view.topAnchor),
-            containerStackView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
-
-        let constraint =  featureFlagger.isFeatureOn(.aiChatSidebar) ? sidebarContainer.leadingAnchor : view.trailingAnchor
-        NSLayoutConstraint.activate([
-            containerStackView.trailingAnchor.constraint(equalTo: constraint)
+            containerStackView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            containerStackView.trailingAnchor.constraint(equalTo: sidebarContainer.leadingAnchor)
         ])
 
         containerStackView.addArrangedSubview(container)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209671977594486/task/1210012482760771?focus=true
Tech Design URL:
CC:

### Description
This PR contains various fixes and visual tweaks related to Duck.ai sidebar feature:
- fix for crash when sidebar was toggled after the feature flag was changed without restart
- clean up of right click menu in the sidebar
- fix background color and dark mode of the sidebar
- add tooltips for sidebar buttons
- fix for crash when sidebar was toggled repeateadly and rapidly


### Testing Steps
**Fix for crash when sidebar was toggled after the feature flag was changed without restart**
1. Check if feature flag for sidebar is disabled
2. Open tab and navigate to website
3. Click the Duck.ai address bar button (it should open a new tab)
4. Enable feature flag for the sidebar
5. Navigate to a website
6. Click the Duck.ai address bar button (it should open the sidebar)
Expected: Sidebar works depending on the feature flag and the app does not crash or is not reporting broken layout constraints


**Right click menu in the sidebar**
1. Ensure internal user mode is enabled
2. Opena tab and navigate to a website
3. Click the Duck.ai address bar button to open the sidebar
4. Right click in the sidebar -> the context menu should contain "Inspect element"
5. Disable internal user mode from the debug menu
6. Right click in the sidebar -> the context menu should not contain "Inspect element"


**Fix background color and dark mode of the sidebar**
1. Verify sidebar's background color to be aligned with the app's navigation area
2. Check if dark mode also looks consistent


**Tooltips for sidebar buttons**
1. Verify tooltips for the native sidebar buttons


**Fix for crash when sidebar was toggled repeateadly and rapidly**
1. Open multiple tabs with websites and toggle sidebar on some of them
2. Start repeateadly and rapidly clicking on the Duck.ai address bar button to trigger sidebar's collapse and reveal
Expected: App should not crash due to assert for unallocated webview


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
Fixes for a feature behind feature flag, so no potential impact expected 

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)