### PR TITLE
macOS: Update folder structure for Firefox bookmarks import

### DIFF
--- a/macOS/DuckDuckGo/DataImport/Logins/Firefox/FirefoxDataImporter.swift
+++ b/macOS/DuckDuckGo/DataImport/Logins/Firefox/FirefoxDataImporter.swift
@@ -27,18 +27,20 @@ internal class FirefoxDataImporter: DataImporter {
     private let bookmarkImporter: BookmarkImporter
     private let faviconManager: FaviconManagement
     private let profile: DataImport.BrowserProfile
+    private let featureFlagger: FeatureFlagger
     private var source: DataImport.Source {
         profile.browser.importSource
     }
 
     private let primaryPassword: String?
 
-    init(profile: DataImport.BrowserProfile, primaryPassword: String?, loginImporter: LoginImporter, bookmarkImporter: BookmarkImporter, faviconManager: FaviconManagement) {
+    init(profile: DataImport.BrowserProfile, primaryPassword: String?, loginImporter: LoginImporter, bookmarkImporter: BookmarkImporter, faviconManager: FaviconManagement, featureFlagger: FeatureFlagger) {
         self.profile = profile
         self.primaryPassword = primaryPassword
         self.loginImporter = loginImporter
         self.bookmarkImporter = bookmarkImporter
         self.faviconManager = faviconManager
+        self.featureFlagger = featureFlagger
     }
 
     var importableTypes: [DataImport.DataType] {
@@ -96,7 +98,7 @@ internal class FirefoxDataImporter: DataImporter {
 
             try updateProgress(.importingBookmarks(numberOfBookmarks: nil, fraction: passwordsFraction + 0.0))
 
-            let bookmarkReader = FirefoxBookmarksReader(firefoxDataDirectoryURL: profile.profileURL)
+            let bookmarkReader = FirefoxBookmarksReader(firefoxDataDirectoryURL: profile.profileURL, featureFlagger: featureFlagger)
             let bookmarkResult = bookmarkReader.readBookmarks()
 
             try updateProgress(.importingBookmarks(numberOfBookmarks: try? bookmarkResult.get().numberOfBookmarks,

--- a/macOS/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
+++ b/macOS/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
@@ -444,7 +444,8 @@ private func dataImporter(for source: DataImport.Source, fileDataType: DataImpor
                             primaryPassword: primaryPassword,
                             loginImporter: SecureVaultLoginImporter(loginImportState: AutofillLoginImportState()),
                             bookmarkImporter: CoreDataBookmarkImporter(bookmarkManager: NSApp.delegateTyped.bookmarkManager),
-                            faviconManager: NSApp.delegateTyped.faviconManager)
+                            faviconManager: NSApp.delegateTyped.faviconManager,
+                            featureFlagger: Application.appDelegate.featureFlagger)
     case .safari, .safariTechnologyPreview:
         SafariDataImporter(profile: profile,
                            bookmarkImporter: CoreDataBookmarkImporter(bookmarkManager: NSApp.delegateTyped.bookmarkManager),

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -129,6 +129,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1209825025475019/task/1210649149275753?focus=true
     case updateSafariBookmarksImport
 
+    /// https://app.asana.com/1/137249556945/project/1209825025475019/task/1210649149275753?focus=true
+    case updateFirefoxBookmarksImport
+
     /// https://app.asana.com/1/137249556945/project/1204006570077678/task/1210522798790015?focus=true
     case disableFireAnimation
 
@@ -189,6 +192,7 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .shortHistoryMenu,
                 .importChromeShortcuts,
                 .updateSafariBookmarksImport,
+                .updateFirefoxBookmarksImport,
                 .disableFireAnimation,
                 .newTabPageOmnibar:
             return true
@@ -292,6 +296,8 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .importChromeShortcuts:
             return .disabled
         case .updateSafariBookmarksImport:
+            return .disabled
+        case .updateFirefoxBookmarksImport:
             return .disabled
         case .disableFireAnimation:
             return .remoteReleasable(.feature(.disableFireAnimation))

--- a/macOS/UnitTests/DataImport/FirefoxDataImporterTests.swift
+++ b/macOS/UnitTests/DataImport/FirefoxDataImporterTests.swift
@@ -28,7 +28,8 @@ class FirefoxDataImporterTests: XCTestCase {
         let loginImporter = MockLoginImporter()
         let faviconManager = FaviconManagerMock()
         let bookmarkImporter = MockBookmarkImporter(importBookmarks: { _, _, _, _ in .init(successful: 1, duplicates: 2, failed: 3) })
-        let importer = FirefoxDataImporter(profile: .init(browser: .firefox, profileURL: resourceURL()), primaryPassword: nil, loginImporter: loginImporter, bookmarkImporter: bookmarkImporter, faviconManager: faviconManager)
+        let featureFlagger = MockFeatureFlagger()
+        let importer = FirefoxDataImporter(profile: .init(browser: .firefox, profileURL: resourceURL()), primaryPassword: nil, loginImporter: loginImporter, bookmarkImporter: bookmarkImporter, faviconManager: faviconManager, featureFlagger: featureFlagger)
 
         let result = await importer.importData(types: [.bookmarks])
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210674932129669?focus=true

### Description

This updates the folder structure when bookmarks are imported from Firefox. Previously, bookmarks from both the bookmarks bar and bookmarks menu went into the Bookmarks root, and the “Other Bookmarks” folder became a folder off the root. Now, the imported bookmarks more closely match the Firefox folder structure:

* "Bookmarks Toolbar" goes to the root
* "Bookmarks Menu" becomes a folder off the root (new behavior)
* "Other Bookmarks" becomes a folder off the root

These changes are behind a feature flag that is disabled by default.

### Testing Steps

Firefox setup:
1. Install Firefox if needed.
2. Add at least one bookmark to each folder in Firefox (Bookmarks Toolbar, Bookmarks Menu, Other Bookmarks).
3. Close Firefox. (This ensures the Firefox Bookmarks database contains your latest changes.)

Test new behavior:
1. In DuckDuckGo, go to Debug menu > Feature flag overrides > Other > enable `updateFirefoxBookmarksImport` flag.
2. Go to Bookmarks menu > Import bookmarks.
3. Follow the prompts in the UI to import Firefox bookmarks.
4. Go to the Bookmarks menu and confirm your bookmarks are imported into the correct locations:
   * Toolbar bookmarks are in the root
   * "Bookmarks Menu” bookmarks are in the “Bookmarks menu” folder
   * "Other Bookmarks" bookmarks are in the “Other bookmarks” folder

Test previous behavior:
1. In DuckDuckGo, go to Debug menu > Feature flag overrides > Other > disable `updateFirefoxBookmarksImport` flag.
2. Go to Bookmarks menu > Import bookmarks.
3. Follow the prompts in the UI to import Firefox bookmarks.
4. Go to the Bookmarks menu and confirm your bookmarks are imported into the correct locations:
   * Toolbar bookmarks are in the root
   * "Bookmarks Menu” and "Other Bookmarks" bookmarks are in the “Other bookmarks” folder

### Impact and Risks
Low: behind feature flag

### Notes to Reviewer

* The new “Bookmarks menu” text will be localized after copy review.

Before|After
-|-
<img width="596" height="331" alt="Screenshot 2025-07-11 at 17 30 35" src="https://github.com/user-attachments/assets/9c95cb8f-9497-4514-9527-b9a0dfe6d956" />|<img width="623" height="309" alt="Screenshot 2025-07-11 at 17 34 25" src="https://github.com/user-attachments/assets/60c69d81-1edd-4425-a726-2a4374ca6d04" />


—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)