### PR TITLE
Blind Fix: WebKit ResponsivenessTimer crash on app startup

### DIFF
--- a/iOS/Core/UserAgentManager.swift
+++ b/iOS/Core/UserAgentManager.swift
@@ -41,20 +41,13 @@ public class DefaultUserAgentManager: UserAgentManager {
     private var userAgent = UserAgent()
 
     init() {
-        prepareUserAgent()
-    }
-
-    private func prepareUserAgent() {
-        if Thread.isMainThread {
-            createWebViewAndExtractUserAgent()
-        } else {
-            DispatchQueue.main.sync {
-                createWebViewAndExtractUserAgent()
-            }
+        // Defer WKWebView creation until we're on main thread
+        DispatchQueue.main.async { [weak self] in
+            self?.prepareUserAgent()
         }
     }
 
-    private func createWebViewAndExtractUserAgent() {
+    private func prepareUserAgent() {
         let webview = WKWebView()
         webview.load(URLRequest.developerInitiated(URL(string: "about:blank")!))
         getDefaultAgent(webView: webview) { [weak self] agent in

--- a/iOS/Core/UserAgentManager.swift
+++ b/iOS/Core/UserAgentManager.swift
@@ -45,6 +45,16 @@ public class DefaultUserAgentManager: UserAgentManager {
     }
 
     private func prepareUserAgent() {
+        if Thread.isMainThread {
+            createWebViewAndExtractUserAgent()
+        } else {
+            DispatchQueue.main.sync {
+                createWebViewAndExtractUserAgent()
+            }
+        }
+    }
+
+    private func createWebViewAndExtractUserAgent() {
         let webview = WKWebView()
         webview.load(URLRequest.developerInitiated(URL(string: "about:blank")!))
         getDefaultAgent(webView: webview) { [weak self] agent in


### PR DESCRIPTION
Task/Issue URL: <\!-- Please provide Asana task URL -->
Tech Design URL:
CC:

### Description

Fixes a crash during app startup if `WKWebView` is created on a background thread.

Seems to happen in the static initialization chain:
- `SyncService.init` → `Favicons.shared` → `DefaultUserAgentManager.shared` → creates `WKWebView`

This initialization could happen on any thread at launch, but `WKWebView` needs ato be created on main.

We're now simply deferring `WKWebView` via `DispatchQueue.main.async`, which:

### Testing Steps
1. Build and run the app on a device or simulator
2. Force quit the app and launch it again multiple times
3. Verify the app launches successfully without crashing
4. Verify that web pages load correctly with the proper user agent (check in browser console)
5. Test that user agent switching (desktop/mobile) still works as expected

### Impact and Risks

**Impact Level: Low** - Improve launch approach and prevents potential crashes

#### What could go wrong?
- There's a VERY brief window during app startup where the fallback user agent is used.


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)