### PR TITLE
Authentication change  subscription message

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
@@ -48,7 +48,7 @@ protocol SubscriptionUserScriptHandling {
     // Notification message, Subscription purchase flow should be open
     func openSubscriptionPurchase(params: Any, message: any UserScriptMessage) async throws -> Encodable?
 
-    func setBroker(_ broker: UserScriptMessageBroker)
+    func setBroker(_ broker: UserScriptMessagePushing)
     func setWebView(_ webView: WKWebView?)
     func setUserScript(_ userScript: SubscriptionUserScript)
 }
@@ -62,6 +62,12 @@ public protocol SubscriptionUserScriptNavigationDelegate: AnyObject {
     @MainActor func navigateToSubscriptionPurchase()
 }
 
+protocol UserScriptMessagePushing: AnyObject {
+    func push(method: String, params: Encodable?, for delegate: Subfeature, into webView: WKWebView)
+}
+
+extension UserScriptMessageBroker: UserScriptMessagePushing {}
+
 final class SubscriptionUserScriptHandler: SubscriptionUserScriptHandling {
     typealias DataModel = SubscriptionUserScript.DataModel
 
@@ -70,7 +76,7 @@ final class SubscriptionUserScriptHandler: SubscriptionUserScriptHandling {
     private var paidAIChatFlagStatusProvider: () -> Bool
     weak var navigationDelegate: SubscriptionUserScriptNavigationDelegate?
     weak private var webView: WKWebView?
-    weak private var broker: UserScriptMessageBroker?
+    weak private var broker: UserScriptMessagePushing?
     private weak var userScript: SubscriptionUserScript?
     private var cancellables = Set<AnyCancellable>()
 
@@ -86,7 +92,7 @@ final class SubscriptionUserScriptHandler: SubscriptionUserScriptHandling {
         setupSubscriptionEventObservers()
     }
 
-    func setBroker(_ broker: UserScriptMessageBroker) {
+    func setBroker(_ broker: UserScriptMessagePushing) {
         self.broker = broker
     }
 
@@ -99,7 +105,7 @@ final class SubscriptionUserScriptHandler: SubscriptionUserScriptHandling {
     }
 
     func handshake(params: Any, message: any UserScriptMessage) async throws -> DataModel.HandshakeResponse {
-        return .init(availableMessages: [.subscriptionDetails, .getAuthAccessToken, .getFeatureConfig, .backToSettings, .openSubscriptionActivation, .openSubscriptionPurchase, .onAuthUpdate], platform: platform)
+        return .init(availableMessages: [.subscriptionDetails, .getAuthAccessToken, .getFeatureConfig, .backToSettings, .openSubscriptionActivation, .openSubscriptionPurchase, .authUpdate], platform: platform)
     }
 
     func subscriptionDetails(params: Any, message: any UserScriptMessage) async throws -> DataModel.SubscriptionDetails {
@@ -139,27 +145,27 @@ final class SubscriptionUserScriptHandler: SubscriptionUserScriptHandling {
 
     private func handleSubscriptionChanged() {
         guard let webView, let userScript else { return }
-        broker?.push(method: SubscriptionUserScript.MessageName.onAuthUpdate.rawValue, params: nil, for: userScript, into: webView)
+        broker?.push(method: SubscriptionUserScript.MessageName.authUpdate.rawValue, params: nil, for: userScript, into: webView)
     }
 
     private func setupSubscriptionEventObservers() {
         NotificationCenter.default.publisher(for: .subscriptionDidChange)
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] notification in
+            .sink { [weak self] _ in
                 self?.handleSubscriptionChanged()
             }
             .store(in: &cancellables)
 
         NotificationCenter.default.publisher(for: .accountDidSignIn)
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] notification in
+            .sink { [weak self] _ in
                 self?.handleSubscriptionChanged()
             }
             .store(in: &cancellables)
 
         NotificationCenter.default.publisher(for: .accountDidSignOut)
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] notification in
+            .sink { [weak self] _ in
                 self?.handleSubscriptionChanged()
             }
             .store(in: &cancellables)
@@ -182,7 +188,7 @@ public final class SubscriptionUserScript: NSObject, Subfeature {
         case backToSettings
         case openSubscriptionActivation
         case openSubscriptionPurchase
-        case onAuthUpdate
+        case authUpdate
     }
 
     public let featureName: String = "subscriptions"
@@ -196,9 +202,7 @@ public final class SubscriptionUserScript: NSObject, Subfeature {
     weak public var broker: UserScriptMessageBroker?
     public weak var webView: WKWebView? {
         didSet {
-            if let scriptHandler = handler as? SubscriptionUserScriptHandler {
-                scriptHandler.setWebView(webView)
-            }
+            handler.setWebView(webView)
         }
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
@@ -19,6 +19,7 @@
 import Common
 import UserScript
 import WebKit
+import Combine
 
 ///
 /// This protocol describes the interface for `SubscriptionUserScript` message handler
@@ -46,6 +47,10 @@ protocol SubscriptionUserScriptHandling {
 
     // Notification message, Subscription purchase flow should be open
     func openSubscriptionPurchase(params: Any, message: any UserScriptMessage) async throws -> Encodable?
+
+    func setBroker(_ broker: UserScriptMessageBroker)
+    func setWebView(_ webView: WKWebView?)
+    func setUserScript(_ userScript: SubscriptionUserScript)
 }
 
 ///
@@ -64,6 +69,10 @@ final class SubscriptionUserScriptHandler: SubscriptionUserScriptHandling {
     let subscriptionManager: any SubscriptionAuthV1toV2Bridge
     private var paidAIChatFlagStatusProvider: () -> Bool
     weak var navigationDelegate: SubscriptionUserScriptNavigationDelegate?
+    weak private var webView: WKWebView?
+    weak private var broker: UserScriptMessageBroker?
+    private weak var userScript: SubscriptionUserScript?
+    private var cancellables = Set<AnyCancellable>()
 
     init(platform: DataModel.Platform,
          subscriptionManager: any SubscriptionAuthV1toV2Bridge,
@@ -73,10 +82,24 @@ final class SubscriptionUserScriptHandler: SubscriptionUserScriptHandling {
         self.subscriptionManager = subscriptionManager
         self.paidAIChatFlagStatusProvider = paidAIChatFlagStatusProvider
         self.navigationDelegate = navigationDelegate
+
+        setupSubscriptionEventObservers()
+    }
+
+    func setBroker(_ broker: UserScriptMessageBroker) {
+        self.broker = broker
+    }
+
+    func setWebView(_ webView: WKWebView?) {
+        self.webView = webView
+    }
+
+    func setUserScript(_ userScript: SubscriptionUserScript) {
+        self.userScript = userScript
     }
 
     func handshake(params: Any, message: any UserScriptMessage) async throws -> DataModel.HandshakeResponse {
-        return .init(availableMessages: [.subscriptionDetails, .getAuthAccessToken, .getFeatureConfig, .backToSettings, .openSubscriptionActivation, .openSubscriptionPurchase], platform: platform)
+        return .init(availableMessages: [.subscriptionDetails, .getAuthAccessToken, .getFeatureConfig, .backToSettings, .openSubscriptionActivation, .openSubscriptionPurchase, .onAuthUpdate], platform: platform)
     }
 
     func subscriptionDetails(params: Any, message: any UserScriptMessage) async throws -> DataModel.SubscriptionDetails {
@@ -114,6 +137,34 @@ final class SubscriptionUserScriptHandler: SubscriptionUserScriptHandling {
         return nil
     }
 
+    private func handleSubscriptionChanged() {
+        guard let webView, let userScript else { return }
+        broker?.push(method: SubscriptionUserScript.MessageName.onAuthUpdate.rawValue, params: nil, for: userScript, into: webView)
+    }
+
+    private func setupSubscriptionEventObservers() {
+        NotificationCenter.default.publisher(for: .subscriptionDidChange)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                self?.handleSubscriptionChanged()
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: .accountDidSignIn)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                self?.handleSubscriptionChanged()
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: .accountDidSignOut)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                self?.handleSubscriptionChanged()
+            }
+            .store(in: &cancellables)
+    }
+
 }
 
 ///
@@ -131,6 +182,7 @@ public final class SubscriptionUserScript: NSObject, Subfeature {
         case backToSettings
         case openSubscriptionActivation
         case openSubscriptionPurchase
+        case onAuthUpdate
     }
 
     public let featureName: String = "subscriptions"
@@ -141,7 +193,20 @@ public final class SubscriptionUserScript: NSObject, Subfeature {
         }
         return .only(rules: rules)
     }
-    public weak var broker: UserScriptMessageBroker?
+    weak public var broker: UserScriptMessageBroker?
+    public weak var webView: WKWebView? {
+        didSet {
+            if let scriptHandler = handler as? SubscriptionUserScriptHandler {
+                scriptHandler.setWebView(webView)
+            }
+        }
+    }
+
+    public func with(broker: UserScriptMessageBroker) {
+        self.broker = broker
+        handler.setBroker(broker)
+        handler.setUserScript(self)
+    }
 
     public func handler(forMethodNamed methodName: String) -> Subfeature.Handler? {
         switch MessageName(rawValue: methodName) {

--- a/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/SubscriptionUserScript/MockSubscriptionUserScriptHandler.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/SubscriptionUserScript/MockSubscriptionUserScriptHandler.swift
@@ -18,6 +18,7 @@
 
 @testable import Subscription
 import UserScript
+import WebKit
 
 public final class MockSubscriptionUserScriptHandler: SubscriptionUserScriptHandling {
 
@@ -30,8 +31,13 @@ public final class MockSubscriptionUserScriptHandler: SubscriptionUserScriptHand
     public var backToSettingsCallCount = 0
     public var openSubscriptionActivationCallCount = 0
     public var openSubscriptionPurchaseCallCount = 0
+    
+    // Setter method tracking
+    public var lastSetBroker: UserScriptMessagePushing?
+    public var lastSetWebView: WKWebView?
+    public var lastSetUserScript: SubscriptionUserScript?
 
-    public var handshake: (Any, any UserScriptMessage) async throws -> SubscriptionUserScript.DataModel.HandshakeResponse = { _, _ in .init(availableMessages: [.subscriptionDetails, .getAuthAccessToken, .getFeatureConfig, .backToSettings, .openSubscriptionActivation, .openSubscriptionPurchase], platform: .ios) }
+    public var handshake: (Any, any UserScriptMessage) async throws -> SubscriptionUserScript.DataModel.HandshakeResponse = { _, _ in .init(availableMessages: [.subscriptionDetails, .getAuthAccessToken, .getFeatureConfig, .backToSettings, .openSubscriptionActivation, .openSubscriptionPurchase, .authUpdate], platform: .ios) }
     public var subscriptionDetails: (Any, any UserScriptMessage) async throws -> SubscriptionUserScript.DataModel.SubscriptionDetails = { _, _ in .notSubscribed }
     public var getAuthAccessToken: (Any, any UserScriptMessage) async throws -> SubscriptionUserScript.DataModel.GetAuthAccessTokenResponse = { _, _ in .init(accessToken: "mock_token") }
     public var getFeatureConfig: (Any, any UserScriptMessage) async throws -> SubscriptionUserScript.DataModel.GetFeatureConfigurationResponse = { _, _ in .init(usePaidDuckAi: false) }
@@ -72,5 +78,17 @@ public final class MockSubscriptionUserScriptHandler: SubscriptionUserScriptHand
     public func openSubscriptionPurchase(params: Any, message: any UserScriptMessage) async throws -> Encodable? {
         openSubscriptionPurchaseCallCount += 1
         return try await openSubscriptionPurchase(params, message)
+    }
+
+    public func setBroker(_ broker: any Subscription.UserScriptMessagePushing) {
+        lastSetBroker = broker
+    }
+
+    public func setWebView(_ webView: WKWebView?) {
+        lastSetWebView = webView
+    }
+
+    public func setUserScript(_ userScript: Subscription.SubscriptionUserScript) {
+        lastSetUserScript = userScript
     }
 }

--- a/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/SubscriptionUserScript/MockSubscriptionUserScriptHandler.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/SubscriptionUserScript/MockSubscriptionUserScriptHandler.swift
@@ -31,7 +31,7 @@ public final class MockSubscriptionUserScriptHandler: SubscriptionUserScriptHand
     public var backToSettingsCallCount = 0
     public var openSubscriptionActivationCallCount = 0
     public var openSubscriptionPurchaseCallCount = 0
-    
+
     // Setter method tracking
     public var lastSetBroker: UserScriptMessagePushing?
     public var lastSetWebView: WKWebView?

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionUserScript/SubscriptionUserScriptHandlerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionUserScript/SubscriptionUserScriptHandlerTests.swift
@@ -61,7 +61,7 @@ final class SubscriptionUserScriptHandlerTests: XCTestCase {
                        paidAIChatFlagStatusProvider: { false },
                        navigationDelegate: mockNavigationDelegate)
         let handshake = try await handler.handshake(params: [], message: WKScriptMessage())
-        XCTAssertEqual(handshake.availableMessages, [.subscriptionDetails, .getAuthAccessToken, .getFeatureConfig, .backToSettings, .openSubscriptionActivation, .openSubscriptionPurchase])
+        XCTAssertEqual(handshake.availableMessages, [.subscriptionDetails, .getAuthAccessToken, .getFeatureConfig, .backToSettings, .openSubscriptionActivation, .openSubscriptionPurchase, .authUpdate])
     }
 
     func testWhenSubscriptionFailsToBeFetchedThenSubscriptionDetailsReturnsNotSubscribedState() async throws {
@@ -185,6 +185,57 @@ final class SubscriptionUserScriptHandlerTests: XCTestCase {
         XCTAssertNil(response)
         XCTAssertTrue(mockNavigationDelegate.navigateToSubscriptionPurchaseCalled)
     }
+
+    // MARK: - Auth Update Push Tests
+
+    func testThatSubscriptionDidChangeNotificationTriggersAuthUpdate() {
+        let mockBroker = MockUserScriptMessagePusher()
+        let mockWebView = WKWebView()
+        let mockUserScript = SubscriptionUserScript(handler: handler, debugHost: nil)
+
+        handler.setBroker(mockBroker)
+        handler.setWebView(mockWebView)
+        handler.setUserScript(mockUserScript)
+
+        NotificationCenter.default.post(name: .subscriptionDidChange, object: nil)
+        let result = XCTWaiter().wait(for: [mockBroker.pushExpectation], timeout: 1)
+        XCTAssertEqual(result, .completed)
+
+        XCTAssertEqual(mockBroker.lastPushedMethod, SubscriptionUserScript.MessageName.authUpdate.rawValue)
+    }
+
+    func testThatAccountDidSignInNotificationTriggersAuthUpdate() {
+        let mockBroker = MockUserScriptMessagePusher()
+        let mockWebView = WKWebView()
+        let mockUserScript = SubscriptionUserScript(handler: handler, debugHost: nil)
+
+        handler.setBroker(mockBroker)
+        handler.setWebView(mockWebView)
+        handler.setUserScript(mockUserScript)
+
+        NotificationCenter.default.post(name: .accountDidSignIn, object: nil)
+        let result = XCTWaiter().wait(for: [mockBroker.pushExpectation], timeout: 1)
+        XCTAssertEqual(result, .completed)
+
+        XCTAssertEqual(mockBroker.lastPushedMethod, SubscriptionUserScript.MessageName.authUpdate.rawValue)
+    }
+
+    func testThatAccountDidSignOutNotificationTriggersAuthUpdate() {
+        let mockBroker = MockUserScriptMessagePusher()
+        let mockWebView = WKWebView()
+        let mockUserScript = SubscriptionUserScript(handler: handler, debugHost: nil)
+
+        handler.setBroker(mockBroker)
+        handler.setWebView(mockWebView)
+        handler.setUserScript(mockUserScript)
+
+        NotificationCenter.default.post(name: .accountDidSignOut, object: nil)
+        let result = XCTWaiter().wait(for: [mockBroker.pushExpectation], timeout: 1)
+        XCTAssertEqual(result, .completed)
+
+        XCTAssertEqual(mockBroker.lastPushedMethod, SubscriptionUserScript.MessageName.authUpdate.rawValue)
+    }
+
 }
 
 private extension PrivacyProSubscription {
@@ -209,5 +260,15 @@ class MockNavigationDelegate: SubscriptionUserScriptNavigationDelegate {
 
     func navigateToSubscriptionPurchase() {
         navigateToSubscriptionPurchaseCalled = true
+    }
+}
+
+class MockUserScriptMessagePusher: UserScriptMessagePushing {
+    var lastPushedMethod: String?
+    let pushExpectation = XCTestExpectation(description: "Push method called")
+
+    func push(method: String, params: Encodable?, for delegate: Subfeature, into webView: WKWebView) {
+        lastPushedMethod = method
+        pushExpectation.fulfill()
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionUserScript/SubscriptionUserScriptTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionUserScript/SubscriptionUserScriptTests.swift
@@ -121,6 +121,58 @@ final class SubscriptionUserScriptTests: XCTestCase {
         XCTAssertEqual(handler.openSubscriptionPurchaseCallCount, 1)
     }
 
+    func testThatHandshakeIncludesAuthUpdateInAvailableMessages() async throws {
+        let response = try await handler.handshake(params: [], message: WKScriptMessage())
+        XCTAssertTrue(response.availableMessages.contains(.authUpdate), "authUpdate should be included in available messages")
+    }
+
+    func testThatAuthUpdateMessageNameExists() {
+        // Test that the new message name enum case exists and has correct raw value
+        XCTAssertEqual(SubscriptionUserScript.MessageName.authUpdate.rawValue, "authUpdate")
+    }
+
+    // MARK: - Integration Tests - SubscriptionUserScript to Handler Wiring
+
+    func testThatWebViewIsPassedToHandlerWhenSet() {
+        let mockHandler = MockSubscriptionUserScriptHandler()
+        let userScript = SubscriptionUserScript(handler: mockHandler, debugHost: nil)
+        let webView = WKWebView()
+
+        userScript.webView = webView
+
+        XCTAssertIdentical(mockHandler.lastSetWebView, webView)
+    }
+
+    func testThatBrokerIsPassedToHandlerWhenWithBrokerCalled() {
+        let mockHandler = MockSubscriptionUserScriptHandler()
+        let userScript = SubscriptionUserScript(handler: mockHandler, debugHost: nil)
+        let broker = UserScriptMessageBroker(context: "test")
+
+        userScript.with(broker: broker)
+
+        XCTAssertIdentical(mockHandler.lastSetBroker as? UserScriptMessageBroker, broker)
+    }
+
+    func testThatUserScriptIsPassedToHandlerWhenWithBrokerCalled() {
+        let mockHandler = MockSubscriptionUserScriptHandler()
+        let userScript = SubscriptionUserScript(handler: mockHandler, debugHost: nil)
+        let broker = UserScriptMessageBroker(context: "test")
+
+        userScript.with(broker: broker)
+
+        XCTAssertIdentical(mockHandler.lastSetUserScript, userScript)
+    }
+
+    func testThatBrokerIsStoredOnUserScriptWhenWithBrokerCalled() {
+        let mockHandler = MockSubscriptionUserScriptHandler()
+        let userScript = SubscriptionUserScript(handler: mockHandler, debugHost: nil)
+        let broker = UserScriptMessageBroker(context: "test")
+
+        userScript.with(broker: broker)
+
+        XCTAssertIdentical(userScript.broker, broker)
+    }
+
     // MARK: - Helpers
 
     private func handleMessageIgnoringResponse<MessageName: RawRepresentable>(

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -1973,6 +1973,8 @@
 		56DB9FED2CD2515F001BEC23 /* OnboardingPixelReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DB9FEB2CD2515F001BEC23 /* OnboardingPixelReporter.swift */; };
 		56EA40292DB7830800B5061E /* LocalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EA40282DB7830800B5061E /* LocalizationTests.swift */; };
 		56EA402A2DB7830800B5061E /* LocalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EA40282DB7830800B5061E /* LocalizationTests.swift */; };
+		56F0CB2F2E20FBD2000FF58B /* SubscriptionTabExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F0CB2E2E20FBD2000FF58B /* SubscriptionTabExtension.swift */; };
+		56F0CB302E20FBD2000FF58B /* SubscriptionTabExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F0CB2E2E20FBD2000FF58B /* SubscriptionTabExtension.swift */; };
 		6590DB552DB7D59F007D6046 /* DuckPlayerTabExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6590DB542DB7D59F007D6046 /* DuckPlayerTabExtensionTests.swift */; };
 		6590DB562DB7D59F007D6046 /* DuckPlayerTabExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6590DB542DB7D59F007D6046 /* DuckPlayerTabExtensionTests.swift */; };
 		7B00997D2B6508B700FE7C31 /* NetworkProtectionProxy in Frameworks */ = {isa = PBXBuildFile; productRef = 7B00997C2B6508B700FE7C31 /* NetworkProtectionProxy */; };
@@ -4636,6 +4638,7 @@
 		56DB9FE82CD24B47001BEC23 /* ContextualOnboardingPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingPixel.swift; sourceTree = "<group>"; };
 		56DB9FEB2CD2515F001BEC23 /* OnboardingPixelReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPixelReporter.swift; sourceTree = "<group>"; };
 		56EA40282DB7830800B5061E /* LocalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationTests.swift; sourceTree = "<group>"; };
+		56F0CB2E2E20FBD2000FF58B /* SubscriptionTabExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionTabExtension.swift; sourceTree = "<group>"; };
 		6590DB542DB7D59F007D6046 /* DuckPlayerTabExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckPlayerTabExtensionTests.swift; sourceTree = "<group>"; };
 		7B0099802B65C6B300FE7C31 /* MacTransparentProxyProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacTransparentProxyProvider.swift; sourceTree = "<group>"; };
 		7B05829D2A812AC000AC3F7C /* NetworkProtectionOnboardingMenu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkProtectionOnboardingMenu.swift; sourceTree = "<group>"; };
@@ -10047,6 +10050,7 @@
 				B6BDDA002942389000F68088 /* TabExtensions.swift */,
 				1D9A4E592B43213B00F449E2 /* TabSnapshotExtension.swift */,
 				B626A76C29928B1600053070 /* TestsClosureNavigationResponder.swift */,
+				56F0CB2E2E20FBD2000FF58B /* SubscriptionTabExtension.swift */,
 			);
 			path = TabExtensions;
 			sourceTree = "<group>";
@@ -13232,6 +13236,7 @@
 				3199AF782C80734A003AEBDC /* DuckPlayerOnboardingViewController.swift in Sources */,
 				3706FC64293F65D500E42796 /* SuggestionContainer.swift in Sources */,
 				C16127EF2BDFB46400966BB9 /* DataImportShortcutsView.swift in Sources */,
+				56F0CB2F2E20FBD2000FF58B /* SubscriptionTabExtension.swift in Sources */,
 				3706FC65293F65D500E42796 /* BurnerHomePageViewController.swift in Sources */,
 				371209262C232E76003ADF3D /* RemoteMessagingClient.swift in Sources */,
 				3706FC67293F65D500E42796 /* OperatingSystemVersionExtension.swift in Sources */,
@@ -14205,6 +14210,7 @@
 				BB960BD32DD7890B002C46DD /* BookmarksIconsProviding.swift in Sources */,
 				AADCBF3A26F7C2CE00EF67A8 /* LottieAnimationCache.swift in Sources */,
 				371BFF5F2D3936140075DB87 /* HistoryViewActionsManagerExtension.swift in Sources */,
+				56F0CB302E20FBD2000FF58B /* SubscriptionTabExtension.swift in Sources */,
 				841BE93B2C6F1CB200E9C2B5 /* MenuItemNode.swift in Sources */,
 				4B9DB0412A983B24000927DB /* WaitlistDialogView.swift in Sources */,
 				37D2377A287EB8CA00BCE03B /* TabIndex.swift in Sources */,

--- a/macOS/DuckDuckGo/Tab/TabExtensions/AIChatTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/AIChatTabExtension.swift
@@ -21,7 +21,6 @@ import Foundation
 import Combine
 import WebKit
 import AIChat
-import Subscription
 
 protocol AIChatUserScriptProvider {
     var aiChatUserScript: AIChatUserScript? { get }
@@ -134,47 +133,4 @@ extension AIChatTabExtension: AIChatProtocol, TabExtension {
 
 extension TabExtensions {
     var aiChat: AIChatProtocol? { resolve(AIChatTabExtension.self) }
-}
-
-
-protocol SubscriptionUserScriptProvider {
-    var subscriptionUserScript: SubscriptionUserScript? { get }
-}
-extension UserScripts: SubscriptionUserScriptProvider {}
-
-final class SubscriptionTabExtension: NSObject {
-    private weak var webView: WKWebView?
-    private weak var subscriptionUserScript: SubscriptionUserScript?
-    private var cancellables = Set<AnyCancellable>()
-
-    init(scriptsPublisher: some Publisher<UserScripts, Never>,
-         webViewPublisher: some Publisher<WKWebView, Never>) {
-
-        super.init()
-
-        webViewPublisher.sink { [weak self] webView in
-            self?.webView = webView
-            self?.subscriptionUserScript?.webView = webView
-        }.store(in: &cancellables)
-        
-        scriptsPublisher.sink { [weak self] scripts in
-            Task { @MainActor in
-                self?.subscriptionUserScript = scripts.subscriptionUserScript // ← This was missing!
-                self?.subscriptionUserScript?.webView = self?.webView
-            }
-        }.store(in: &cancellables)
-    }
-}
-
-protocol SubscriptionProtocol: AnyObject, NavigationResponder {
-}
-extension SubscriptionTabExtension: TabExtension, SubscriptionProtocol {
-    func getPublicProtocol() -> SubscriptionProtocol { self }
-
-}
-
-extension TabExtensions {
-    var subscriptionProtocol: SubscriptionProtocol? {
-        resolve(SubscriptionTabExtension.self)
-    }
 }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/AIChatTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/AIChatTabExtension.swift
@@ -21,6 +21,7 @@ import Foundation
 import Combine
 import WebKit
 import AIChat
+import Subscription
 
 protocol AIChatUserScriptProvider {
     var aiChatUserScript: AIChatUserScript? { get }
@@ -133,4 +134,47 @@ extension AIChatTabExtension: AIChatProtocol, TabExtension {
 
 extension TabExtensions {
     var aiChat: AIChatProtocol? { resolve(AIChatTabExtension.self) }
+}
+
+
+protocol SubscriptionUserScriptProvider {
+    var subscriptionUserScript: SubscriptionUserScript? { get }
+}
+extension UserScripts: SubscriptionUserScriptProvider {}
+
+final class SubscriptionTabExtension: NSObject {
+    private weak var webView: WKWebView?
+    private weak var subscriptionUserScript: SubscriptionUserScript?
+    private var cancellables = Set<AnyCancellable>()
+
+    init(scriptsPublisher: some Publisher<UserScripts, Never>,
+         webViewPublisher: some Publisher<WKWebView, Never>) {
+
+        super.init()
+
+        webViewPublisher.sink { [weak self] webView in
+            self?.webView = webView
+            self?.subscriptionUserScript?.webView = webView
+        }.store(in: &cancellables)
+        
+        scriptsPublisher.sink { [weak self] scripts in
+            Task { @MainActor in
+                self?.subscriptionUserScript = scripts.subscriptionUserScript // ← This was missing!
+                self?.subscriptionUserScript?.webView = self?.webView
+            }
+        }.store(in: &cancellables)
+    }
+}
+
+protocol SubscriptionProtocol: AnyObject, NavigationResponder {
+}
+extension SubscriptionTabExtension: TabExtension, SubscriptionProtocol {
+    func getPublicProtocol() -> SubscriptionProtocol { self }
+
+}
+
+extension TabExtensions {
+    var subscriptionProtocol: SubscriptionProtocol? {
+        resolve(SubscriptionTabExtension.self)
+    }
 }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/SubscriptionTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/SubscriptionTabExtension.swift
@@ -1,0 +1,64 @@
+//
+//  SubscriptionTabExtension.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Subscription
+import WebKit
+import Combine
+
+protocol SubscriptionUserScriptProvider {
+    var subscriptionUserScript: SubscriptionUserScript? { get }
+}
+extension UserScripts: SubscriptionUserScriptProvider {}
+
+final class SubscriptionTabExtension: NSObject {
+    private weak var webView: WKWebView?
+    private weak var subscriptionUserScript: SubscriptionUserScript?
+    private var cancellables = Set<AnyCancellable>()
+
+    init(scriptsPublisher: some Publisher<UserScripts, Never>,
+         webViewPublisher: some Publisher<WKWebView, Never>) {
+
+        super.init()
+
+        webViewPublisher.sink { [weak self] webView in
+            self?.webView = webView
+            self?.subscriptionUserScript?.webView = webView
+        }.store(in: &cancellables)
+
+        scriptsPublisher.sink { [weak self] scripts in
+            Task { @MainActor in
+                self?.subscriptionUserScript = scripts.subscriptionUserScript // ← This was missing!
+                self?.subscriptionUserScript?.webView = self?.webView
+            }
+        }.store(in: &cancellables)
+    }
+}
+
+protocol SubscriptionProtocol: AnyObject {
+}
+extension SubscriptionTabExtension: TabExtension, SubscriptionProtocol {
+    func getPublicProtocol() -> SubscriptionProtocol { self }
+
+}
+
+extension TabExtensions {
+    var subscriptionProtocol: SubscriptionProtocol? {
+        resolve(SubscriptionTabExtension.self)
+    }
+}

--- a/macOS/DuckDuckGo/Tab/TabExtensions/SubscriptionTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/SubscriptionTabExtension.swift
@@ -37,13 +37,15 @@ final class SubscriptionTabExtension: NSObject {
         super.init()
 
         webViewPublisher.sink { [weak self] webView in
-            self?.webView = webView
-            self?.subscriptionUserScript?.webView = webView
+            Task { @MainActor in
+                self?.webView = webView
+                self?.subscriptionUserScript?.webView = webView
+            }
         }.store(in: &cancellables)
 
         scriptsPublisher.sink { [weak self] scripts in
             Task { @MainActor in
-                self?.subscriptionUserScript = scripts.subscriptionUserScript // ← This was missing!
+                self?.subscriptionUserScript = scripts.subscriptionUserScript
                 self?.subscriptionUserScript?.webView = self?.webView
             }
         }.store(in: &cancellables)

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
@@ -249,6 +249,10 @@ extension TabExtensionsBuilder {
             )
         }
 
+        add {
+            SubscriptionTabExtension(scriptsPublisher: userScripts.compactMap { $0 }, webViewPublisher: args.webViewFuture)
+        }
+
 #if SPARKLE
         add {
             ReleaseNotesTabExtension(scriptsPublisher: userScripts.compactMap { $0 }, webViewPublisher: args.webViewFuture)

--- a/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeatureV2.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionPagesUseSubscriptionFeatureV2.swift
@@ -311,6 +311,7 @@ final class SubscriptionPagesUseSubscriptionFeatureV2: Subfeature {
                     PixelKit.fire(PrivacyProPixel.privacyProSubscriptionActivated, frequency: .uniqueByName)
                     subscriptionSuccessPixelHandler.fireSuccessfulSubscriptionAttributionPixel()
                     sendSubscriptionUpgradeFromFreemiumNotificationIfFreemiumActivated()
+                    notificationCenter.post(name: .subscriptionDidChange, object: self)
                     await pushPurchaseUpdate(originalMessage: message, purchaseUpdate: purchaseUpdate)
                 case .failure(let error):
                     switch error {
@@ -414,6 +415,7 @@ final class SubscriptionPagesUseSubscriptionFeatureV2: Subfeature {
         saveSubscriptionUpgradeTimestampIfFreemiumActivated()
         subscriptionSuccessPixelHandler.fireSuccessfulSubscriptionAttributionPixel()
         sendSubscriptionUpgradeFromFreemiumNotificationIfFreemiumActivated()
+        notificationCenter.post(name: .subscriptionDidChange, object: self)
         return [String: String]() // cannot be nil, the web app expect something back before redirecting the user to the final page
     }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1210749020623120?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1210754463607480?focus=true

### Description The Duck.ai FE reacts to notification sent by the native side on subscription auth changes so that the UI is always up to date also on old tabs

### Testing Steps
1. "Debug" → "Feature Flag Overrides” → Others, check that paidAIChat feature flag is enabled if not then select 
2. "Debug" → "Feature Flag Overrides” → Others, check that PrivacyProAuthV2 feature flag is enabled if not then select it
3. “Debug” → “AI Chat” → "Web Communication” → “Set custom URL” set URL to https://euw-serp-dev-testing10.duck.co/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=1
4. Open Duck.ai it and should show your current subscription status
5. leave the tab open and subscibe
6. Reopen the previous Duck.ai Tab and check the UI reflects the subscription state
7. Unsubscribe
8. Reopen the previous Duck.ai Tab and check the UI reflects the subscription state

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!--
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)