### PR TITLE
Make summarization dependent on Duck.ai application menus settings

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
@@ -210,7 +210,7 @@ extension ContextMenuManager {
     }
 
     private func handleSearchWebItem(_ item: NSMenuItem, at index: Int, in menu: NSMenu) {
-        let isSummarizationAvailable = featureFlagger.isFeatureOn(.aiChatTextSummarization)
+        let isSummarizationAvailable = featureFlagger.isFeatureOn(.aiChatTextSummarization) && AIChatMenuConfiguration().shouldDisplayApplicationMenuShortcut
         var currentIndex = index
         if isSummarizationAvailable {
             menu.insertItem(.separator(), at: currentIndex)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210750726093985?focus=true

### Description
This change connects text summarization feature to a checkbox in AI Features settings
related to controlling Duck.ai shortcuts in menus.

### Testing Steps
1. Launch the app, ensure that `aiChatTextSummarization` feature flag is enabled.
3. Go to Settings -> AI Features and verify that the _Show “New Duck.ai chat” in File and application menus_ option is enabled.
4. Right click text on a website, trigger context menu and verify that “Summarize with Duck.ai” is present in the menu.
5. Verify that summarization works by opening a sidebar or new tab (depending on the sidebar setting in AI Features).
6. Go to Settings -> AI Features and disable _Show “New Duck.ai chat” in File and application menus_ option.
7. Right click text on a website, trigger context menu and verify that “Summarize with Duck.ai” is not present in the menu.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)