### PR TITLE
Do not use AI Features in the address bar when on Duck.ai

### DIFF
--- a/macOS/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
+++ b/macOS/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
@@ -652,6 +652,6 @@ private extension NSAttributedString {
     static let releaseNotesTrustedIndicator = trustedIndicatorAttributedString(with: .releaseNotesIndicator,
                                                                                title: UserText.releaseNotesTitle)
     static let aiChatTrustedIndicator = trustedIndicatorAttributedString(with: .aiChatPreferences,
-                                                                         title: UserText.aiFeatures)
+                                                                         title: "Duck.ai")
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210642179885345?focus=true
Tech Design URL:
CC:

### Description
Do not show AI Features in the address bar; show Duck.ai instead.

### Testing Steps
1. Open Duck.ai
2. Check the address bar, and verify it says DuckDuckGo -> Duck.ai, instead of DuckDuckGo -> AI Features.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
We need to ship this before it hits external users.

### Quality Considerations
Nothing.

### Notes to Reviewer
I’ve added a question about translations.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)