### PR TITLE
Fix Xcode 26 builds when running the iOS app

### DIFF
--- a/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
@@ -32,6 +32,7 @@ import PageRefreshMonitor
 import PixelKit
 import PixelExperimentKit
 import Networking
+import Network
 
 protocol DependencyProvider {
 
@@ -105,6 +106,12 @@ final class AppDependencyProvider: DependencyProvider {
     let persistentPixel: PersistentPixelFiring = PersistentPixel()
 
     private init() {
+#if DEBUG
+        // Workaround for Xcode 26 crash: https://developer.apple.com/forums/thread/787365?answerId=846043022#846043022
+        // This is a known issue in Xcode 26 betas 1 and 2, if the issue is fixed in beta 3 onward then this can be removed
+        nw_tls_create_options()
+#endif
+
         let featureFlaggerOverrides = FeatureFlagLocalOverrides(keyValueStore: UserDefaults(suiteName: FeatureFlag.localOverrideStoreName)!,
                                                                 actionHandler: FeatureFlagOverridesPublishingHandler<FeatureFlag>()
         )

--- a/iOS/scripts/fix_libswiftWebkit_simulator.sh
+++ b/iOS/scripts/fix_libswiftWebkit_simulator.sh
@@ -38,7 +38,6 @@ get_build_id_for_version() {
     case "$1" in
         18.4*) echo "22E238" ;;
         18.5*) echo "22F77" ;;
-        26.0*) echo "23A5260l" ;;
         *) return 1 ;;
     esac
 }

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -35,6 +35,7 @@ import History
 import HistoryView
 import Lottie
 import MetricKit
+import Network
 import Networking
 import VPN
 import NetworkProtectionIPC
@@ -684,6 +685,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // swiftlint:enable cyclomatic_complexity
 
     func applicationWillFinishLaunching(_ notification: Notification) {
+#if DEBUG
+        // Workaround for Xcode 26 crash: https://developer.apple.com/forums/thread/787365?answerId=846043022#846043022
+        // This is a known issue in Xcode 26 betas 1 and 2, if the issue is fixed in beta 3 onward then this can be removed
+        nw_tls_create_options()
+#endif
+        
         APIRequest.Headers.setUserAgent(UserAgent.duckDuckGoUserAgent())
         Configuration.setURLProvider(AppConfigurationURLProvider(
             privacyConfigurationManager: privacyFeatures.contentBlocking.privacyConfigurationManager,


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1210701952204964?focus=true
Tech Design URL:
CC:

### Description

This PR fixes a crash on launch when running the app from Xcode 26. This is a known issue with the betas, and Apple will be fixing it at a later date. For now, we can apply a workaround.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Grab Xcode 26 beta 2 (or later)
2. Check that the app runs

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)