### PR TITLE
Pull mutable connection controller state into separate actor

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
@@ -19,46 +19,6 @@
 import Foundation
 import BrowserServicesKit
 
-private actor SyncConnectionState {
-    private var _isCodeHandlingInFlight: Bool = false
-    private var _exchanger: RemoteKeyExchanging?
-    private var _connector: RemoteConnecting?
-    
-    func setCodeHandlingInFlight(_ value: Bool) {
-        _isCodeHandlingInFlight = value
-    }
-    
-    func isCodeHandlingInFlight() -> Bool {
-        return _isCodeHandlingInFlight
-    }
-    
-    func setExchanger(_ exchanger: RemoteKeyExchanging?) {
-        _exchanger = exchanger
-    }
-    
-    func getExchanger() -> RemoteKeyExchanging? {
-        return _exchanger
-    }
-    
-    func setConnector(_ connector: RemoteConnecting?) {
-        _connector = connector
-    }
-    
-    func getConnector() -> RemoteConnecting? {
-        return _connector
-    }
-    
-    func stopConnectMode() {
-        _connector?.stopPolling()
-        _connector = nil
-    }
-    
-    func stopExchangeMode() {
-        _exchanger?.stopPolling()
-        _exchanger = nil
-    }
-}
-
 @MainActor
 public protocol SyncConnectionControllerDelegate: AnyObject {
     func controllerWillBeginTransmittingRecoveryKey() async
@@ -121,13 +81,53 @@ public protocol SyncConnectionControlling {
     func syncCodeEntered(code: String, canScanURLBarcodes: Bool, codeSource: SyncCodeSource) async -> Bool
 }
 
+private actor SyncConnectionState {
+    private var _isCodeHandlingInFlight: Bool = false
+    private var _exchanger: RemoteKeyExchanging?
+    private var _connector: RemoteConnecting?
+
+    func setCodeHandlingInFlight(_ value: Bool) {
+        _isCodeHandlingInFlight = value
+    }
+
+    func isCodeHandlingInFlight() -> Bool {
+        return _isCodeHandlingInFlight
+    }
+
+    func setExchanger(_ exchanger: RemoteKeyExchanging?) {
+        _exchanger = exchanger
+    }
+
+    func getExchanger() -> RemoteKeyExchanging? {
+        return _exchanger
+    }
+
+    func setConnector(_ connector: RemoteConnecting?) {
+        _connector = connector
+    }
+
+    func getConnector() -> RemoteConnecting? {
+        return _connector
+    }
+
+    func stopConnectMode() {
+        _connector?.stopPolling()
+        _connector = nil
+    }
+
+    func stopExchangeMode() {
+        _exchanger?.stopPolling()
+        _exchanger = nil
+    }
+}
+
 public class SyncConnectionController: SyncConnectionControlling {
     private let deviceName: String
     private let deviceType: String
     private let syncService: DDGSyncing
     private let dependencies: SyncDependencies
 
-    weak var delegate: SyncConnectionControllerDelegate?
+    private weak var delegate: SyncConnectionControllerDelegate?
 
     private let state = SyncConnectionState()
 
@@ -274,8 +274,8 @@ public class SyncConnectionController: SyncConnectionControlling {
                 await delegate?.controllerDidError(.failedToTransmitExchangeRecoveryKey, underlyingError: error, setupRole: .sharer)
             }
 
-            await delegate?.controllerDidFinishTransmittingRecoveryKey()
-            await (await state.getExchanger())?.stopPolling()
+            delegate?.controllerDidFinishTransmittingRecoveryKey()
+            (await state.getExchanger())?.stopPolling()
         }
     }
 
@@ -293,7 +293,7 @@ public class SyncConnectionController: SyncConnectionControlling {
                 return
             }
 
-            await delegate?.controllerDidReceiveRecoveryKey()
+            delegate?.controllerDidReceiveRecoveryKey()
 
             do {
                 try await loginAndShowDeviceConnected(recoveryKey: recoveryKey, isRecovery: false, setupRole: .sharer)

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
@@ -19,6 +19,46 @@
 import Foundation
 import BrowserServicesKit
 
+private actor SyncConnectionState {
+    private var _isCodeHandlingInFlight: Bool = false
+    private var _exchanger: RemoteKeyExchanging?
+    private var _connector: RemoteConnecting?
+    
+    func setCodeHandlingInFlight(_ value: Bool) {
+        _isCodeHandlingInFlight = value
+    }
+    
+    func isCodeHandlingInFlight() -> Bool {
+        return _isCodeHandlingInFlight
+    }
+    
+    func setExchanger(_ exchanger: RemoteKeyExchanging?) {
+        _exchanger = exchanger
+    }
+    
+    func getExchanger() -> RemoteKeyExchanging? {
+        return _exchanger
+    }
+    
+    func setConnector(_ connector: RemoteConnecting?) {
+        _connector = connector
+    }
+    
+    func getConnector() -> RemoteConnecting? {
+        return _connector
+    }
+    
+    func stopConnectMode() {
+        _connector?.stopPolling()
+        _connector = nil
+    }
+    
+    func stopExchangeMode() {
+        _exchanger?.stopPolling()
+        _exchanger = nil
+    }
+}
+
 @MainActor
 public protocol SyncConnectionControllerDelegate: AnyObject {
     func controllerWillBeginTransmittingRecoveryKey() async
@@ -59,7 +99,7 @@ public protocol SyncConnectionControlling {
     /**
      Returns a device ID, public key and secret key ready for display and allows callers attempt to fetch the transmitted public key
      */
-    func startExchangeMode()  async throws -> PairingInfo
+    func startExchangeMode() async throws -> PairingInfo
 
     /**
      Returns a device id and temporary secret key ready for display and allows callers attempt to fetch the transmitted recovery key.
@@ -89,9 +129,7 @@ public class SyncConnectionController: SyncConnectionControlling {
 
     weak var delegate: SyncConnectionControllerDelegate?
 
-    private var exchanger: RemoteKeyExchanging?
-    private var connector: RemoteConnecting?
-    private var isCodeHandlingInFlight: Bool = false
+    private let state = SyncConnectionState()
 
     private var recoveryCode: String {
         guard let code = syncService.account?.recoveryCode else {
@@ -109,26 +147,26 @@ public class SyncConnectionController: SyncConnectionControlling {
         self.dependencies = dependencies
     }
 
-    public func startExchangeMode() throws -> PairingInfo {
+    public func startExchangeMode() async throws -> PairingInfo {
         let exchanger = try remoteExchange()
-        self.exchanger = exchanger
+        await state.setExchanger(exchanger)
         startExchangePolling()
         let pairingInfo = PairingInfo(base64Code: exchanger.code, deviceName: deviceName)
         return pairingInfo
     }
 
-    public func startConnectMode() throws -> PairingInfo {
+    public func startConnectMode() async throws -> PairingInfo {
         let connector = try remoteConnect()
-        self.connector = connector
+        await state.setConnector(connector)
         self.startConnectPolling()
         let pairingInfo = PairingInfo(base64Code: connector.code, deviceName: deviceName)
         return pairingInfo
     }
 
-    public func cancel() {
-        isCodeHandlingInFlight = false
-        stopConnectMode()
-        stopExchangeMode()
+    public func cancel() async {
+        await state.setCodeHandlingInFlight(false)
+        await state.stopConnectMode()
+        await state.stopExchangeMode()
     }
 
     @discardableResult
@@ -161,12 +199,14 @@ public class SyncConnectionController: SyncConnectionControlling {
 
     @discardableResult
     public func syncCodeEntered(code: String, canScanURLBarcodes: Bool, codeSource: SyncCodeSource) async -> Bool {
-        guard !isCodeHandlingInFlight else {
+        guard !(await state.isCodeHandlingInFlight()) else {
             return false
         }
-        isCodeHandlingInFlight = true
+        await state.setCodeHandlingInFlight(true)
         defer {
-            isCodeHandlingInFlight = false
+            Task {
+                await state.setCodeHandlingInFlight(false)
+            }
         }
 
         let syncCode: SyncCode
@@ -217,7 +257,7 @@ public class SyncConnectionController: SyncConnectionControlling {
         Task { @MainActor in
             let exchangeMessage: ExchangeMessage
             do {
-                guard let message = try await exchanger?.pollForPublicKey() else {
+                guard let message = try await (await state.getExchanger())?.pollForPublicKey() else {
                     // Polling likely cancelled
                     return
                 }
@@ -235,7 +275,7 @@ public class SyncConnectionController: SyncConnectionControlling {
             }
 
             await delegate?.controllerDidFinishTransmittingRecoveryKey()
-            await exchanger?.stopPolling()
+            await (await state.getExchanger())?.stopPolling()
         }
     }
 
@@ -243,7 +283,7 @@ public class SyncConnectionController: SyncConnectionControlling {
         Task { @MainActor in
             let recoveryKey: SyncCode.RecoveryKey
             do {
-                guard let key = try await connector?.pollForRecoveryKey() else {
+                guard let key = try await (await state.getConnector())?.pollForRecoveryKey() else {
                     // Polling likely cancelled
                     return
                 }
@@ -328,15 +368,7 @@ public class SyncConnectionController: SyncConnectionControlling {
         return true
     }
 
-    private func stopConnectMode() {
-        self.connector?.stopPolling()
-        self.connector = nil
-    }
 
-    private func stopExchangeMode() {
-        exchanger?.stopPolling()
-        exchanger = nil
-    }
 
     private func handleRecoveryCodeLoginError(recoveryKey: SyncCode.RecoveryKey, error: Error, setupRole: SyncSetupRole) async {
         if syncService.account != nil {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
@@ -368,8 +368,6 @@ public class SyncConnectionController: SyncConnectionControlling {
         return true
     }
 
-
-
     private func handleRecoveryCodeLoginError(recoveryKey: SyncCode.RecoveryKey, error: Error, setupRole: SyncSetupRole) async {
         if syncService.account != nil {
             await delegate?.controllerDidFindTwoAccountsDuringRecovery(recoveryKey, setupRole: setupRole)

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncConnectionControllerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncConnectionControllerTests.swift
@@ -136,7 +136,7 @@ final class SyncConnectionControllerTests: XCTestCase {
         let mockRemoteKeyExchanger: MockRemoteKeyExchanging = .init()
         dependencies.createRemoteKeyExchangerStub = mockRemoteKeyExchanger
         mockRemoteKeyExchanger.code = expectedExchangeCode
-        let pairingInfo = try controller.startExchangeMode()
+        let pairingInfo = try await controller.startExchangeMode()
 
         XCTAssertEqual(pairingInfo.base64Code, expectedExchangeCode)
         XCTAssertEqual(pairingInfo.deviceName, Self.deviceName)
@@ -155,7 +155,7 @@ final class SyncConnectionControllerTests: XCTestCase {
             expectation.fulfill()
         }
 
-        _ = try controller.startExchangeMode()
+        _ = try await controller.startExchangeMode()
 
         await fulfillment(of: [expectation], timeout: 5)
 
@@ -175,7 +175,7 @@ final class SyncConnectionControllerTests: XCTestCase {
             expectation.fulfill()
         }
 
-        _ = try controller.startExchangeMode()
+        _ = try await controller.startExchangeMode()
 
         await fulfillment(of: [expectation], timeout: 5)
 
@@ -188,7 +188,7 @@ final class SyncConnectionControllerTests: XCTestCase {
         dependencies.createRemoteKeyExchangerStub = remoteExchanger
         remoteExchanger.pollForPublicKeyError = SyncError.unableToDecodeResponse("")
 
-        _ = try controller.startExchangeMode()
+        _ = try await controller.startExchangeMode()
 
         let error = try await waitForError()
 
@@ -203,7 +203,7 @@ final class SyncConnectionControllerTests: XCTestCase {
         dependencies.createExchangeRecoveryKeyTransmitterStub = exchangeRecoveryKeyTransmitter
         exchangeRecoveryKeyTransmitter.sendError = SyncError.unableToDecodeResponse("")
 
-        _ = try controller.startExchangeMode()
+        _ = try await controller.startExchangeMode()
 
         let error = try await waitForError()
 
@@ -224,7 +224,7 @@ final class SyncConnectionControllerTests: XCTestCase {
         dependencies.createRemoteConnectorStub = mockRemoteConnector
         mockRemoteConnector.code = expectedConnectorCode
 
-        let pairingInfo = try controller.startConnectMode()
+        let pairingInfo = try await controller.startConnectMode()
 
         XCTAssertEqual(pairingInfo.base64Code, expectedConnectorCode)
         XCTAssertEqual(pairingInfo.deviceName, Self.deviceName)
@@ -241,7 +241,7 @@ final class SyncConnectionControllerTests: XCTestCase {
             expectation.fulfill()
         }
 
-        _ = try controller.startConnectMode()
+        _ = try await controller.startConnectMode()
 
         await fulfillment(of: [expectation], timeout: 5)
     }
@@ -261,7 +261,7 @@ final class SyncConnectionControllerTests: XCTestCase {
             expectation.fulfill()
         }
 
-        _ = try controller.startConnectMode()
+        _ = try await controller.startConnectMode()
 
         await fulfillment(of: [expectation], timeout: 5)
 
@@ -273,7 +273,7 @@ final class SyncConnectionControllerTests: XCTestCase {
         remoteConnector.pollForRecoveryKeyError = SyncError.failedToPrepareForConnect("")
         dependencies.createRemoteConnectorStub = remoteConnector
 
-        _ = try controller.startConnectMode()
+        _ = try await controller.startConnectMode()
 
         let error = try await waitForError()
 
@@ -289,7 +289,7 @@ final class SyncConnectionControllerTests: XCTestCase {
         dependencies.account = mockAccountManager
         mockAccountManager.loginError = SyncError.failedToDecryptValue("")
 
-        _ = try controller.startConnectMode()
+        _ = try await controller.startConnectMode()
 
         let error = try await waitForError()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1210707877097609?focus=true

### Description

I hastily made the whole connection controller an actor which was a bit of a sledgehammer tactic, particularly given this would cause a deadlock if its delegate were to call back into it during a callback. As such, I've made it a class again and instead extracted the mutable state into an actor.

### Testing Steps
1. Green UI tests https://github.com/duckduckgo/apple-browsers/actions/runs/16652014315
2. Could give sync a quick smoke test.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Can't really think of anything. This is correct use of actors.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)