### PR TITLE
disable WebKit termination tests

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/NavigationTests/ClosureNavigationResponderTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/NavigationTests/ClosureNavigationResponderTests.swift
@@ -399,6 +399,8 @@ class ClosureNavigationResponderTests: DistributedNavigationDelegateTestsBase {
 
     @MainActor
     func testWhenWebContentProcessIsTerminated_webProcessDidTerminateAndNavigationDidFailReceived() throws {
+        throw XCTSkip("termination handler broken on macOS 15.5+")
+
         let eDidFail = expectation(description: "onDidFail")
         let eDidTerminate = expectation(description: "onDidTerminate")
         let responder = ClosureNavigationResponder(decidePolicy: { _, _ in

--- a/SharedPackages/BrowserServicesKit/Tests/NavigationTests/DistributedNavigationDelegateTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/NavigationTests/DistributedNavigationDelegateTests.swift
@@ -1627,6 +1627,8 @@ class DistributedNavigationDelegateTests: DistributedNavigationDelegateTestsBase
     }
 
     func testWhenWebContentProcessIsTerminated_webProcessDidTerminateAndNavigationDidFailReceived() throws {
+        throw XCTSkip("termination handler broken on macOS 15.5+")
+
         navigationDelegate.setResponders(.strong(NavigationResponderMock(defaultHandler: { _ in })))
 
         responder(at: 0).onNavigationResponse = { [unowned webView=withWebView(do: { $0 })] _ in


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1206506149377247?focus=true

### Description
- disable navigation delegate webcontent process termination tests since the handler is broken on macOS 15.5+

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Validate Navigation tests pass locally and on CI

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
We lose track of termination handlers stop working

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)