### PR TITLE
Send pixel when summarization source link was clicked

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PixelKitTestingUtilities/PixelKitMock.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKitTestingUtilities/PixelKitMock.swift
@@ -28,7 +28,7 @@ public final class PixelKitMock: PixelFiring {
 
     /// The actual fire calls
     ///
-    private var actualFireCalls = [ExpectedFireCall]()
+    public private(set) var actualFireCalls = [ExpectedFireCall]()
 
     public init(expecting expectedFireCalls: [ExpectedFireCall] = []) {
         self.expectedFireCalls = expectedFireCalls

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -81,9 +81,6 @@ enum AIChatPixel: PixelKitEventV2 {
     /// Event Trigger: User triggers summarize action (either via keyboard shortcut or a context menu action)
     case aiChatSummarizeText(source: AIChatTextSummarizationRequest.Source)
 
-    /// Event Trigger: User clicks "Show more" on a (collapsed by default) summarize prompt in Duck.ai tab or sidebar
-    case aiChatSummarizePromptExpanded
-
     /// Event Trigger: User clicks the website link on a summarize prompt in Duck.ai tab or sidebar
     case aiChatSummarizeSourceLinkClicked
 
@@ -119,8 +116,6 @@ enum AIChatPixel: PixelKitEventV2 {
             return "aichat_sidebar_setting_changed_u"
         case .aiChatSummarizeText:
             return "aichat_summarize_text"
-        case .aiChatSummarizePromptExpanded:
-            return "aichat_summarize_prompt_expanded"
         case .aiChatSummarizeSourceLinkClicked:
             return "aichat_summarize_source_link_clicked"
         }
@@ -138,7 +133,6 @@ enum AIChatPixel: PixelKitEventV2 {
                 .aiChatSettingsDisplayed,
                 .aiChatSidebarExpanded,
                 .aiChatSidebarSettingChanged,
-                .aiChatSummarizePromptExpanded,
                 .aiChatSummarizeSourceLinkClicked:
             return nil
         case .aiChatAddressBarButtonClicked(let action):

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -20,6 +20,7 @@ import AIChat
 import AppKit
 import Combine
 import Foundation
+import PixelKit
 import UserScript
 
 protocol AIChatUserScriptHandling {
@@ -47,16 +48,19 @@ struct AIChatUserScriptHandler: AIChatUserScriptHandling {
     private let storage: AIChatPreferencesStorage
     private let windowControllersManager: WindowControllersManagerProtocol
     private let notificationCenter: NotificationCenter
+    private let pixelFiring: PixelFiring?
 
     init(
         storage: AIChatPreferencesStorage,
         messageHandling: AIChatMessageHandling = AIChatMessageHandler(),
         windowControllersManager: WindowControllersManagerProtocol,
+        pixelFiring: PixelFiring?,
         notificationCenter: NotificationCenter = .default
     ) {
         self.storage = storage
         self.messageHandling = messageHandling
         self.windowControllersManager = windowControllersManager
+        self.pixelFiring = pixelFiring
         self.notificationCenter = notificationCenter
         self.aiChatNativePromptPublisher = aiChatNativePromptSubject.eraseToAnyPublisher()
     }
@@ -128,6 +132,7 @@ struct AIChatUserScriptHandler: AIChatUserScriptHandling {
         else { return nil }
 
         windowControllersManager.open(url, source: .link, target: nil, event: NSApp.currentEvent)
+        pixelFiring?.fire(AIChatPixel.aiChatSummarizeSourceLinkClicked, frequency: .dailyAndStandard)
         return nil
     }
 

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -20,6 +20,7 @@ import AIChat
 import BrowserServicesKit
 import Foundation
 import HistoryView
+import PixelKit
 import SpecialErrorPages
 import Subscription
 import UserScript
@@ -65,7 +66,8 @@ final class UserScripts: UserScriptsProvider {
         aiChatUserScript = AIChatUserScript(
             handler: AIChatUserScriptHandler(
                 storage: DefaultAIChatPreferencesStorage(),
-                windowControllersManager: sourceProvider.windowControllersManager
+                windowControllersManager: sourceProvider.windowControllersManager,
+                pixelFiring: PixelKit.shared
             ),
             urlSettings: aiChatDebugURLSettings
         )

--- a/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -17,6 +17,7 @@
 //
 
 import Combine
+import PixelKitTestingUtilities
 import Testing
 import WebKit
 @testable import DuckDuckGo_Privacy_Browser
@@ -54,6 +55,7 @@ struct AIChatUserScriptHandlerTests {
     private var messageHandler = MockAIChatMessageHandler()
     private var windowControllersManager: WindowControllersManagerMock
     private var notificationCenter = NotificationCenter()
+    private var pixelFiring = PixelKitMock()
     private var handler: AIChatUserScriptHandler
 
     @MainActor
@@ -64,6 +66,7 @@ struct AIChatUserScriptHandlerTests {
             storage: storage,
             messageHandling: messageHandler,
             windowControllersManager: windowControllersManager,
+            pixelFiring: pixelFiring,
             notificationCenter: notificationCenter
         )
     }
@@ -169,6 +172,7 @@ struct AIChatUserScriptHandlerTests {
     func testThatOpenSummarizationSourceLinkCallsWindowControllersManager() async throws {
         let urlString = "https://example.com"
         let params = [AIChatUserScriptHandler.AIChatKeys.url: urlString]
+        pixelFiring.expectedFireCalls = [.init(pixel: AIChatPixel.aiChatSummarizeSourceLinkClicked, frequency: .dailyAndStandard)]
 
         _ = await handler.openSummarizationSourceLink(params: params, message: WKScriptMessage())
 
@@ -176,6 +180,7 @@ struct AIChatUserScriptHandlerTests {
         let openCall = try #require(windowControllersManager.openCalls.first)
         #expect(openCall.url.absoluteString == urlString)
         #expect(openCall.source == .link)
+        #expect(pixelFiring.expectedFireCalls == pixelFiring.actualFireCalls)
     }
 
     @Test("openSummarizationSourceLink doesn't call windowControllersManager when invalid URL is passed")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1210809230764459

### Description
This change adds a pixel that’s sent from the text summarization link in the Duck.ai chat bubble.

### Testing Steps
1. Cherry-pick commit `25994651697de295035456ed0caa65fdc798c848` for the new summarization payload.
2. Run the app and in Main Menu -> Debug -> AI Chat -> Web Communication set `https://euw-serp-dev-testing13.duck.co/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=2&placement=sidebar` URL.
3. Visit that url in a tab to perform Duo authentication.
4. Now summarize some text
5. Filter Xcode logs to display PixelKit category.
6. In the Duck.ai chat, click the link in the chat bubble and verify that `m_mac_aichat_summarize_source_link_clicked` and `m_mac_aichat_summarize_source_link_clicked_daily` were sent.
<img width="393" height="284" alt="Screenshot 2025-07-16 at 16 08 52" src="https://github.com/user-attachments/assets/c198d673-e91f-427f-8fbd-6546361c5323” />

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)