### PR TITLE
Fix WebKit ResponsivenessTimer crash on app startup

### DIFF
--- a/iOS/Core/UserAgentManager.swift
+++ b/iOS/Core/UserAgentManager.swift
@@ -45,6 +45,16 @@ public class DefaultUserAgentManager: UserAgentManager {
     }
 
     private func prepareUserAgent() {
+        if Thread.isMainThread {
+            createWebViewAndExtractUserAgent()
+        } else {
+            DispatchQueue.main.sync {
+                createWebViewAndExtractUserAgent()
+            }
+        }
+    }
+
+    private func createWebViewAndExtractUserAgent() {
         let webview = WKWebView()
         webview.load(URLRequest.developerInitiated(URL(string: "about:blank")!))
         getDefaultAgent(webView: webview) { [weak self] agent in


### PR DESCRIPTION
Task/Issue URL: <\!-- Please provide Asana task URL -->
Tech Design URL:
CC:

### Description

This PR fixes a crash that occurs during app startup when `WKWebView` is created on a background thread. The crash manifests as a WebKit ResponsivenessTimer error.

The issue occurs in the static initialization chain:
- `SyncService.init` → `Favicons.shared` → `DefaultUserAgentManager.shared` → creates `WKWebView`

Since this initialization can happen on any thread during app launch, but `WKWebView` must be created on the main thread, the app crashes.

### Testing Steps
1. Build and run the app on a device or simulator
2. Force quit the app and launch it again multiple times
3. Verify the app launches successfully without crashing
4. Check that user agent functionality still works correctly (web pages load with proper user agent)

### Impact and Risks

**Impact Level: High** - This crash affects app startup and could prevent users from launching the app.

#### What could go wrong?
- If the main thread is blocked during startup, using `DispatchQueue.main.sync` could potentially cause a deadlock. However, this is unlikely as the initialization happens early in the app lifecycle before complex UI operations.
- The synchronous dispatch adds a small delay to initialization, but this is negligible compared to the crash prevention benefit.

### Quality Considerations
- **Edge cases**: The fix handles both main thread and background thread scenarios
- **Performance**: Minimal impact - only adds thread switching overhead when needed
- **Thread safety**: Ensures WebKit requirements are met by guaranteeing main thread execution

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)