### PR TITLE
Add context menu option to summarize selected text with Duck.ai

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
@@ -23,6 +23,7 @@ public enum AIChatUserScriptMessages: String, CaseIterable {
     case getAIChatNativePrompt
     case openAIChat
     case getAIChatNativeHandoffData
+    case submitAIChatNativePrompt
     case responseState
     case showChatInput
     case hideChatInput

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
@@ -81,7 +81,7 @@ extension AIChatMessageHandler {
                                             supportsClosingAIChat: true,
                                             supportsOpeningSettings: true,
                                             supportsNativePrompt: true,
-                                            supportsNativeChatInput: false,
+                                            supportsNativeChatInput: true, // enabled in order to make submitAIChatNativePrompt message available
                                             supportsURLChatIDRestoration: true)
         } else {
             return AIChatNativeConfigValues.defaultValues

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
@@ -81,7 +81,7 @@ extension AIChatMessageHandler {
                                             supportsClosingAIChat: true,
                                             supportsOpeningSettings: true,
                                             supportsNativePrompt: true,
-                                            supportsNativeChatInput: true, // enabled in order to make submitAIChatNativePrompt message available
+                                            supportsNativeChatInput: featureFlagger.isFeatureOn(.aiChatTextSummarization), // enabled in order to make submitAIChatNativePrompt message available
                                             supportsURLChatIDRestoration: true)
         } else {
             return AIChatNativeConfigValues.defaultValues

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
@@ -17,15 +17,24 @@
 //
 
 import AIChat
+import Combine
 import Common
 import Foundation
 import UserScript
+import WebKit
 
 final class AIChatUserScript: NSObject, Subfeature {
     public let handler: AIChatUserScriptHandling
     public let featureName: String = "aiChat"
     weak var broker: UserScriptMessageBroker?
+    weak var webView: WKWebView?
     private(set) var messageOriginPolicy: MessageOriginPolicy
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    public func with(broker: UserScriptMessageBroker) {
+        self.broker = broker
+    }
 
     init(handler: AIChatUserScriptHandling, urlSettings: AIChatDebugURLSettingsRepresentable) {
         self.handler = handler
@@ -42,6 +51,21 @@ final class AIChatUserScript: NSObject, Subfeature {
             rules.append(.exact(hostname: customURLHostname))
         }
         self.messageOriginPolicy = .only(rules: rules)
+        super.init()
+
+        handler.aiChatNativePromptPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] prompt in
+                self?.submitAIChatNativePrompt(prompt)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func submitAIChatNativePrompt(_ prompt: AIChatNativePrompt) {
+        guard let webView else {
+            return
+        }
+        broker?.push(method: AIChatUserScriptMessages.submitAIChatNativePrompt.rawValue, params: prompt, for: self, into: webView)
     }
 
     func handler(forMethodNamed methodName: String) -> Subfeature.Handler? {

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -16,9 +16,10 @@
 //  limitations under the License.
 //
 
+import AIChat
+import Combine
 import Foundation
 import UserScript
-import AIChat
 
 protocol AIChatUserScriptHandling {
     func openAIChatSettings(params: Any, message: UserScriptMessage) async -> Encodable?
@@ -30,18 +31,24 @@ protocol AIChatUserScriptHandling {
     func recordChat(params: Any, message: UserScriptMessage) -> Encodable?
     func restoreChat(params: Any, message: UserScriptMessage) -> Encodable?
     func removeChat(params: Any, message: UserScriptMessage) -> Encodable?
+    var aiChatNativePromptPublisher: AnyPublisher<AIChatNativePrompt, Never> { get }
 
     var messageHandling: AIChatMessageHandling { get }
+    func submitAIChatNativePrompt(_ prompt: AIChatNativePrompt)
 }
 
 struct AIChatUserScriptHandler: AIChatUserScriptHandling {
     public let messageHandling: AIChatMessageHandling
+    public let aiChatNativePromptPublisher: AnyPublisher<AIChatNativePrompt, Never>
+
+    private let aiChatNativePromptSubject = PassthroughSubject<AIChatNativePrompt, Never>()
     private let storage: AIChatPreferencesStorage
 
     init(storage: AIChatPreferencesStorage,
          messageHandling: AIChatMessageHandling = AIChatMessageHandler()) {
         self.storage = storage
         self.messageHandling = messageHandling
+        self.aiChatNativePromptPublisher = aiChatNativePromptSubject.eraseToAnyPublisher()
     }
 
     enum AIChatKeys {
@@ -103,6 +110,10 @@ struct AIChatUserScriptHandler: AIChatUserScriptHandling {
     public func removeChat(params: Any, message: any UserScriptMessage) -> (any Encodable)? {
         messageHandling.setData(nil, forMessageType: .chatRestorationData)
         return nil
+    }
+
+    func submitAIChatNativePrompt(_ prompt: AIChatNativePrompt) {
+        aiChatNativePromptSubject.send(prompt)
     }
 }
 

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -108,4 +108,5 @@ struct AIChatUserScriptHandler: AIChatUserScriptHandling {
 
 extension NSNotification.Name {
     static let aiChatNativeHandoffData: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.notification.aiChatNativeHandoffData")
+    static let aiChatSummarizationQuery: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.notification.aiChatSummarizationQuery")
 }

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -752,11 +752,9 @@ extension MainViewController {
                 guard let selectedText, !selectedText.isEmpty else {
                     return
                 }
-
                 NotificationCenter.default.post(name: .aiChatSummarizationQuery,
                                                 object: selectedText,
                                                 userInfo: nil)
-
             } catch {
                 Logger.aiChat.error("Failed to get selected text from the webView")
             }

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -745,6 +745,22 @@ extension MainViewController {
             return
         }
         Logger.aiChat.debug("Summarize action to be implemented")
+
+        Task {
+            do {
+                let selectedText = try await getActiveTabAndIndex()?.tab.webView.evaluateJavaScript("window.getSelection().toString()") as? String
+                guard let selectedText, !selectedText.isEmpty else {
+                    return
+                }
+
+                NotificationCenter.default.post(name: .aiChatSummarizationQuery,
+                                                object: selectedText,
+                                                userInfo: nil)
+
+            } catch {
+                Logger.aiChat.error("Failed to get selected text from the webView")
+            }
+        }
     }
 
     @objc func toggleDownloads(_ sender: Any) {

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -741,7 +741,7 @@ extension MainViewController {
     }
 
     @objc func summarize(_ sender: Any) {
-        guard featureFlagger.isFeatureOn(.aiChatTextSummarization) else {
+        guard featureFlagger.isFeatureOn(.aiChatTextSummarization), featureFlagger.isFeatureOn(.aiChatSidebar) else {
             return
         }
         Logger.aiChat.debug("Summarize action to be implemented")

--- a/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarPresenter.swift
+++ b/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarPresenter.swift
@@ -170,9 +170,9 @@ final class AIChatSidebarPresenter: AIChatSidebarPresenting {
         let isShowingSidebar = sidebarProvider.isShowingSidebar(for: currentTabID)
 
         if !isShowingSidebar {
-            AIChatPromptHandler.shared.setData(.queryPrompt("Summarize the following text snippet:\n\n \(text)", autoSubmit: true))
+            AIChatPromptHandler.shared.setData(.queryPrompt("Summarize the following text snippet:\n\n\(text)", autoSubmit: true))
 
-            // If not showing the sidebar open it with the payload received
+            // If not showing the sidebar open it with the summarization prompt
             updateSidebarConstraints(for: currentTabID, isShowingSidebar: true, withAnimation: true)
         }
     }

--- a/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarPresenter.swift
+++ b/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarPresenter.swift
@@ -169,11 +169,16 @@ final class AIChatSidebarPresenter: AIChatSidebarPresenting {
 
         let isShowingSidebar = sidebarProvider.isShowingSidebar(for: currentTabID)
 
+        let prompt = AIChatNativePrompt.queryPrompt("Summarize the following text snippet:\n\n\(text)", autoSubmit: true)
+
         if !isShowingSidebar {
-            AIChatPromptHandler.shared.setData(.queryPrompt("Summarize the following text snippet:\n\n\(text)", autoSubmit: true))
+            AIChatPromptHandler.shared.setData(prompt)
 
             // If not showing the sidebar open it with the summarization prompt
             updateSidebarConstraints(for: currentTabID, isShowingSidebar: true, withAnimation: true)
+        } else {
+            let sidebarViewController = sidebarProvider.sidebar(for: currentTabID).sidebarViewController
+            sidebarViewController.setAIChatPrompt(prompt)
         }
     }
 }

--- a/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarViewController.swift
+++ b/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarViewController.swift
@@ -75,6 +75,10 @@ final class AIChatSidebarViewController: NSViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    public func setAIChatPrompt(_ prompt: AIChatNativePrompt) {
+        aiTab.aiChat?.submitAIChatNativePrompt(prompt)
+    }
+
     override func loadView() {
         let container = ColorView(frame: .zero, backgroundColor: visualStyle.colorsProvider.navigationBackgroundColor)
 

--- a/macOS/DuckDuckGo/Tab/Model/Tab+UIDelegate.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab+UIDelegate.swift
@@ -141,6 +141,7 @@ extension Tab: WKUIDelegate, PrintingUserScriptDelegate {
         }
     }
 
+    @MainActor
     private func newWindowPolicy(for navigationAction: WKNavigationAction) -> NavigationDecision? {
         if let newWindowPolicy = self.decideNewWindowPolicy(for: navigationAction) {
             return newWindowPolicy

--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -41,6 +41,7 @@ protocol TabDelegate: ContentOverlayUserScriptDelegate {
     func closeTab(_ tab: Tab)
 }
 
+@MainActor
 protocol NewWindowPolicyDecisionMaker {
     func decideNewWindowPolicy(for navigationAction: WKNavigationAction) -> NavigationDecision?
 }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
@@ -206,13 +206,14 @@ extension ContextMenuManager {
     }
 
     private func handleSearchWebItem(_ item: NSMenuItem, at index: Int, in menu: NSMenu) {
+        let isSummarizationAvailable = featureFlagger.isFeatureOn(.aiChatTextSummarization) && featureFlagger.isFeatureOn(.aiChatSidebar)
         var currentIndex = index
-        if featureFlagger.isFeatureOn(.aiChatTextSummarization) {
+        if isSummarizationAvailable {
             menu.insertItem(.separator(), at: currentIndex)
             currentIndex += 1
         }
         menu.replaceItem(at: currentIndex, with: self.searchMenuItem(makeBurner: isCurrentWindowBurner))
-        if featureFlagger.isFeatureOn(.aiChatTextSummarization) {
+        if isSummarizationAvailable {
             menu.insertItem(summarizeMenuItem(), at: currentIndex + 1)
         }
     }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
@@ -17,6 +17,7 @@
 //
 
 import AppKit
+import AIChat
 import Combine
 import Foundation
 import WebKitExtensions
@@ -39,6 +40,7 @@ final class ContextMenuManager: NSObject {
     private var tabsPreferences: TabsPreferences
     private let isLoadedInSidebar: Bool
     private let featureFlagger: FeatureFlagger
+    private let aiChatPromptHandler: AIChatPromptHandler
 
     private var isEmailAddress: Bool {
         guard let linkURL, let url = URL(string: linkURL) else {
@@ -60,10 +62,12 @@ final class ContextMenuManager: NSObject {
     init(contextMenuScriptPublisher: some Publisher<ContextMenuUserScript?, Never>,
          tabsPreferences: TabsPreferences = TabsPreferences.shared,
          isLoadedInSidebar: Bool = false,
-         featureFlagger: FeatureFlagger) {
+         featureFlagger: FeatureFlagger,
+         aiChatPromptHandler: AIChatPromptHandler = .shared) {
         self.tabsPreferences = tabsPreferences
         self.isLoadedInSidebar = isLoadedInSidebar
         self.featureFlagger = featureFlagger
+        self.aiChatPromptHandler = aiChatPromptHandler
         super.init()
 
         userScriptCancellable = contextMenuScriptPublisher.sink { [weak self] contextMenuScript in
@@ -384,6 +388,14 @@ private extension ContextMenuManager {
     }
 
     func summarize(_ sender: NSMenuItem) {
+        guard let selectedText else {
+            assertionFailure("Failed to get selected text")
+            return
+        }
+
+        NotificationCenter.default.post(name: .aiChatSummarizationQuery,
+                                        object: selectedText,
+                                        userInfo: nil)
     }
 
     func openLinkInNewTab(_ sender: NSMenuItem) {

--- a/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
@@ -38,7 +38,7 @@ final class ContextMenuManager: NSObject {
 
     private var tabsPreferences: TabsPreferences
     private let isLoadedInSidebar: Bool
-    private let internalUserDecider: InternalUserDecider
+    private let featureFlagger: FeatureFlagger
 
     private var isEmailAddress: Bool {
         guard let linkURL, let url = URL(string: linkURL) else {
@@ -60,10 +60,10 @@ final class ContextMenuManager: NSObject {
     init(contextMenuScriptPublisher: some Publisher<ContextMenuUserScript?, Never>,
          tabsPreferences: TabsPreferences = TabsPreferences.shared,
          isLoadedInSidebar: Bool = false,
-         internalUserDecider: InternalUserDecider) {
+         featureFlagger: FeatureFlagger) {
         self.tabsPreferences = tabsPreferences
         self.isLoadedInSidebar = isLoadedInSidebar
-        self.internalUserDecider = internalUserDecider
+        self.featureFlagger = featureFlagger
         super.init()
 
         userScriptCancellable = contextMenuScriptPublisher.sink { [weak self] contextMenuScript in
@@ -202,7 +202,15 @@ extension ContextMenuManager {
     }
 
     private func handleSearchWebItem(_ item: NSMenuItem, at index: Int, in menu: NSMenu) {
-        menu.replaceItem(at: index, with: self.searchMenuItem(makeBurner: isCurrentWindowBurner))
+        var currentIndex = index
+        if featureFlagger.isFeatureOn(.aiChatTextSummarization) {
+            menu.insertItem(.separator(), at: currentIndex)
+            currentIndex += 1
+        }
+        menu.replaceItem(at: currentIndex, with: self.searchMenuItem(makeBurner: isCurrentWindowBurner))
+        if featureFlagger.isFeatureOn(.aiChatTextSummarization) {
+            menu.insertItem(summarizeMenuItem(), at: currentIndex + 1)
+        }
     }
 
     private func handleReloadItem(_ item: NSMenuItem, at index: Int, in menu: NSMenu) {
@@ -211,7 +219,7 @@ extension ContextMenuManager {
     }
 
     private func handleInspectElementItem(_ item: NSMenuItem, at index: Int, in menu: NSMenu) {
-        guard isLoadedInSidebar, !internalUserDecider.isInternalUser else { return }
+        guard isLoadedInSidebar, !featureFlagger.internalUserDecider.isInternalUser else { return }
         menu.removeItem(at: index)
     }
 }
@@ -320,6 +328,10 @@ private extension ContextMenuManager {
         return NSMenuItem(title: UserText.searchWithDuckDuckGo, action: action, target: self)
     }
 
+    func summarizeMenuItem() -> NSMenuItem {
+        NSMenuItem(title: "Summarize with Duck.ai", action: #selector(summarize), target: self, keyEquivalent: [.command, .shift, "\r"])
+    }
+
     private func makeMenuItem(withTitle title: String, action: Selector, from item: NSMenuItem, with identifier: WKMenuItemIdentifier, keyEquivalent: String? = nil) -> NSMenuItem {
         return makeMenuItem(withTitle: title, action: action, from: item, withIdentifierIn: [identifier], keyEquivalent: keyEquivalent)
     }
@@ -369,6 +381,9 @@ private extension ContextMenuManager {
         }
 
         NSPasteboard.general.copy(selectedText)
+    }
+
+    func summarize(_ sender: NSMenuItem) {
     }
 
     func openLinkInNewTab(_ sender: NSMenuItem) {

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
@@ -230,6 +230,7 @@ extension TabExtensionsBuilder {
 
         add {
             AIChatTabExtension(scriptsPublisher: userScripts.compactMap { $0 },
+                               webViewPublisher: args.webViewFuture,
                                isLoadedInSidebar: args.isTabLoadedInSidebar)
         }
 

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
@@ -176,7 +176,7 @@ extension TabExtensionsBuilder {
         add {
             ContextMenuManager(contextMenuScriptPublisher: userScripts.map(\.?.contextMenuScript),
                                isLoadedInSidebar: args.isTabLoadedInSidebar,
-                               internalUserDecider: dependencies.featureFlagger.internalUserDecider)
+                               featureFlagger: dependencies.featureFlagger)
         }
         add {
             HoveredLinkTabExtension(hoverUserScriptPublisher: userScripts.map(\.?.hoverUserScript))

--- a/macOS/DuckDuckGo/Tab/UserScripts/ContextMenuUserScript.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/ContextMenuUserScript.swift
@@ -19,6 +19,7 @@
 import WebKit
 import UserScript
 
+@MainActor
 protocol ContextMenuUserScriptDelegate: AnyObject {
     func willShowContextMenu(withSelectedText selectedText: String?, linkURL: String?)
 }

--- a/macOS/DuckDuckGo/Tab/View/WebView.swift
+++ b/macOS/DuckDuckGo/Tab/View/WebView.swift
@@ -21,6 +21,7 @@ import Cocoa
 import CommonObjCExtensions
 import WebKit
 
+@MainActor
 protocol WebViewContextMenuDelegate: AnyObject {
     func webView(_ webView: WebView, willOpenContextMenu menu: NSMenu, with event: NSEvent)
     func webView(_ webView: WebView, didCloseContextMenu menu: NSMenu, with event: NSEvent?)

--- a/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
@@ -17,6 +17,7 @@
 //
 
 import AIChat
+import Combine
 import UserScript
 import WebKit
 import XCTest
@@ -99,6 +100,9 @@ final class MockAIChatUserScriptHandler: AIChatUserScriptHandling {
     var didRestoreChat = false
     var didRemoveChat = false
 
+    var didSubmitAIChatNativePrompt = false
+    var aiChatNativePromptSubject = PassthroughSubject<AIChatNativePrompt, Never>()
+
     var messageHandling: any DuckDuckGo_Privacy_Browser.AIChatMessageHandling
 
     init(messageHandling: any AIChatMessageHandling = MockAIChatMessageHandling()) {
@@ -148,6 +152,14 @@ final class MockAIChatUserScriptHandler: AIChatUserScriptHandling {
     func removeChat(params: Any, message: any UserScriptMessage) -> (any Encodable)? {
         didRemoveChat = true
         return nil
+    }
+
+    func submitAIChatNativePrompt(_ prompt: AIChatNativePrompt) {
+        didSubmitAIChatNativePrompt = true
+    }
+
+    var aiChatNativePromptPublisher: AnyPublisher<AIChatNativePrompt, Never> {
+        aiChatNativePromptSubject.eraseToAnyPublisher()
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201621708115095/task/1210567792963682?focus=true

### Description
This change adds a webView context menu action that allows users to summarize selected text using Duck.ai.
It currently uses a simple summarization prompt (while we wait for the proper summarization FE API) and
a regular FE UI (while we wait for the summarization UI).
Summarization is also triggered by cmd+shift+enter shortcut (if there’s any text selected).

### Testing Steps
1. Launch the app and ensure that `aiChatTextSummarization` feature flag is not enabled.
2. Select text on a website and verify that the context menu doesn’t contain “Summarize with Duck.ai” option.
3. Select text on a website and verify that pressing cmd+shift+enter has no effect.
4. Enable `aiChatTextSummarization` feature flag.
5. Select text on a website, open context menu and select “Summarize with Duck.ai” option. Verify that it opens a sidebar with a prompt to summarize the selected text.
6. Close the sidebar.
7. Select some text again and press cmd+shift+enter. Verify that it opens a sidebar with a prompt to summarize the selected text.
8. Select another text snippet and press cmd+shift+enter. Verify that it appends a new summarization prompt to an already open sidebar.
9. Close the sidebar and clear text selection.
10. Press cmd+shift+enter and verify that nothing happens.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)