### PR TITLE
iOS: implement Duck.ai session update based on subscription state

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -326,6 +326,7 @@
 		4BF557F02DF79393008E16A8 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4BF557EF2DF79393008E16A8 /* WebKit.framework */; };
 		56038D5F2E0E97B20001419D /* SubscriptionURLNavigationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56038D5E2E0E97B20001419D /* SubscriptionURLNavigationHandler.swift */; };
 		560E990F2BEE2CB800507CE0 /* SyncErrorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560E990E2BEE2CB800507CE0 /* SyncErrorMessage.swift */; };
+		562BE5652E1C270A0064F305 /* AIChatViewControllerManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DC47192E1C087B00ADE613 /* AIChatViewControllerManagerTests.swift */; };
 		563A3CFE2D37B8FA001966FD /* ConfigurationManagerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563A3CFD2D37B8FA001966FD /* ConfigurationManagerIntegrationTests.swift */; };
 		563A3D012D37BF83001966FD /* ConfigurationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563A3D002D37BF83001966FD /* ConfigurationManagerTests.swift */; };
 		563A3D032D37C363001966FD /* AppConfigurationURLProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563A3D022D37C363001966FD /* AppConfigurationURLProviderTests.swift */; };
@@ -2253,6 +2254,7 @@
 		56D5B3992DD3831800407440 /* ScriptSourceProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptSourceProviderTests.swift; sourceTree = "<group>"; };
 		56D855692BEA9169009F9698 /* CurrentDateProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentDateProviding.swift; sourceTree = "<group>"; };
 		56D8556B2BEA91C4009F9698 /* SyncAlertsPresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncAlertsPresenting.swift; sourceTree = "<group>"; };
+		56DC47192E1C087B00ADE613 /* AIChatViewControllerManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatViewControllerManagerTests.swift; sourceTree = "<group>"; };
 		650552962D673E440067D4F2 /* muteAudio.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = muteAudio.js; sourceTree = "<group>"; };
 		650552A12D67768E0067D4F2 /* DuckPlayerEntryPillViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckPlayerEntryPillViewModel.swift; sourceTree = "<group>"; };
 		6526CA6A2D70CAAD0048819E /* DuckPlayerMiniPillViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DuckPlayerMiniPillViewModel.swift; sourceTree = "<group>"; };
@@ -4946,6 +4948,14 @@
 			name = LiveActivity;
 			sourceTree = "<group>";
 		};
+		562BE5642E1C26F80064F305 /* AiChat */ = {
+			isa = PBXGroup;
+			children = (
+				56DC47192E1C087B00ADE613 /* AIChatViewControllerManagerTests.swift */,
+			);
+			path = AiChat;
+			sourceTree = "<group>";
+		};
 		563A3CFC2D37B8E3001966FD /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
@@ -5038,6 +5048,13 @@
 				56D060272C380D83003BAEB5 /* OnboardingSuggestedSearchesProvider.swift */,
 			);
 			path = OnboardingHelpers;
+			sourceTree = "<group>";
+		};
+		56DC47182E1C079000ADE613 /* New Group */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = "New Group";
 			sourceTree = "<group>";
 		};
 		650552982D673E440067D4F2 /* Scripts */ = {
@@ -6065,6 +6082,7 @@
 		85D33FCC25C97B6E002B91A6 /* IntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
+				562BE5642E1C26F80064F305 /* AiChat */,
 				563A3CFC2D37B8E3001966FD /* Configuration */,
 				1E1D8B5F29950FB300C96994 /* Autoconsent */,
 				85F21DBD21121147002631A6 /* AtbServerTests.swift */,
@@ -7929,6 +7947,7 @@
 		F12D98401F266B30003C2EE3 /* DuckDuckGo */ = {
 			isa = PBXGroup;
 			children = (
+				56DC47182E1C079000ADE613 /* New Group */,
 				6FE23A842DF193BE00E44664 /* RemoteMessage */,
 				56CA25EC2DB7ABAC00BE4226 /* Localization */,
 				6FF9157F2B88E04F0042AC87 /* AdAttribution */,
@@ -10895,6 +10914,7 @@
 				98E564282DE8B32D00E6E75F /* MockTimer.swift in Sources */,
 				98E564292DE8B32D00E6E75F /* MockBookmarksCoreDataStorage.swift in Sources */,
 				98E5642A2DE8B32D00E6E75F /* DefaultBrowserManagerMock.swift in Sources */,
+				562BE5652E1C270A0064F305 /* AIChatViewControllerManagerTests.swift in Sources */,
 				98E5642B2DE8B32D00E6E75F /* MockAIChatSettingsProvider.swift in Sources */,
 				98E5642C2DE8B32D00E6E75F /* MockDDGSyncing.swift in Sources */,
 				98E564AC2DE8EDF000E6E75F /* CapturingAdapterErrorHandler.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 		319A37152829A55F0079FBCE /* AutofillListItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319A37142829A55F0079FBCE /* AutofillListItemTableViewCell.swift */; };
 		319A37172829C8AD0079FBCE /* UITableViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319A37162829C8AD0079FBCE /* UITableViewExtension.swift */; };
 		319BE1092D47EBE300E510A4 /* AIChatUserScriptHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319BE1082D47EBE300E510A4 /* AIChatUserScriptHandlerTests.swift */; };
+		31A2B6E02E1C3BE000391020 /* SubscriptionAIChatStateHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A2B6DF2E1C3BDF00391020 /* SubscriptionAIChatStateHandler.swift */; };
 		31A42564285A09E800049386 /* FaviconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A42563285A09E800049386 /* FaviconView.swift */; };
 		31A42566285A0A6300049386 /* FaviconViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A42565285A0A6300049386 /* FaviconViewModel.swift */; };
 		31A71F382E0B225A00F23147 /* SwitchBarButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A71F372E0B225A00F23147 /* SwitchBarButtonsView.swift */; };
@@ -2123,6 +2124,7 @@
 		319A37142829A55F0079FBCE /* AutofillListItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillListItemTableViewCell.swift; sourceTree = "<group>"; };
 		319A37162829C8AD0079FBCE /* UITableViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITableViewExtension.swift; sourceTree = "<group>"; };
 		319BE1082D47EBE300E510A4 /* AIChatUserScriptHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatUserScriptHandlerTests.swift; sourceTree = "<group>"; };
+		31A2B6DF2E1C3BDF00391020 /* SubscriptionAIChatStateHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionAIChatStateHandler.swift; sourceTree = "<group>"; };
 		31A42563285A09E800049386 /* FaviconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconView.swift; sourceTree = "<group>"; };
 		31A42565285A0A6300049386 /* FaviconViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconViewModel.swift; sourceTree = "<group>"; };
 		31A71F372E0B225A00F23147 /* SwitchBarButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchBarButtonsView.swift; sourceTree = "<group>"; };
@@ -4590,6 +4592,7 @@
 				31C314A32D2EF9DF009A412A /* UserScript */,
 				31D2D2A12D40F7E900549D12 /* AIChatDeepLinkHandler.swift */,
 				3105BCF02DF214A000EB755E /* AIChatPixelMetricHandler.swift */,
+				31A2B6DF2E1C3BDF00391020 /* SubscriptionAIChatStateHandler.swift */,
 				31C314A12D2EF60A009A412A /* AIChatViewControllerManager.swift */,
 				311711902D00E53A0063AC3D /* OmnibarAccessoryHandling.swift */,
 				316AA4592CF8E31F00A2ED28 /* AIChatSettings.swift */,
@@ -10239,6 +10242,7 @@
 				C17B595A2A03AAD30055F2D1 /* PasswordGenerationPromptViewController.swift in Sources */,
 				8531A08E1F9950E6000484F0 /* UnprotectedSitesViewController.swift in Sources */,
 				CBF259C72D4ED93F00AC63E4 /* OnboardingConfiguration.swift in Sources */,
+				31A2B6E02E1C3BE000391020 /* SubscriptionAIChatStateHandler.swift in Sources */,
 				CBD4F13C279EBF4A00B20FD7 /* HomeMessage.swift in Sources */,
 				6FB2A67E2C2DAFB4004D20C8 /* NewTabPageGridView.swift in Sources */,
 				31D4CD4B2D4D1C2D00BC27C6 /* ToolbarStateHandling.swift in Sources */,

--- a/iOS/DuckDuckGo/AIChat/AIChatViewControllerManager.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatViewControllerManager.swift
@@ -46,7 +46,7 @@ final class AIChatViewControllerManager {
 
     private var aiChatUserScript: AIChatUserScript?
     private var payloadHandler = AIChatPayloadHandler()
-    private var shouldInvalidateOnNextOpen = false
+    private let subscriptionAIChatStateHandler: SubscriptionAIChatStateHandling
 
     private let privacyConfigurationManager: PrivacyConfigurationManaging
     private let downloadsDirectoryHandler: DownloadsDirectoryHandling
@@ -57,7 +57,6 @@ final class AIChatViewControllerManager {
     private var cancellables = Set<AnyCancellable>()
     private var sessionTimer: AIChatSessionTimer?
     private var pixelMetricHandler: (any AIChatPixelMetricHandling)?
-    private var subscriptionCancellables = Set<AnyCancellable>()
 
     // MARK: - Initialization
 
@@ -66,7 +65,8 @@ final class AIChatViewControllerManager {
          userAgentManager: UserAgentManager = DefaultUserAgentManager.shared,
          experimentalAIChatManager: ExperimentalAIChatManager,
          featureFlagger: FeatureFlagger,
-         aiChatSettings: AIChatSettingsProvider) {
+         aiChatSettings: AIChatSettingsProvider,
+         subscriptionAIChatStateHandler: SubscriptionAIChatStateHandling = SubscriptionAIChatStateHandler()) {
 
         self.privacyConfigurationManager = privacyConfigurationManager
         self.downloadsDirectoryHandler = downloadsDirectoryHandler
@@ -74,8 +74,7 @@ final class AIChatViewControllerManager {
         self.experimentalAIChatManager = experimentalAIChatManager
         self.featureFlagger = featureFlagger
         self.aiChatSettings = aiChatSettings
-
-        setupSubscriptionStateObservers()
+        self.subscriptionAIChatStateHandler = subscriptionAIChatStateHandler
     }
 
     // MARK: - Public Methods
@@ -87,12 +86,17 @@ final class AIChatViewControllerManager {
                     on viewController: UIViewController) {
         downloadsDirectoryHandler.createDownloadsDirectoryIfNeeded()
 
+        /// Reset the session timer if the subscription state has changed, as we will force a refresh on AI Chat
+        if subscriptionAIChatStateHandler.shouldForceAIChatRefresh {
+            stopSessionTimer()
+        }
+
         pixelMetricHandler = AIChatPixelMetricHandler(timeElapsedInMinutes: sessionTimer?.timeElapsedInMinutes())
         pixelMetricHandler?.fireOpenAIChat()
 
         /// If we have a query or payload, let's clean the previous session and start fresh
-        if query != nil || payload != nil || shouldInvalidateOnNextOpen {
-            shouldInvalidateOnNextOpen = false
+        if query != nil || payload != nil || subscriptionAIChatStateHandler.shouldForceAIChatRefresh {
+            subscriptionAIChatStateHandler.reset()
             Task {
                 await cleanUpSession()
                 setupAndPresentAIChat(query, payload: payload, autoSend: autoSend, on: viewController)
@@ -143,6 +147,7 @@ final class AIChatViewControllerManager {
 
     private func stopSessionTimer() {
         sessionTimer?.cancel()
+        sessionTimer = nil
     }
 
     private var isKeepSessionEnabled: Bool {
@@ -191,33 +196,6 @@ final class AIChatViewControllerManager {
             payloadHandler.setData(payload)
             aiChatViewController.reload()
         }
-    }
-
-    private func setupSubscriptionStateObservers() {
-        NotificationCenter.default.publisher(for: .subscriptionDidChange)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] notification in
-                self?.handleSubscriptionStateChange(notification)
-            }
-            .store(in: &subscriptionCancellables)
-
-        NotificationCenter.default.publisher(for: .accountDidSignIn)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] notification in
-                self?.handleSubscriptionStateChange(notification)
-            }
-            .store(in: &subscriptionCancellables)
-
-        NotificationCenter.default.publisher(for: .accountDidSignOut)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] notification in
-                self?.handleSubscriptionStateChange(notification)
-            }
-            .store(in: &subscriptionCancellables)
-    }
-
-    private func handleSubscriptionStateChange(_ notification: Notification, ) {
-        shouldInvalidateOnNextOpen = true
     }
 
     private func isInspectableWebViewEnabled() -> Bool {

--- a/iOS/DuckDuckGo/AIChat/AIChatViewControllerManager.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatViewControllerManager.swift
@@ -41,11 +41,12 @@ final class AIChatViewControllerManager {
 
     // MARK: - Private Properties
 
-    private var chatViewController: AIChatViewController?
+    private(set) var chatViewController: AIChatViewController?
     private weak var userContentController: UserContentController?
 
     private var aiChatUserScript: AIChatUserScript?
     private var payloadHandler = AIChatPayloadHandler()
+    private var shouldInvalidateOnNextOpen = false
 
     private let privacyConfigurationManager: PrivacyConfigurationManaging
     private let downloadsDirectoryHandler: DownloadsDirectoryHandling
@@ -56,6 +57,7 @@ final class AIChatViewControllerManager {
     private var cancellables = Set<AnyCancellable>()
     private var sessionTimer: AIChatSessionTimer?
     private var pixelMetricHandler: (any AIChatPixelMetricHandling)?
+    private var subscriptionCancellables = Set<AnyCancellable>()
 
     // MARK: - Initialization
 
@@ -72,6 +74,8 @@ final class AIChatViewControllerManager {
         self.experimentalAIChatManager = experimentalAIChatManager
         self.featureFlagger = featureFlagger
         self.aiChatSettings = aiChatSettings
+
+        setupSubscriptionStateObservers()
     }
 
     // MARK: - Public Methods
@@ -87,7 +91,8 @@ final class AIChatViewControllerManager {
         pixelMetricHandler?.fireOpenAIChat()
 
         /// If we have a query or payload, let's clean the previous session and start fresh
-        if query != nil || payload != nil {
+        if query != nil || payload != nil || shouldInvalidateOnNextOpen {
+            shouldInvalidateOnNextOpen = false
             Task {
                 await cleanUpSession()
                 setupAndPresentAIChat(query, payload: payload, autoSend: autoSend, on: viewController)
@@ -186,6 +191,33 @@ final class AIChatViewControllerManager {
             payloadHandler.setData(payload)
             aiChatViewController.reload()
         }
+    }
+
+    private func setupSubscriptionStateObservers() {
+        NotificationCenter.default.publisher(for: .subscriptionDidChange)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                self?.handleSubscriptionStateChange(notification)
+            }
+            .store(in: &subscriptionCancellables)
+
+        NotificationCenter.default.publisher(for: .accountDidSignIn)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                self?.handleSubscriptionStateChange(notification)
+            }
+            .store(in: &subscriptionCancellables)
+
+        NotificationCenter.default.publisher(for: .accountDidSignOut)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                self?.handleSubscriptionStateChange(notification)
+            }
+            .store(in: &subscriptionCancellables)
+    }
+
+    private func handleSubscriptionStateChange(_ notification: Notification, ) {
+        shouldInvalidateOnNextOpen = true
     }
 
     private func isInspectableWebViewEnabled() -> Bool {

--- a/iOS/DuckDuckGo/AIChat/SubscriptionAIChatStateHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/SubscriptionAIChatStateHandler.swift
@@ -1,0 +1,75 @@
+//
+//  SubscriptionAIChatStateHandler.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import Foundation
+
+/// Manages AI Chat refresh state when subscription status changes.
+///
+/// When a user's subscription changes (sign-in, sign-out, or plan change),
+/// AI Chat needs to reload to reflect the new subscription features and limits.
+protocol SubscriptionAIChatStateHandling {
+    /// Indicates if AI Chat should refresh due to subscription changes.
+    ///
+    /// Becomes `true` when subscription status changes.
+    var shouldForceAIChatRefresh: Bool { get }
+
+    /// Clears the refresh flag after AI Chat has been reloaded.
+    func reset()
+}
+
+final class SubscriptionAIChatStateHandler: SubscriptionAIChatStateHandling {
+    private(set) var shouldForceAIChatRefresh: Bool = false
+    private var subscriptionCancellables = Set<AnyCancellable>()
+
+    init() {
+        setupSubscriptionStateObservers()
+    }
+
+    private func setupSubscriptionStateObservers() {
+        NotificationCenter.default.publisher(for: .subscriptionDidChange)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                self?.handleSubscriptionStateChange(notification)
+            }
+            .store(in: &subscriptionCancellables)
+
+        NotificationCenter.default.publisher(for: .accountDidSignIn)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                self?.handleSubscriptionStateChange(notification)
+            }
+            .store(in: &subscriptionCancellables)
+
+        NotificationCenter.default.publisher(for: .accountDidSignOut)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                self?.handleSubscriptionStateChange(notification)
+            }
+            .store(in: &subscriptionCancellables)
+    }
+
+    private func handleSubscriptionStateChange(_ notification: Notification, ) {
+        shouldForceAIChatRefresh = true
+    }
+
+    func reset() {
+        shouldForceAIChatRefresh = false
+    }
+}

--- a/iOS/IntegrationTests/AiChat/AIChatViewControllerManagerTests.swift
+++ b/iOS/IntegrationTests/AiChat/AIChatViewControllerManagerTests.swift
@@ -1,0 +1,215 @@
+//
+//  AIChatViewControllerManagerTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Testing
+import Foundation
+import Combine
+import BrowserServicesKit
+import Subscription
+@testable import DuckDuckGo
+import UIKit
+
+struct AIChatViewControllerManagerTests {
+    
+    // MARK: - Helper Methods
+    private var delegate = MockAIChatViewControllerManagerDelegate()
+    private func createManager() -> AIChatViewControllerManager {
+        let manager = AIChatViewControllerManager(
+            privacyConfigurationManager: MockPrivacyConfigurationManager(),
+            downloadsDirectoryHandler: MockDownloadsDirectoryHandler(),
+            userAgentManager: MockUserAgentManager(privacyConfig: MockPrivacyConfiguration()),
+            experimentalAIChatManager: ExperimentalAIChatManager(),
+            featureFlagger: MockFeatureFlagger(),
+            aiChatSettings: MockAIChatSettingsProvider()
+        )
+
+        manager.delegate = delegate
+        return manager
+    }
+    
+    @MainActor
+    private func createMockViewController() -> MockUIViewController {
+        return MockUIViewController()
+    }
+    
+    private func waitForMainThreadProcessing() async {
+        // Allow time for processing on main queue
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+    }
+
+    @Test("When no notification triggers view controller not updated")
+    @MainActor
+    func testOpeningAIChatTwiceReusesTheSameViewController() async throws {
+        let manager = createManager()
+        let mockViewController = createMockViewController()
+
+        // First, establish an AI chat session
+        manager.openAIChat(on: mockViewController)
+        await waitForMainThreadProcessing()
+        let firstViewController = manager.chatViewController
+
+        // Open AI chat again - should use the same view controller
+        manager.openAIChat(on: mockViewController)
+        await waitForMainThreadProcessing()
+
+        // Verify the session invalidation was triggered by account sign in
+        #expect(manager.chatViewController != nil)
+        #expect(firstViewController != nil)
+        #expect(manager.chatViewController === firstViewController)
+    }
+
+    @Test("Account sign in notification triggers session invalidation")
+    @MainActor
+    func testAccountSignInTriggersSessionInvalidation() async throws {
+        let manager = createManager()
+        let mockViewController = createMockViewController()
+        
+        // First, establish an AI chat session
+        manager.openAIChat(on: mockViewController)
+        await waitForMainThreadProcessing()
+
+        let firstViewController = manager.chatViewController
+        // Simulate user signing in to their account
+        NotificationCenter.default.post(
+            name: .accountDidSignIn,
+            object: nil,
+            userInfo: nil
+        )
+        await waitForMainThreadProcessing()
+
+        // Open AI chat again - session should be invalidated due to account sign in
+        manager.openAIChat(on: mockViewController)
+        await waitForMainThreadProcessing()
+        
+        // Verify the session invalidation was triggered by account sign in
+        #expect(manager.chatViewController != nil)
+        #expect(firstViewController != nil)
+        #expect(manager.chatViewController !== firstViewController)
+    }
+
+    @Test("Account sign out notification triggers session invalidation")
+    @MainActor
+    func testAccountSignOutTriggersSessionInvalidation() async throws {
+        let manager = createManager()
+        let mockViewController = createMockViewController()
+
+        // First, establish an AI chat session
+        manager.openAIChat(on: mockViewController)
+        await waitForMainThreadProcessing()
+
+        let firstViewController = manager.chatViewController
+        // Simulate user signing in to their account
+        NotificationCenter.default.post(
+            name: .accountDidSignOut,
+            object: nil,
+            userInfo: nil
+        )
+        await waitForMainThreadProcessing()
+
+        // Open AI chat again - session should be invalidated due to account sign in
+        manager.openAIChat(on: mockViewController)
+        await waitForMainThreadProcessing()
+
+        // Verify the session invalidation was triggered by account sign in
+        #expect(manager.chatViewController != nil)
+        #expect(firstViewController != nil)
+        #expect(manager.chatViewController !== firstViewController)
+    }
+
+    @Test("Subscription Did Change notification triggers session invalidation")
+    @MainActor
+    func testSubscriptionDidChangeTriggersSessionInvalidation() async throws {
+        let manager = createManager()
+        let mockViewController = createMockViewController()
+
+        // First, establish an AI chat session
+        manager.openAIChat(on: mockViewController)
+        await waitForMainThreadProcessing()
+
+        let firstViewController = manager.chatViewController
+        // Simulate user signing in to their account
+        NotificationCenter.default.post(
+            name: .subscriptionDidChange,
+            object: nil,
+            userInfo: nil
+        )
+        await waitForMainThreadProcessing()
+
+        // Open AI chat again - session should be invalidated due to account sign in
+        manager.openAIChat(on: mockViewController)
+        await waitForMainThreadProcessing()
+
+        // Verify the session invalidation was triggered by account sign in
+        #expect(manager.chatViewController != nil)
+        #expect(firstViewController != nil)
+        #expect(manager.chatViewController !== firstViewController)
+    }
+
+}
+
+// MARK: - Mock UIViewController for Testing
+
+private class MockUIViewController: UIViewController {
+    var presentedViewControllerForTest: UIViewController?
+    var presentCallCount = 0
+
+    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        presentedViewControllerForTest = viewControllerToPresent
+        presentCallCount += 1
+        completion?()
+    }
+}
+
+private final class MockDownloadsDirectoryHandler: DownloadsDirectoryHandling {
+    var downloadsDirectoryFiles: [URL] = []
+
+    func downloadsDirectoryExists() -> Bool {
+        return false
+    }
+
+    func createDownloadsDirectory() {
+    }
+
+    var downloadsDirectory: URL = URL(string: "/tmp/downloads")!
+    func createDownloadsDirectoryIfNeeded() {}
+}
+
+private final class MockAIChatViewControllerManagerDelegate: AIChatViewControllerManagerDelegate {
+    var loadedURL: URL?
+    var downloadFileName: String?
+    var didReceiveOpenSettingsRequest: Bool = false
+    var submittedQuery: String?
+
+    func aiChatViewControllerManager(_ manager: AIChatViewControllerManager, didRequestToLoad url: URL) {
+        loadedURL = url
+    }
+
+    func aiChatViewControllerManager(_ manager: AIChatViewControllerManager, didRequestOpenDownloadWithFileName fileName: String) {
+        downloadFileName = fileName
+    }
+
+    func aiChatViewControllerManagerDidReceiveOpenSettingsRequest(_ manager: AIChatViewControllerManager) {
+        didReceiveOpenSettingsRequest = true
+    }
+
+    func aiChatViewControllerManager(_ manager: AIChatViewControllerManager, didSubmitQuery query: String) {
+        submittedQuery = query
+    }
+}

--- a/iOS/IntegrationTests/AiChat/AIChatViewControllerManagerTests.swift
+++ b/iOS/IntegrationTests/AiChat/AIChatViewControllerManagerTests.swift
@@ -48,7 +48,7 @@ struct AIChatViewControllerManagerTests {
         return MockUIViewController()
     }
     
-    private func waitForMainThreadProcessing() async {
+    private func waitForTaskProcessing() async {
         // Allow time for processing on main queue
         await Task.yield()
         try? await Task.sleep(nanoseconds: 100_000_000)
@@ -62,12 +62,12 @@ struct AIChatViewControllerManagerTests {
 
         // First, establish an AI chat session
         manager.openAIChat(on: mockViewController)
-        await waitForMainThreadProcessing()
+        await waitForTaskProcessing()
         let firstViewController = manager.chatViewController
 
         // Open AI chat again - should use the same view controller
         manager.openAIChat(on: mockViewController)
-        await waitForMainThreadProcessing()
+        await waitForTaskProcessing()
 
         // Verify the session invalidation was triggered by account sign in
         #expect(manager.chatViewController != nil)
@@ -83,7 +83,7 @@ struct AIChatViewControllerManagerTests {
         
         // First, establish an AI chat session
         manager.openAIChat(on: mockViewController)
-        await waitForMainThreadProcessing()
+        await waitForTaskProcessing()
 
         let firstViewController = manager.chatViewController
         // Simulate user signing in to their account
@@ -92,12 +92,12 @@ struct AIChatViewControllerManagerTests {
             object: nil,
             userInfo: nil
         )
-        await waitForMainThreadProcessing()
+        await waitForTaskProcessing()
 
         // Open AI chat again - session should be invalidated due to account sign in
         manager.openAIChat(on: mockViewController)
-        await waitForMainThreadProcessing()
-        
+        await waitForTaskProcessing()
+
         // Verify the session invalidation was triggered by account sign in
         #expect(manager.chatViewController != nil)
         #expect(firstViewController != nil)
@@ -112,7 +112,7 @@ struct AIChatViewControllerManagerTests {
 
         // First, establish an AI chat session
         manager.openAIChat(on: mockViewController)
-        await waitForMainThreadProcessing()
+        await waitForTaskProcessing()
 
         let firstViewController = manager.chatViewController
         // Simulate user signing in to their account
@@ -121,11 +121,11 @@ struct AIChatViewControllerManagerTests {
             object: nil,
             userInfo: nil
         )
-        await waitForMainThreadProcessing()
+        await waitForTaskProcessing()
 
         // Open AI chat again - session should be invalidated due to account sign in
         manager.openAIChat(on: mockViewController)
-        await waitForMainThreadProcessing()
+        await waitForTaskProcessing()
 
         // Verify the session invalidation was triggered by account sign in
         #expect(manager.chatViewController != nil)
@@ -141,7 +141,7 @@ struct AIChatViewControllerManagerTests {
 
         // First, establish an AI chat session
         manager.openAIChat(on: mockViewController)
-        await waitForMainThreadProcessing()
+        await waitForTaskProcessing()
 
         let firstViewController = manager.chatViewController
         // Simulate user signing in to their account
@@ -150,11 +150,11 @@ struct AIChatViewControllerManagerTests {
             object: nil,
             userInfo: nil
         )
-        await waitForMainThreadProcessing()
+        await waitForTaskProcessing()
 
         // Open AI chat again - session should be invalidated due to account sign in
         manager.openAIChat(on: mockViewController)
-        await waitForMainThreadProcessing()
+        await waitForTaskProcessing()
 
         // Verify the session invalidation was triggered by account sign in
         #expect(manager.chatViewController != nil)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1210723156401816
Tech Design URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1210723156215684

### Description Implement subscription state change listeners that reset active Duck.ai sessions when subscription status changes, ensuring immediate reflection of subscription state.

### Testing Steps
1. Make sure you are unsubscribed
2. Turn paidAiChat feature flag on
3. go to all debug settings -> Set Custom AI Chat URL  to https://euw-serp-dev-testing10.duck.co/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=1 
4. Open Duck.ai which should have a drop down menu at the top and should shoe the “Free” logo
5. Subscribe to DuckDuckGo
6.  Open Duck.ai which should have a drop down menu at the top and should shoe the “Subscribed” logo
7. Go to subscription settings and remove subscription from device 
8. Open Duck.ai which should have a drop down menu at the top and should shoe the “Free” logo
9. Close and open Duck.ai again and check it does not reload the page.


### Impact and Risks
<!— 
What's the impact on users if something goes wrong?
Low: Minor visual changes, small bug fixes, improvement to existing features
—>

#### What could go wrong?
- Session is reset when not needed: We use flag that is reset when opening duckAI

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)