### PR TITLE
Always send all crash reports from DMG app and don't ask internal users for permission

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -82,7 +82,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let crashCollection = CrashCollection(crashReportSender: CrashReportSender(platform: .macOSAppStore,
                                                                                        pixelEvents: CrashReportSender.pixelEvents))
 #else
-    private let crashReporter = CrashReporter()
+    private let crashReporter: CrashReporter
 #endif
 
     let keyValueStore: ThrowingKeyValueStoring
@@ -757,6 +757,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 #endif
+
+#if !APPSTORE
+        crashReporter = CrashReporter(internalUserDecider: internalUserDecider)
+#endif
     }
     // swiftlint:enable cyclomatic_complexity
 
@@ -891,7 +895,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         applyPreferredTheme()
 
 #if APPSTORE
-        crashCollection.startAttachingCrashLogMessages { pixelParameters, payloads, completion in
+        crashCollection.startAttachingCrashLogMessages { [weak self] pixelParameters, payloads, completion in
 
             pixelParameters.forEach { parameters in
                 var params = parameters
@@ -908,12 +912,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let lastPayload = payloads.last else {
                 return
             }
-            DispatchQueue.main.async {
-                CrashReportPromptPresenter().showPrompt(for: CrashDataPayload(data: lastPayload), userDidAllowToReport: completion)
+            if self?.internalUserDecider.isInternalUser == true {
+                completion()
+            } else {
+                Task { @MainActor in
+                    if await CrashReportPromptPresenter().showPrompt(for: CrashDataPayload(data: lastPayload)) == .allow {
+                        completion()
+                    }
+                }
             }
         }
 #else
-        crashReporter.checkForNewReports()
+        Task {
+            await crashReporter.checkForNewReports()
+        }
 #endif
         urlEventHandler.applicationDidFinishLaunching()
 

--- a/macOS/DuckDuckGo/CrashReports/Model/CrashReportPromptPresenter.swift
+++ b/macOS/DuckDuckGo/CrashReports/Model/CrashReportPromptPresenter.swift
@@ -19,6 +19,9 @@
 import Cocoa
 
 final class CrashReportPromptPresenter {
+    enum Response: Equatable {
+        case allow, deny
+    }
 
     lazy var windowController: NSWindowController = {
         let storyboard = NSStoryboard(name: "CrashReports", bundle: nil)
@@ -31,12 +34,17 @@ final class CrashReportPromptPresenter {
         // swiftlint:enable force_cast
     }
 
-    func showPrompt(for crashReport: CrashReportPresenting, userDidAllowToReport: @escaping () -> Void) {
-        viewController.crashReport = crashReport
-        viewController.userDidAllowToReport = userDidAllowToReport
+    @MainActor
+    func showPrompt(for crashReport: CrashReportPresenting) async -> Response {
+        await withCheckedContinuation { continuation in
+            viewController.crashReport = crashReport
+            viewController.userDidAnswerPrompt = { response in
+                continuation.resume(returning: response)
+            }
 
-        windowController.showWindow(self)
-        windowController.window?.center()
+            windowController.showWindow(self)
+            windowController.window?.center()
+        }
     }
 
 }

--- a/macOS/DuckDuckGo/CrashReports/Model/CrashReporter.swift
+++ b/macOS/DuckDuckGo/CrashReports/Model/CrashReporter.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import BrowserServicesKit
 import Common
 import Crashes
 import Foundation
@@ -23,6 +24,11 @@ import PixelKit
 
 final class CrashReporter {
 
+    init(internalUserDecider: InternalUserDecider) {
+        self.internalUserDecider = internalUserDecider
+    }
+
+    private let internalUserDecider: InternalUserDecider
     private let reader = CrashReportReader()
     private lazy var sender = CrashReportSender(platform: .macOS, pixelEvents: CrashReportSender.pixelEvents)
     private lazy var crcidManager = CRCIDManager()
@@ -31,10 +37,8 @@ final class CrashReporter {
     @UserDefaultsWrapper(key: .lastCrashReportCheckDate, defaultValue: nil)
     private var lastCheckDate: Date?
 
-    func checkForNewReports() {
-
-#if !DEBUG
-
+    func checkForNewReports() async {
+ #if !DEBUG
         guard let lastCheckDate = lastCheckDate else {
             // Initial run
             self.lastCheckDate = Date()
@@ -59,19 +63,22 @@ final class CrashReporter {
             }
         }
 
-        promptPresenter.showPrompt(for: latest) {
-            guard let contentData = latest.contentData else {
+        if internalUserDecider.isInternalUser {
+            await send(crashReports)
+        } else if await promptPresenter.showPrompt(for: latest) == .allow {
+            await send(crashReports)
+        }
+ #endif
+    }
+
+    private func send(_ crashReports: [CrashReport]) async {
+        for crashReport in crashReports {
+            guard let contentData = crashReport.contentData else {
                 assertionFailure("CrashReporter: Can't get the content of the crash report")
                 return
             }
-            Task {
-                let crcid = self.crcidManager.crcid
-                let result = await self.sender.send(contentData, crcid: crcid)
-                self.crcidManager.handleCrashSenderResult(result: result.result, response: result.response)
-            }
+            let result = await sender.send(contentData, crcid: crcidManager.crcid)
+            crcidManager.handleCrashSenderResult(result: result.result, response: result.response)
         }
-
-#endif
-
     }
 }

--- a/macOS/DuckDuckGo/CrashReports/View/CrashReportPromptViewController.swift
+++ b/macOS/DuckDuckGo/CrashReports/View/CrashReportPromptViewController.swift
@@ -26,7 +26,7 @@ final class CrashReportPromptViewController: NSViewController {
     @IBOutlet weak var descriptionLabel: NSTextField!
     @IBOutlet var textView: NSTextView!
 
-    var userDidAllowToReport: () -> Void = {}
+    var userDidAnswerPrompt: ((CrashReportPromptPresenter.Response) -> Void)?
 
     var crashReport: CrashReportPresenting? {
         didSet {
@@ -52,11 +52,12 @@ final class CrashReportPromptViewController: NSViewController {
     }
 
     @IBAction func sendAction(_ sender: Any) {
-        userDidAllowToReport()
+        userDidAnswerPrompt?(.allow)
         view.window?.close()
     }
 
     @IBAction func dontSendAction(_ sender: Any) {
+        userDidAnswerPrompt?(.deny)
         view.window?.close()
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1210781608329135?focus=true

### Description
This change fixes CrashReporter to always send all found crash reports and not only the latest one.
Additionally it skips asking internal users for permission.

### Testing Steps
1. In CrashReporter.swift remove `#if !DEBUG` and `#endif` statements.
2. Launch the app from Xcode, make sure that you’re an internal user.
3. In Xcode, select Main Menu -> Debug -> Detach from DuckDuckGo.
4. In the browser, force a crash via Main Menu -> Debug -> Simulate crash.
5. In Xcode, filter console logs by `CrashReportSender`
6. Launch the browser again
7. Verify that you haven’t seen crash report prompt and the logs were emitted confirming sending the crash report.
8. Remove internal user flag, repeat steps 2-6 and verify that you’ve been presented with the crash report prompt and the crash report wasn’t uploaded automatically. Verify that accepting the prompt sends crash report.
9. Repeat steps 2-8 with the App Store target.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Crash report uploading can get broken

### Quality Considerations
I’ve tested all cases extensively.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)