### PR TITLE
[iOS][Set As Default] Enable SwiftUI previews for package

### DIFF
--- a/iOS/LocalPackages/SetDefaultBrowser/Package.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Package.swift
@@ -36,6 +36,7 @@ let package = Package(
         .target(
             name: "SetDefaultBrowserUI",
             dependencies: [
+                "SetDefaultBrowserCore",
                 .product(name: "DuckUI", package: "DuckUI"),
                 .product(name: "MetricBuilder", package: "MetricBuilder"),
                 .product(name: "DesignResourcesKitIcons", package: "DesignResourcesKitIcons"),

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/DefaultBrowserPromptModalView.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/DefaultBrowserPromptModalView.swift
@@ -165,3 +165,7 @@ private enum Metrics {
     }
 
 }
+
+#Preview {
+    DefaultBrowserPromptModalView(closeAction: {}, setAsDefaultAction: {}, doNotAskAgainAction: {})
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1210758893284409?focus=true
Tech Design URL:
CC:

### Description

This PR fix the dependency graph of SetDefaultBrowserUI in iOS and resolve SwiftUI previews not showing in package.

<img width="1828" alt="Screenshot 2025-07-10 at 4 23 49 pm" src="https://github.com/user-attachments/assets/16dc9b8e-aedb-42d7-86bc-88f5a707a2df" />

### Testing Steps
1. Select ‘SetDefaultBrowserUI' scheme.
2. Open ‘DefaultBrowserPromptModalView’.
3. Ensure SwiftUI Preview loads fine. If not ensure that ‘Use Legacy Preview Execution’ is unchecked. See below screenshot.
<img width="697" alt="Screenshot 2025-07-10 at 4 24 43 pm" src="https://github.com/user-attachments/assets/289c6313-2ddb-4b41-9fe4-dd5b2114dfb3" />

### Impact and Risks
None, internal SwiftUI Previews used for development.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)