### PR TITLE
Use proper summarization payload

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatScriptUserValues.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatScriptUserValues.swift
@@ -119,17 +119,84 @@ public struct AIChatNativeConfigValues: Codable {
 }
 
 public struct AIChatNativePrompt: Codable, Equatable {
+    public let platform: String
+    public let tool: Tool?
+
+    public enum Tool: Equatable {
+        case query(Query)
+        case summary(TextSummary)
+    }
+
     public struct Query: Codable, Equatable {
+        public static let tool = "query"
+
         public let prompt: String
         public let autoSubmit: Bool
     }
 
-    public let platform: String
-    public let query: Query?
+    public struct TextSummary: Codable, Equatable {
+        public static let tool = "summary"
+
+        public let text: String
+        public let sourceURL: String?
+        public let sourceTitle: String?
+    }
+
+    // Custom coding keys for flat structure
+    private enum CodingKeys: String, CodingKey {
+        case platform
+        case tool
+        case query
+        case summary
+    }
+
+    public init(platform: String, tool: Tool?) {
+        self.platform = platform
+        self.tool = tool
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        platform = try container.decode(String.self, forKey: .platform)
+
+        let toolString = try container.decodeIfPresent(String.self, forKey: .tool)
+
+        switch toolString {
+        case Query.tool:
+            let query = try container.decode(Query.self, forKey: .query)
+            tool = .query(query)
+        case TextSummary.tool:
+            let summary = try container.decode(TextSummary.self, forKey: .summary)
+            tool = .summary(summary)
+        default:
+            tool = nil
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(platform, forKey: .platform)
+
+        switch tool {
+        case .query(let query):
+            try container.encode(Query.tool, forKey: .tool)
+            try container.encode(query, forKey: .query)
+        case .summary(let summary):
+            try container.encode(TextSummary.tool, forKey: .tool)
+            try container.encode(summary, forKey: .summary)
+        case .none:
+            try container.encodeNil(forKey: .tool)
+        }
+    }
 
     public static func queryPrompt(_ prompt: String, autoSubmit: Bool) -> AIChatNativePrompt {
-        AIChatNativePrompt(platform: Platform.name, query: .init(prompt: prompt,
-                                                                 autoSubmit: autoSubmit))
+        AIChatNativePrompt(platform: Platform.name, tool: .query(.init(prompt: prompt, autoSubmit: autoSubmit)))
+    }
+
+    public static func summaryPrompt(_ text: String, url: URL?, title: String?) -> AIChatNativePrompt {
+        AIChatNativePrompt(platform: Platform.name, tool: .summary(.init(text: text, sourceURL: url?.absoluteString, sourceTitle: title)))
     }
 }
 

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatNativePromptTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatNativePromptTests.swift
@@ -1,0 +1,109 @@
+//
+//  AIChatNativePromptTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Testing
+@testable import AIChat
+
+struct AIChatNativePromptTests {
+
+    @Test
+    func decodingQuery() throws {
+        let json = """
+            {
+                "platform": "\(Platform.name)",
+                "tool": "query",
+                "query": {
+                    "prompt": "hello",
+                    "autoSubmit": true
+                }
+            }
+            """
+
+        let prompt = try decodePrompt(from: json)
+        #expect(prompt == AIChatNativePrompt.queryPrompt("hello", autoSubmit: true))
+    }
+
+    @Test
+    func decodingSummary() throws {
+        let json = """
+            {
+                "platform": "\(Platform.name)",
+                "tool": "summary",
+                "summary": {
+                    "text": "This is a sample text to summarize",
+                    "sourceURL": "https://example.com",
+                    "sourceTitle": "Example Page"
+                }
+            }
+            """
+
+        let prompt = try decodePrompt(from: json)
+        let expectedURL = URL(string: "https://example.com")
+        #expect(prompt == AIChatNativePrompt.summaryPrompt("This is a sample text to summarize", url: expectedURL, title: "Example Page"))
+    }
+
+    @Test
+    func encodingQuery() throws {
+        let prompt = AIChatNativePrompt.queryPrompt("hello", autoSubmit: true)
+        let jsonDict = try encodePrompt(prompt)
+
+        let expected: [String: Any] = [
+            "platform": Platform.name,
+            "tool": "query",
+            "query": [
+                "prompt": "hello",
+                "autoSubmit": true
+            ]
+        ]
+
+        #expect(NSDictionary(dictionary: jsonDict).isEqual(to: expected))
+    }
+
+    @Test
+    func encodingSummary() throws {
+        let expectedURL = URL(string: "https://example.com")
+        let prompt = AIChatNativePrompt.summaryPrompt("This is a sample text to summarize", url: expectedURL, title: "Example Page")
+        let jsonDict = try encodePrompt(prompt)
+
+        let expected: [String: Any] = [
+            "platform": Platform.name,
+            "tool": "summary",
+            "summary": [
+                "text": "This is a sample text to summarize",
+                "sourceURL": "https://example.com",
+                "sourceTitle": "Example Page"
+            ]
+        ]
+
+        #expect(NSDictionary(dictionary: jsonDict).isEqual(to: expected))
+    }
+
+    // MARK: - Helpers
+
+    private func decodePrompt(from json: String) throws -> AIChatNativePrompt {
+        let jsonData = try #require(json.data(using: .utf8))
+        return try JSONDecoder().decode(AIChatNativePrompt.self, from: jsonData)
+    }
+
+    private func encodePrompt(_ prompt: AIChatNativePrompt) throws -> [String: Any] {
+        let jsonData = try JSONEncoder().encode(prompt)
+        let jsonObject = try JSONSerialization.jsonObject(with: jsonData, options: [])
+        return try #require(jsonObject as? [String: Any])
+    }
+}

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatPromptHandlerTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatPromptHandlerTests.swift
@@ -23,7 +23,7 @@ final class AIChatPromptHandlerTests: XCTestCase {
 
     func testSetData() {
         let handler = AIChatPromptHandler.shared
-        let testData: AIChatPromptHandler.DataType = .init(platform: "platform", query: .init(prompt: "Test Prompt", autoSubmit: false))
+        let testData: AIChatPromptHandler.DataType = .init(platform: "platform", tool: .query(.init(prompt: "Test Prompt", autoSubmit: false)))
 
         handler.setData(testData)
 
@@ -32,7 +32,7 @@ final class AIChatPromptHandlerTests: XCTestCase {
 
     func testConsumeData() {
         let handler = AIChatPromptHandler.shared
-        let testData: AIChatPromptHandler.DataType = .init(platform: "platform", query: .init(prompt: "Test Prompt", autoSubmit: false))
+        let testData: AIChatPromptHandler.DataType = .init(platform: "platform", tool: .query(.init(prompt: "Test Prompt", autoSubmit: false)))
 
         handler.setData(testData)
         let consumedData = handler.consumeData()
@@ -43,7 +43,7 @@ final class AIChatPromptHandlerTests: XCTestCase {
 
     func testReset() {
         let handler = AIChatPromptHandler.shared
-        let testData: AIChatPromptHandler.DataType = .init(platform: "platform", query: .init(prompt: "Test Prompt", autoSubmit: false))
+        let testData: AIChatPromptHandler.DataType = .init(platform: "platform", tool: .query(.init(prompt: "Test Prompt", autoSubmit: false)))
 
         handler.setData(testData)
         handler.reset()

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatRequestAuthorizationHandlerTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatRequestAuthorizationHandlerTests.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+#if os(iOS)
 import XCTest
 import WebKit
 @testable import AIChat
@@ -178,3 +179,4 @@ final class MockWKFrameInfo: WKFrameInfo {
         return mockIsMainFrame
     }
 }
+#endif

--- a/macOS/DuckDuckGo/AIChat/AIChatSummarizer.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatSummarizer.swift
@@ -80,14 +80,7 @@ final class AIChatSummarizer: AIChatSummarizing {
             return
         }
 
-        let promptText = """
-            You are an expert summarizer AI. Your purpose is to read the provided text and generate a concise, accurate, and easy-to-understand summary. Summarize the following text in a neutral, encyclopedic tone. The summary should be a single paragraph and should not exceed 50 words. Use the same language as the original text.
-            <text>
-            \(request.text)
-            </text>
-            """
-
-        let prompt = AIChatNativePrompt.queryPrompt(promptText, autoSubmit: true)
+        let prompt = AIChatNativePrompt.summaryPrompt(request.text, url: request.websiteURL, title: request.websiteTitle)
         pixelFiring?.fire(AIChatPixel.aiChatSummarizeText(source: request.source), frequency: .dailyAndStandard)
 
         if featureFlagger.isFeatureOn(.aiChatSidebar) && aiChatMenuConfig.openAIChatInSidebar {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1210637781018871?focus=true

### Description
This change includes the new native prompt payload for summarization and queries.

### Testing Steps
1. Run the app and in Main Menu -> Debug -> AI Chat -> Web Communication set https://euw-serp-dev-testing13.duck.co/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=2&placement=sidebar URL.
2. Visit that url in a tab to perform Duo authentication.
3. Select text on a website and select “Summarize with Duck.ai” from the context menu. Verify that it opens sidebar and displays a special summarization chat bubble containing the link to the source website.
4. Verify that submitting prompts via address bar works as expected (the prompt is handed over to Duck.ai).

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
It will break Duck.ai if merged before FE change is released, so I’ve added a label as a reminder.

### Quality Considerations
Unit tests are in place 👍 

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)