### PR TITLE
Do not show suggestion when tapping the bar from a website

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -324,8 +324,9 @@ final class OmniBarEditingStateViewController: UIViewController {
         delegate?.onVoiceSearchRequested(from: switchBarHandler.currentToggleState)
     }
 
-    func selectAllText() {
+    func setUpForInitialSelectedState() {
         switchBarVC.textEntryViewController.selectAllText()
+        showSuggestionTray(.favorites)
     }
 
     private func installDaxLogoView() {

--- a/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarViewController.swift
@@ -145,7 +145,7 @@ final class UpdatedOmniBarViewController: OmniBarViewController {
 
         if shouldAutoSelectText {
             DispatchQueue.main.async {
-                editingStateViewController.selectAllText()
+                editingStateViewController.setUpForInitialSelectedState()
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210601460385822?focus=true

### Description
Do not show suggestion when tapping the bar from a website

### Testing Steps
1. Enable the new UI (Settings -> Appearance -> Experimental)
2. Enable duck.ai experimental (Settings -> Duck.ai -> Experimental)
3. Open a website, tap the omnibar, check that the logo is being displayed (or favorites)
4. Open the SERP, tap the omnibar, check that we're displaying the suggestions

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Regressions when opening the omnibar

### Quality Considerations
There's a flash on the animation that happens when the view is displayed. This is expected, it will be fixed lated
