### PR TITLE
Add aiChatTextSummarization feature flag

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "442bf756b54632b4662105fa2faeac5ed2868858",
-        "version" : "17.3.0"
+        "revision" : "c504edade04adc0535ecf1b4636cbb17e81b78ad",
+        "version" : "18.0.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/OpenSSL-XCFramework",
       "state" : {
-        "revision" : "71d303cbfa150e1fac99ffc7b4f67aad9c7a5002",
-        "version" : "3.1.5004"
+        "revision" : "263f0422b0b516838bc4f8cf5f4b5aac4df144c1",
+        "version" : "3.3.2000"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/privacy-dashboard",
       "state" : {
-        "revision" : "810b50a7e10c08ac676da1153dd8cf35212f1930",
-        "version" : "9.1.0"
+        "revision" : "fd3b7e2d8194e265c537f227c706de7db3085da5",
+        "version" : "9.4.0"
       }
     },
     {

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -666,14 +666,20 @@ extension MainViewController {
         let isWebViewFocused = view.window?.firstResponder is WebView
 
         // Handle Enter
-        if event.keyCode == kVK_Return,
-           navigationBarViewController.addressBarViewController?.addressBarTextField.isFirstResponder == true {
-            if flags.contains(.shift) && aiChatMenuConfig.shouldDisplayAddressBarShortcut {
-                navigationBarViewController.addressBarViewController?.addressBarTextField.aiChatQueryEnterPressed()
-            } else {
-                navigationBarViewController.addressBarViewController?.addressBarTextField.addressBarEnterPressed()
+        if event.keyCode == kVK_Return {
+            if navigationBarViewController.addressBarViewController?.addressBarTextField.isFirstResponder == true {
+                if flags.contains(.shift) && aiChatMenuConfig.shouldDisplayAddressBarShortcut {
+                    navigationBarViewController.addressBarViewController?.addressBarTextField.aiChatQueryEnterPressed()
+                } else {
+                    navigationBarViewController.addressBarViewController?.addressBarTextField.addressBarEnterPressed()
+                }
+                return true
             }
-            return true
+
+            if featureFlagger.isFeatureOn(.aiChatTextSummarization) && flags == [.shift] {
+                NSApp.menu?.performKeyEquivalent(with: event)
+                return true
+            }
         }
 
         // Handle Escape

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -666,20 +666,14 @@ extension MainViewController {
         let isWebViewFocused = view.window?.firstResponder is WebView
 
         // Handle Enter
-        if event.keyCode == kVK_Return {
-            if navigationBarViewController.addressBarViewController?.addressBarTextField.isFirstResponder == true {
-                if flags.contains(.shift) && aiChatMenuConfig.shouldDisplayAddressBarShortcut {
-                    navigationBarViewController.addressBarViewController?.addressBarTextField.aiChatQueryEnterPressed()
-                } else {
-                    navigationBarViewController.addressBarViewController?.addressBarTextField.addressBarEnterPressed()
-                }
-                return true
+        if event.keyCode == kVK_Return,
+           navigationBarViewController.addressBarViewController?.addressBarTextField.isFirstResponder == true {
+            if flags.contains(.shift) && aiChatMenuConfig.shouldDisplayAddressBarShortcut {
+                navigationBarViewController.addressBarViewController?.addressBarTextField.aiChatQueryEnterPressed()
+            } else {
+                navigationBarViewController.addressBarViewController?.addressBarTextField.addressBarEnterPressed()
             }
-
-            if featureFlagger.isFeatureOn(.aiChatTextSummarization) && flags == [.shift] {
-                NSApp.menu?.performKeyEquivalent(with: event)
-                return true
-            }
+            return true
         }
 
         // Handle Escape

--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -244,6 +244,9 @@ final class MainMenu: NSMenu {
 
             NSMenuItem(title: UserText.mainMenuEditDelete, action: #selector(NSText.delete))
             NSMenuItem(title: UserText.mainMenuEditSelectAll, action: #selector(NSText.selectAll), keyEquivalent: "a")
+
+            NSMenuItem(title: "", action: #selector(MainViewController.summarize), keyEquivalent: [.shift, "\r"])
+                .hidden()
             NSMenuItem.separator()
 
             NSMenuItem(title: UserText.mainMenuEditFind) {

--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -245,7 +245,7 @@ final class MainMenu: NSMenu {
             NSMenuItem(title: UserText.mainMenuEditDelete, action: #selector(NSText.delete))
             NSMenuItem(title: UserText.mainMenuEditSelectAll, action: #selector(NSText.selectAll), keyEquivalent: "a")
 
-            NSMenuItem(title: "", action: #selector(MainViewController.summarize), keyEquivalent: [.shift, "\r"])
+            NSMenuItem(title: "", action: #selector(MainViewController.summarize), keyEquivalent: [.command, .shift, "\r"])
                 .hidden()
             NSMenuItem.separator()
 

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -741,6 +741,9 @@ extension MainViewController {
     }
 
     @objc func summarize(_ sender: Any) {
+        guard featureFlagger.isFeatureOn(.aiChatTextSummarization) else {
+            return
+        }
         Logger.aiChat.debug("Summarize action to be implemented")
     }
 

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -740,6 +740,10 @@ extension MainViewController {
         getActiveTabAndIndex()?.tab.webView.resetZoomLevel()
     }
 
+    @objc func summarize(_ sender: Any) {
+        Logger.aiChat.debug("Summarize action to be implemented")
+    }
+
     @objc func toggleDownloads(_ sender: Any) {
         var navigationBarViewController = self.navigationBarViewController
         if view.window?.isPopUpWindow == true {

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -106,6 +106,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1209671977594486/task/1210410403692636?focus=true
     case aiChatSidebar
 
+    /// https://app.asana.com/1/137249556945/project/1201899738287924/task/1210012162616039?focus=true
+    case aiChatTextSummarization
+
     /// https://app.asana.com/1/137249556945/project/1206580121312550/task/1209808389662317?focus=true
     case osSupportForceUnsupportedMessage
 
@@ -168,6 +171,7 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .osSupportForceWillSoonDropSupportMessage,
                 .willSoonDropBigSurSupport,
 				.aiChatSidebar,
+                .aiChatTextSummarization,
                 .shortHistoryMenu:
             return true
         case .debugMenu,
@@ -257,6 +261,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(MaliciousSiteProtectionSubfeature.removeWWWInCanonicalization))
         case .aiChatSidebar:
             return .internalOnly()
+        case .aiChatTextSummarization:
+            return .disabled
         case .osSupportForceUnsupportedMessage:
             return .disabled
         case .osSupportForceWillSoonDropSupportMessage:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210567792963681?focus=true

### Description
This change adds a new local feature flag to control AI chat text summarization. It’s disabled by default
and will remain disabled until it’s ready to be tested internally.
Also an action is added to Main Menu to support shift+Enter keyboard shortcut for text summarization
when the feature flag is enabled.

### Testing Steps
1. Run the app and open a website. Make sure that the address bar is not focused.
2. Filter Xcode logs for “Summarize”.
3. Press command+shift+Enter and verify that nothing happens and nothing gets logged.
4. Enable aiChatTextSummarization feature flag from Feature Flag Overrides menu.
5. Press command+shift+Enter and verify that “Summarize” gets logged.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)