### PR TITLE
Allow to cancel Publish DMG release workflow

### DIFF
--- a/.github/workflows/macos_publish_dmg_release.yml
+++ b/.github/workflows/macos_publish_dmg_release.yml
@@ -78,7 +78,8 @@ jobs:
 
     # Allow to run even if the tag-public-release job was skipped (e.g. for internal releases)
     # or failed (for public releases or hotfixes), because tagging doesn't block publishing the release
-    if: always()
+    # but still allow the workflow to be cancelled
+    if: !cancelled()
 
     runs-on: macos-15-xlarge
     timeout-minutes: 10


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1210784601649457?focus=true

### Description
This change updates macos_publish_dmg_release.yml to allow cancelling the publishing job.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)