### PR TITLE
Fix an issue where SAD/ATT prompts would not show if user do not close the app after onboarding

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -556,6 +556,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             )
         )
 
+        let onboardingManager = onboardingContextualDialogsManager
         defaultBrowserAndDockPromptKeyValueStore = DefaultBrowserAndDockPromptKeyValueStore(keyValueStoring: keyValueStore)
         DefaultBrowserAndDockPromptStoreMigrator(
             oldStore: DefaultBrowserAndDockPromptLegacyStore(),
@@ -576,7 +577,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let coordinator = DefaultBrowserAndDockPromptCoordinator(
             promptTypeDecider: defaultBrowserAndDockPromptDecider,
             store: defaultBrowserAndDockPromptKeyValueStore,
-            isOnboardingCompleted: onboardingContextualDialogsManager.state == .onboardingCompleted,
+            isOnboardingCompleted: { onboardingManager.state == .onboardingCompleted },
             dateProvider: defaultBrowserAndDockPromptDateProvider
         )
         let statusUpdateNotifier = DefaultBrowserAndDockPromptStatusUpdateNotifier()

--- a/macOS/DuckDuckGo/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptCoordinator.swift
+++ b/macOS/DuckDuckGo/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptCoordinator.swift
@@ -70,13 +70,13 @@ final class DefaultBrowserAndDockPromptCoordinator: DefaultBrowserAndDockPrompt 
     private let defaultBrowserProvider: DefaultBrowserProvider
     private let pixelFiring: PixelFiring?
     private let isSparkleBuild: Bool
-    private let isOnboardingCompleted: Bool
+    private let isOnboardingCompleted: () -> Bool
     private let dateProvider: () -> Date
 
     init(
         promptTypeDecider: DefaultBrowserAndDockPromptTypeDeciding,
         store: DefaultBrowserAndDockPromptStorage,
-        isOnboardingCompleted: Bool,
+        isOnboardingCompleted: @escaping () -> Bool,
         dockCustomization: DockCustomization = DockCustomizer(),
         defaultBrowserProvider: DefaultBrowserProvider = SystemDefaultBrowserProvider(),
         applicationBuildType: ApplicationBuildType = StandardApplicationBuildType(),
@@ -114,7 +114,7 @@ final class DefaultBrowserAndDockPromptCoordinator: DefaultBrowserAndDockPrompt 
 
     func getPromptType() -> DefaultBrowserAndDockPromptPresentationType? {
         // If user has not completed the onboarding do not show any prompts.
-        guard isOnboardingCompleted else { return nil }
+        guard isOnboardingCompleted() else { return nil }
 
         // If user has set browser as default and app is added to the dock do not show any prompts.
         guard let evaluatePromptEligibility else { return nil }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1210646559468282?focus=true
Tech Design URL:
CC:

### Description

This PR addresses an issue with the onboarding completion check. The value used to determine if onboarding was completed was passed as a variable rather than utilizing a closure that evaluates the condition on demand.

**Issue:**

The prompt to the user was not displayed after they finished onboarding unless the app was closed in the meantime.


**Solution:**

By implementing a closure for the onboarding completion check, the app will now evaluate the status each time, ensuring that the prompt is presented immediately after onboarding is completed, regardless of whether the app was closed or not.

### Testing Steps
Ensure new unit test pass.

### Impact and Risks
Low: Improvement on existing code.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
Added unit test to validate behaviour.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)