### PR TITLE
Update autofill to 18.2.0

### DIFF
--- a/SharedPackages/BrowserServicesKit/Package.resolved
+++ b/SharedPackages/BrowserServicesKit/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "7532135989abb6ddbde48632b7222e0abed7d253",
-        "version" : "18.1.0"
+        "revision" : "21abb6f36a0cefc238c7366c50144ca792ada305",
+        "version" : "18.2.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -49,7 +49,7 @@ let package = Package(
         .library(name: "SharedObjCTestsUtils", targets: ["SharedObjCTestsUtils"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "18.1.0"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "18.2.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit.git", exact: "3.0.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.5.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "3.0.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210792743787678
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.2.0
Apple PR: 

## Description
Updates Autofill to version [18.2.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.2.0).

### Autofill 18.2.0 release notes
## What's Changed
* fix scanner debugging by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/611
* [GH Action] Reduce dependabot frequency by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/871
* Fix: acehardware.com - update submitButtonSelector ignoring aria-label="clear" by @borgateo in https://github.com/duckduckgo/duckduckgo-autofill/pull/877
* build(deps-dev): bump eslint from 9.28.0 to 9.30.1 by @dependabot[bot] in https://github.com/duckduckgo/duckduckgo-autofill/pull/873
* [CredentialsImport] Credentials import support for iOS and Android by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/823
* [site-specific-fixes] Move thresholds to site-specific-fixes by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/832
* Chore: UI refresh — Update Icons by @borgateo in https://github.com/duckduckgo/duckduckgo-autofill/pull/876
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/879
* [CredentialsImport] Only show prompts on empty input by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/878
* [Windows] Call setSize after font load finishes by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/864
* [HTMLTooltip] type htmltooltipoptions by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/880


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/18.1.0...18.2.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).