### PR TITLE
Fix internal import debug view bug

### DIFF
--- a/macOS/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
+++ b/macOS/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
@@ -132,7 +132,7 @@ struct DataImportViewModel {
     /// collected import summary for current import operation per selected import source
     private(set) var summary: [DataTypeImportResult]
 
-    private(set) var errors: [[DataType: any DataImportError]] = []
+    var errors: [[DataType: any DataImportError]] = []
 
     private var userReportText: String = ""
 

--- a/macOS/DuckDuckGo/DataImport/View/DataImportView.swift
+++ b/macOS/DuckDuckGo/DataImport/View/DataImportView.swift
@@ -48,15 +48,13 @@ struct DataImportView: ModalView {
 
 #if DEBUG || REVIEW
     @State private var debugViewDisabled: Bool = false
-#else
-    @State private var debugViewDisabled: Bool = true
 #endif
 
     private var shouldShowDebugView: Bool {
 #if DEBUG || REVIEW
         return !debugViewDisabled
 #else
-        return (!debugViewDisabled && isInternalUser) || (!model.errors.isEmpty && isInternalUser)
+        return (!model.errors.isEmpty && isInternalUser)
 #endif
     }
 
@@ -343,7 +341,23 @@ struct DataImportView: ModalView {
     private func debugView() -> some View {
         HStack(alignment: .top) {
             VStack(alignment: .leading, spacing: 10) {
-                if model.errors.count > 0 {
+#if DEBUG || REVIEW
+                Text("REVIEW:" as String).bold()
+                    .padding(.top, 10)
+                    .padding(.leading, 20)
+
+                ForEach(DataImport.DataType.allCases.filter(model.selectedDataTypes.contains), id: \.self) { selectedDataType in
+                    failureReasonPicker(for: selectedDataType)
+                        .padding(.leading, 20)
+                        .padding(.trailing, 20)
+                }
+
+                if model.errors.count > 0 && isInternalUser {
+                    Divider()
+                }
+#endif
+                
+                if model.errors.count > 0 && isInternalUser {
                     Text(verbatim: "ERRORS:" as String).bold()
                         .padding(.top, 10)
                         .padding(.leading, 20)
@@ -361,24 +375,13 @@ struct DataImportView: ModalView {
                     }
                     .padding(.horizontal, 20)
                     .padding(.bottom, 10)
-
-                    Divider()
                 }
-#if DEBUG || REVIEW
-                Text("REVIEW:" as String).bold()
-                    .padding(.top, 10)
-                    .padding(.leading, 20)
-
-                ForEach(DataImport.DataType.allCases.filter(model.selectedDataTypes.contains), id: \.self) { selectedDataType in
-                    failureReasonPicker(for: selectedDataType)
-                        .padding(.leading, 20)
-                        .padding(.trailing, 20)
-                }
-#endif
             }
             Spacer()
             Button {
-                debugViewDisabled.toggle()
+#if DEBUG || REVIEW
+                debugViewDisabled = true
+#endif  
                 model.errors.removeAll()
             } label: {
                 Image(.closeLarge)

--- a/macOS/DuckDuckGo/DataImport/View/DataImportView.swift
+++ b/macOS/DuckDuckGo/DataImport/View/DataImportView.swift
@@ -356,7 +356,7 @@ struct DataImportView: ModalView {
                     Divider()
                 }
 #endif
-                
+
                 if model.errors.count > 0 && isInternalUser {
                     Text(verbatim: "ERRORS:" as String).bold()
                         .padding(.top, 10)
@@ -381,7 +381,7 @@ struct DataImportView: ModalView {
             Button {
 #if DEBUG || REVIEW
                 debugViewDisabled = true
-#endif  
+#endif
                 model.errors.removeAll()
             } label: {
                 Image(.closeLarge)

--- a/macOS/DuckDuckGo/DataImport/View/DataImportView.swift
+++ b/macOS/DuckDuckGo/DataImport/View/DataImportView.swift
@@ -46,7 +46,11 @@ struct DataImportView: ModalView {
     }
     @State private var progress: ProgressState?
 
+#if DEBUG || REVIEW
     @State private var debugViewDisabled: Bool = false
+#else
+    @State private var debugViewDisabled: Bool = true
+#endif
 
     private var shouldShowDebugView: Bool {
 #if DEBUG || REVIEW

--- a/macOS/DuckDuckGo/DataImport/View/DataImportView.swift
+++ b/macOS/DuckDuckGo/DataImport/View/DataImportView.swift
@@ -379,6 +379,7 @@ struct DataImportView: ModalView {
             Spacer()
             Button {
                 debugViewDisabled.toggle()
+                model.errors.removeAll()
             } label: {
                 Image(.closeLarge)
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1199230911884351/task/1210785808806844?focus=true

### Description
When [✓ Display copyable error messages on the import UI](https://app.asana.com/1/137249556945/task/1210732287708280) was merged, there was a bug where the error view could not be dismissed by pressing the button

I've now changed the logic so that the debug view only shows in production if the user is internal and there were errors during import.

### Testing Steps
In the linked task above.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

### What could go wrong?

If the logic was wrong, this debug view could show for production users. But the test steps should cover that.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)