### PR TITLE
Diego/add pixels to track startup client check failures

### DIFF
--- a/SharedPackages/VPN/Sources/VPN/Subscription/VPNSubscriptionClientCheckPixel.swift
+++ b/SharedPackages/VPN/Sources/VPN/Subscription/VPNSubscriptionClientCheckPixel.swift
@@ -1,0 +1,110 @@
+//
+//  VPNSubscriptionClientCheckPixel.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import PixelKit
+import Subscription
+
+public enum VPNSubscriptionClientCheckPixel: PixelKitEventV2, PixelKitEventWithCustomPrefix {
+    case vpnFeatureEnabled(isSubscriptionActive: Bool?,
+                    isAuthV2Enabled: Bool,
+                    trigger: Trigger)
+    case vpnFeatureDisabled(isSubscriptionActive: Bool?,
+                     isAuthV2Enabled: Bool,
+                     trigger: Trigger)
+    case failed(isSubscriptionActive: Bool?,
+                isAuthV2Enabled: Bool,
+                trigger: Trigger,
+                error: Error)
+
+    public enum Trigger {
+        case appStartup
+#if os(macOS)
+        case deviceWake
+#elseif os(iOS)
+        case appForegrounded
+#endif
+    }
+
+    public var namePrefix: String {
+        let trigger: Trigger = {
+            switch self {
+            case .vpnFeatureEnabled(_, _, let trigger),
+                    .vpnFeatureDisabled(_, _, let trigger),
+                    .failed(_, _, let trigger, _):
+                return trigger
+            }
+        }()
+
+#if os(macOS)
+        switch trigger {
+        case .appStartup:
+            return "m_mac_vpn_subs_client_check_"
+        case .deviceWake:
+            return "m_mac_vpn_subs_client_check_on_wake_"
+        }
+#elseif os(iOS)
+        switch trigger {
+        case .appStartup:
+            return "m_vpn_subs_client_check_"
+        case .appForegrounded:
+            return "m_vpn_subs_client_check_on_foreground_"
+        }
+#endif
+    }
+
+    public var name: String {
+        switch self {
+        case .vpnFeatureEnabled:
+            return "vpn_feature_enabled"
+        case .vpnFeatureDisabled:
+            return "vpn_feature_disabled"
+        case .failed:
+            return "failed"
+        }
+    }
+
+    public var parameters: [String: String]? {
+        switch self {
+        case .vpnFeatureEnabled(let isSubscriptionActive, let isAuthV2, _),
+                .vpnFeatureDisabled(let isSubscriptionActive, let isAuthV2, _),
+                .failed(let isSubscriptionActive, let isAuthV2, _, _):
+
+            let isSubscriptionActiveString = {
+                guard let isSubscriptionActive else {
+                    return "no_subscription"
+                }
+
+                return String(isSubscriptionActive)
+            }()
+
+            return [
+                "isSubscriptionActive": isSubscriptionActiveString,
+                "authVersion": isAuthV2 ? "v2" : "v1"
+            ]
+        }
+    }
+
+    public var error: (any Error)? {
+        switch self {
+        case .vpnFeatureEnabled, .vpnFeatureDisabled:
+            return nil
+        case .failed(_, _, _, let error):
+            return error
+        }
+    }
+}

--- a/SharedPackages/VPN/Tests/VPNTests/Subscription/VPNSubscriptionClientCheckPixelTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/Subscription/VPNSubscriptionClientCheckPixelTests.swift
@@ -1,0 +1,272 @@
+//
+//  VPNSubscriptionClientCheckPixelTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import XCTest
+@testable import VPN
+
+final class VPNSubscriptionClientCheckPixelTests: XCTestCase {
+
+    // MARK: - Name Prefix Tests
+    
+    func testNamePrefix_appStartup() {
+#if os(macOS)
+        let pixel = VPNSubscriptionClientCheckPixel.vpnFeatureEnabled(
+            isSubscriptionActive: true,
+            isAuthV2Enabled: true,
+            trigger: .appStartup
+        )
+        XCTAssertEqual(pixel.namePrefix, "m_mac_vpn_subs_client_check_")
+#elseif os(iOS)
+        let pixel = VPNSubscriptionClientCheckPixel.vpnFeatureEnabled(
+            isSubscriptionActive: true,
+            isAuthV2Enabled: true,
+            trigger: .appStartup
+        )
+        XCTAssertEqual(pixel.namePrefix, "m_vpn_subs_client_check_")
+#endif
+    }
+    
+#if os(macOS)
+    func testNamePrefix_deviceWake() {
+        let pixel = VPNSubscriptionClientCheckPixel.vpnFeatureEnabled(
+            isSubscriptionActive: true,
+            isAuthV2Enabled: true,
+            trigger: .deviceWake
+        )
+        XCTAssertEqual(pixel.namePrefix, "m_mac_vpn_subs_client_check_on_wake_")
+    }
+#elseif os(iOS)
+    func testNamePrefix_appForegrounded() {
+        let pixel = VPNSubscriptionClientCheckPixel.vpnFeatureEnabled(
+            isSubscriptionActive: true,
+            isAuthV2Enabled: true,
+            trigger: .appForegrounded
+        )
+        XCTAssertEqual(pixel.namePrefix, "m_vpn_subs_client_check_on_foreground_")
+    }
+#endif
+    
+    // MARK: - Pixel Name Tests
+    
+    func testPixelName_vpnFeatureEnabled() {
+        let pixel = VPNSubscriptionClientCheckPixel.vpnFeatureEnabled(
+            isSubscriptionActive: true,
+            isAuthV2Enabled: true,
+            trigger: .appStartup
+        )
+        XCTAssertEqual(pixel.name, "vpn_feature_enabled")
+    }
+    
+    func testPixelName_vpnFeatureDisabled() {
+        let pixel = VPNSubscriptionClientCheckPixel.vpnFeatureDisabled(
+            isSubscriptionActive: false,
+            isAuthV2Enabled: true,
+            trigger: .appStartup
+        )
+        XCTAssertEqual(pixel.name, "vpn_feature_disabled")
+    }
+    
+    func testPixelName_failed() {
+        let error = NSError(domain: "TestError", code: 1, userInfo: nil)
+        let pixel = VPNSubscriptionClientCheckPixel.failed(
+            isSubscriptionActive: true,
+            isAuthV2Enabled: true,
+            trigger: .appStartup,
+            error: error
+        )
+        XCTAssertEqual(pixel.name, "failed")
+    }
+    
+    // MARK: - Parameters Tests
+    
+    func testParameters_activeSubscriptionAuthV2() {
+        let pixel = VPNSubscriptionClientCheckPixel.vpnFeatureEnabled(
+            isSubscriptionActive: true,
+            isAuthV2Enabled: true,
+            trigger: .appStartup
+        )
+        
+        let parameters = pixel.parameters
+        XCTAssertNotNil(parameters)
+        XCTAssertEqual(parameters?["isSubscriptionActive"], "true")
+        XCTAssertEqual(parameters?["authVersion"], "v2")
+    }
+    
+    func testParameters_activeSubscriptionAuthV1() {
+        let pixel = VPNSubscriptionClientCheckPixel.vpnFeatureEnabled(
+            isSubscriptionActive: true,
+            isAuthV2Enabled: false,
+            trigger: .appStartup
+        )
+        
+        let parameters = pixel.parameters
+        XCTAssertNotNil(parameters)
+        XCTAssertEqual(parameters?["isSubscriptionActive"], "true")
+        XCTAssertEqual(parameters?["authVersion"], "v1")
+    }
+    
+    func testParameters_inactiveSubscription() {
+        let pixel = VPNSubscriptionClientCheckPixel.vpnFeatureDisabled(
+            isSubscriptionActive: false,
+            isAuthV2Enabled: true,
+            trigger: .appStartup
+        )
+        
+        let parameters = pixel.parameters
+        XCTAssertNotNil(parameters)
+        XCTAssertEqual(parameters?["isSubscriptionActive"], "false")
+        XCTAssertEqual(parameters?["authVersion"], "v2")
+    }
+    
+    func testParameters_nilSubscription() {
+        let pixel = VPNSubscriptionClientCheckPixel.vpnFeatureEnabled(
+            isSubscriptionActive: nil,
+            isAuthV2Enabled: true,
+            trigger: .appStartup
+        )
+        
+        let parameters = pixel.parameters
+        XCTAssertNotNil(parameters)
+        XCTAssertEqual(parameters?["isSubscriptionActive"], "no_subscription")
+        XCTAssertEqual(parameters?["authVersion"], "v2")
+    }
+    
+    func testParameters_failedPixel() {
+        let error = NSError(domain: "TestError", code: 1, userInfo: nil)
+        let pixel = VPNSubscriptionClientCheckPixel.failed(
+            isSubscriptionActive: true,
+            isAuthV2Enabled: false,
+            trigger: .appStartup,
+            error: error
+        )
+        
+        let parameters = pixel.parameters
+        XCTAssertNotNil(parameters)
+        XCTAssertEqual(parameters?["isSubscriptionActive"], "true")
+        XCTAssertEqual(parameters?["authVersion"], "v1")
+    }
+    
+    // MARK: - Error Handling Tests
+    
+    func testError_successfulPixels() {
+        let enabledPixel = VPNSubscriptionClientCheckPixel.vpnFeatureEnabled(
+            isSubscriptionActive: true,
+            isAuthV2Enabled: true,
+            trigger: .appStartup
+        )
+        XCTAssertNil(enabledPixel.error)
+        
+        let disabledPixel = VPNSubscriptionClientCheckPixel.vpnFeatureDisabled(
+            isSubscriptionActive: false,
+            isAuthV2Enabled: true,
+            trigger: .appStartup
+        )
+        XCTAssertNil(disabledPixel.error)
+    }
+    
+    func testError_failedPixel() {
+        let testError = NSError(domain: "TestDomain", code: 42, userInfo: [NSLocalizedDescriptionKey: "Test error"])
+        let pixel = VPNSubscriptionClientCheckPixel.failed(
+            isSubscriptionActive: nil,
+            isAuthV2Enabled: true,
+            trigger: .appStartup,
+            error: testError
+        )
+        
+        XCTAssertNotNil(pixel.error)
+        XCTAssertEqual((pixel.error as NSError?)?.domain, "TestDomain")
+        XCTAssertEqual((pixel.error as NSError?)?.code, 42)
+        XCTAssertEqual((pixel.error as NSError?)?.localizedDescription, "Test error")
+    }
+    
+    // MARK: - Integration Tests
+    
+    func testFullPixelName_appStartupEnabled() {
+#if os(macOS)
+        let expectedPrefix = "m_mac_vpn_subs_client_check_"
+#elseif os(iOS)
+        let expectedPrefix = "m_vpn_subs_client_check_"
+#endif
+        
+        let pixel = VPNSubscriptionClientCheckPixel.vpnFeatureEnabled(
+            isSubscriptionActive: true,
+            isAuthV2Enabled: true,
+            trigger: .appStartup
+        )
+        
+        let fullName = pixel.namePrefix + pixel.name
+        XCTAssertEqual(fullName, expectedPrefix + "vpn_feature_enabled")
+    }
+    
+#if os(macOS)
+    func testFullPixelName_deviceWakeFailed() {
+        let error = NSError(domain: "NetworkError", code: 500, userInfo: nil)
+        let pixel = VPNSubscriptionClientCheckPixel.failed(
+            isSubscriptionActive: nil,
+            isAuthV2Enabled: false,
+            trigger: .deviceWake,
+            error: error
+        )
+        
+        let fullName = pixel.namePrefix + pixel.name
+        XCTAssertEqual(fullName, "m_mac_vpn_subs_client_check_on_wake_failed")
+    }
+#elseif os(iOS)
+    func testFullPixelName_appForegroundedFailed() {
+        let error = NSError(domain: "NetworkError", code: 500, userInfo: nil)
+        let pixel = VPNSubscriptionClientCheckPixel.failed(
+            isSubscriptionActive: nil,
+            isAuthV2Enabled: false,
+            trigger: .appForegrounded,
+            error: error
+        )
+        
+        let fullName = pixel.namePrefix + pixel.name
+        XCTAssertEqual(fullName, "m_vpn_subs_client_check_on_foreground_failed")
+    }
+#endif
+    
+    // MARK: - Edge Cases
+    
+    func testParameters_allCombinations() {
+        let combinations: [(Bool?, Bool)] = [
+            (true, true), (true, false),
+            (false, true), (false, false),
+            (nil, true), (nil, false)
+        ]
+        
+        for (isActive, isAuthV2) in combinations {
+            let pixel = VPNSubscriptionClientCheckPixel.vpnFeatureEnabled(
+                isSubscriptionActive: isActive,
+                isAuthV2Enabled: isAuthV2,
+                trigger: .appStartup
+            )
+            
+            let parameters = pixel.parameters
+            XCTAssertNotNil(parameters, "Parameters should never be nil")
+            XCTAssertNotNil(parameters?["isSubscriptionActive"], "isSubscriptionActive should always be present")
+            XCTAssertNotNil(parameters?["authVersion"], "authVersion should always be present")
+            
+            // Verify specific values
+            let expectedSubscriptionValue = isActive != nil ? String(isActive!) : "no_subscription"
+            XCTAssertEqual(parameters?["isSubscriptionActive"], expectedSubscriptionValue)
+            XCTAssertEqual(parameters?["authVersion"], isAuthV2 ? "v2" : "v1")
+        }
+    }
+} 

--- a/SharedPackages/VPN/Tests/VPNTests/Subscription/VPNSubscriptionStatusPixelTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/Subscription/VPNSubscriptionStatusPixelTests.swift
@@ -1,0 +1,329 @@
+//
+//  VPNSubscriptionStatusPixelTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import XCTest
+@testable import VPN
+
+final class VPNSubscriptionStatusPixelTests: XCTestCase {
+
+    // MARK: - Test Helpers
+    
+    private class TestSourceObject {
+        let name = "TestSourceObject"
+    }
+    
+    private class AnotherTestObject {
+        let value = 42
+    }
+
+    // MARK: - Name Prefix Tests
+    
+    func testNamePrefix_platformSpecific() {
+#if os(macOS)
+        let pixel = VPNSubscriptionStatusPixel.signedIn(
+            isSubscriptionActive: true,
+            isAuthV2Enabled: true,
+            sourceObject: nil
+        )
+        XCTAssertEqual(pixel.namePrefix, "m_mac_vpn_subs_notification_")
+#elseif os(iOS)
+        let pixel = VPNSubscriptionStatusPixel.signedIn(
+            isSubscriptionActive: true,
+            isAuthV2Enabled: true,
+            sourceObject: nil
+        )
+        XCTAssertEqual(pixel.namePrefix, "m_vpn_subs_notification_")
+#endif
+    }
+    
+    // MARK: - Pixel Name Tests
+    
+    func testPixelName_signedIn() {
+        let pixel = VPNSubscriptionStatusPixel.signedIn(
+            isSubscriptionActive: true,
+            isAuthV2Enabled: true,
+            sourceObject: nil
+        )
+        XCTAssertEqual(pixel.name, "signed_in")
+    }
+    
+    func testPixelName_signedOut() {
+        let pixel = VPNSubscriptionStatusPixel.signedOut(
+            isSubscriptionActive: false,
+            isAuthV2Enabled: true,
+            sourceObject: nil
+        )
+        XCTAssertEqual(pixel.name, "signed_out")
+    }
+    
+    func testPixelName_vpnFeatureEnabled() {
+        let pixel = VPNSubscriptionStatusPixel.vpnFeatureEnabled(
+            isSubscriptionActive: true,
+            isAuthV2Enabled: true,
+            sourceObject: nil
+        )
+        XCTAssertEqual(pixel.name, "vpn_feature_enabled")
+    }
+    
+    func testPixelName_vpnFeatureDisabled() {
+        let pixel = VPNSubscriptionStatusPixel.vpnFeatureDisabled(
+            isSubscriptionActive: false,
+            isAuthV2Enabled: true,
+            sourceObject: nil
+        )
+        XCTAssertEqual(pixel.name, "vpn_feature_disabled")
+    }
+    
+    // MARK: - Parameters Tests
+    
+    func testParameters_activeSubscriptionAuthV2WithSourceObject() {
+        let sourceObject = TestSourceObject()
+        let pixel = VPNSubscriptionStatusPixel.vpnFeatureEnabled(
+            isSubscriptionActive: true,
+            isAuthV2Enabled: true,
+            sourceObject: sourceObject
+        )
+        
+        let parameters = pixel.parameters
+        XCTAssertNotNil(parameters)
+        XCTAssertEqual(parameters?["isSubscriptionActive"], "true")
+        XCTAssertEqual(parameters?["authVersion"], "v2")
+        XCTAssertEqual(parameters?["notificationObjectClass"], "TestSourceObject")
+    }
+    
+    func testParameters_activeSubscriptionAuthV1() {
+        let pixel = VPNSubscriptionStatusPixel.signedIn(
+            isSubscriptionActive: true,
+            isAuthV2Enabled: false,
+            sourceObject: nil
+        )
+        
+        let parameters = pixel.parameters
+        XCTAssertNotNil(parameters)
+        XCTAssertEqual(parameters?["isSubscriptionActive"], "true")
+        XCTAssertEqual(parameters?["authVersion"], "v1")
+        XCTAssertEqual(parameters?["notificationObjectClass"], "nil")
+    }
+    
+    func testParameters_inactiveSubscription() {
+        let sourceObject = AnotherTestObject()
+        let pixel = VPNSubscriptionStatusPixel.vpnFeatureDisabled(
+            isSubscriptionActive: false,
+            isAuthV2Enabled: true,
+            sourceObject: sourceObject
+        )
+        
+        let parameters = pixel.parameters
+        XCTAssertNotNil(parameters)
+        XCTAssertEqual(parameters?["isSubscriptionActive"], "false")
+        XCTAssertEqual(parameters?["authVersion"], "v2")
+        XCTAssertEqual(parameters?["notificationObjectClass"], "AnotherTestObject")
+    }
+    
+    func testParameters_nilSubscription() {
+        let pixel = VPNSubscriptionStatusPixel.signedOut(
+            isSubscriptionActive: nil,
+            isAuthV2Enabled: true,
+            sourceObject: NSString(string: "test")
+        )
+        
+        let parameters = pixel.parameters
+        XCTAssertNotNil(parameters)
+        XCTAssertEqual(parameters?["isSubscriptionActive"], "no_subscription")
+        XCTAssertEqual(parameters?["authVersion"], "v2")
+        // NSString implementation can vary between OS versions (__NSCFConstantString vs NSTaggedPointerString)
+        let objectClass = parameters?["notificationObjectClass"]
+        XCTAssertTrue(objectClass?.contains("String") == true, "Expected string class name, got: \(objectClass ?? "nil")")
+    }
+    
+    // MARK: - Source Class Tests
+    
+    func testSourceClass_nilObject() {
+        let result = VPNSubscriptionStatusPixel.sourceClass(from: nil)
+        XCTAssertEqual(result, "nil")
+    }
+    
+    func testSourceClass_regularObject() {
+        let testObject = TestSourceObject()
+        let result = VPNSubscriptionStatusPixel.sourceClass(from: testObject)
+        XCTAssertEqual(result, "TestSourceObject")
+    }
+    
+    func testSourceClass_nsStringObject() {
+        let nsString = NSString(string: "test")
+        let result = VPNSubscriptionStatusPixel.sourceClass(from: nsString)
+        // NSString implementation can vary between OS versions (__NSCFConstantString vs NSTaggedPointerString)
+        XCTAssertTrue(result.contains("String"), "Expected string class name, got: \(result)")
+    }
+    
+    func testSourceClass_arrayObject() {
+        let array = [1, 2, 3]
+        let result = VPNSubscriptionStatusPixel.sourceClass(from: array)
+        XCTAssertEqual(result, "Array<Int>")
+    }
+    
+    func testSourceClass_variousObjectTypes() {
+        // Test the general type detection logic with various object types
+        let nsString = NSString(string: "test")
+        let array = [1, 2, 3]
+        let testObj = TestSourceObject()
+        let anotherTestObj = AnotherTestObject()
+        
+        // Test NSString (implementation can vary between OS versions)
+        let stringResult = VPNSubscriptionStatusPixel.sourceClass(from: nsString)
+        XCTAssertTrue(stringResult.contains("String"), "Expected string class name, got: \(stringResult)")
+        
+        // Test Array
+        let arrayResult = VPNSubscriptionStatusPixel.sourceClass(from: array)
+        XCTAssertEqual(arrayResult, "Array<Int>")
+        
+        // Test custom objects
+        let testObjResult = VPNSubscriptionStatusPixel.sourceClass(from: testObj)
+        XCTAssertEqual(testObjResult, "TestSourceObject")
+        
+        let anotherTestObjResult = VPNSubscriptionStatusPixel.sourceClass(from: anotherTestObj)
+        XCTAssertEqual(anotherTestObjResult, "AnotherTestObject")
+    }
+    
+    // MARK: - Error Tests
+    
+    func testError_alwaysNil() {
+        let pixels = [
+            VPNSubscriptionStatusPixel.signedIn(isSubscriptionActive: true, isAuthV2Enabled: true, sourceObject: nil),
+            VPNSubscriptionStatusPixel.signedOut(isSubscriptionActive: false, isAuthV2Enabled: false, sourceObject: nil),
+            VPNSubscriptionStatusPixel.vpnFeatureEnabled(isSubscriptionActive: true, isAuthV2Enabled: true, sourceObject: nil),
+            VPNSubscriptionStatusPixel.vpnFeatureDisabled(isSubscriptionActive: false, isAuthV2Enabled: false, sourceObject: nil)
+        ]
+        
+        for pixel in pixels {
+            XCTAssertNil(pixel.error, "Notification pixels should never have errors")
+        }
+    }
+    
+    // MARK: - Integration Tests
+    
+    func testFullPixelName_signedIn() {
+#if os(macOS)
+        let expectedPrefix = "m_mac_vpn_subs_notification_"
+#elseif os(iOS)
+        let expectedPrefix = "m_vpn_subs_notification_"
+#endif
+        
+        let pixel = VPNSubscriptionStatusPixel.signedIn(
+            isSubscriptionActive: true,
+            isAuthV2Enabled: true,
+            sourceObject: nil
+        )
+        
+        let fullName = pixel.namePrefix + pixel.name
+        XCTAssertEqual(fullName, expectedPrefix + "signed_in")
+    }
+    
+    func testFullPixelName_vpnFeatureDisabled() {
+#if os(macOS)
+        let expectedPrefix = "m_mac_vpn_subs_notification_"
+#elseif os(iOS)
+        let expectedPrefix = "m_vpn_subs_notification_"
+#endif
+        
+        let pixel = VPNSubscriptionStatusPixel.vpnFeatureDisabled(
+            isSubscriptionActive: false,
+            isAuthV2Enabled: false,
+            sourceObject: TestSourceObject()
+        )
+        
+        let fullName = pixel.namePrefix + pixel.name
+        XCTAssertEqual(fullName, expectedPrefix + "vpn_feature_disabled")
+    }
+    
+    // MARK: - Edge Cases and Comprehensive Testing
+    
+    func testParameters_allPixelTypesWithAllCombinations() {
+        let subscriptionStates: [Bool?] = [true, false, nil]
+        let authVersions: [Bool] = [true, false]
+        let sourceObjects: [Any?] = [nil, TestSourceObject(), NSString(string: "test")]
+        
+        let pixelFactories: [(Bool?, Bool, Any?) -> VPNSubscriptionStatusPixel] = [
+            VPNSubscriptionStatusPixel.signedIn,
+            VPNSubscriptionStatusPixel.signedOut,
+            VPNSubscriptionStatusPixel.vpnFeatureEnabled,
+            VPNSubscriptionStatusPixel.vpnFeatureDisabled
+        ]
+        
+        for factory in pixelFactories {
+            for subscriptionState in subscriptionStates {
+                for authV2 in authVersions {
+                    for sourceObject in sourceObjects {
+                        let pixel = factory(subscriptionState, authV2, sourceObject)
+                        
+                        // Verify parameters are always present
+                        let parameters = pixel.parameters
+                        XCTAssertNotNil(parameters, "Parameters should never be nil")
+                        XCTAssertNotNil(parameters?["isSubscriptionActive"], "isSubscriptionActive should always be present")
+                        XCTAssertNotNil(parameters?["authVersion"], "authVersion should always be present")
+                        XCTAssertNotNil(parameters?["notificationObjectClass"], "notificationObjectClass should always be present")
+                        
+                        // Verify specific values
+                        let expectedSubscriptionValue = subscriptionState != nil ? String(subscriptionState!) : "no_subscription"
+                        XCTAssertEqual(parameters?["isSubscriptionActive"], expectedSubscriptionValue)
+                        XCTAssertEqual(parameters?["authVersion"], authV2 ? "v2" : "v1")
+                        
+                        // Verify source object class
+                        if sourceObject == nil {
+                            XCTAssertEqual(parameters?["notificationObjectClass"], "nil")
+                        } else {
+                            XCTAssertNotEqual(parameters?["notificationObjectClass"], "nil")
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    func testSourceClass_customObject() {
+        // Test with a more complex custom object
+        struct CustomStruct {
+            let id: String = "test"
+        }
+        
+        let customStruct = CustomStruct()
+        let result = VPNSubscriptionStatusPixel.sourceClass(from: customStruct)
+        XCTAssertTrue(result.contains("CustomStruct"), "Should contain struct name")
+    }
+    
+    func testPixelConsistency_sameParametersAcrossPixelTypes() {
+        let sourceObject = TestSourceObject()
+        
+        let pixels = [
+            VPNSubscriptionStatusPixel.signedIn(isSubscriptionActive: true, isAuthV2Enabled: false, sourceObject: sourceObject),
+            VPNSubscriptionStatusPixel.signedOut(isSubscriptionActive: true, isAuthV2Enabled: false, sourceObject: sourceObject),
+            VPNSubscriptionStatusPixel.vpnFeatureEnabled(isSubscriptionActive: true, isAuthV2Enabled: false, sourceObject: sourceObject),
+            VPNSubscriptionStatusPixel.vpnFeatureDisabled(isSubscriptionActive: true, isAuthV2Enabled: false, sourceObject: sourceObject)
+        ]
+        
+        // All pixels should have the same parameter structure (keys and values) except for the pixel name
+        let firstPixelParams = pixels[0].parameters!
+        for pixel in pixels.dropFirst() {
+            let params = pixel.parameters!
+            XCTAssertEqual(params["isSubscriptionActive"], firstPixelParams["isSubscriptionActive"])
+            XCTAssertEqual(params["authVersion"], firstPixelParams["authVersion"])
+            XCTAssertEqual(params["notificationObjectClass"], firstPixelParams["notificationObjectClass"])
+        }
+    }
+} 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1807,37 +1807,8 @@ class MainViewController: UIViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 Logger.networkProtection.log("App foreground notification received, checking entitlements")
-                Task {
-                    guard let self else { return }
-
-                    do {
-                        let hasEntitlement = try await self.subscriptionManager.isFeatureEnabled(.networkProtection)
-                        let isAuthV2Enabled = AppDependencyProvider.shared.isUsingAuthV2
-                        let isSubscriptionActive = try? await self.subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
-
-                        if hasEntitlement && self.lastKnownEntitlementsExpired {
-                            PixelKit.fire(
-                                VPNSubscriptionClientCheckPixel.vpnFeatureEnabled(
-                                    isSubscriptionActive: isSubscriptionActive,
-                                    isAuthV2Enabled: isAuthV2Enabled,
-                                    trigger: .appForegrounded),
-                                frequency: .dailyAndCount)
-
-                            self.lastKnownEntitlementsExpired = false
-                        } else if !hasEntitlement && !self.lastKnownEntitlementsExpired {
-                            PixelKit.fire(
-                                VPNSubscriptionClientCheckPixel.vpnFeatureDisabled(
-                                    isSubscriptionActive: isSubscriptionActive,
-                                    isAuthV2Enabled: isAuthV2Enabled,
-                                    trigger: .appForegrounded),
-                                frequency: .dailyAndCount)
-
-                            self.lastKnownEntitlementsExpired = true
-                        }
-                    } catch {
-                        await self.handleClientCheckFailure(error: error, trigger: .appForegrounded)
-                    }
-                }
+                guard let self else { return }
+                self.performClientCheck(trigger: .appForegrounded)
             }
             .store(in: &vpnCancellables)
 
@@ -1953,6 +1924,38 @@ class MainViewController: UIViewController {
         AppDependencyProvider.shared.networkProtectionTunnelController
     }
 
+    private func performClientCheck(trigger: VPNSubscriptionClientCheckPixel.Trigger) {
+        Task {
+            do {
+                let isAuthV2Enabled = AppDependencyProvider.shared.isUsingAuthV2
+                let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
+                let hasEntitlement = try await subscriptionManager.isFeatureEnabled(.networkProtection)
+
+                if hasEntitlement && lastKnownEntitlementsExpired {
+                    PixelKit.fire(
+                        VPNSubscriptionClientCheckPixel.vpnFeatureEnabled(
+                            isSubscriptionActive: isSubscriptionActive,
+                            isAuthV2Enabled: isAuthV2Enabled,
+                            trigger: trigger),
+                        frequency: .dailyAndCount)
+                    
+                    lastKnownEntitlementsExpired = false
+                } else if !hasEntitlement && !lastKnownEntitlementsExpired {
+                    PixelKit.fire(
+                        VPNSubscriptionClientCheckPixel.vpnFeatureDisabled(
+                            isSubscriptionActive: isSubscriptionActive,
+                            isAuthV2Enabled: isAuthV2Enabled,
+                            trigger: trigger),
+                        frequency: .dailyAndCount)
+                    
+                    lastKnownEntitlementsExpired = true
+                }
+            } catch {
+                await handleClientCheckFailure(error: error, trigger: trigger)
+            }
+        }
+    }
+
     private func handleClientCheckFailure(error: Error, trigger: VPNSubscriptionClientCheckPixel.Trigger) async {
         let isAuthV2Enabled = AppDependencyProvider.shared.isUsingAuthV2
         let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
@@ -1967,35 +1970,7 @@ class MainViewController: UIViewController {
     }
 
     func checkSubscriptionEntitlements() {
-        Task {
-            do {
-                let isAuthV2Enabled = AppDependencyProvider.shared.isUsingAuthV2
-                let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
-                let hasEntitlement = try await subscriptionManager.isFeatureEnabled(.networkProtection)
-
-                if hasEntitlement && lastKnownEntitlementsExpired {
-                    PixelKit.fire(
-                        VPNSubscriptionClientCheckPixel.vpnFeatureEnabled(
-                            isSubscriptionActive: isSubscriptionActive,
-                            isAuthV2Enabled: isAuthV2Enabled,
-                            trigger: .appStartup),
-                        frequency: .dailyAndCount)
-                    
-                    lastKnownEntitlementsExpired = false
-                } else if !hasEntitlement && !lastKnownEntitlementsExpired {
-                    PixelKit.fire(
-                        VPNSubscriptionClientCheckPixel.vpnFeatureDisabled(
-                            isSubscriptionActive: isSubscriptionActive,
-                            isAuthV2Enabled: isAuthV2Enabled,
-                            trigger: .appStartup),
-                        frequency: .dailyAndCount)
-                    
-                    lastKnownEntitlementsExpired = true
-                }
-            } catch {
-                await handleClientCheckFailure(error: error, trigger: .appStartup)
-            }
-        }
+        performClientCheck(trigger: .appStartup)
     }
 
     @objc

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1810,30 +1810,32 @@ class MainViewController: UIViewController {
                 Task {
                     guard let self else { return }
 
-                    guard let hasEntitlement = try? await self.subscriptionManager.isFeatureEnabled(.networkProtection) else {
-                        return
-                    }
-                    let isAuthV2Enabled = AppDependencyProvider.shared.isUsingAuthV2
-                    let isSubscriptionActive = try? await self.subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
+                    do {
+                        let hasEntitlement = try await self.subscriptionManager.isFeatureEnabled(.networkProtection)
+                        let isAuthV2Enabled = AppDependencyProvider.shared.isUsingAuthV2
+                        let isSubscriptionActive = try? await self.subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
 
-                    if hasEntitlement && self.lastKnownEntitlementsExpired {
-                        PixelKit.fire(
-                            VPNSubscriptionStatusPixel.vpnFeatureEnabled(
-                                isSubscriptionActive: isSubscriptionActive,
-                                isAuthV2Enabled: isAuthV2Enabled,
-                                trigger: .clientForegrounded),
-                            frequency: .dailyAndCount)
+                        if hasEntitlement && self.lastKnownEntitlementsExpired {
+                            PixelKit.fire(
+                                VPNSubscriptionClientCheckPixel.vpnFeatureEnabled(
+                                    isSubscriptionActive: isSubscriptionActive,
+                                    isAuthV2Enabled: isAuthV2Enabled,
+                                    trigger: .appForegrounded),
+                                frequency: .dailyAndCount)
 
-                        self.lastKnownEntitlementsExpired = false
-                    } else if !hasEntitlement && !self.lastKnownEntitlementsExpired {
-                        PixelKit.fire(
-                            VPNSubscriptionStatusPixel.vpnFeatureDisabled(
-                                isSubscriptionActive: isSubscriptionActive,
-                                isAuthV2Enabled: isAuthV2Enabled,
-                                trigger: .clientForegrounded),
-                            frequency: .dailyAndCount)
+                            self.lastKnownEntitlementsExpired = false
+                        } else if !hasEntitlement && !self.lastKnownEntitlementsExpired {
+                            PixelKit.fire(
+                                VPNSubscriptionClientCheckPixel.vpnFeatureDisabled(
+                                    isSubscriptionActive: isSubscriptionActive,
+                                    isAuthV2Enabled: isAuthV2Enabled,
+                                    trigger: .appForegrounded),
+                                frequency: .dailyAndCount)
 
-                        self.lastKnownEntitlementsExpired = true
+                            self.lastKnownEntitlementsExpired = true
+                        }
+                    } catch {
+                        await self.handleClientCheckFailure(error: error, trigger: .appForegrounded)
                     }
                 }
             }
@@ -1940,7 +1942,7 @@ class MainViewController: UIViewController {
                 VPNSubscriptionStatusPixel.signedIn(
                     isSubscriptionActive: isSubscriptionActive,
                     isAuthV2Enabled: isAuthV2Enabled,
-                    trigger: .notification(sourceObject: notification.object)),
+                    sourceObject: notification.object),
                 frequency: .dailyAndCount)
             tunnelDefaults.resetEntitlementMessaging()
             Logger.networkProtection.info("[NetP Subscription] Reset expired entitlement messaging")
@@ -1951,32 +1953,47 @@ class MainViewController: UIViewController {
         AppDependencyProvider.shared.networkProtectionTunnelController
     }
 
+    private func handleClientCheckFailure(error: Error, trigger: VPNSubscriptionClientCheckPixel.Trigger) async {
+        let isAuthV2Enabled = AppDependencyProvider.shared.isUsingAuthV2
+        let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
+        
+        PixelKit.fire(
+            VPNSubscriptionClientCheckPixel.failed(
+                isSubscriptionActive: isSubscriptionActive,
+                isAuthV2Enabled: isAuthV2Enabled,
+                trigger: trigger,
+                error: error),
+            frequency: .dailyAndCount)
+    }
+
     func checkSubscriptionEntitlements() {
         Task {
-            let isAuthV2Enabled = AppDependencyProvider.shared.isUsingAuthV2
-            let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
-            guard let hasEntitlement = try? await subscriptionManager.isFeatureEnabled(.networkProtection) else {
-                return
-            }
+            do {
+                let isAuthV2Enabled = AppDependencyProvider.shared.isUsingAuthV2
+                let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
+                let hasEntitlement = try await subscriptionManager.isFeatureEnabled(.networkProtection)
 
-            if hasEntitlement && lastKnownEntitlementsExpired {
-                PixelKit.fire(
-                    VPNSubscriptionStatusPixel.vpnFeatureEnabled(
-                        isSubscriptionActive: isSubscriptionActive,
-                        isAuthV2Enabled: isAuthV2Enabled,
-                        trigger: .clientCheck),
-                    frequency: .dailyAndCount)
-                
-                lastKnownEntitlementsExpired = false
-            } else if !hasEntitlement && !lastKnownEntitlementsExpired {
-                PixelKit.fire(
-                    VPNSubscriptionStatusPixel.vpnFeatureDisabled(
-                        isSubscriptionActive: isSubscriptionActive,
-                        isAuthV2Enabled: isAuthV2Enabled,
-                        trigger: .clientCheck),
-                    frequency: .dailyAndCount)
-                
-                lastKnownEntitlementsExpired = true
+                if hasEntitlement && lastKnownEntitlementsExpired {
+                    PixelKit.fire(
+                        VPNSubscriptionClientCheckPixel.vpnFeatureEnabled(
+                            isSubscriptionActive: isSubscriptionActive,
+                            isAuthV2Enabled: isAuthV2Enabled,
+                            trigger: .appStartup),
+                        frequency: .dailyAndCount)
+                    
+                    lastKnownEntitlementsExpired = false
+                } else if !hasEntitlement && !lastKnownEntitlementsExpired {
+                    PixelKit.fire(
+                        VPNSubscriptionClientCheckPixel.vpnFeatureDisabled(
+                            isSubscriptionActive: isSubscriptionActive,
+                            isAuthV2Enabled: isAuthV2Enabled,
+                            trigger: .appStartup),
+                        frequency: .dailyAndCount)
+                    
+                    lastKnownEntitlementsExpired = true
+                }
+            } catch {
+                await handleClientCheckFailure(error: error, trigger: .appStartup)
             }
         }
     }
@@ -1999,7 +2016,7 @@ class MainViewController: UIViewController {
                     VPNSubscriptionStatusPixel.vpnFeatureEnabled(
                         isSubscriptionActive: isSubscriptionActive,
                         isAuthV2Enabled: isAuthV2Enabled,
-                        trigger: .notification(sourceObject: notification.object)),
+                        sourceObject: notification.object),
                     frequency: .dailyAndCount)
 
                 if lastKnownEntitlementsExpired {
@@ -2012,7 +2029,7 @@ class MainViewController: UIViewController {
                     VPNSubscriptionStatusPixel.vpnFeatureDisabled(
                         isSubscriptionActive: isSubscriptionActive,
                         isAuthV2Enabled: isAuthV2Enabled,
-                        trigger: .notification(sourceObject: notification.object)),
+                        sourceObject: notification.object),
                     frequency: .dailyAndCount)
 
                 if !lastKnownEntitlementsExpired {
@@ -2040,7 +2057,7 @@ class MainViewController: UIViewController {
                 VPNSubscriptionStatusPixel.signedOut(
                     isSubscriptionActive: isSubscriptionActive,
                     isAuthV2Enabled: isAuthV2Enabled,
-                    trigger: .notification(sourceObject: notification.object)),
+                    sourceObject: notification.object),
                 frequency: .dailyAndCount)
 
             await networkProtectionTunnelController.stop()

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/VPNSubscriptionEventsHandler.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/VPNSubscriptionEventsHandler.swift
@@ -59,10 +59,7 @@ final class VPNSubscriptionEventsHandler {
     }
 
     private func checkEntitlements() {
-        Task {
-            let hasEntitlement = try await subscriptionManager.isFeatureEnabled(.networkProtection)
-            await handleEntitlementsChange(hasEntitlements: hasEntitlement, trigger: .clientCheck)
-        }
+        performClientCheck(trigger: .appStartup)
     }
 
     private func subscribeToWakeNotifications() {
@@ -71,11 +68,7 @@ final class VPNSubscriptionEventsHandler {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 Logger.networkProtection.log("System wake notification received, checking entitlements")
-                Task { [weak self] in
-                    if let hasEntitlement = try? await self?.subscriptionManager.isFeatureEnabled(.networkProtection) {
-                        await self?.handleEntitlementsChange(hasEntitlements: hasEntitlement, trigger: .clientCheckOnWake)
-                    }
-                }
+                self?.performClientCheck(trigger: .deviceWake)
             }
             .store(in: &cancellables)
     }
@@ -97,71 +90,97 @@ final class VPNSubscriptionEventsHandler {
                     }
 
                     let hasEntitlements = payload.entitlements.contains(.networkProtection)
-                    await self.handleEntitlementsChange(hasEntitlements: hasEntitlements, trigger: .notification(sourceObject: notification.object))
+                    await self.handleEntitlementsChangeNotification(hasEntitlements: hasEntitlements, sourceObject: notification.object)
                 }
             }
             .store(in: &cancellables)
     }
 
+    private func performClientCheck(trigger: VPNSubscriptionClientCheckPixel.Trigger) {
+        Task {
+            do {
+                let hasEntitlement = try await subscriptionManager.isFeatureEnabled(.networkProtection)
+                await handleEntitlementsChangeClientCheck(hasEntitlements: hasEntitlement, trigger: trigger)
+            } catch {
+                await handleClientCheckFailure(error: error, trigger: trigger)
+            }
+        }
+    }
+
     @MainActor
-    private func handleEntitlementsChange(hasEntitlements: Bool, trigger: VPNSubscriptionStatusPixel.Trigger) async {
+    private func handleClientCheckFailure(error: Error, trigger: VPNSubscriptionClientCheckPixel.Trigger) async {
         let isAuthV2Enabled = NSApp.delegateTyped.isUsingAuthV2
         let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
 
-        // For trigger == .clientCheck we only fire pixels if there's an actual change, because they're not guaranteed
-        // to be executed only when there are changes - they'll run at every app launch.
-        //
-        // For trigger == .notification we assume the notifications are fired on actual changes, so we want to fire
-        // pixels without additional checks.
-        //
-        switch trigger {
-        case .clientCheck, .clientCheckOnWake:
-            if hasEntitlements && lastKnownEntitlementsExpired {
-                PixelKit.fire(
-                    VPNSubscriptionStatusPixel.vpnFeatureEnabled(
-                        isSubscriptionActive: isSubscriptionActive,
-                        isAuthV2Enabled: isAuthV2Enabled,
-                        trigger: trigger),
-                    frequency: .dailyAndCount)
+        PixelKit.fire(
+            VPNSubscriptionClientCheckPixel.failed(
+                isSubscriptionActive: isSubscriptionActive,
+                isAuthV2Enabled: isAuthV2Enabled,
+                trigger: trigger,
+                error: error),
+            frequency: .dailyAndCount)
+    }
 
+    @MainActor
+    private func handleEntitlementsChangeClientCheck(hasEntitlements: Bool, trigger: VPNSubscriptionClientCheckPixel.Trigger) async {
+        let isAuthV2Enabled = NSApp.delegateTyped.isUsingAuthV2
+        let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
+
+        // For client checks we only fire pixels if there's an actual change, because they're not guaranteed
+        // to be executed only when there are changes - they'll run at every app launch.
+        if hasEntitlements && lastKnownEntitlementsExpired {
+            PixelKit.fire(
+                VPNSubscriptionClientCheckPixel.vpnFeatureEnabled(
+                    isSubscriptionActive: isSubscriptionActive,
+                    isAuthV2Enabled: isAuthV2Enabled,
+                    trigger: trigger),
+                frequency: .dailyAndCount)
+
+            /// This is a shared user default that the VPN menu app listens to to know whether it's enabled or disabled
+            lastKnownEntitlementsExpired = false
+        } else if !hasEntitlements && !lastKnownEntitlementsExpired {
+            PixelKit.fire(
+                VPNSubscriptionClientCheckPixel.vpnFeatureDisabled(
+                    isSubscriptionActive: isSubscriptionActive,
+                    isAuthV2Enabled: isAuthV2Enabled,
+                    trigger: trigger),
+                frequency: .dailyAndCount)
+
+            /// This is a shared user default that the VPN menu app listens to to know whether it's enabled or disabled
+            lastKnownEntitlementsExpired = true
+        }
+    }
+
+    @MainActor
+    private func handleEntitlementsChangeNotification(hasEntitlements: Bool, sourceObject: Any?) async {
+        let isAuthV2Enabled = NSApp.delegateTyped.isUsingAuthV2
+        let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
+
+        // For notifications we assume they are fired on actual changes, so we want to fire
+        // pixels without additional checks.
+        if hasEntitlements {
+            PixelKit.fire(
+                VPNSubscriptionStatusPixel.vpnFeatureEnabled(
+                    isSubscriptionActive: isSubscriptionActive,
+                    isAuthV2Enabled: isAuthV2Enabled,
+                    sourceObject: sourceObject),
+                frequency: .dailyAndCount)
+
+            if lastKnownEntitlementsExpired {
                 /// This is a shared user default that the VPN menu app listens to to know whether it's enabled or disabled
                 lastKnownEntitlementsExpired = false
-            } else if !hasEntitlements && !lastKnownEntitlementsExpired {
-                PixelKit.fire(
-                    VPNSubscriptionStatusPixel.vpnFeatureDisabled(
-                        isSubscriptionActive: isSubscriptionActive,
-                        isAuthV2Enabled: isAuthV2Enabled,
-                        trigger: trigger),
-                    frequency: .dailyAndCount)
+            }
+        } else {
+            PixelKit.fire(
+                VPNSubscriptionStatusPixel.vpnFeatureDisabled(
+                    isSubscriptionActive: isSubscriptionActive,
+                    isAuthV2Enabled: isAuthV2Enabled,
+                    sourceObject: sourceObject),
+                frequency: .dailyAndCount)
 
+            if !lastKnownEntitlementsExpired {
                 /// This is a shared user default that the VPN menu app listens to to know whether it's enabled or disabled
                 lastKnownEntitlementsExpired = true
-            }
-        case .notification:
-            if hasEntitlements {
-                PixelKit.fire(
-                    VPNSubscriptionStatusPixel.vpnFeatureEnabled(
-                        isSubscriptionActive: isSubscriptionActive,
-                        isAuthV2Enabled: isAuthV2Enabled,
-                        trigger: trigger),
-                    frequency: .dailyAndCount)
-
-                if lastKnownEntitlementsExpired {
-                    /// This is a shared user default that the VPN menu app listens to to know whether it's enabled or disabled
-                    lastKnownEntitlementsExpired = false
-                }
-            } else {
-                PixelKit.fire(
-                    VPNSubscriptionStatusPixel.vpnFeatureDisabled(
-                        isSubscriptionActive: isSubscriptionActive,
-                        isAuthV2Enabled: isAuthV2Enabled,
-                        trigger: trigger),
-                    frequency: .dailyAndCount)
-
-                if !lastKnownEntitlementsExpired {
-                    /// This is a shared user default that the VPN menu app listens to to know whether it's enabled or disabled
-                    lastKnownEntitlementsExpired = true
-                }
             }
         }
     }
@@ -196,7 +215,7 @@ final class VPNSubscriptionEventsHandler {
                 VPNSubscriptionStatusPixel.signedIn(
                     isSubscriptionActive: isSubscriptionActive,
                     isAuthV2Enabled: isAuthV2Enabled,
-                    trigger: .notification(sourceObject: notification.object)),
+                    sourceObject: notification.object),
                 frequency: .dailyAndCount)
 
             /// This is a shared user default that the VPN menu app listens to to know whether it's enabled or disabled
@@ -215,7 +234,7 @@ final class VPNSubscriptionEventsHandler {
                 VPNSubscriptionStatusPixel.signedOut(
                     isSubscriptionActive: isSubscriptionActive,
                     isAuthV2Enabled: isAuthV2Enabled,
-                    trigger: .notification(sourceObject: notification.object)),
+                    sourceObject: notification.object),
                 frequency: .dailyAndCount)
 
             try? await vpnUninstaller.uninstall(removeSystemExtension: false, showNotification: true)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL:
Tech Design URL:
CC:

## Description

This PR splits `VPNSubscriptionStatusPixel` into two focused classes: `VPNSubscriptionClientCheckPixel` for app-initiated entitlement checks (startup, wake/foreground) and `VPNSubscriptionStatusPixel` for subscription service notifications. The new client check class adds a failed case to track operational issues like network failures during startup. This separation improves maintainability, enables better debugging of client check failures, and unifies iOS implementation to eliminate code duplication. All existing pixel names are preserved for backward compatibility.

## Testing

### Test Client Check Failures
- Easiest approach: Temporarily throw an error in subscriptionManager.isFeatureEnabled(.networkProtection)
- macOS: Check for `m_mac_vpn_subs_client_check_failed` and `m_mac_vpn_subs_client_check_on_wake_failed`
- iOS: Check for `m_vpn_subs_client_check_failed` and `m_vpn_subs_client_check_on_foreground_failed`

### Impact and Risks

Low

#### What could go wrong?

There could be an unintentional change in the logic.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)