### PR TITLE
Reload any open history tabs after clearing all history without burning

### DIFF
--- a/macOS/DuckDuckGo/Menus/HistoryMenu.swift
+++ b/macOS/DuckDuckGo/Menus/HistoryMenu.swift
@@ -45,7 +45,7 @@ final class HistoryMenu: NSMenu {
     )
     private let showHistorySeparator = NSMenuItem.separator()
     private let clearAllHistoryMenuItem = NSMenuItem(title: UserText.mainMenuHistoryClearAllHistory,
-                                                     action: #selector(MainViewController.clearAllHistory),
+                                                     action: #selector(AppDelegate.clearAllHistory),
                                                      keyEquivalent: [.command, .shift, .backspace])
         .withAccessibilityIdentifier("HistoryMenu.clearAllHistory")
     private let clearAllHistorySeparator = NSMenuItem.separator()

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -124,14 +124,46 @@ extension AppDelegate {
     }
 
     @objc func clearAllHistory(_ sender: NSMenuItem) {
-        DispatchQueue.main.async {
-            guard let window = WindowsManager.openNewWindow(with: Tab(content: .newtab)),
-                  let windowController = window.windowController as? MainWindowController else {
+        Task { @MainActor in
+            let window: NSWindow? = windowControllersManager.lastKeyMainWindowController?.window ?? WindowsManager.openNewWindow(with: Tab(content: .newtab))
+            guard let window else {
                 assertionFailure("No reference to main window controller")
                 return
             }
 
-            windowController.mainViewController.clearAllHistory(sender)
+            if featureFlagger.isFeatureOn(.historyView) {
+                let historyViewDataProvider = HistoryViewDataProvider(
+                    historyDataSource: historyCoordinator,
+                    historyBurner: FireHistoryBurner(fireproofDomains: fireproofDomains, fire: { @MainActor in self.fireCoordinator.fireViewModel.fire })
+                )
+                await historyViewDataProvider.refreshData()
+                let visitsCount = await historyViewDataProvider.countVisibleVisits(matching: .rangeFilter(.all))
+
+                let presenter = DefaultHistoryViewDialogPresenter()
+                switch await presenter.showDeleteDialog(for: visitsCount, deleteMode: .all, in: window) {
+                case .burn:
+                    fireCoordinator.fireViewModel.fire.burnAll()
+                case .delete:
+                    historyCoordinator.burnAll {
+                        // History View doesn't currently support having new data pushed to it
+                        // so we need to instruct all open history tabs to reload themselves.
+                        let historyTabs = self.windowControllersManager.mainWindowControllers
+                            .flatMap(\.mainViewController.tabCollectionViewModel.tabCollection.tabs)
+                            .filter { $0.content == .history }
+                        historyTabs.forEach { $0.reload() }
+                    }
+                default:
+                    break
+                }
+            } else {
+                let alert = NSAlert.clearAllHistoryAndDataAlert()
+                alert.beginSheetModal(for: window, completionHandler: { response in
+                    guard case .alertFirstButtonReturn = response else {
+                        return
+                    }
+                    self.fireCoordinator.fireViewModel.fire.burnAll()
+                })
+            }
         }
     }
 
@@ -820,41 +852,6 @@ extension MainViewController {
         makeKeyIfNeeded()
 
         Application.appDelegate.windowControllersManager.open(historyEntry, with: NSApp.currentEvent)
-    }
-
-    @objc func clearAllHistory(_ sender: NSMenuItem) {
-        if featureFlagger.isFeatureOn(.historyView) {
-            Task {
-                let historyViewDataProvider = HistoryViewDataProvider(
-                    historyDataSource: historyCoordinator,
-                    historyBurner: FireHistoryBurner(fireproofDomains: fireproofDomains, fire: { @MainActor in self.fireCoordinator.fireViewModel.fire })
-                )
-                await historyViewDataProvider.refreshData()
-                let visitsCount = await historyViewDataProvider.countVisibleVisits(matching: .rangeFilter(.all))
-
-                let presenter = DefaultHistoryViewDialogPresenter()
-                switch await presenter.showDeleteDialog(for: visitsCount, deleteMode: .all, in: nil) {
-                case .burn:
-                    self.fireCoordinator.fireViewModel.fire.burnAll()
-                case .delete:
-                    historyCoordinator.burnAll {}
-                default:
-                    break
-                }
-            }
-        } else {
-            guard let window = view.window else {
-                assertionFailure("No window")
-                return
-            }
-            let alert = NSAlert.clearAllHistoryAndDataAlert()
-            alert.beginSheetModal(for: window, completionHandler: { response in
-                guard case .alertFirstButtonReturn = response else {
-                    return
-                }
-                self.fireCoordinator.fireViewModel.fire.burnAll()
-            })
-        }
     }
 
     @objc func clearThisHistory(_ sender: ClearThisHistoryMenuItem) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201621708115095/task/1210580813193272?focus=true

### Description
This change forces reload on all open history page tabs after clearing all history without burning.
Clearing all history was moved to AppDelegate which owns windowControllerManager that’s used to
find all tabs with history page.

### Testing Steps
1. Run the app and populate history (Main Menu -> Debug -> History -> Add 10 history visits each day)
2. Open history page (cmd+y)
3. Open a new window with 2 history tabs.
4. Clear all history from the main menu, but leave burn checkmark **unchecked**.
5. Verify that all 3 history tabs were reloaded and show empty history now.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)