### PR TITLE
test paid duckai serp messages

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/iOS/PublicAPI/AIChatDebugSettingsHandling.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/iOS/PublicAPI/AIChatDebugSettingsHandling.swift
@@ -21,10 +21,13 @@ import Foundation
 
 public protocol AIChatDebugSettingsHandling {
     var messagePolicyHostname: String? { get set }
+    var customURL: String? { get set }
+    func reset()
 }
 
-public struct AIChatDebugSettings: AIChatDebugSettingsHandling {
-    private let userDefaultsKey = "aichat.debug.messagePolicyHostname"
+public class AIChatDebugSettings: AIChatDebugSettingsHandling {
+    private let hostnameUserDefaultsKey = "aichat.debug.messagePolicyHostname"
+    private let customURLUserDefaultsKey = "aichat.debug.customURL"
     private let userDefault: UserDefaults
 
     public init(userDefault: UserDefaults = .standard) {
@@ -33,16 +36,35 @@ public struct AIChatDebugSettings: AIChatDebugSettingsHandling {
 
     public var messagePolicyHostname: String? {
         get {
-            let value = userDefault.string(forKey: userDefaultsKey)
+            let value = userDefault.string(forKey: hostnameUserDefaultsKey)
             return value?.isEmpty == true ? nil : value
         }
         set {
             if let newValue = newValue, !newValue.isEmpty {
-                userDefault.set(newValue, forKey: userDefaultsKey)
+                userDefault.set(newValue, forKey: hostnameUserDefaultsKey)
             } else {
-                userDefault.removeObject(forKey: userDefaultsKey)
+                userDefault.removeObject(forKey: hostnameUserDefaultsKey)
             }
         }
+    }
+
+    public var customURL: String? {
+        get {
+            let value = userDefault.string(forKey: customURLUserDefaultsKey)
+            return value?.isEmpty == true ? nil : value
+        }
+        set {
+            if let newValue = newValue, !newValue.isEmpty {
+                userDefault.set(newValue, forKey: customURLUserDefaultsKey)
+            } else {
+                userDefault.removeObject(forKey: customURLUserDefaultsKey)
+            }
+        }
+    }
+
+    public func reset() {
+        messagePolicyHostname = nil
+        customURL = nil
     }
 }
 #endif

--- a/SharedPackages/AIChat/Sources/AIChat/iOS/PublicAPI/AIChatRequestAuthorizationHandling.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/iOS/PublicAPI/AIChatRequestAuthorizationHandling.swift
@@ -42,7 +42,7 @@ public struct AIChatRequestAuthorizationHandler: AIChatRequestAuthorizationHandl
     @MainActor
     public func shouldAllowRequestWithNavigationAction(_ navigationAction: WKNavigationAction) -> Bool {
         /// If we have debug settings, lets allow all requests since we might have redirects like Duo
-        if debugSettings.messagePolicyHostname?.isEmpty == false || debugSettings.customURL?.isEmpty == false {
+        if debugSettings.messagePolicyHostname?.isEmpty == false {
             return true
         }
         if let url = navigationAction.request.url {

--- a/SharedPackages/AIChat/Sources/AIChat/iOS/PublicAPI/AIChatRequestAuthorizationHandling.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/iOS/PublicAPI/AIChatRequestAuthorizationHandling.swift
@@ -42,7 +42,7 @@ public struct AIChatRequestAuthorizationHandler: AIChatRequestAuthorizationHandl
     @MainActor
     public func shouldAllowRequestWithNavigationAction(_ navigationAction: WKNavigationAction) -> Bool {
         /// If we have debug settings, lets allow all requests since we might have redirects like Duo
-        if debugSettings.messagePolicyHostname?.isEmpty == false {
+        if debugSettings.messagePolicyHostname?.isEmpty == false || debugSettings.customURL?.isEmpty == false {
             return true
         }
         if let url = navigationAction.request.url {

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatRequestAuthorizationHandlerTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatRequestAuthorizationHandlerTests.swift
@@ -22,6 +22,8 @@ import WebKit
 
 final class MockAIChatDebugSettings: AIChatDebugSettingsHandling {
     var messagePolicyHostname: String?
+    var customURL: String?
+    func reset() {}
 }
 
 final class AIChatRequestAuthorizationHandlerTests: XCTestCase {

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
@@ -120,9 +120,7 @@ final class SubscriptionUserScriptHandler: SubscriptionUserScriptHandling {
 ///
 public final class SubscriptionUserScript: NSObject, Subfeature {
 
-    private enum OriginDomains {
-        static let duckduckgo = "duckduckgo.com"
-    }
+    private let defaultOriginDomain = "duckduckgo.com"
 
     public enum MessageName: String, CaseIterable, Codable {
         case handshake

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
@@ -134,7 +134,7 @@ public final class SubscriptionUserScript: NSObject, Subfeature {
 
     public let featureName: String = "subscriptions"
     public lazy var messageOriginPolicy: MessageOriginPolicy = .only(rules: [
-        .exact(hostname: aiChatURL.host ?? OriginDomains.duckduckgo)
+        .exact(hostname: aiChatURL.host ?? defaultOriginDomain)
     ])
     public weak var broker: UserScriptMessageBroker?
 

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
@@ -120,6 +120,10 @@ final class SubscriptionUserScriptHandler: SubscriptionUserScriptHandling {
 ///
 public final class SubscriptionUserScript: NSObject, Subfeature {
 
+    private enum OriginDomains {
+        static let duckduckgo = "duckduckgo.com"
+    }
+
     public enum MessageName: String, CaseIterable, Codable {
         case handshake
         case subscriptionDetails
@@ -131,7 +135,9 @@ public final class SubscriptionUserScript: NSObject, Subfeature {
     }
 
     public let featureName: String = "subscriptions"
-    public let messageOriginPolicy: MessageOriginPolicy = .only(rules: [.exact(hostname: "duckduckgo.com")])
+    public lazy var messageOriginPolicy: MessageOriginPolicy = .only(rules: [
+        .exact(hostname: aiChatURL.host ?? OriginDomains.duckduckgo)
+    ])
     public weak var broker: UserScriptMessageBroker?
 
     public func handler(forMethodNamed methodName: String) -> Subfeature.Handler? {
@@ -155,18 +161,24 @@ public final class SubscriptionUserScript: NSObject, Subfeature {
         }
     }
 
+    private let aiChatURL: URL
+
     public convenience init(platform: DataModel.Platform,
                             subscriptionManager: any SubscriptionAuthV1toV2Bridge,
                             paidAIChatFlagStatusProvider: @escaping () -> Bool,
-                            navigationDelegate: SubscriptionUserScriptNavigationDelegate?) {
+                            navigationDelegate: SubscriptionUserScriptNavigationDelegate?,
+                            aiChatURL: URL) {
         self.init(handler: SubscriptionUserScriptHandler(platform: platform,
                                                          subscriptionManager: subscriptionManager,
                                                          paidAIChatFlagStatusProvider: paidAIChatFlagStatusProvider,
-                                                         navigationDelegate: navigationDelegate))
+                                                         navigationDelegate: navigationDelegate),
+                  aiChatURL: aiChatURL)
     }
 
-    init(handler: SubscriptionUserScriptHandling) {
+    init(handler: SubscriptionUserScriptHandling, aiChatURL: URL) {
         self.handler = handler
+        self.aiChatURL = aiChatURL
+        super.init()
     }
 
     let handler: SubscriptionUserScriptHandling

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
@@ -134,7 +134,7 @@ public final class SubscriptionUserScript: NSObject, Subfeature {
 
     public let featureName: String = "subscriptions"
     public var messageOriginPolicy: MessageOriginPolicy {
-        var rules: [HostnameMatchingRule] = [.exact(hostname: "duckduckgo.com")]
+        var rules: [HostnameMatchingRule] = [.exact(hostname: defaultOriginDomain)]
         if let debugHost {
             rules.append(.exact(hostname: debugHost))
         }
@@ -143,7 +143,6 @@ public final class SubscriptionUserScript: NSObject, Subfeature {
     public weak var broker: UserScriptMessageBroker?
 
     public func handler(forMethodNamed methodName: String) -> Subfeature.Handler? {
-        print("METHOD: \(methodName)")
         switch MessageName(rawValue: methodName) {
         case .handshake:
             return handler.handshake

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
@@ -133,12 +133,17 @@ public final class SubscriptionUserScript: NSObject, Subfeature {
     }
 
     public let featureName: String = "subscriptions"
-    public lazy var messageOriginPolicy: MessageOriginPolicy = .only(rules: [
-        .exact(hostname: aiChatURL.host ?? defaultOriginDomain)
-    ])
+    public var messageOriginPolicy: MessageOriginPolicy {
+        var rules: [HostnameMatchingRule] = [.exact(hostname: "duckduckgo.com")]
+        if let debugHost {
+            rules.append(.exact(hostname: debugHost))
+        }
+        return .only(rules: rules)
+    }
     public weak var broker: UserScriptMessageBroker?
 
     public func handler(forMethodNamed methodName: String) -> Subfeature.Handler? {
+        print("METHOD: \(methodName)")
         switch MessageName(rawValue: methodName) {
         case .handshake:
             return handler.handshake
@@ -159,23 +164,23 @@ public final class SubscriptionUserScript: NSObject, Subfeature {
         }
     }
 
-    private let aiChatURL: URL
+    private let debugHost: String?
 
     public convenience init(platform: DataModel.Platform,
                             subscriptionManager: any SubscriptionAuthV1toV2Bridge,
                             paidAIChatFlagStatusProvider: @escaping () -> Bool,
                             navigationDelegate: SubscriptionUserScriptNavigationDelegate?,
-                            aiChatURL: URL) {
+                            debugHost: String?) {
         self.init(handler: SubscriptionUserScriptHandler(platform: platform,
                                                          subscriptionManager: subscriptionManager,
                                                          paidAIChatFlagStatusProvider: paidAIChatFlagStatusProvider,
                                                          navigationDelegate: navigationDelegate),
-                  aiChatURL: aiChatURL)
+                  debugHost: debugHost)
     }
 
-    init(handler: SubscriptionUserScriptHandling, aiChatURL: URL) {
+    init(handler: SubscriptionUserScriptHandling, debugHost: String?) {
         self.handler = handler
-        self.aiChatURL = aiChatURL
+        self.debugHost = debugHost
         super.init()
     }
 

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionUserScript/SubscriptionUserScriptTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionUserScript/SubscriptionUserScriptTests.swift
@@ -29,7 +29,7 @@ final class SubscriptionUserScriptTests: XCTestCase {
 
     override func setUp() async throws {
         handler = MockSubscriptionUserScriptHandler()
-        userScript = SubscriptionUserScript(handler: handler)
+        userScript = SubscriptionUserScript(handler: handler, aiChatURL: URL(string: "https://duck.ai")!)
     }
 
     func testThatPublicInitializerSetsUpHandlerWithCorrectArguments() throws {
@@ -37,7 +37,8 @@ final class SubscriptionUserScriptTests: XCTestCase {
         userScript = SubscriptionUserScript(platform: .ios,
                                           subscriptionManager: subscriptionManager,
                                           paidAIChatFlagStatusProvider: { false },
-                                          navigationDelegate: nil)
+                                          navigationDelegate: nil,
+                                          aiChatURL: URL(string: "https://duck.ai")!)
         let messageHandler = try XCTUnwrap(userScript.handler as? SubscriptionUserScriptHandler)
         XCTAssertEqual(messageHandler.platform, .ios)
         XCTAssertIdentical(messageHandler.subscriptionManager as AnyObject, subscriptionManager)

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionUserScript/SubscriptionUserScriptTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionUserScript/SubscriptionUserScriptTests.swift
@@ -29,16 +29,16 @@ final class SubscriptionUserScriptTests: XCTestCase {
 
     override func setUp() async throws {
         handler = MockSubscriptionUserScriptHandler()
-        userScript = SubscriptionUserScript(handler: handler, aiChatURL: URL(string: "https://duck.ai")!)
+        userScript = SubscriptionUserScript(handler: handler, debugHost: nil)
     }
 
     func testThatPublicInitializerSetsUpHandlerWithCorrectArguments() throws {
         let subscriptionManager = SubscriptionAuthV1toV2BridgeMock()
         userScript = SubscriptionUserScript(platform: .ios,
-                                          subscriptionManager: subscriptionManager,
-                                          paidAIChatFlagStatusProvider: { false },
-                                          navigationDelegate: nil,
-                                          aiChatURL: URL(string: "https://duck.ai")!)
+                                            subscriptionManager: subscriptionManager,
+                                            paidAIChatFlagStatusProvider: { false },
+                                            navigationDelegate: nil,
+                                            debugHost: nil)
         let messageHandler = try XCTUnwrap(userScript.handler as? SubscriptionUserScriptHandler)
         XCTAssertEqual(messageHandler.platform, .ios)
         XCTAssertIdentical(messageHandler.subscriptionManager as AnyObject, subscriptionManager)

--- a/iOS/DuckDuckGo/AIChat/AIChatSettings.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatSettings.swift
@@ -44,6 +44,7 @@ struct AIChatSettings: AIChatSettingsProvider {
     }
 
     private let privacyConfigurationManager: PrivacyConfigurationManaging
+    private let debugSettings: AIChatDebugSettingsHandling
     private var remoteSettings: PrivacyConfigurationData.PrivacyFeature.FeatureSettings {
         privacyConfigurationManager.privacyConfig.settings(for: .aiChat)
     }
@@ -51,10 +52,12 @@ struct AIChatSettings: AIChatSettingsProvider {
     private let notificationCenter: NotificationCenter
     private let featureFlagger: FeatureFlagger
     init(privacyConfigurationManager: PrivacyConfigurationManaging = ContentBlocking.shared.privacyConfigurationManager,
+         debugSettings: AIChatDebugSettingsHandling = AIChatDebugSettings(),
          userDefaults: UserDefaults = .standard,
          notificationCenter: NotificationCenter = .default,
          featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger) {
         self.privacyConfigurationManager = privacyConfigurationManager
+        self.debugSettings = debugSettings
         self.userDefaults = userDefaults
         self.notificationCenter = notificationCenter
         self.featureFlagger = featureFlagger
@@ -63,6 +66,13 @@ struct AIChatSettings: AIChatSettingsProvider {
     // MARK: - Public
 
     var aiChatURL: URL {
+        // 1. First check for debug URL override
+        if let debugURL = debugSettings.customURL,
+           let url = URL(string: debugURL) {
+            return url
+        }
+        
+        // 2. Then check remote configuration
         guard let url = URL(string: getSettingsData(.aiChatURL)) else {
             return URL(string: SettingsValue.aiChatURL.defaultValue)!
         }

--- a/iOS/DuckDuckGo/AIChatDebugView.swift
+++ b/iOS/DuckDuckGo/AIChatDebugView.swift
@@ -32,6 +32,16 @@ struct AIChatDebugView: View {
                     Text("Message policy hostname")
                 }
             }
+            
+            Section(footer: Text("Custom URL: \(viewModel.customURL.isEmpty ? "Default" : viewModel.customURL)")) {
+                NavigationLink(destination: AIChatDebugURLEntryView(viewModel: viewModel)) {
+                    Text("Set Custom AI Chat URL")
+                }
+                Button("Reset Custom URL") {
+                    viewModel.resetCustomURL()
+                }
+                .foregroundColor(.red)
+            }
         }
         .navigationTitle("AI Chat")
     }
@@ -46,12 +56,29 @@ private final class AIChatDebugViewModel: ObservableObject {
         }
     }
 
+    @Published var customURL: String {
+        didSet {
+            debugSettings.customURL = customURL.isEmpty ? nil : customURL
+        }
+    }
+
     init() {
         self.enteredHostname = debugSettings.messagePolicyHostname ?? ""
+        self.customURL = debugSettings.customURL ?? ""
     }
 
     func resetHostname() {
         enteredHostname = ""
+    }
+
+    func resetCustomURL() {
+        customURL = ""
+    }
+
+    func resetAll() {
+        debugSettings.reset()
+        enteredHostname = ""
+        customURL = ""
     }
 }
 
@@ -86,6 +113,54 @@ private struct AIChatDebugHostnameEntryView: View {
         .onAppear {
             policyHostname = viewModel.enteredHostname
         }
+    }
+}
+
+private struct AIChatDebugURLEntryView: View {
+    @ObservedObject var viewModel: AIChatDebugViewModel
+    @State private var customURLText: String = ""
+    @Environment(\.presentationMode) var presentationMode
+
+    var body: some View {
+        Form {
+            Section(header: Text("Custom AI Chat URL"),
+                    footer: Text("Enter a full URL like https://duck.ai or https://euw-serp-dev-testing10.duck.co")) {
+                TextField("https://duck.ai", text: $customURLText)
+                    .autocorrectionDisabled(true)
+                    .textInputAutocapitalization(.never)
+                    .keyboardType(.URL)
+            }
+            
+            Section {
+                Button {
+                    if isValidURL(customURLText) {
+                        viewModel.customURL = customURLText
+                        presentationMode.wrappedValue.dismiss()
+                    }
+                } label: {
+                    Text("Save")
+                }
+                .disabled(!isValidURL(customURLText))
+
+                Button {
+                    viewModel.resetCustomURL()
+                    customURLText = ""
+                    presentationMode.wrappedValue.dismiss()
+                } label: {
+                    Text("Reset to Default")
+                }
+                .foregroundColor(.red)
+            }
+        }
+        .navigationTitle("Custom AI Chat URL")
+        .onAppear {
+            customURLText = viewModel.customURL
+        }
+    }
+    
+    private func isValidURL(_ string: String) -> Bool {
+        if string.isEmpty { return true } // Allow empty to reset
+        return URL(string: string) != nil && (string.hasPrefix("http://") || string.hasPrefix("https://"))
     }
 }
 

--- a/iOS/DuckDuckGo/AIChatDebugView.swift
+++ b/iOS/DuckDuckGo/AIChatDebugView.swift
@@ -123,8 +123,7 @@ private struct AIChatDebugURLEntryView: View {
 
     var body: some View {
         Form {
-            Section(header: Text("Custom AI Chat URL"),
-                    footer: Text("Enter a full URL like https://duck.ai or https://euw-serp-dev-testing10.duck.co")) {
+            Section(header: Text(verbatim: "Custom AI Chat URL")) {
                 TextField("https://duck.ai", text: $customURLText)
                     .autocorrectionDisabled(true)
                     .textInputAutocapitalization(.never)
@@ -138,7 +137,7 @@ private struct AIChatDebugURLEntryView: View {
                         presentationMode.wrappedValue.dismiss()
                     }
                 } label: {
-                    Text("Save")
+                    Text(verbatim: "Save")
                 }
                 .disabled(!isValidURL(customURLText))
 
@@ -147,7 +146,7 @@ private struct AIChatDebugURLEntryView: View {
                     customURLText = ""
                     presentationMode.wrappedValue.dismiss()
                 } label: {
-                    Text("Reset to Default")
+                    Text(verbatim: "Reset to Default")
                 }
                 .foregroundColor(.red)
             }

--- a/iOS/DuckDuckGo/AIChatDebugView.swift
+++ b/iOS/DuckDuckGo/AIChatDebugView.swift
@@ -59,6 +59,12 @@ private final class AIChatDebugViewModel: ObservableObject {
     @Published var customURL: String {
         didSet {
             debugSettings.customURL = customURL.isEmpty ? nil : customURL
+            // Update the hostname in the UI when URL changes
+            if customURL.isEmpty {
+                enteredHostname = ""
+            } else if let url = URL(string: customURL), let host = url.host {
+                enteredHostname = host
+            }
         }
     }
 

--- a/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
@@ -897,8 +897,7 @@ final class DefaultSubscriptionPagesUseSubscriptionFeatureV2: SubscriptionPagesU
         case .identityTheftRestorationGlobal:
             onFeatureSelected?(.identityTheftRestorationGlobal)
         case .paidAIChat:
-            // Follow up: Implement paidAIChat selection
-            break
+            onFeatureSelected?(.paidAIChat)
         case .unknown:
             break
         }

--- a/iOS/DuckDuckGo/UserScripts.swift
+++ b/iOS/DuckDuckGo/UserScripts.swift
@@ -88,7 +88,7 @@ final class UserScripts: UserScriptsProvider {
             subscriptionManager: AppDependencyProvider.shared.subscriptionAuthV1toV2Bridge,
             paidAIChatFlagStatusProvider: { featureFlagger.isFeatureOn(.paidAIChat) },
             navigationDelegate: subscriptionNavigationHandler,
-            aiChatURL: AIChatSettings().aiChatURL)
+            debugHost: aiChatDebugSettings.messagePolicyHostname)
         contentScopeUserScriptIsolated.registerSubfeature(delegate: aiChatUserScript)
         contentScopeUserScriptIsolated.registerSubfeature(delegate: subscriptionUserScript)
 

--- a/iOS/DuckDuckGo/UserScripts.swift
+++ b/iOS/DuckDuckGo/UserScripts.swift
@@ -87,7 +87,8 @@ final class UserScripts: UserScriptsProvider {
             platform: .ios,
             subscriptionManager: AppDependencyProvider.shared.subscriptionAuthV1toV2Bridge,
             paidAIChatFlagStatusProvider: { featureFlagger.isFeatureOn(.paidAIChat) },
-            navigationDelegate: subscriptionNavigationHandler)
+            navigationDelegate: subscriptionNavigationHandler,
+            aiChatURL: AIChatSettings().aiChatURL)
         contentScopeUserScriptIsolated.registerSubfeature(delegate: aiChatUserScript)
         contentScopeUserScriptIsolated.registerSubfeature(delegate: subscriptionUserScript)
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatSettingsTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatSettingsTests.swift
@@ -22,6 +22,7 @@ import XCTest
 @testable import DuckDuckGo
 import BrowserServicesKit
 import Combine
+import AIChat
 
 class AIChatSettingsTests: XCTestCase {
 
@@ -29,6 +30,7 @@ class AIChatSettingsTests: XCTestCase {
     private var mockUserDefaults: UserDefaults!
     private var mockNotificationCenter: NotificationCenter!
     private var mockFeatureFlagger: FeatureFlagger!
+    private var mockAIChatDebugSettings: MockAIChatDebugSettings!
 
     override func setUp() {
         super.setUp()
@@ -36,6 +38,7 @@ class AIChatSettingsTests: XCTestCase {
         mockUserDefaults = UserDefaults(suiteName: "TestDefaults")
         mockNotificationCenter = NotificationCenter()
         mockFeatureFlagger = MockFeatureFlagger()
+        mockAIChatDebugSettings = MockAIChatDebugSettings()
     }
 
     override func tearDown() {
@@ -49,6 +52,7 @@ class AIChatSettingsTests: XCTestCase {
 
     func testAIChatURLReturnsDefaultWhenRemoteSettingsMissing() {
         let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
+                                      debugSettings: mockAIChatDebugSettings,
                                       userDefaults: mockUserDefaults,
                                       notificationCenter: mockNotificationCenter)
 
@@ -60,6 +64,7 @@ class AIChatSettingsTests: XCTestCase {
 
     func testAIChatURLReturnsRemoteSettingWhenAvailable() {
         let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
+                                      debugSettings: mockAIChatDebugSettings,
                                       userDefaults: mockUserDefaults,
                                       notificationCenter: mockNotificationCenter)
 
@@ -71,8 +76,21 @@ class AIChatSettingsTests: XCTestCase {
         XCTAssertEqual(settings.aiChatURL, URL(string: remoteURL))
     }
 
+    func testAIChatURLReturnsOverriddenSettingWhenAvailable() {
+        let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
+                                      debugSettings: mockAIChatDebugSettings,
+                                      userDefaults: mockUserDefaults,
+                                      notificationCenter: mockNotificationCenter)
+
+        let override = "https://override.com/ai-chat"
+        mockAIChatDebugSettings.customURL = override
+
+        XCTAssertEqual(settings.aiChatURL, URL(string: override))
+    }
+
     func testEnableAIChatBrowsingMenuUserSettings() {
         let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
+                                      debugSettings: mockAIChatDebugSettings,
                                       userDefaults: mockUserDefaults,
                                       notificationCenter: mockNotificationCenter)
 
@@ -85,6 +103,7 @@ class AIChatSettingsTests: XCTestCase {
 
     func testEnableAIChatAddressBarUserSettings() {
         let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
+                                      debugSettings: mockAIChatDebugSettings,
                                       userDefaults: mockUserDefaults,
                                       notificationCenter: mockNotificationCenter)
 
@@ -97,6 +116,7 @@ class AIChatSettingsTests: XCTestCase {
 
     func testNotificationPostedWhenSettingsChange() {
         let settings = AIChatSettings(privacyConfigurationManager: mockPrivacyConfigurationManager,
+                                      debugSettings: mockAIChatDebugSettings,
                                       userDefaults: mockUserDefaults,
                                       notificationCenter: mockNotificationCenter)
 
@@ -111,4 +131,10 @@ class AIChatSettingsTests: XCTestCase {
         mockNotificationCenter.removeObserver(observer)
     }
 
+}
+
+final class MockAIChatDebugSettings: AIChatDebugSettingsHandling {
+    var messagePolicyHostname: String?
+    var customURL: String?
+    func reset() {}
 }

--- a/macOS/DuckDuckGo/AIChat/AIChatRemoteSettings.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatRemoteSettings.swift
@@ -43,12 +43,15 @@ struct AIChatRemoteSettings: AIChatRemoteSettingsProvider {
     }
 
     private let privacyConfigurationManager: PrivacyConfigurationManaging
+    private let debugURLSettings: AIChatDebugURLSettingsRepresentable
     private var settings: PrivacyConfigurationData.PrivacyFeature.FeatureSettings {
         privacyConfigurationManager.privacyConfig.settings(for: .aiChat)
     }
 
-    init(privacyConfigurationManager: PrivacyConfigurationManaging = Application.appDelegate.privacyFeatures.contentBlocking.privacyConfigurationManager) {
+    init(privacyConfigurationManager: PrivacyConfigurationManaging = Application.appDelegate.privacyFeatures.contentBlocking.privacyConfigurationManager,
+         debugURLSettings: AIChatDebugURLSettingsRepresentable = AIChatDebugURLSettings()) {
         self.privacyConfigurationManager = privacyConfigurationManager
+        self.debugURLSettings = debugURLSettings
     }
 
     // MARK: - Public
@@ -59,6 +62,13 @@ struct AIChatRemoteSettings: AIChatRemoteSettingsProvider {
     var aiChatURLIdentifiableQueryValue: String { getSettingsData(.aiChatURLIdentifiableQueryValue) }
 
     var aiChatURL: URL {
+        // 1. First check for debug URL override
+        if let debugURL = debugURLSettings.customURL,
+           let url = URL(string: debugURL) {
+            return url
+        }
+        
+        // 2. Then check remote configuration
         guard let url = URL(string: getSettingsData(.aiChatURL)) else {
             return URL(string: SettingsValue.aiChatURL.defaultValue)!
         }

--- a/macOS/DuckDuckGo/AIChat/AIChatRemoteSettings.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatRemoteSettings.swift
@@ -67,7 +67,7 @@ struct AIChatRemoteSettings: AIChatRemoteSettingsProvider {
            let url = URL(string: debugURL) {
             return url
         }
-        
+
         // 2. Then check remote configuration
         guard let url = URL(string: getSettingsData(.aiChatURL)) else {
             return URL(string: SettingsValue.aiChatURL.defaultValue)!

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -1735,7 +1735,7 @@ extension NavigationBarViewController: OptionsButtonMenuDelegate {
     }
 
     func optionsButtonMenuRequestedPaidAIChat(_ menu: NSMenu) {
-        let aiChatURL = URL(string: AIChatRemoteSettings.SettingsValue.aiChatURL.defaultValue)!
+        let aiChatURL = AIChatRemoteSettings().aiChatURL
         showTab(.aiChat(aiChatURL))
     }
 

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesRootView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesRootView.swift
@@ -451,7 +451,7 @@ enum Preferences {
                      switch event {
                      case .openAIC:
                          PixelKit.fire(PrivacyProPixel.privacyProPaidAIChatSettings)
-                         let aiChatURL = URL(string: AIChatRemoteSettings.SettingsValue.aiChatURL.defaultValue)!
+                         let aiChatURL = AIChatRemoteSettings().aiChatURL
                          showTab(.url(aiChatURL, source: .ui))
                      case .openURL(let url):
                          openURL(subscriptionURL: url)

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesRootView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesRootView.swift
@@ -25,6 +25,7 @@ import BrowserServicesKit
 import PixelKit
 import Subscription
 import SubscriptionUI
+import AIChat
 
 enum Preferences {
 
@@ -286,11 +287,13 @@ enum Preferences {
         let subscriptionUIHandler: SubscriptionUIHandling
         let visualStyle: VisualStyleProviding
         let showTab: @MainActor (Tab.TabContent) -> Void
+        let aiChatURLSettings: AIChatRemoteSettingsProvider
 
         init(
             model: PreferencesSidebarModel,
             subscriptionManager: SubscriptionManagerV2,
             subscriptionUIHandler: SubscriptionUIHandling,
+            aiChatURLSettings: AIChatRemoteSettingsProvider,
             showTab: @escaping @MainActor (Tab.TabContent) -> Void = { Application.appDelegate.windowControllersManager.showTab(with: $0) },
             visualStyle: VisualStyleProviding = NSApp.delegateTyped.visualStyle
         ) {
@@ -299,6 +302,7 @@ enum Preferences {
             self.subscriptionUIHandler = subscriptionUIHandler
             self.showTab = showTab
             self.visualStyle = visualStyle
+            self.aiChatURLSettings = aiChatURLSettings
             self.purchaseSubscriptionModel = makePurchaseSubscriptionViewModel()
             self.personalInformationRemovalModel = makePersonalInformationRemovalViewModel()
             self.paidAIChatModel = makePaidAIChatViewModel()
@@ -451,7 +455,7 @@ enum Preferences {
                      switch event {
                      case .openAIC:
                          PixelKit.fire(PrivacyProPixel.privacyProPaidAIChatSettings)
-                         let aiChatURL = AIChatRemoteSettings().aiChatURL
+                         let aiChatURL = aiChatURLSettings.aiChatURL
                          showTab(.url(aiChatURL, source: .ui))
                      case .openURL(let url):
                          openURL(subscriptionURL: url)

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesViewController.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesViewController.swift
@@ -33,6 +33,7 @@ final class PreferencesViewController: NSViewController {
     let model: PreferencesSidebarModel
     let tabCollectionViewModel: TabCollectionViewModel
     let privacyConfigurationManager: PrivacyConfigurationManaging
+    let aiChatRemoteSettings: AIChatRemoteSettingsProvider
     private var selectedTabContentCancellable: AnyCancellable?
     private var selectedPreferencePaneCancellable: AnyCancellable?
 
@@ -49,6 +50,7 @@ final class PreferencesViewController: NSViewController {
     ) {
         self.tabCollectionViewModel = tabCollectionViewModel
         self.privacyConfigurationManager = privacyConfigurationManager
+        self.aiChatRemoteSettings = aiChatRemoteSettings
         model = PreferencesSidebarModel(privacyConfigurationManager: privacyConfigurationManager,
                                         featureFlagger: featureFlagger,
                                         syncService: syncService,
@@ -79,7 +81,8 @@ final class PreferencesViewController: NSViewController {
         } else {
             let prefRootView = Preferences.RootViewV2(model: model,
                                                       subscriptionManager: Application.appDelegate.subscriptionManagerV2!,
-                                                      subscriptionUIHandler: Application.appDelegate.subscriptionUIHandler)
+                                                      subscriptionUIHandler: Application.appDelegate.subscriptionUIHandler,
+                                                      aiChatURLSettings: aiChatRemoteSettings)
             let host = NSHostingView(rootView: prefRootView)
             view.addAndLayout(host)
         }

--- a/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeatureV2.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeatureV2.swift
@@ -82,7 +82,8 @@ final class SubscriptionPagesUseSubscriptionFeatureV2: Subfeature {
                 freemiumDBPUserStateManager: FreemiumDBPUserStateManager = DefaultFreemiumDBPUserStateManager(userDefaults: .dbp),
                 notificationCenter: NotificationCenter = .default,
                 dataBrokerProtectionFreemiumPixelHandler: EventMapping<DataBrokerProtectionFreemiumPixels> = DataBrokerProtectionFreemiumPixelHandler(),
-                featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger) {
+                featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
+                aiChatURL: URL) {
         self.subscriptionManager = subscriptionManager
         self.stripePurchaseFlow = stripePurchaseFlow
         self.subscriptionSuccessPixelHandler = subscriptionSuccessPixelHandler

--- a/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeatureV2.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeatureV2.swift
@@ -393,7 +393,7 @@ final class SubscriptionPagesUseSubscriptionFeatureV2: Subfeature {
             await uiHandler.showTab(with: .identityTheftRestoration(url))
         case .paidAIChat:
             PixelKit.fire(PrivacyProPixel.privacyProWelcomeAIChat, frequency: .uniqueByName)
-            let aiChatURL = URL(string: AIChatRemoteSettings.SettingsValue.aiChatURL.defaultValue)!
+            let aiChatURL = AIChatRemoteSettings().aiChatURL
             await uiHandler.showTab(with: .aiChat(aiChatURL))
         case .unknown:
             break

--- a/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeatureV2.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeatureV2.swift
@@ -73,6 +73,7 @@ final class SubscriptionPagesUseSubscriptionFeatureV2: Subfeature {
     private let dataBrokerProtectionFreemiumPixelHandler: EventMapping<DataBrokerProtectionFreemiumPixels>
 
     private let featureFlagger: FeatureFlagger
+    private let aiChatURL: URL
 
     public init(subscriptionManager: SubscriptionManagerV2,
                 subscriptionSuccessPixelHandler: SubscriptionAttributionPixelHandler = PrivacyProSubscriptionAttributionPixelHandler(),
@@ -88,6 +89,7 @@ final class SubscriptionPagesUseSubscriptionFeatureV2: Subfeature {
         self.stripePurchaseFlow = stripePurchaseFlow
         self.subscriptionSuccessPixelHandler = subscriptionSuccessPixelHandler
         self.uiHandler = uiHandler
+        self.aiChatURL = aiChatURL
         self.subscriptionFeatureAvailability = subscriptionFeatureAvailability
         self.freemiumDBPUserStateManager = freemiumDBPUserStateManager
         self.notificationCenter = notificationCenter
@@ -394,7 +396,6 @@ final class SubscriptionPagesUseSubscriptionFeatureV2: Subfeature {
             await uiHandler.showTab(with: .identityTheftRestoration(url))
         case .paidAIChat:
             PixelKit.fire(PrivacyProPixel.privacyProWelcomeAIChat, frequency: .uniqueByName)
-            let aiChatURL = AIChatRemoteSettings().aiChatURL
             await uiHandler.showTab(with: .aiChat(aiChatURL))
         case .unknown:
             break

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -61,14 +61,15 @@ final class UserScripts: UserScriptsProvider {
         clickToLoadScript = ClickToLoadUserScript()
         contentBlockerRulesScript = ContentBlockerRulesUserScript(configuration: sourceProvider.contentBlockerRulesConfig!)
         surrogatesScript = SurrogatesUserScript(configuration: sourceProvider.surrogatesConfig!)
+        let aiChatDebugURLSettings = AIChatDebugURLSettings()
         aiChatUserScript = AIChatUserScript(handler: AIChatUserScriptHandler(storage: DefaultAIChatPreferencesStorage()),
-                                            urlSettings: AIChatDebugURLSettings())
+                                            urlSettings: aiChatDebugURLSettings)
         subscriptionUserScript = SubscriptionUserScript(
             platform: .macos,
             subscriptionManager: NSApp.delegateTyped.subscriptionAuthV1toV2Bridge,
             paidAIChatFlagStatusProvider: { NSApp.delegateTyped.featureFlagger.isFeatureOn(.paidAIChat) },
             navigationDelegate: NSApp.delegateTyped.subscriptionNavigationCoordinator,
-            aiChatURL: AIChatRemoteSettings().aiChatURL
+            debugHost: aiChatDebugURLSettings.customURLHostname
         )
 
         let isGPCEnabled = WebTrackingProtectionPreferences.shared.isGPCEnabled

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -67,7 +67,8 @@ final class UserScripts: UserScriptsProvider {
             platform: .macos,
             subscriptionManager: NSApp.delegateTyped.subscriptionAuthV1toV2Bridge,
             paidAIChatFlagStatusProvider: { NSApp.delegateTyped.featureFlagger.isFeatureOn(.paidAIChat) },
-            navigationDelegate: NSApp.delegateTyped.subscriptionNavigationCoordinator
+            navigationDelegate: NSApp.delegateTyped.subscriptionNavigationCoordinator,
+            aiChatURL: AIChatRemoteSettings().aiChatURL
         )
 
         let isGPCEnabled = WebTrackingProtectionPreferences.shared.isGPCEnabled

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -178,7 +178,8 @@ final class UserScripts: UserScriptsProvider {
             let stripePurchaseFlow = DefaultStripePurchaseFlowV2(subscriptionManager: subscriptionManager)
             delegate = SubscriptionPagesUseSubscriptionFeatureV2(subscriptionManager: subscriptionManager,
                                                                  stripePurchaseFlow: stripePurchaseFlow,
-                                                                 uiHandler: Application.appDelegate.subscriptionUIHandler)
+                                                                 uiHandler: Application.appDelegate.subscriptionUIHandler,
+                                                                 aiChatURL: AIChatRemoteSettings().aiChatURL)
         }
 
         subscriptionPagesUserScript.registerSubfeature(delegate: delegate)

--- a/macOS/UnitTests/AIChat/AIChatRemoteSettingsTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatRemoteSettingsTests.swift
@@ -25,18 +25,20 @@ import BrowserServicesKit
 class AIChatRemoteSettingsTests: XCTestCase {
     var mockPrivacyConfigurationManager: MockPrivacyConfigurationManager!
     var aiChatRemoteSettings: AIChatRemoteSettings!
+    var debugURLProvider: AIChatDebugURLSettingsRepresentable!
 
     private func setupAIChatRemoteSettings(with config: MockConfig) -> AIChatRemoteSettings {
         let embeddedDataProvider = MockEmbeddedDataProvider()
         embeddedDataProvider.embeddedDataEtag = "12345"
         embeddedDataProvider.embeddedData = config.embeddedData
+        debugURLProvider = AIChatMockDebugSettings()
 
         let manager = PrivacyConfigurationManager(fetchedETag: nil,
                                                   fetchedData: nil,
                                                   embeddedDataProvider: embeddedDataProvider,
                                                   localProtection: MockDomainsProtectionStore(),
                                                   internalUserDecider: MockInternalUserDecider())
-        return AIChatRemoteSettings(privacyConfigurationManager: manager)
+        return AIChatRemoteSettings(privacyConfigurationManager: manager, debugURLSettings: debugURLProvider)
     }
 
     func testValidRemoteURL_ThenConfigUsesRemoteURL() {
@@ -44,6 +46,15 @@ class AIChatRemoteSettingsTests: XCTestCase {
         config.embeddedData = config.configWithSettings
         aiChatRemoteSettings = setupAIChatRemoteSettings(with: config)
         XCTAssertEqual(config.aiChatURL, aiChatRemoteSettings.aiChatURL.absoluteString)
+    }
+
+    func testValidCustomURL_ThenConfigUsesCutomURL() {
+        var config = MockConfig()
+        config.embeddedData = config.configWithSettings
+        aiChatRemoteSettings = setupAIChatRemoteSettings(with: config)
+        let customURL = "https://example.com"
+        debugURLProvider.customURL = customURL
+        XCTAssertEqual(customURL, aiChatRemoteSettings.aiChatURL.absoluteString)
     }
 
     func testInvalidRemoteURL_ThenConfigUsesDefaultURL() {

--- a/macOS/UnitTests/AIChat/AIChatRemoteSettingsTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatRemoteSettingsTests.swift
@@ -48,7 +48,7 @@ class AIChatRemoteSettingsTests: XCTestCase {
         XCTAssertEqual(config.aiChatURL, aiChatRemoteSettings.aiChatURL.absoluteString)
     }
 
-    func testValidCustomURL_ThenConfigUsesCutomURL() {
+    func testValidCustomURL_ThenConfigUsesCustomURL() {
         var config = MockConfig()
         config.embeddedData = config.configWithSettings
         aiChatRemoteSettings = setupAIChatRemoteSettings(with: config)

--- a/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
@@ -163,7 +163,7 @@ final class MockAIChatUserScriptHandler: AIChatUserScriptHandling {
     }
 }
 
-private final class AIChatMockDebugSettings: AIChatDebugURLSettingsRepresentable {
+final class AIChatMockDebugSettings: AIChatDebugURLSettingsRepresentable {
     var customURLHostname: String?
     var customURL: String?
     func reset() { }

--- a/macOS/UnitTests/Preferences/RootViewV2Tests.swift
+++ b/macOS/UnitTests/Preferences/RootViewV2Tests.swift
@@ -57,6 +57,7 @@ final class RootViewV2Tests: XCTestCase {
             model: sidebarModel,
             subscriptionManager: subscriptionManager,
             subscriptionUIHandler: subscriptionUIHandler,
+            aiChatURLSettings: MockRemoteAISettings(),
             showTab: {_ in },
             )
 
@@ -67,12 +68,13 @@ final class RootViewV2Tests: XCTestCase {
 
     func testPaidAIChatViewModel_OpenAIChat() throws {
         let expectation = expectation(description: "Wait for showTab to be called")
-
+        let mockRemoteAISettings = MockRemoteAISettings()
         // Given
         let rootView = Preferences.RootViewV2(
             model: sidebarModel,
             subscriptionManager: subscriptionManager,
-            subscriptionUIHandler: subscriptionUIHandler
+            subscriptionUIHandler: subscriptionUIHandler,
+            aiChatURLSettings: MockRemoteAISettings()
         ) { content in
             self.showTabCalled = true
             self.showTabContent = content
@@ -88,7 +90,7 @@ final class RootViewV2Tests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
         XCTAssertTrue(showTabCalled, "Should call showTab")
         if case .url(let url, _, let source) = showTabContent {
-            XCTAssertEqual(url.absoluteString, AIChatRemoteSettings.SettingsValue.aiChatURL.defaultValue)
+            XCTAssertEqual(url.absoluteString, mockRemoteAISettings.aiChatURL.absoluteString)
             XCTAssertEqual(source, .ui)
         } else {
             XCTFail("Expected URL tab content")
@@ -103,7 +105,8 @@ final class RootViewV2Tests: XCTestCase {
         let rootView = Preferences.RootViewV2(
             model: sidebarModel,
             subscriptionManager: subscriptionManager,
-            subscriptionUIHandler: subscriptionUIHandler
+            subscriptionUIHandler: subscriptionUIHandler,
+            aiChatURLSettings: MockRemoteAISettings()
         ) { content in
             self.showTabCalled = true
             self.showTabContent = content

--- a/macOS/UnitTests/Preferences/RootViewV2Tests.swift
+++ b/macOS/UnitTests/Preferences/RootViewV2Tests.swift
@@ -74,7 +74,7 @@ final class RootViewV2Tests: XCTestCase {
             model: sidebarModel,
             subscriptionManager: subscriptionManager,
             subscriptionUIHandler: subscriptionUIHandler,
-            aiChatURLSettings: MockRemoteAISettings()
+            aiChatURLSettings: mockRemoteAISettings
         ) { content in
             self.showTabCalled = true
             self.showTabContent = content

--- a/macOS/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureV2Tests.swift
+++ b/macOS/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureV2Tests.swift
@@ -96,7 +96,8 @@ final class SubscriptionPagesUseSubscriptionFeatureV2Tests: XCTestCase {
                                                         freemiumDBPUserStateManager: mockFreemiumDBPUserStateManager,
                                                         notificationCenter: mockNotificationCenter,
                                                         dataBrokerProtectionFreemiumPixelHandler: mockPixelHandler,
-                                                        featureFlagger: mockFeatureFlagger)
+                                                        featureFlagger: mockFeatureFlagger,
+                                                        aiChatURL: URL.duckDuckGo)
     }
 
     // MARK: - Free Trials


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1210686986062299
cc: @Bunn 

### Description This allows testing paid Duck.ai with testing domains using the debug menu

### Testing Steps
On both platforms 
1. Go to Debug -> AI Chat -> Web Communication -> Set Custom URL to https://euw-serp-dev-testing10.duck.co/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=1 (for iOS go to all debug settings -> Set Custom AI Chat URL)
2. Go to Duck.ai from address bar, from Duck.ai subscription menu and check you get the testing duck ai (with the drop down menu on the right)
3. Go to Debug -> AI Chat -> Web Communication -> Reset custom URL (for iOS go to all debug settings -> Reset Custom URL)
4. Go to Duck.ai from address bar, from Duck.ai subscription menu and check you get the production duck ai

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)