### PR TITLE
macOS: Show new icon when fire animation is happening

### DIFF
--- a/macOS/DuckDuckGo/Fire/View/Fire.storyboard
+++ b/macOS/DuckDuckGo/Fire/View/Fire.storyboard
@@ -81,7 +81,7 @@
                                 </userDefinedRuntimeAttributes>
                             </customView>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="l2o-no-SFP" userLabel="Burn Button">
-                                <rect key="frame" x="681" y="443" width="28" height="28"/>
+                                <rect key="frame" x="681" y="446" width="28" height="28"/>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="Burn" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="gej-cp-HsL">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -102,7 +102,7 @@
                             <constraint firstAttribute="trailing" secondItem="cmz-06-1Ay" secondAttribute="trailing" id="0K9-Ki-pRH"/>
                             <constraint firstAttribute="bottom" secondItem="cmz-06-1Ay" secondAttribute="bottom" id="B02-aa-Nm3"/>
                             <constraint firstItem="cmz-06-1Ay" firstAttribute="leading" secondItem="tOy-S4-hL0" secondAttribute="leading" id="IPL-C4-zho"/>
-                            <constraint firstItem="l2o-no-SFP" firstAttribute="top" secondItem="tOy-S4-hL0" secondAttribute="top" constant="8" id="VhL-VV-TZc"/>
+                            <constraint firstItem="l2o-no-SFP" firstAttribute="top" secondItem="tOy-S4-hL0" secondAttribute="top" constant="5" id="VhL-VV-TZc"/>
                             <constraint firstItem="uFV-kr-0rY" firstAttribute="centerY" secondItem="tOy-S4-hL0" secondAttribute="centerY" id="aFg-Dk-hZE"/>
                             <constraint firstItem="uFV-kr-0rY" firstAttribute="centerX" secondItem="tOy-S4-hL0" secondAttribute="centerX" id="hHN-Ge-Wm8"/>
                             <constraint firstAttribute="trailing" secondItem="l2o-no-SFP" secondAttribute="trailing" constant="12" id="ouM-95-c85"/>
@@ -112,6 +112,8 @@
                     <connections>
                         <outlet property="deletingDataLabel" destination="1tt-F5-h1d" id="ehh-fM-TjA"/>
                         <outlet property="fakeFireButton" destination="l2o-no-SFP" id="xqv-ch-iAF"/>
+                        <outlet property="fakeFireButtonHeightConstraint" destination="kob-t8-nJR" id="Fam-l5-xne"/>
+                        <outlet property="fakeFireButtonWidthConstraint" destination="xnz-xJ-NB2" id="VsF-eq-BDR"/>
                         <outlet property="progressIndicator" destination="Nf3-CP-318" id="nq9-vZ-Fzk"/>
                         <outlet property="progressIndicatorWrapper" destination="uFV-kr-0rY" id="RTJ-f8-iuU"/>
                         <outlet property="progressIndicatorWrapperBG" destination="Yly-fF-tnL" id="zNP-2N-cC6"/>

--- a/macOS/DuckDuckGo/Fire/View/FireViewController.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireViewController.swift
@@ -30,6 +30,7 @@ final class FireViewController: NSViewController {
 
     private(set) var fireViewModel: FireViewModel
     private let tabCollectionViewModel: TabCollectionViewModel
+    private let visualStyle: VisualStyleProviding
     private var cancellables = Set<AnyCancellable>()
 
     private lazy var fireDialogViewController: FirePopoverViewController = {
@@ -56,9 +57,12 @@ final class FireViewController: NSViewController {
         fatalError("TabBarViewController: Bad initializer")
     }
 
-    init?(coder: NSCoder, tabCollectionViewModel: TabCollectionViewModel, fireViewModel: FireViewModel) {
+    init?(coder: NSCoder, tabCollectionViewModel: TabCollectionViewModel,
+          fireViewModel: FireViewModel,
+          visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle) {
         self.tabCollectionViewModel = tabCollectionViewModel
         self.fireViewModel = fireViewModel
+        self.visualStyle = visualStyle
 
         super.init(coder: coder)
     }
@@ -122,6 +126,7 @@ final class FireViewController: NSViewController {
         fakeFireButton.layer?.backgroundColor = NSColor.buttonMouseDown.cgColor
 
         fakeFireButton.setAccessibilityIdentifier("FireViewController.fakeFireButton")
+        fakeFireButton.image = visualStyle.iconsProvider.fireButtonStyleProvider.icon
         subscribeToIsBurning()
     }
 

--- a/macOS/DuckDuckGo/Fire/View/FireViewController.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireViewController.swift
@@ -38,6 +38,8 @@ final class FireViewController: NSViewController {
         return storyboard.instantiateController(identifier: "FirePopoverViewController")
     }()
 
+    @IBOutlet weak var fakeFireButtonWidthConstraint: NSLayoutConstraint!
+    @IBOutlet weak var fakeFireButtonHeightConstraint: NSLayoutConstraint!
     @IBOutlet weak var deletingDataLabel: NSTextField!
     @IBOutlet weak var fakeFireButton: NSButton!
     @IBOutlet weak var progressIndicatorWrapper: NSView!
@@ -73,6 +75,9 @@ final class FireViewController: NSViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        fakeFireButton.image = visualStyle.iconsProvider.fireButtonStyleProvider.icon
+        fakeFireButtonWidthConstraint.constant = visualStyle.tabBarButtonSize
+        fakeFireButtonHeightConstraint.constant = visualStyle.tabBarButtonSize
         deletingDataLabel.stringValue = UserText.fireDialogDelitingData
         if case .normal = AppVersion.runType {
             fireAnimationViewLoadingTask = Task.detached(priority: .userInitiated) {
@@ -126,7 +131,6 @@ final class FireViewController: NSViewController {
         fakeFireButton.layer?.backgroundColor = NSColor.buttonMouseDown.cgColor
 
         fakeFireButton.setAccessibilityIdentifier("FireViewController.fakeFireButton")
-        fakeFireButton.image = visualStyle.iconsProvider.fireButtonStyleProvider.icon
         subscribeToIsBurning()
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210626259488220?focus=true
Tech Design URL:
CC:

### Description
Show the new icon when the fire animation is running.

### Testing Steps
1. Run the app 
2. Check you are seeing the new UI
3. Tap the fire button and clear
4. When the fire animation is running, you should see the new icon not the old one

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)