### PR TITLE
Show favorites when selecting the address bar

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
@@ -155,16 +155,33 @@ final class SuggestionTrayManager: NSObject {
                 
                 switch newState {
                 case .search:
-                    if self.switchBarHandler.currentText.isEmpty {
-                        self.showSuggestionTray(.favorites)
-                    } else {
-                        self.showSuggestionTray(.autocomplete(query: self.switchBarHandler.currentText))
-                    }
+                    self.updateSuggestionTrayForCurrentState()
                 case .aiChat:
                     break
                 }
             }
             .store(in: &cancellables)
+        
+        switchBarHandler.hasUserInteractedWithTextPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                if self.switchBarHandler.currentToggleState == .search {
+                    self.updateSuggestionTrayForCurrentState()
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func updateSuggestionTrayForCurrentState() {
+        let query = switchBarHandler.currentText
+        let hasUserInteracted = switchBarHandler.hasUserInteractedWithText
+        
+        if query.isEmpty || !hasUserInteracted {
+            showSuggestionTray(.favorites)
+        } else {
+            showSuggestionTray(.autocomplete(query: query))
+        }
     }
     
     private func showSuggestionTray(_ type: SuggestionTrayViewController.SuggestionType) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1210799150480183?focus=true

### Description
Show favorites when selecting the address bar

### Testing Steps
1. Enable AI Features -> Search Input
2. Open a website
3. Tap the address bar, you should see your favorites or the Dax logo
4. Start typing, you should see the auto-complete results

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
Show favorites when the user is typing
