### PR TITLE
macOS: Change when to show close button threshold to 88px

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -99,7 +99,7 @@ final class TabBarItemCellView: NSView {
         init(width: CGFloat) {
             switch width {
             case 0..<61: self = .withoutTitle
-            case 61..<120: self = .withoutCloseButton
+            case 61..<88: self = .withoutCloseButton
             default: self = .full
             }
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210652115247060?focus=true
Tech Design URL:
CC:

### Description
Changes the threshold for when to display the X button when hovering over standard tabs.

**Before**
That was the max amount of tabs you could have before the close button stopped showing on hover.

<img width="1512" alt="Screenshot 2025-06-26 at 1 16 27 PM" src="https://github.com/user-attachments/assets/437d7f6c-f6c8-474f-a689-a86ef8d25965" />

**After**
Now, you can have more tabs opened and the close button will be shown.
<img width="1505" alt="Screenshot 2025-06-26 at 1 13 31 PM" src="https://github.com/user-attachments/assets/228fe1c6-2c89-4fc8-8636-6b8360a7ba53" />


### Testing Steps
1. Open a bunch of tabs
2. Check that we show the X when hovering over more tabs compared to production.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing.

### Quality Considerations
Nothing.

### Notes to Reviewer
Nothing specific.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)