### PR TITLE
Fix flaky CrashLogMessageExtractor test

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Crashes/CrashLogMessageExtractor.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Crashes/CrashLogMessageExtractor.swift
@@ -165,10 +165,12 @@ public struct CrashLogMessageExtractor {
 
     let fileManager: FileManager
     let diagnosticsDirectory: URL
+    let dateProvider: () -> Date
 
-    public init(fileManager: FileManager? = nil, diagnosticsDirectory: URL? = nil) {
+    public init(fileManager: FileManager? = nil, diagnosticsDirectory: URL? = nil, dateProvider: @escaping () -> Date = Date.init) {
         self.fileManager = fileManager ?? .default
         self.diagnosticsDirectory = diagnosticsDirectory ?? Self.diagnosticsDirectory ?? self.fileManager.diagnosticsDirectory
+        self.dateProvider = dateProvider
     }
 
     /// Write exception diagnostics as JSON data, including the exception name, reason, and `userInfo` dictionary,
@@ -186,7 +188,8 @@ public struct CrashLogMessageExtractor {
         Logger.general.log("😵 crashing on: \(message, privacy: .public)")
 
         // save crash log with `2024-05-20T12:11:33Z-%pid%.log` file name format
-        let timestamp = ISO8601DateFormatter().string(from: Date())
+        let date = dateProvider()
+        let timestamp = ISO8601DateFormatter().string(from: date)
         let fileName = "\(timestamp)-\(ProcessInfo().processIdentifier).log"
         let fileURL = diagnosticsDirectory.appendingPathComponent(fileName)
 

--- a/SharedPackages/BrowserServicesKit/Tests/CrashesTests/CrashLogMessageExtractorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/CrashesTests/CrashLogMessageExtractorTests.swift
@@ -82,7 +82,7 @@ final class CrashLogMessageExtractorTests: XCTestCase {
         let fileName = "\(date)-\(ProcessInfo().processIdentifier).log"
         let dir = fm.temporaryDirectory
         let url = dir.appendingPathComponent(fileName)
-        extractor = CrashLogMessageExtractor(diagnosticsDirectory: dir)
+        extractor = CrashLogMessageExtractor(diagnosticsDirectory: dir, dateProvider: { referenceDate })
 
         let exception =  NSException(name: NSExceptionName(rawValue: "TestException"), reason: "Test crash message /with/file/path", userInfo: ["key1": "value1"])
         exception.setValue(["callStackSymbols": [


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1210723549550858?focus=true
Tech Design URL:
CC:

### Description

This PR fixes a flaky CrashLogMessageExtractor test, where the test and extractor were using different `Date` objects, occasionally running into a mismatch when one of them was slightly ahead.

An example failure can be seen in https://github.com/duckduckgo/apple-browsers/actions/runs/16095628688.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI is green
2. For bonus points, run the test locally with a large number of iterations

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)