### PR TITLE
Only load internal feedback form user script for internal users

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/InternalFeedbackFormTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/InternalFeedbackFormTabExtension.swift
@@ -90,11 +90,6 @@ extension InternalFeedbackFormTabExtension: NavigationResponder {
         guard internalUserDecider.isInternalUser, let webView, navigation.navigationAction.isForMainFrame, isInternalFeedbackURL(navigation.url) else {
             return
         }
-#if APPSTORE
-        let distributionType = "App Store"
-#else
-        let distributionType = "DMG"
-#endif
         webView.evaluateJavaScript(scriptSource)
     }
 

--- a/macOS/DuckDuckGo/Tab/TabExtensions/InternalFeedbackFormTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/InternalFeedbackFormTabExtension.swift
@@ -69,14 +69,13 @@ final class InternalFeedbackFormTabExtension {
     private let internalUserDecider: InternalUserDecider
     private weak var webView: WKWebView?
     private var cancellables = Set<AnyCancellable>()
-    private let scriptSource: String
+    private lazy var scriptSource: String = InternalFeedbackFormUserScript().source
 
     init(
         webViewPublisher: some Publisher<WKWebView, Never>,
         internalUserDecider: InternalUserDecider
     ) {
         self.internalUserDecider = internalUserDecider
-        self.scriptSource = InternalFeedbackFormUserScript().source
 
         webViewPublisher.sink { [weak self] webView in
             self?.webView = webView


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1210761549737943?focus=true

### Description
This change makes internal feedback form user script load only for internal users.
Previously it would run for internal users only, but load for everyone.
Since it has been occasionally failing to load and crashing because of that,
this change limits the potential impact to internal users.

### Testing Steps
Launch the app and go to https://go.duckduckgo.com/feedback. Verify that platform, OS version and app version are pre-filled. 

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)