### PR TITLE
Always call urlChange for DuckPlayer

### DIFF
--- a/iOS/DuckDuckGo/DuckPlayer/NativeUI/NativeDuckPlayerNavigationHandler.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/NativeUI/NativeDuckPlayerNavigationHandler.swift
@@ -316,6 +316,9 @@ extension NativeDuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
 
         guard featureFlagger.isFeatureOn(.duckPlayer) else { return .notHandled(.featureOff) }
 
+        // Notify user script of URL change for all URLs
+        notifyUserScriptOfURLChange(webView: webView, newURL: newURL)
+
         // Skip if the new URL is a YouTube watch page with a hashtag
         // This is a special case where YouTube navigates to/from intenal UI (Search, setttings, etc)
         if let previousID = previousURL?.youtubeVideoParams?.0,
@@ -382,7 +385,6 @@ extension NativeDuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
         // Present Duck Player Pill (Native entry point)
         if duckPlayer.settings.nativeUIYoutubeMode == .ask {
             lastHandledVideoID = videoID
-            notifyUserScriptOfURLChange(webView: webView, newURL: newURL)
             presentDuckPlayerPill(for: videoID, timestamp: nil)
             return .handled(.duckPlayerEnabled)
         }
@@ -390,7 +392,6 @@ extension NativeDuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
         // Present Duck Player
         if duckPlayer.settings.nativeUIYoutubeMode == .auto {
             lastHandledVideoID = videoID
-            notifyUserScriptOfURLChange(webView: webView, newURL: newURL)
             Task { @MainActor in await pauseVideoStart(webView: webView) }
             presentDuckPlayerPill(for: videoID, timestamp: nil)
             presentDuckPlayer(for: videoID, timestamp: nil)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204099484721401/task/1210584560074598?focus=true
Tech Design URL: 
CC: N/A

### Description
Moves `notifyUserScriptOfURLChange` to always execute early in the URL change flow, ensuring user scripts receive consistent notifications regardless of DuckPlayer's handling mode.

### Testing Steps
1. Navigate to video with shorts listed: (https://m.youtube.com/watch?v=L3gOf2XDp8Y&pp=ygUHRGlzbmV5dA%3D%3D)
2. Open Duck Player
3. Close Duck Player (Observe video is paused)
4. Tap a short
5. Observe shorts plays (Before the fix, shorts were paused)

![CleanShot 2025-07-04 at 17 32 48](https://github.com/user-attachments/assets/d35e69e4-818b-4a0c-9261-ae77269f663e)


### Impact and Risks
**Impact Level: Low** - Improves user script communication reliability

#### What could go wrong?
- Additional notifications might affect user script behavior

**Mitigation:**
- User scripts designed to handle URL changes efficiently
- No changes to main DuckPlayer functionality

### Quality Considerations

### Notes to Reviewer