### PR TITLE
[iOS][Set As Default Browser] Ship Review Changes

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -325,7 +325,10 @@ public enum SetAsDefaultAndAddToDockSubfeature: String, PrivacySubfeature {
     public var parent: PrivacyFeature { .setAsDefaultAndAddToDock }
 
     // https://app.asana.com/1/137249556945/project/1206329551987282/task/1210225579353384?focus=true
-    case scheduledDefaultBrowserAndDockPrompts
+    case scheduledDefaultBrowserAndDockPrompts // macOS
+
+    // https://app.asana.com/1/137249556945/project/1206329551987282/task/1209304767941984?focus=true
+    case scheduledDefaultBrowserPrompts // iOS
 }
 
 public enum OnboardingSubfeature: String, PrivacySubfeature {

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -335,7 +335,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .showSettingsCompleteSetupSection:
             return .remoteReleasable(.subfeature(OnboardingSubfeature.showSettingsCompleteSetupSection))
         case .scheduledSetDefaultBrowserPrompts:
-            return .internalOnly()
+            return .remoteReleasable(.subfeature(SetAsDefaultAndAddToDockSubfeature.scheduledDefaultBrowserPrompts))
         }
     }
 }

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
@@ -120,7 +120,6 @@ struct Foreground: ForegroundHandling {
         services.defaultBrowserPromptService.resume()
 
         appDependencies.mainCoordinator.onForeground()
-        services.defaultBrowserPromptService.presentDefaultBrowserPromptIfNeeded()
     }
 
     private func configureAppearance() {

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
@@ -120,6 +120,7 @@ struct Foreground: ForegroundHandling {
         services.defaultBrowserPromptService.resume()
 
         appDependencies.mainCoordinator.onForeground()
+        services.defaultBrowserPromptService.presentDefaultBrowserPromptIfNeeded()
     }
 
     private func configureAppearance() {

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -90,6 +90,12 @@ struct Launching: LaunchingHandling {
                                                             privacyConfigurationManager: privacyConfigurationManager)
         let subscriptionService = SubscriptionService(privacyConfigurationManager: privacyConfigurationManager, featureFlagger: featureFlagger)
         let maliciousSiteProtectionService = MaliciousSiteProtectionService(featureFlagger: featureFlagger)
+        // Service to display the Default Browser prompt.
+        let defaultBrowserPromptService = DefaultBrowserPromptService(
+            featureFlagger: featureFlagger,
+            privacyConfigManager: privacyConfigurationManager,
+            keyValueFilesStore: appKeyValueFileStoreService.keyValueFilesStore
+        )
 
         // MARK: - Main Coordinator Setup
         // Initialize the main coordinator which manages the app's primary view controller
@@ -110,6 +116,7 @@ struct Launching: LaunchingHandling {
                                               maliciousSiteProtectionService: maliciousSiteProtectionService,
                                               didFinishLaunchingStartTime: didFinishLaunchingStartTime,
                                               keyValueStore: appKeyValueFileStoreService.keyValueFilesStore,
+                                              defaultBrowserPromptPresenter: defaultBrowserPromptService.presenter
         )
 
         // MARK: - UI-Dependent Services Setup
@@ -127,13 +134,6 @@ struct Launching: LaunchingHandling {
         let autoClearService = AutoClearService(autoClear: AutoClear(worker: mainCoordinator.controller), overlayWindowManager: overlayWindowManager)
         let authenticationService = AuthenticationService(overlayWindowManager: overlayWindowManager)
         let screenshotService = ScreenshotService(window: window, mainViewController: mainCoordinator.controller)
-        // Set Default Browser Prompt Service to display SAD prompts to active users.
-        let defaultBrowserPromptService = DefaultBrowserPromptService(
-            presentingController: mainCoordinator.controller,
-            featureFlagger: featureFlagger,
-            privacyConfigManager: privacyConfigurationManager,
-            keyValueFilesStore: appKeyValueFileStoreService.keyValueFilesStore
-        )
 
         // MARK: - App Services aggregation
         // This object serves as a central hub for app-wide services that:

--- a/iOS/DuckDuckGo/AppServices/DefaultBrowserPromptService.swift
+++ b/iOS/DuckDuckGo/AppServices/DefaultBrowserPromptService.swift
@@ -26,18 +26,15 @@ import SetDefaultBrowserUI
 
 @MainActor
 final class DefaultBrowserPromptService {
-    private weak var presentingController: UIViewController?
+    let presenter: DefaultBrowserPromptPresenting
     private let userActivityManager: DefaultBrowserPromptUserActivityRecorder & DefaultBrowserPromptUserActivityManager
-    private let presenter: DefaultBrowserPromptPresenting
     private let featureFlagAdapter: DefaultBrowserPromptFeatureFlagAdapter
 
     init(
-        presentingController: UIViewController,
         featureFlagger: FeatureFlagger,
         privacyConfigManager: PrivacyConfigurationManaging,
         keyValueFilesStore: ThrowingKeyValueStoring
     ) {
-        self.presentingController = presentingController
 
 #if DEBUG || ALPHA
         let debugDateProvider = DefaultBrowserPromptDebugDateProvider()
@@ -77,12 +74,6 @@ final class DefaultBrowserPromptService {
         guard featureFlagAdapter.isDefaultBrowserPromptsFeatureEnabled else { return }
         Logger.defaultBrowserPrompt.debug("[Default Browser Prompt] - Record User Activity If Needed.")
         userActivityManager.recordActivity()
-    }
-
-    func presentDefaultBrowserPromptIfNeeded() {
-        guard let presentingController else { return }
-        Logger.defaultBrowserPrompt.debug("[Default Browser Prompt] - Attempt to present default browser prompt.")
-        presenter.tryPresentDefaultModalPrompt(from: presentingController)
     }
 }
 

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -23,6 +23,7 @@ import BrowserServicesKit
 import Subscription
 import Persistence
 import DDGSync
+import SetDefaultBrowserUI
 
 @MainActor
 protocol URLHandling {
@@ -45,6 +46,7 @@ final class MainCoordinator {
     let controller: MainViewController
     private let subscriptionManager: any SubscriptionAuthV1toV2Bridge
     private let featureFlagger: FeatureFlagger
+    private let defaultBrowserPromptPresenter: DefaultBrowserPromptPresenting
 
     init(syncService: SyncService,
          bookmarksDatabase: CoreDataDatabase,
@@ -61,9 +63,13 @@ final class MainCoordinator {
          subscriptionManager: any SubscriptionAuthV1toV2Bridge = AppDependencyProvider.shared.subscriptionAuthV1toV2Bridge,
          maliciousSiteProtectionService: MaliciousSiteProtectionService,
          didFinishLaunchingStartTime: CFAbsoluteTime,
-         keyValueStore: ThrowingKeyValueStoring) throws {
+         keyValueStore: ThrowingKeyValueStoring,
+         defaultBrowserPromptPresenter: DefaultBrowserPromptPresenting
+    ) throws {
         self.subscriptionManager = subscriptionManager
         self.featureFlagger = featureFlagger
+        self.defaultBrowserPromptPresenter = defaultBrowserPromptPresenter
+
         let homePageConfiguration = HomePageConfiguration(variantManager: AppDependencyProvider.shared.variantManager,
                                                           remoteMessagingClient: remoteMessagingService.remoteMessagingClient,
                                                           privacyProDataReporter: reportingService.privacyProDataReporter)
@@ -184,6 +190,9 @@ final class MainCoordinator {
     func onForeground() {
         controller.showBars()
         controller.onForeground()
+
+        // Present Default Browser Prompt if user is eligible.
+        defaultBrowserPromptPresenter.tryPresentDefaultModalPrompt(from: controller)
     }
 
     func onBackground() {

--- a/iOS/DuckDuckGo/bg.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/bg.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Преки пътища за Duck.ai";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Търсене на въведен текст";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Потърсете в мрежата или попитайте Duck.ai директно от адресната лента";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Настройки за Assist при търсене";
 

--- a/iOS/DuckDuckGo/cs.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/cs.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Zkratky Duck.ai";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Zadání hledání";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Hledej na webu nebo se zeptej Duck.ai přímo v adresním řádku.";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Nastavení vyhledávání s funkcí Assist";
 

--- a/iOS/DuckDuckGo/da.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/da.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Duck.ai-genveje";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Søgefelt";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Søg på nettet eller spørg Duck.ai direkte fra adresselinjen";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Indstillinger for Search Assist";
 

--- a/iOS/DuckDuckGo/de.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/de.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Duck.ai-Shortcuts";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Sucheingabe";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Suche im Web oder frag Duck.ai direkt über die Adressleiste";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Such-Assist-Einstellungen";
 

--- a/iOS/DuckDuckGo/el.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/el.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Συντομεύσεις Duck.ai";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Εισαγωγή αναζήτησης";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Κάντε αναζήτηση στο διαδίκτυο ή ρωτήστε το Duck.ai απευθείας από τη Γραμμή διευθύνσεων";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Ρυθμίσεις αναζήτησης Assist";
 

--- a/iOS/DuckDuckGo/es.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/es.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Atajos de Duck.ai";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Buscar entrada";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Busca en la web o pregúntale a Duck.ai directamente desde la barra de direcciones";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Configuración de Asistente de búsqueda";
 

--- a/iOS/DuckDuckGo/et.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/et.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Duck.ai otseteed";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Otsingusisend";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Otsi veebist või küsi Duck.ai-lt otse aadressiribal";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Otsingu Assist seaded";
 

--- a/iOS/DuckDuckGo/fi.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fi.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Duck.ai-pikakuvakkeet";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Hakukenttä";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Hae verkosta tai kysy Duck.ai:lta kirjoittamalla suoraan osoiteriville";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Search Assist -asetukset";
 

--- a/iOS/DuckDuckGo/fr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fr.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Raccourcis Duck.ai";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Saisie de recherche";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Effectuez une recherche sur le Web ou interrogez Duck.ai directement à partir de la barre d’adresse";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Paramètres de recherche Assist";
 

--- a/iOS/DuckDuckGo/hr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hr.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Duck.ai prečaci";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Unos pretraživanja";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Pretraži mrežu ili pitaj Duck.ai izravno iz adresne trake";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Pretraži postavke Assista";
 

--- a/iOS/DuckDuckGo/hu.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hu.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Duck.ai-gyorsparancsok";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Keresési mező";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Keresés a weben vagy a Duck.ai megkérdezése közvetlenül a címsorból";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Keresési asszisztens beállításai";
 

--- a/iOS/DuckDuckGo/it.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/it.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Scorciatoie Duck.ai";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Parole di ricerca";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Cerca sul web o chiedi a Duck.ai direttamente dalla barra degli indirizzi";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Impostazioni di Search Assist";
 

--- a/iOS/DuckDuckGo/lt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lt.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "„Duck.ai“ spartieji klavišai";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Paieškos įvestis";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Ieškok internete arba klausk „Duck.ai“ tiesiai iš adreso juostos";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "„Assist“ paieškos nustatymai";
 

--- a/iOS/DuckDuckGo/lv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lv.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Duck.ai īsceļi";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Meklēšanas ievade";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Meklē tīmeklī vai jautā Duck.ai tieši adrešu joslā";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Meklēšanas Assist iestatījumi";
 

--- a/iOS/DuckDuckGo/nb.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nb.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Duck.ai-snarveier";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Søkefelt";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Søk på nettet eller spør Duck.ai direkte fra adressefeltet";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Innstillinger for Search Assist";
 

--- a/iOS/DuckDuckGo/nl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nl.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Duck.ai-snelkoppelingen";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Zoekinvoer";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Zoeken op het web of direct een vraag stellen aan Duck.ai vanuit de adresbalk";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Instellingen voor zoek Assist";
 

--- a/iOS/DuckDuckGo/pl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pl.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Skróty Duck.ai";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Pole wyszukiwania";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Wyszukaj w Internecie lub zapytaj Duck.ai bezpośrednio z paska adresu";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Ustawienia wyszukiwania Assist";
 

--- a/iOS/DuckDuckGo/pt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pt.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Atalhos Duck.ai";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Entrada de pesquisa";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Pesquise na web ou pergunte diretamente ao Duck.ai na barra de endereços";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Definições do Assist de pesquisa";
 

--- a/iOS/DuckDuckGo/ro.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ro.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Comenzi rapide Duck.ai";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Caută intrarea";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Caută pe web sau întreabă Duck.ai direct din bara de adrese";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Setări Search Assist";
 

--- a/iOS/DuckDuckGo/ru.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ru.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Ярлыки Duck.ai";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Поисковый запрос";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Выполнить поиск в интернете или задать вопрос ИИ-ассистенту Duck.ai можно прямо из адресной строки.";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Настройки Search Assist";
 

--- a/iOS/DuckDuckGo/sk.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sk.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Skratky Duck.ai";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Vstup vyhľadávania";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Vyhľadaj na webe alebo sa opýtaj Duck.ai priamo z riadku pre adresu";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Nastavenia Assist vyhľadávania";
 

--- a/iOS/DuckDuckGo/sl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sl.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Bližnjice do Duck.ai";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Iskalni vnos";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Išči po spletu ali vprašaj Duck.ai neposredno iz naslovne vrstice";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Nastavitve modula Search Assist";
 

--- a/iOS/DuckDuckGo/sv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sv.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Duck.ai-genvägar";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Sökning";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Sök på webben eller fråga Duck.ai direkt i adressfältet";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Inställningar för Search Assist";
 

--- a/iOS/DuckDuckGo/tr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/tr.lproj/Localizable.strings
@@ -2650,6 +2650,12 @@
 /* Settings screen text for showing AI Chat in various places in the app */
 "settings.aichat.shortcuts" = "Duck.ai Kısayolları";
 
+/* Settings screen text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input" = "Arama Girdisi";
+
+/* Settings screen footer text for showing AI Chat in the input box */
+"settings.aichat.shortcuts.input.footer" = "Web'de arama yapın veya doğrudan Adres Çubuğundan Duck.ai'a sorun";
+
 /* Title of search assist settings link */
 "settings.aifeatures.assist" = "Search Assist Ayarları";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserCore/PromptDecider/DefaultBrowserPromptTypeDecider.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserCore/PromptDecider/DefaultBrowserPromptTypeDecider.swift
@@ -130,7 +130,7 @@ private extension DefaultBrowserPromptTypeDecider {
         userActivityProvider.numberOfActiveDays() == featureFlagger.secondModalDelayDays
     }
 
-    // If the user has seen the last modal and they have been active for `secondModalDelayDays`, show the second modal.
+    // If the user has seen the last modal and they have been active for `subsequentModalRepeatIntervalDays`, show the subsequentModalRepeatIntervalDays modal.
     func shouldShowSubsequentModal(for user: DefaultBrowserPromptUserType) -> Bool {
         let modalSeenCondition = user.isNewOrReturningUser ? store.hasSeenSecondModal : store.hasSeenFirstModal
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/DefaultBrowserPromptModalView.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/DefaultBrowserPromptModalView.swift
@@ -39,12 +39,12 @@ struct DefaultBrowserPromptModalView: View {
                 .padding(.horizontal, Metrics.Header.horizontalPadding.build(v: verticalSizeClass, h: horizontalSizeClass))
                 .ignoresSafeArea(edges: .horizontal)
 
-            Spacer(minLength: Metrics.Container.spacerMinLength)
+            Spacer(minLength: Metrics.Container.topSpacerMinLength)
 
             Content()
                 .padding(.horizontal, horizontalPadding)
 
-            Spacer(minLength: Metrics.Container.spacerMinLength)
+            Spacer(minLength: Metrics.Container.bottomSpacerMinLength)
 
             Footer(setDefaultBrowserAction: setAsDefaultAction, doNotAskAgainAction: doNotAskAgainAction)
                 .padding(.horizontal, horizontalPadding)
@@ -83,7 +83,7 @@ private extension DefaultBrowserPromptModalView {
         var body: some View {
             let imageSize = Metrics.Content.imageSize.build(v: verticalSizeClass, h: horizontalSizeClass)
 
-            VStack(spacing: Metrics.Content.itemsVerticalSpacing) {
+            VStack(spacing: Metrics.Content.itemsVerticalSpacing.build(v: verticalSizeClass, h: horizontalSizeClass)) {
                 Image(.deviceMobileDefault128)
                     .resizable()
                     .scaledToFit()
@@ -100,6 +100,7 @@ private extension DefaultBrowserPromptModalView {
                 .foregroundStyle(Color.primary)
                 .opacity(0.84)
                 .multilineTextAlignment(.center)
+                .minimumScaleFactor(0.7)
             }
         }
 
@@ -134,9 +135,10 @@ private enum Metrics {
 
     enum Container {
         static let itemsVerticalSpacing: CGFloat = 0
-        static let spacerMinLength: CGFloat = 0
+        static let topSpacerMinLength: CGFloat = 0
+        static let bottomSpacerMinLength: CGFloat = 10
         static let topPadding: CGFloat = 16
-        static let horizontalPadding = MetricBuilder<CGFloat>(iPhone: 24, iPad: 92)
+        static let horizontalPadding = MetricBuilder<CGFloat>(iPhone: 24, iPad: 92).iPhone(landscape: 10)
     }
 
     enum Header {
@@ -146,7 +148,7 @@ private enum Metrics {
     }
 
     enum Content {
-        static let itemsVerticalSpacing: CGFloat = 24
+        static let itemsVerticalSpacing = MetricBuilder<CGFloat>(default: 24).iPhone(landscape: 20)
         static let titleFontSize: CGFloat = 28
         static let kerning: CGFloat = 0.38
         static let messageFontSize: CGFloat = 16

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/DefaultBrowserPromptPresenter.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/DefaultBrowserPromptPresenter.swift
@@ -36,6 +36,7 @@ final class DefaultBrowserModalPresenter: NSObject, DefaultBrowserPromptPresenti
     }
 
     public func tryPresentDefaultModalPrompt(from viewController: UIViewController) {
+        Logger.defaultBrowserPrompt.debug("[Default Browser Prompt] - Attempting To Present Default Browser Prompt.")
         // When prompt for inactive user is implemented check prompt type and present different view accordingly.
         guard coordinator.getPrompt() != nil else { return }
         presentDefaultDefaultBrowserPrompt(from: viewController)

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/bg.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/bg.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Задаване като браузър по подразбиране";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Не питай повече";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Затваряне";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Направете ни браузър по подразбиране, за да отваряте връзките към сайтове в DuckDuckGo.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Доверете се на DuckDuckGo да защитава повече от нещата, които правите онлайн";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/cs.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/cs.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Nastavit jako výchozí prohlížeč";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Znovu se neptat";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Zavřít";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Nastav si nás jako výchozí prohlížeč, aby se všechny odkazy na stránky otevíraly v DuckDuckGo.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Používej DuckDuckGo a získej větší ochranu při prohlížení internetu";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/da.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/da.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Angiv som standardbrowser";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Spørg ikke igen";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Luk";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Gør os til din standardbrowser, så alle links åbner i DuckDuckGo.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Lad DuckDuckGo beskytte mere af det, du foretager dig online";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/de.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/de.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Als Standard-Browser festlegen";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Nicht erneut fragen";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Schließen";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Mach uns zu deinem Standardbrowser, damit alle Links in DuckDuckGo geöffnet werden.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Mit DuckDuckGo kannst du mehr von dem schützen, was du online tust";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/el.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/el.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Ορισμός ως προεπιλεγμένο πρόγραμμα περιήγησης";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Μη ρωτήσετε ξανά";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Κλείσιμο";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Ορίστε μας ως το προεπιλεγμένο πρόγραμμα περιήγησής σας ώστε όλοι οι σύνδεσμοι του ιστότοπου να ανοίγουν στο DuckDuckGo.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Αφήστε το DuckDuckGo να προστατεύσει περισσότερα από όσα κάνετε στο διαδίκτυο";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/es.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/es.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Definir como navegador predeterminado";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "No volver a preguntar";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Cerrar";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Haznos tu navegador predeterminado para que todos los enlaces a sitios se abran en DuckDuckGo.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Deja que DuckDuckGo proteja más de lo que haces en línea";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/et.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/et.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Määrake vaikebrauseriks";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Ära küsi enam";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Sulge";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Muutke meid oma vaikebrauseriks, et kõik saidilingid avaneksid DuckDuckGos.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Laske DuckDuckGo'l kaitsta rohkem seda, mida te veebis teete";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/fi.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/fi.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Aseta oletusselaimeksi";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Älä kysy uudelleen";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Sulje";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Tee meistä oletusselaimesi, niin kaikki sivustolinkit avautuvat DuckDuckGo-selaimessa.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Anna DuckDuckGon suojata enemmän tekemisiäsi verkossa.";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/fr.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/fr.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Définir comme navigateur par défaut";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Ne plus demander";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Fermer";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Choisissez-nous comme navigateur par défaut afin que tous les liens de site s'ouvrent dans DuckDuckGo.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Laissez DuckDuckGo protéger davantage ce que vous faites en ligne";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/hr.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/hr.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Postavi kao zadani preglednik";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Ne pitaj ponovno";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Zatvori";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Postavi nas kao svoj zadani preglednik kako bi se sve poveznice otvorile u DuckDuckGou.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Neka DuckDuckGo zaštiti više onoga što radiš online";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/hu.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/hu.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Beállítás alapértelmezett böngészőként";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Ne kérdezzen rá újra";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Bezárás";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Legyen a DuckDuckGo az alapértelmezett böngésződ, hogy minden weboldal linkje a DuckDuckGóban nyíljon meg.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Hagyd, hogy a DuckDuckGo jobban megvédje, amit online csinálsz";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/it.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/it.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Imposta come Browser predefinito";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Non chiederlo più";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Chiudi";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Imposta DuckDuckGo come browser predefinito in modo che apra tutti i link dei siti.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Lascia che DuckDuckGo protegga meglio ciò che fai online";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/lt.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/lt.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Nustatyti kaip numatytąją naršyklę";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Daugiau neklausti";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Uždaryti";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Nustatykite „DuckDuckGo“ kaip numatytąją naršyklę, kad visos svetainių nuorodos atsidarytų su ja.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Leiskite „DuckDuckGo“ apsaugoti daugiau jūsų veiklos internete";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/lv.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/lv.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Iestatīt kā noklusējuma pārlūku";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Vairs nejautāt";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Aizvērt";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Iestati mūs kā savu noklusējuma pārlūku, lai visas vietņu saites atvērtos DuckDuckGo.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Ļauj DuckDuckGo vairāk aizsargāt to, ko dari tiešsaistē";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/nb.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/nb.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Gjør til standardnettleser";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Ikke spør igjen";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Lukk";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Gjør oss til standardnettleseren din slik at alle nettstedslenker åpnes i DuckDuckGo.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "La DuckDuckGo beskytte mer av det du gjør på nettet";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/nl.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/nl.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Instellen als standaard browser";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Niet opnieuw vragen";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Sluiten";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Maak ons je standaardbrowser zodat alle sitelinks in DuckDuckGo worden geopend.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Laat DuckDuckGo meer beschermen van wat je online doet";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/pl.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/pl.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Ustaw jako domyślną przeglądarkę";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Nie pytaj ponownie";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Zamknij";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Ustaw naszą przeglądarkę jako domyślną, aby wszystkie linki były otwierane w DuckDuckGo.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Skorzystaj z DuckDuckGo, aby chronić swoją aktywność w Internecie";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/pt.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/pt.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Definir como navegador padrão";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Não perguntar novamente";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Fechar";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Torna-nos o teu navegador predefinido para que todos os links dos sites sejam abertos no DuckDuckGo.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Deixa o DuckDuckGo proteger melhor o que fazes online";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/ro.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/ro.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Setare ca browser implicit";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Nu mai întreba";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Închidere";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Transformă-ne în browserul tău implicit, astfel încât toate linkurile de pe site să se deschidă în DuckDuckGo.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Lasă DuckDuckGo să protejeze mai mult din ceea ce faci online";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/ru.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/ru.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Сделать браузером по умолчанию";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Больше не спрашивать";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Закрыть";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Сделайте его браузером по умолчанию, чтобы все ссылки на сайты открывались в DuckDuckGo.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Оставайтесь под защитой DuckDuckGo большую часть времени, проводимого в Интернете";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/sk.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/sk.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Nastaviť ako predvolený prehliadač";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Už sa nepýtať";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Zatvoriť";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Nastav si nás ako svoj predvolený prehliadač, aby sa všetky odkazy na stránky otvárali v DuckDuckGo.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Nechaj DuckDuckGo chrániť viac toho, čo robíš online";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/sl.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/sl.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Nastavite za privzeti brskalnik";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Ne sprašuj več";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Zapri";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Nastavite nas kot privzeti brskalnik, da se vse povezave do spletnih mest odprejo v DuckDuckGo.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Naj DuckDuckGo zaščiti več vaše dejavnosti na spletu.";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/sv.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/sv.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Ställ in som standardwebbläsare";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Fråga inte igen";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Stäng";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Gör oss till din standardwebbläsare så att alla webbplatslänkar öppnas i DuckDuckGo.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "Låt DuckDuckGo skydda mer av det du gör online";
+

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/tr.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/tr.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* The tile of the CTA to set the browser as default. */
+"setDefaultBrowser.cta.primary.title" = "Varsayılan tarayıcı olarak ayarla";
+
+/* The title of the CTA to permanently dismiss the modal sheet. */
+"setDefaultBrowser.cta.secondary.title" = "Bir Daha Sorma";
+
+/* The title of the button to dismiss the modal sheet. */
+"setDefaultBrowser.modal.cta.cancel" = "Kapat";
+
+/* Set Default Browser Modal Sheet Message. */
+"setDefaultBrowser.modal.message" = "Tüm site bağlantılarının DuckDuckGo'da açılması için bizi varsayılan tarayıcınız yapın.";
+
+/* Set Default Browser Modal Sheet Title. */
+"setDefaultBrowser.modal.title" = "DuckDuckGo'nun internette yaptıklarınızın daha fazlasını korumasına izin verin";
+


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1210683081153607?focus=true
Tech Design URL:
CC:

### Description

This PR implements the following changes for Default Browser Prompt:
- Apply design changes discussed during ship review for small screen devices.
- Add string translations.
- Refactor service logic to make Main Coordinator present the dialog.
- Set the feature flag remote releasable.

### Testing Steps

**Prerequisites**
- Change the Privacy Config URL to https://www.jsonblob.com/api/1390576819966763008
- To facilitate testing feel free to override remote feature settings in “setAsDefaultAndAddToDock” and change 
`secondModalDelayDays` & `subsequentModalRepeatIntervalDays` values to a shorter number of days. E.g. 2 and 3.
- Ensure DDG is not set as default browser.
- Comment out lines 39-42 and 44 in `DefaultBrowserPromptService` to use real date provider.

**Scenario 1 - New/Returning User**
1. Open the Debug menu and select ‘Default Browser Prompt’.
2. Select 'New' or ‘Returning’ user.
3. Dismiss the Debug Menu.
4. Change the system settings date to 1 day in advance. Ensure that 24h have passed to be safe you can change the date 2 days in advance.
5. Bring the app back to foreground.
7. A modal should appear.
8. Tap the ‘Close’ button or manually dimiss it by pulling it down.
9. Send the app to background and bring it back to foreground.
10. Ensure the modal is not showed again.
11. The next modal should display in ‘x’ days depending on the remote config settings ‘secondModalDelayDays' as stated in the prerequisites. 
12. Send the app in the background and advance of 1 day. Bring the app to foreground. This will record an active day.
13. Repeat step 12 depending on the number of days specified in ‘secondModalDelayDays'.
15. When bringing the app to foreground, ensure the modal is shown when the number of active days matches ‘secondModalDelayDays’.
16. Tap the ‘Close’ button or manually dimiss it by pulling it down.
17. The next modal should display in ‘x’ days depending on the remote config settings 'subsequentModalRepeatIntervalDays ‘ as stated in the prerequisites. 
18. Send the app in the background and advance of 1 day. Bring the app to foreground. This will record an active day.
19. Repeat step 18 depending on the number of days specified in ‘subsequentModalRepeatIntervalDays'.
20. When bringing the app to foreground, ensure the modal is shown when the number of active days matches ‘subsequentModalRepeatIntervalDays’.
21. Tap ’Set Default Browser’ Button.
22. Ensure the app deeplinks to the settings.
23. Set DDG as default browser.
24. The next modal should display in ‘x’ days depending on the remote config settings 'subsequentModalRepeatIntervalDays ‘ as stated in the prerequisites. 
25. Send the app in the background and advance of 1 day. Bring the app to foreground. This will record an active day.
26. Repeat step 25 depending on the number of days specified in ‘subsequentModalRepeatIntervalDays'.
27. When bringing the app to foreground, ensure the modal is NOT SHOWN when the number of active days matches ‘subsequentModalRepeatIntervalDays’.

Reset Safari as Default browser and repeat the scenario by selecting ’Don't Ask again’ after showing the first modal and ensure no modal are shown again.

**Scenario 2 - Existing User
1. Open the Debug menu and select ‘Default Browser Prompt’.
2. Select ‘Existig’ user and Reset the prompt settings.
3. Dismiss the Debug Menu.
4. Change the system settings date to 1 day in advance. Ensure that 24h have passed to be safe you can change the date 2 days in advance.
5. Bring the app back to foreground.
7. A modal should appear.
8. Tap the ‘Close’ button or manually dimiss it by pulling it down.
9. Send the app to background and bring it back to foreground.
10. Ensure the modal is not showed again.
11. The next modal should display in ‘x’ days depending on the remote config settings 'subsequentModalRepeatIntervalDays ‘ as stated in the prerequisites. 
12. Send the app in the background and advance of 1 day. Bring the app to foreground. This will record an active day.
13. Repeat step 18 depending on the number of days specified in ‘subsequentModalRepeatIntervalDays'.
14. When bringing the app to foreground, ensure the modal is shown when the number of active days matches ‘subsequentModalRepeatIntervalDays’.
15. Tap ’Set Default Browser’ Button.
16. Ensure the app deeplinks to the settings.
17. Set DDG as default browser.
18. The next modal should display in ‘x’ days depending on the remote config settings 'subsequentModalRepeatIntervalDays ‘ as stated in the prerequisites. 
19. Send the app in the background and advance of 1 day. Bring the app to foreground. This will record an active day.
20. Repeat step 19 depending on the number of days specified in ‘subsequentModalRepeatIntervalDays'.
27. When bringing the app to foreground, ensure the modal is NOT SHOWN when the number of active days matches ‘subsequentModalRepeatIntervalDays’.

Reset Safari as Default browser and repeat the scenario by selecting ’Don't Ask again’ after showing the first modal and ensure no modal are shown again.

**Scenario 3 - Translations**
1. Select a language different from English and ensure modal is correctly translated.

### Impact and Risks
Medium. Users could be prompted with the modal more times than necessary if the logic is not implemented correctly. However, users can opt out by tapping “Don’t ask again" button which should reduce the risk of bad ux if anything goes wrong.

#### What could go wrong?
If the logic is not implemented correctly there’s a risk we could present the modal sheet more often than expected.

### Quality Considerations
The business logic is extensively tested to ensure modal are only presented at the right time.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)