### PR TITLE
Fix expectation action retrying loop on failure

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/SubJobWebRunner/BrokerProfileScanSubJobWebRunner.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/SubJobWebRunner/BrokerProfileScanSubJobWebRunner.swift
@@ -125,7 +125,7 @@ public final class BrokerProfileScanSubJobWebRunner: SubJobWebRunning, BrokerPro
         /// To minimize the impact of this change, we set the number of retries to 1 for now.
         ///
         /// https://app.asana.com/1/137249556945/project/481882893211075/task/1210079565270206?focus=true
-        if action is ExpectationAction {
+        if action is ExpectationAction, !stageCalculator.isRetrying {
             retriesCountOnError = 1
         }
 

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionStageDurationCalculator.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionStageDurationCalculator.swift
@@ -68,6 +68,12 @@ public protocol StageDurationCalculator {
     func incrementTries()
 }
 
+extension StageDurationCalculator {
+    public var isRetrying: Bool {
+        tries != 1
+    }
+}
+
 final class DataBrokerProtectionStageDurationCalculator: StageDurationCalculator {
     let isImmediateOperation: Bool
     let handler: EventMapping<DataBrokerProtectionSharedPixels>

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
@@ -1113,9 +1113,11 @@ public final class MockStageDurationCalculator: StageDurationCalculator {
     }
 
     public func resetTries() {
+        self.tries = 1
     }
 
     public func incrementTries() {
+        self.tries += 1
     }
 
     func clear() {

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/Debug/DataBrokerRunCustomJSONViewModel.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/Debug/DataBrokerRunCustomJSONViewModel.swift
@@ -596,9 +596,11 @@ final class FakeStageDurationCalculator: StageDurationCalculator {
     }
 
     func resetTries() {
+        self.tries = 1
     }
 
     func incrementTries() {
+        self.tries += 1
     }
 }
 

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/Debug/DebugScanJob.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/Debug/DebugScanJob.swift
@@ -175,7 +175,7 @@ final class DebugScanJob: SubJobWebRunning {
     }
 
     func evaluateActionAndHaltIfNeeded(_ action: Action) async -> Bool {
-        if action.actionType == .expectation {
+        if action.actionType == .expectation, !stageCalculator.isRetrying {
             retriesCountOnError = 1
         }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209465029498474/task/1210738801919185?focus=true
Tech Design URL:
CC:

### Description

Fixes an issue where expectation actions keep retrying even after failure.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Go to Debug > PIR > Debug mode
2. Use a test profile with this JSON as the broker config: https://app.asana.com/1/137249556945/project/1209465029498474/task/1210738801919185?focus=true
3. Run a scan
4. Expect it to terminate with “actionFailed” after 2 mins or so

### Impact and Risks
<!— 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
—>

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)