### PR TITLE
Fire a pixel when the VPN tunnel detects access revoked.

### DIFF
--- a/SharedPackages/VPN/Sources/VPN/Diagnostics/NetworkProtectionError.swift
+++ b/SharedPackages/VPN/Sources/VPN/Diagnostics/NetworkProtectionError.swift
@@ -64,6 +64,7 @@ public enum NetworkProtectionError: LocalizedError, CustomNSError {
 
     // Subscription errors
     case vpnAccessRevoked(Error)
+    case unmanagedSubscriptionError(Error)
 
     // Unhandled error
     case unhandledError(function: String, line: Int, error: Error)
@@ -107,6 +108,7 @@ public enum NetworkProtectionError: LocalizedError, CustomNSError {
         case .noAuthTokenFound: return 400
             // 500+ Subscription errors
         case .vpnAccessRevoked: return 500
+        case .unmanagedSubscriptionError: return 501
             // 600+ Unhandled errors
         case .unhandledError: return 600
         }
@@ -151,7 +153,8 @@ public enum NetworkProtectionError: LocalizedError, CustomNSError {
                 .failedToFetchServerStatus(let error),
                 .failedToParseServerStatusResponse(let error),
                 .noAuthTokenFound(let error),
-                .vpnAccessRevoked(let error):
+                .vpnAccessRevoked(let error),
+                .unmanagedSubscriptionError(let error):
             return [
                 NSUnderlyingErrorKey: error
             ]

--- a/SharedPackages/VPN/Sources/VPN/NetworkProtectionDeviceManager.swift
+++ b/SharedPackages/VPN/Sources/VPN/NetworkProtectionDeviceManager.swift
@@ -211,11 +211,18 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
             return wrappedError
         }
 
+        func unmanagedSubscriptionError(underlyingError: Error) -> Error {
+            let wrappedError = NetworkProtectionError.unmanagedSubscriptionError(underlyingError)
+            errorEvents?.fire(wrappedError)
+            return wrappedError
+        }
+
         Logger.networkProtection.log("Registering with server using method: \(selectionMethod.debugDescription, privacy: .public)")
 
         let token: String
 
         do {
+            throw SubscriptionManagerError.noTokenAvailable
             token = try await VPNAuthTokenBuilder.getVPNAuthToken(from: tokenHandler)
         } catch {
             Logger.networkProtection.error("Missing auth token: \(error.localizedDescription)")
@@ -224,7 +231,7 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
             case SubscriptionManagerError.noTokenAvailable:
                 throw accessRevokedError(underlyingError: error)
             default:
-                throw NetworkProtectionError.unmanagedSubscriptionError(error)
+                throw unmanagedSubscriptionError(underlyingError: error)
             }
         }
 
@@ -275,7 +282,7 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
             case .accessDenied, .invalidAuthToken:
                 throw accessRevokedError(underlyingError: error)
             default:
-                break
+                throw unmanagedSubscriptionError(underlyingError: error)
             }
             throw error
         }

--- a/SharedPackages/VPN/Sources/VPN/NetworkProtectionDeviceManager.swift
+++ b/SharedPackages/VPN/Sources/VPN/NetworkProtectionDeviceManager.swift
@@ -125,7 +125,6 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
         case .success(let serverList):
             completeServerList = serverList
         case .failure(let failure):
-            await handle(clientError: failure)
             throw failure
         }
 
@@ -201,9 +200,16 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
     //
     // - Throws:`NetworkProtectionError`
     //
-    private func register(keyPair: KeyPair,
-                          selectionMethod: NetworkProtectionServerSelectionMethod) async throws -> (server: NetworkProtectionServer,
+    private func register(
+        keyPair: KeyPair,
+        selectionMethod: NetworkProtectionServerSelectionMethod) async throws -> (server: NetworkProtectionServer,
                                                                                                     newExpiration: Date?) {
+
+        func accessRevokedError(underlyingError: Error) -> Error {
+            let wrappedError = NetworkProtectionError.vpnAccessRevoked(underlyingError)
+            errorEvents?.fire(wrappedError)
+            return wrappedError
+        }
 
         Logger.networkProtection.log("Registering with server using method: \(selectionMethod.debugDescription, privacy: .public)")
 
@@ -216,9 +222,9 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
 
             switch error {
             case SubscriptionManagerError.noTokenAvailable:
-                throw NetworkProtectionError.vpnAccessRevoked(error)
+                throw accessRevokedError(underlyingError: error)
             default:
-                throw NetworkProtectionError.noAuthTokenFound(error)
+                throw NetworkProtectionError.unmanagedSubscriptionError(error)
             }
         }
 
@@ -264,8 +270,13 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
             return (selectedServer, selectedServer.expirationDate)
         case .failure(let error):
             Logger.networkProtection.error("Server registration failed: \(error, privacy: .public)")
-            await handle(clientError: error)
-            try handleAccessRevoked(error)
+
+            switch error {
+            case .accessDenied, .invalidAuthToken:
+                throw accessRevokedError(underlyingError: error)
+            default:
+                break
+            }
             throw error
         }
     }
@@ -345,26 +356,6 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
         peerConfiguration.endpoint = serverEndpoint
 
         return peerConfiguration
-    }
-
-    private func handle(clientError: NetworkProtectionClientError) async {
- #if os(macOS)
-        if case .invalidAuthToken = clientError {
-            try? await tokenHandler.removeToken()
-        }
- #endif
-        errorEvents?.fire(clientError.networkProtectionError)
-    }
-
-    private func handleAccessRevoked(_ error: NetworkProtectionClientError) throws {
-        switch error {
-        case .accessDenied, .invalidAuthToken:
-            let newError = NetworkProtectionError.vpnAccessRevoked(error)
-            errorEvents?.fire(newError)
-            throw newError
-        default:
-            break
-        }
     }
 }
 

--- a/SharedPackages/VPN/Sources/VPN/NetworkProtectionDeviceManager.swift
+++ b/SharedPackages/VPN/Sources/VPN/NetworkProtectionDeviceManager.swift
@@ -222,7 +222,6 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
         let token: String
 
         do {
-            throw SubscriptionManagerError.noTokenAvailable
             token = try await VPNAuthTokenBuilder.getVPNAuthToken(from: tokenHandler)
         } catch {
             Logger.networkProtection.error("Missing auth token: \(error.localizedDescription)")

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -603,6 +603,7 @@ extension Pixel {
         
         case networkProtectionNoAccessTokenFoundError
         case networkProtectionVPNAccessRevoked
+        case networkProtectionUnmanagedSubscriptionError
 
         case networkProtectionMemoryWarning
         case networkProtectionMemoryCritical
@@ -1786,6 +1787,7 @@ extension Pixel.Event {
         case .networkProtectionDisconnected: return "m_netp_vpn_disconnect"
         case .networkProtectionNoAccessTokenFoundError: return "m_netp_no_access_token_found_error"
         case .networkProtectionVPNAccessRevoked: return "m_vpn_access_revoked"
+        case .networkProtectionUnmanagedSubscriptionError: return "vpn_access_unmanaged_error"
         case .networkProtectionMemoryWarning: return "m_netp_vpn_memory_warning"
         case .networkProtectionMemoryCritical: return "m_netp_vpn_memory_critical"
         case .networkProtectionUnhandledError: return "m_netp_unhandled_error"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -602,7 +602,8 @@ extension Pixel {
         case networkProtectionDisconnected
         
         case networkProtectionNoAccessTokenFoundError
-        
+        case networkProtectionVPNAccessRevoked
+
         case networkProtectionMemoryWarning
         case networkProtectionMemoryCritical
         
@@ -1784,6 +1785,7 @@ extension Pixel.Event {
         case .networkProtectionActivationRequestFailed: return "m_netp_network_extension_error_activation_request_failed"
         case .networkProtectionDisconnected: return "m_netp_vpn_disconnect"
         case .networkProtectionNoAccessTokenFoundError: return "m_netp_no_access_token_found_error"
+        case .networkProtectionVPNAccessRevoked: return "m_vpn_access_revoked"
         case .networkProtectionMemoryWarning: return "m_netp_vpn_memory_warning"
         case .networkProtectionMemoryCritical: return "m_netp_vpn_memory_critical"
         case .networkProtectionUnhandledError: return "m_netp_unhandled_error"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1787,7 +1787,7 @@ extension Pixel.Event {
         case .networkProtectionDisconnected: return "m_netp_vpn_disconnect"
         case .networkProtectionNoAccessTokenFoundError: return "m_netp_no_access_token_found_error"
         case .networkProtectionVPNAccessRevoked: return "m_vpn_access_revoked"
-        case .networkProtectionUnmanagedSubscriptionError: return "vpn_access_unmanaged_error"
+        case .networkProtectionUnmanagedSubscriptionError: return "m_vpn_access_unmanaged_error"
         case .networkProtectionMemoryWarning: return "m_netp_vpn_memory_warning"
         case .networkProtectionMemoryCritical: return "m_netp_vpn_memory_critical"
         case .networkProtectionUnhandledError: return "m_netp_unhandled_error"

--- a/iOS/DuckDuckGo/EventMapping+NetworkProtectionError.swift
+++ b/iOS/DuckDuckGo/EventMapping+NetworkProtectionError.swift
@@ -58,8 +58,12 @@ extension EventMapping where Event == NetworkProtectionError {
             params[PixelParameters.keychainErrorCode] = String(status)
         case .noAuthTokenFound:
             pixelEvent = .networkProtectionNoAccessTokenFoundError
-        case .vpnAccessRevoked:
-            return
+        case .vpnAccessRevoked(let error):
+            pixelEvent = .networkProtectionVPNAccessRevoked
+            pixelError = error
+        case .unmanagedSubscriptionError(let error):
+            pixelEvent = .networkProtectionUnmanagedSubscriptionError
+            pixelError = error
         case .noServerRegistrationInfo,
                 .couldNotSelectClosestServer,
                 .couldNotGetPeerPublicKey,

--- a/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -332,6 +332,12 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
                 pixelEvent = .networkProtectionClientFailedToParseRegisteredServersResponse
             case .invalidAuthToken:
                 pixelEvent = .networkProtectionClientInvalidAuthToken
+            case .vpnAccessRevoked(let error):
+                pixelEvent = .networkProtectionVPNAccessRevoked
+                pixelError = error
+            case .unmanagedSubscriptionError(let error):
+                pixelEvent = .networkProtectionUnmanagedSubscriptionError
+                pixelError = error
             case .serverListInconsistency:
                 return
             case .failedToCastKeychainValueToData(let field):

--- a/macOS/DuckDuckGo/NetworkProtection/AppAndExtensionAndAgentTargets/NetworkProtectionPixelEvent.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppAndExtensionAndAgentTargets/NetworkProtectionPixelEvent.swift
@@ -97,6 +97,8 @@ enum NetworkProtectionPixelEvent: PixelKitEventV2 {
     case networkProtectionWireguardErrorCannotSetWireguardConfig(_ error: Error)
 
     case networkProtectionNoAuthTokenFoundError
+    case networkProtectionVPNAccessRevoked(_ error: Error)
+    case networkProtectionUnmanagedSubscriptionError(_ error: Error)
 
     case networkProtectionRekeyAttempt
     case networkProtectionRekeyCompleted
@@ -280,6 +282,12 @@ enum NetworkProtectionPixelEvent: PixelKitEventV2 {
         case .networkProtectionNoAuthTokenFoundError:
             return "netp_no_auth_token_found_error"
 
+        case .networkProtectionVPNAccessRevoked:
+            return "vpn_access_revoked"
+
+        case .networkProtectionUnmanagedSubscriptionError:
+            return "vpn_access_unmanaged_error"
+
         case .networkProtectionRekeyAttempt:
             return "netp_rekey_attempt"
 
@@ -394,6 +402,10 @@ enum NetworkProtectionPixelEvent: PixelKitEventV2 {
             return error.pixelParameters
         case .networkProtectionConfigurationFailedToParse(let error):
             return error.pixelParameters
+        case .networkProtectionVPNAccessRevoked(let error):
+            return error.pixelParameters
+        case .networkProtectionUnmanagedSubscriptionError(let error):
+            return error.pixelParameters
         case .networkProtectionActiveUser,
                 .networkProtectionNewUser,
                 .networkProtectionControllerStartAttempt,
@@ -467,7 +479,9 @@ enum NetworkProtectionPixelEvent: PixelKitEventV2 {
                 .networkProtectionSystemExtensionActivationFailure(let error),
                 .networkProtectionServerMigrationFailure(let error),
                 .networkProtectionConfigurationErrorLoadingCachedConfig(let error),
-                .networkProtectionConfigurationFailedToParse(let error):
+                .networkProtectionConfigurationFailedToParse(let error),
+                .networkProtectionVPNAccessRevoked(let error),
+                .networkProtectionUnmanagedSubscriptionError(let error):
             return error
         case .networkProtectionActiveUser,
                 .networkProtectionNewUser,

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/EventMapping+NetworkProtectionError.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/EventMapping+NetworkProtectionError.swift
@@ -80,8 +80,10 @@ extension EventMapping where Event == NetworkProtectionError {
             domainEvent = .networkProtectionUnhandledError(function: function, line: line, error: error)
             frequency = .standard
             return
-        case .vpnAccessRevoked:
-            return
+        case .vpnAccessRevoked(let error):
+            domainEvent = .networkProtectionVPNAccessRevoked(error)
+        case .unmanagedSubscriptionError(let error):
+            domainEvent = .networkProtectionVPNAccessRevoked(error)
         }
 
         let debugEvent = DebugEvent(eventType: .custom(domainEvent))

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/EventMapping+NetworkProtectionError.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/EventMapping+NetworkProtectionError.swift
@@ -83,7 +83,7 @@ extension EventMapping where Event == NetworkProtectionError {
         case .vpnAccessRevoked(let error):
             domainEvent = .networkProtectionVPNAccessRevoked(error)
         case .unmanagedSubscriptionError(let error):
-            domainEvent = .networkProtectionVPNAccessRevoked(error)
+            domainEvent = .networkProtectionUnmanagedSubscriptionError(error)
         }
 
         let debugEvent = DebugEvent(eventType: .custom(domainEvent))

--- a/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
@@ -98,6 +98,8 @@ final class MacPacketTunnelProvider: PacketTunnelProvider {
                 domainEvent = .networkProtectionWireguardErrorCannotSetWireguardConfig(error)
             case .noAuthTokenFound:
                 domainEvent = .networkProtectionNoAuthTokenFoundError
+            case .vpnAccessRevoked(let error):
+                domainEvent = .networkProtectionVPNAccessRevoked(error)
             case .failedToFetchServerStatus(let error):
                 domainEvent = .networkProtectionClientFailedToFetchServerStatus(error)
             case .failedToParseServerStatusResponse(let error):
@@ -108,8 +110,8 @@ final class MacPacketTunnelProvider: PacketTunnelProvider {
                     .failedToParseLocationListResponse:
                 // Needs Privacy triage for macOS Geoswitching pixels
                 return
-            case .vpnAccessRevoked:
-                return
+            case .unmanagedSubscriptionError(let error):
+                domainEvent = .networkProtectionUnmanagedSubscriptionError(error)
             }
 
             PixelKit.fire(domainEvent, frequency: .legacyDailyAndCount, includeAppVersionParameter: true)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207603085593419/task/1210618804136019?focus=true

### IMPORTANT:

⚠️ This will be merged against the internal macOS branch.  When merging we want to also cherry-pick into the iOS release branch.

### Description

Fires a pixel when the VPN learns the subscription has expired after calling `VPNAuthTokenBuilder.getVPNAuthToken`.

See the privacy triage [here](https://app.asana.com/1/137249556945/project/69071770703008/task/1210625635821516).

## Testing

Test in both iOS and macOS.

### Test 1: Make sure the VPN connects.

1. Just start the VPN normally and ensure it connects.

### Test 2: Verify pixel on VPN access revoked

1. Open Console.app, start streaming (make sure to pick the right device for macOS vs iOS).
2. Filter by "vpn_access_revoked"
3. Go to [this line](https://github.com/duckduckgo/apple-browsers/blob/ba52c52a8f104eba76a7c05ec4552d7add2169ea/SharedPackages/VPN/Sources/VPN/NetworkProtectionDeviceManager.swift#L219), and add right before it:

`throw SubscriptionManagerError.noTokenAvailable`

4. You may need to [override this](https://github.com/duckduckgo/apple-browsers/blob/ba52c52a8f104eba76a7c05ec4552d7add2169ea/iOS/Core/DailyPixel.swift#L95) to `if true` in iOS to see the log for the daily on subsequent tests.
5. Start the VPN.
6. Ensure you see the pixel fire.

MacOS pixels:
```
👾[Legacy Daily and Count-Fired] m_mac_vpn_access_revoked_d ["d": "Subscription.SubscriptionManagerError", "appVersion": "1.145.0", "pixelSource": "vpnSystemExtension", "e": "1"]
👾[Legacy Daily and Count-Fired] m_mac_vpn_access_revoked_c ["appVersion": "1.145.0", "d": "Subscription.SubscriptionManagerError", "e": "1", "pixelSource": "vpnSystemExtension"]
```


iOS pixels:
```
Pixel fired m.vpn.access.revoked.d
Pixel fired m.vpn.access.revoked.c ["e": "1", "d": "Subscription.SubscriptionManagerError"]
```

### Test 3: Verify pixel on unmanaged subscription error

1. Open Console.app, start streaming (make sure to pick the right device for macOS vs iOS).
2. Filter by "vpn_access_unmanaged"
3. Go to [this line](https://github.com/duckduckgo/apple-browsers/blob/ba52c52a8f104eba76a7c05ec4552d7add2169ea/SharedPackages/VPN/Sources/VPN/NetworkProtectionDeviceManager.swift#L219), and add right before it:

`throw NSError(domain: "test", code: 1)`

4. You may need to [override this](https://github.com/duckduckgo/apple-browsers/blob/ba52c52a8f104eba76a7c05ec4552d7add2169ea/iOS/Core/DailyPixel.swift#L95) to `if true` in iOS to see the log for the daily on subsequent tests.
5. Start the VPN.
6. Ensure you see the pixel fire.

MacOS pixels:
```
👾[Legacy Daily and Count-Fired] m_mac_vpn_access_unmanaged_error_d ["d": "test", "appVersion": "1.145.0", "e": "1", "pixelSource": "vpnSystemExtension"]
👾[Legacy Daily and Count-Fired] m_mac_vpn_access_unmanaged_error_c ["e": "1", "d": "test", "appVersion": "1.145.0", "pixelSource": "vpnSystemExtension"]
```


iOS pixels:
```
12:44:27.829493+0200	16154: 0x4e9982	debug	Pixels	PacketTunnelProvider		Pixel fired vpn.access.unmanaged.error.d
12:44:27.829679+0200	16154: 0x4e9982	debug	Pixels	PacketTunnelProvider		Pixel fired vpn.access.unmanaged.error.c ["e": "1", "d": "test"]

```

### Impact and Risks

Low.

#### What could go wrong?

The pixel logic needs to be simplified in the VPN - it predates PixelKit.  We just gotta make sure the changes are fine.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)