### PR TITLE
Add Summarization to AI Features settings

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/macOS/PublicAPI/AIChatPreferencesStorage.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/macOS/PublicAPI/AIChatPreferencesStorage.swift
@@ -24,6 +24,9 @@ public protocol AIChatPreferencesStorage {
     var showShortcutInApplicationMenu: Bool { get set }
     var showShortcutInApplicationMenuPublisher: AnyPublisher<Bool, Never> { get }
 
+    var isSummarizationEnabled: Bool { get set }
+    var isSummarizationEnabledPublisher: AnyPublisher<Bool, Never> { get }
+
     var showShortcutInAddressBar: Bool { get set }
     var showShortcutInAddressBarPublisher: AnyPublisher<Bool, Never> { get }
 
@@ -36,6 +39,10 @@ public protocol AIChatPreferencesStorage {
 public struct DefaultAIChatPreferencesStorage: AIChatPreferencesStorage {
     private let userDefaults: UserDefaults
     private let notificationCenter: NotificationCenter
+
+    public var isSummarizationEnabledPublisher: AnyPublisher<Bool, Never> {
+        userDefaults.isSummarizationEnabledPublisher
+    }
 
     public var showShortcutInApplicationMenuPublisher: AnyPublisher<Bool, Never> {
         userDefaults.showAIChatShortcutInApplicationMenuPublisher
@@ -55,6 +62,11 @@ public struct DefaultAIChatPreferencesStorage: AIChatPreferencesStorage {
         self.notificationCenter = notificationCenter
     }
 
+    public var isSummarizationEnabled: Bool {
+        get { userDefaults.isSummarizationEnabled }
+        set { userDefaults.isSummarizationEnabled = newValue }
+    }
+
     public var showShortcutInApplicationMenu: Bool {
         get { userDefaults.showAIChatShortcutInApplicationMenu }
         set { userDefaults.showAIChatShortcutInApplicationMenu = newValue }
@@ -71,6 +83,7 @@ public struct DefaultAIChatPreferencesStorage: AIChatPreferencesStorage {
     }
 
     public func reset() {
+        userDefaults.isSummarizationEnabled = UserDefaults.isSummarizationEnabledDefaultValue
         userDefaults.showAIChatShortcutInApplicationMenu = UserDefaults.showAIChatShortcutInApplicationMenuDefaultValue
         userDefaults.showAIChatShortcutInAddressBar = UserDefaults.showAIChatShortcutInAddressBarDefaultValue
         userDefaults.openAIChatInSidebar = UserDefaults.openAIChatInSidebarDefaultValue
@@ -79,14 +92,27 @@ public struct DefaultAIChatPreferencesStorage: AIChatPreferencesStorage {
 
 private extension UserDefaults {
     enum Keys {
+        static let summarization = "aichat.summarization"
         static let showAIChatShortcutInApplicationMenuKey = "aichat.showAIChatShortcutInApplicationMenu"
         static let showAIChatShortcutInAddressBarKey = "aichat.showAIChatShortcutInAddressBar"
         static let openAIChatInSidebarKey = "aichat.openAIChatInSidebar"
     }
 
     static let showAIChatShortcutInApplicationMenuDefaultValue = true
+    static let isSummarizationEnabledDefaultValue = true
     static let showAIChatShortcutInAddressBarDefaultValue = true
     static let openAIChatInSidebarDefaultValue = true
+
+    @objc dynamic var isSummarizationEnabled: Bool {
+        get {
+            value(forKey: Keys.summarization) as? Bool ?? Self.isSummarizationEnabledDefaultValue
+        }
+
+        set {
+            guard newValue != isSummarizationEnabled else { return }
+            set(newValue, forKey: Keys.summarization)
+        }
+    }
 
     @objc dynamic var showAIChatShortcutInApplicationMenu: Bool {
         get {
@@ -119,6 +145,10 @@ private extension UserDefaults {
             guard newValue != openAIChatInSidebar else { return }
             set(newValue, forKey: Keys.openAIChatInSidebarKey)
         }
+    }
+
+    var isSummarizationEnabledPublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.isSummarizationEnabled).eraseToAnyPublisher()
     }
 
     var showAIChatShortcutInApplicationMenuPublisher: AnyPublisher<Bool, Never> {

--- a/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
@@ -35,6 +35,12 @@ protocol AIChatMenuVisibilityConfigurable {
     /// - Returns: `true` if the application menu shortcut should be displayed; otherwise, `false`.
     var shouldDisplayApplicationMenuShortcut: Bool { get }
 
+    /// This property validates user settings to determine if the text summarization
+    /// feature should be presented to the user.
+    ///
+    /// - Returns: `true` if the text summarization menu action should be displayed; otherwise, `false`.
+    var shouldDisplaySummarizationMenuItem: Bool { get }
+
     /// This property determines whether AI Chat should open in the sidebar.
     ///
     /// - Returns: `true` if AI Chat should open in the sidebar; otherwise, `false`.
@@ -62,6 +68,10 @@ final class AIChatMenuConfiguration: AIChatMenuVisibilityConfigurable {
     private let remoteSettings: AIChatRemoteSettingsProvider
 
     var valuesChangedPublisher = PassthroughSubject<Void, Never>()
+
+    var shouldDisplaySummarizationMenuItem: Bool {
+        storage.isSummarizationEnabled
+    }
 
     var shouldDisplayApplicationMenuShortcut: Bool {
         return storage.showShortcutInApplicationMenu

--- a/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
@@ -95,6 +95,10 @@ final class AIChatMenuConfiguration: AIChatMenuVisibilityConfigurable {
         self.subscribeToValuesChanged()
     }
 
+    /// Changes to isSummarizationEnabled aren't causing `valuesChangedPublisher` to fire because nothing
+    /// should be interested in listening to these changes - summarization doesn't provide a persistent
+    /// view that need to have visibility adjusted when a setting changes. The context menu will always
+    /// read the current state of a setting at the time of creating its contents.
     private func subscribeToValuesChanged() {
         storage.showShortcutInApplicationMenuPublisher
             .removeDuplicates()

--- a/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
@@ -42,6 +42,7 @@ final class AIChatPreferences: ObservableObject {
         showShortcutInApplicationMenu = storage.showShortcutInApplicationMenu
         showShortcutInAddressBar = storage.showShortcutInAddressBar
         openAIChatInSidebar = storage.openAIChatInSidebar
+        isSummarizationEnabled = storage.isSummarizationEnabled
 
         subscribeToShowInApplicationMenuSettingsChanges()
     }
@@ -64,6 +65,12 @@ final class AIChatPreferences: ObservableObject {
             .receive(on: DispatchQueue.main)
             .assign(to: \.openAIChatInSidebar, onWeaklyHeld: self)
             .store(in: &cancellables)
+
+        storage.isSummarizationEnabledPublisher
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .assign(to: \.isSummarizationEnabled, onWeaklyHeld: self)
+            .store(in: &cancellables)
     }
 
     var shouldShowOpenAIChatInSidebarToggle: Bool {
@@ -80,6 +87,14 @@ final class AIChatPreferences: ObservableObject {
 
     @Published var openAIChatInSidebar: Bool {
         didSet { storage.openAIChatInSidebar = openAIChatInSidebar }
+    }
+
+    var isSummarizationAvailable: Bool {
+        featureFlagger.isFeatureOn(.aiChatTextSummarization)
+    }
+
+    @Published var isSummarizationEnabled: Bool {
+        didSet { storage.isSummarizationEnabled = isSummarizationEnabled }
     }
 
     @MainActor func openLearnMoreLink() {

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
@@ -85,6 +85,11 @@ extension Preferences {
                             }
                         }
                     }
+
+                    ToggleMenuItem("Show “Summarize with Duck.ai” in context menu on websites",
+                                   isOn: $model.isSummarizationEnabled)
+                    .accessibilityIdentifier("Preferences.AIChat.showTextSummarizationMenuAction")
+                    .visibility(model.isSummarizationAvailable ? .visible : .gone)
                 }
 
                 PreferencePaneSection(UserText.searchAssistSettings) {

--- a/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
@@ -210,7 +210,7 @@ extension ContextMenuManager {
     }
 
     private func handleSearchWebItem(_ item: NSMenuItem, at index: Int, in menu: NSMenu) {
-        let isSummarizationAvailable = featureFlagger.isFeatureOn(.aiChatTextSummarization)
+        let isSummarizationAvailable = featureFlagger.isFeatureOn(.aiChatTextSummarization) && AIChatMenuConfiguration().shouldDisplaySummarizationMenuItem
         var currentIndex = index
         if isSummarizationAvailable {
             menu.insertItem(.separator(), at: currentIndex)

--- a/macOS/UnitTests/AIChat/AIChatMenuConfigurationTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatMenuConfigurationTests.swift
@@ -39,6 +39,13 @@ class AIChatMenuConfigurationTests: XCTestCase {
         super.tearDown()
     }
 
+    func testIsSummarizationEnabled() {
+        mockStorage.isSummarizationEnabled = true
+        let result = configuration.shouldDisplaySummarizationMenuItem
+
+        XCTAssertTrue(result, "Text Summarization menu action should be displayed when enabled.")
+    }
+
     func testShouldDisplayApplicationMenuShortcut() {
         mockStorage.showShortcutInApplicationMenu = true
         let result = configuration.shouldDisplayApplicationMenuShortcut
@@ -106,6 +113,7 @@ class AIChatMenuConfigurationTests: XCTestCase {
     }
 
     func testReset() {
+        mockStorage.isSummarizationEnabled = true
         mockStorage.showShortcutInApplicationMenu = true
         mockStorage.showShortcutInAddressBar = true
         mockStorage.openAIChatInSidebar = true
@@ -113,6 +121,7 @@ class AIChatMenuConfigurationTests: XCTestCase {
 
         mockStorage.reset()
 
+        XCTAssertFalse(mockStorage.isSummarizationEnabled, "Summarization menu option should be reset to false.")
         XCTAssertFalse(mockStorage.showShortcutInApplicationMenu, "Application menu shortcut should be reset to false.")
         XCTAssertFalse(mockStorage.showShortcutInAddressBar, "Address bar shortcut should be reset to false.")
         XCTAssertFalse(mockStorage.openAIChatInSidebar, "Open AI Chat in sidebar should be reset to false.")
@@ -149,6 +158,12 @@ class AIChatMenuConfigurationTests: XCTestCase {
 class MockAIChatPreferencesStorage: AIChatPreferencesStorage {
     var didDisplayAIChatAddressBarOnboarding: Bool = false
 
+    var isSummarizationEnabled: Bool = false {
+        didSet {
+            isSummarizationEnabledSubject.send(isSummarizationEnabled)
+        }
+    }
+
     var showShortcutInApplicationMenu: Bool = false {
         didSet {
             showShortcutInApplicationMenuSubject.send(showShortcutInApplicationMenu)
@@ -167,9 +182,14 @@ class MockAIChatPreferencesStorage: AIChatPreferencesStorage {
         }
     }
 
+    private var isSummarizationEnabledSubject = PassthroughSubject<Bool, Never>()
     private var showShortcutInApplicationMenuSubject = PassthroughSubject<Bool, Never>()
     private var showShortcutInAddressBarSubject = PassthroughSubject<Bool, Never>()
     private var openAIChatInSidebarSubject = PassthroughSubject<Bool, Never>()
+
+    var isSummarizationEnabledPublisher: AnyPublisher<Bool, Never> {
+        isSummarizationEnabledSubject.eraseToAnyPublisher()
+    }
 
     var showShortcutInApplicationMenuPublisher: AnyPublisher<Bool, Never> {
         showShortcutInApplicationMenuSubject.eraseToAnyPublisher()
@@ -184,10 +204,15 @@ class MockAIChatPreferencesStorage: AIChatPreferencesStorage {
     }
 
     func reset() {
+        isSummarizationEnabled = false
         showShortcutInApplicationMenu = false
         showShortcutInAddressBar = false
         didDisplayAIChatAddressBarOnboarding = false
         openAIChatInSidebar = false
+    }
+
+    func updateIsSummarizationEnabled(to value: Bool) {
+        isSummarizationEnabled = value
     }
 
     func updateApplicationMenuShortcutDisplay(to value: Bool) {

--- a/macOS/UnitTests/Menus/MainMenuTests.swift
+++ b/macOS/UnitTests/Menus/MainMenuTests.swift
@@ -318,6 +318,7 @@ private class DummyFeatureFlagger: FeatureFlagger {
 }
 
 private class DummyAIChatConfig: AIChatMenuVisibilityConfigurable {
+    var shouldDisplaySummarizationMenuItem = false
     var shouldDisplayApplicationMenuShortcut = false
     var shouldDisplayAddressBarShortcut = false
     var openAIChatInSidebar = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210750726093985?focus=true

### Description
This change adds a checkbox in AI Features settings to control summarization menu action visibility.

### Testing Steps
1. Launch the app, ensure that feature flags are in the default state (`aiChatSidebar` on, `aiChatTextSummarization` off)
2. Right click text on a website, trigger context menu and verify that “Summarize with Duck.ai” is not present in the menu.
3. Go to Settings -> AI Features and verify that the option to control summarization is not present.
4. Enable `aiChatTextSummarization` feature flag.
5. Switch to another Settings pane and back to AI Features and verify that the option to control summarization is present.
6. Right click text on a website, trigger context menu and verify that “Summarize with Duck.ai” is present in the menu.
7. Verify that summarization works by opening a sidebar or new tab (depending on the sidebar setting in AI Features).

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)