### PR TITLE
Pixels for autofill keyboard accessory

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Autofill/AutofillVaultUserScriptTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Autofill/AutofillVaultUserScriptTests.swift
@@ -564,16 +564,28 @@ class AutofillVaultUserScriptTests: XCTestCase {
         class CreditCardDelegate: MockSecureVaultDelegate {
             var didRequestCreditCardCalled = false
             var capturedTrigger: AutofillUserScript.GetTriggerType?
+            let expectation: XCTestExpectation
+
+            init(expectation: XCTestExpectation) {
+                self.expectation = expectation
+                super.init()
+            }
 
             override func autofillUserScriptDidRequestCreditCard(_: AutofillUserScript,
                                                                  trigger: AutofillUserScript.GetTriggerType,
                                                                  completionHandler: @escaping (SecureVaultModels.CreditCard?, RequestVaultDataAction) -> Void) {
                 didRequestCreditCardCalled = true
                 capturedTrigger = trigger
+
+                DispatchQueue.main.async {
+                    completionHandler(nil, .none)
+                    self.expectation.fulfill()
+                }
             }
         }
 
-        let delegate = CreditCardDelegate()
+        let expect = expectation(description: #function)
+        let delegate = CreditCardDelegate(expectation: expect)
         userScript.vaultDelegate = delegate
 
         // Construct the message body
@@ -587,6 +599,12 @@ class AutofillVaultUserScriptTests: XCTestCase {
 
         userScript.userContentController(userContentController, didReceive: message) { _, _ in }
 
+        waitForExpectations(timeout: 1.0) { error in
+            if let error = error {
+                XCTFail("Expectation failed with error: \(error)")
+            }
+        }
+
         XCTAssertTrue(delegate.didRequestCreditCardCalled, "Delegate should receive the credit-card request")
         XCTAssertEqual(delegate.capturedTrigger, .userInitiated)
     }
@@ -595,16 +613,28 @@ class AutofillVaultUserScriptTests: XCTestCase {
         class FocusDelegate: MockSecureVaultDelegate {
             var didCallDidFocus = false
             var capturedMainType: AutofillUserScript.GetAutofillDataMainType?
+            let expectation: XCTestExpectation
+
+            init(expectation: XCTestExpectation) {
+                self.expectation = expectation
+                super.init()
+            }
 
             override func autofillUserScriptDidFocus(_: AutofillUserScript,
                                                      mainType: AutofillUserScript.GetAutofillDataMainType,
                                                      completionHandler: @escaping (SecureVaultModels.CreditCard?, RequestVaultDataAction) -> Void) {
                 didCallDidFocus = true
                 capturedMainType = mainType
+
+                DispatchQueue.main.async {
+                    completionHandler(nil, .none)
+                    self.expectation.fulfill()
+                }
             }
         }
 
-        let delegate = FocusDelegate()
+        let expect = expectation(description: #function)
+        let delegate = FocusDelegate(expectation: expect)
         userScript.vaultDelegate = delegate
 
         // Construct the message body
@@ -616,6 +646,12 @@ class AutofillVaultUserScriptTests: XCTestCase {
 
         userScript.userContentController(userContentController, didReceive: message) { _, _ in }
 
+        waitForExpectations(timeout: 1.0) { error in
+            if let error = error {
+                XCTFail("Expectation failed with error: \(error)")
+            }
+        }
+
         XCTAssertTrue(delegate.didCallDidFocus, "Delegate should receive focus request")
         XCTAssertEqual(delegate.capturedMainType, .creditCards)
     }
@@ -625,7 +661,9 @@ class AutofillVaultUserScriptTests: XCTestCase {
             override func autofillUserScriptDidFocus(_: AutofillUserScript,
                                                      mainType: AutofillUserScript.GetAutofillDataMainType,
                                                      completionHandler: @escaping (SecureVaultModels.CreditCard?, RequestVaultDataAction) -> Void) {
-                completionHandler(nil, .none)
+                DispatchQueue.main.async {
+                    completionHandler(nil, .none)
+                }
             }
         }
 
@@ -641,20 +679,23 @@ class AutofillVaultUserScriptTests: XCTestCase {
         let expect = expectation(description: #function)
 
         userScript.userContentController(userContentController, didReceive: message) { result, error in
-            XCTAssertNil(error)
+            defer { expect.fulfill() }
 
-            guard let jsonString = result as? String,
-                  let data = jsonString.data(using: .utf8),
-                  let response = try? JSONDecoder().decode(AutofillUserScript.RequestVaultCreditCardResponse.self, from: data)
-            else {
+            XCTAssertNil(error, "Should not receive an error")
+            XCTAssertNotNil(result, "Should receive a result")
+
+            guard let jsonString = result as? String, let data = jsonString.data(using: .utf8) else {
                 XCTFail("Could not decode `RequestVaultCreditCardResponse`")
                 return
             }
 
-            XCTAssertNil(response.success.creditCards)
-            XCTAssertEqual(response.success.action, RequestVaultDataAction.none)
-
-            expect.fulfill()
+            do {
+                let response = try JSONDecoder().decode(AutofillUserScript.RequestVaultCreditCardResponse.self, from: data)
+                XCTAssertNil(response.success.creditCards)
+                XCTAssertEqual(response.success.action, RequestVaultDataAction.none)
+            } catch {
+                XCTFail("Failed to decode response: \(error)")
+            }
         }
 
         waitForExpectations(timeout: 1.0)
@@ -668,7 +709,9 @@ class AutofillVaultUserScriptTests: XCTestCase {
                                                      mainType: AutofillUserScript.GetAutofillDataMainType,
                                                      completionHandler: @escaping (SecureVaultModels.CreditCard?, RequestVaultDataAction) -> Void) {
                 capturedMainType = mainType
-                completionHandler(nil, .none)
+                DispatchQueue.main.async {
+                    completionHandler(nil, .none)
+                }
             }
         }
 
@@ -677,50 +720,73 @@ class AutofillVaultUserScriptTests: XCTestCase {
 
         // Test with different main types
         let mainTypes = ["credentials", "identities", "unknown"]
+        let expectations = mainTypes.map { expectation(description: "Response for mainType: \($0)") }
 
-        for mainType in mainTypes {
+        for (index, mainType) in mainTypes.enumerated() {
             var body = encryptedMessagingParams
             body["mainType"] = mainType
 
             let mockWebView = MockWebView()
             let message = MockWKScriptMessage(name: "getAutofillDataFocus", body: body, webView: mockWebView)
-
-            let expect = expectation(description: "Testing mainType: \(mainType)")
+            let currentExpectation = expectations[index]
 
             userScript.userContentController(userContentController, didReceive: message) { result, error in
-                XCTAssertNil(error)
+                defer { currentExpectation.fulfill() }
 
-                guard let jsonString = result as? String,
-                      let data = jsonString.data(using: .utf8),
-                      let response = try? JSONDecoder().decode(AutofillUserScript.RequestVaultCreditCardResponse.self, from: data)
-                else {
+                XCTAssertNil(error, "Should not receive an error for mainType: \(mainType)")
+                XCTAssertNotNil(result, "Should receive a result for mainType: \(mainType)")
+
+                guard let jsonString = result as? String, let data = jsonString.data(using: .utf8) else {
                     XCTFail("Could not decode `RequestVaultCreditCardResponse` for mainType \(mainType)")
                     return
                 }
 
-                XCTAssertNil(response.success.creditCards)
-                XCTAssertEqual(response.success.action, RequestVaultDataAction.none)
-
-                expect.fulfill()
+                do {
+                    let response = try JSONDecoder().decode(AutofillUserScript.RequestVaultCreditCardResponse.self, from: data)
+                    XCTAssertNil(response.success.creditCards)
+                    XCTAssertEqual(response.success.action, RequestVaultDataAction.none)
+                } catch {
+                    XCTFail("Failed to decode response for mainType \(mainType): \(error)")
+                }
             }
-
-            waitForExpectations(timeout: 1.0)
         }
+
+        wait(for: expectations, timeout: 2.0)
     }
 
     func testWhenMultipleRequestsForSameMessageType_PreviousRepliesAreCancelled() {
         class SlowFocusDelegate: MockSecureVaultDelegate {
             var completionHandlers: [(SecureVaultModels.CreditCard?, RequestVaultDataAction) -> Void] = []
+            let firstCallExpectation: XCTestExpectation
+            let secondCallExpectation: XCTestExpectation
+
+            init(firstCallExpectation: XCTestExpectation, secondCallExpectation: XCTestExpectation) {
+                self.firstCallExpectation = firstCallExpectation
+                self.secondCallExpectation = secondCallExpectation
+                super.init()
+            }
 
             override func autofillUserScriptDidFocus(_: AutofillUserScript,
                                                      mainType: AutofillUserScript.GetAutofillDataMainType,
                                                      completionHandler: @escaping (SecureVaultModels.CreditCard?, RequestVaultDataAction) -> Void) {
                 // Store the handler but don't call it immediately
                 completionHandlers.append(completionHandler)
+
+                if completionHandlers.count == 1 {
+                    firstCallExpectation.fulfill()
+                } else if completionHandlers.count == 2 {
+                    secondCallExpectation.fulfill()
+                }
             }
         }
 
-        let delegate = SlowFocusDelegate()
+        let firstDelegateCallExpect = expectation(description: "First delegate call")
+        let secondDelegateCallExpect = expectation(description: "Second delegate call")
+        let firstReplyExpect = expectation(description: "First reply received")
+        let secondReplyExpect = expectation(description: "Second reply received")
+
+        let delegate = SlowFocusDelegate(firstCallExpectation: firstDelegateCallExpect,
+                                         secondCallExpectation: secondDelegateCallExpect)
         userScript.vaultDelegate = delegate
 
         var body = encryptedMessagingParams
@@ -728,34 +794,37 @@ class AutofillVaultUserScriptTests: XCTestCase {
 
         let mockWebView = MockWebView()
 
-        // Send first request
-        let message1 = MockWKScriptMessage(name: "getAutofillDataFocus", body: body, webView: mockWebView)
         var firstReplyReceived = false
         var firstReplyResult: String?
-
-        userScript.userContentController(userContentController, didReceive: message1) { result, error in
-            firstReplyReceived = true
-            firstReplyResult = result as? String
-        }
-
-        // Send second request before first completes
-        let message2 = MockWKScriptMessage(name: "getAutofillDataFocus", body: body, webView: mockWebView)
         var secondReplyReceived = false
         var secondReplyResult: String?
 
+        // Send first request
+        let message1 = MockWKScriptMessage(name: "getAutofillDataFocus", body: body, webView: mockWebView)
+        userScript.userContentController(userContentController, didReceive: message1) { result, error in
+            firstReplyReceived = true
+            firstReplyResult = result as? String
+            firstReplyExpect.fulfill()
+        }
+
+        // Wait for first delegate call before sending second request
+        wait(for: [firstDelegateCallExpect], timeout: 1.0)
+
+        // Send second request before first completes
+        let message2 = MockWKScriptMessage(name: "getAutofillDataFocus", body: body, webView: mockWebView)
         userScript.userContentController(userContentController, didReceive: message2) { result, error in
             secondReplyReceived = true
             secondReplyResult = result as? String
+            secondReplyExpect.fulfill()
         }
 
-        // Allow time for cancellation to process
-        let cancelExpectation = expectation(description: "Waiting for cancellation")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            cancelExpectation.fulfill()
-        }
-        waitForExpectations(timeout: 0.5)
+        // Wait for second delegate call
+        wait(for: [secondDelegateCallExpect], timeout: 1.0)
 
-        // First reply should have been cancelled with NoActionResponse
+        // First reply should complete quickly with cancellation
+        wait(for: [firstReplyExpect], timeout: 0.5)
+
+        // Verify first reply was cancelled
         XCTAssertTrue(firstReplyReceived)
         if let firstResult = firstReplyResult,
            let data = firstResult.data(using: .utf8),
@@ -779,11 +848,7 @@ class AutofillVaultUserScriptTests: XCTestCase {
         delegate.completionHandlers[1](mockCard, .fill)
 
         // Wait for second reply
-        let replyExpectation = expectation(description: "Waiting for second reply")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            replyExpectation.fulfill()
-        }
-        waitForExpectations(timeout: 0.5)
+        wait(for: [secondReplyExpect], timeout: 1.0)
 
         // Second reply should have the actual card data
         XCTAssertTrue(secondReplyReceived)
@@ -799,65 +864,97 @@ class AutofillVaultUserScriptTests: XCTestCase {
 
     func testCancelAllPendingReplies() {
         class NeverCompletingDelegate: MockSecureVaultDelegate {
+            let delegateCalledExpectation: XCTestExpectation
+            var callCount = 0
+
+            init(delegateCalledExpectation: XCTestExpectation) {
+                self.delegateCalledExpectation = delegateCalledExpectation
+                super.init()
+            }
+
             override func autofillUserScriptDidFocus(_: AutofillUserScript,
                                                      mainType: AutofillUserScript.GetAutofillDataMainType,
                                                      completionHandler: @escaping (SecureVaultModels.CreditCard?, RequestVaultDataAction) -> Void) {
                 // Never call the completion handler
+                callCount += 1
+                if callCount == 1 {
+                    delegateCalledExpectation.fulfill()
+                }
             }
 
             override func autofillUserScriptDidRequestCreditCard(_: AutofillUserScript,
                                                                  trigger: AutofillUserScript.GetTriggerType,
                                                                  completionHandler: @escaping (SecureVaultModels.CreditCard?, RequestVaultDataAction) -> Void) {
                 // Never call the completion handler
+                callCount += 1
+                if callCount == 2 {
+                    delegateCalledExpectation.fulfill()
+                }
             }
         }
 
-        let delegate = NeverCompletingDelegate()
+        let delegateCalledExpect = expectation(description: "Delegate methods called")
+        delegateCalledExpect.expectedFulfillmentCount = 2
+
+        let delegate = NeverCompletingDelegate(delegateCalledExpectation: delegateCalledExpect)
         userScript.vaultDelegate = delegate
 
         let expFocus = expectation(description: "focus field no-action")
         let expGet = expectation(description: "getData no-action")
 
+        // Send focus message
+        var focusBody = encryptedMessagingParams
+        focusBody["mainType"] = "creditCards"
+
         userScript.userContentController(userContentController,
                                          didReceive: MockWKScriptMessage(name: "getAutofillDataFocus",
-                                                                         body: {
-            var b = encryptedMessagingParams
-            b["mainType"] = "creditCards"
-            return b
-        }(),
+                                                                         body: focusBody,
                                                                          webView: MockWebView())
-        ) { result, _ in
-            if let json = result as? String,
-               let data = json.data(using: .utf8),
-               let resp = try? JSONDecoder().decode(AutofillUserScript.NoActionResponse.self, from: data),
-               resp.success.action == .none {
-                expFocus.fulfill()
-            } else {
-                XCTFail("Expected NoActionResponse for focus")
+        ) { result, error in
+            defer { expFocus.fulfill() }
+
+            guard let json = result as? String, let data = json.data(using: .utf8) else {
+                XCTFail("Expected JSON string response for focus")
+                return
+            }
+
+            do {
+                let resp = try JSONDecoder().decode(AutofillUserScript.NoActionResponse.self, from: data)
+                XCTAssertEqual(resp.success.action, .none)
+            } catch {
+                XCTFail("Failed to decode NoActionResponse for focus: \(error)")
             }
         }
+
+        // Send getData message
+        var getDataBody = encryptedMessagingParams
+        getDataBody["mainType"] = "creditCards"
+        getDataBody["subType"] = "cardNumber"
+        getDataBody["trigger"] = "userInitiated"
 
         userScript.userContentController(userContentController,
                                          didReceive: MockWKScriptMessage(name: "getAutofillData",
-                                                                         body: {
-            var b = encryptedMessagingParams
-            b["mainType"] = "creditCards"
-            b["subType"] = "cardNumber"
-            b["trigger"] = "userInitiated"
-            return b
-        }(),
+                                                                         body: getDataBody,
                                                                          webView: MockWebView())
-        ) { result, _ in
-            if let json = result as? String,
-               let data = json.data(using: .utf8),
-               let resp = try? JSONDecoder().decode(AutofillUserScript.NoActionResponse.self, from: data),
-               resp.success.action == .none {
-                expGet.fulfill()
-            } else {
-                XCTFail("Expected NoActionResponse for getData")
+        ) { result, error in
+            defer { expGet.fulfill() }
+
+            guard let json = result as? String, let data = json.data(using: .utf8) else {
+                XCTFail("Expected JSON string response for getData")
+                return
+            }
+
+            do {
+                let resp = try JSONDecoder().decode(AutofillUserScript.NoActionResponse.self, from: data)
+                XCTAssertEqual(resp.success.action, .none)
+            } catch {
+                XCTFail("Failed to decode NoActionResponse for getData: \(error)")
             }
         }
 
+        wait(for: [delegateCalledExpect], timeout: 1.0)
+
+        // Now cancel all pending replies
         userScript.cancelAllPendingReplies()
 
         wait(for: [expFocus, expGet], timeout: 1.0)

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Autofill/AutofillVaultUserScriptTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Autofill/AutofillVaultUserScriptTests.swift
@@ -570,17 +570,6 @@ class AutofillVaultUserScriptTests: XCTestCase {
                                                                  completionHandler: @escaping (SecureVaultModels.CreditCard?, RequestVaultDataAction) -> Void) {
                 didRequestCreditCardCalled = true
                 capturedTrigger = trigger
-
-                let mockCard = SecureVaultModels.CreditCard(
-                    id: 123,
-                    title: "Test Card",
-                    cardNumber: "4111111111111111",
-                    cardholderName: "Test User",
-                    cardSecurityCode: "123",
-                    expirationMonth: 12,
-                    expirationYear: 2030)
-
-                completionHandler(mockCard, .fill)
             }
         }
 
@@ -596,31 +585,10 @@ class AutofillVaultUserScriptTests: XCTestCase {
         let mockWebView = MockWebView()
         let message = MockWKScriptMessage(name: "getAutofillData", body: body, webView: mockWebView)
 
-        let expect = expectation(description: #function)
+        userScript.userContentController(userContentController, didReceive: message) { _, _ in }
 
-        userScript.userContentController(userContentController, didReceive: message) {
-            XCTAssertNotNil($0)
-            XCTAssertNil($1)
-
-            // Verify the response format
-            let data = ($0 as? String)?.data(using: .utf8)
-            let response = try? JSONDecoder().decode(AutofillUserScript.RequestVaultCreditCardResponse.self, from: data!)
-
-            XCTAssertNotNil(response)
-            XCTAssertNotNil(response?.success.creditCards)
-            XCTAssertEqual(response?.success.action, .fill)
-            XCTAssertEqual(response?.success.creditCards?.id, "123")
-            XCTAssertEqual(response?.success.creditCards?.cardNumber, "4111111111111111")
-            XCTAssertEqual(response?.success.creditCards?.cardName, "Test User")
-
-            // Verify the delegate was called correctly
-            XCTAssertTrue(delegate.didRequestCreditCardCalled)
-            XCTAssertEqual(delegate.capturedTrigger, .userInitiated)
-
-            expect.fulfill()
-        }
-
-        waitForExpectations(timeout: 1.0)
+        XCTAssertTrue(delegate.didRequestCreditCardCalled, "Delegate should receive the credit-card request")
+        XCTAssertEqual(delegate.capturedTrigger, .userInitiated)
     }
 
     func testWhenGetAutofillDataFocusCalledForCreditCards_ThenDelegateMethodCalled() {
@@ -633,17 +601,6 @@ class AutofillVaultUserScriptTests: XCTestCase {
                                                      completionHandler: @escaping (SecureVaultModels.CreditCard?, RequestVaultDataAction) -> Void) {
                 didCallDidFocus = true
                 capturedMainType = mainType
-
-                let mockCard = SecureVaultModels.CreditCard(
-                        id: 456,
-                        title: "Focus Test Card",
-                        cardNumber: "5555555555554444",
-                        cardholderName: "Focus User",
-                        cardSecurityCode: "999",
-                        expirationMonth: 6,
-                        expirationYear: 2025)
-
-                completionHandler(mockCard, .fill)
             }
         }
 
@@ -657,31 +614,10 @@ class AutofillVaultUserScriptTests: XCTestCase {
         let mockWebView = MockWebView()
         let message = MockWKScriptMessage(name: "getAutofillDataFocus", body: body, webView: mockWebView)
 
-        let expect = expectation(description: #function)
+        userScript.userContentController(userContentController, didReceive: message) { _, _ in }
 
-        userScript.userContentController(userContentController, didReceive: message) {
-            XCTAssertNotNil($0)
-            XCTAssertNil($1)
-
-            // Verify the response format
-            let data = ($0 as? String)?.data(using: .utf8)
-            let response = try? JSONDecoder().decode(AutofillUserScript.RequestVaultCreditCardResponse.self, from: data!)
-
-            XCTAssertNotNil(response)
-            XCTAssertNotNil(response?.success.creditCards)
-            XCTAssertEqual(response?.success.action, .fill)
-            XCTAssertEqual(response?.success.creditCards?.id, "456")
-            XCTAssertEqual(response?.success.creditCards?.cardNumber, "5555555555554444")
-            XCTAssertEqual(response?.success.creditCards?.cardName, "Focus User")
-
-            // Verify the delegate was called correctly
-            XCTAssertTrue(delegate.didCallDidFocus)
-            XCTAssertEqual(delegate.capturedMainType, .creditCards)
-
-            expect.fulfill()
-        }
-
-        waitForExpectations(timeout: 1.0)
+        XCTAssertTrue(delegate.didCallDidFocus, "Delegate should receive focus request")
+        XCTAssertEqual(delegate.capturedMainType, .creditCards)
     }
 
     func testWhenGetAutofillDataFocusCalledWithNilCard_ThenNoneActionReturned() {
@@ -704,16 +640,19 @@ class AutofillVaultUserScriptTests: XCTestCase {
 
         let expect = expectation(description: #function)
 
-        userScript.userContentController(userContentController, didReceive: message) {
-            XCTAssertNotNil($0)
-            XCTAssertNil($1)
+        userScript.userContentController(userContentController, didReceive: message) { result, error in
+            XCTAssertNil(error)
 
-            let data = ($0 as? String)?.data(using: .utf8)
-            let response = try? JSONDecoder().decode(AutofillUserScript.RequestVaultCreditCardResponse.self, from: data!)
+            guard let jsonString = result as? String,
+                  let data = jsonString.data(using: .utf8),
+                  let response = try? JSONDecoder().decode(AutofillUserScript.RequestVaultCreditCardResponse.self, from: data)
+            else {
+                XCTFail("Could not decode `RequestVaultCreditCardResponse`")
+                return
+            }
 
-            XCTAssertNotNil(response)
-            XCTAssertNil(response?.success.creditCards)
-            XCTAssertEqual(response?.success.action, RequestVaultDataAction.none)
+            XCTAssertNil(response.success.creditCards)
+            XCTAssertEqual(response.success.action, RequestVaultDataAction.none)
 
             expect.fulfill()
         }
@@ -749,15 +688,18 @@ class AutofillVaultUserScriptTests: XCTestCase {
             let expect = expectation(description: "Testing mainType: \(mainType)")
 
             userScript.userContentController(userContentController, didReceive: message) { result, error in
-                XCTAssertNotNil(result)
                 XCTAssertNil(error)
 
-                let data = (result as? String)?.data(using: .utf8)
-                let response = try? JSONDecoder().decode(AutofillUserScript.RequestVaultCreditCardResponse.self, from: data!)
+                guard let jsonString = result as? String,
+                      let data = jsonString.data(using: .utf8),
+                      let response = try? JSONDecoder().decode(AutofillUserScript.RequestVaultCreditCardResponse.self, from: data)
+                else {
+                    XCTFail("Could not decode `RequestVaultCreditCardResponse` for mainType \(mainType)")
+                    return
+                }
 
-                XCTAssertNotNil(response)
-                XCTAssertNil(response?.success.creditCards)
-                XCTAssertEqual(response?.success.action, RequestVaultDataAction.none)
+                XCTAssertNil(response.success.creditCards)
+                XCTAssertEqual(response.success.action, RequestVaultDataAction.none)
 
                 expect.fulfill()
             }
@@ -873,55 +815,52 @@ class AutofillVaultUserScriptTests: XCTestCase {
         let delegate = NeverCompletingDelegate()
         userScript.vaultDelegate = delegate
 
-        var repliesReceived = 0
-        var allRepliesWereNoAction = true
+        let expFocus = expectation(description: "focus field no-action")
+        let expGet = expectation(description: "getData no-action")
 
-        // Send multiple requests of different types
-        var focusBody = encryptedMessagingParams
-        focusBody["mainType"] = "creditCards"
-
-        let focusMessage = MockWKScriptMessage(name: "getAutofillDataFocus", body: focusBody, webView: MockWebView())
-        userScript.userContentController(userContentController, didReceive: focusMessage) { result, error in
-            repliesReceived += 1
-            if let resultString = result as? String,
-               let data = resultString.data(using: .utf8),
-               let response = try? JSONDecoder().decode(AutofillUserScript.NoActionResponse.self, from: data) {
-                allRepliesWereNoAction = allRepliesWereNoAction && (response.success.action == .none)
+        userScript.userContentController(userContentController,
+                                         didReceive: MockWKScriptMessage(name: "getAutofillDataFocus",
+                                                                         body: {
+            var b = encryptedMessagingParams
+            b["mainType"] = "creditCards"
+            return b
+        }(),
+                                                                         webView: MockWebView())
+        ) { result, _ in
+            if let json = result as? String,
+               let data = json.data(using: .utf8),
+               let resp = try? JSONDecoder().decode(AutofillUserScript.NoActionResponse.self, from: data),
+               resp.success.action == .none {
+                expFocus.fulfill()
             } else {
-                allRepliesWereNoAction = false
+                XCTFail("Expected NoActionResponse for focus")
             }
         }
 
-        var getDataBody = encryptedMessagingParams
-        getDataBody["mainType"] = "creditCards"
-        getDataBody["subType"] = "cardNumber"
-        getDataBody["trigger"] = "userInitiated"
-
-        let getDataMessage = MockWKScriptMessage(name: "getAutofillData", body: getDataBody, webView: MockWebView())
-        userScript.userContentController(userContentController, didReceive: getDataMessage) { result, error in
-            repliesReceived += 1
-            if let resultString = result as? String,
-               let data = resultString.data(using: .utf8),
-               let response = try? JSONDecoder().decode(AutofillUserScript.NoActionResponse.self, from: data) {
-                allRepliesWereNoAction = allRepliesWereNoAction && (response.success.action == .none)
+        userScript.userContentController(userContentController,
+                                         didReceive: MockWKScriptMessage(name: "getAutofillData",
+                                                                         body: {
+            var b = encryptedMessagingParams
+            b["mainType"] = "creditCards"
+            b["subType"] = "cardNumber"
+            b["trigger"] = "userInitiated"
+            return b
+        }(),
+                                                                         webView: MockWebView())
+        ) { result, _ in
+            if let json = result as? String,
+               let data = json.data(using: .utf8),
+               let resp = try? JSONDecoder().decode(AutofillUserScript.NoActionResponse.self, from: data),
+               resp.success.action == .none {
+                expGet.fulfill()
             } else {
-                allRepliesWereNoAction = false
+                XCTFail("Expected NoActionResponse for getData")
             }
         }
 
-        // Cancel all pending replies
         userScript.cancelAllPendingReplies()
 
-        // Wait for cancellations to process
-        let cancelExpectation = expectation(description: "Waiting for cancellations")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            cancelExpectation.fulfill()
-        }
-        waitForExpectations(timeout: 0.5)
-
-        // Verify all replies were received and were NoActionResponses
-        XCTAssertEqual(repliesReceived, 2)
-        XCTAssertTrue(allRepliesWereNoAction)
+        wait(for: [expFocus, expGet], timeout: 1.0)
     }
 
     func testWhenInvalidMessageBodyForGetAutofillDataFocus_ThenNothingHappens() {

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -226,9 +226,9 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .autofillPartialFormSaves:
             return .remoteReleasable(.subfeature(AutofillSubfeature.partialFormSaves))
         case .autofillCreditCards:
-            return .disabled
+            return .remoteReleasable(.subfeature(AutofillSubfeature.autofillCreditCards))
         case .autofillCreditCardsOnByDefault:
-            return .disabled
+            return .remoteReleasable(.subfeature(AutofillSubfeature.autofillCreditCardsOnByDefault))
         case .incontextSignup:
             return .remoteReleasable(.feature(.incontextSignup))
         case .autoconsentOnByDefault:

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -439,6 +439,8 @@ extension Pixel {
         case autofillCardsFillCardManualInlineDisplayed
         case autofillCardsFillCardManualInlineConfirmed
         case autofillCardsFillCardManualInlineDismissed
+        case autofillCardsKeyboardFill
+        case autofillCardsKeyboardOpenSettings
         case autofillCardsSaveDisableSnackbarShown
         case autofillCardsSaveDisableSnackbarOpenSettings
         case autofillCardsSettingsEnabled
@@ -1641,6 +1643,8 @@ extension Pixel.Event {
         case .autofillCardsFillCardManualInlineDisplayed: return "autofill_cards_fill_card_inline_manual_displayed"
         case .autofillCardsFillCardManualInlineConfirmed: return "autofill_cards_fill_card_inline_manual_confirmed"
         case .autofillCardsFillCardManualInlineDismissed: return "autofill_cards_fill_card_inline_manual_dismissed"
+        case .autofillCardsKeyboardFill: return "autofill_cards_keyboard_fill_confirmed"
+        case .autofillCardsKeyboardOpenSettings: return "autofill_cards_keyboard_open_settings"
         case .autofillCardsSaveDisableSnackbarShown: return "autofill_cards_save_disable_snackbar_shown"
         case .autofillCardsSaveDisableSnackbarOpenSettings: return "autofill_cards_save_disable_snackbar_open_settings"
         case .autofillCardsSettingsEnabled: return "autofill_cards_settings_enabled"

--- a/iOS/DuckDuckGo/KeyboardInputAccessory/CreditCardInputAccessoryView.swift
+++ b/iOS/DuckDuckGo/KeyboardInputAccessory/CreditCardInputAccessoryView.swift
@@ -21,6 +21,7 @@ import Foundation
 import UIKit
 import SwiftUI
 import BrowserServicesKit
+import Core
 import DesignResourcesKit
 import DesignResourcesKitIcons
 
@@ -399,7 +400,8 @@ class CreditCardInputAccessoryView: UIView {
     @objc private func cardTapped(_ gesture: UITapGestureRecognizer) {
         if let view = gesture.view,
            let index = creditCards.indices.contains(view.tag) ? view.tag : nil {
-
+            Pixel.fire(pixel: .autofillCardsKeyboardFill)
+            
             if AppDependencyProvider.shared.autofillLoginSession.isSessionValid {
                 onCardSelected?(creditCards[index].creditCard)
                 return
@@ -427,6 +429,7 @@ class CreditCardInputAccessoryView: UIView {
     
     @objc private func manageButtonTapped() {
         onCardManagementSelected?()
+        Pixel.fire(pixel: .autofillCardsKeyboardOpenSettings)
     }
 
     @objc private func doneButtonTapped() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210618971158384?focus=true
Tech Design URL:
CC:

### Description
Add pixels for credit card keyboard accessory actions

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Enable the credit card feature flag in Debug menu and ensure you have at least 1 card saved
2. Go to https://privacy-test-pages.site/autofill/credit-card-various-inputs.html and tap into a card field.
3. Dismiss the prompt and tap into a card field again so that the credit card keyboard accessory 
4. Select a card and confirm pixel `autofill.cards.keyboard.fill.confirmed` is fired
5. Tap into a card field again and this time tap on the manage button.
6. Confirm pixel `autofill.cards.keyboard.open.settings` is fired

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)