### PR TITLE
Don’t assign post-merge failed PR Checks tasks to non-Apple team members

### DIFF
--- a/.github/actions/asana-failed-pr-checks/action.yml
+++ b/.github/actions/asana-failed-pr-checks/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: "Last commit author's GitHub handle"
     required: false
     type: string
+  pr-reviewers:
+    description: "Comma-separated list of PR reviewers' GitHub handles"
+    required: false
+    type: string
   github-token:
     description: "GitHub token"
     required: true
@@ -36,6 +40,7 @@ runs:
         WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         GITHUB_REF_NAME: ${{ github.ref_name }}
         GITHUB_RUN_ID: ${{ github.run_id }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
         ASANA_SECTION_ID: ${{ inputs.asana-section-id }}
         ASANA_ACCESS_TOKEN: ${{ inputs.asana-access-token }}
         ASANA_ASSIGNEE: ${{ steps.get-asana-user-id.outputs.asanaUserId }}

--- a/.github/actions/asana-failed-pr-checks/action.yml
+++ b/.github/actions/asana-failed-pr-checks/action.yml
@@ -40,7 +40,8 @@ runs:
         WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         GITHUB_REF_NAME: ${{ github.ref_name }}
         GITHUB_RUN_ID: ${{ github.run_id }}
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GH_TOKEN: ${{ inputs.github-token }}
+        GITHUB_PR_REVIEWERS: ${{ inputs.pr-reviewers }}
         ASANA_SECTION_ID: ${{ inputs.asana-section-id }}
         ASANA_ACCESS_TOKEN: ${{ inputs.asana-access-token }}
         ASANA_ASSIGNEE: ${{ steps.get-asana-user-id.outputs.asanaUserId }}

--- a/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
+++ b/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
@@ -5,6 +5,7 @@ set -eo pipefail
 workspace_id="137249556945"
 project_id="1205237866452338"
 workflow_id_custom_field_id="1205563320492190"
+apple_team_id="1203552211911076"
 asana_api_url="https://app.asana.com/api/1.0"
 
 print_usage_and_exit() {
@@ -158,6 +159,14 @@ close_task() {
 	[[ ${return_code} -eq 200 ]]
 }
 
+_validate_assignee() {
+	local assignee=$1
+
+	curl -s "${asana_api_url}/teams/${apple_team_id}/users?opt_fields=gid" \
+		-H "Authorization: Bearer ${asana_personal_access_token}" \
+		| jq -e "any(.data[]?; .gid == \"${assignee}\")" > /dev/null
+}
+
 main() {
 	local asana_personal_access_token="${ASANA_ACCESS_TOKEN}"
 	local section_id="${ASANA_SECTION_ID}"
@@ -167,6 +176,8 @@ main() {
 	local title
 	local description
 	local message
+
+	_validate_assignee "${assignee}"
 
 	read_command_line_arguments "$@"
 

--- a/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
+++ b/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
@@ -160,6 +160,35 @@ close_task() {
 	[[ ${return_code} -eq 200 ]]
 }
 
+_fetch_github_asana_mapping() {
+	echo "Fetching GitHub to Asana user mapping..." >&2
+
+	local gh_asana_mapping_content
+	local gh_asana_mapping
+
+	if gh_asana_mapping_content="$(gh api https://api.github.com/repos/duckduckgo/internal-github-asana-utils/contents/user_map.yml --jq .content 2>/dev/null)" && \
+	   [[ -n "${gh_asana_mapping_content}" ]] && \
+	   [[ "${gh_asana_mapping_content}" != "null" ]] && \
+	   gh_asana_mapping="$(echo "${gh_asana_mapping_content}" | base64 -d 2>/dev/null)" && \
+	   [[ -n "${gh_asana_mapping}" ]]; then
+
+		echo "Successfully retrieved user mapping" >&2
+		echo "${gh_asana_mapping}"
+		return 0
+	else
+		echo "Failed to fetch or parse GitHub to Asana user mapping" >&2
+		return 1
+	fi
+}
+
+_is_user_in_apple_team() {
+	local user_id=$1
+
+	curl -s "${asana_api_url}/teams/${apple_team_id}/users?opt_fields=gid" \
+		-H "Authorization: Bearer ${asana_personal_access_token}" \
+		| jq -e "any(.data[]?; .gid == \"${user_id}\")" > /dev/null
+}
+
 validate_assignee() {
 	local assignee=$1
 	local pr_reviewers=$2
@@ -171,16 +200,8 @@ validate_assignee() {
 
 		# Check each PR reviewer if pr_reviewers is not empty
 		if [[ -n "${pr_reviewers}" ]]; then
-			# Fetch GitHub to Asana user mapping with error handling
-			echo "Fetching GitHub to Asana user mapping..." >&2
-			if gh_asana_mapping_content="$(gh api https://api.github.com/repos/duckduckgo/internal-github-asana-utils/contents/user_map.yml --jq .content 2>/dev/null)" && \
-			   [[ -n "${gh_asana_mapping_content}" ]] && \
-			   [[ "${gh_asana_mapping_content}" != "null" ]] && \
-			   gh_asana_mapping="$(echo "${gh_asana_mapping_content}" | base64 -d 2>/dev/null)" && \
-			   [[ -n "${gh_asana_mapping}" ]]; then
-
-				echo "Successfully retrieved user mapping" >&2
-
+			local gh_asana_mapping
+			if gh_asana_mapping="$(_fetch_github_asana_mapping)"; then
 				# Split comma-separated reviewers and iterate through them
 				IFS=',' read -ra reviewer_array <<< "${pr_reviewers}"
 				for reviewer in "${reviewer_array[@]}"; do
@@ -200,21 +221,13 @@ validate_assignee() {
 					fi
 				done
 			else
-				echo "Failed to fetch or parse GitHub to Asana user mapping, skipping reviewer validation" >&2
+				echo "Skipping reviewer validation due to mapping fetch failure" >&2
 			fi
 		fi
 
 		echo "No Apple team members found among PR reviewers, using fallback" >&2
 		echo "${fallback_assignee_id}"
 	fi
-}
-
-_is_user_in_apple_team() {
-	local user_id=$1
-
-	curl -s "${asana_api_url}/teams/${apple_team_id}/users?opt_fields=gid" \
-		-H "Authorization: Bearer ${asana_personal_access_token}" \
-		| jq -e "any(.data[]?; .gid == \"${user_id}\")" > /dev/null
 }
 
 main() {

--- a/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
+++ b/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
@@ -166,19 +166,34 @@ _fetch_github_asana_mapping() {
 	local gh_asana_mapping_content
 	local gh_asana_mapping
 
-	if gh_asana_mapping_content="$(gh api https://api.github.com/repos/duckduckgo/internal-github-asana-utils/contents/user_map.yml --jq .content 2>/dev/null)" && \
-	   [[ -n "${gh_asana_mapping_content}" ]] && \
-	   [[ "${gh_asana_mapping_content}" != "null" ]] && \
-	   gh_asana_mapping="$(echo "${gh_asana_mapping_content}" | base64 -d 2>/dev/null)" && \
-	   [[ -n "${gh_asana_mapping}" ]]; then
-
-		echo "Successfully retrieved user mapping" >&2
-		echo "${gh_asana_mapping}"
-		return 0
-	else
-		echo "Failed to fetch or parse GitHub to Asana user mapping" >&2
+	# Try to fetch the mapping content from GitHub API
+	if ! gh_asana_mapping_content="$(gh api https://api.github.com/repos/duckduckgo/internal-github-asana-utils/contents/user_map.yml --jq .content 2>/dev/null)"; then
+		echo "Failed to fetch user mapping from GitHub API" >&2
 		return 1
 	fi
+
+	# Check if content is empty or null
+	if [[ -z "${gh_asana_mapping_content}" ]] || [[ "${gh_asana_mapping_content}" == "null" ]]; then
+		echo "GitHub API returned empty or null content" >&2
+		return 1
+	fi
+
+	# Try to decode base64 content
+	if ! gh_asana_mapping="$(echo "${gh_asana_mapping_content}" | base64 -d 2>/dev/null)"; then
+		echo "Failed to decode base64 content" >&2
+		return 1
+	fi
+
+	# Check if decoded content is empty
+	if [[ -z "${gh_asana_mapping}" ]]; then
+		echo "Decoded mapping content is empty" >&2
+		return 1
+	fi
+
+	# Happy path - all checks passed
+	echo "Successfully retrieved user mapping" >&2
+	echo "${gh_asana_mapping}"
+	return 0
 }
 
 _is_user_in_apple_team() {
@@ -201,14 +216,19 @@ validate_assignee() {
 		# Check each PR reviewer if pr_reviewers is not empty
 		if [[ -n "${pr_reviewers}" ]]; then
 			local gh_asana_mapping
-			if gh_asana_mapping="$(_fetch_github_asana_mapping)"; then
+			if ! gh_asana_mapping="$(_fetch_github_asana_mapping)"; then
+				echo "Skipping reviewer validation due to mapping fetch failure" >&2
+			else
 				# Split comma-separated reviewers and iterate through them
 				IFS=',' read -ra reviewer_array <<< "${pr_reviewers}"
 				for reviewer in "${reviewer_array[@]}"; do
 					# Trim whitespace
 					reviewer="$(echo "${reviewer}" | xargs)"
+
 					if reviewer_asana_id="$(yq -r ".${reviewer}" <<< "${gh_asana_mapping}" 2>/dev/null)" && \
-					   [[ -n "${reviewer_asana_id}" ]] && [[ "${reviewer_asana_id}" != "null" ]]; then
+						[[ -n "${reviewer_asana_id}" ]] && \
+						[[ "${reviewer_asana_id}" != "null" ]]; then
+
 						echo "Checking reviewer: ${reviewer_asana_id}" >&2
 
 						if _is_user_in_apple_team "${reviewer_asana_id}"; then
@@ -220,8 +240,6 @@ validate_assignee() {
 						echo "Could not find Asana ID for GitHub user: ${reviewer}" >&2
 					fi
 				done
-			else
-				echo "Skipping reviewer validation due to mapping fetch failure" >&2
 			fi
 		fi
 

--- a/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
+++ b/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
@@ -7,6 +7,7 @@ project_id="1205237866452338"
 workflow_id_custom_field_id="1205563320492190"
 apple_team_id="1203552211911076"
 asana_api_url="https://app.asana.com/api/1.0"
+fallback_assignee_id="856498666990313" # (bwaresiak)
 
 print_usage_and_exit() {
 	local reason=$1
@@ -189,7 +190,7 @@ validate_assignee() {
 		fi
 
 		echo "No Apple team members found among PR reviewers, using fallback" >&2
-		echo "856498666990313" # (bwaresiak)
+		echo "${fallback_assignee_id}"
 	fi
 }
 

--- a/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
+++ b/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
@@ -212,7 +212,7 @@ main() {
 	local description
 	local message
 
-	assignee=$(validate_assignee "${assignee}" "${pr_reviewers}")
+	assignee="$(validate_assignee "${assignee}" "${pr_reviewers}")"
 
 	read_command_line_arguments "$@"
 

--- a/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
+++ b/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
@@ -213,13 +213,12 @@ main() {
 	local description
 	local message
 
-	assignee="$(validate_assignee "${assignee}" "${pr_reviewers}")"
-
 	read_command_line_arguments "$@"
 
 	case "${action}" in
 		create-task)
-			create_task "${title}" "${description}"
+			assignee="$(validate_assignee "${assignee}" "${pr_reviewers}")"
+			create_task "${title}" "${description}" "${assignee}"
 			;;
 		close-task)
 			task_id=$(find_task_for_workflow_id "${workflow_id}")

--- a/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
+++ b/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
@@ -201,6 +201,7 @@ main() {
 	local asana_personal_access_token="${ASANA_ACCESS_TOKEN}"
 	local section_id="${ASANA_SECTION_ID}"
 	local assignee="${ASANA_ASSIGNEE}"
+	local github_token="${GITHUB_TOKEN}"
 	local workflow_id="${GITHUB_RUN_ID}"
 	local action
 	local title

--- a/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
+++ b/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
@@ -171,22 +171,37 @@ validate_assignee() {
 
 		# Check each PR reviewer if pr_reviewers is not empty
 		if [[ -n "${pr_reviewers}" ]]; then
-			gh_asana_mapping="$(gh api https://api.github.com/repos/duckduckgo/internal-github-asana-utils/contents/user_map.yml --jq .content | base64 -d)"
+			# Fetch GitHub to Asana user mapping with error handling
+			echo "Fetching GitHub to Asana user mapping..." >&2
+			if gh_asana_mapping_content="$(gh api https://api.github.com/repos/duckduckgo/internal-github-asana-utils/contents/user_map.yml --jq .content 2>/dev/null)" && \
+			   [[ -n "${gh_asana_mapping_content}" ]] && \
+			   [[ "${gh_asana_mapping_content}" != "null" ]] && \
+			   gh_asana_mapping="$(echo "${gh_asana_mapping_content}" | base64 -d 2>/dev/null)" && \
+			   [[ -n "${gh_asana_mapping}" ]]; then
 
-			# Split comma-separated reviewers and iterate through them
-			IFS=',' read -ra reviewer_array <<< "${pr_reviewers}"
-			for reviewer in "${reviewer_array[@]}"; do
-				# Trim whitespace
-				reviewer="$(echo "${reviewer}" | xargs)"
-				reviewer_asana_id="$(yq -r ".${reviewer}" <<< "${gh_asana_mapping}")"
-				echo "Checking reviewer: ${reviewer_asana_id}" >&2
+				echo "Successfully retrieved user mapping" >&2
 
-				if _is_user_in_apple_team "${reviewer_asana_id}"; then
-					echo "Found Apple team member reviewer: ${reviewer_asana_id}" >&2
-					echo "${reviewer_asana_id}"
-					return
-				fi
-			done
+				# Split comma-separated reviewers and iterate through them
+				IFS=',' read -ra reviewer_array <<< "${pr_reviewers}"
+				for reviewer in "${reviewer_array[@]}"; do
+					# Trim whitespace
+					reviewer="$(echo "${reviewer}" | xargs)"
+					if reviewer_asana_id="$(yq -r ".${reviewer}" <<< "${gh_asana_mapping}" 2>/dev/null)" && \
+					   [[ -n "${reviewer_asana_id}" ]] && [[ "${reviewer_asana_id}" != "null" ]]; then
+						echo "Checking reviewer: ${reviewer_asana_id}" >&2
+
+						if _is_user_in_apple_team "${reviewer_asana_id}"; then
+							echo "Found Apple team member reviewer: ${reviewer_asana_id}" >&2
+							echo "${reviewer_asana_id}"
+							return
+						fi
+					else
+						echo "Could not find Asana ID for GitHub user: ${reviewer}" >&2
+					fi
+				done
+			else
+				echo "Failed to fetch or parse GitHub to Asana user mapping, skipping reviewer validation" >&2
+			fi
 		fi
 
 		echo "No Apple team members found among PR reviewers, using fallback" >&2

--- a/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
+++ b/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
@@ -161,8 +161,30 @@ close_task() {
 
 validate_assignee() {
 	local assignee=$1
+	local workflow_url="${WORKFLOW_URL:-}"
 
+	# First try to get PR reviewers if this is a PR merge
+	local pr_reviewers
+	pr_reviewers=$(get_pr_reviewers_from_merge_commit)
+
+	if [[ -n "$pr_reviewers" ]]; then
+		echo "Found PR reviewers: $pr_reviewers"
+
+		# Try each reviewer until we find one in the Apple team
+		while IFS= read -r reviewer; do
+			if [[ -n "$reviewer" ]] && _is_user_in_apple_team "$reviewer"; then
+				echo "Using PR reviewer: $reviewer"
+				assignee="$reviewer"
+				return 0
+			fi
+		done <<< "$pr_reviewers"
+
+		echo "No valid PR reviewers found in Apple team, falling back to commit author"
+	fi
+
+	# Fall back to original assignee (commit author) or hardcoded ID
 	if ! _is_user_in_apple_team "${assignee}"; then
+		echo "Assignee $assignee not found in Apple team, using fallback"
 		assignee="33604954490307"
 	fi
 }

--- a/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
+++ b/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
@@ -7,7 +7,6 @@ project_id="1205237866452338"
 workflow_id_custom_field_id="1205563320492190"
 apple_team_id="1203552211911076"
 asana_api_url="https://app.asana.com/api/1.0"
-fallback_assignee_id="856498666990313" # (bwaresiak)
 
 print_usage_and_exit() {
 	local reason=$1
@@ -210,42 +209,43 @@ validate_assignee() {
 
 	if _is_user_in_apple_team "${assignee}"; then
 		echo "${assignee}"
-	else
-		echo "Assignee $assignee not found in Apple team, checking PR reviewers" >&2
+		return
+	fi
 
-		# Check each PR reviewer if pr_reviewers is not empty
-		if [[ -n "${pr_reviewers}" ]]; then
-			local gh_asana_mapping
-			if ! gh_asana_mapping="$(_fetch_github_asana_mapping)"; then
-				echo "Skipping reviewer validation due to mapping fetch failure" >&2
-			else
-				# Split comma-separated reviewers and iterate through them
-				IFS=',' read -ra reviewer_array <<< "${pr_reviewers}"
-				for reviewer in "${reviewer_array[@]}"; do
-					# Trim whitespace
-					reviewer="$(echo "${reviewer}" | xargs)"
+	echo "Assignee $assignee not found in Apple team, checking PR reviewers" >&2
 
-					if reviewer_asana_id="$(yq -r ".${reviewer}" <<< "${gh_asana_mapping}" 2>/dev/null)" && \
-						[[ -n "${reviewer_asana_id}" ]] && \
-						[[ "${reviewer_asana_id}" != "null" ]]; then
-
-						echo "Checking reviewer: ${reviewer_asana_id}" >&2
-
-						if _is_user_in_apple_team "${reviewer_asana_id}"; then
-							echo "Found Apple team member reviewer: ${reviewer_asana_id}" >&2
-							echo "${reviewer_asana_id}"
-							return
-						fi
-					else
-						echo "Could not find Asana ID for GitHub user: ${reviewer}" >&2
-					fi
-				done
-			fi
+	# Check each PR reviewer if pr_reviewers is not empty
+	if [[ -n "${pr_reviewers}" ]]; then
+		local gh_asana_mapping
+		if ! gh_asana_mapping="$(_fetch_github_asana_mapping)"; then
+			echo "Skipping reviewer validation due to mapping fetch failure" >&2
+			return
 		fi
 
-		echo "No Apple team members found among PR reviewers, using fallback" >&2
-		echo "${fallback_assignee_id}"
+		# Split comma-separated reviewers and iterate through them
+		IFS=',' read -ra reviewer_array <<< "${pr_reviewers}"
+		for reviewer in "${reviewer_array[@]}"; do
+			# Trim whitespace
+			reviewer="$(echo "${reviewer}" | xargs)"
+
+			if reviewer_asana_id="$(yq -r ".${reviewer}" <<< "${gh_asana_mapping}" 2>/dev/null)" && \
+				[[ -n "${reviewer_asana_id}" ]] && \
+				[[ "${reviewer_asana_id}" != "null" ]]; then
+
+				echo "Checking reviewer: ${reviewer_asana_id}" >&2
+
+				if _is_user_in_apple_team "${reviewer_asana_id}"; then
+					echo "Found Apple team member reviewer: ${reviewer_asana_id}" >&2
+					echo "${reviewer_asana_id}"
+					return
+				fi
+			else
+				echo "Could not find Asana ID for GitHub user: ${reviewer}" >&2
+			fi
+		done
 	fi
+
+	echo "No Apple team members found among PR reviewers, skipping task assignment" >&2
 }
 
 main() {

--- a/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
+++ b/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
@@ -161,31 +161,35 @@ close_task() {
 
 validate_assignee() {
 	local assignee=$1
-	local workflow_url="${WORKFLOW_URL:-}"
+	local pr_reviewers=$2
 
-	# First try to get PR reviewers if this is a PR merge
-	local pr_reviewers
-	pr_reviewers=$(get_pr_reviewers_from_merge_commit)
+	if _is_user_in_apple_team "${assignee}"; then
+		echo "${assignee}"
+	else
+		echo "Assignee $assignee not found in Apple team, checking PR reviewers" >&2
 
-	if [[ -n "$pr_reviewers" ]]; then
-		echo "Found PR reviewers: $pr_reviewers"
+		# Check each PR reviewer if pr_reviewers is not empty
+		if [[ -n "${pr_reviewers}" ]]; then
+			gh_asana_mapping="$(gh api https://api.github.com/repos/duckduckgo/internal-github-asana-utils/contents/user_map.yml --jq .content | base64 -d)"
 
-		# Try each reviewer until we find one in the Apple team
-		while IFS= read -r reviewer; do
-			if [[ -n "$reviewer" ]] && _is_user_in_apple_team "$reviewer"; then
-				echo "Using PR reviewer: $reviewer"
-				assignee="$reviewer"
-				return 0
-			fi
-		done <<< "$pr_reviewers"
+			# Split comma-separated reviewers and iterate through them
+			IFS=',' read -ra reviewer_array <<< "${pr_reviewers}"
+			for reviewer in "${reviewer_array[@]}"; do
+				# Trim whitespace
+				reviewer="$(echo "${reviewer}" | xargs)"
+				reviewer_asana_id="$(yq -r ".${reviewer}" <<< "${gh_asana_mapping}")"
+				echo "Checking reviewer: ${reviewer_asana_id}" >&2
 
-		echo "No valid PR reviewers found in Apple team, falling back to commit author"
-	fi
+				if _is_user_in_apple_team "${reviewer_asana_id}"; then
+					echo "Found Apple team member reviewer: ${reviewer_asana_id}" >&2
+					echo "${reviewer_asana_id}"
+					return
+				fi
+			done
+		fi
 
-	# Fall back to original assignee (commit author) or hardcoded ID
-	if ! _is_user_in_apple_team "${assignee}"; then
-		echo "Assignee $assignee not found in Apple team, using fallback"
-		assignee="33604954490307"
+		echo "No Apple team members found among PR reviewers, using fallback" >&2
+		echo "856498666990313" # (bwaresiak)
 	fi
 }
 
@@ -201,14 +205,14 @@ main() {
 	local asana_personal_access_token="${ASANA_ACCESS_TOKEN}"
 	local section_id="${ASANA_SECTION_ID}"
 	local assignee="${ASANA_ASSIGNEE}"
-	local github_token="${GITHUB_TOKEN}"
 	local workflow_id="${GITHUB_RUN_ID}"
+	local pr_reviewers="${GITHUB_PR_REVIEWERS}"
 	local action
 	local title
 	local description
 	local message
 
-	validate_assignee "${assignee}"
+	assignee=$(validate_assignee "${assignee}" "${pr_reviewers}")
 
 	read_command_line_arguments "$@"
 

--- a/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
+++ b/.github/actions/asana-failed-pr-checks/report-failed-pr-checks.sh
@@ -159,12 +159,20 @@ close_task() {
 	[[ ${return_code} -eq 200 ]]
 }
 
-_validate_assignee() {
+validate_assignee() {
 	local assignee=$1
+
+	if ! _is_user_in_apple_team "${assignee}"; then
+		assignee="33604954490307"
+	fi
+}
+
+_is_user_in_apple_team() {
+	local user_id=$1
 
 	curl -s "${asana_api_url}/teams/${apple_team_id}/users?opt_fields=gid" \
 		-H "Authorization: Bearer ${asana_personal_access_token}" \
-		| jq -e "any(.data[]?; .gid == \"${assignee}\")" > /dev/null
+		| jq -e "any(.data[]?; .gid == \"${user_id}\")" > /dev/null
 }
 
 main() {
@@ -177,7 +185,7 @@ main() {
 	local description
 	local message
 
-	_validate_assignee "${assignee}"
+	validate_assignee "${assignee}"
 
 	read_command_line_arguments "$@"
 

--- a/.github/actions/fetch-commit-info/action.yml
+++ b/.github/actions/fetch-commit-info/action.yml
@@ -31,8 +31,10 @@ runs:
         # Check if this is a merge commit from a PR
         commit_message=$(gh api https://api.github.com/repos/${{ github.repository }}/commits/${head_commit} --jq .commit.message)
 
-        # Extract PR number from merge commit message (format: "Merge pull request #123 from ...")
-        pr_number=$(echo "$commit_message" | grep -oE "Merge pull request #[0-9]+" | grep -oE "[0-9]+")
+        # Extract PR number from commit message
+        # Format 1: "Merge pull request #123 from ..." (merge commits)
+        # Format 2: "Some message (#123)" (squash commits)
+        pr_number=$(echo "$commit_message" | grep -oE "(Merge pull request #[0-9]+|\(#[0-9]+\))" | grep -oE "[0-9]+")
 
         if [[ -n "$pr_number" ]]; then
           echo "Found PR merge: #${pr_number}"

--- a/.github/actions/fetch-commit-info/action.yml
+++ b/.github/actions/fetch-commit-info/action.yml
@@ -1,0 +1,62 @@
+name: 'Fetch Commit Info'
+description: 'Fetches commit author and PR reviewers information from GitHub API'
+
+inputs:
+  github-token:
+    description: 'GitHub token for API access'
+    required: true
+    default: ${{ github.token }}
+
+outputs:
+  commit_author:
+    description: 'The commit author username'
+    value: ${{ steps.fetch_info.outputs.commit_author }}
+  pr_reviewers:
+    description: 'Comma-separated list of all PR reviewers (or commit author if not a PR merge)'
+    value: ${{ steps.fetch_info.outputs.pr_reviewers }}
+  pr_reviewer:
+    description: 'First PR reviewer (for backward compatibility)'
+    value: ${{ steps.fetch_info.outputs.pr_reviewer }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Fetch commit author and PR reviewers
+      id: fetch_info
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        head_commit=$(git rev-parse HEAD)
+        author=$(gh api https://api.github.com/repos/${{ github.repository }}/commits/${head_commit} --jq .author.login)
+        echo "commit_author=${author}" >> $GITHUB_OUTPUT
+
+        # Check if this is a merge commit from a PR
+        commit_message=$(gh api https://api.github.com/repos/${{ github.repository }}/commits/${head_commit} --jq .commit.message)
+
+        # Extract PR number from merge commit message (format: "Merge pull request #123 from ...")
+        pr_number=$(echo "$commit_message" | grep -oE "Merge pull request #[0-9]+" | grep -oE "[0-9]+")
+
+        if [[ -n "$pr_number" ]]; then
+          echo "Found PR merge: #${pr_number}"
+
+          # Get all PR reviewers who approved (unique reviewers only)
+          reviewers=$(gh api https://api.github.com/repos/${{ github.repository }}/pulls/${pr_number}/reviews \
+            --jq '[.[] | select(.state == "APPROVED") | .user.login] | unique | join(",")')
+
+          if [[ -n "$reviewers" && "$reviewers" != "null" && "$reviewers" != "" ]]; then
+            echo "PR reviewers found: ${reviewers}"
+            echo "pr_reviewers=${reviewers}" >> $GITHUB_OUTPUT
+            # Also set the first reviewer for backward compatibility
+            first_reviewer=$(echo "$reviewers" | cut -d',' -f1)
+            echo "pr_reviewer=${first_reviewer}" >> $GITHUB_OUTPUT
+          else
+            echo "No reviewers found for PR #${pr_number}, using commit author"
+            echo "pr_reviewers=${author}" >> $GITHUB_OUTPUT
+            echo "pr_reviewer=${author}" >> $GITHUB_OUTPUT
+          fi
+        else
+          echo "Not a PR merge, using commit author"
+          echo "pr_reviewers=${author}" >> $GITHUB_OUTPUT
+          echo "pr_reviewer=${author}" >> $GITHUB_OUTPUT
+        fi

--- a/.github/actions/fetch-commit-info/action.yml
+++ b/.github/actions/fetch-commit-info/action.yml
@@ -12,7 +12,7 @@ outputs:
     description: 'The commit author username'
     value: ${{ steps.fetch_info.outputs.commit_author }}
   pr_reviewers:
-    description: 'Comma-separated list of all PR reviewers (or commit author if not a PR merge)'
+    description: 'Comma-separated list of all PR reviewers (empty if not a PR merge)'
     value: ${{ steps.fetch_info.outputs.pr_reviewers }}
 
 runs:

--- a/.github/actions/fetch-commit-info/action.yml
+++ b/.github/actions/fetch-commit-info/action.yml
@@ -45,10 +45,10 @@ runs:
             echo "PR reviewers found: ${reviewers}"
             echo "pr_reviewers=${reviewers}" >> $GITHUB_OUTPUT
           else
-            echo "No reviewers found for PR #${pr_number}, using commit author"
-            echo "pr_reviewers=${author}" >> $GITHUB_OUTPUT
+            echo "No reviewers found for PR #${pr_number}"
+            echo "pr_reviewers=" >> $GITHUB_OUTPUT
           fi
         else
-          echo "Not a PR merge, using commit author"
-          echo "pr_reviewers=${author}" >> $GITHUB_OUTPUT
+          echo "Not a PR merge"
+          echo "pr_reviewers=" >> $GITHUB_OUTPUT
         fi

--- a/.github/actions/fetch-commit-info/action.yml
+++ b/.github/actions/fetch-commit-info/action.yml
@@ -14,9 +14,6 @@ outputs:
   pr_reviewers:
     description: 'Comma-separated list of all PR reviewers (or commit author if not a PR merge)'
     value: ${{ steps.fetch_info.outputs.pr_reviewers }}
-  pr_reviewer:
-    description: 'First PR reviewer (for backward compatibility)'
-    value: ${{ steps.fetch_info.outputs.pr_reviewer }}
 
 runs:
   using: "composite"
@@ -47,16 +44,11 @@ runs:
           if [[ -n "$reviewers" && "$reviewers" != "null" && "$reviewers" != "" ]]; then
             echo "PR reviewers found: ${reviewers}"
             echo "pr_reviewers=${reviewers}" >> $GITHUB_OUTPUT
-            # Also set the first reviewer for backward compatibility
-            first_reviewer=$(echo "$reviewers" | cut -d',' -f1)
-            echo "pr_reviewer=${first_reviewer}" >> $GITHUB_OUTPUT
           else
             echo "No reviewers found for PR #${pr_number}, using commit author"
             echo "pr_reviewers=${author}" >> $GITHUB_OUTPUT
-            echo "pr_reviewer=${author}" >> $GITHUB_OUTPUT
           fi
         else
           echo "Not a PR merge, using commit author"
           echo "pr_reviewers=${author}" >> $GITHUB_OUTPUT
-          echo "pr_reviewer=${author}" >> $GITHUB_OUTPUT
         fi

--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -309,6 +309,7 @@ jobs:
           asana-access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-section-id: ${{ vars.APPLE_CI_FAILING_TESTS_BSK_POST_MERGE_SECTION_ID }}
           commit-author: ${{ needs.unit-tests.outputs.commit_author }}
+          pr-reviewers: ${{ needs.unit-tests.outputs.pr_reviewers }}
           github-token: ${{ secrets.GH_RO_PAT }}
 
   close-asana-task:

--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -32,6 +32,7 @@ jobs:
 
       outputs:
         commit_author: ${{ steps.fetch_commit_author.outputs.commit_author }}
+        pr_reviewers: ${{ steps.fetch_commit_author.outputs.pr_reviewers }}
 
       steps:
 
@@ -158,15 +159,12 @@ jobs:
           name: build-log.txt
           path: SharedPackages/BrowserServicesKit/build-log.txt
 
-      - name: Fetch latest commit author
+      - name: Fetch latest commit author and PR reviewers
         if: always() && github.ref_name == 'main'
         id: fetch_commit_author
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          head_commit=$(git rev-parse HEAD)
-          author=$(gh api https://api.github.com/repos/${{ github.repository }}/commits/${head_commit} --jq .author.login)
-          echo "commit_author=${author}" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/fetch-commit-info
+        with:
+          github-token: ${{ github.token }}
 
   unit-tests-ios:
 

--- a/.github/workflows/dbp_pr_checks.yml
+++ b/.github/workflows/dbp_pr_checks.yml
@@ -32,6 +32,7 @@ jobs:
 
       outputs:
         commit_author: ${{ steps.fetch_commit_author.outputs.commit_author }}
+        pr_reviewers: ${{ steps.fetch_commit_author.outputs.pr_reviewers }}
 
       steps:
 
@@ -124,15 +125,12 @@ jobs:
           name: build-log.txt
           path: SharedPackages/DataBrokerProtectionCore/build-log.txt
 
-      - name: Fetch latest commit author
+      - name: Fetch latest commit author and PR reviewers
         if: always() && github.ref_name == 'main'
         id: fetch_commit_author
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          head_commit=$(git rev-parse HEAD)
-          author=$(gh api https://api.github.com/repos/${{ github.repository }}/commits/${head_commit} --jq .author.login)
-          echo "commit_author=${author}" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/fetch-commit-info
+        with:
+          github-token: ${{ github.token }}
 
   unit-tests-ios:
 

--- a/.github/workflows/dbp_pr_checks.yml
+++ b/.github/workflows/dbp_pr_checks.yml
@@ -266,6 +266,7 @@ jobs:
           asana-access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-section-id: ${{ vars.APPLE_CI_FAILING_TESTS_BSK_POST_MERGE_SECTION_ID }}
           commit-author: ${{ needs.unit-tests.outputs.commit_author }}
+          pr-reviewers: ${{ needs.unit-tests.outputs.pr_reviewers }}
           github-token: ${{ secrets.GH_RO_PAT }}
 
   close-asana-task:

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -82,7 +82,7 @@ jobs:
 
     outputs:
       commit_author: ${{ steps.fetch_commit_author.outputs.commit_author }}
-      pr_reviewer: ${{ steps.fetch_commit_author.outputs.pr_reviewer }}
+      pr_reviewers: ${{ steps.fetch_commit_author.outputs.pr_reviewers }}
 
     steps:
 
@@ -192,7 +192,7 @@ jobs:
       with:
         pixel-name: m_ci_apple_status_ios_main_unit_tests_${{ steps.run-unit-tests.outcome }}
 
-    - name: Fetch latest commit author and PR reviewer
+    - name: Fetch latest commit author and PR reviewers
       if: always() && github.ref_name == 'main'
       id: fetch_commit_author
       env:
@@ -211,20 +211,20 @@ jobs:
         if [[ -n "$pr_number" ]]; then
           echo "Found PR merge: #${pr_number}"
 
-          # Get the PR reviewer (first reviewer who approved)
-          reviewer=$(gh api https://api.github.com/repos/${{ github.repository }}/pulls/${pr_number}/reviews \
-            --jq '.[] | select(.state == "APPROVED") | .user.login' | head -n 1)
+          # Get all PR reviewers who approved (unique reviewers only)
+          reviewers=$(gh api https://api.github.com/repos/${{ github.repository }}/pulls/${pr_number}/reviews \
+            --jq '[.[] | select(.state == "APPROVED") | .user.login] | unique | join(",")')
 
-          if [[ -n "$reviewer" ]]; then
-            echo "PR reviewer found: ${reviewer}"
-            echo "pr_reviewer=${reviewer}" >> $GITHUB_OUTPUT
+          if [[ -n "$reviewers" && "$reviewers" != "null" && "$reviewers" != "" ]]; then
+            echo "PR reviewers found: ${reviewers}"
+            echo "pr_reviewers=${reviewers}" >> $GITHUB_OUTPUT
           else
-            echo "No reviewer found for PR #${pr_number}, using commit author"
-            echo "pr_reviewer=${author}" >> $GITHUB_OUTPUT
+            echo "No reviewers found for PR #${pr_number}, using commit author"
+            echo "pr_reviewers=${author}" >> $GITHUB_OUTPUT
           fi
         else
           echo "Not a PR merge, using commit author"
-          echo "pr_reviewer=${author}" >> $GITHUB_OUTPUT
+          echo "pr_reviewers=${author}" >> $GITHUB_OUTPUT
         fi
 
   release-build:

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -307,6 +307,7 @@ jobs:
           asana-access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-section-id: ${{ vars.APPLE_CI_FAILING_TESTS_IOS_POST_MERGE_SECTION_ID }}
           commit-author: ${{ needs.unit-tests.outputs.commit_author }}
+          pr-reviewers: ${{ needs.unit-tests.outputs.pr_reviewers }}
           github-token: ${{ secrets.GH_RO_PAT }}
 
   close-asana-task:

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -82,6 +82,7 @@ jobs:
 
     outputs:
       commit_author: ${{ steps.fetch_commit_author.outputs.commit_author }}
+      pr_reviewer: ${{ steps.fetch_commit_author.outputs.pr_reviewer }}
 
     steps:
 
@@ -191,7 +192,7 @@ jobs:
       with:
         pixel-name: m_ci_apple_status_ios_main_unit_tests_${{ steps.run-unit-tests.outcome }}
 
-    - name: Fetch latest commit author
+    - name: Fetch latest commit author and PR reviewer
       if: always() && github.ref_name == 'main'
       id: fetch_commit_author
       env:
@@ -200,6 +201,31 @@ jobs:
         head_commit=$(git rev-parse HEAD)
         author=$(gh api https://api.github.com/repos/${{ github.repository }}/commits/${head_commit} --jq .author.login)
         echo "commit_author=${author}" >> $GITHUB_OUTPUT
+
+        # Check if this is a merge commit from a PR
+        commit_message=$(gh api https://api.github.com/repos/${{ github.repository }}/commits/${head_commit} --jq .commit.message)
+
+        # Extract PR number from merge commit message (format: "Merge pull request #123 from ...")
+        pr_number=$(echo "$commit_message" | grep -oE "Merge pull request #[0-9]+" | grep -oE "[0-9]+")
+
+        if [[ -n "$pr_number" ]]; then
+          echo "Found PR merge: #${pr_number}"
+
+          # Get the PR reviewer (first reviewer who approved)
+          reviewer=$(gh api https://api.github.com/repos/${{ github.repository }}/pulls/${pr_number}/reviews \
+            --jq '.[] | select(.state == "APPROVED") | .user.login' | head -n 1)
+
+          if [[ -n "$reviewer" ]]; then
+            echo "PR reviewer found: ${reviewer}"
+            echo "pr_reviewer=${reviewer}" >> $GITHUB_OUTPUT
+          else
+            echo "No reviewer found for PR #${pr_number}, using commit author"
+            echo "pr_reviewer=${author}" >> $GITHUB_OUTPUT
+          fi
+        else
+          echo "Not a PR merge, using commit author"
+          echo "pr_reviewer=${author}" >> $GITHUB_OUTPUT
+        fi
 
   release-build:
 

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -195,37 +195,9 @@ jobs:
     - name: Fetch latest commit author and PR reviewers
       if: always() && github.ref_name == 'main'
       id: fetch_commit_author
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        head_commit=$(git rev-parse HEAD)
-        author=$(gh api https://api.github.com/repos/${{ github.repository }}/commits/${head_commit} --jq .author.login)
-        echo "commit_author=${author}" >> $GITHUB_OUTPUT
-
-        # Check if this is a merge commit from a PR
-        commit_message=$(gh api https://api.github.com/repos/${{ github.repository }}/commits/${head_commit} --jq .commit.message)
-
-        # Extract PR number from merge commit message (format: "Merge pull request #123 from ...")
-        pr_number=$(echo "$commit_message" | grep -oE "Merge pull request #[0-9]+" | grep -oE "[0-9]+")
-
-        if [[ -n "$pr_number" ]]; then
-          echo "Found PR merge: #${pr_number}"
-
-          # Get all PR reviewers who approved (unique reviewers only)
-          reviewers=$(gh api https://api.github.com/repos/${{ github.repository }}/pulls/${pr_number}/reviews \
-            --jq '[.[] | select(.state == "APPROVED") | .user.login] | unique | join(",")')
-
-          if [[ -n "$reviewers" && "$reviewers" != "null" && "$reviewers" != "" ]]; then
-            echo "PR reviewers found: ${reviewers}"
-            echo "pr_reviewers=${reviewers}" >> $GITHUB_OUTPUT
-          else
-            echo "No reviewers found for PR #${pr_number}, using commit author"
-            echo "pr_reviewers=${author}" >> $GITHUB_OUTPUT
-          fi
-        else
-          echo "Not a PR merge, using commit author"
-          echo "pr_reviewers=${author}" >> $GITHUB_OUTPUT
-        fi
+      uses: ./.github/actions/fetch-commit-info
+      with:
+        github-token: ${{ github.token }}
 
   release-build:
 

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -489,6 +489,7 @@ jobs:
           asana-access-token: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-section-id: ${{ vars.APPLE_CI_FAILING_TESTS_MACOS_POST_MERGE_SECTION_ID }}
           commit-author: ${{ needs.tests.outputs.commit_author }}
+          pr-reviewers: ${{ needs.tests.outputs.pr_reviewers }}
           github-token: ${{ secrets.GH_RO_PAT }}
 
   close-asana-task:

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -135,6 +135,7 @@ jobs:
     outputs:
       private-api-check-report: ${{ steps.private-api.outputs.report }}
       commit_author: ${{ steps.fetch_commit_author.outputs.commit_author }}
+      pr_reviewers: ${{ steps.fetch_commit_author.outputs.pr_reviewers }}
 
     steps:
     - name: Register SSH key for certificates repository access
@@ -342,15 +343,12 @@ jobs:
         path: macOS/${{ matrix.flavor }}-integrationtests.xcresult
         retention-days: 7
 
-    - name: Fetch latest commit author
+    - name: Fetch latest commit author and PR reviewers
       if: always() && github.ref_name == 'main'
       id: fetch_commit_author
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        head_commit=$(git rev-parse HEAD)
-        author=$(gh api https://api.github.com/repos/${{ github.repository }}/commits/${head_commit} --jq .author.login)
-        echo "commit_author=${author}" >> $GITHUB_OUTPUT
+      uses: ./.github/actions/fetch-commit-info
+      with:
+        github-token: ${{ github.token }}
 
   private-api:
     name: Private API Report


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1210625492570315?focus=true

### Description
This change updates the `asana-failed-pr-checks` GitHub Action to ensure that post-merge failed PR Checks tasks are only assigned to Apple team members. If a PR was authored by a non-Apple team member, the PR reviewer will be assigned.

### Testing Steps

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
It can break reporting PR Checks failures and it can’t really be tested without previously merging it...

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)