### PR TITLE
Disable developer menu items in an empty Fire window

### DIFF
--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -1319,7 +1319,7 @@ extension MainViewController: NSMenuItemValidation {
              #selector(MainViewController.showPageSource(_:)),
              #selector(MainViewController.showPageResources(_:)):
             let canReload = activeTabViewModel?.canReload == true
-            let isHTMLNewTabPage = activeTabViewModel?.tab.content == .newtab
+            let isHTMLNewTabPage = activeTabViewModel?.tab.content == .newtab && !isBurner
             let isHistoryView = featureFlagger.isFeatureOn(.historyView) && activeTabViewModel?.tab.content == .history
             return canReload || isHTMLNewTabPage || isHistoryView
 

--- a/macOS/UITests/FireWindowTests.swift
+++ b/macOS/UITests/FireWindowTests.swift
@@ -113,6 +113,17 @@ class FireWindowTests: UITestCase {
         openLoginSite()
         signInUsingAutoFill()
     }
+    
+    func testDevelopMenuIsDisabledInNewFireWindow() {
+        openFireWindow()
+        assertDeveloperToolsEnabled(false)
+    }
+    
+    func testDevelopMenuIsEnabledInFireWindowAfterNavigation() {
+        openFireWindow()
+        openSite(pageTitle: "Some site")
+        assertDeveloperToolsEnabled(true)
+    }
 
     // MARK: - Utilities
 
@@ -343,5 +354,15 @@ class FireWindowTests: UITestCase {
 
     private func areTestsRunningOnMacos13() -> Bool {
         return ProcessInfo.processInfo.operatingSystemVersion.majorVersion == 13
+    }
+    
+    private func assertDeveloperToolsEnabled(_ shouldBeEnabled: Bool) {
+        let developerTools = app.menuItems["toggleDeveloperTools:"]
+        
+        if shouldBeEnabled {
+            XCTAssertTrue(developerTools.isEnabled)
+        } else {
+            XCTAssertFalse(developerTools.isEnabled)
+        }
     }
 }

--- a/macOS/UITests/FireWindowTests.swift
+++ b/macOS/UITests/FireWindowTests.swift
@@ -111,14 +111,14 @@ class FireWindowTests: UITestCase {
         openFireWindow()
         hoverMouseOutsideTabSoPreviewIsNotShown()
         openLoginSite()
-        signInUsingAutoFill()
+                signInUsingAutoFill()
     }
-    
+
     func testDevelopMenuIsDisabledInNewFireWindow() {
         openFireWindow()
         assertDeveloperToolsEnabled(false)
     }
-    
+
     func testDevelopMenuIsEnabledInFireWindowAfterNavigation() {
         openFireWindow()
         openSite(pageTitle: "Some site")
@@ -355,10 +355,10 @@ class FireWindowTests: UITestCase {
     private func areTestsRunningOnMacos13() -> Bool {
         return ProcessInfo.processInfo.operatingSystemVersion.majorVersion == 13
     }
-    
+
     private func assertDeveloperToolsEnabled(_ shouldBeEnabled: Bool) {
         let developerTools = app.menuItems["toggleDeveloperTools:"]
-        
+
         if shouldBeEnabled {
             XCTAssertTrue(developerTools.isEnabled)
         } else {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210594645229050/task/1210613509788456?focus=true
Tech Design URL:
CC:

### Description

This PR ensures that Developer menu items are disabled in empty Fire windows. Previously, the menu items appeared enabled but had no effect when clicked.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Launch the app and open a new Fire window (File > New Fire Window).
2. Verify that the menu items under View > Developer are disabled.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low: This change only affects access to Developer tools in new Fire windows.

#### What could go wrong?
Developer tools might be unintentionally disabled or enabled in the wrong state, but the added UI tests should catch regressions.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
Two UI tests were added to cover the expected behavior:
* Developer menu items are disabled in a new Fire window.
* Developer menu items are enabled in a Fire window after navigation.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->
N/A
---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)