### PR TITLE
Add macOS launch pixel

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1022,10 +1022,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func fireAppLaunchPixel() {
+        PixelKit.fire(NonStandardEvent(GeneralPixel.launch))
 #if SPARKLE
-        PixelKit.fire(NonStandardEvent(GeneralPixel.launch(isDefault: DefaultBrowserPreferences().isDefault, isAddedToDock: DockCustomizer().isAddedToDock)), frequency: .legacyDaily)
+        PixelKit.fire(NonStandardEvent(GeneralPixel.dailyActiveUser(isDefault: DefaultBrowserPreferences().isDefault, isAddedToDock: DockCustomizer().isAddedToDock)), frequency: .legacyDaily)
 #else
-        PixelKit.fire(NonStandardEvent(GeneralPixel.launch(isDefault: DefaultBrowserPreferences().isDefault, isAddedToDock: nil)), frequency: .legacyDaily)
+        PixelKit.fire(NonStandardEvent(GeneralPixel.dailyActiveUser(isDefault: DefaultBrowserPreferences().isDefault, isAddedToDock: nil)), frequency: .legacyDaily)
 #endif
     }
 

--- a/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -29,7 +29,8 @@ enum GeneralPixel: PixelKitEventV2 {
     case crashReportingSubmissionFailed
     case crashReportCRCIDMissing
     case compileRulesWait(onboardingShown: OnboardingShown, waitTime: CompileRulesWaitTime, result: WaitResult)
-    case launch(isDefault: Bool, isAddedToDock: Bool?)
+    case launch
+    case dailyActiveUser(isDefault: Bool, isAddedToDock: Bool?)
 
     case serp
     case serpInitial
@@ -537,6 +538,9 @@ enum GeneralPixel: PixelKitEventV2 {
             return "m_mac_cbr-wait_\(onboardingShown)_\(waitTime)_\(result)"
 
         case .launch:
+            return "ml_mac"
+
+        case .dailyActiveUser:
             return  "m_mac_daily_active_user"
 
         case .serp:
@@ -1240,7 +1244,7 @@ enum GeneralPixel: PixelKitEventV2 {
         case .loginItemUpdateError(let loginItemBundleID, let action, let buildType, let osVersion):
             return ["loginItemBundleID": loginItemBundleID, "action": action, "buildType": buildType, "macosVersion": osVersion]
 
-        case .launch(let isDefault, let isAddedToDock):
+        case .dailyActiveUser(let isDefault, let isAddedToDock):
             var params = [String: String]()
             params["default_browser"] = isDefault ? "1" : "0"
 

--- a/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -538,7 +538,7 @@ enum GeneralPixel: PixelKitEventV2 {
             return "m_mac_cbr-wait_\(onboardingShown)_\(waitTime)_\(result)"
 
         case .launch:
-            return "ml_mac"
+            return "ml_mac_app-launch"
 
         case .dailyActiveUser:
             return  "m_mac_daily_active_user"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1210763248257877?focus=true

### Description
This change adds ml.mac.app-launch pixel fired at every app launch. This is to count crash-free sessions.

### Testing Steps
1. Launch the app and verify that `ml.mac.app-launch` pixel is fired.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)