### PR TITLE
macOS: Remove visual updates pixel

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -907,11 +907,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 #else
         crashReporter.checkForNewReports()
 #endif
-
-        if visualStyleDecider.shouldFirePixel(style: visualStyle) {
-            PixelKit.fire(VisualStylePixel.visualUpdatesEnabled, frequency: .uniqueByName)
-        }
-
         urlEventHandler.applicationDidFinishLaunching()
 
         subscribeToEmailProtectionStatusNotifications()

--- a/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/VisualStyleProviding.swift
@@ -43,8 +43,6 @@ protocol VisualStyleProviding {
 
 protocol VisualStyleDecider {
     var style: any VisualStyleProviding { get }
-
-    func shouldFirePixel(style: VisualStyleProviding) -> Bool
 }
 
 enum AddressBarSizeClass {
@@ -131,33 +129,5 @@ final class DefaultVisualStyleDecider: VisualStyleDecider {
         }
 
         return isVisualRefreshEnabled ? VisualStyle.current : VisualStyle.legacy
-    }
-
-    func shouldFirePixel(style: any VisualStyleProviding) -> Bool {
-        return !internalUserDecider.isInternalUser && style.isNewStyle
-    }
-}
-
-/// This enum keeps pixels related to the Visual Refresh
-/// > Related links:
-/// [Pixel Triage](https://app.asana.com/1/137249556945/project/69071770703008/task/1210516955340232)
-enum VisualStylePixel: PixelKitEventV2 {
-
-    /// This pixel will be fired once time per user. The logic will be fired at app launch if the user has the new UI enabled and it is not an internal user.
-    case visualUpdatesEnabled
-
-    var name: String {
-        switch self {
-        case .visualUpdatesEnabled:
-            return "visual_update_enabled_u"
-        }
-    }
-
-    var parameters: [String: String]? {
-        nil
-    }
-
-    var error: (any Error)? {
-        nil
     }
 }

--- a/macOS/UnitTests/VisualRefresh/VisualStyleManagerTests.swift
+++ b/macOS/UnitTests/VisualRefresh/VisualStyleManagerTests.swift
@@ -316,22 +316,4 @@ class VisualStyleManagerTests: XCTestCase {
         style = visualStyleDecider.style
         XCTAssertEqual(style.toolbarButtonsCornerRadius, 4.0)
     }
-
-    // MARK: - Should Send Pixel Tests
-
-    func testWhenNotInternalUserAndNewStyleThenPixelShouldBeSent() {
-        mockInternalUserDecider.isInternalUser = false
-        XCTAssertTrue(visualStyleDecider.shouldFirePixel(style: VisualStyle.current))
-    }
-
-    func testWhenInternalUserAndNewStyleThenPixelShouldNotBeSent() {
-        mockInternalUserDecider.isInternalUser = true
-        XCTAssertFalse(visualStyleDecider.shouldFirePixel(style: VisualStyle.current))
-    }
-
-    func testWhenNotInternalUserAndLegacyStyleThenPixelShouldNotBeSent() {
-        mockInternalUserDecider.isInternalUser = false
-        XCTAssertFalse(visualStyleDecider.shouldFirePixel(style: VisualStyle.legacy))
-    }
-
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1210533076861171
Tech Design URL:
CC:

### Description
We are now at 100% rollout of the new visual updates, so we want to remove the pixel to measure users that are seeing the new UI.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)