### PR TITLE
Disable all potentially flakey macOS sync tests

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -448,7 +448,8 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertTrue(api.createRequestCallArgs.isEmpty)
     }
 
-    func testThatSyncOperationRequestReturningHTTP401CausesLoggingOutOfSync() {
+    func testThatSyncOperationRequestReturningHTTP401CausesLoggingOutOfSync() throws {
+        throw XCTSkip("Flakey test")
         let dataProvider = DataProvidingMock(feature: .init(name: "bookmarks"))
         dataProvider.updateSyncTimestamps(server: "1234", local: nil)
         setUpDataProviderCallbacks(for: dataProvider)
@@ -478,7 +479,8 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual(syncService.authState, .inactive)
     }
 
-    func testThatSyncOperationRequestThrowingHTTP401CausesLoggingOutOfSync() {
+    func testThatSyncOperationRequestThrowingHTTP401CausesLoggingOutOfSync() throws {
+        throw XCTSkip("Flakey test")
         let dataProvider = DataProvidingMock(feature: .init(name: "bookmarks"))
         dataProvider.updateSyncTimestamps(server: "1234", local: nil)
         setUpDataProviderCallbacks(for: dataProvider)

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncConnectionControllerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncConnectionControllerTests.swift
@@ -143,6 +143,7 @@ final class SyncConnectionControllerTests: XCTestCase {
     }
 
     func test_startExchangeMode_pollSucceeds_transmitsRecoveryKey() async throws {
+        throw XCTSkip("Flakey test")
         // Mock exchanger creation
         givenExchangerPollForPublicKeySucceeds()
 
@@ -174,6 +175,7 @@ final class SyncConnectionControllerTests: XCTestCase {
     }
 
     func test_startExchangeMode_pollFails_sendsError() async throws {
+        throw XCTSkip("Flakey test")
         // Mock exchanger creation
         let remoteExchanger = MockRemoteKeyExchanging()
         dependencies.createRemoteKeyExchangerStub = remoteExchanger
@@ -187,6 +189,7 @@ final class SyncConnectionControllerTests: XCTestCase {
     }
 
     func test_startExchangeMode_recoveryKeyTransmitFails_sendsError() async throws {
+        throw XCTSkip("Flakey test")
         // Mock exchanger creation
         givenExchangerPollForPublicKeySucceeds()
 
@@ -222,6 +225,7 @@ final class SyncConnectionControllerTests: XCTestCase {
     }
 
     func test_startConnectMode_pollSucceeds_informsDelegate() async throws {
+        throw XCTSkip("Flakey test")
         let remoteConnector = MockRemoteConnecting()
         dependencies.createRemoteConnectorStub = remoteConnector
         remoteConnector.pollForRecoveryKeyStub = SyncCode.RecoveryKey(userId: "", primaryKey: Data())
@@ -233,6 +237,7 @@ final class SyncConnectionControllerTests: XCTestCase {
     }
 
     func test_startConnectMode_pollSucceeds_logsIn() async throws {
+        throw XCTSkip("Flakey test")
         let remoteConnector = MockRemoteConnecting()
         let userId = "TestUserId"
         remoteConnector.pollForRecoveryKeyStub = SyncCode.RecoveryKey(userId: userId, primaryKey: Data())
@@ -248,6 +253,7 @@ final class SyncConnectionControllerTests: XCTestCase {
     }
 
     func test_startConnectMode_pollingFails_sendsError() async throws {
+        throw XCTSkip("Flakey test")
         let remoteConnector = MockRemoteConnecting()
         remoteConnector.pollForRecoveryKeyError = SyncError.failedToPrepareForConnect("")
         dependencies.createRemoteConnectorStub = remoteConnector
@@ -260,6 +266,7 @@ final class SyncConnectionControllerTests: XCTestCase {
     }
 
     func test_startConnectMode_loginFails_sendsError() async throws {
+        throw XCTSkip("Flakey test")
         let remoteConnector = MockRemoteConnecting()
         dependencies.createRemoteConnectorStub = remoteConnector
         remoteConnector.pollForRecoveryKeyStub = SyncCode.RecoveryKey(userId: "", primaryKey: Data())
@@ -369,7 +376,8 @@ final class SyncConnectionControllerTests: XCTestCase {
         XCTAssertTrue(didCreateAccount)
     }
 
-    func test_startPairingMode_withConnectCode_whenAccountCreationThrows_notifiesError() async {
+    func test_startPairingMode_withConnectCode_whenAccountCreationThrows_notifiesError() async throws {
+        throw XCTSkip("Flakey test")
         let mockAccountManager = AccountManagingMock()
         mockAccountManager.createAccountError = SyncError.failedToDecryptValue("")
         dependencies.account = mockAccountManager
@@ -389,7 +397,8 @@ final class SyncConnectionControllerTests: XCTestCase {
         XCTAssertEqual(mockRecoveryKeyTransmitter.sendCalled, 1)
     }
 
-    func test_startPairingMode_withConnectCode_whenTransmitFails_notifiesError() async {
+    func test_startPairingMode_withConnectCode_whenTransmitFails_notifiesError() async throws {
+        throw XCTSkip("Flakey test")
         let mockRecoveryKeyTransmitter = MockRecoveryKeyTransmitting()
         mockRecoveryKeyTransmitter.sendError = SyncError.unableToDecodeResponse("")
         dependencies.createRecoveryTransmitterStub = mockRecoveryKeyTransmitter
@@ -593,7 +602,8 @@ final class SyncConnectionControllerTests: XCTestCase {
         XCTAssertTrue(didCreateAccount)
     }
 
-    func test_syncCodeEntered_withConnectCode_whenAccountCreationThrows_notifiesError() async {
+    func test_syncCodeEntered_withConnectCode_whenAccountCreationThrows_notifiesError() async throws {
+        throw XCTSkip("Flakey test")
         let mockAccountManager = AccountManagingMock()
         mockAccountManager.createAccountError = SyncError.failedToDecryptValue("")
         dependencies.account = mockAccountManager
@@ -613,7 +623,8 @@ final class SyncConnectionControllerTests: XCTestCase {
         XCTAssertEqual(mockRecoveryKeyTransmitter.sendCalled, 1)
     }
 
-    func test_syncCodeEntered_withConnectCode_whenTransmitFails_notifiesError() async {
+    func test_syncCodeEntered_withConnectCode_whenTransmitFails_notifiesError() async throws {
+        throw XCTSkip("Flakey test")
         let mockRecoveryKeyTransmitter = MockRecoveryKeyTransmitting()
         mockRecoveryKeyTransmitter.sendError = SyncError.unableToDecodeResponse("")
         dependencies.createRecoveryTransmitterStub = mockRecoveryKeyTransmitter

--- a/macOS/UnitTests/Sync/SyncPreferencesTests.swift
+++ b/macOS/UnitTests/Sync/SyncPreferencesTests.swift
@@ -423,6 +423,7 @@ final class SyncPreferencesTests: XCTestCase {
     }
 
     func test_syncWithAnotherDevicePressed_accountExists_whenExchangeFeatureFlagOff_usesRecoveryCode() async throws {
+        throw XCTSkip("Flakey test")
         featureFlagger.isFeatureOn[FeatureFlag.exchangeKeysToSyncWithAnotherDevice.rawValue] = false
         let mockAccount = SyncAccount.mock
         ddgSyncing.account = mockAccount
@@ -442,6 +443,7 @@ final class SyncPreferencesTests: XCTestCase {
     }
 
     func test_syncWithAnotherDevicePressed_accountExists_whenExchangeFeatureFlagOn_andUrlBarcodeOn_usesUrlFormat() async throws {
+        throw XCTSkip("Flakey test")
         featureFlagger.isFeatureOn[FeatureFlag.exchangeKeysToSyncWithAnotherDevice.rawValue] = true
         featureFlagger.isFeatureOn[FeatureFlag.syncSetupBarcodeIsUrlBased.rawValue] = true
         let mockAccount = SyncAccount.mock
@@ -465,6 +467,7 @@ final class SyncPreferencesTests: XCTestCase {
     }
 
     func test_enterRecoveryCodePressed_whenUrlBarcodeOn_usesUrlFormat() async throws {
+        throw XCTSkip("Flakey test")
         featureFlagger.isFeatureOn[FeatureFlag.syncSetupBarcodeIsUrlBased.rawValue] = true
         let expectedDisplayCode = "test_code"
         let stubbedPairingInfo = PairingInfo(base64Code: expectedDisplayCode, deviceName: "")
@@ -484,6 +487,7 @@ final class SyncPreferencesTests: XCTestCase {
     }
 
     func test_enterRecoveryCodePressed_whenUrlBarcodeOff_usesBase64Format() async throws {
+        throw XCTSkip("Flakey test")
         featureFlagger.isFeatureOn[FeatureFlag.syncSetupBarcodeIsUrlBased.rawValue] = false
         let expectedDisplayCode = "test_code"
         let stubbedPairingInfo = PairingInfo(base64Code: expectedDisplayCode, deviceName: "")
@@ -499,6 +503,7 @@ final class SyncPreferencesTests: XCTestCase {
     }
 
     func test_syncWithAnotherDevicePressed_whenUrlBarcodeOn_usesUrlFormat() async throws {
+        throw XCTSkip("Flakey test")
         featureFlagger.isFeatureOn[FeatureFlag.syncSetupBarcodeIsUrlBased.rawValue] = true
         featureFlagger.isFeatureOn[FeatureFlag.exchangeKeysToSyncWithAnotherDevice.rawValue] = true
         let expectedCode = "test_code"
@@ -519,7 +524,7 @@ final class SyncPreferencesTests: XCTestCase {
     }
 
     func test_syncWithAnotherDevicePressed_whenUrlBarcodeOff_usesBase64Format() async throws {
-        throw XCTSkip("Flakly test")
+        throw XCTSkip("Flakey test")
         featureFlagger.isFeatureOn[FeatureFlag.syncSetupBarcodeIsUrlBased.rawValue] = false
         featureFlagger.isFeatureOn[FeatureFlag.exchangeKeysToSyncWithAnotherDevice.rawValue] = true
         let expectedCode = "test_code"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210659317398374?focus=true

### Description

Disables a bunch of flaking sync tests to be reenabled later: https://app.asana.com/1/137249556945/project/1202926619870900/task/1210659317398376?focus=true

### Testing Steps
Just green CI

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)