### PR TITLE
Add Duck.ai summarization pixels and implement 'summarize text' pixel

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -1059,6 +1059,8 @@
 		372D43D72DF2573A00A3A10D /* MockFireproofDomains.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372D43D52DF2573600A3A10D /* MockFireproofDomains.swift */; };
 		372D43D82DF2573A00A3A10D /* MockFireproofDomains.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372D43D52DF2573600A3A10D /* MockFireproofDomains.swift */; };
 		372D43D92DF2573A00A3A10D /* MockFireproofDomains.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372D43D52DF2573600A3A10D /* MockFireproofDomains.swift */; };
+		372FA8D32E0D7E8100FD63B8 /* AIChatSummarizationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372FA8D22E0D7E7D00FD63B8 /* AIChatSummarizationRequest.swift */; };
+		372FA8D42E0D7E8100FD63B8 /* AIChatSummarizationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372FA8D22E0D7E7D00FD63B8 /* AIChatSummarizationRequest.swift */; };
 		3730F20F2D2E725D00239F96 /* NewTabPageCustomizationProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3730F20E2D2E725A00239F96 /* NewTabPageCustomizationProviderTests.swift */; };
 		3730F2102D2E725D00239F96 /* NewTabPageCustomizationProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3730F20E2D2E725A00239F96 /* NewTabPageCustomizationProviderTests.swift */; };
 		373114B62DEF0EDD0010C256 /* MockHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373114B52DEF0EDB0010C256 /* MockHistoryStore.swift */; };
@@ -4095,6 +4097,7 @@
 		372BC2A02A4AFA47001D8FD5 /* SyncCredentialsAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncCredentialsAdapter.swift; sourceTree = "<group>"; };
 		372D15EB2D00FA1400A11576 /* AppearancePreferences+NewTabPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppearancePreferences+NewTabPage.swift"; sourceTree = "<group>"; };
 		372D43D52DF2573600A3A10D /* MockFireproofDomains.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFireproofDomains.swift; sourceTree = "<group>"; };
+		372FA8D22E0D7E7D00FD63B8 /* AIChatSummarizationRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSummarizationRequest.swift; sourceTree = "<group>"; };
 		3730F20E2D2E725A00239F96 /* NewTabPageCustomizationProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageCustomizationProviderTests.swift; sourceTree = "<group>"; };
 		373114B52DEF0EDB0010C256 /* MockHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHistoryStore.swift; sourceTree = "<group>"; };
 		373114BB2DEF513D0010C256 /* NavigationBarPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarPixel.swift; sourceTree = "<group>"; };
@@ -6251,6 +6254,7 @@
 		31521ABE2CC0139C00248E6F /* AIChat */ = {
 			isa = PBXGroup;
 			children = (
+				372FA8D22E0D7E7D00FD63B8 /* AIChatSummarizationRequest.swift */,
 				31E3FD712CE39C4600A392C8 /* Debug */,
 				31CF74542CDC1771004ACCE5 /* UserScript */,
 				319FCFF42CC83003004F9288 /* AIChatDebugMenu.swift */,
@@ -12440,6 +12444,7 @@
 				31521AC12CC013AD00248E6F /* AIChatMenuVisibilityConfigurable.swift in Sources */,
 				3706FA8C293F65D500E42796 /* AppStateChangedPublisher.swift in Sources */,
 				9FEE986E2B85BA17002E44E8 /* AddEditBookmarkDialogCoordinatorViewModel.swift in Sources */,
+				372FA8D42E0D7E8100FD63B8 /* AIChatSummarizationRequest.swift in Sources */,
 				C1935A192C88F9D6001AD72D /* SyncPromoManager.swift in Sources */,
 				3706FA8D293F65D500E42796 /* BookmarkTableCellView.swift in Sources */,
 				3706FA8E293F65D500E42796 /* BookmarkManagementSidebarViewController.swift in Sources */,
@@ -14606,6 +14611,7 @@
 				37E13B8E2D54B03D002ECD62 /* HistoryViewDataProvider.swift in Sources */,
 				372A0FEC2B2379310033BF7F /* SyncMetricsEventsHandler.swift in Sources */,
 				1D5C1AF12CFF58220073ED65 /* Logger+WebExtensions.swift in Sources */,
+				372FA8D32E0D7E8100FD63B8 /* AIChatSummarizationRequest.swift in Sources */,
 				85774B032A71CDD000DE0561 /* BlockMenuItem.swift in Sources */,
 				4B9292DB2667125D00AD2C21 /* BookmarksContextMenu.swift in Sources */,
 				AA585DAF2490E6E600E9A3E2 /* MainViewController.swift in Sources */,

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -76,23 +76,23 @@ enum AIChatPixel: PixelKitEventV2 {
     var name: String {
         switch self {
         case .aichatApplicationMenuAppClicked:
-            return "m_mac_aichat_application-menu-app-clicked"
+            return "aichat_application-menu-app-clicked"
         case .aichatApplicationMenuFileClicked:
-            return "m_mac_aichat_application-menu-file-clicked"
+            return "aichat_application-menu-file-clicked"
         case .aichatNoRemoteSettingsFound(let settings):
-            return "m_mac_aichat_no_remote_settings_found-\(settings.rawValue.lowercased())"
+            return "aichat_no_remote_settings_found-\(settings.rawValue.lowercased())"
         case .aiChatSettingsAddressBarShortcutTurnedOn:
-            return "m_mac_aichat_settings_addressbar_on"
+            return "aichat_settings_addressbar_on"
         case .aiChatSettingsAddressBarShortcutTurnedOff:
-            return "m_mac_aichat_settings_addressbar_off"
+            return "aichat_settings_addressbar_off"
         case .aiChatSettingsApplicationMenuShortcutTurnedOff:
-            return "m_mac_aichat_settings_application_menu_off"
+            return "aichat_settings_application_menu_off"
         case .aiChatSettingsApplicationMenuShortcutTurnedOn:
-            return "m_mac_aichat_settings_application_menu_on"
+            return "aichat_settings_application_menu_on"
         case .aiChatSettingsDisplayed:
-            return "m_mac_aichat_settings_displayed"
+            return "aichat_settings_displayed"
         case .aiChatAddressBarButtonClicked:
-            return "m_mac_aichat_addressbar_button_clicked"
+            return "aichat_addressbar_button_clicked"
         case .aiChatSummarizeText:
             return "aichat_summarize_text"
         case .aiChatSummarizePromptExpanded:

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -23,6 +23,7 @@ import PixelKit
 /// > Related links:
 /// [Original Pixel Triage](https://app.asana.com/0/69071770703008/1208619053222285/f)
 /// [Omnibar and Settings Pixel Triage](https://app.asana.com/0/1204167627774280/1209885580000745)
+/// [Summarization Pixel Triage](https://app.asana.com/1/137249556945/project/69071770703008/task/1210636012460969?focus=true)
 
 enum AIChatPixel: PixelKitEventV2 {
 
@@ -59,6 +60,19 @@ enum AIChatPixel: PixelKitEventV2 {
     /// Event Trigger: User clicks in the Omnibar duck.ai button
     case aiChatAddressBarButtonClicked
 
+    // MARK: - Summarization
+
+    /// Event Trigger: User triggers summarize action (either via keyboard shortcut or a context menu action)
+    case aiChatSummarizeText(source: AIChatSummarizationRequest.Source)
+
+    /// Event Trigger: User clicks "Show more" on a (collapsed by default) summarize prompt in Duck.ai tab or sidebar
+    case aiChatSummarizePromptExpanded
+
+    /// Event Trigger: User clicks the website link on a summarize prompt in Duck.ai tab or sidebar
+    case aiChatSummarizeSourceLinkClicked
+
+    // MARK: -
+
     var name: String {
         switch self {
         case .aichatApplicationMenuAppClicked:
@@ -79,11 +93,32 @@ enum AIChatPixel: PixelKitEventV2 {
             return "m_mac_aichat_settings_displayed"
         case .aiChatAddressBarButtonClicked:
             return "m_mac_aichat_addressbar_button_clicked"
+        case .aiChatSummarizeText:
+            return "aichat_summarize_text"
+        case .aiChatSummarizePromptExpanded:
+            return "aichat_summarize_prompt_expanded"
+        case .aiChatSummarizeSourceLinkClicked:
+            return "aichat_summarize_source_link_clicked"
         }
     }
 
     var parameters: [String: String]? {
-        nil
+        switch self {
+        case .aichatApplicationMenuAppClicked,
+                .aichatApplicationMenuFileClicked,
+                .aichatNoRemoteSettingsFound,
+                .aiChatSettingsAddressBarShortcutTurnedOn,
+                .aiChatSettingsAddressBarShortcutTurnedOff,
+                .aiChatSettingsApplicationMenuShortcutTurnedOff,
+                .aiChatSettingsApplicationMenuShortcutTurnedOn,
+                .aiChatSettingsDisplayed,
+                .aiChatAddressBarButtonClicked,
+                .aiChatSummarizePromptExpanded,
+                .aiChatSummarizeSourceLinkClicked:
+            return nil
+        case .aiChatSummarizeText(let source):
+            return ["source": source.rawValue]
+        }
     }
 
     var error: (any Error)? {

--- a/macOS/DuckDuckGo/AIChat/AIChatSummarizationRequest.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatSummarizationRequest.swift
@@ -1,0 +1,36 @@
+//
+//  AIChatSummarizationRequest.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// This struct represents an object that's posted in `aiChatSummarizationRequest` notification.
+struct AIChatSummarizationRequest: Equatable {
+    /// The text to be summarized
+    let text: String
+
+    /// The source of the summarize action
+    let source: Source
+
+    enum Source: String {
+        case contextMenu = "context-menu", keyboardShortcut = "keyboard-shortcut"
+    }
+}
+
+extension NSNotification.Name {
+    static let aiChatSummarizationRequest = Notification.Name(rawValue: "com.duckduckgo.notification.aiChatSummarizationRequest")
+}

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -119,5 +119,4 @@ struct AIChatUserScriptHandler: AIChatUserScriptHandling {
 
 extension NSNotification.Name {
     static let aiChatNativeHandoffData: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.notification.aiChatNativeHandoffData")
-    static let aiChatSummarizationQuery: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.notification.aiChatSummarizationQuery")
 }

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -167,7 +167,7 @@ final class MainViewController: NSViewController {
             aiChatTabOpener: aiChatTabOpener,
             featureFlagger: featureFlagger,
             windowControllersManager: windowControllersManager,
-            pixelFiring: PixelKit.shared
+            pixelFiring: pixelFiring
         )
 
         navigationBarViewController = NavigationBarViewController.create(tabCollectionViewModel: tabCollectionViewModel,

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -16,16 +16,17 @@
 //  limitations under the License.
 //
 
+import BrokenSitePrompt
 import BrowserServicesKit
 import Cocoa
 import Carbon.HIToolbox
 import Combine
 import Common
 import History
-import VPN
 import NetworkProtectionIPC
 import os.log
-import BrokenSitePrompt
+import PixelKit
+import VPN
 
 final class MainViewController: NSViewController {
     private(set) lazy var mainView = MainView(frame: NSRect(x: 0, y: 0, width: 600, height: 660))
@@ -94,7 +95,8 @@ final class MainViewController: NSViewController {
          featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
          defaultBrowserAndDockPromptPresenting: DefaultBrowserAndDockPromptPresenting = NSApp.delegateTyped.defaultBrowserAndDockPromptPresenter,
          visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle,
-         fireCoordinator: FireCoordinator = NSApp.delegateTyped.fireCoordinator
+         fireCoordinator: FireCoordinator = NSApp.delegateTyped.fireCoordinator,
+         pixelFiring: PixelFiring? = PixelKit.shared
     ) {
 
         self.aiChatMenuConfig = aiChatMenuConfig
@@ -164,7 +166,8 @@ final class MainViewController: NSViewController {
             sidebarProvider: aiChatSidebarProvider,
             aiChatTabOpener: aiChatTabOpener,
             featureFlagger: featureFlagger,
-            windowControllersManager: windowControllersManager
+            windowControllersManager: windowControllersManager,
+            pixelFiring: PixelKit.shared
         )
 
         navigationBarViewController = NavigationBarViewController.create(tabCollectionViewModel: tabCollectionViewModel,

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -784,8 +784,8 @@ extension MainViewController {
                 guard let selectedText, !selectedText.isEmpty else {
                     return
                 }
-                NotificationCenter.default.post(name: .aiChatSummarizationQuery,
-                                                object: selectedText,
+                NotificationCenter.default.post(name: .aiChatSummarizationRequest,
+                                                object: AIChatSummarizationRequest(text: selectedText, source: .keyboardShortcut),
                                                 userInfo: nil)
             } catch {
                 Logger.aiChat.error("Failed to get selected text from the webView")

--- a/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
@@ -394,8 +394,8 @@ private extension ContextMenuManager {
             return
         }
 
-        NotificationCenter.default.post(name: .aiChatSummarizationQuery,
-                                        object: selectedText,
+        NotificationCenter.default.post(name: .aiChatSummarizationRequest,
+                                        object: AIChatSummarizationRequest(text: selectedText, source: .contextMenu),
                                         userInfo: nil)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1210625543706130?focus=true

### Description
This change adds pixels agreed upon in the Privacy Triage and implements firing the summarization pixel.

### Testing Steps
1. Enable `aiChatTextSummarization` feature flag.
2. Filter logs by PixelKit category.
3. Select some text, open context menu and select “Summarize with Duck.ai”.
4. Verify that `m_mac_aichat_summarize_text` was fired with "source": "context-menu” (and also the _daily pixel).
5. Select some text and press cmd+shift+enter.
6. Verify that `m_mac_aichat_summarize_text` was fired with "source": “keyboard-shortcut” (the _daily pixel should be skipped this time).

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)