### PR TITLE
[iOS][Flaky Test] Refactor test to wait for deinit event

### DIFF
--- a/iOS/SharedTestUtils/Mocks/DuckPlayerMocks.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckPlayerMocks.swift
@@ -54,6 +54,7 @@ class MockWebView: WKWebView {
     var reloadCalled = false
 
     var loadCompletionHandler: (() -> Void)?
+    var onDeinitHandler: (() -> Void)?
 
     /// The current URL of the web view.
     private var _url: URL?
@@ -124,6 +125,10 @@ class MockWebView: WKWebView {
         historyStack.removeAll()
         _url = nil
         loadCompletionHandler = nil
+    }
+
+    deinit {
+        onDeinitHandler?()
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1210720101347048?focus=true
Tech Design URL:
CC:

### Description

This pull request enhances the reliability of a unit test that verifies whether the webview is not strongly retained by the SpecialErrorPageHandler.

Previously, the test checked that the webview was set to nil after a fixed amount of time. This approach was unreliable, particularly in CI where the execution speed may vary, potentially preventing the condition from being met within the specified timeframe.

The test has been refactored to signal when the WebViewMock deinitialization occurs, ensuring that we no longer rely on a random time interval.

As a safety measure to prevent the test from hanging indefinitely, I have used a timeLimit Tag from Swift Testing.

Single Test Run (Total 5000 times)
<img width="1810" alt="Screenshot 2025-07-10 at 3 32 24 pm" src="https://github.com/user-attachments/assets/5eb6ec94-477e-4344-a365-9f098b9d9174" />

Whole SpecialErrorPageNavigationHandlerTests Test Suite Run (Total 28000 Times)
<img width="1809" alt="Screenshot 2025-07-10 at 3 27 55 pm" src="https://github.com/user-attachments/assets/3bc2fc6e-8e0f-4fac-aaf3-c15ecbc6a3ea" />

### Testing Steps
Ensure CI tests pass.

### Impact and Risks
None, improve test flakiness

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)