### PR TITLE
Skip creating PR review task when reviewer is not provided

### DIFF
--- a/.github/workflows/create_asana_pr_subtask.yml
+++ b/.github/workflows/create_asana_pr_subtask.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
     create-asana-pr-subtask-if-needed:
-        if: ${{ github.event.requested_reviewer.login != 'Copilot' }}
+        if: ${{ github.event.requested_reviewer.login != 'Copilot' && github.event.requested_reviewer.login != '' }}
         name: "Create the PR subtask in Asana"
         runs-on: ubuntu-latest
 

--- a/.github/workflows/create_asana_pr_subtask.yml
+++ b/.github/workflows/create_asana_pr_subtask.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
     create-asana-pr-subtask-if-needed:
-        if: ${{ github.event.requested_reviewer.login != 'Copilot' && github.event.requested_reviewer.login != '' }}
+        if: ${{ github.event.requested_reviewer && github.event.requested_reviewer.login != 'Copilot' && github.event.requested_reviewer.login != '' }}
         name: "Create the PR subtask in Asana"
         runs-on: ubuntu-latest
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1210752234516847?focus=true

### Description
It appears that sometimes this workflow is triggered without a reviewer parameter.

### Testing Steps
Verify that CI is green 🤷 

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)