### PR TITLE
[iOS] Disable contextual Dax dialog factory tests as they use window/views

### DIFF
--- a/iOS/SharedStateTests/ContextualDaxDialogsFactoryTests.swift
+++ b/iOS/SharedStateTests/ContextualDaxDialogsFactoryTests.swift
@@ -33,6 +33,7 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
     private var window: UIWindow!
 
     override func setUpWithError() throws {
+        throw XCTSkip("Implement test related to UI as UITest")
         delegate = ContextualOnboardingDelegateMock()
         settingsMock = ContextualOnboardingSettingsMock()
         pixelReporterMock = OnboardingPixelReporterMock()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1210723156215693?focus=true
Tech Design URL:
CC:

### Description

Disable tests Dax dialogs test that rely on Window/Views. It makes more sense to write them as UITests.

### Testing Steps
Ensure CI pass.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)