### PR TITLE
macOS Duck.ai Sidebar: 9. Add pixels and feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -172,6 +172,9 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
 
     /// Adds context menu action for summarizing text selected on a website.
     case textSummarization
+
+    // Adds capability to load AI Chat in a sidebar
+    case sidebar
 }
 
 public enum NetworkProtectionSubfeature: String, Equatable, PrivacySubfeature {

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -23,6 +23,7 @@ import PixelKit
 /// > Related links:
 /// [Original Pixel Triage](https://app.asana.com/0/69071770703008/1208619053222285/f)
 /// [Omnibar and Settings Pixel Triage](https://app.asana.com/0/1204167627774280/1209885580000745)
+/// [Sidebar Pixel Triage](https://app.asana.com/1/137249556945/project/1209671977594486/task/1210676151750614)
 /// [Summarization Pixel Triage](https://app.asana.com/1/137249556945/project/69071770703008/task/1210636012460969?focus=true)
 
 enum AIChatPixel: PixelKitEventV2 {
@@ -58,7 +59,22 @@ enum AIChatPixel: PixelKitEventV2 {
     case aiChatSettingsDisplayed
 
     /// Event Trigger: User clicks in the Omnibar duck.ai button
-    case aiChatAddressBarButtonClicked
+    case aiChatAddressBarButtonClicked(action: AIChatAddressBarAction)
+
+    // MARK: - Sidebar
+
+    /// Event Trigger: User opens a tab sidebar
+    case aiChatSidebarOpened(source: AIChatSidebarOpenSource)
+
+    /// Event Trigger: User closes a tab sidebar
+    case aiChatSidebarClosed(source: AIChatSidebarCloseSource)
+
+    /// Event Trigger: User expands the sidebar to a full-size tab
+    case aiChatSidebarExpanded
+
+    /// Event Trigger: User changes sidebar setting in AI Features settings
+    /// This is a unique pixel (sent once per app installation)
+    case aiChatSidebarSettingChanged
 
     // MARK: - Summarization
 
@@ -93,6 +109,14 @@ enum AIChatPixel: PixelKitEventV2 {
             return "aichat_settings_displayed"
         case .aiChatAddressBarButtonClicked:
             return "aichat_addressbar_button_clicked"
+        case .aiChatSidebarOpened:
+            return "m_mac_aichat_sidebar_opened"
+        case .aiChatSidebarClosed:
+            return "m_mac_aichat_sidebar_closed"
+        case .aiChatSidebarExpanded:
+            return "m_mac_aichat_sidebar_expanded"
+        case .aiChatSidebarSettingChanged:
+            return "m_mac_aichat_sidebar_setting_changed_u"
         case .aiChatSummarizeText:
             return "aichat_summarize_text"
         case .aiChatSummarizePromptExpanded:
@@ -112,10 +136,17 @@ enum AIChatPixel: PixelKitEventV2 {
                 .aiChatSettingsApplicationMenuShortcutTurnedOff,
                 .aiChatSettingsApplicationMenuShortcutTurnedOn,
                 .aiChatSettingsDisplayed,
-                .aiChatAddressBarButtonClicked,
+                .aiChatSidebarExpanded,
+                .aiChatSidebarSettingChanged,
                 .aiChatSummarizePromptExpanded,
                 .aiChatSummarizeSourceLinkClicked:
             return nil
+        case .aiChatAddressBarButtonClicked(let action):
+            return ["action": action.rawValue]
+        case .aiChatSidebarOpened(let source):
+            return ["source": source.rawValue]
+        case .aiChatSidebarClosed(let source):
+            return ["source": source.rawValue]
         case .aiChatSummarizeText(let source):
             return ["source": source.rawValue]
         }
@@ -124,4 +155,27 @@ enum AIChatPixel: PixelKitEventV2 {
     var error: (any Error)? {
         nil
     }
+}
+
+// MARK: - Parameter values
+
+/// Action performed when address bar button is clicked
+enum AIChatAddressBarAction: String, CaseIterable {
+    case sidebar = "sidebar"
+    case newTab = "new-tab"
+    case newTabWithPrompt = "new-tab-with-prompt"
+}
+
+/// Source of AI Chat sidebar open action
+enum AIChatSidebarOpenSource: String, CaseIterable {
+    case addressBarButton = "address-bar-button"
+    case summarization = "summarization"
+    case serp = "serp"
+    case contextMenu = "context-menu"
+}
+
+/// Source of AI Chat sidebar close action
+enum AIChatSidebarCloseSource: String, CaseIterable {
+    case addressBarButton = "address-bar-button"
+    case sidebarCloseButton = "sidebar-close-button"
 }

--- a/macOS/DuckDuckGo/AIChat/AIChatSummarizer.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatSummarizer.swift
@@ -92,6 +92,7 @@ final class AIChatSummarizer: AIChatSummarizing {
 
         if featureFlagger.isFeatureOn(.aiChatSidebar) && aiChatMenuConfig.openAIChatInSidebar {
             aiChatSidebarPresenter.presentSidebar(for: prompt)
+            pixelFiring?.fire(AIChatPixel.aiChatSidebarOpened(source: .serp), frequency: .dailyAndStandard)
         } else {
             AIChatPromptHandler.shared.setData(prompt)
             aiChatTabOpener.openAIChatTab(nil, with: .newTab(selected: true))

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -453,7 +453,7 @@ struct UserText {
 
     static let aiChatAddressBarShortcutTooltip = NSLocalizedString("tooltip.aichat.address-bar-shortcut", value: "Duck.ai ⇧↵", comment: "Tooltip With Shortcut for the AI Chat address bar button")
 
-    static let aiChatAddressBarTooltip = NSLocalizedString("tooltip.aichat.address-bar", value: "Duck.ai", comment: "Tooltip for the AI Chat address bar button")
+    static let aiChatAddressBarTooltip = NSLocalizedString("tooltip.aichat.address-bar", value: "Duck.ai ⌥⌘N", comment: "Tooltip for the AI Chat address bar button")
 
     static let aiChatAddressBarTrustedIndicator = NSLocalizedString("aichat.address-bar.trusted-indicator", value: "Duck.ai", comment: "Label for the AI Chat displayed in the address bar")
 

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -70372,55 +70372,55 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Duck.ai"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Duck.ai"
+            "value" : "Duck.ai ⌥⌘N"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Duck.ai"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Duck.ai"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Duck.ai"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Duck.ai"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Duck.ai"
           }
         },
         "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Duck.ai"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Duck.ai"
           }
         }

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -647,6 +647,7 @@ final class AddressBarButtonsViewController: NSViewController {
 
         askAIChatButton.isEnabled = true
         askAIChatButton.state = .off
+        askAIChatButton.toolTip = nil
         askAIChatButton.backgroundColor = visualStyle.colorsProvider.fillButtonBackgroundColor
         askAIChatButton.mouseOverColor = visualStyle.colorsProvider.fillButtonMouseOverColor
 
@@ -656,6 +657,7 @@ final class AddressBarButtonsViewController: NSViewController {
     private func contractAskAIChatButton(isSidebarOpen: Bool) {
         askAIChatButton.backgroundColor = .clear
         askAIChatButton.mouseOverColor = visualStyle.colorsProvider.buttonMouseOverColor
+        askAIChatButton.toolTip = UserText.aiChatAddressBarShortcutTooltip
 
         if isSidebarOpen {
             askAIChatButton.isEnabled = false

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -400,19 +400,13 @@ final class AddressBarButtonsViewController: NSViewController {
            !isTextFieldEditorFirstResponder,
            case .url = tab.content,
            behavior == .currentTab {
-
-//            if !aiChatSidebarPresenter.isSidebarOpen(for: tab.uuid),
-//               isTextFieldEditorFirstResponder,
-//               let value = textFieldValue,
-//               let query = AIChatAddressBarPromptExtractor().queryForValue(value) {
-//                // If sidebar is not open and the address bar is in focus and has viable query use it to pass as a prompt to sidebar
-//                let prompt = AIChatNativePrompt.queryPrompt(query, autoSubmit: true)
-//                aiChatSidebarPresenter.presentSidebar(for: prompt)
-//            } else {
-                // Otherwise just toggle the sidebar
+            // Toggle (open or close) the sidebar only when feature flag and setting option are enabled and:
+            // - address bar text field is not in focus
+            // - the current tab is displaying a standard web page (not a special page),
+            // - intended link open behavior is to use the current tab
                 aiChatSidebarPresenter.toggleSidebar()
-//            }
         } else {
+            // Otherwise open Duck.ai in a full tab
             openAIChatTab(for: tab, with: behavior)
         }
 

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -383,8 +383,6 @@ final class AddressBarButtonsViewController: NSViewController {
     }
 
     @IBAction func aiChatButtonAction(_ sender: Any) {
-        PixelKit.fire(AIChatPixel.aiChatAddressBarButtonClicked, frequency: .dailyAndCount, includeAppVersionParameter: true)
-
         guard let tab = tabViewModel?.tab else { return }
 
         // Close the sidebar if it's currently open and the user preference is set to open AI chat in new tabs
@@ -404,7 +402,7 @@ final class AddressBarButtonsViewController: NSViewController {
             // - address bar text field is not in focus
             // - the current tab is displaying a standard web page (not a special page),
             // - intended link open behavior is to use the current tab
-                aiChatSidebarPresenter.toggleSidebar()
+            toggleAIChatSidebar(for: tab)
         } else {
             // Otherwise open Duck.ai in a full tab
             openAIChatTab(for: tab, with: behavior)
@@ -427,14 +425,28 @@ final class AddressBarButtonsViewController: NSViewController {
                                 shouldSelectNewTab: shouldSelectNewTab)
     }
 
+    private func toggleAIChatSidebar(for tab: Tab) {
+        let isSidebarCurrentlyOpen = aiChatSidebarPresenter.isSidebarOpen(for: tab.uuid)
+
+        let pixel: AIChatPixel = isSidebarCurrentlyOpen ? .aiChatSidebarClosed(source: .addressBarButton) : .aiChatSidebarOpened(source: .addressBarButton)
+        PixelKit.fire(pixel, frequency: .dailyAndStandard)
+        if !isSidebarCurrentlyOpen {
+            PixelKit.fire(AIChatPixel.aiChatAddressBarButtonClicked(action: .sidebar), frequency: .dailyAndStandard)
+        }
+
+        aiChatSidebarPresenter.toggleSidebar()
+    }
+
     private func openAIChatTab(for tab: Tab, with behavior: LinkOpenBehavior) {
-        // Force new tab when sidebar is open and the behaviour would also load Duck.ai in current tab
+        // Force new tab behaviour when sidebar is open to avoid  loading Duck.ai in current tab
         let shouldOverrideToNewTab = aiChatSidebarPresenter.isSidebarOpen(for: tab.uuid) && behavior == .currentTab
         let updatedBehaviour: LinkOpenBehavior = shouldOverrideToNewTab ? .newTab(selected: behavior.shouldSelectNewTab) : behavior
 
-        if let value = textFieldValue {
+        if let value = textFieldValue, !value.isEmpty {
+            PixelKit.fire(AIChatPixel.aiChatAddressBarButtonClicked(action: .newTabWithPrompt), frequency: .dailyAndStandard)
             aiChatTabOpener.openAIChatTab(value, with: updatedBehaviour)
         } else {
+            PixelKit.fire(AIChatPixel.aiChatAddressBarButtonClicked(action: .newTab), frequency: .dailyAndStandard)
             aiChatTabOpener.openAIChatTab(nil, with: updatedBehaviour)
         }
     }
@@ -723,6 +735,7 @@ final class AddressBarButtonsViewController: NSViewController {
         } else {
             // Default is new tab, menu action forces sidebar
             aiChatSidebarPresenter.toggleSidebar()
+            PixelKit.fire(AIChatPixel.aiChatSidebarOpened(source: .contextMenu), frequency: .dailyAndStandard)
         }
     }
 

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -397,20 +397,21 @@ final class AddressBarButtonsViewController: NSViewController {
 
         if featureFlagger.isFeatureOn(.aiChatSidebar),
            aiChatMenuConfig.openAIChatInSidebar,
+           !isTextFieldEditorFirstResponder,
            case .url = tab.content,
            behavior == .currentTab {
 
-            if !aiChatSidebarPresenter.isSidebarOpen(for: tab.uuid),
-               isTextFieldEditorFirstResponder,
-               let value = textFieldValue,
-               let query = AIChatAddressBarPromptExtractor().queryForValue(value) {
-                // If sidebar is not open and the address bar is in focus and has viable query use it to pass as a prompt to sidebar
-                let prompt = AIChatNativePrompt.queryPrompt(query, autoSubmit: true)
-                aiChatSidebarPresenter.presentSidebar(for: prompt)
-            } else {
+//            if !aiChatSidebarPresenter.isSidebarOpen(for: tab.uuid),
+//               isTextFieldEditorFirstResponder,
+//               let value = textFieldValue,
+//               let query = AIChatAddressBarPromptExtractor().queryForValue(value) {
+//                // If sidebar is not open and the address bar is in focus and has viable query use it to pass as a prompt to sidebar
+//                let prompt = AIChatNativePrompt.queryPrompt(query, autoSubmit: true)
+//                aiChatSidebarPresenter.presentSidebar(for: prompt)
+//            } else {
                 // Otherwise just toggle the sidebar
                 aiChatSidebarPresenter.toggleSidebar()
-            }
+//            }
         } else {
             openAIChatTab(for: tab, with: behavior)
         }

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
@@ -73,16 +73,10 @@ extension Preferences {
                         ToggleMenuItem(UserText.aiChatOpenInSidebarToggle,
                                        isOn: $model.openAIChatInSidebar)
                         .accessibilityIdentifier("Preferences.AIChat.openInSidebarToggle")
-                        .onChange(of: model.openAIChatInSidebar) { newValue in
-                            if newValue {
-    //                            PixelKit.fire(AIChatPixel.aiChatSettingsOpenInSidebarTurnedOn,
-    //                                          frequency: .dailyAndCount,
-    //                                          includeAppVersionParameter: true)
-                            } else {
-    //                            PixelKit.fire(AIChatPixel.aiChatSettingsOpenInSidebarTurnedOff,
-    //                                          frequency: .dailyAndCount,
-    //                                          includeAppVersionParameter: true)
-                            }
+                        .onChange(of: model.openAIChatInSidebar) { _ in
+                            PixelKit.fire(AIChatPixel.aiChatSidebarSettingChanged,
+                                          frequency: .uniqueByName,
+                                          includeAppVersionParameter: true)
                         }
                     }
                 }

--- a/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarPresenter.swift
+++ b/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarPresenter.swift
@@ -182,6 +182,7 @@ final class AIChatSidebarPresenter: AIChatSidebarPresenting {
             let sidebarViewController = sidebarProvider.makeSidebar(for: currentTabID, burnerMode: sidebarHost.burnerMode).sidebarViewController
             sidebarViewController.aiChatPayload = payload
             updateSidebarConstraints(for: currentTabID, isShowingSidebar: true, withAnimation: true)
+            pixelFiring?.fire(AIChatPixel.aiChatSidebarOpened(source: .serp), frequency: .dailyAndStandard)
         } else {
             // If sidebar is open then pass the payload to a new AIChat tab
             aiChatTabOpener.openNewAIChatTab(withPayload: payload)
@@ -205,7 +206,9 @@ extension AIChatSidebarPresenter: AIChatSidebarHostingDelegate {
 extension AIChatSidebarPresenter: AIChatSidebarViewControllerDelegate {
 
     func didClickOpenInNewTabButton(currentAIChatURL: URL, aiChatRestorationData: AIChatRestorationData?) {
-        self.toggleSidebar()
+        pixelFiring?.fire(AIChatPixel.aiChatSidebarExpanded, frequency: .dailyAndStandard)
+
+        toggleSidebar()
 
         Task { @MainActor in
             if let data = aiChatRestorationData {
@@ -217,6 +220,8 @@ extension AIChatSidebarPresenter: AIChatSidebarViewControllerDelegate {
     }
 
     func didClickCloseButton() {
+        pixelFiring?.fire(AIChatPixel.aiChatSidebarClosed(source: .sidebarCloseButton), frequency: .dailyAndStandard)
+
         windowControllersManager.lastKeyMainWindowController?.window?.makeFirstResponder(nil)
         toggleSidebar()
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210767916222017
Tech Design URL:
CC: @Bunn 

### Description
Add pixels and privacy config feature flag.

### Testing Steps
1. Verify if pixels are implemented and fired according to the spec: https://app.asana.com/1/137249556945/project/1209671977594486/task/1210410403692637?focus=true

2. Verify privacy config feature name

3. Update to "Ask Duck.ai" button behaviour when address bar is in focus: in that state the button should not toggle the sidebar but open a full Duck.ai in same or a new tab

4. Update to Duck.ai button tooltip, it should now include the "⌥⌘N" keyboard shortcut.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Low risk, feature behind a flag

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)