### PR TITLE
Fix E2E tests after Settings change

### DIFF
--- a/.maestro/release_tests/autoclear.yaml
+++ b/.maestro/release_tests/autoclear.yaml
@@ -18,7 +18,8 @@ tags:
 
 - tapOn: "Browsing Menu"
 - tapOn: "Settings"
-- assertVisible: "Default Browser"
+- assertVisible:
+    id: "Settings.ListItem.Field_DefaultBrowser"
 - scrollUntilVisible:
     centerElement: true
     element:

--- a/.maestro/release_tests/backgrounding.yaml
+++ b/.maestro/release_tests/backgrounding.yaml
@@ -58,7 +58,8 @@ tags:
 - tapOn: "Cancel"
 - tapOn: "Browsing menu"
 - tapOn: "Settings"
-- assertVisible: "Default Browser"
+- assertVisible:
+    id: "Settings.ListItem.Field_DefaultBrowser"
 - tapOn: "Done"
 
 - assertVisible: "Bookmarks"

--- a/iOS/DuckDuckGo/SettingsCompleteSetupView.swift
+++ b/iOS/DuckDuckGo/SettingsCompleteSetupView.swift
@@ -46,6 +46,7 @@ struct SettingsCompleteSetupView: View {
                                  action: { viewModel.setAsDefaultBrowser("complete-setup") },
                                  webLinkIndicator: true,
                                  isButton: true)
+                .accessibilityIdentifier("Settings.ListItem.Field_DefaultBrowser")
                 .swipeActions {
                     Button {
                         viewModel.dismissSetAsDefaultBrowser()

--- a/iOS/DuckDuckGo/SettingsPrivacyProtectionsView.swift
+++ b/iOS/DuckDuckGo/SettingsPrivacyProtectionsView.swift
@@ -36,6 +36,7 @@ struct SettingsPrivacyProtectionsView: View {
                                  action: { viewModel.setAsDefaultBrowser() },
                                  webLinkIndicator: true,
                                  isButton: true)
+                .accessibilityIdentifier("Settings.ListItem.Field_DefaultBrowser")
             }
             // Private Search
             NavigationLink(destination: PrivateSearchView().environmentObject(viewModel)) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1210645804719021?focus=true
Tech Design URL:
CC:

### Description
Update E2E tests to reflect changes in the Settings screen

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Confirm [workflow](https://github.com/duckduckgo/apple-browsers/actions/runs/15898961240) runs successfully 

### Impact and Risks
None: Internal tooling

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)