### PR TITLE
Fix flaky subscription tests

### DIFF
--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
@@ -29,6 +29,7 @@ import OHHTTPStubs
 import OHHTTPStubsSwift
 import os.log
 
+@MainActor
 final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
 
     private struct Constants {
@@ -68,7 +69,7 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
                                                                                                         externalID: Constants.externalID))
 
         static let mockParams: [String: String] = [:]
-        @MainActor static let mockScriptMessage = MockWKScriptMessage(name: "", body: "", webView: WKWebView() )
+        static let mockScriptMessage = MockWKScriptMessage(name: "", body: "", webView: WKWebView() )
 
         static let invalidTokenError = APIServiceError.serverError(statusCode: 401, error: "invalid_token")
     }

--- a/macOS/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureForStripeTests.swift
+++ b/macOS/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureForStripeTests.swift
@@ -28,6 +28,7 @@ import PixelKitTestingUtilities
 import os.log
 
 @available(macOS 12.0, *)
+@MainActor
 final class SubscriptionPagesUseSubscriptionFeatureForStripeTests: XCTestCase {
 
     private struct Constants {
@@ -74,7 +75,7 @@ final class SubscriptionPagesUseSubscriptionFeatureForStripeTests: XCTestCase {
                                                                                                         externalID: Constants.externalID))
 
         static let mockParams: [String: String] = [:]
-        @MainActor static let mockScriptMessage = MockWKScriptMessage(name: "", body: "", webView: WKWebView() )
+        static let mockScriptMessage = MockWKScriptMessage(name: "", body: "", webView: WKWebView() )
 
         static let invalidTokenError = APIServiceError.serverError(statusCode: 401, error: "invalid_token")
     }
@@ -112,7 +113,7 @@ final class SubscriptionPagesUseSubscriptionFeatureForStripeTests: XCTestCase {
     var pixelsFired: [String] = []
     var uiEventsHappened: [SubscriptionUIHandlerMock.UIHandlerMockPerformedAction] = []
 
-    @MainActor override func setUpWithError() throws {
+    override func setUpWithError() throws {
         // Mocks
         userDefaults = UserDefaults(suiteName: Constants.userDefaultsSuiteName)!
         userDefaults.removePersistentDomain(forName: Constants.userDefaultsSuiteName)

--- a/macOS/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
+++ b/macOS/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
@@ -30,6 +30,7 @@ import DataBrokerProtection_macOS
 import DataBrokerProtectionCore
 
 @available(macOS 12.0, *)
+@MainActor
 final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
 
     private struct Constants {
@@ -107,7 +108,7 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
     var pixelsFired: [String] = []
     var uiEventsHappened: [SubscriptionUIHandlerMock.UIHandlerMockPerformedAction] = []
 
-    @MainActor override func setUpWithError() throws {
+    override func setUpWithError() throws {
         // Mocks
         userDefaults = UserDefaults(suiteName: Constants.userDefaultsSuiteName)!
         userDefaults.removePersistentDomain(forName: Constants.userDefaultsSuiteName)
@@ -1123,7 +1124,6 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
 
     // MARK: - Free Trials
 
-    @MainActor
     func testGetSubscriptionOptions_FreeTrialFlagOn_AndFreeTrialOptionsAvailable_ReturnsFreeTrialOptions() async throws {
         // Given
         mockFeatureFlagger.enabledFeatureFlags = [.privacyProFreeTrial]
@@ -1146,7 +1146,6 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
         XCTAssertEqual(subscriptionOptionsResult, freeTrialOptions)
     }
 
-    @MainActor
     func testGetSubscriptionOptions_FreeTrialFlagOn_AndFreeTrialReturnsNil_ReturnsRegularOptions() async throws {
         // Given
         mockFeatureFlagger.enabledFeatureFlags = [.privacyProFreeTrial]
@@ -1163,7 +1162,6 @@ final class SubscriptionPagesUseSubscriptionFeatureTests: XCTestCase {
         XCTAssertEqual(subscriptionOptionsResult, Constants.subscriptionOptions)
     }
 
-    @MainActor
     func testGetSubscriptionOptions_FreeTrialFlagOff_AndFreeTrialOptionsAvailable_ReturnsRegularOptions() async throws {
         // Given
         subscriptionFeatureAvailability.isSubscriptionPurchaseAllowed = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1210674657043954?focus=true
Tech Design URL:
CC:

### Description
Fix flaky tests due to not thread-safe access to `pixelsFired` used to gather and assert fired pixels.

### Testing Steps
1. Repeatedly 1000 run tests from `SubscriptionPagesUseSubscriptionFeatureTests`

### Impact and Risks
None: Internal tooling, documentation


#### What could go wrong?
None, fix for tests.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)