### PR TITLE
Add background task to Statistics Loader

### DIFF
--- a/iOS/Core/QRunInBackgroundAssertion.swift
+++ b/iOS/Core/QRunInBackgroundAssertion.swift
@@ -1,0 +1,123 @@
+//
+//  QRunInBackgroundAssertion.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+
+/// Based on: https://developer.apple.com/forums/thread/729335
+///
+/// Prevents the process from suspending by holding a `UIApplication` background
+/// task assertion.
+///
+/// The assertion is released if:
+///
+/// * You explicitly release the assertion by calling ``release()``.
+/// * There are no more strong references to the object and so it gets deinitialised.
+/// * The system ‘calls in’ the assertion, in which case it calls the
+///   ``systemDidReleaseAssertion`` closure, if set.
+///
+/// You should aim to explicitly release the assertion yourself, as soon as
+/// you’ve completed the work that the assertion covers.
+
+public final class QRunInBackgroundAssertion {
+
+    /// The name used when creating the assertion.
+
+    public let name: String
+
+    public let application: UIApplication
+
+    /// Called when the system releases the assertion itself.
+    ///
+    /// This is called on the main thread.
+    ///
+    /// To help avoid retain cycles, the object sets this to `nil` whenever the
+    /// assertion is released.
+
+    public var systemDidReleaseAssertion: (() -> Void)? {
+        willSet { dispatchPrecondition(condition: .onQueue(.main)) }
+    }
+
+    private var taskID: UIBackgroundTaskIdentifier
+
+    /// Creates an assertion with the given name.
+    ///
+    /// The name isn’t used by the system but it does show up in various logs so
+    /// it’s important to choose one that’s meaningful to you.
+    ///
+    /// Must be called on the main thread.
+
+    public init(name: String, application: UIApplication) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        self.name = name
+        self.application = application
+        self.systemDidReleaseAssertion = nil
+        // Have to initialise `taskID` first so that I can capture a fully
+        // initialised `self` in the expiration handler.  If the expiration
+        // handler ran ／before／ I got a chance to set `self.taskID` to `t`,
+        // things would end badly.  However, that can’t happen because I’m
+        // running on the main thread — courtesy of the Dispatch precondition
+        // above — and the expiration handler also runs on the main thread.
+        self.taskID = .invalid
+        let t = self.application.beginBackgroundTask(withName: name) {
+            self.taskDidExpire()
+        }
+        self.taskID = t
+    }
+
+    /// Release the assertion.
+    ///
+    /// It’s safe to call this redundantly, that is, call it twice in a row or
+    /// call it on an assertion that’s expired.
+    ///
+    /// Must be called on the main thread.
+
+    public func release() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        self.consumeValidTaskID() { }
+    }
+
+    deinit {
+        // We don’t apply this assert because it’s hard to force the last object
+        // reference to be released on the main thread.  However, it should be
+        // safe to call through to `consumeValidTaskID(_:)` because no other
+        // thread can be running inside this object (because that would have its
+        // own retain on us).
+        //
+        // dispatchPrecondition(condition: .onQueue(.main))
+        self.consumeValidTaskID() { }
+    }
+
+    private func consumeValidTaskID(_ body: () -> Void) {
+        // Move this check to all clients except the deinitialiser.
+        //
+        // dispatchPrecondition(condition: .onQueue(.main))
+        guard self.taskID != .invalid else { return }
+        self.application.endBackgroundTask(self.taskID)
+        self.taskID = .invalid
+        body()
+        self.systemDidReleaseAssertion = nil
+    }
+
+    private func taskDidExpire() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        self.consumeValidTaskID() {
+            self.systemDidReleaseAssertion?()
+        }
+    }
+}

--- a/iOS/Core/QRunInBackgroundAssertion.swift
+++ b/iOS/Core/QRunInBackgroundAssertion.swift
@@ -93,20 +93,15 @@ public final class QRunInBackgroundAssertion {
     }
 
     deinit {
-        // We don’t apply this assert because it’s hard to force the last object
+        // We don’t check the main thread precondition because it’s hard to force the last object
         // reference to be released on the main thread.  However, it should be
         // safe to call through to `consumeValidTaskID(_:)` because no other
         // thread can be running inside this object (because that would have its
         // own retain on us).
-        //
-        // dispatchPrecondition(condition: .onQueue(.main))
         self.consumeValidTaskID { }
     }
 
     private func consumeValidTaskID(_ body: () -> Void) {
-        // Move this check to all clients except the deinitialiser.
-        //
-        // dispatchPrecondition(condition: .onQueue(.main))
         guard self.taskID != .invalid else { return }
         self.application.endBackgroundTask(self.taskID)
         self.taskID = .invalid

--- a/iOS/Core/QRunInBackgroundAssertion.swift
+++ b/iOS/Core/QRunInBackgroundAssertion.swift
@@ -89,7 +89,7 @@ public final class QRunInBackgroundAssertion {
 
     public func release() {
         dispatchPrecondition(condition: .onQueue(.main))
-        self.consumeValidTaskID() { }
+        self.consumeValidTaskID { }
     }
 
     deinit {
@@ -100,7 +100,7 @@ public final class QRunInBackgroundAssertion {
         // own retain on us).
         //
         // dispatchPrecondition(condition: .onQueue(.main))
-        self.consumeValidTaskID() { }
+        self.consumeValidTaskID { }
     }
 
     private func consumeValidTaskID(_ body: () -> Void) {
@@ -116,7 +116,7 @@ public final class QRunInBackgroundAssertion {
 
     private func taskDidExpire() {
         dispatchPrecondition(condition: .onQueue(.main))
-        self.consumeValidTaskID() {
+        self.consumeValidTaskID {
             self.systemDidReleaseAssertion?()
         }
     }

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -800,6 +800,7 @@
 		9830A06325ED0DB900DB64DE /* BrowsingMenu.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9830A06225ED0DB900DB64DE /* BrowsingMenu.xcassets */; };
 		9833913727AC400800DAF119 /* AppTrackerDataSetProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9833913627AC400800DAF119 /* AppTrackerDataSetProvider.swift */; };
 		9838059F2228208E00385F1A /* PositiveFeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9838059E2228208E00385F1A /* PositiveFeedbackViewController.swift */; };
+		983AB2312E12CFBF00F0223F /* QRunInBackgroundAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983AB2302E12CFBE00F0223F /* QRunInBackgroundAssertion.swift */; };
 		983C52E42C2C050B007B5747 /* BookmarksStateRepair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983C52E32C2C050B007B5747 /* BookmarksStateRepair.swift */; };
 		983C52E72C2C0ACB007B5747 /* BookmarkStateRepairTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983C52E52C2C0ABA007B5747 /* BookmarkStateRepairTests.swift */; };
 		983D71B12A286E810072E26D /* SyncDebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983D71B02A286E810072E26D /* SyncDebugViewController.swift */; };
@@ -2718,6 +2719,7 @@
 		983A4B8F251EABEA00F3EDF1 /* et */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = et; path = et.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		983A4B90251EABEA00F3EDF1 /* et */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = et; path = et.lproj/Localizable.strings; sourceTree = "<group>"; };
 		983A4B91251EABEA00F3EDF1 /* et */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = et; path = et.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		983AB2302E12CFBE00F0223F /* QRunInBackgroundAssertion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRunInBackgroundAssertion.swift; sourceTree = "<group>"; };
 		983C52E32C2C050B007B5747 /* BookmarksStateRepair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksStateRepair.swift; sourceTree = "<group>"; };
 		983C52E52C2C0ABA007B5747 /* BookmarkStateRepairTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkStateRepairTests.swift; sourceTree = "<group>"; };
 		983D71B02A286E810072E26D /* SyncDebugViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncDebugViewController.swift; sourceTree = "<group>"; };
@@ -8015,6 +8017,7 @@
 		F143C3191E4A99DD00CFDE3A /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				983AB2302E12CFBE00F0223F /* QRunInBackgroundAssertion.swift */,
 				6F9857332CD27F98001BE9A0 /* BoolFileMarker.swift */,
 				9FCFCD7D2C6AF52A006EB7A0 /* LaunchOptionsHandler.swift */,
 				B603974829C19F6F00902A34 /* Assertions.swift */,
@@ -11098,6 +11101,7 @@
 				31B2F1132C92FEF500CD30E3 /* MarketplaceAdPostbackUpdater.swift in Sources */,
 				4BE2756827304F57006B20B0 /* URLRequestExtension.swift in Sources */,
 				85BA79911F6FF75000F59015 /* ContentBlockerStoreConstants.swift in Sources */,
+				983AB2312E12CFBF00F0223F /* QRunInBackgroundAssertion.swift in Sources */,
 				85E242172AB1B54D000F3E28 /* ReturnUserMeasurement.swift in Sources */,
 				85BDC3142434D8F80053DB07 /* DebugUserScript.swift in Sources */,
 				85011867290028C400BDEE27 /* BookmarksDatabase.swift in Sources */,

--- a/iOS/DuckDuckGo/AppServices/StatisticsService.swift
+++ b/iOS/DuckDuckGo/AppServices/StatisticsService.swift
@@ -33,8 +33,13 @@ final class StatisticsService {
     // MARK: - Resume
 
     func resume() {
+        let backgroundAssertion = QRunInBackgroundAssertion(name: "StatisticsLoader background assertion",
+                                                            application: UIApplication.shared)
         statisticsLoader.load {
             NotificationCenter.default.post(name: .didLoadStatisticsOnForeground, object: nil)
+            DispatchQueue.main.async {
+                backgroundAssertion.release()
+            }
         }
     }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/856498667320406/task/1210672892676451?focus=true
Tech Design URL:
CC:

### Description

Statistic Loader can trigger two async operations (fetches) that could take some time to complete. When done, notification is posted, that can invoke `AutofillPixelReporter` and cause SecureVault fetches. If that coincide with transition from Background to Suspended, app is getting killed as it is not allowed to hold an active lock on a DB file.

### Testing Steps

This is actually impossible to trigger with debugger attached, and nearly impossible to trigger in general unless you prolong the operations - so just sanity check for the logic is needed here.

Current setup does not cancel the in flight requests in case of the timeout, assuming it will be extremely rare situation for that handler to be invoked.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)