### PR TITLE
macOS: Update behavior for Safari bookmarks import

### DIFF
--- a/macOS/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
@@ -51,7 +51,7 @@ protocol BookmarkManager: AnyObject {
     func canMoveObjectWithUUID(objectUUID uuid: String, to parent: BookmarkFolder) -> Bool
     func move(objectUUIDs: [String], toIndex: Int?, withinParentFolder: ParentFolderType, completion: @escaping (Error?) -> Void)
     func moveFavorites(with objectUUIDs: [String], toIndex: Int?, completion: @escaping (Error?) -> Void)
-    func importBookmarks(_ bookmarks: ImportedBookmarks, source: BookmarkImportSource, markRootBookmarksAsFavoritesByDefault: Bool) -> BookmarksImportSummary
+    func importBookmarks(_ bookmarks: ImportedBookmarks, source: BookmarkImportSource, markRootBookmarksAsFavoritesByDefault: Bool, maxFavoritesCount: Int?) -> BookmarksImportSummary
     func handleFavoritesAfterDisablingSync()
 
     /// Searches for bookmarks and folders by title. If query is blank empty list is returned
@@ -453,8 +453,8 @@ final class LocalBookmarkManager: BookmarkManager {
 
     // MARK: - Import
 
-    func importBookmarks(_ bookmarks: ImportedBookmarks, source: BookmarkImportSource, markRootBookmarksAsFavoritesByDefault: Bool) -> BookmarksImportSummary {
-        let results = bookmarkStore.importBookmarks(bookmarks, source: source, markRootBookmarksAsFavoritesByDefault: markRootBookmarksAsFavoritesByDefault)
+    func importBookmarks(_ bookmarks: ImportedBookmarks, source: BookmarkImportSource, markRootBookmarksAsFavoritesByDefault: Bool, maxFavoritesCount: Int?) -> BookmarksImportSummary {
+        let results = bookmarkStore.importBookmarks(bookmarks, source: source, markRootBookmarksAsFavoritesByDefault: markRootBookmarksAsFavoritesByDefault, maxFavoritesCount: maxFavoritesCount)
         loadBookmarks()
         requestSync()
 

--- a/macOS/DuckDuckGo/Bookmarks/Services/BookmarkStore.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Services/BookmarkStore.swift
@@ -57,7 +57,7 @@ protocol BookmarkStore {
     func canMoveObjectWithUUID(objectUUID uuid: String, to parent: BookmarkFolder) -> Bool
     func move(objectUUIDs: [String], toIndex: Int?, withinParentFolder: ParentFolderType, completion: @escaping (Error?) -> Void)
     func moveFavorites(with objectUUIDs: [String], toIndex: Int?, completion: @escaping (Error?) -> Void)
-    func importBookmarks(_ bookmarks: ImportedBookmarks, source: BookmarkImportSource, markRootBookmarksAsFavoritesByDefault: Bool) -> BookmarksImportSummary
+    func importBookmarks(_ bookmarks: ImportedBookmarks, source: BookmarkImportSource, markRootBookmarksAsFavoritesByDefault: Bool, maxFavoritesCount: Int?) -> BookmarksImportSummary
     func handleFavoritesAfterDisablingSync()
 }
 extension BookmarkStore {

--- a/macOS/DuckDuckGo/Bookmarks/Services/BookmarkStoreMock.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Services/BookmarkStoreMock.swift
@@ -206,9 +206,9 @@ final class BookmarkStoreMock: BookmarkStore, CustomDebugStringConvertible {
     }
 
     var importBookmarksCalled = false
-    func importBookmarks(_ bookmarks: ImportedBookmarks, source: BookmarkImportSource, markRootBookmarksAsFavoritesByDefault: Bool = true) -> BookmarksImportSummary {
+    func importBookmarks(_ bookmarks: ImportedBookmarks, source: BookmarkImportSource, markRootBookmarksAsFavoritesByDefault: Bool = true, maxFavoritesCount: Int? = nil) -> BookmarksImportSummary {
         importBookmarksCalled = true
-        return store?.importBookmarks(bookmarks, source: source, markRootBookmarksAsFavoritesByDefault: markRootBookmarksAsFavoritesByDefault) ?? BookmarksImportSummary(successful: 0, duplicates: 0, failed: 0)
+        return store?.importBookmarks(bookmarks, source: source, markRootBookmarksAsFavoritesByDefault: markRootBookmarksAsFavoritesByDefault, maxFavoritesCount: maxFavoritesCount) ?? BookmarksImportSummary(successful: 0, duplicates: 0, failed: 0)
     }
 
     var saveBookmarksInNewFolderNamedCalled = false

--- a/macOS/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift
@@ -719,7 +719,7 @@ final class LocalBookmarkStore: BookmarkStore {
     ///   - bookmarks: The bookmarks to import.
     ///   - source: The source of the bookmarks. Used to determine where to put bookmarks, as we want to match the source browser's structure as closely as possible.
     ///   - markRootBookmarksAsFavoritesByDefault: If true, the bookmarks at the root level will be marked as favorites by default.
-    func importBookmarks(_ bookmarks: ImportedBookmarks, source: BookmarkImportSource, markRootBookmarksAsFavoritesByDefault: Bool = true) -> BookmarksImportSummary {
+    func importBookmarks(_ bookmarks: ImportedBookmarks, source: BookmarkImportSource, markRootBookmarksAsFavoritesByDefault: Bool = true, maxFavoritesCount: Int? = nil) -> BookmarksImportSummary {
         var total = BookmarksImportSummary(successful: 0, duplicates: 0, failed: 0)
 
         do {
@@ -735,6 +735,7 @@ final class LocalBookmarkStore: BookmarkStore {
                                                      bookmarks: bookmarks,
                                                      importSourceName: source.importSourceName,
                                                      markRootBookmarksAsFavoritesByDefault: markRootBookmarksAsFavoritesByDefault,
+                                                     maxFavoritesCount: maxFavoritesCount,
                                                      in: context)
             }
 
@@ -765,6 +766,7 @@ final class LocalBookmarkStore: BookmarkStore {
                                              bookmarks: ImportedBookmarks,
                                              importSourceName: String,
                                              markRootBookmarksAsFavoritesByDefault: Bool,
+                                             maxFavoritesCount: Int?,
                                              in context: NSManagedObjectContext) -> BookmarksImportSummary {
 
         guard let root = bookmarksRoot(in: context) else {
@@ -814,7 +816,7 @@ final class LocalBookmarkStore: BookmarkStore {
             allFavorites.append(contentsOf: favorites)
         }
 
-        addFavoritesInOrder(allFavorites, in: context)
+        addFavoritesInOrder(allFavorites, limit: maxFavoritesCount, in: context)
 
         return total
     }
@@ -874,17 +876,21 @@ final class LocalBookmarkStore: BookmarkStore {
         return (total, favorites)
     }
 
-    /// Adds bookmarks to the favorites folders in the order specified by their indices, de-duping any existing favorites.
-    private func addFavoritesInOrder(_ allFavorites: [(bookmark: BookmarkEntity, index: Int?)], in context: NSManagedObjectContext) {
-        let sortedFavorites = allFavorites.sorted { ($0.index ?? Int.max) < ($1.index ?? Int.max) }.map(\.bookmark)
-
+    /// Adds bookmarks to the favorites folders in the order specified by their indices, up to the provided limit (if any), de-duping any existing favorites.
+    private func addFavoritesInOrder(_ allFavorites: [(bookmark: BookmarkEntity, index: Int?)], limit: Int?, in context: NSManagedObjectContext) {
         let favoritesFolders = BookmarkUtils.fetchFavoritesFolders(for: favoritesDisplayMode, in: context)
         let existingFavoriteURLs = Set(favoritesFolders.flatMap { $0.favoritesArray }.compactMap { $0.urlObject?.naked })
 
-        for bookmarkManagedObject in sortedFavorites {
-            guard let url = bookmarkManagedObject.urlObject?.naked, !existingFavoriteURLs.contains(url) else { continue }
-            bookmarkManagedObject.addToFavorites(folders: favoritesFolders)
-        }
+        allFavorites
+            .sorted { ($0.index ?? Int.max) < ($1.index ?? Int.max) }
+            .lazy
+            .compactMap { favorite -> BookmarkEntity? in
+                guard let url = favorite.bookmark.urlObject?.naked,
+                      !existingFavoriteURLs.contains(url) else { return nil }
+                return favorite.bookmark
+            }
+            .prefix(limit ?? Int.max)
+            .forEach { $0.addToFavorites(folders: favoritesFolders) }
 
         // Send pixel for success: https://app.asana.com/1/137249556945/task/1210674932129670
     }

--- a/macOS/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Services/LocalBookmarkStore.swift
@@ -780,7 +780,8 @@ final class LocalBookmarkStore: BookmarkStore {
         var parent = root
         var markFavorites = markRootBookmarksAsFavoritesByDefault
         if root.children?.count != 0 {
-            markFavorites = false
+            // Keep adding favorites from the root folder if there is a specified limit for favorites
+            markFavorites = markRootBookmarksAsFavoritesByDefault ? maxFavoritesCount != nil : false
             parent = BookmarkEntity.makeFolder(title: "\(UserText.bookmarkImportedFromFolder) \(importSourceName)",
                                                parent: root,
                                                context: context)
@@ -880,6 +881,11 @@ final class LocalBookmarkStore: BookmarkStore {
     private func addFavoritesInOrder(_ allFavorites: [(bookmark: BookmarkEntity, index: Int?)], limit: Int?, in context: NSManagedObjectContext) {
         let favoritesFolders = BookmarkUtils.fetchFavoritesFolders(for: favoritesDisplayMode, in: context)
         let existingFavoriteURLs = Set(favoritesFolders.flatMap { $0.favoritesArray }.compactMap { $0.urlObject?.naked })
+        let availableFavoriteSlots = limit.map { max(0, $0 - existingFavoriteURLs.count) } ?? Int.max
+
+        guard availableFavoriteSlots > 0 else {
+            return
+        }
 
         allFavorites
             .sorted { ($0.index ?? Int.max) < ($1.index ?? Int.max) }
@@ -889,7 +895,7 @@ final class LocalBookmarkStore: BookmarkStore {
                       !existingFavoriteURLs.contains(url) else { return nil }
                 return favorite.bookmark
             }
-            .prefix(limit ?? Int.max)
+            .prefix(availableFavoriteSlots)
             .forEach { $0.addToFavorites(folders: favoritesFolders) }
 
         // Send pixel for success: https://app.asana.com/1/137249556945/task/1210674932129670

--- a/macOS/DuckDuckGo/DataImport/Bookmarks/BookmarkImport.swift
+++ b/macOS/DuckDuckGo/DataImport/Bookmarks/BookmarkImport.swift
@@ -33,6 +33,6 @@ enum BookmarkImportSource: Equatable {
 
 protocol BookmarkImporter {
 
-    func importBookmarks(_ bookmarks: ImportedBookmarks, source: BookmarkImportSource, markRootBookmarksAsFavoritesByDefault: Bool) -> BookmarksImportSummary
+    func importBookmarks(_ bookmarks: ImportedBookmarks, source: BookmarkImportSource, markRootBookmarksAsFavoritesByDefault: Bool, maxFavoritesCount: Int?) -> BookmarksImportSummary
 
 }

--- a/macOS/DuckDuckGo/DataImport/Bookmarks/CoreDataBookmarkImporter.swift
+++ b/macOS/DuckDuckGo/DataImport/Bookmarks/CoreDataBookmarkImporter.swift
@@ -27,8 +27,8 @@ final class CoreDataBookmarkImporter: BookmarkImporter {
         self.bookmarkManager = bookmarkManager
     }
 
-    func importBookmarks(_ bookmarks: ImportedBookmarks, source: BookmarkImportSource, markRootBookmarksAsFavoritesByDefault: Bool) -> BookmarksImportSummary {
-        return bookmarkManager.importBookmarks(bookmarks, source: source, markRootBookmarksAsFavoritesByDefault: markRootBookmarksAsFavoritesByDefault)
+    func importBookmarks(_ bookmarks: ImportedBookmarks, source: BookmarkImportSource, markRootBookmarksAsFavoritesByDefault: Bool, maxFavoritesCount: Int?) -> BookmarksImportSummary {
+        return bookmarkManager.importBookmarks(bookmarks, source: source, markRootBookmarksAsFavoritesByDefault: markRootBookmarksAsFavoritesByDefault, maxFavoritesCount: maxFavoritesCount)
     }
 
 }

--- a/macOS/DuckDuckGo/DataImport/Bookmarks/HTML/BookmarkHTMLImporter.swift
+++ b/macOS/DuckDuckGo/DataImport/Bookmarks/HTML/BookmarkHTMLImporter.swift
@@ -47,7 +47,7 @@ final class BookmarkHTMLImporter: DataImporter {
         switch self.bookmarkReaderResult {
         case let .success(importedData):
             let source: BookmarkImportSource = importedData.source ?? .thirdPartyBrowser(.bookmarksHTML)
-            let bookmarksResult = self.bookmarkImporter.importBookmarks(importedData.bookmarks, source: source, markRootBookmarksAsFavoritesByDefault: true)
+            let bookmarksResult = self.bookmarkImporter.importBookmarks(importedData.bookmarks, source: source, markRootBookmarksAsFavoritesByDefault: true, maxFavoritesCount: nil)
             return .success(.init(bookmarksResult))
 
         case let .failure(error):

--- a/macOS/DuckDuckGo/DataImport/Bookmarks/Safari/SafariBookmarksReader.swift
+++ b/macOS/DuckDuckGo/DataImport/Bookmarks/Safari/SafariBookmarksReader.swift
@@ -63,9 +63,10 @@ final class SafariBookmarksReader {
     private var currentOperationType: ImportError.OperationType = .readPlist
     private let otherBookmarksFolderTitle: String
 
-    init(safariBookmarksFileURL: URL, otherBookmarksFolderTitle: String = UserText.otherBookmarksImportedFolderTitle) {
+    init(safariBookmarksFileURL: URL, otherBookmarksFolderTitle: String = UserText.otherBookmarksImportedFolderTitle, featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger) {
         self.safariBookmarksFileURL = safariBookmarksFileURL
-        self.otherBookmarksFolderTitle = otherBookmarksFolderTitle
+        // TODO: Replace with localized string after copy review
+        self.otherBookmarksFolderTitle = featureFlagger.isFeatureOn(.updatedBookmarksFavoritesImport) ? "Bookmarks" : otherBookmarksFolderTitle
     }
 
     func readBookmarks() -> DataImportResult<ImportedBookmarks> {

--- a/macOS/DuckDuckGo/DataImport/Bookmarks/Safari/SafariBookmarksReader.swift
+++ b/macOS/DuckDuckGo/DataImport/Bookmarks/Safari/SafariBookmarksReader.swift
@@ -65,7 +65,7 @@ final class SafariBookmarksReader {
 
     init(safariBookmarksFileURL: URL, otherBookmarksFolderTitle: String = UserText.otherBookmarksImportedFolderTitle, featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger) {
         self.safariBookmarksFileURL = safariBookmarksFileURL
-        // Replace "Bookmarks" with localized string after copy review
+        // Replace "Bookmarks" with localized string after copy review: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210728265847799?focus=true
         self.otherBookmarksFolderTitle = featureFlagger.isFeatureOn(.updatedBookmarksFavoritesImport) ? "Bookmarks" : otherBookmarksFolderTitle
     }
 

--- a/macOS/DuckDuckGo/DataImport/Bookmarks/Safari/SafariBookmarksReader.swift
+++ b/macOS/DuckDuckGo/DataImport/Bookmarks/Safari/SafariBookmarksReader.swift
@@ -65,7 +65,7 @@ final class SafariBookmarksReader {
 
     init(safariBookmarksFileURL: URL, otherBookmarksFolderTitle: String = UserText.otherBookmarksImportedFolderTitle, featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger) {
         self.safariBookmarksFileURL = safariBookmarksFileURL
-        // TODO: Replace with localized string after copy review
+        // Replace "Bookmarks" with localized string after copy review
         self.otherBookmarksFolderTitle = featureFlagger.isFeatureOn(.updatedBookmarksFavoritesImport) ? "Bookmarks" : otherBookmarksFolderTitle
     }
 

--- a/macOS/DuckDuckGo/DataImport/Bookmarks/Safari/SafariBookmarksReader.swift
+++ b/macOS/DuckDuckGo/DataImport/Bookmarks/Safari/SafariBookmarksReader.swift
@@ -66,7 +66,7 @@ final class SafariBookmarksReader {
     init(safariBookmarksFileURL: URL, otherBookmarksFolderTitle: String = UserText.otherBookmarksImportedFolderTitle, featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger) {
         self.safariBookmarksFileURL = safariBookmarksFileURL
         // Replace "Bookmarks" with localized string after copy review: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210728265847799?focus=true
-        self.otherBookmarksFolderTitle = featureFlagger.isFeatureOn(.updatedBookmarksFavoritesImport) ? "Bookmarks" : otherBookmarksFolderTitle
+        self.otherBookmarksFolderTitle = featureFlagger.isFeatureOn(.updateSafariBookmarksImport) ? "Bookmarks" : otherBookmarksFolderTitle
     }
 
     func readBookmarks() -> DataImportResult<ImportedBookmarks> {

--- a/macOS/DuckDuckGo/DataImport/Bookmarks/Safari/SafariBookmarksReader.swift
+++ b/macOS/DuckDuckGo/DataImport/Bookmarks/Safari/SafariBookmarksReader.swift
@@ -63,7 +63,7 @@ final class SafariBookmarksReader {
     private var currentOperationType: ImportError.OperationType = .readPlist
     private let otherBookmarksFolderTitle: String
 
-    init(safariBookmarksFileURL: URL, otherBookmarksFolderTitle: String = UserText.otherBookmarksImportedFolderTitle, featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger) {
+    init(safariBookmarksFileURL: URL, otherBookmarksFolderTitle: String = UserText.otherBookmarksImportedFolderTitle, featureFlagger: FeatureFlagger) {
         self.safariBookmarksFileURL = safariBookmarksFileURL
         // Replace "Bookmarks" with localized string after copy review: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210728265847799?focus=true
         self.otherBookmarksFolderTitle = featureFlagger.isFeatureOn(.updateSafariBookmarksImport) ? "Bookmarks" : otherBookmarksFolderTitle

--- a/macOS/DuckDuckGo/DataImport/Bookmarks/Safari/SafariDataImporter.swift
+++ b/macOS/DuckDuckGo/DataImport/Bookmarks/Safari/SafariDataImporter.swift
@@ -86,7 +86,7 @@ final class SafariDataImporter: DataImporter {
         let bookmarkResult = bookmarkReader.readBookmarks()
 
         let summary = bookmarkResult.map { bookmarks in
-            let maxFavoritesCount = featureFlagger.isFeatureOn(.updatedBookmarksFavoritesImport) ? 12 : nil
+            let maxFavoritesCount = featureFlagger.isFeatureOn(.updateSafariBookmarksImport) ? 12 : nil
             return bookmarkImporter.importBookmarks(bookmarks, source: .thirdPartyBrowser(source), markRootBookmarksAsFavoritesByDefault: true, maxFavoritesCount: maxFavoritesCount)
         }
 

--- a/macOS/DuckDuckGo/DataImport/Bookmarks/Safari/SafariDataImporter.swift
+++ b/macOS/DuckDuckGo/DataImport/Bookmarks/Safari/SafariDataImporter.swift
@@ -71,7 +71,7 @@ final class SafariDataImporter: DataImporter {
     func validateAccess(for types: Set<DataImport.DataType>) -> [DataImport.DataType: any DataImportError]? {
         guard types.contains(.bookmarks) else { return nil }
 
-        if case .failure(let error) = SafariBookmarksReader(safariBookmarksFileURL: fileUrl).validateFileReadAccess() {
+        if case .failure(let error) = SafariBookmarksReader(safariBookmarksFileURL: fileUrl, featureFlagger: featureFlagger).validateFileReadAccess() {
             return [.bookmarks: error]
         }
         return nil
@@ -82,7 +82,7 @@ final class SafariDataImporter: DataImporter {
         // logins will be imported from CSV
         guard types.contains(.bookmarks) else { return [:] }
 
-        let bookmarkReader = SafariBookmarksReader(safariBookmarksFileURL: fileUrl)
+        let bookmarkReader = SafariBookmarksReader(safariBookmarksFileURL: fileUrl, featureFlagger: featureFlagger)
         let bookmarkResult = bookmarkReader.readBookmarks()
 
         let summary = bookmarkResult.map { bookmarks in

--- a/macOS/DuckDuckGo/DataImport/Bookmarks/Safari/SafariDataImporter.swift
+++ b/macOS/DuckDuckGo/DataImport/Bookmarks/Safari/SafariDataImporter.swift
@@ -44,7 +44,7 @@ final class SafariDataImporter: DataImporter {
     }
     private let featureFlagger: FeatureFlagger
 
-    init(profile: DataImport.BrowserProfile, bookmarkImporter: BookmarkImporter, faviconManager: FaviconManagement = NSApp.delegateTyped.faviconManager, featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger) {
+    init(profile: DataImport.BrowserProfile, bookmarkImporter: BookmarkImporter, faviconManager: FaviconManagement = NSApp.delegateTyped.faviconManager, featureFlagger: FeatureFlagger) {
         self.profile = profile
         self.bookmarkImporter = bookmarkImporter
         self.faviconManager = faviconManager

--- a/macOS/DuckDuckGo/DataImport/Bookmarks/Safari/SafariDataImporter.swift
+++ b/macOS/DuckDuckGo/DataImport/Bookmarks/Safari/SafariDataImporter.swift
@@ -42,11 +42,13 @@ final class SafariDataImporter: DataImporter {
     private var source: DataImport.Source {
         profile.browser.importSource
     }
+    private let featureFlagger: FeatureFlagger
 
-    init(profile: DataImport.BrowserProfile, bookmarkImporter: BookmarkImporter, faviconManager: FaviconManagement = NSApp.delegateTyped.faviconManager) {
+    init(profile: DataImport.BrowserProfile, bookmarkImporter: BookmarkImporter, faviconManager: FaviconManagement = NSApp.delegateTyped.faviconManager, featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger) {
         self.profile = profile
         self.bookmarkImporter = bookmarkImporter
         self.faviconManager = faviconManager
+        self.featureFlagger = featureFlagger
     }
 
     var importableTypes: [DataImport.DataType] {
@@ -84,7 +86,8 @@ final class SafariDataImporter: DataImporter {
         let bookmarkResult = bookmarkReader.readBookmarks()
 
         let summary = bookmarkResult.map { bookmarks in
-            bookmarkImporter.importBookmarks(bookmarks, source: .thirdPartyBrowser(source), markRootBookmarksAsFavoritesByDefault: true)
+            let maxFavoritesCount = featureFlagger.isFeatureOn(.updatedBookmarksFavoritesImport) ? 12 : nil
+            return bookmarkImporter.importBookmarks(bookmarks, source: .thirdPartyBrowser(source), markRootBookmarksAsFavoritesByDefault: true, maxFavoritesCount: maxFavoritesCount)
         }
 
         if case .success = summary {

--- a/macOS/DuckDuckGo/DataImport/Logins/Chromium/ChromiumDataImporter.swift
+++ b/macOS/DuckDuckGo/DataImport/Logins/Chromium/ChromiumDataImporter.swift
@@ -110,7 +110,7 @@ internal class ChromiumDataImporter: DataImporter {
             }
 
             var markRootBookmarksAsFavoritesByDefault = true
-            if featureFlagger.isFeatureOn(.updatedBookmarksFavoritesImport) {
+            if featureFlagger.isFeatureOn(.importChromeShortcuts) {
                 markRootBookmarksAsFavoritesByDefault = false
                 let newTabShortcuts = fetchShortcutsAsFavorites()
                 FavoritesImportProcessor.mergeBookmarksAndFavorites(bookmarks: &importedBookmarks, favorites: newTabShortcuts)

--- a/macOS/DuckDuckGo/DataImport/Logins/Chromium/ChromiumDataImporter.swift
+++ b/macOS/DuckDuckGo/DataImport/Logins/Chromium/ChromiumDataImporter.swift
@@ -119,7 +119,7 @@ internal class ChromiumDataImporter: DataImporter {
             try updateProgress(.importingBookmarks(numberOfBookmarks: importedBookmarks.numberOfBookmarks,
                                                    fraction: passwordsFraction + dataTypeFraction * 0.5))
 
-            let bookmarksSummary = bookmarkImporter.importBookmarks(importedBookmarks, source: .thirdPartyBrowser(source), markRootBookmarksAsFavoritesByDefault: markRootBookmarksAsFavoritesByDefault)
+            let bookmarksSummary = bookmarkImporter.importBookmarks(importedBookmarks, source: .thirdPartyBrowser(source), markRootBookmarksAsFavoritesByDefault: markRootBookmarksAsFavoritesByDefault, maxFavoritesCount: nil)
 
             await importFavicons()
 

--- a/macOS/DuckDuckGo/DataImport/Logins/Firefox/FirefoxDataImporter.swift
+++ b/macOS/DuckDuckGo/DataImport/Logins/Firefox/FirefoxDataImporter.swift
@@ -103,7 +103,7 @@ internal class FirefoxDataImporter: DataImporter {
                                                    fraction: passwordsFraction + dataTypeFraction * 0.5))
 
             let bookmarksSummary = bookmarkResult.map { bookmarks in
-                bookmarkImporter.importBookmarks(bookmarks, source: .thirdPartyBrowser(source), markRootBookmarksAsFavoritesByDefault: true)
+                bookmarkImporter.importBookmarks(bookmarks, source: .thirdPartyBrowser(source), markRootBookmarksAsFavoritesByDefault: true, maxFavoritesCount: nil)
             }
 
             if case .success = bookmarksSummary {

--- a/macOS/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
+++ b/macOS/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
@@ -447,7 +447,8 @@ private func dataImporter(for source: DataImport.Source, fileDataType: DataImpor
                             faviconManager: NSApp.delegateTyped.faviconManager)
     case .safari, .safariTechnologyPreview:
         SafariDataImporter(profile: profile,
-                           bookmarkImporter: CoreDataBookmarkImporter(bookmarkManager: NSApp.delegateTyped.bookmarkManager))
+                           bookmarkImporter: CoreDataBookmarkImporter(bookmarkManager: NSApp.delegateTyped.bookmarkManager),
+                           featureFlagger: Application.appDelegate.featureFlagger)
     }
 }
 

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -124,7 +124,10 @@ public enum FeatureFlag: String, CaseIterable {
     case shortHistoryMenu
 
     /// https://app.asana.com/1/137249556945/project/1209825025475019/task/1210649149275753?focus=true
-    case updatedBookmarksFavoritesImport
+    case importChromeShortcuts
+
+    /// https://app.asana.com/1/137249556945/project/1209825025475019/task/1210649149275753?focus=true
+    case updateSafariBookmarksImport
 
     /// https://app.asana.com/1/137249556945/project/1204006570077678/task/1210522798790015?focus=true
     case disableFireAnimation
@@ -184,7 +187,8 @@ extension FeatureFlag: FeatureFlagDescribing {
 				.aiChatSidebar,
                 .aiChatTextSummarization,
                 .shortHistoryMenu,
-                .updatedBookmarksFavoritesImport,
+                .importChromeShortcuts,
+                .updateSafariBookmarksImport,
                 .disableFireAnimation,
                 .newTabPageOmnibar:
             return true
@@ -285,7 +289,9 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .internalOnly()
         case .shortHistoryMenu:
             return .remoteReleasable(.feature(.shortHistoryMenu))
-        case .updatedBookmarksFavoritesImport:
+        case .importChromeShortcuts:
+            return .disabled
+        case .updateSafariBookmarksImport:
             return .disabled
         case .disableFireAnimation:
             return .remoteReleasable(.feature(.disableFireAnimation))

--- a/macOS/UnitTests/Bookmarks/Services/LocalBookmarkStoreTests.swift
+++ b/macOS/UnitTests/Bookmarks/Services/LocalBookmarkStoreTests.swift
@@ -1605,6 +1605,27 @@ final class LocalBookmarkStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testWhenBookmarksAreImported_AndMaxFavoritesCountIsSet_ThenFavoritesAreLimitedToThatCount() async throws {
+        let maxFavoritesCount = 1
+        let context = container.viewContext
+        let bookmarkStore = LocalBookmarkStore(context: context)
+
+        let bookmark1 = ImportedBookmarks.BookmarkOrFolder(name: "DuckDuckGo", type: .bookmark, urlString: "https://duckduckgo.com", children: nil, isDDGFavorite: true)
+        let bookmark2 = ImportedBookmarks.BookmarkOrFolder(name: "Duck", type: .bookmark, urlString: "https://duck.com", children: nil, isDDGFavorite: true)
+        let bookmarkBar = ImportedBookmarks.BookmarkOrFolder(name: "Bookmark Bar", type: .folder, urlString: nil, children: [bookmark1, bookmark2])
+        let otherBookmarks = ImportedBookmarks.BookmarkOrFolder(name: "Other Bookmarks", type: .folder, urlString: nil, children: [])
+
+        let topLevelFolders = ImportedBookmarks.TopLevelFolders(bookmarkBar: bookmarkBar, otherBookmarks: otherBookmarks, syncedBookmarks: nil)
+        let importedBookmarks = ImportedBookmarks(topLevelFolders: topLevelFolders)
+
+        _ = bookmarkStore.importBookmarks(importedBookmarks, source: .thirdPartyBrowser(.chrome), markRootBookmarksAsFavoritesByDefault: true, maxFavoritesCount: maxFavoritesCount)
+
+        let favorites = try await bookmarkStore.loadAll(type: .favorites)
+
+        XCTAssertEqual(favorites.count, maxFavoritesCount)
+    }
+
+    @MainActor
     private func validateInitialImport(for source: BookmarkImportSource) async throws {
         let context = container.viewContext
         let bookmarkStore = LocalBookmarkStore(context: context)

--- a/macOS/UnitTests/Bookmarks/Services/LocalBookmarkStoreTests.swift
+++ b/macOS/UnitTests/Bookmarks/Services/LocalBookmarkStoreTests.swift
@@ -1626,6 +1626,33 @@ final class LocalBookmarkStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testWhenBookmarksAreImportedWithMaxFavoritesCount_AndTheBookmarksStoreIsNotEmpty_ThenTotalFavoritesAreLimitedToThatCount() async throws {
+        let maxFavoritesCount = 2
+        let context = container.viewContext
+        let bookmarkStore = LocalBookmarkStore(context: context)
+
+        // Initial condition: Store has one favorite bookmark.
+        let existingBookmark = Bookmark(id: UUID().uuidString, url: "https://example.com", title: "Example", isFavorite: true)
+        _ = try await bookmarkStore.save(bookmark: existingBookmark)
+        let existingFavorites = try await bookmarkStore.loadAll(type: .favorites)
+        XCTAssertEqual(existingFavorites.count, 1)
+
+        let bookmark1 = ImportedBookmarks.BookmarkOrFolder(name: "DuckDuckGo", type: .bookmark, urlString: "https://duckduckgo.com", children: nil, isDDGFavorite: true)
+        let bookmark2 = ImportedBookmarks.BookmarkOrFolder(name: "Duck", type: .bookmark, urlString: "https://duck.com", children: nil, isDDGFavorite: true)
+        let bookmarkBar = ImportedBookmarks.BookmarkOrFolder(name: "Bookmark Bar", type: .folder, urlString: nil, children: [bookmark1, bookmark2])
+        let otherBookmarks = ImportedBookmarks.BookmarkOrFolder(name: "Other Bookmarks", type: .folder, urlString: nil, children: [])
+
+        let topLevelFolders = ImportedBookmarks.TopLevelFolders(bookmarkBar: bookmarkBar, otherBookmarks: otherBookmarks, syncedBookmarks: nil)
+        let importedBookmarks = ImportedBookmarks(topLevelFolders: topLevelFolders)
+
+        _ = bookmarkStore.importBookmarks(importedBookmarks, source: .thirdPartyBrowser(.chrome), markRootBookmarksAsFavoritesByDefault: true, maxFavoritesCount: maxFavoritesCount)
+
+        let favorites = try await bookmarkStore.loadAll(type: .favorites)
+
+        XCTAssertEqual(favorites.count, maxFavoritesCount)
+    }
+
+    @MainActor
     private func validateInitialImport(for source: BookmarkImportSource) async throws {
         let context = container.viewContext
         let bookmarkStore = LocalBookmarkStore(context: context)

--- a/macOS/UnitTests/DataImport/BookmarksHTMLImporterTests.swift
+++ b/macOS/UnitTests/DataImport/BookmarksHTMLImporterTests.swift
@@ -25,7 +25,7 @@ final class BookmarksHTMLImporterTests: XCTestCase {
     var underlyingBookmarkImporter: MockBookmarkImporter!
 
     override func setUp() {
-        underlyingBookmarkImporter = MockBookmarkImporter(importBookmarks: { _, _, _ in
+        underlyingBookmarkImporter = MockBookmarkImporter(importBookmarks: { _, _, _, _ in
             .init(successful: 0, duplicates: 0, failed: 0)
         })
     }
@@ -53,7 +53,7 @@ final class BookmarksHTMLImporterTests: XCTestCase {
     }
 
     func testWhenValidBookmarksFileIsLoadedThenBookmarksImportIsSuccessful() async {
-        underlyingBookmarkImporter.importBookmarks = { (_, _, _) in
+        underlyingBookmarkImporter.importBookmarks = { (_, _, _, _) in
             .init(successful: 42, duplicates: 2, failed: 3)
         }
 
@@ -65,7 +65,7 @@ final class BookmarksHTMLImporterTests: XCTestCase {
     }
 
     func testWhenInvalidBookmarksFileIsLoadedThenBookmarksImportReturnsFailure() async {
-        underlyingBookmarkImporter.importBookmarks = { (_, _, _) in
+        underlyingBookmarkImporter.importBookmarks = { (_, _, _, _) in
             .init(successful: 0, duplicates: 0, failed: 0)
         }
 

--- a/macOS/UnitTests/DataImport/ChromiumDataImporterTests.swift
+++ b/macOS/UnitTests/DataImport/ChromiumDataImporterTests.swift
@@ -26,7 +26,7 @@ class ChromiumDataImporterTests {
     func whenImportingBookmarks_AndBookmarkImportSucceeds_ThenSummaryIsPopulated() async throws {
         let loginImporter = MockLoginImporter()
         let faviconManager = FaviconManagerMock()
-        let bookmarkImporter = MockBookmarkImporter(importBookmarks: { _, _, _ in .init(successful: 1, duplicates: 2, failed: 3) })
+        let bookmarkImporter = MockBookmarkImporter(importBookmarks: { _, _, _, _ in .init(successful: 1, duplicates: 2, failed: 3) })
         let featureFlagger = MockFeatureFlagger()
         let importer = ChromiumDataImporter(profile: .init(browser: .chrome, profileURL: ChromiumBookmarkStore().resourceURL), loginImporter: loginImporter, bookmarkImporter: bookmarkImporter, faviconManager: faviconManager, featureFlagger: featureFlagger)
 
@@ -46,7 +46,7 @@ class ChromiumDataImporterTests {
 
         let loginImporter = MockLoginImporter()
         let faviconManager = FaviconManagerMock()
-        let bookmarkImporter = MockBookmarkImporter(importBookmarks: { bookmarks, _, markBookmarksBarAsFavorites in
+        let bookmarkImporter = MockBookmarkImporter(importBookmarks: { bookmarks, _, markBookmarksBarAsFavorites, _ in
             bookmarksToImport = bookmarks
             bookmarksBarMarkedAsFavorites = markBookmarksBarAsFavorites
             return .init(successful: 1, duplicates: 2, failed: 3)
@@ -67,7 +67,7 @@ class ChromiumDataImporterTests {
 
         let loginImporter = MockLoginImporter()
         let faviconManager = FaviconManagerMock()
-        let bookmarkImporter = MockBookmarkImporter(importBookmarks: { bookmarks, _, markBookmarksBarAsFavorites in
+        let bookmarkImporter = MockBookmarkImporter(importBookmarks: { bookmarks, _, markBookmarksBarAsFavorites, _ in
             bookmarksToImport = bookmarks
             bookmarksBarMarkedAsFavorites = markBookmarksBarAsFavorites
             return .init(successful: 1, duplicates: 2, failed: 3)
@@ -89,7 +89,7 @@ class ChromiumDataImporterTests {
 
         let loginImporter = MockLoginImporter()
         let faviconManager = FaviconManagerMock()
-        let bookmarkImporter = MockBookmarkImporter(importBookmarks: { bookmarks, _, markBookmarksBarAsFavorites in
+        let bookmarkImporter = MockBookmarkImporter(importBookmarks: { bookmarks, _, markBookmarksBarAsFavorites, _ in
             bookmarksToImport = bookmarks
             bookmarksBarMarkedAsFavorites = markBookmarksBarAsFavorites
             return .init(successful: 1, duplicates: 2, failed: 3)

--- a/macOS/UnitTests/DataImport/ChromiumDataImporterTests.swift
+++ b/macOS/UnitTests/DataImport/ChromiumDataImporterTests.swift
@@ -73,7 +73,7 @@ class ChromiumDataImporterTests {
             return .init(successful: 1, duplicates: 2, failed: 3)
         })
         let featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags.append(.updatedBookmarksFavoritesImport)
+        featureFlagger.enabledFeatureFlags.append(.importChromeShortcuts)
         let importer = ChromiumDataImporter(profile: .init(browser: .chrome, profileURL: ChromiumBookmarkStore.customShortcuts.resourceURL), loginImporter: loginImporter, bookmarkImporter: bookmarkImporter, faviconManager: faviconManager, featureFlagger: featureFlagger)
 
         _ = await importer.importData(types: [.bookmarks])
@@ -95,7 +95,7 @@ class ChromiumDataImporterTests {
             return .init(successful: 1, duplicates: 2, failed: 3)
         })
         let featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags.append(.updatedBookmarksFavoritesImport)
+        featureFlagger.enabledFeatureFlags.append(.importChromeShortcuts)
         let importer = ChromiumDataImporter(profile: .init(browser: .chrome, profileURL: ChromiumBookmarkStore.topSitesShortcuts.resourceURL), loginImporter: loginImporter, bookmarkImporter: bookmarkImporter, faviconManager: faviconManager, featureFlagger: featureFlagger)
 
         _ = await importer.importData(types: [.bookmarks])

--- a/macOS/UnitTests/DataImport/DataImportMocks.swift
+++ b/macOS/UnitTests/DataImport/DataImportMocks.swift
@@ -37,10 +37,10 @@ struct BookmarkImportErrorMock: Error {}
 
 struct MockBookmarkImporter: BookmarkImporter {
 
-    func importBookmarks(_ bookmarks: ImportedBookmarks, source: BookmarkImportSource, markRootBookmarksAsFavoritesByDefault: Bool) -> BookmarksImportSummary {
-        return importBookmarks(bookmarks, source, markRootBookmarksAsFavoritesByDefault)
+    func importBookmarks(_ bookmarks: ImportedBookmarks, source: BookmarkImportSource, markRootBookmarksAsFavoritesByDefault: Bool, maxFavoritesCount: Int? = nil) -> BookmarksImportSummary {
+        return importBookmarks(bookmarks, source, markRootBookmarksAsFavoritesByDefault, maxFavoritesCount)
     }
 
-    var importBookmarks: (ImportedBookmarks, BookmarkImportSource, Bool) -> BookmarksImportSummary
+    var importBookmarks: (ImportedBookmarks, BookmarkImportSource, Bool, Int?) -> BookmarksImportSummary
 
 }

--- a/macOS/UnitTests/DataImport/FirefoxDataImporterTests.swift
+++ b/macOS/UnitTests/DataImport/FirefoxDataImporterTests.swift
@@ -27,7 +27,7 @@ class FirefoxDataImporterTests: XCTestCase {
     func testWhenImportingBookmarks_AndBookmarkImportSucceeds_ThenSummaryIsPopulated() async {
         let loginImporter = MockLoginImporter()
         let faviconManager = FaviconManagerMock()
-        let bookmarkImporter = MockBookmarkImporter(importBookmarks: { _, _, _ in .init(successful: 1, duplicates: 2, failed: 3) })
+        let bookmarkImporter = MockBookmarkImporter(importBookmarks: { _, _, _, _ in .init(successful: 1, duplicates: 2, failed: 3) })
         let importer = FirefoxDataImporter(profile: .init(browser: .firefox, profileURL: resourceURL()), primaryPassword: nil, loginImporter: loginImporter, bookmarkImporter: bookmarkImporter, faviconManager: faviconManager)
 
         let result = await importer.importData(types: [.bookmarks])

--- a/macOS/UnitTests/DataImport/SafariBookmarksReaderTests.swift
+++ b/macOS/UnitTests/DataImport/SafariBookmarksReaderTests.swift
@@ -23,7 +23,7 @@ import XCTest
 class SafariBookmarksReaderTests: XCTestCase {
 
     func testImportingBookmarks() {
-        let bookmarksReader = SafariBookmarksReader(safariBookmarksFileURL: bookmarksFileURL())
+        let bookmarksReader = SafariBookmarksReader(safariBookmarksFileURL: bookmarksFileURL(), featureFlagger: MockFeatureFlagger())
         let bookmarks = bookmarksReader.readBookmarks()
 
         guard case let .success(bookmarks) = bookmarks else {

--- a/macOS/UnitTests/HomePage/Mocks/MockBookmarkManager.swift
+++ b/macOS/UnitTests/HomePage/Mocks/MockBookmarkManager.swift
@@ -141,7 +141,7 @@ class MockBookmarkManager: BookmarkManager, URLFavoriteStatusProviding, RecentAc
 
     func moveFavorites(with objectUUIDs: [String], toIndex: Int?, completion: @escaping (Error?) -> Void) {}
 
-    func importBookmarks(_ bookmarks: DuckDuckGo_Privacy_Browser.ImportedBookmarks, source: DuckDuckGo_Privacy_Browser.BookmarkImportSource, markRootBookmarksAsFavoritesByDefault: Bool = true) -> BrowserServicesKit.BookmarksImportSummary {
+    func importBookmarks(_ bookmarks: DuckDuckGo_Privacy_Browser.ImportedBookmarks, source: DuckDuckGo_Privacy_Browser.BookmarkImportSource, markRootBookmarksAsFavoritesByDefault: Bool = true, maxFavoritesCount: Int?) -> BrowserServicesKit.BookmarksImportSummary {
         BookmarksImportSummary(successful: 0, duplicates: 0, failed: 0)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210726801397642?focus=true

### Description

This PR updates the bookmarks import feature for Safari: 

* “Favorites” from Safari are still imported in the Bookmarks root.
* “Bookmarks” from Safari are still imported into a folder off the root, but with the name “Bookmarks” (previously “Other bookmarks”)
* “Favorites” are still marked as favorites (e.g. on the new tab page), up to a limit of 12. This includes topping up the favorites list if there are already favorites.

This new behavior is behind a feature flag and is disabled by default.

⚠️ These changes are based on https://github.com/duckduckgo/apple-browsers/pull/1235 ⚠️ 

### Testing Steps

#### New behavior (feature flag enabled)

1. Go to Debug menu > Feature flag overrides > Other > enable `updatedBookmarksFavoritesImport` flag.
2. Go to Bookmarks menu > Import bookmarks.
3. Follow the prompts in the UI to import Safari bookmarks.
4. Confirm your new tab Favorites section show up to 12 of your favorites from Safari.

Additional scenarios:

- Add some favorites and then import from Safari, and confirm your Safari favorites are still imported (up to 12 total).
- Import twice and confirm your bookmarks are imported a second time but you don’t have duplicate favorites.
- Import bookmarks from a non-Safari browser and confirm they work as before.

#### Previous behavior (feature flag disabled)

1. Go to Debug menu > Feature flag overrides > Other > disable `updatedBookmarksFavoritesImport` flag.
2. Go to Bookmarks menu > Import bookmarks.
3. Follow the prompts in the UI to import Safari bookmarks.
4. Confirm your new tab Favorites section is the same as your Safari favorites.

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?

The following scenarios have been tested manually and covered with unit tests:

* The specified number of favorites are imported when a limit is set and the bookmark store is empty.
* Favorites are topped up to the limit when the bookmark store already contains favorites.

### Quality Considerations

* The new string will be localized after copy review.

### Notes to Reviewer

Safari favorites | Imported favorites
-|-
![Screenshot 2025-07-08 at 11 21 35](https://github.com/user-attachments/assets/772696e7-489d-4c6b-88eb-84441045da4f)|![Screenshot 2025-07-08 at 11 22 12](https://github.com/user-attachments/assets/92f38c33-b5d0-45ab-94e9-419663ccfd50)


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)