### PR TITLE
macOS: Fix hover color on tabs

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -754,11 +754,12 @@ final class TabBarViewItem: NSCollectionViewItem {
             if isSelected || isDragged {
                 cell.mouseOverView.mouseOverColor = nil
                 cell.mouseOverView.backgroundColor = visualStyle.colorsProvider.navigationBackgroundColor
+                cell.roundedBackgroundColorView.isHidden = true
             } else {
                 if visualStyle.tabStyleProvider.isRoundedBackgroundPresentOnHover {
                     cell.mouseOverView.mouseOverColor = nil
                     cell.mouseOverView.backgroundColor = visualStyle.colorsProvider.baseBackgroundColor
-                    cell.roundedBackgroundColorView.backgroundColor = visualStyle.colorsProvider.navigationBackgroundColor
+                    cell.roundedBackgroundColorView.backgroundColor = visualStyle.tabStyleProvider.hoverTabColor
                     cell.roundedBackgroundColorView.isHidden = !isMouseOver || isSelected
                 } else {
                     cell.mouseOverView.mouseOverColor = .tabMouseOver


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207340338530322/task/1210702826996017?focus=true
Tech Design URL:
CC:

### Description
Fix hover color on standard tabs

### Testing Steps
1. Run the app
2. Open a pinned tab and a standard tab
3. Hover both and check the color is the same
4. Repeat for both light and dark. modes

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing.

### Quality Considerations
Nothing.

### Notes to Reviewer
The tab with the incorrect hover color was the standard tab, not the pinned tab. I had to add another check to hide the rounded view when selected, before it was not impacting because the colors were the same, now it works as expected.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)