### PR TITLE
Fixes an issue where entitlements are sometimes absent at startup.

### DIFF
--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/NetworkProtectionSubscriptionEventHandler.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/NetworkProtectionSubscriptionEventHandler.swift
@@ -45,6 +45,7 @@ final class NetworkProtectionSubscriptionEventHandler {
         subscribeToEntitlementChanges()
     }
 
+    @MainActor
     private var lastKnownEntitlementsExpired: Bool {
         get {
             userDefaults.networkProtectionEntitlementsExpired
@@ -88,8 +89,9 @@ final class NetworkProtectionSubscriptionEventHandler {
         }
     }
 
+    @MainActor
     private func handleEntitlementsChange(hasEntitlements: Bool, source: VPNSubscriptionStatusPixel.Source) async {
-        let isAuthV2Enabled = await NSApp.delegateTyped.isAuthV2Enabled
+        let isAuthV2Enabled = NSApp.delegateTyped.isAuthV2Enabled
         let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheOnly).isActive
 
         if hasEntitlements && lastKnownEntitlementsExpired {

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/NetworkProtectionSubscriptionEventHandler.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/NetworkProtectionSubscriptionEventHandler.swift
@@ -94,22 +94,57 @@ final class NetworkProtectionSubscriptionEventHandler {
         let isAuthV2Enabled = NSApp.delegateTyped.isAuthV2Enabled
         let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheOnly).isActive
 
-        if hasEntitlements && lastKnownEntitlementsExpired {
-            PixelKit.fire(
-                VPNSubscriptionStatusPixel.vpnFeatureEnabled(
-                    isSubscriptionActive: isSubscriptionActive,
-                    isAuthV2Enabled: isAuthV2Enabled,
-                    source: source),
-                frequency: .dailyAndCount)
-            lastKnownEntitlementsExpired = false
-        } else if !hasEntitlements && !lastKnownEntitlementsExpired {
-            PixelKit.fire(
-                VPNSubscriptionStatusPixel.vpnFeatureDisabled(
-                    isSubscriptionActive: isSubscriptionActive,
-                    isAuthV2Enabled: isAuthV2Enabled,
-                    source: source),
-                frequency: .dailyAndCount)
-            lastKnownEntitlementsExpired = true
+        // For source == .clientCheck we only fire pixels if there's an actual change, because they're not guaranteed
+        // to be executed only when there are changes - they'll run at every app launch.
+        //
+        // For source == .notification we assume the notifications are fired on actual changes, so we want to fire
+        // pixels without additiona checks.
+        //
+        switch source {
+        case .clientCheck:
+            if hasEntitlements && lastKnownEntitlementsExpired {
+                PixelKit.fire(
+                    VPNSubscriptionStatusPixel.vpnFeatureEnabled(
+                        isSubscriptionActive: isSubscriptionActive,
+                        isAuthV2Enabled: isAuthV2Enabled,
+                        source: source),
+                    frequency: .dailyAndCount)
+
+                lastKnownEntitlementsExpired = false
+            } else if !hasEntitlements && !lastKnownEntitlementsExpired {
+                PixelKit.fire(
+                    VPNSubscriptionStatusPixel.vpnFeatureDisabled(
+                        isSubscriptionActive: isSubscriptionActive,
+                        isAuthV2Enabled: isAuthV2Enabled,
+                        source: source),
+                    frequency: .dailyAndCount)
+
+                lastKnownEntitlementsExpired = true
+            }
+        case .notification:
+            if hasEntitlements {
+                PixelKit.fire(
+                    VPNSubscriptionStatusPixel.vpnFeatureEnabled(
+                        isSubscriptionActive: isSubscriptionActive,
+                        isAuthV2Enabled: isAuthV2Enabled,
+                        source: source),
+                    frequency: .dailyAndCount)
+
+                if lastKnownEntitlementsExpired {
+                    lastKnownEntitlementsExpired = false
+                }
+            } else if !hasEntitlements {
+                PixelKit.fire(
+                    VPNSubscriptionStatusPixel.vpnFeatureDisabled(
+                        isSubscriptionActive: isSubscriptionActive,
+                        isAuthV2Enabled: isAuthV2Enabled,
+                        source: source),
+                    frequency: .dailyAndCount)
+
+                if !lastKnownEntitlementsExpired {
+                    lastKnownEntitlementsExpired = true
+                }
+            }
         }
     }
 

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/NetworkProtectionSubscriptionEventHandler.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/NetworkProtectionSubscriptionEventHandler.swift
@@ -45,6 +45,16 @@ final class NetworkProtectionSubscriptionEventHandler {
         subscribeToEntitlementChanges()
     }
 
+    private var lastKnownEntitlementsExpired: Bool {
+        get {
+            userDefaults.networkProtectionEntitlementsExpired
+        }
+
+        set {
+            userDefaults.networkProtectionEntitlementsExpired = newValue
+        }
+    }
+
     private func subscribeToEntitlementChanges() {
         Task {
             let hasEntitlement = await subscriptionManager.isFeatureEnabledForUser(feature: .networkProtection)
@@ -82,23 +92,22 @@ final class NetworkProtectionSubscriptionEventHandler {
         let isAuthV2Enabled = await NSApp.delegateTyped.isAuthV2Enabled
         let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheOnly).isActive
 
-        if hasEntitlements {
+        if hasEntitlements && lastKnownEntitlementsExpired {
             PixelKit.fire(
                 VPNSubscriptionStatusPixel.vpnFeatureEnabled(
                     isSubscriptionActive: isSubscriptionActive,
                     isAuthV2Enabled: isAuthV2Enabled,
                     source: source),
                 frequency: .dailyAndCount)
-            UserDefaults.netP.networkProtectionEntitlementsExpired = false
-        } else {
+            lastKnownEntitlementsExpired = false
+        } else if !hasEntitlements && !lastKnownEntitlementsExpired {
             PixelKit.fire(
                 VPNSubscriptionStatusPixel.vpnFeatureDisabled(
                     isSubscriptionActive: isSubscriptionActive,
                     isAuthV2Enabled: isAuthV2Enabled,
                     source: source),
                 frequency: .dailyAndCount)
-            await tunnelController.stop()
-            UserDefaults.netP.networkProtectionEntitlementsExpired = true
+            lastKnownEntitlementsExpired = true
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210669615202799?focus=true

### Description

Fixes an issue where entitlements are sometimes absent at startup, which was causing a huge number of attempts to enable the login item to stop the VPN.

### Testing Steps

There are no steps to reproduce the original crash.

#### Test VPN without Subscription

1. Remove the subscription
3. Restart the App
4. Ensure VPN is disabled if it was previously enabled, or stays disabled if not (and the menu item doesn't come up).

#### Test VPN on AuthV1

1. Start on AuthV1
2. Enable the VPN
3. Restart the App
4. Ensure the VPN stays connected

#### Note about VPN on AuthV1 > AuthV2
This is disabling all features at first launch, but that's beyond scope for this PR.

#### Test VPN on AuthV2

1. Start on AuthV1
2. Enable the VPN
3. Restart the App
4. Ensure the VPN stays connected

### Impact and Risks

High impact, medium risk

#### What could go wrong?

Impact is likely high in a positive way.  RIsk is medium as it's sensitive code and any minor mistake could have consecuences in the VPN startup logic.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)