### PR TITLE
Fix Duck Player audio continuing in background tabs

### DIFF
--- a/iOS/DuckDuckGo/DuckPlayer/WebUI/WebDuckPlayerNavigationHandler.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/WebUI/WebDuckPlayerNavigationHandler.swift
@@ -1045,14 +1045,22 @@ extension WebDuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
     ///
     /// - Parameter hostViewController: The `TabViewController` to set as the host.
     func updateDuckPlayerForWebViewAppearance(_ hostViewController: TabViewController) {
-        // NOOP
+        guard let webView = hostViewController.webView else { return }
+        
+        // Resume media playback capability when tab appears (user switches back to tab)
+        // This allows media to play again when the tab becomes active
+        webView.setAllMediaPlaybackSuspended(false) { }
     }
 
     /// Update DuckPlayer for WebView Disappearance
     ///
     /// - Parameter hostViewController: The `TabViewController` to set as the host.
     func updateDuckPlayerForWebViewDisappearance(_ hostViewController: TabViewController) {
-        // NOOP
+        guard let webView = hostViewController.webView else { return }
+        
+        // Pause all media playback when tab disappears (user switches to another tab)
+        // This matches normal browser behavior where background tabs pause media
+        webView.setAllMediaPlaybackSuspended(true) { }
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207252092703676/task/1210059188286314
Tech Design URL: N/A
CC: N/A

### Description
Duck Player tabs opened with "Open in New Tab" setting did not pause audio when switching tabs, unlike normal web content. This was because Duck Player's custom HTML implementation bypassed normal browser audio management.

### Testing Steps
1. Enable Duck Player "Open in New Tab" setting
2. Open a YouTube video from search results (opens in new Duck Player tab)
3. Switch back to original tab
4. Verify audio pauses (previously continued playing)
5. Switch back to Duck Player tab
6. Verify audio can resume

### Impact and Risks
Low: Bug fix for existing feature, improves user experience

#### What could go wrong?
- Audio might not resume when switching back to Duck Player tab
- Performance impact from audio suspension calls
- Addressed by using iOS 15+ native APIs designed for this purpose

### Quality Considerations
- Uses iOS 15+ native setAllMediaPlaybackSuspended API
- Matches standard browser behavior for background tab audio
- Only affects Duck Player tabs with "Open in New Tab" enabled
- Minimal performance impact (single API call per tab switch)

### Notes to Reviewer
Focus on the tab switching behavior - ensure audio properly pauses/resumes when switching to/from Duck Player tabs opened in new tabs.