### PR TITLE
fix sandboxed testWhenLocalFile_downloadStartsAlwaysDisplayingSavePanel

### DIFF
--- a/macOS/IntegrationTests/Downloads/DownloadsIntegrationTests.swift
+++ b/macOS/IntegrationTests/Downloads/DownloadsIntegrationTests.swift
@@ -124,11 +124,11 @@ class DownloadsIntegrationTests: XCTestCase {
 
     @MainActor
     func testWhenLocalFile_downloadStartsAlwaysDisplayingSavePanel() async throws {
-#if APPSTORE
-        throw XCTSkip("https://app.asana.com/0/0/1208100078742790/f")
-#else
         let tempFileURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        let destDirURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let destDirURL = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask)[0].appendingPathComponent(UUID().uuidString)
+        defer {
+            try? FileManager.default.removeItem(at: destDirURL)
+        }
         try FileManager.default.createDirectory(at: destDirURL, withIntermediateDirectories: true)
         try data.html.write(to: tempFileURL)
 
@@ -164,7 +164,6 @@ class DownloadsIntegrationTests: XCTestCase {
 
         XCTAssertEqual(fileUrl.resolvingSymlinksInPath(), destDirURL.appendingPathComponent(tempFileURL.lastPathComponent).resolvingSymlinksInPath())
         XCTAssertEqual(try? Data(contentsOf: fileUrl), data.html)
-#endif
     }
 
     @MainActor
@@ -432,6 +431,7 @@ class DownloadsIntegrationTests: XCTestCase {
 
     @MainActor
     func testWhenSaveDialogOpenInBackgroundTabAndWindowIsClosed_downloadIsCancelled() throws {
+
         var taskCancelledCancellable: AnyCancellable!
         var taskCancelledExpectation: XCTestExpectation!
         let persistor = DownloadsPreferencesUserDefaultsPersistor()


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1208100078742790?focus=true

### Description
- Fix `testWhenLocalFile_downloadStartsAlwaysDisplayingSavePanel` failing in sandboxed env

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Validate `testWhenLocalFile_downloadStartsAlwaysDisplayingSavePanel` passes locally for `macOS App Store` target

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)