### PR TITLE
Add pixel for internal switch bar

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1221,6 +1221,7 @@ extension Pixel {
         case aiChatMetricOpenHistory
         case aiChatMetricOpenMostRecentHistoryChat
         case aiChatMetricSentPromptOngoingChat
+        case aiChatInternalSwitchBarDisplayed
 
         // MARK: Lifecycle
         case appDidTransitionToUnexpectedState
@@ -2391,6 +2392,7 @@ extension Pixel.Event {
         case .aiChatMetricOpenHistory: return "m_aichat_open_history"
         case .aiChatMetricOpenMostRecentHistoryChat: return "m_aichat_open_most_recent_history_chat"
         case .aiChatMetricSentPromptOngoingChat: return "m_aichat_sent_prompt_ongoing_chat"
+        case .aiChatInternalSwitchBarDisplayed: return "m_aichat_internal_switch_bar_displayed"
 
         // MARK: Lifecycle
         case .appDidTransitionToUnexpectedState: return "m_debug_app-did-transition-to-unexpected-state-4"

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -107,6 +107,7 @@ final class OmniBarEditingStateViewController: UIViewController {
         super.viewDidAppear(animated)
 
         animateAppearance()
+        DailyPixel.fireDailyAndCount(pixel: .aiChatInternalSwitchBarDisplayed)
     }
 
     private func animateAppearance() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1210696554139393?focus=true

### Description
Fire a pixel prefixed with internal when the switch bar is displayed

### Testing Steps
1. Turn on duck.ai switch bar
2. Check if the new pixel is fired
3. Check if the pixel is fired with the regular omnibar (it shouldn't)


### Impact and Risks
None: Internal tooling, documentation
