### PR TITLE
killswitch for tab manager changes

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -106,6 +106,9 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
 
     // Demonstrative case for default value. Remove once a real-world feature is added
     case intentionallyLocalOnlySubfeatureForTests
+
+    // This is fairly temporary and will likely be removed in a release or two one way or another
+    case june2025TabManagerLayoutChanges
 }
 
 public enum TabManagerSubfeature: String, PrivacySubfeature {

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -100,6 +100,9 @@ public enum FeatureFlag: String {
     case failsafeExampleCrossPlatformFeature
     case failsafeExamplePlatformSpecificSubfeature
 
+    // https://app.asana.com/1/137249556945/project/715106103902962/task/1210647253853346?focus=true
+    case june2025TabManagerLayoutChanges
+
     /// https://app.asana.com/1/137249556945/project/72649045549333/task/1210055762484807?focus=true
     case experimentalAIChat
 
@@ -143,7 +146,12 @@ public enum FeatureFlag: String {
 extension FeatureFlag: FeatureFlagDescribing {
     public var defaultValue: Bool {
         switch self {
-        case .failsafeExampleCrossPlatformFeature, .failsafeExamplePlatformSpecificSubfeature, .canScanUrlBasedSyncSetupBarcodes, .canInterceptSyncSetupUrls, .removeWWWInCanonicalizationInThreatProtection:
+        case .failsafeExampleCrossPlatformFeature,
+             .failsafeExamplePlatformSpecificSubfeature,
+             .canScanUrlBasedSyncSetupBarcodes,
+             .canInterceptSyncSetupUrls,
+             .removeWWWInCanonicalizationInThreatProtection,
+             .june2025TabManagerLayoutChanges:
             true
         default:
             false
@@ -183,7 +191,8 @@ extension FeatureFlag: FeatureFlagDescribing {
              .paidAIChat,
              .canInterceptSyncSetupUrls,
              .exchangeKeysToSyncWithAnotherDevice,
-             .experimentalSwitcherBarTransition:
+             .experimentalSwitcherBarTransition,
+             .june2025TabManagerLayoutChanges:
             return true
         case .showSettingsCompleteSetupSection:
             if #available(iOS 18.2, *) {
@@ -290,6 +299,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.feature(.intentionallyLocalOnlyFeatureForTests))
         case .failsafeExamplePlatformSpecificSubfeature:
             return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.intentionallyLocalOnlySubfeatureForTests))
+        case .june2025TabManagerLayoutChanges:
+            return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.june2025TabManagerLayoutChanges))
         case .experimentalAIChat:
             return .internalOnly()
         case .experimentalSwitcherBarTransition:

--- a/iOS/DuckDuckGo/FeatureFlagsDebugSettings/FeatureFlagsSettingViewModel.swift
+++ b/iOS/DuckDuckGo/FeatureFlagsDebugSettings/FeatureFlagsSettingViewModel.swift
@@ -30,8 +30,8 @@ class FeatureFlagsSettingViewModel: ObservableObject {
     @Published var experiments: [FeatureFlag] = []
 
     init() {
-        self.featureFlags = FeatureFlag.allCases.filter { $0.supportsLocalOverriding && $0.cohortType == nil }
-        self.experiments = FeatureFlag.allCases.filter { $0.supportsLocalOverriding && $0.cohortType != nil }
+        self.featureFlags = FeatureFlag.allCases.filter { $0.supportsLocalOverriding && $0.cohortType == nil }.sorted(by: { $0.rawValue < $1.rawValue })
+        self.experiments = FeatureFlag.allCases.filter { $0.supportsLocalOverriding && $0.cohortType != nil }.sorted(by: { $0.rawValue < $1.rawValue })
     }
 
     var isInternalUser: Bool {

--- a/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
+++ b/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
@@ -20,7 +20,36 @@
 import UIKit
 import BrowserServicesKit
 
-class TabSwitcherBarsStateHandler {
+protocol TabSwitcherBarsStateHandling {
+
+    var plusButton: UIBarButtonItem { get }
+    var fireButton: UIBarButtonItem { get }
+    var doneButton: UIBarButtonItem { get }
+    var closeTabsButton: UIBarButtonItem { get }
+    var menuButton: UIBarButtonItem { get }
+    var addAllBookmarksButton: UIBarButtonItem { get }
+    var tabSwitcherStyleButton: UIBarButtonItem { get }
+    var editButton: UIBarButtonItem { get }
+    var selectAllButton: UIBarButtonItem { get }
+    var deselectAllButton: UIBarButtonItem { get }
+    var duckChatButton: UIBarButtonItem { get }
+
+    var bottomBarItems: [UIBarButtonItem] { get }
+    var topBarLeftButtonItems: [UIBarButtonItem] { get }
+    var topBarRightButtonItems: [UIBarButtonItem] { get }
+
+    var isBottomBarHidden: Bool { get }
+
+    func update(_ interfaceMode: TabSwitcherViewController.InterfaceMode,
+                selectedTabsCount: Int,
+                totalTabsCount: Int,
+                containsWebPages: Bool,
+                showAIChatButton: Bool)
+
+}
+
+/// This is what we hope will be the new version long term.
+class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
 
     let plusButton = UIBarButtonItem()
     let fireButton = UIBarButtonItem()
@@ -206,5 +235,187 @@ private extension UIBarButtonItem {
 
     static func additionalFixedSpaceItem() -> UIBarButtonItem {
         .fixedSpace(additionalHorizontalSpace)
+    }
+}
+
+/// To be removed once we're happy there's no abundance of negative user feedback.
+class LegacyTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
+
+    let plusButton = UIBarButtonItem()
+    let fireButton = UIBarButtonItem()
+    let doneButton = UIBarButtonItem()
+    let closeTabsButton = UIBarButtonItem()
+    let menuButton = UIBarButtonItem()
+    let addAllBookmarksButton = UIBarButtonItem()
+    let tabSwitcherStyleButton = UIBarButtonItem()
+    let editButton = UIBarButtonItem()
+    let selectAllButton = UIBarButtonItem()
+    let deselectAllButton = UIBarButtonItem()
+    let duckChatButton = UIBarButtonItem()
+
+    private(set) var bottomBarItems = [UIBarButtonItem]()
+    private(set) var isBottomBarHidden = false
+    private(set) var topBarLeftButtonItems = [UIBarButtonItem]()
+    private(set) var topBarRightButtonItems = [UIBarButtonItem]()
+
+    private(set) var interfaceMode: TabSwitcherViewController.InterfaceMode = .regularSize
+    private(set) var selectedTabsCount: Int = 0
+    private(set) var totalTabsCount: Int = 0
+    private(set) var containsWebPages = false
+    private(set) var showAIChatButton = false
+    private(set) var canShowEditButton = false
+
+    private(set) var isFirstUpdate = true
+
+    private let themingProperties: ExperimentalThemingProperties
+    private var isExperimentalThemingEnabled: Bool {
+        themingProperties.isExperimentalThemingEnabled
+    }
+
+    init(themingProperties: ExperimentalThemingProperties = ThemeManager.shared.properties) {
+        self.themingProperties = themingProperties
+    }
+
+    func update(_ interfaceMode: TabSwitcherViewController.InterfaceMode,
+                selectedTabsCount: Int,
+                totalTabsCount: Int,
+                containsWebPages: Bool,
+                showAIChatButton: Bool) {
+
+        guard isFirstUpdate
+                || interfaceMode != self.interfaceMode
+                || selectedTabsCount != self.selectedTabsCount
+                || totalTabsCount != self.totalTabsCount
+                || containsWebPages != self.containsWebPages
+                || showAIChatButton != self.showAIChatButton
+        else {
+            // If nothing has changed, don't update
+            return
+        }
+
+        self.isFirstUpdate = false
+        self.interfaceMode = interfaceMode
+        self.selectedTabsCount = selectedTabsCount
+        self.totalTabsCount = totalTabsCount
+        self.containsWebPages = containsWebPages
+        self.showAIChatButton = showAIChatButton
+
+        self.fireButton.accessibilityLabel = "Close all tabs and clear data"
+        self.tabSwitcherStyleButton.accessibilityLabel = "Toggle between grid and list view"
+        self.duckChatButton.accessibilityLabel = UserText.aiChatFeatureName
+
+        self.canShowEditButton = self.totalTabsCount > 1 || containsWebPages
+
+        updateBottomBar()
+        updateTopLeftButtons()
+        updateTopRightButtons()
+    }
+
+    func updateBottomBar() {
+        var newItems: [UIBarButtonItem]
+
+        let regularItemWidth: CGFloat = 34
+        let leadingSideWidthDifference: CGFloat = isExperimentalThemingEnabled ? 6 : 11
+
+        switch interfaceMode {
+        case .regularSize:
+
+            newItems = [
+                tabSwitcherStyleButton,
+
+                .flexibleSpace(),
+                .fixedSpace(leadingSideWidthDifference),
+                .flexibleSpace(),
+
+                fireButton,
+
+                .flexibleSpace(),
+                showAIChatButton ? duckChatButton : .fixedSpace(regularItemWidth),
+                .flexibleSpace(),
+
+                plusButton
+            ].compactMap { $0 }
+
+            isBottomBarHidden = false
+
+        case .editingRegularSize:
+            newItems = [
+                closeTabsButton,
+                UIBarButtonItem.flexibleSpace(),
+                menuButton,
+            ]
+            isBottomBarHidden = false
+
+        case .editingLargeSize,
+                .largeSize:
+            newItems = []
+            isBottomBarHidden = true
+        }
+
+        if !newItems.isEmpty && isExperimentalThemingEnabled {
+            // This aligns items with the toolbar on main screen,
+            // which is supposed to be aligned with Omnibar buttons.
+            newItems = [.additionalFixedSpaceItem()] + newItems + [.additionalFixedSpaceItem()]
+        }
+
+        bottomBarItems = newItems
+    }
+
+    func updateTopLeftButtons() {
+
+        switch interfaceMode {
+
+        case .regularSize:
+            topBarLeftButtonItems = [
+                canShowEditButton ? editButton : nil,
+            ].compactMap { $0 }
+
+        case .largeSize:
+            topBarLeftButtonItems = [
+                canShowEditButton ? editButton : nil,
+                tabSwitcherStyleButton,
+            ].compactMap { $0 }
+
+        case .editingRegularSize:
+            topBarLeftButtonItems = [
+                doneButton
+            ]
+
+        case .editingLargeSize:
+            topBarLeftButtonItems = [
+                doneButton,
+            ]
+
+        }
+    }
+
+    func updateTopRightButtons() {
+
+        switch interfaceMode {
+
+        case .largeSize:
+            topBarRightButtonItems = [
+                doneButton,
+                fireButton,
+                plusButton,
+                showAIChatButton ? duckChatButton : nil,
+            ].compactMap { $0 }
+
+        case .regularSize:
+            topBarRightButtonItems = [
+                doneButton
+            ]
+
+        case .editingRegularSize:
+            topBarRightButtonItems = [
+                selectedTabsCount == totalTabsCount ? deselectAllButton : selectAllButton,
+            ]
+
+        case .editingLargeSize:
+            topBarRightButtonItems = [
+                menuButton,
+            ]
+
+        }
     }
 }

--- a/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
@@ -452,7 +452,7 @@ extension TabSwitcherViewController {
             self?.burn(sender: self!.barsHandler.fireButton)
         }
 
-        if interfaceMode == .largeSize {
+        if interfaceMode == .largeSize || !isJune2025LayoutChangeEnabled {
             barsHandler.doneButton.primaryAction = action(UserText.navigationTitleDone) { [weak self] in
                 self?.onDonePressed(self!.barsHandler.doneButton)
             }
@@ -463,8 +463,14 @@ extension TabSwitcherViewController {
             barsHandler.doneButton.accessibilityLabel = UserText.navigationTitleDone
         }
 
-        barsHandler.editButton.image = DesignSystemImages.Glyphs.Size24.menuDotsVertical
-        barsHandler.editButton.title = nil
+        if isJune2025LayoutChangeEnabled {
+            barsHandler.editButton.image = DesignSystemImages.Glyphs.Size24.menuDotsVertical
+            barsHandler.editButton.title = nil
+        } else {
+            barsHandler.editButton.image = nil
+            barsHandler.editButton.title = UserText.actionGenericEdit
+        }
+
         barsHandler.editButton.accessibilityLabel = UserText.actionGenericEdit
         barsHandler.editButton.menu = createEditMenu()
 

--- a/iOS/DuckDuckGoTests/TabSwitcherBarsStateHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/TabSwitcherBarsStateHandlerTests.swift
@@ -24,11 +24,11 @@ import Core
 
 class TabSwitcherBarsStateHandlerTests: XCTestCase {
 
-    var stateHandler: TabSwitcherBarsStateHandler!
+    var stateHandler: TabSwitcherBarsStateHandling!
 
     override func setUp() {
         super.setUp()
-        stateHandler = TabSwitcherBarsStateHandler(themingProperties: ExperimentalThemingProperties(isExperimentalThemingEnabled: false, isRoundedCornersTreatmentEnabled: false))
+        stateHandler = DefaultTabSwitcherBarsStateHandler(themingProperties: ExperimentalThemingProperties(isExperimentalThemingEnabled: false, isRoundedCornersTreatmentEnabled: false))
     }
 
     override func tearDown() {
@@ -180,6 +180,134 @@ class TabSwitcherBarsStateHandlerTests: XCTestCase {
         XCTAssertEqual(stateHandler.topBarLeftButtonItems, [
             stateHandler.editButton,
             stateHandler.tabSwitcherStyleButton,
+        ])
+    }
+
+    func testWhenInterfaceModeIsLargeSizeThenTopRightButtonItemsAreSetCorrectly() {
+        stateHandler.update(.largeSize, selectedTabsCount: 0, totalTabsCount: 0, containsWebPages: false, showAIChatButton: true)
+
+        XCTAssertEqual(stateHandler.topBarRightButtonItems, [
+            stateHandler.doneButton,
+            stateHandler.fireButton,
+            stateHandler.plusButton,
+            stateHandler.duckChatButton,
+        ])
+    }
+
+}
+
+class LegacyTabSwitcherBarsStateHandlerTests: XCTestCase {
+
+    var stateHandler: LegacyTabSwitcherBarsStateHandler!
+
+    override func setUp() {
+        super.setUp()
+        stateHandler = LegacyTabSwitcherBarsStateHandler(themingProperties: ExperimentalThemingProperties(isExperimentalThemingEnabled: false, isRoundedCornersTreatmentEnabled: false))
+    }
+
+    override func tearDown() {
+        stateHandler = nil
+        super.tearDown()
+    }
+
+    func testWhenDuckChatEnabledThenBottomBarItemsAreSetCorrectly() {
+        stateHandler.update(.regularSize, selectedTabsCount: 0, totalTabsCount: 0, containsWebPages: false, showAIChatButton: true)
+
+        XCTAssertEqual(stateHandler.bottomBarItems, [
+            stateHandler.tabSwitcherStyleButton,
+            UIBarButtonItem.flexibleSpace(),
+            UIBarButtonItem.fixedSpace(11),
+            UIBarButtonItem.flexibleSpace(),
+            stateHandler.fireButton,
+            UIBarButtonItem.flexibleSpace(),
+            stateHandler.duckChatButton,
+            UIBarButtonItem.flexibleSpace(),
+            stateHandler.plusButton
+        ])
+        XCTAssertFalse(stateHandler.isBottomBarHidden)
+    }
+
+    func testWhenInterfaceModeIsEditingRegularSizeThenBottomBarItemsAreSetCorrectly() {
+        stateHandler.update(.editingRegularSize, selectedTabsCount: 0, totalTabsCount: 0, containsWebPages: false, showAIChatButton: false)
+
+        XCTAssertEqual(stateHandler.bottomBarItems, [
+            stateHandler.closeTabsButton,
+            UIBarButtonItem.flexibleSpace(),
+            stateHandler.menuButton
+        ])
+        XCTAssertFalse(stateHandler.isBottomBarHidden)
+    }
+
+    func testWhenInterfaceModeIsEditingLargeThenBottomBarIsHidden() {
+        stateHandler.update(.editingLargeSize, selectedTabsCount: 0, totalTabsCount: 0, containsWebPages: false, showAIChatButton: false)
+
+        XCTAssertTrue(stateHandler.bottomBarItems.isEmpty)
+        XCTAssertTrue(stateHandler.isBottomBarHidden)
+    }
+
+    func testWhenInterfaceModeIsRegularSizeThenTopRightButtonItemsAreSetCorrectly() {
+        stateHandler.update(.regularSize, selectedTabsCount: 0, totalTabsCount: 2, containsWebPages: false, showAIChatButton: false)
+
+        XCTAssertEqual(stateHandler.topBarRightButtonItems, [
+            stateHandler.doneButton
+        ])
+    }
+
+    func testWhenInterfaceModeIsEditingRegularSizeThenTopRightButtonItemsAreSetCorrectly() {
+        stateHandler.update(.editingRegularSize, selectedTabsCount: 0, totalTabsCount: 2, containsWebPages: false, showAIChatButton: false)
+
+        XCTAssertEqual(stateHandler.topBarRightButtonItems, [
+            stateHandler.selectAllButton
+        ])
+    }
+
+    func testWhenShowAIChatButtonIsTrueThenDuckChatButtonIsIncludedInToolbarItems() {
+        stateHandler.update(.regularSize, selectedTabsCount: 0, totalTabsCount: 0, containsWebPages: false, showAIChatButton: true)
+
+        XCTAssertTrue(stateHandler.bottomBarItems.contains(stateHandler.duckChatButton))
+    }
+
+    func testWhenTotalTabsCountIsGreaterThanOneThenCanShowEditButtonIsTrue() {
+        stateHandler.update(.regularSize, selectedTabsCount: 0, totalTabsCount: 2, containsWebPages: false, showAIChatButton: false)
+
+        XCTAssertTrue(stateHandler.canShowEditButton)
+    }
+
+    func testWhenContainsWebPagesIsTrueThenCanShowEditButtonIsTrue() {
+        stateHandler.update(.regularSize, selectedTabsCount: 0, totalTabsCount: 0, containsWebPages: true, showAIChatButton: false)
+
+        XCTAssertTrue(stateHandler.canShowEditButton)
+    }
+
+    func testWhenInterfaceModeIsLargeSizeThenBottomBarIsHidden() {
+        stateHandler.update(.largeSize, selectedTabsCount: 0, totalTabsCount: 0, containsWebPages: false, showAIChatButton: false)
+
+        XCTAssertTrue(stateHandler.bottomBarItems.isEmpty)
+        XCTAssertTrue(stateHandler.isBottomBarHidden)
+    }
+
+    func testWhenInterfaceModeIsEditingRegularSizeThenTopLeftButtonItemsAreSetCorrectly() {
+        stateHandler.update(.editingRegularSize, selectedTabsCount: 0, totalTabsCount: 2, containsWebPages: false, showAIChatButton: false)
+
+        XCTAssertEqual(stateHandler.topBarLeftButtonItems, [
+            stateHandler.doneButton
+        ])
+    }
+
+    func testWhenInterfaceModeIsLargeSizeThenTopLeftButtonItemsAreSetCorrectly() {
+        stateHandler.update(.largeSize, selectedTabsCount: 0, totalTabsCount: 2, containsWebPages: false, showAIChatButton: false)
+
+        XCTAssertEqual(stateHandler.topBarLeftButtonItems, [
+            stateHandler.editButton,
+            stateHandler.tabSwitcherStyleButton
+        ])
+    }
+
+    func testWhenInterfaceModeIsLargeSizeAndCannotShowEditButtonThenTopLeftButtonItemsAreSetCorrectly() {
+        stateHandler.update(.largeSize, selectedTabsCount: 0, totalTabsCount: 0, containsWebPages: false, showAIChatButton: false)
+
+        XCTAssertEqual(stateHandler.topBarLeftButtonItems, [
+            stateHandler.tabSwitcherStyleButton
         ])
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1210647253853346?focus=true
Tech Design URL:
CC: @graeme 

### Description
Restores previous version of tab switcher bars state code and uses strategy pattern to respect the feature flag.  TabSwitcherViewController checks the state of the flag directly for everything else.

### Testing Steps
1. Check current production app and go to the tab switcher - this is the "legacy layout"
1. Launch app from current head of main - check tab manager layout - this is the new "default layout" aka "June 2025 tab manager layout changes"
2. Upgrade app using this branch - check tab manager layout - should be unchanged
3. Go to debug screen > Feature Flags and turn off `june2025TabManagerLayoutChanges` 
4. Without restarting the app, go back to the tab switcher. It should now be the "legacy layout"
5. Clean install should show new layout.

### Impact and Risks
Medium: Could disrupt specific features or user flows - specifically tab switcher

#### What could go wrong?
Feature flag gets disabled by accident?

### Quality Considerations
* Note that the new layout supports the tab switcher navigation bar in the bottom position based on the bar setting in Settings > Appearance.  When the legacy layout is applied the tab switcher navigation bar should only ever be at the top.

### Notes to Reviewer
n/a

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)