### PR TITLE
Resolves an issue that was causing a pixel to be misfired in AuthV1

### DIFF
--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/VPNSubscriptionEventsHandler.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/VPNSubscriptionEventsHandler.swift
@@ -60,9 +60,8 @@ final class VPNSubscriptionEventsHandler {
 
     private func checkEntitlements() {
         Task {
-            if let hasEntitlement = try? await subscriptionManager.isFeatureEnabled(.networkProtection) {
-                await handleEntitlementsChange(hasEntitlements: hasEntitlement, trigger: .clientCheck)
-            }
+            let hasEntitlement = try await subscriptionManager.isFeatureEnabled(.networkProtection)
+            await handleEntitlementsChange(hasEntitlements: hasEntitlement, trigger: .clientCheck)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210812088652953?focus=true

### Description

Resolves an issue that was causing a pixel to be misfired in AuthV1

### Testing Steps

Honestly you can validate this visually because a transient error should not be interpreted as not having entitlements in the lines I modified.

But if you want to test:
1. Force an error to be thrown [here](https://github.com/duckduckgo/apple-browsers/blob/8f715834f8af1470ee75f1a65b44fcff3f883fcd/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/V1toV2Bridging/SubscriptionAuthV1toV2Bridge.swift#L68).  Imagine this error being "Connection timeout" - ie: a transient error
2. Place a breakpoint [here](https://github.com/duckduckgo/apple-browsers/blob/8f715834f8af1470ee75f1a65b44fcff3f883fcd/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/VPNSubscriptionEventsHandler.swift#L64).  The breakpoint should not be hit.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)