### PR TITLE
Fix v1 entitlements regression

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/API/SubscriptionAPIService.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/API/SubscriptionAPIService.swift
@@ -27,6 +27,7 @@ public enum APIServiceError: Swift.Error, LocalizedError {
     case serverError(statusCode: Int, error: String?)
     case unknownServerError
     case connectionError
+    case invalidToken
 
     public var errorDescription: String? {
         switch self {
@@ -40,6 +41,8 @@ public enum APIServiceError: Swift.Error, LocalizedError {
             return "Unknown server error"
         case .connectionError:
             return "Connection error"
+        case .invalidToken:
+            return "Invalid Token"
         }
     }
 
@@ -102,6 +105,8 @@ public struct DefaultSubscriptionAPIService: SubscriptionAPIService {
                     Logger.subscription.error("Service error: APIServiceError.decodingError")
                     return .failure(.decodingError)
                 }
+            } else if httpResponse.statusCode == 401 {
+                return .failure(.invalidToken)
             } else {
                 var errorString: String?
 

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/API/SubscriptionAPIService.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/API/SubscriptionAPIService.swift
@@ -63,7 +63,6 @@ public protocol SubscriptionAPIService {
 public enum APICachePolicy {
     case reloadIgnoringLocalCacheData
     case returnCacheDataElseLoad
-    case returnCacheDataDontLoad
 
     public var subscriptionCachePolicy: SubscriptionCachePolicy {
         switch self {
@@ -71,8 +70,6 @@ public enum APICachePolicy {
             return .remoteFirst
         case .returnCacheDataElseLoad:
             return .cacheFirst
-        case .returnCacheDataDontLoad:
-            return .cacheOnly
         }
     }
 }

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/API/SubscriptionEndpointService.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/API/SubscriptionEndpointService.swift
@@ -126,13 +126,6 @@ public struct DefaultSubscriptionEndpointService: SubscriptionEndpointService {
             } else {
                 return await getRemoteSubscription(accessToken: accessToken)
             }
-
-        case .returnCacheDataDontLoad:
-            if let cachedSubscription = subscriptionCache.get() {
-                return .success(cachedSubscription)
-            } else {
-                return .failure(.noCachedData)
-            }
         }
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/AccountManager.swift
@@ -256,13 +256,6 @@ public final class DefaultAccountManager: AccountManager {
             } else {
                 return await fetchRemoteEntitlements()
             }
-
-        case .returnCacheDataDontLoad:
-            if let cachedEntitlements: [Entitlement] = entitlementsCache.get() {
-                return .success(cachedEntitlements)
-            } else {
-                return .failure(EntitlementsError.noCachedData)
-            }
         }
 
     }

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/AccountManager.swift
@@ -209,7 +209,7 @@ public final class DefaultAccountManager: AccountManager {
     private func fetchRemoteEntitlements() async -> Result<[Entitlement], Error> {
         guard let accessToken else {
             entitlementsCache.reset()
-            return .failure(EntitlementsError.noAccessToken)
+            return .success([])
         }
 
         switch await authEndpointService.validateToken(accessToken: accessToken) {

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
@@ -315,13 +315,10 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
                 throw SubscriptionEndpointServiceError.noData
             } catch {
                 // Failed to get a valid token, fall back on cache
-                subscription = try await subscriptionEndpointService.getSubscription(accessToken: nil, cachePolicy: .cacheOnly)
+                subscription = try await subscriptionEndpointService.getSubscription(accessToken: nil, cachePolicy: .cacheFirst)
                 break
             }
             subscription = try await subscriptionEndpointService.getSubscription(accessToken: tokenContainer.accessToken, cachePolicy: cachePolicy)
-
-        case .cacheOnly:
-            subscription = try await subscriptionEndpointService.getSubscription(accessToken: nil, cachePolicy: cachePolicy)
         }
 
         if subscription.isActive {

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/V1toV2Bridging/SubscriptionAuthV1toV2Bridge.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/V1toV2Bridging/SubscriptionAuthV1toV2Bridge.swift
@@ -30,7 +30,7 @@ public protocol SubscriptionAuthV1toV2Bridge: SubscriptionTokenProvider, Subscri
     func isFeatureAvailableAndEnabled(feature: Entitlement.ProductName, cachePolicy: APICachePolicy) async throws -> Bool
     /// If the user is allowed to use the feature, base on the TokenContainer entitlements
     /// This is used by VPN and PIR
-    func isFeatureEnabledForUser(feature: Entitlement.ProductName) async -> Bool
+    func isFeatureEnabledForUser(feature: Entitlement.ProductName) async throws -> Bool
 
     func currentSubscriptionFeatures() async -> [Entitlement.ProductName]
     func signOut(notifyUI: Bool) async
@@ -62,13 +62,13 @@ extension SubscriptionAuthV1toV2Bridge {
 
 extension DefaultSubscriptionManager: SubscriptionAuthV1toV2Bridge {
 
-    public func isFeatureEnabledForUser(feature: Entitlement.ProductName) async -> Bool {
+    public func isFeatureEnabledForUser(feature: Entitlement.ProductName) async throws -> Bool {
         let result = await accountManager.hasEntitlement(forProductName: feature, cachePolicy: .returnCacheDataDontLoad)
         switch result {
         case .success(let hasEntitlements):
             return hasEntitlements
-        case .failure:
-            return false
+        case .failure(let error):
+            throw error
         }
     }
 
@@ -122,7 +122,7 @@ extension DefaultSubscriptionManager: SubscriptionAuthV1toV2Bridge {
 
 extension DefaultSubscriptionManagerV2: SubscriptionAuthV1toV2Bridge {
 
-    public func isFeatureEnabledForUser(feature: Entitlement.ProductName) async -> Bool {
+    public func isFeatureEnabledForUser(feature: Entitlement.ProductName) async throws -> Bool {
         do {
             guard isUserAuthenticated else { return false }
             let tokenContainer = try await getTokenContainer(policy: .localValid)

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/V1toV2Bridging/SubscriptionAuthV1toV2Bridge.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/V1toV2Bridging/SubscriptionAuthV1toV2Bridge.swift
@@ -68,7 +68,12 @@ extension DefaultSubscriptionManager: SubscriptionAuthV1toV2Bridge {
         case .success(let hasEntitlements):
             return hasEntitlements
         case .failure(let error):
-            throw error
+            switch error {
+            case APIServiceError.invalidToken:
+                return false
+            default:
+                throw error
+            }
         }
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/V1toV2Bridging/SubscriptionAuthV1toV2Bridge.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/V1toV2Bridging/SubscriptionAuthV1toV2Bridge.swift
@@ -63,7 +63,7 @@ extension SubscriptionAuthV1toV2Bridge {
 extension DefaultSubscriptionManager: SubscriptionAuthV1toV2Bridge {
 
     public func isFeatureEnabledForUser(feature: Entitlement.ProductName) async throws -> Bool {
-        let result = await accountManager.hasEntitlement(forProductName: feature, cachePolicy: .returnCacheDataDontLoad)
+        let result = await accountManager.hasEntitlement(forProductName: feature, cachePolicy: .returnCacheDataElseLoad)
         switch result {
         case .success(let hasEntitlements):
             return hasEntitlements

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/API/SubscriptionEndpointServiceV2Tests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/API/SubscriptionEndpointServiceV2Tests.swift
@@ -94,7 +94,7 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
         )
         endpointService.updateCache(with: cachedSubscription)
 
-        let subscription = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .cacheOnly)
+        let subscription = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .cacheFirst)
         XCTAssertEqual(subscription, cachedSubscription)
     }
 
@@ -119,7 +119,7 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
 
     func testGetSubscriptionThrowsNoDataWhenNoCacheAndFetchFails() async {
         do {
-            _ = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .cacheOnly)
+            _ = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .cacheFirst)
             XCTFail("Expected noData error")
         } catch SubscriptionEndpointServiceError.noData {
             // Success
@@ -229,7 +229,7 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
         )
         endpointService.updateCache(with: subscription)
 
-        let cachedSubscription = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .cacheOnly)
+        let cachedSubscription = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .cacheFirst)
         XCTAssertEqual(cachedSubscription, subscription)
     }
 
@@ -249,7 +249,7 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
 
         endpointService.clearSubscription()
         do {
-            _ = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .cacheOnly)
+            _ = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .cacheFirst)
         } catch SubscriptionEndpointServiceError.noData {
             // Success
         } catch {

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/API/SubscriptionEndpointServiceV2Tests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/API/SubscriptionEndpointServiceV2Tests.swift
@@ -117,17 +117,6 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
         XCTAssertEqual(subscription.status, .autoRenewable)
     }
 
-    func testGetSubscriptionThrowsNoDataWhenNoCacheAndFetchFails() async {
-        do {
-            _ = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .cacheFirst)
-            XCTFail("Expected noData error")
-        } catch SubscriptionEndpointServiceError.noData {
-            // Success
-        } catch {
-            XCTFail("Unexpected error: \(error)")
-        }
-    }
-
     // MARK: - getProducts Tests
 
     func testGetProductsReturnsListOfProducts() async throws {
@@ -233,7 +222,17 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
         XCTAssertEqual(cachedSubscription, subscription)
     }
 
-    func testClearSubscriptionRemovesCachedSubscription() async throws {
+    func testClearSubscriptionRemovesCachedSubscription_AndGetSubscriptionReFetchesIt() async throws {
+        // mock subscription response
+        let subscriptionData = try createSubscriptionResponseData()
+        let apiResponse = createAPIResponse(statusCode: 200, data: subscriptionData)
+        let request = SubscriptionRequest.getSubscription(baseURL: baseURL, accessToken: "token")!.apiRequest
+
+        // mock features
+        SubscriptionAPIMockResponseFactory.mockGetFeatures(destinationMockAPIService: apiService, success: true, subscriptionID: "prod123")
+
+        apiService.set(response: apiResponse, forRequest: request)
+
         let date = Date(timeIntervalSince1970: 123456789)
         let subscription = PrivacyProSubscription(
             productId: "prod123",
@@ -250,7 +249,6 @@ final class SubscriptionEndpointServiceV2Tests: XCTestCase {
         endpointService.clearSubscription()
         do {
             _ = try await endpointService.getSubscription(accessToken: "token", cachePolicy: .cacheFirst)
-        } catch SubscriptionEndpointServiceError.noData {
             // Success
         } catch {
             XCTFail("Wrong error: \(error)")

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/AccountManagerTests.swift
@@ -354,47 +354,6 @@ final class AccountManagerTests: XCTestCase {
         }
     }
 
-    func testFetchEntitlementsReturnCacheDataDontLoad() async throws {
-        // Given
-        accessTokenStorage.accessToken = Constants.accessToken
-        entitlementsCache.set(Constants.entitlements)
-
-        // When
-        let result = await accountManager.fetchEntitlements(cachePolicy: .returnCacheDataDontLoad)
-
-        // Then
-        switch result {
-        case .success(let success):
-            XCTAssertEqual(success, Constants.entitlements)
-            XCTAssertFalse(authService.validateTokenCalled)
-            XCTAssertEqual(entitlementsCache.get(), Constants.entitlements)
-        case .failure:
-            XCTFail("Unexpected failure")
-        }
-    }
-
-    func testFetchEntitlementsReturnCacheDataDontLoadWhenCacheIsExpired() async throws {
-        // Given
-        accessTokenStorage.accessToken = Constants.accessToken
-        entitlementsCache.set(Constants.entitlements, expires: Date.distantPast)
-
-        // When
-        let result = await accountManager.fetchEntitlements(cachePolicy: .returnCacheDataDontLoad)
-
-        // Then
-        switch result {
-        case .success:
-            XCTFail("Unexpected success")
-        case .failure(let error):
-            guard let entitlementsError = error as? DefaultAccountManager.EntitlementsError else {
-                XCTFail("Incorrect error type")
-                return
-            }
-
-            XCTAssertEqual(entitlementsError, .noCachedData)
-        }
-    }
-
     // MARK: - Tests for exchangeAuthTokenToAccessToken
 
     func testExchangeAuthTokenToAccessToken() async throws {

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Authentication/DataBrokerProtectionSubscriptionManaging.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Authentication/DataBrokerProtectionSubscriptionManaging.swift
@@ -61,7 +61,7 @@ public final class DataBrokerProtectionSubscriptionManager: DataBrokerProtection
         if runTypeProvider.runType == .integrationTests {
             return true // real entitlements check are not possible here in AuthV2 because the SubscriptionManager has no token
         } else {
-            return await subscriptionManager.isFeatureEnabledForUser(feature: .dataBrokerProtection)
+            return try await subscriptionManager.isFeatureEnabledForUser(feature: .dataBrokerProtection)
         }
     }
 }

--- a/iOS/DuckDuckGo/AppServices/VPNService.swift
+++ b/iOS/DuckDuckGo/AppServices/VPNService.swift
@@ -115,7 +115,7 @@ final class VPNService: NSObject {
     private func refreshVPNShortcuts() async {
         guard await vpnFeatureVisibility.shouldShowVPNShortcut(),
               let hasEntitlement = try? await subscriptionManager.isFeatureAvailableAndEnabled(feature: .networkProtection,
-                                                                            cachePolicy: .returnCacheDataDontLoad),
+                                                                            cachePolicy: .returnCacheDataElseLoad),
               hasEntitlement
         else {
             application.shortcutItems = nil

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1810,9 +1810,11 @@ class MainViewController: UIViewController {
                 Task {
                     guard let self else { return }
 
-                    let hasEntitlement = await self.subscriptionManager.isFeatureEnabledForUser(feature: .networkProtection)
+                    guard let hasEntitlement = try? await self.subscriptionManager.isFeatureEnabledForUser(feature: .networkProtection) else {
+                        return
+                    }
                     let isAuthV2Enabled = AppDependencyProvider.shared.isUsingAuthV2
-                    let isSubscriptionActive = try? await self.subscriptionManager.getSubscription(cachePolicy: .cacheOnly).isActive
+                    let isSubscriptionActive = try? await self.subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
 
                     if hasEntitlement && self.lastKnownEntitlementsExpired {
                         PixelKit.fire(
@@ -1939,7 +1941,7 @@ class MainViewController: UIViewController {
         Task {
             let subscriptionManager = AppDependencyProvider.shared.subscriptionAuthV1toV2Bridge
             let isAuthV2Enabled = AppDependencyProvider.shared.isUsingAuthV2
-            let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheOnly).isActive
+            let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
 
             PixelKit.fire(
                 VPNSubscriptionStatusPixel.signedIn(
@@ -1964,8 +1966,10 @@ class MainViewController: UIViewController {
     func checkSubscriptionEntitlements() {
         Task {
             let isAuthV2Enabled = AppDependencyProvider.shared.isUsingAuthV2
-            let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheOnly).isActive
-            let hasEntitlement = await subscriptionManager.isFeatureEnabledForUser(feature: .networkProtection)
+            let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
+            guard let hasEntitlement = try? await subscriptionManager.isFeatureEnabledForUser(feature: .networkProtection) else {
+                return
+            }
 
             if hasEntitlement && lastKnownEntitlementsExpired {
                 PixelKit.fire(
@@ -2000,7 +2004,7 @@ class MainViewController: UIViewController {
             }
             let hasEntitlements = payload.entitlements.contains(.networkProtection)
             let isAuthV2Enabled = AppDependencyProvider.shared.isUsingAuthV2
-            let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheOnly).isActive
+            let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
 
             if hasEntitlements {
                 PixelKit.fire(
@@ -2042,7 +2046,7 @@ class MainViewController: UIViewController {
         Task {
             let subscriptionManager = AppDependencyProvider.shared.subscriptionAuthV1toV2Bridge
             let isAuthV2Enabled = AppDependencyProvider.shared.isUsingAuthV2
-            let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheOnly).isActive
+            let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
 
             PixelKit.fire(
                 VPNSubscriptionStatusPixel.signedOut(

--- a/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
+++ b/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
@@ -89,8 +89,8 @@ final class SubscriptionSettingsViewModel: ObservableObject {
     func onFirstAppear() {
         Task {
             // Load initial state from the cache
-            async let loadedEmailFromCache = await self.fetchAndUpdateAccountEmail(cachePolicy: .returnCacheDataDontLoad)
-            async let loadedSubscriptionFromCache = await self.fetchAndUpdateSubscriptionDetails(cachePolicy: .returnCacheDataDontLoad,
+            async let loadedEmailFromCache = await self.fetchAndUpdateAccountEmail(cachePolicy: .returnCacheDataElseLoad)
+            async let loadedSubscriptionFromCache = await self.fetchAndUpdateSubscriptionDetails(cachePolicy: .returnCacheDataElseLoad,
                                                                                                  loadingIndicator: false)
             let (hasLoadedEmailFromCache, hasLoadedSubscriptionFromCache) = await (loadedEmailFromCache, loadedSubscriptionFromCache)
             
@@ -134,7 +134,7 @@ final class SubscriptionSettingsViewModel: ObservableObject {
         guard let token = self.subscriptionManager.accountManager.accessToken else { return false }
         
         switch cachePolicy {
-        case .returnCacheDataDontLoad, .returnCacheDataElseLoad:
+        case .returnCacheDataElseLoad:
             DispatchQueue.main.async {
                 self.state.subscriptionEmail = self.subscriptionManager.accountManager.email
             }

--- a/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModelV2.swift
+++ b/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModelV2.swift
@@ -92,8 +92,8 @@ final class SubscriptionSettingsViewModelV2: ObservableObject {
     func onFirstAppear() {
         Task {
             // Load initial state from the cache
-            async let loadedEmailFromCache = await self.fetchAndUpdateAccountEmail(cachePolicy: .cacheOnly)
-            async let loadedSubscriptionFromCache = await self.fetchAndUpdateSubscriptionDetails(cachePolicy: .cacheOnly,
+            async let loadedEmailFromCache = await self.fetchAndUpdateAccountEmail(cachePolicy: .cacheFirst)
+            async let loadedSubscriptionFromCache = await self.fetchAndUpdateSubscriptionDetails(cachePolicy: .cacheFirst,
                                                                                                  loadingIndicator: false)
             let (hasLoadedEmailFromCache, hasLoadedSubscriptionFromCache) = await (loadedEmailFromCache, loadedSubscriptionFromCache)
 
@@ -135,14 +135,13 @@ final class SubscriptionSettingsViewModelV2: ObservableObject {
         Logger.subscription.log("Fetch and update account email")
         guard subscriptionManager.isUserAuthenticated else { return false }
 
-        var tokensPolicy: AuthTokensCachePolicy = .local
+        let tokensPolicy: AuthTokensCachePolicy
+
         switch cachePolicy {
         case .remoteFirst:
             tokensPolicy = .localForceRefresh
         case .cacheFirst:
             tokensPolicy = .localValid
-        case .cacheOnly:
-            tokensPolicy = .local
         }
 
         do {

--- a/macOS/DuckDuckGo/DBP/DataBrokerProtectionAppEvents.swift
+++ b/macOS/DuckDuckGo/DBP/DataBrokerProtectionAppEvents.swift
@@ -69,7 +69,9 @@ struct DataBrokerProtectionAppEvents {
 
         // Check feature prerequisites and disable the login item if they are not satisfied
         Task { @MainActor in
-            let prerequisitesMet = await featureGatekeeper.arePrerequisitesSatisfied()
+            // Failure doesn't mean no entitlements, so we just bail out and do nothing
+            let prerequisitesMet = try await featureGatekeeper.arePrerequisitesSatisfied()
+
             guard prerequisitesMet else {
                 loginItemsManager.disableLoginItems([LoginItem.dbpBackgroundAgent])
                 NotificationCenter.default.post(name: .dbpLoginItemDisabled, object: nil)

--- a/macOS/DuckDuckGo/DBP/DataBrokerProtectionFeatureGatekeeper.swift
+++ b/macOS/DuckDuckGo/DBP/DataBrokerProtectionFeatureGatekeeper.swift
@@ -27,7 +27,7 @@ import Subscription
 
 protocol DataBrokerProtectionFeatureGatekeeper {
     func disableAndDeleteForAllUsers()
-    func arePrerequisitesSatisfied() async -> Bool
+    func arePrerequisitesSatisfied() async throws -> Bool
 }
 
 struct DefaultDataBrokerProtectionFeatureGatekeeper: DataBrokerProtectionFeatureGatekeeper {
@@ -86,13 +86,13 @@ struct DefaultDataBrokerProtectionFeatureGatekeeper: DataBrokerProtectionFeature
     /// 2. The user has a subscription with valid entitlements
     ///
     /// - Returns: Bool indicating prerequisites are satisfied
-    func arePrerequisitesSatisfied() async -> Bool {
+    func arePrerequisitesSatisfied() async throws -> Bool {
 
         let isAuthenticated = subscriptionManager.isUserAuthenticated
         if !isAuthenticated && freemiumDBPUserStateManager.didActivate { return true }
 
         // NOTE: This check In AuthV1 this can fail in case of bad network, in AuthV2 works as expected in any network condition
-        let hasEntitlements = await subscriptionManager.isFeatureEnabledForUser(feature: .dataBrokerProtection)
+        let hasEntitlements = try await subscriptionManager.isFeatureEnabledForUser(feature: .dataBrokerProtection)
         firePrerequisitePixelsAndLogIfNecessary(hasEntitlements: hasEntitlements, isAuthenticatedResult: isAuthenticated)
         return hasEntitlements && isAuthenticated
     }

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/VPNSubscriptionEventsHandler.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/VPNSubscriptionEventsHandler.swift
@@ -107,7 +107,7 @@ final class VPNSubscriptionEventsHandler {
     @MainActor
     private func handleEntitlementsChange(hasEntitlements: Bool, trigger: VPNSubscriptionStatusPixel.Trigger) async {
         let isAuthV2Enabled = NSApp.delegateTyped.isUsingAuthV2
-        let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheOnly).isActive
+        let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
 
         // For trigger == .clientCheck we only fire pixels if there's an actual change, because they're not guaranteed
         // to be executed only when there are changes - they'll run at every app launch.
@@ -191,7 +191,7 @@ final class VPNSubscriptionEventsHandler {
             }
 
             let isAuthV2Enabled = NSApp.delegateTyped.isUsingAuthV2
-            let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheOnly).isActive
+            let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
 
             PixelKit.fire(
                 VPNSubscriptionStatusPixel.signedIn(
@@ -210,7 +210,7 @@ final class VPNSubscriptionEventsHandler {
             print("[NetP Subscription] Deleted NetP auth token after signing out from Privacy Pro")
 
             let isAuthV2Enabled = await NSApp.delegateTyped.isUsingAuthV2
-            let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheOnly).isActive
+            let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
 
             PixelKit.fire(
                 VPNSubscriptionStatusPixel.signedOut(

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/VPNSubscriptionEventsHandler.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/VPNSubscriptionEventsHandler.swift
@@ -60,8 +60,9 @@ final class VPNSubscriptionEventsHandler {
 
     private func checkEntitlements() {
         Task {
-            let hasEntitlement = await subscriptionManager.isFeatureEnabledForUser(feature: .networkProtection)
-            await handleEntitlementsChange(hasEntitlements: hasEntitlement, trigger: .clientCheck)
+            if let hasEntitlement = try? await subscriptionManager.isFeatureEnabledForUser(feature: .networkProtection) {
+                await handleEntitlementsChange(hasEntitlements: hasEntitlement, trigger: .clientCheck)
+            }
         }
     }
 
@@ -71,9 +72,10 @@ final class VPNSubscriptionEventsHandler {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 Logger.networkProtection.log("System wake notification received, checking entitlements")
-                Task {
-                    let hasEntitlement = await self?.subscriptionManager.isFeatureEnabledForUser(feature: .networkProtection) ?? false
-                    await self?.handleEntitlementsChange(hasEntitlements: hasEntitlement, trigger: .clientCheckOnWake)
+                Task { [weak self] in
+                    if let hasEntitlement = try? await self?.subscriptionManager.isFeatureEnabledForUser(feature: .networkProtection) {
+                        await self?.handleEntitlementsChange(hasEntitlements: hasEntitlement, trigger: .clientCheckOnWake)
+                    }
                 }
             }
             .store(in: &cancellables)

--- a/macOS/DuckDuckGo/Waitlist/VPNFeatureGatekeeper.swift
+++ b/macOS/DuckDuckGo/Waitlist/VPNFeatureGatekeeper.swift
@@ -59,7 +59,7 @@ struct DefaultVPNFeatureGatekeeper: VPNFeatureGatekeeper {
     /// For subscription users this means they have entitlements.
     ///
     func canStartVPN() async throws -> Bool {
-        return await subscriptionManager.isFeatureEnabledForUser(feature: .networkProtection)
+        return try await subscriptionManager.isFeatureEnabledForUser(feature: .networkProtection)
     }
 
     /// Whether the user can see the VPN entry points in the UI.

--- a/macOS/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/Preferences/PreferencesSubscriptionSettingsModelV1.swift
+++ b/macOS/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/Preferences/PreferencesSubscriptionSettingsModelV1.swift
@@ -70,7 +70,7 @@ public final class PreferencesSubscriptionSettingsModelV1: ObservableObject {
                 }
 
                 await self?.fetchEmail()
-                await self?.updateSubscription(cachePolicy: .returnCacheDataDontLoad)
+                await self?.updateSubscription(cachePolicy: .returnCacheDataElseLoad)
             }
         }
 

--- a/macOS/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/Preferences/PreferencesSubscriptionSettingsModelV2.swift
+++ b/macOS/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/Preferences/PreferencesSubscriptionSettingsModelV2.swift
@@ -80,7 +80,7 @@ public final class PreferencesSubscriptionSettingsModelV2: ObservableObject {
                 }
 
                 await self?.fetchEmail()
-                await self?.updateSubscription(cachePolicy: .cacheOnly)
+                await self?.updateSubscription(cachePolicy: .cacheFirst)
             }
         }
 

--- a/macOS/UnitTests/DBP/Tests/DataBrokerProtectionFeatureGatekeeperTests.swift
+++ b/macOS/UnitTests/DBP/Tests/DataBrokerProtectionFeatureGatekeeperTests.swift
@@ -54,7 +54,7 @@ final class DataBrokerProtectionFeatureGatekeeperTests: XCTestCase {
                                                            freemiumDBPUserStateManager: mockFreemiumDBPUserStateManager)
 
         // When
-        let result = await sut.arePrerequisitesSatisfied()
+        let result = (try? await sut.arePrerequisitesSatisfied()) ?? false
 
         // Then
         XCTAssertFalse(result)
@@ -73,7 +73,7 @@ final class DataBrokerProtectionFeatureGatekeeperTests: XCTestCase {
                                                            freemiumDBPUserStateManager: mockFreemiumDBPUserStateManager)
 
         // When
-        let result = await sut.arePrerequisitesSatisfied()
+        let result = (try? await sut.arePrerequisitesSatisfied()) ?? false
 
         // Then
         XCTAssertFalse(result)
@@ -91,7 +91,7 @@ final class DataBrokerProtectionFeatureGatekeeperTests: XCTestCase {
                                                            freemiumDBPUserStateManager: mockFreemiumDBPUserStateManager)
 
         // When
-        let result = await sut.arePrerequisitesSatisfied()
+        let result = (try? await sut.arePrerequisitesSatisfied()) ?? false
 
         // Then
         XCTAssertFalse(result)
@@ -108,7 +108,7 @@ final class DataBrokerProtectionFeatureGatekeeperTests: XCTestCase {
                                                            freemiumDBPUserStateManager: mockFreemiumDBPUserStateManager)
 
         // When
-        let result = await sut.arePrerequisitesSatisfied()
+        let result = (try? await sut.arePrerequisitesSatisfied()) ?? false
 
         // Then
         XCTAssertFalse(result)
@@ -127,7 +127,7 @@ final class DataBrokerProtectionFeatureGatekeeperTests: XCTestCase {
                                                            freemiumDBPUserStateManager: mockFreemiumDBPUserStateManager)
 
         // When
-        let result = await sut.arePrerequisitesSatisfied()
+        let result = (try? await sut.arePrerequisitesSatisfied()) ?? false
 
         // Then
         XCTAssertTrue(result)
@@ -144,7 +144,7 @@ final class DataBrokerProtectionFeatureGatekeeperTests: XCTestCase {
                                                            freemiumDBPUserStateManager: mockFreemiumDBPUserStateManager)
 
         // When
-        let result = await sut.arePrerequisitesSatisfied()
+        let result = (try? await sut.arePrerequisitesSatisfied()) ?? false
 
         // Then
         XCTAssertTrue(result)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1210746879873137?focus=true

### Description

Fixes a regression with entitlement checks on AuthV1.

The issue was introduced in [this line](https://github.com/duckduckgo/apple-browsers/pull/936/files#diff-ef31b1cf1db6fe730b6cadd9926e1466fd19b34e0fd567a3144ee6ecee597cf3R90) and [this line](https://github.com/duckduckgo/apple-browsers/pull/936/files#diff-ef31b1cf1db6fe730b6cadd9926e1466fd19b34e0fd567a3144ee6ecee597cf3R95).

Local cache expires after 20 minutes, so the first line would often return an error about no cache being available.  The second line would then proceed to inform there are no entitlements to the app.

### Testing Steps

1. Throw an error here.
2. Start the app.
3. See that the VPN and DBP are disabled.

### Impact and Risks

Medium

#### What could go wrong?

This is making changes to AuthV1 logic to fix a regression.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)