### PR TITLE
Remember toggle on the new omnibar

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		317A247F2D8336650033A0D6 /* DownloadsDirectoryHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317A247E2D8336650033A0D6 /* DownloadsDirectoryHandling.swift */; };
 		317A24812D8339C10033A0D6 /* DownloadsDirectoryHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317A24802D8339C10033A0D6 /* DownloadsDirectoryHandlerTests.swift */; };
 		317CA3432CFF82E100F88848 /* SettingsAIChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317CA3422CFF82DB00F88848 /* SettingsAIChatView.swift */; };
+		317DD5552E0D5DD300CCC28C /* SwitchBarHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317DD5542E0D5DD300CCC28C /* SwitchBarHandlerTests.swift */; };
 		317DF6082D01E7B900DE0145 /* RoundedPageSheetContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317DF6072D01E7B900DE0145 /* RoundedPageSheetContainerViewController.swift */; };
 		317DF60B2D01E7D600DE0145 /* RoundedPageSheetPresentationAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317DF60A2D01E7D600DE0145 /* RoundedPageSheetPresentationAnimator.swift */; };
 		317F5F982C94A9EB0081666F /* MarketplaceAdPostbackStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317F5F972C94A9EB0081666F /* MarketplaceAdPostbackStorage.swift */; };
@@ -2095,6 +2096,7 @@
 		317A247E2D8336650033A0D6 /* DownloadsDirectoryHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsDirectoryHandling.swift; sourceTree = "<group>"; };
 		317A24802D8339C10033A0D6 /* DownloadsDirectoryHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsDirectoryHandlerTests.swift; sourceTree = "<group>"; };
 		317CA3422CFF82DB00F88848 /* SettingsAIChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAIChatView.swift; sourceTree = "<group>"; };
+		317DD5542E0D5DD300CCC28C /* SwitchBarHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchBarHandlerTests.swift; sourceTree = "<group>"; };
 		317DF6072D01E7B900DE0145 /* RoundedPageSheetContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedPageSheetContainerViewController.swift; sourceTree = "<group>"; };
 		317DF60A2D01E7D600DE0145 /* RoundedPageSheetPresentationAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedPageSheetPresentationAnimator.swift; sourceTree = "<group>"; };
 		317F5F972C94A9EB0081666F /* MarketplaceAdPostbackStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceAdPostbackStorage.swift; sourceTree = "<group>"; };
@@ -4649,6 +4651,14 @@
 				C14E2F7629DE14EA002AC515 /* AutofillInterfaceUsernameTruncatorTests.swift */,
 			);
 			name = Utils;
+			sourceTree = "<group>";
+		};
+		317DD5532E0D5DB900CCC28C /* SwitchBar */ = {
+			isa = PBXGroup;
+			children = (
+				317DD5542E0D5DD300CCC28C /* SwitchBarHandlerTests.swift */,
+			);
+			path = SwitchBar;
 			sourceTree = "<group>";
 		};
 		317DF6092D01E7C400DE0145 /* RoundedPageContainer */ = {
@@ -8432,6 +8442,7 @@
 		F1E092B31E92A6B900732CCC /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				317DD5532E0D5DB900CCC28C /* SwitchBar */,
 				310EEA2D2CFFCDB60043CA1A /* AIChat */,
 				83EDCC3E1F86B363005CDFCD /* API */,
 				C1BF4BA82D26E08F00A83C77 /* Autofill */,
@@ -10642,6 +10653,7 @@
 				F1134ED61F40F29F00B73467 /* StatisticsUserDefaultsTests.swift in Sources */,
 				98629D342C21BE37001E6031 /* BookmarksStateValidationTests.swift in Sources */,
 				C1FFBD462C761BE20073622B /* SyncPromoManagerTests.swift in Sources */,
+				317DD5552E0D5DD300CCC28C /* SwitchBarHandlerTests.swift in Sources */,
 				CB3B4D502D63957F006DAD63 /* UIInteractionManagerTests.swift in Sources */,
 				9F254AD32CF5D3A80063B308 /* MockSpecialErrorWebView.swift in Sources */,
 				317A24812D8339C10033A0D6 /* DownloadsDirectoryHandlerTests.swift in Sources */,

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -290,7 +290,6 @@ final class OmniBarEditingStateViewController: UIViewController {
 
         switchBarHandler.toggleStatePublisher
             .receive(on: DispatchQueue.main)
-            .dropFirst()
             .sink { [weak self] newState in
                 guard let self = self else { return }
                 switch newState {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
@@ -19,11 +19,12 @@
 
 import Foundation
 import Combine
+import Persistence
 
 // MARK: - TextEntryMode Enum
-public enum TextEntryMode {
-    case search
-    case aiChat
+public enum TextEntryMode: String, CaseIterable {
+    case search = "search"
+    case aiChat = "aiChat"
 }
 
 // MARK: - SwitchBarHandling Protocol
@@ -54,8 +55,14 @@ protocol SwitchBarHandling: AnyObject {
 // MARK: - SwitchBarHandler Implementation
 final class SwitchBarHandler: SwitchBarHandling {
 
+    // MARK: - Constants
+    private enum StorageKey {
+        static let toggleState = "SwitchBarHandler.toggleState"
+    }
+
     // MARK: - Dependencies
     private let voiceSearchHelper: VoiceSearchHelperProtocol
+    private let storage: KeyValueStoring
 
     // MARK: - Published Properties
     @Published private(set) var currentText: String = ""
@@ -89,8 +96,10 @@ final class SwitchBarHandler: SwitchBarHandling {
     private let textSubmissionSubject = PassthroughSubject<(text: String, mode: TextEntryMode), Never>()
     private let microphoneButtonTappedSubject = PassthroughSubject<Void, Never>()
 
-    init(voiceSearchHelper: VoiceSearchHelperProtocol) {
+    init(voiceSearchHelper: VoiceSearchHelperProtocol, storage: KeyValueStoring) {
         self.voiceSearchHelper = voiceSearchHelper
+        self.storage = storage
+        restoreToggleState()
     }
 
     // MARK: - SwitchBarHandling Implementation
@@ -105,6 +114,7 @@ final class SwitchBarHandler: SwitchBarHandling {
 
     func setToggleState(_ state: TextEntryMode) {
         currentToggleState = state
+        saveToggleState()
     }
 
     func clearText() {
@@ -121,5 +131,16 @@ final class SwitchBarHandler: SwitchBarHandling {
 
     func setForceWebSearch(_ enabled: Bool) {
         forceWebSearch = enabled
+    }
+
+    func saveToggleState() {
+        storage.set(currentToggleState.rawValue, forKey: StorageKey.toggleState)
+    }
+
+    func restoreToggleState() {
+        if let storedValue = storage.object(forKey: StorageKey.toggleState) as? String,
+           let restoredState = TextEntryMode(rawValue: storedValue) {
+            currentToggleState = restoredState
+        }
     }
 }

--- a/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/Refactoring/Updated/UpdatedOmniBarViewController.swift
@@ -151,7 +151,8 @@ final class UpdatedOmniBarViewController: OmniBarViewController {
     }
 
     private func createSwitchBarHandler(for textField: UITextField) -> SwitchBarHandler {
-        let switchBarHandler = SwitchBarHandler(voiceSearchHelper: dependencies.voiceSearchHelper)
+        let switchBarHandler = SwitchBarHandler(voiceSearchHelper: dependencies.voiceSearchHelper,
+                                                storage: UserDefaults.standard)
 
         guard let currentText = omniBarView.text?.trimmingWhitespace(), !currentText.isEmpty else {
             return switchBarHandler

--- a/iOS/DuckDuckGoTests/SwitchBar/SwitchBarHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/SwitchBar/SwitchBarHandlerTests.swift
@@ -1,0 +1,391 @@
+//
+//  SwitchBarHandlerTests.swift
+//  DuckDuckGoTests
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import Core
+@testable import DuckDuckGo
+import Combine
+import PersistenceTestingUtils
+
+final class SwitchBarHandlerTests: XCTestCase {
+
+    private enum StorageKey {
+        static let toggleState = "SwitchBarHandler.toggleState"
+    }
+
+    private var sut: SwitchBarHandler!
+    private var mockVoiceSearchHelper: MockVoiceSearchHelper!
+    private var mockStorage: MockKeyValueStore!
+    private var cancellables: Set<AnyCancellable>!
+
+    override func setUp() {
+        super.setUp()
+        mockVoiceSearchHelper = MockVoiceSearchHelper()
+        mockStorage = MockKeyValueStore()
+        cancellables = Set<AnyCancellable>()
+        createSUT()
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        sut = nil
+        mockVoiceSearchHelper = nil
+        mockStorage = nil
+        super.tearDown()
+    }
+
+    private func createSUT() {
+        sut = SwitchBarHandler(
+            voiceSearchHelper: mockVoiceSearchHelper,
+            storage: mockStorage
+        )
+    }
+
+    // MARK: - Toggle State Persistence Tests
+
+    func testRestoreToggleState_WhenNoStoredValue_ShouldDefaultToSearch() {
+        // Given: No stored value in storage
+        mockStorage.clearAll()
+
+        // When: Creating a new handler
+        createSUT()
+
+        // Then: Should default to search mode
+        XCTAssertEqual(sut.currentToggleState, .search)
+    }
+
+    func testRestoreToggleState_WhenStoredValueIsSearch_ShouldRestoreSearch() {
+        // Given: Stored value is "search"
+        mockStorage.set(TextEntryMode.search.rawValue, forKey: StorageKey.toggleState)
+
+        // When: Creating a new handler
+        createSUT()
+
+        // Then: Should restore search mode
+        XCTAssertEqual(sut.currentToggleState, .search)
+    }
+
+    func testRestoreToggleState_WhenStoredValueIsAIChat_ShouldRestoreAIChat() {
+        // Given: Stored value is "aiChat"
+        mockStorage.set(TextEntryMode.aiChat.rawValue, forKey: StorageKey.toggleState)
+
+        // When: Creating a new handler
+        createSUT()
+
+        // Then: Should restore aiChat mode
+        XCTAssertEqual(sut.currentToggleState, .aiChat)
+    }
+
+    func testRestoreToggleState_WhenStoredValueIsInvalid_ShouldDefaultToSearch() {
+        // Given: Stored value is invalid
+        mockStorage.set("invalidValue", forKey: StorageKey.toggleState)
+
+        // When: Creating a new handler
+        createSUT()
+
+        // Then: Should default to search mode
+        XCTAssertEqual(sut.currentToggleState, .search)
+    }
+
+    func testRestoreToggleState_WhenStoredValueIsWrongType_ShouldDefaultToSearch() {
+        // Given: Stored value is wrong type (number instead of string)
+        mockStorage.set(123, forKey: StorageKey.toggleState)
+
+        // When: Creating a new handler
+        createSUT()
+
+        // Then: Should default to search mode
+        XCTAssertEqual(sut.currentToggleState, .search)
+    }
+
+    func testSaveToggleState_WhenSetToSearch_ShouldPersistSearchValue() {
+        // Given: Handler is initialized
+        createSUT()
+
+        // When: Setting toggle state to search
+        sut.setToggleState(.search)
+
+        // Then: Should save "search" to storage
+        XCTAssertEqual(mockStorage.object(forKey: StorageKey.toggleState) as? String, "search")
+    }
+
+    func testSaveToggleState_WhenSetToAIChat_ShouldPersistAIChatValue() {
+        // Given: Handler is initialized
+        createSUT()
+
+        // When: Setting toggle state to aiChat
+        sut.setToggleState(.aiChat)
+
+        // Then: Should save "aiChat" to storage
+        XCTAssertEqual(mockStorage.object(forKey: StorageKey.toggleState) as? String, "aiChat")
+    }
+
+    func testToggleStatePersistence_WhenMultipleChanges_ShouldPersistLatestValue() {
+        // Given: Handler is initialized
+        createSUT()
+
+        // When: Making multiple changes
+        sut.setToggleState(.search)
+        sut.setToggleState(.aiChat)
+        sut.setToggleState(.search)
+
+        // Then: Should persist the latest value
+        XCTAssertEqual(mockStorage.object(forKey: StorageKey.toggleState) as? String, "search")
+        XCTAssertEqual(sut.currentToggleState, .search)
+    }
+
+    func testToggleStatePersistenceAcrossInstances_ShouldMaintainState() {
+        // Given: First handler instance with aiChat mode
+        sut.setToggleState(.aiChat)
+        let firstInstanceState = sut.currentToggleState
+
+        // When: Creating a new handler instance
+        createSUT()
+
+        // Then: New instance should restore the same state
+        XCTAssertEqual(firstInstanceState, .aiChat)
+        XCTAssertEqual(sut.currentToggleState, .aiChat)
+    }
+
+    // MARK: - Toggle State Publisher Tests
+
+    func testToggleStatePublisher_WhenStateChanges_ShouldEmitNewValue() {
+        // Given: Subscription to toggle state publisher
+        var receivedStates: [TextEntryMode] = []
+        sut.toggleStatePublisher
+            .sink { receivedStates.append($0) }
+            .store(in: &cancellables)
+
+        // When: Changing toggle state
+        sut.setToggleState(.aiChat)
+
+        // Then: Should emit new state
+        XCTAssertEqual(receivedStates.last, .aiChat)
+    }
+
+    func testToggleStatePublisher_InitialValue_ShouldBeCurrentState() {
+        // Given: Handler with specific state
+        mockStorage.set("aiChat", forKey: StorageKey.toggleState)
+        createSUT()
+
+        // When: Subscribing to toggle state publisher
+        var receivedState: TextEntryMode?
+        sut.toggleStatePublisher
+            .sink { receivedState = $0 }
+            .store(in: &cancellables)
+
+        // Then: Should emit current state
+        XCTAssertEqual(receivedState, .aiChat)
+    }
+
+    // MARK: - Text Functionality Tests
+
+    func testUpdateCurrentText_ShouldUpdateCurrentText() {
+        // Given: Handler is initialized
+        createSUT()
+
+        // When: Updating current text
+        sut.updateCurrentText("test query")
+
+        // Then: Should update current text
+        XCTAssertEqual(sut.currentText, "test query")
+    }
+
+    func testCurrentTextPublisher_WhenTextChanges_ShouldEmitNewValue() {
+        // Given: Subscription to current text publisher
+        var receivedTexts: [String] = []
+        sut.currentTextPublisher
+            .sink { receivedTexts.append($0) }
+            .store(in: &cancellables)
+
+        // When: Updating text
+        sut.updateCurrentText("new text")
+
+        // Then: Should emit new text
+        XCTAssertEqual(receivedTexts.last, "new text")
+    }
+
+    func testSubmitText_WithValidText_ShouldEmitSubmission() {
+        // Given: Subscription to text submission publisher
+        var submissions: [(text: String, mode: TextEntryMode)] = []
+        sut.textSubmissionPublisher
+            .sink { submissions.append($0) }
+            .store(in: &cancellables)
+
+        // When: Submitting text
+        sut.submitText("test query")
+
+        // Then: Should emit submission with current mode
+        XCTAssertEqual(submissions.count, 1)
+        XCTAssertEqual(submissions.first?.text, "test query")
+        XCTAssertEqual(submissions.first?.mode, .search)
+    }
+
+    func testSubmitText_WithEmptyText_ShouldNotEmitSubmission() {
+        // Given: Subscription to text submission publisher
+        var submissions: [(text: String, mode: TextEntryMode)] = []
+        sut.textSubmissionPublisher
+            .sink { submissions.append($0) }
+            .store(in: &cancellables)
+
+        // When: Submitting empty text
+        sut.submitText("")
+
+        // Then: Should not emit submission
+        XCTAssertEqual(submissions.count, 0)
+    }
+
+    func testSubmitText_WithWhitespaceOnlyText_ShouldNotEmitSubmission() {
+        // Given: Subscription to text submission publisher
+        var submissions: [(text: String, mode: TextEntryMode)] = []
+        sut.textSubmissionPublisher
+            .sink { submissions.append($0) }
+            .store(in: &cancellables)
+
+        // When: Submitting whitespace-only text
+        sut.submitText("   \n\t  ")
+
+        // Then: Should not emit submission
+        XCTAssertEqual(submissions.count, 0)
+    }
+
+    func testClearText_ShouldResetCurrentText() {
+        // Given: Handler with text
+        sut.updateCurrentText("some text")
+
+        // When: Clearing text
+        sut.clearText()
+
+        // Then: Should reset current text
+        XCTAssertEqual(sut.currentText, "")
+    }
+
+    // MARK: - Voice Search Tests
+
+    func testIsVoiceSearchEnabled_ShouldReturnHelperValue() {
+        // Given: Voice search helper with specific enabled state
+        mockVoiceSearchHelper.isVoiceSearchEnabled = true
+
+        // When: Checking if voice search is enabled
+        let isEnabled = sut.isVoiceSearchEnabled
+
+        // Then: Should return helper's value
+        XCTAssertTrue(isEnabled)
+    }
+
+    func testMicrophoneButtonTapped_ShouldEmitEvent() {
+        // Given: Subscription to microphone button tapped publisher
+        var tappedCount = 0
+        sut.microphoneButtonTappedPublisher
+            .sink { _ in tappedCount += 1 }
+            .store(in: &cancellables)
+
+        // When: Tapping microphone button
+        sut.microphoneButtonTapped()
+
+        // Then: Should emit event
+        XCTAssertEqual(tappedCount, 1)
+    }
+
+    // MARK: - Force Web Search Tests
+
+    func testToggleForceWebSearch_ShouldToggleValue() {
+        // Given: Handler with initial force web search state
+        let initialState = sut.forceWebSearch
+
+        // When: Toggling force web search
+        sut.toggleForceWebSearch()
+
+        // Then: Should toggle the value
+        XCTAssertEqual(sut.forceWebSearch, !initialState)
+    }
+
+    func testSetForceWebSearch_ShouldSetSpecificValue() {
+        // Given: Handler is initialized
+        createSUT()
+
+        // When: Setting force web search to true
+        sut.setForceWebSearch(true)
+
+        // Then: Should set the value
+        XCTAssertTrue(sut.forceWebSearch)
+
+        // When: Setting force web search to false
+        sut.setForceWebSearch(false)
+
+        // Then: Should set the value
+        XCTAssertFalse(sut.forceWebSearch)
+    }
+
+    func testForceWebSearchPublisher_WhenValueChanges_ShouldEmitNewValue() {
+        // Given: Subscription to force web search publisher
+        var receivedValues: [Bool] = []
+        sut.forceWebSearchPublisher
+            .sink { receivedValues.append($0) }
+            .store(in: &cancellables)
+
+        // When: Changing force web search value
+        sut.toggleForceWebSearch()
+
+        // Then: Should emit new value
+        XCTAssertTrue(receivedValues.contains(sut.forceWebSearch))
+    }
+
+    // MARK: - Integration Tests
+
+    func testEndToEndToggleStatePersistence_ShouldWorkCorrectly() {
+        // Given: Fresh storage
+        mockStorage.clearAll()
+
+        // When: Creating handler, changing state, and recreating
+        createSUT()
+        XCTAssertEqual(sut.currentToggleState, .search) // Default
+
+        sut.setToggleState(.aiChat)
+        XCTAssertEqual(sut.currentToggleState, .aiChat)
+
+        // Create new instance to test persistence
+        createSUT()
+
+        // Then: Should restore the saved state
+        XCTAssertEqual(sut.currentToggleState, .aiChat)
+    }
+
+    func testTextSubmissionWithDifferentModes_ShouldEmitCorrectMode() {
+        // Given: Subscription to text submission publisher
+        var submissions: [(text: String, mode: TextEntryMode)] = []
+        sut.textSubmissionPublisher
+            .sink { submissions.append($0) }
+            .store(in: &cancellables)
+
+        // When: Submitting text in search mode
+        sut.setToggleState(.search)
+        sut.submitText("search query")
+
+        // Then: Should emit with search mode
+        XCTAssertEqual(submissions.last?.mode, .search)
+
+        // When: Changing to AI chat mode and submitting
+        sut.setToggleState(.aiChat)
+        sut.submitText("ai chat query")
+
+        // Then: Should emit with aiChat mode
+        XCTAssertEqual(submissions.last?.mode, .aiChat)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1210647698307623?focus=true

### Description
Remember the last selected toggle on the new omnibar

### Testing Steps
1. Enable the new UI (Settings -> Appearance -> Experimental)
2. Enable duck.ai experimental (Settings -> Duck.ai -> Experimental)
3. Select the omnibar, it should be defaulted to search
4. Do a search, tap on it again, it should still be on search
5. Now move to duck.ai, do a prompt
6. Go back, tap the omnibar again, it should have duck.ai selected


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
Incorrectly select the toggle option