### PR TITLE
Add macOS alpha release workflow

### DIFF
--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -61,7 +61,6 @@ jobs:
     with:
       release-type: alpha
       create-dmg: true
-      branch: ${{ inputs.branch }}
       build-number-override: ${{ needs.calculate-alpha-build-number.outputs.build-number }}
       skip-notify: true
     secrets:
@@ -87,7 +86,6 @@ jobs:
     uses: ./.github/workflows/macos_build_appstore.yml
     with:
       destination: testflight_alpha
-      branch: ${{ inputs.branch }}
       build-number-override: ${{ needs.calculate-alpha-build-number.outputs.build-number }}
       skip-notify: true
     secrets:

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -138,7 +138,6 @@ jobs:
           curl -fLSs -O "${{ env.APPCAST_URL }}"
           curl -fLSs -O "${{ env.DMG_URL }}"
           echo "dmg-name=$(basename "${{ env.DMG_URL }}")" >> $GITHUB_OUTPUT
-          echo "dmg-path=$DMG_NAME" >> $GITHUB_OUTPUT
 
       - name: Add release notes
         id: add-release-notes
@@ -152,7 +151,6 @@ jobs:
         id: appcast
         working-directory: sparkle
         env:
-          DMG_PATH: ${{ steps.fetch-dmg.outputs.dmg-path }}
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
           echo "$SPARKLE_PRIVATE_KEY" | generate_appcast --ed-key-file - \

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -149,6 +149,7 @@ jobs:
 
       - name: Upload to S3
         id: upload
+        working-directory: sparkle
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_RELEASE_S3 }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_RELEASE_S3 }}

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -144,7 +144,7 @@ jobs:
           DMG_PATH: ${{ steps.fetch-dmg.outputs.dmg-path }}
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
-          echo "$SPARKLE_PRIVATE_KEY" | ./generate_appcast --ed-key-file - .
+          echo "$SPARKLE_PRIVATE_KEY" | generate_appcast --ed-key-file - .
           mv -f appcast.xml appcast-alpha.xml
 
       - name: Upload to S3

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -1,0 +1,126 @@
+name: macOS - Prepare Alpha Release
+
+defaults:
+  run:
+    working-directory: macOS
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip-appstore:
+        description: "Skip App Store release and only make a DMG build"
+        default: false
+        type: boolean
+  workflow_call:
+    inputs:
+      branch:
+        description: "Branch name"
+        required: false
+        type: string
+      skip-appstore:
+        description: "Skip App Store release and only make a DMG build"
+        default: false
+        type: boolean
+    secrets:
+      APPLE_API_KEY_BASE64:
+        required: true
+      APPLE_API_KEY_ID:
+        required: true
+      APPLE_API_KEY_ISSUER:
+        required: true
+      ASANA_ACCESS_TOKEN:
+        required: true
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_ACCESS_KEY_ID_RELEASE_S3:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      AWS_SECRET_ACCESS_KEY_RELEASE_S3:
+        required: true
+      MATCH_PASSWORD:
+        required: true
+      MM_WEBHOOK_URL:
+        required: true
+      SSH_PRIVATE_KEY_FASTLANE_MATCH:
+        required: true
+
+jobs:
+
+  calcaulate-alpha-build-number:
+    name: Calculate Alpha Build Number
+    runs-on: macos-latest
+
+    outputs:
+      build-number: ${{ steps.build-number.outputs.next_build_number }}
+
+    steps:
+    - name: Check out the code
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Setup Ruby and dependencies
+      uses: ./.github/actions/setup-ruby
+      with:
+        working-directory: macOS
+        cache-key-prefix: macos-ruby
+
+    - name: Calculate Alpha Build Number
+      id: build-number
+      env:
+        APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+        APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+        APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
+      run: |
+        bundle exec fastlane calculate_next_build_number \
+          platform:macos \
+          config:alpha \
+          bundle_id:com.duckduckgo.mobile.ios.alpha
+
+  dmg-release:
+    name: Prepare DMG Release
+
+    needs: calcaulate-alpha-build-number
+
+    uses: ./.github/workflows/macos_build_notarized.yml
+    with:
+      release-type: release
+      create-dmg: true
+      branch: ${{ inputs.branch }}
+      override-build-number: ${{ needs.calcaulate-alpha-build-number.outputs.build-number }}
+    secrets:
+      APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+      APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
+      ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_ACCESS_KEY_ID_RELEASE_S3: ${{ secrets.AWS_ACCESS_KEY_ID_RELEASE_S3 }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY_RELEASE_S3: ${{ secrets.AWS_SECRET_ACCESS_KEY_RELEASE_S3 }}
+      MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+      MM_WEBHOOK_URL: ${{ secrets.MM_WEBHOOK_URL }}
+      SSH_PRIVATE_KEY_FASTLANE_MATCH: ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
+
+  appstore-release:
+    name: Prepare AppStore Release
+
+    needs: calcaulate-alpha-build-number
+
+    if: inputs.skip-appstore != 'true'
+
+    uses: ./.github/workflows/macos_build_appstore.yml
+    with:
+      destination: testflight_alpha
+      branch: ${{ inputs.branch }}
+      override-build-number: ${{ needs.calcaulate-alpha-build-number.outputs.build-number }}
+    secrets:
+      SSH_PRIVATE_KEY_FASTLANE_MATCH: ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
+      APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+      APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
+      MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+      ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+      MM_WEBHOOK_URL: ${{ secrets.MM_WEBHOOK_URL }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -5,9 +5,10 @@ defaults:
     working-directory: macOS
 
 on:
-  push:
-    branches:
-      - main
+  # To be enabled later
+  # push:
+  #   branches:
+  #     - main
   workflow_dispatch:
     inputs:
       skip-appstore:

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -145,7 +145,7 @@ jobs:
         env:
           DMG_NAME: ${{ steps.fetch-dmg.outputs.dmg-name }}
         run: |
-          echo <<EOF > ${DMG_NAME}.html
+          echo <<EOF > ${DMG_NAME/dmg/html}
           Alpha release built from <a href="https://github.com/duckduckgo/apple-browsers/commits/main/?since=${{ github.sha }}">commit ${{ github.sha }}</a>.
           EOF
 

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
 
-  calcaulate-alpha-build-number:
+  calculate-alpha-build-number:
     name: Calculate Alpha Build Number
     runs-on: macos-15
 
@@ -55,14 +55,14 @@ jobs:
   dmg-release:
     name: Prepare DMG Release
 
-    needs: calcaulate-alpha-build-number
+    needs: calculate-alpha-build-number
 
     uses: ./.github/workflows/macos_build_notarized.yml
     with:
       release-type: alpha
       create-dmg: true
       branch: ${{ inputs.branch }}
-      override-build-number: ${{ needs.calcaulate-alpha-build-number.outputs.build-number }}
+      override-build-number: ${{ needs.calculate-alpha-build-number.outputs.build-number }}
     secrets:
       APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
       APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
@@ -79,7 +79,7 @@ jobs:
   appstore-release:
     name: Prepare AppStore Release
 
-    needs: calcaulate-alpha-build-number
+    needs: calculate-alpha-build-number
 
     if: inputs.skip-appstore != 'true'
 
@@ -87,7 +87,7 @@ jobs:
     with:
       destination: testflight_alpha
       branch: ${{ inputs.branch }}
-      override-build-number: ${{ needs.calcaulate-alpha-build-number.outputs.build-number }}
+      override-build-number: ${{ needs.calculate-alpha-build-number.outputs.build-number }}
     secrets:
       SSH_PRIVATE_KEY_FASTLANE_MATCH: ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
       APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -137,15 +137,23 @@ jobs:
           echo "dmg-name=$(basename "${{ env.DMG_URL }}")" >> $GITHUB_OUTPUT
           echo "dmg-path=$DMG_NAME" >> $GITHUB_OUTPUT
 
+      - name: Add release notes
+        id: add-release-notes
+        working-directory: sparkle
+        env:
+          DMG_NAME: ${{ steps.fetch-dmg.outputs.dmg-name }}
+        run: |
+          echo <<EOF > ${DMG_NAME}.html
+          Alpha release built from <a href="https://github.com/duckduckgo/apple-browsers/commits/main/?since=${{ github.sha }}">commit ${{ github.sha }}</a>.
+          EOF
+
       - name: Generate appcast
         id: appcast
         working-directory: sparkle
         env:
           DMG_PATH: ${{ steps.fetch-dmg.outputs.dmg-path }}
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-        run: |
-          echo "$SPARKLE_PRIVATE_KEY" | generate_appcast --ed-key-file - .
-          mv -f appcast.xml appcast-alpha.xml
+        run: echo "$SPARKLE_PRIVATE_KEY" | generate_appcast --ed-key-file - -o appcast-alpha.xml .
 
       - name: Upload to S3
         id: upload

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -146,9 +146,7 @@ jobs:
         env:
           DMG_NAME: ${{ steps.fetch-dmg.outputs.dmg-name }}
         run: |
-          echo <<EOF > ${DMG_NAME/dmg/html}
-          Alpha release built from <a href="https://github.com/duckduckgo/apple-browsers/commits/main/?since=${{ github.sha }}">commit ${{ github.sha }}</a>.
-          EOF
+          echo "Alpha release built from <a href=\"${{ github.server_url }}/${{ github.repository }}/commits/main/?since=${{ github.sha }}\">commit ${{ github.sha }}</a>." > ${DMG_NAME/dmg/html}
 
       - name: Generate appcast
         id: appcast

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -14,45 +14,12 @@ on:
         description: "Skip App Store release and only make a DMG build"
         default: false
         type: boolean
-  workflow_call:
-    inputs:
-      branch:
-        description: "Branch name"
-        required: false
-        type: string
-      skip-appstore:
-        description: "Skip App Store release and only make a DMG build"
-        default: false
-        type: boolean
-    secrets:
-      APPLE_API_KEY_BASE64:
-        required: true
-      APPLE_API_KEY_ID:
-        required: true
-      APPLE_API_KEY_ISSUER:
-        required: true
-      ASANA_ACCESS_TOKEN:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_ACCESS_KEY_ID_RELEASE_S3:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      AWS_SECRET_ACCESS_KEY_RELEASE_S3:
-        required: true
-      MATCH_PASSWORD:
-        required: true
-      MM_WEBHOOK_URL:
-        required: true
-      SSH_PRIVATE_KEY_FASTLANE_MATCH:
-        required: true
 
 jobs:
 
   calcaulate-alpha-build-number:
     name: Calculate Alpha Build Number
-    runs-on: macos-latest
+    runs-on: macos-15
 
     outputs:
       build-number: ${{ steps.build-number.outputs.next_build_number }}
@@ -130,3 +97,65 @@ jobs:
       MM_WEBHOOK_URL: ${{ secrets.MM_WEBHOOK_URL }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  publish-alpha-dmg:
+    name: Publish Alpha DMG
+
+    needs: dmg-release
+
+    runs-on: macos-15
+
+    defaults:
+      run:
+        working-directory: .
+
+    steps:
+      - name: Download DMG URL artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dmg_url
+
+      - name: Set DMG URL variable
+        id: set-dmg-url
+        run: echo "DMG_URL=$(<${{ github.workspace }}/dmg_url.txt)" >> $GITHUB_OUTPUT
+
+      - name: Set up Sparkle tools
+        env:
+          SPARKLE_URL: https://github.com/sparkle-project/Sparkle/releases/download/${{ vars.SPARKLE_VERSION }}/Sparkle-${{ vars.SPARKLE_VERSION }}.tar.xz
+        run: |
+          curl -fLSs $SPARKLE_URL | tar xJ bin
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+          mkdir -p sparkle
+
+      - name: Fetch DMG
+        id: fetch-dmg
+        working-directory: sparkle
+        env:
+          DMG_URL: ${{ steps.set-dmg-url.outputs.DMG_URL }}
+        run: |
+          curl -fLSs -O "${{ env.DMG_URL }}"
+          echo "dmg-name=$(basename "${{ env.DMG_URL }}")" >> $GITHUB_OUTPUT
+          echo "dmg-path=$DMG_NAME" >> $GITHUB_OUTPUT
+
+      - name: Generate appcast
+        id: appcast
+        working-directory: sparkle
+        env:
+          DMG_PATH: ${{ steps.fetch-dmg.outputs.dmg-path }}
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          echo "$SPARKLE_PRIVATE_KEY" | ./generate_appcast --ed-key-file - .
+          mv -f appcast.xml appcast-alpha.xml
+
+      - name: Upload to S3
+        id: upload
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_RELEASE_S3 }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_RELEASE_S3 }}
+          AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
+          DMG_NAME: ${{ steps.fetch-dmg.outputs.dmg-name }}
+        run: |
+          s3_path="s3://${{ vars.RELEASE_BUCKET_NAME }}/${{ vars.RELEASE_BUCKET_PREFIX }}/alpha"
+          aws s3 cp appcast-alpha.xml "$s3_path" --acl public-read
+          aws s3 cp "$DMG_NAME" "$s3_path" --acl public-read
+          aws s3 cp "$DMG_NAME" "${s3_path}/duckduckgo-alpha.dmg" --acl public-read

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -63,6 +63,7 @@ jobs:
       create-dmg: true
       branch: ${{ inputs.branch }}
       build-number-override: ${{ needs.calculate-alpha-build-number.outputs.build-number }}
+      skip-notify: true
     secrets:
       APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
       APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
@@ -88,6 +89,7 @@ jobs:
       destination: testflight_alpha
       branch: ${{ inputs.branch }}
       build-number-override: ${{ needs.calculate-alpha-build-number.outputs.build-number }}
+      skip-notify: true
     secrets:
       SSH_PRIVATE_KEY_FASTLANE_MATCH: ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
       APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
@@ -145,7 +147,7 @@ jobs:
         env:
           DMG_NAME: ${{ steps.fetch-dmg.outputs.dmg-name }}
         run: |
-          echo "Alpha release built from <a href=\"${{ github.server_url }}/${{ github.repository }}/commits/main/?since=${{ github.sha }}\">commit ${{ github.sha }}</a>." > ${DMG_NAME/dmg/html}
+          echo "<h3>What's new</h3><ul><li>Alpha release built from <a href=\"${{ github.server_url }}/${{ github.repository }}/commits/main/?since=${{ github.sha }}\">commit ${{ github.sha }}</a>.</li></ul>" > ${DMG_NAME/dmg/html}
 
       - name: Generate appcast
         id: appcast

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -5,6 +5,7 @@ defaults:
     working-directory: macOS
 
 on:
+  push:
   workflow_dispatch:
     inputs:
       skip-appstore:

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -62,7 +62,7 @@ jobs:
       release-type: alpha
       create-dmg: true
       branch: ${{ inputs.branch }}
-      override-build-number: ${{ needs.calculate-alpha-build-number.outputs.build-number }}
+      build-number-override: ${{ needs.calculate-alpha-build-number.outputs.build-number }}
     secrets:
       APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
       APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
@@ -87,7 +87,7 @@ jobs:
     with:
       destination: testflight_alpha
       branch: ${{ inputs.branch }}
-      override-build-number: ${{ needs.calculate-alpha-build-number.outputs.build-number }}
+      build-number-override: ${{ needs.calculate-alpha-build-number.outputs.build-number }}
     secrets:
       SSH_PRIVATE_KEY_FASTLANE_MATCH: ${{ secrets.SSH_PRIVATE_KEY_FASTLANE_MATCH }}
       APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -127,12 +127,14 @@ jobs:
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
           mkdir -p sparkle
 
-      - name: Fetch DMG
+      - name: Fetch DMG and current appcast
         id: fetch-dmg
         working-directory: sparkle
         env:
+          APPCAST_URL: ${{ vars.DMG_URL_ROOT }}alpha/appcast-alpha.xml
           DMG_URL: ${{ steps.set-dmg-url.outputs.DMG_URL }}
         run: |
+          curl -fLSs -O "${{ env.APPCAST_URL }}"
           curl -fLSs -O "${{ env.DMG_URL }}"
           echo "dmg-name=$(basename "${{ env.DMG_URL }}")" >> $GITHUB_OUTPUT
           echo "dmg-path=$DMG_NAME" >> $GITHUB_OUTPUT
@@ -153,7 +155,11 @@ jobs:
         env:
           DMG_PATH: ${{ steps.fetch-dmg.outputs.dmg-path }}
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-        run: echo "$SPARKLE_PRIVATE_KEY" | generate_appcast --ed-key-file - -o appcast-alpha.xml .
+        run: |
+          echo "$SPARKLE_PRIVATE_KEY" | generate_appcast --ed-key-file - \
+            -o appcast-alpha.xml \
+            --embed-release-notes \
+            .
 
       - name: Upload to S3
         id: upload

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -157,6 +157,6 @@ jobs:
           DMG_NAME: ${{ steps.fetch-dmg.outputs.dmg-name }}
         run: |
           s3_path="s3://${{ vars.RELEASE_BUCKET_NAME }}/${{ vars.RELEASE_BUCKET_PREFIX }}/alpha"
-          aws s3 cp appcast-alpha.xml "$s3_path" --acl public-read
-          aws s3 cp "$DMG_NAME" "$s3_path" --acl public-read
+          aws s3 cp appcast-alpha.xml "${s3_path}/appcast-alpha.xml" --acl public-read
+          aws s3 cp "$DMG_NAME" "${s3_path}/${DMG_NAME}" --acl public-read
           aws s3 cp "$DMG_NAME" "${s3_path}/duckduckgo-alpha.dmg" --acl public-read

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -81,6 +81,9 @@ jobs:
           config:alpha \
           bundle_id:com.duckduckgo.mobile.ios.alpha
 
+    - name: Report build number
+      run: echo "::notice::Using build number ${{ steps.build-number.outputs.next_build_number }}"
+
   dmg-release:
     name: Prepare DMG Release
 

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -88,7 +88,7 @@ jobs:
 
     uses: ./.github/workflows/macos_build_notarized.yml
     with:
-      release-type: release
+      release-type: alpha
       create-dmg: true
       branch: ${{ inputs.branch }}
       override-build-number: ${{ needs.calcaulate-alpha-build-number.outputs.build-number }}

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -6,6 +6,8 @@ defaults:
 
 on:
   push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       skip-appstore:

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -145,7 +145,7 @@ jobs:
         env:
           DMG_NAME: ${{ steps.fetch-dmg.outputs.dmg-name }}
         run: |
-          echo "<h3>What's new</h3><ul><li>Alpha release built from <a href=\"${{ github.server_url }}/${{ github.repository }}/commits/main/?since=${{ github.sha }}\">commit ${{ github.sha }}</a>.</li></ul>" > ${DMG_NAME/dmg/html}
+          echo "<h3>What's new</h3><ul><li>Alpha releases are built from the main branch after every commit.</li></ul>" > ${DMG_NAME/dmg/html}
 
       - name: Generate appcast
         id: appcast

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -76,7 +76,7 @@ jobs:
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
       run: |
-        bundle exec fastlane calculate_next_build_number \
+        bundle exec fastlane run calculate_next_build_number \
           platform:macos \
           config:alpha \
           bundle_id:com.duckduckgo.mobile.ios.alpha

--- a/.github/workflows/macos_build_appstore.yml
+++ b/.github/workflows/macos_build_appstore.yml
@@ -40,6 +40,11 @@ on:
         description: "Override build number (for Alpha builds)"
         required: false
         type: string
+      skip-notify:
+        description: "Skip Mattermost notification"
+        required: false
+        default: false
+        type: boolean
     secrets:
       SSH_PRIVATE_KEY_FASTLANE_MATCH:
         required: true
@@ -190,7 +195,9 @@ jobs:
         DESTINATION: ${{ env.destination }}
         PLATFORM: macOS
       run: |
-        bundle exec fastlane run mattermost_send_message \
-          mattermost_webhook_url:${{ secrets.MM_WEBHOOK_URL }} \
-          github_handle:${{ github.actor }} \
-          template_name:$([[ "${{ job.status }}" == "success" ]] && echo "public-release-complete" || echo "public-release-failed")
+        if [[ "${{ inputs.skip-notify }}" == "false" ]]; then
+          bundle exec fastlane run mattermost_send_message \
+            mattermost_webhook_url:${{ secrets.MM_WEBHOOK_URL }} \
+            github_handle:${{ github.actor }} \
+            template_name:$([[ "${{ job.status }}" == "success" ]] && echo "public-release-complete" || echo "public-release-failed")
+        fi

--- a/.github/workflows/macos_build_appstore.yml
+++ b/.github/workflows/macos_build_appstore.yml
@@ -118,7 +118,7 @@ jobs:
       if: ${{ env.destination == 'testflight_alpha' && inputs.override-build-number != '' }}
       run: |
         echo "Overriding build number to ${{ inputs.override-build-number }}"
-        echo "CURRENT_PROJECT_VERSION = ${{ inputs.override-build-number }}" >> Configuration/BuildNumber.xcconfig
+        echo "CURRENT_PROJECT_VERSION = ${{ inputs.override-build-number }}" > Configuration/BuildNumber.xcconfig
 
     - name: Archive and Upload the App
       env:

--- a/.github/workflows/macos_build_appstore.yml
+++ b/.github/workflows/macos_build_appstore.yml
@@ -30,10 +30,14 @@ on:
         type: string
       asana-task-url:
         description: "Asana release task URL"
-        required: true
+        required: false
         type: string
       branch:
         description: "Branch name"
+        required: false
+        type: string
+      override-build-number:
+        description: "Override build number (for Alpha builds)"
         required: false
         type: string
     secrets:
@@ -101,7 +105,7 @@ jobs:
       env:
         is-official-release: ${{ (env.destination == 'appstore' || env.destination == 'testflight') && (startsWith(env.branch, 'release') || startsWith(env.branch, 'hotfix')) }}
       run: |
-        if [[ "${{ env.is-official-release }}" == "true" ]]; then
+        if [[ "${{ env.is-official-release }}" == "true" ]] || [[ "${{ env.destination }}" == "testflight_alpha" ]]; then
           upload_to=s3
           echo "upload-to=${upload_to}" >> $GITHUB_OUTPUT
           echo "upload-to=${upload_to}" >> $GITHUB_ENV
@@ -109,6 +113,12 @@ jobs:
 
     - name: Select Xcode
       uses: ./.github/actions/select-xcode-version
+
+    - name: Override build number for Alpha release
+      if: ${{ env.destination == 'testflight_alpha' }} && ${{ inputs.override-build-number != '' }}
+      run: |
+        echo "Overriding build number to ${{ inputs.override-build-number }}"
+        echo "CURRENT_PROJECT_VERSION = ${{ inputs.override-build-number }}" >> Configuration/BuildNumber.xcconfig
 
     - name: Archive and Upload the App
       env:
@@ -139,6 +149,7 @@ jobs:
         build_number="$(cut -d ' ' -f 3 < Configuration/BuildNumber.xcconfig)"
         echo "dsym-path=${dsym_path}" >> $GITHUB_ENV
         echo "app-version=${version}.${build_number}" >> $GITHUB_ENV
+        echo "app-dsym-name=${app_dsym_name}" >> $GITHUB_ENV
 
     - name: Upload dSYMs artifact
       uses: actions/upload-artifact@v4
@@ -153,7 +164,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
-        DSYM_S3_PATH: s3://${{ vars.DSYM_BUCKET_NAME }}/${{ vars.MACOS_DSYM_BUCKET_PREFIX }}/DuckDuckGo-AppStore-${{ env.app-version }}-dSYM.zip
+        DSYM_S3_PATH: s3://${{ vars.DSYM_BUCKET_NAME }}/${{ vars.MACOS_DSYM_BUCKET_PREFIX }}/${{ env.app-dsym-name }}-${{ env.app-version }}-dSYM.zip
       run: |
         echo "dsym-s3-path=${DSYM_S3_PATH}" >> $GITHUB_OUTPUT
         aws s3 cp ${{ env.dsym-path }} ${{ env.DSYM_S3_PATH }}

--- a/.github/workflows/macos_build_appstore.yml
+++ b/.github/workflows/macos_build_appstore.yml
@@ -145,8 +145,8 @@ jobs:
         bundle exec fastlane release_${{ env.destination }}
         dsym_path="${{ github.workspace }}/macOS/${app_dsym_name}.app.dSYM.zip"
         mv -f "${{ github.workspace }}/macOS/${app_bundle_name}.app.dSYM.zip" "${dsym_path}"
-        version="$(cut -d ' ' -f 3 < Configuration/Version.xcconfig)"
-        build_number="$(cut -d ' ' -f 3 < Configuration/BuildNumber.xcconfig)"
+        version="$(cut -d ' ' -f 3 < Configuration/Version.xcconfig | tr -d '\n')"
+        build_number="$(cut -d ' ' -f 3 < Configuration/BuildNumber.xcconfig | tr -d '\n')"
         echo "dsym-path=${dsym_path}" >> $GITHUB_ENV
         echo "app-version=${version}.${build_number}" >> $GITHUB_ENV
         echo "app-dsym-name=${app_dsym_name}" >> $GITHUB_ENV

--- a/.github/workflows/macos_build_appstore.yml
+++ b/.github/workflows/macos_build_appstore.yml
@@ -36,7 +36,7 @@ on:
         description: "Branch name"
         required: false
         type: string
-      override-build-number:
+      build-number-override:
         description: "Override build number (for Alpha builds)"
         required: false
         type: string
@@ -115,10 +115,10 @@ jobs:
       uses: ./.github/actions/select-xcode-version
 
     - name: Override build number for Alpha release
-      if: ${{ env.destination == 'testflight_alpha' && inputs.override-build-number != '' }}
+      if: ${{ env.destination == 'testflight_alpha' && inputs.build-number-override != '' }}
       run: |
-        echo "Overriding build number to ${{ inputs.override-build-number }}"
-        echo "CURRENT_PROJECT_VERSION = ${{ inputs.override-build-number }}" > Configuration/BuildNumber.xcconfig
+        echo "Overriding build number to ${{ inputs.build-number-override }}"
+        echo "CURRENT_PROJECT_VERSION = ${{ inputs.build-number-override }}" > Configuration/BuildNumber.xcconfig
 
     - name: Archive and Upload the App
       env:

--- a/.github/workflows/macos_build_appstore.yml
+++ b/.github/workflows/macos_build_appstore.yml
@@ -115,7 +115,7 @@ jobs:
       uses: ./.github/actions/select-xcode-version
 
     - name: Override build number for Alpha release
-      if: ${{ env.destination == 'testflight_alpha' }} && ${{ inputs.override-build-number != '' }}
+      if: ${{ env.destination == 'testflight_alpha' && inputs.override-build-number != '' }}
       run: |
         echo "Overriding build number to ${{ inputs.override-build-number }}"
         echo "CURRENT_PROJECT_VERSION = ${{ inputs.override-build-number }}" >> Configuration/BuildNumber.xcconfig

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -415,10 +415,10 @@ jobs:
         RELEASE_BUCKET_PREFIX: ${{ vars.RELEASE_BUCKET_PREFIX }}
       run: |
         if [[ "${{ env.upload-to }}" == 's3' ]]; then
-          dmg_s3_path="s3://${RELEASE_BUCKET_NAME}/${RELEASE_BUCKET_PREFIX}/${{ steps.create-dmg.outputs.dmg }}"
-          if [[ ${{ env.release-type }} == 'alpha' ]]; then
+          if [[ "${{ env.release-type }}" == 'alpha' ]]; then
             RELEASE_BUCKET_PREFIX="${RELEASE_BUCKET_PREFIX}/alpha"
           fi
+          dmg_s3_path="s3://${RELEASE_BUCKET_NAME}/${RELEASE_BUCKET_PREFIX}/${{ steps.create-dmg.outputs.dmg }}"
         else
           dmg_s3_path="${TEST_BUILD_S3_PATH}${{ steps.create-dmg.outputs.dmg }}"
 

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -29,7 +29,7 @@ on:
     inputs:
       release-type:
         description: "Build type (product review or public release)"
-        required: true
+        required: false
         default: release
         type: string
       create-dmg:
@@ -43,6 +43,10 @@ on:
         type: string
       branch:
         description: "Branch name"
+        required: false
+        type: string
+      override-build-number:
+        description: "Override build number (for Alpha builds)"
         required: false
         type: string
       skip-notify:
@@ -144,7 +148,8 @@ jobs:
       env:
         is-official-release: ${{ env.release-type == 'release' && (startsWith(env.branch, 'release') || startsWith(env.branch, 'hotfix')) }}
       run: |
-        if [[ "${{ env.is-official-release }}" == "true" ]]; then
+        echo "is-official-release=${{ env.is-official-release }}" >> $GITHUB_ENV
+        if [[ "${{ env.is-official-release }}" == "true" ]] || [[ "${{ env.release-type }}" == "alpha" ]]; then
           echo "upload-to=s3" >> $GITHUB_OUTPUT
           echo "upload-to=s3" >> $GITHUB_ENV
         else
@@ -154,6 +159,12 @@ jobs:
 
     - name: Select Xcode
       uses: ./.github/actions/select-xcode-version
+
+    - name: Override build number for Alpha release
+      if: ${{ env.release-type == 'alpha' }} && ${{ inputs.override-build-number != '' }}
+      run: |
+        echo "Overriding build number to ${{ inputs.override-build-number }}"
+        echo "CURRENT_PROJECT_VERSION = ${{ inputs.override-build-number }}" >> Configuration/BuildNumber.xcconfig
 
     - name: Archive and notarize the app
       id: archive
@@ -264,7 +275,7 @@ jobs:
         echo "dsym-s3-path=${dsym_s3_path}" >> $GITHUB_OUTPUT
 
     - name: Report success
-      if: ${{ env.upload-to == 's3' }}
+      if: ${{ env.upload-to == 's3' }} && ${{ env.asana-task-url != '' }}
       env:
         DSYM_S3_PATH: ${{ steps.upload-dsyms-to-s3.outputs.dsym-s3-path }}
         TAG: ${{ env.app-version }}
@@ -403,6 +414,10 @@ jobs:
         RELEASE_BUCKET_NAME: ${{ vars.RELEASE_BUCKET_NAME }}
         RELEASE_BUCKET_PREFIX: ${{ vars.RELEASE_BUCKET_PREFIX }}
       run: |
+        if [[ ${{ env.release-type }} == 'alpha' ]]; then
+          DMG_URL_ROOT="${DMG_URL_ROOT}alpha/"
+          RELEASE_BUCKET_PREFIX="${RELEASE_BUCKET_PREFIX}/alpha"
+        fi
         if [[ "${{ env.upload-to }}" == 's3' ]]; then
           dmg_s3_path="s3://${RELEASE_BUCKET_NAME}/${RELEASE_BUCKET_PREFIX}/${{ steps.create-dmg.outputs.dmg }}"
         else

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -436,7 +436,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: dmg_url
-        path: dmg_url.txt
+        path: ${{ github.workspace }}/macOS/dmg_url.txt
 
     - name: Report success
       if: ${{ env.asana-task-url != '' && env.upload-to == 's3' }}

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -164,7 +164,7 @@ jobs:
       if: ${{ env.release-type == 'alpha' && inputs.override-build-number != '' }}
       run: |
         echo "Overriding build number to ${{ inputs.override-build-number }}"
-        echo "CURRENT_PROJECT_VERSION = ${{ inputs.override-build-number }}" >> Configuration/BuildNumber.xcconfig
+        echo "CURRENT_PROJECT_VERSION = ${{ inputs.override-build-number }}" > Configuration/BuildNumber.xcconfig
 
     - name: Archive and notarize the app
       id: archive

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -417,6 +417,7 @@ jobs:
         if [[ "${{ env.upload-to }}" == 's3' ]]; then
           if [[ "${{ env.release-type }}" == 'alpha' ]]; then
             RELEASE_BUCKET_PREFIX="${RELEASE_BUCKET_PREFIX}/alpha"
+            echo "${DMG_URL_ROOT}alpha/${{ steps.create-dmg.outputs.dmg }}" > dmg_url.txt
           fi
           dmg_s3_path="s3://${RELEASE_BUCKET_NAME}/${RELEASE_BUCKET_PREFIX}/${{ steps.create-dmg.outputs.dmg }}"
         else
@@ -429,7 +430,6 @@ jobs:
         fi
         aws s3 cp $DMG_LOCAL_PATH $dmg_s3_path --acl public-read
         echo "dmg-s3-path=${dmg_s3_path}" >> $GITHUB_OUTPUT
-        echo "${dmg_url}" > dmg_url.txt
 
     - name: Upload DMG URL artifact
       if: ${{ env.release-type == 'alpha' }}

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -161,7 +161,7 @@ jobs:
       uses: ./.github/actions/select-xcode-version
 
     - name: Override build number for Alpha release
-      if: ${{ env.release-type == 'alpha' }} && ${{ inputs.override-build-number != '' }}
+      if: ${{ env.release-type == 'alpha' && inputs.override-build-number != '' }}
       run: |
         echo "Overriding build number to ${{ inputs.override-build-number }}"
         echo "CURRENT_PROJECT_VERSION = ${{ inputs.override-build-number }}" >> Configuration/BuildNumber.xcconfig
@@ -275,7 +275,7 @@ jobs:
         echo "dsym-s3-path=${dsym_s3_path}" >> $GITHUB_OUTPUT
 
     - name: Report success
-      if: ${{ env.upload-to == 's3' }} && ${{ env.asana-task-url != '' }}
+      if: ${{ env.upload-to == 's3' && env.asana-task-url != '' }}
       env:
         DSYM_S3_PATH: ${{ steps.upload-dsyms-to-s3.outputs.dsym-s3-path }}
         TAG: ${{ env.app-version }}
@@ -431,7 +431,7 @@ jobs:
         echo "dmg-s3-path=${dmg_s3_path}" >> $GITHUB_OUTPUT
 
     - name: Report success
-      if: ${{ env.asana-task-url != '' }} && ${{ env.upload-to == 's3' }}
+      if: ${{ env.asana-task-url != '' && env.upload-to == 's3' }}
       env:
         DMG_URL: ${{ vars.DMG_URL_ROOT }}${{ steps.create-dmg.outputs.dmg }}
         TAG: ${{ env.app-version }}
@@ -445,7 +445,7 @@ jobs:
           is_scheduled_release:"${{ github.event_name == 'schedule' }}"
 
     - name: Report success (test build)
-      if: ${{ env.asana-task-url != '' }} && ${{ env.upload-to == 's3testbuilds' }}
+      if: ${{ env.asana-task-url != '' && env.upload-to == 's3testbuilds' }}
       env:
         DMG_URL: ${{ steps.upload-dmg-to-s3.outputs.dmg-url }}
         DMG_S3_PATH: ${{ steps.upload-dmg-to-s3.outputs.dmg-s3-path }}

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -45,7 +45,7 @@ on:
         description: "Branch name"
         required: false
         type: string
-      override-build-number:
+      build-number-override:
         description: "Override build number (for Alpha builds)"
         required: false
         type: string
@@ -161,10 +161,10 @@ jobs:
       uses: ./.github/actions/select-xcode-version
 
     - name: Override build number for Alpha release
-      if: ${{ env.release-type == 'alpha' && inputs.override-build-number != '' }}
+      if: ${{ env.release-type == 'alpha' && inputs.build-number-override != '' }}
       run: |
-        echo "Overriding build number to ${{ inputs.override-build-number }}"
-        echo "CURRENT_PROJECT_VERSION = ${{ inputs.override-build-number }}" > Configuration/BuildNumber.xcconfig
+        echo "Overriding build number to ${{ inputs.build-number-override }}"
+        echo "CURRENT_PROJECT_VERSION = ${{ inputs.build-number-override }}" > Configuration/BuildNumber.xcconfig
 
     - name: Archive and notarize the app
       id: archive

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -431,7 +431,7 @@ jobs:
         echo "dmg-s3-path=${dmg_s3_path}" >> $GITHUB_OUTPUT
 
     - name: Report success
-      if: ${{ env.upload-to == 's3' }}
+      if: ${{ env.asana-task-url != '' }} && ${{ env.upload-to == 's3' }}
       env:
         DMG_URL: ${{ vars.DMG_URL_ROOT }}${{ steps.create-dmg.outputs.dmg }}
         TAG: ${{ env.app-version }}
@@ -445,7 +445,7 @@ jobs:
           is_scheduled_release:"${{ github.event_name == 'schedule' }}"
 
     - name: Report success (test build)
-      if: ${{ env.upload-to == 's3testbuilds' }}
+      if: ${{ env.asana-task-url != '' }} && ${{ env.upload-to == 's3testbuilds' }}
       env:
         DMG_URL: ${{ steps.upload-dmg-to-s3.outputs.dmg-url }}
         DMG_S3_PATH: ${{ steps.upload-dmg-to-s3.outputs.dmg-s3-path }}

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -429,6 +429,14 @@ jobs:
         fi
         aws s3 cp $DMG_LOCAL_PATH $dmg_s3_path --acl public-read
         echo "dmg-s3-path=${dmg_s3_path}" >> $GITHUB_OUTPUT
+        echo "${dmg_url}" > dmg_url.txt
+
+    - name: Upload DMG URL artifact
+      if: ${{ env.release-type == 'alpha' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: dmg_url
+        path: dmg_url.txt
 
     - name: Report success
       if: ${{ env.asana-task-url != '' && env.upload-to == 's3' }}

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -414,12 +414,11 @@ jobs:
         RELEASE_BUCKET_NAME: ${{ vars.RELEASE_BUCKET_NAME }}
         RELEASE_BUCKET_PREFIX: ${{ vars.RELEASE_BUCKET_PREFIX }}
       run: |
-        if [[ ${{ env.release-type }} == 'alpha' ]]; then
-          DMG_URL_ROOT="${DMG_URL_ROOT}alpha/"
-          RELEASE_BUCKET_PREFIX="${RELEASE_BUCKET_PREFIX}/alpha"
-        fi
         if [[ "${{ env.upload-to }}" == 's3' ]]; then
           dmg_s3_path="s3://${RELEASE_BUCKET_NAME}/${RELEASE_BUCKET_PREFIX}/${{ steps.create-dmg.outputs.dmg }}"
+          if [[ ${{ env.release-type }} == 'alpha' ]]; then
+            RELEASE_BUCKET_PREFIX="${RELEASE_BUCKET_PREFIX}/alpha"
+          fi
         else
           dmg_s3_path="${TEST_BUILD_S3_PATH}${{ steps.create-dmg.outputs.dmg }}"
 

--- a/iOS/Gemfile.lock
+++ b/iOS/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: c3f6b3ebbaa95e2121051ac6621e0fe65572b0b9
-  tag: 2.6.1
+  revision: dea711b1a7fce3b21da21849270d6c8b82a4190e
+  tag: 2.6.2
   specs:
     fastlane-plugin-ddg_apple_automation (2.6.0)
       asana
@@ -27,7 +27,7 @@ GEM
       oauth2 (>= 1.4, < 3)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1128.0)
+    aws-partitions (1.1129.0)
     aws-sdk-core (3.226.2)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)

--- a/iOS/Gemfile.lock
+++ b/iOS/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: f7e73eec227ced2af3057a400c5668aedfd9eb16
-  tag: 2.6.0
+  revision: c3f6b3ebbaa95e2121051ac6621e0fe65572b0b9
+  tag: 2.6.1
   specs:
     fastlane-plugin-ddg_apple_automation (2.6.0)
       asana

--- a/iOS/Gemfile.lock
+++ b/iOS/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: dea711b1a7fce3b21da21849270d6c8b82a4190e
+  revision: b469ad17cd89bc7515196d0065679e3754d0995f
   tag: 2.6.2
   specs:
     fastlane-plugin-ddg_apple_automation (2.6.0)

--- a/iOS/fastlane/Pluginfile
+++ b/iOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '2.6.0'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '2.6.1'

--- a/iOS/fastlane/Pluginfile
+++ b/iOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '2.6.1'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '2.6.2'

--- a/macOS/Configuration/App/Sparkle.xcconfig
+++ b/macOS/Configuration/App/Sparkle.xcconfig
@@ -16,8 +16,10 @@
 // URLs for various build configuration should be kept here in the format of
 // SPARKLE_URL_<CONFIG> where <CONFIG> stands for the build configuration.
 // Release automation is looking for URLs here following that format.
-SPARKLE_URL_RELEASE = https:\/\/staticcdn.duckduckgo.com/macos-desktop-browser/appcast2.xml
-SPARKLE_URL_ALPHA = https:\/\/staticcdn.duckduckgo.com/macos-desktop-browser/alpha/appcast-alpha.xml
+// `/$()/` is a workaround for adding 2 forward slashes so that they aren't
+// interpreted as a comment.
+SPARKLE_URL_RELEASE = https:/$()/staticcdn.duckduckgo.com/macos-desktop-browser/appcast2.xml
+SPARKLE_URL_ALPHA = https:/$()/staticcdn.duckduckgo.com/macos-desktop-browser/alpha/appcast-alpha.xml
 
 SPARKLE_FEED_URL = $(SPARKLE_URL_RELEASE)
 SPARKLE_FEED_URL[config=Alpha] = $(SPARKLE_URL_ALPHA)

--- a/macOS/Configuration/App/Sparkle.xcconfig
+++ b/macOS/Configuration/App/Sparkle.xcconfig
@@ -17,7 +17,7 @@
 // SPARKLE_URL_<CONFIG> where <CONFIG> stands for the build configuration.
 // Release automation is looking for URLs here following that format.
 SPARKLE_URL_RELEASE = "https://staticcdn.duckduckgo.com/macos-desktop-browser/appcast2.xml"
-SPARKLE_URL_ALPHA = "https://staticcdn.duckduckgo.com/macos-desktop-browser/appcast-alpha.xml"
+SPARKLE_URL_ALPHA = "https://staticcdn.duckduckgo.com/macos-desktop-browser/alpha/appcast-alpha.xml"
 
 SPARKLE_FEED_URL = $(SPARKLE_URL_RELEASE)
 SPARKLE_FEED_URL[config=Alpha] = $(SPARKLE_URL_ALPHA)

--- a/macOS/Configuration/App/Sparkle.xcconfig
+++ b/macOS/Configuration/App/Sparkle.xcconfig
@@ -16,8 +16,8 @@
 // URLs for various build configuration should be kept here in the format of
 // SPARKLE_URL_<CONFIG> where <CONFIG> stands for the build configuration.
 // Release automation is looking for URLs here following that format.
-SPARKLE_URL_RELEASE = "https://staticcdn.duckduckgo.com/macos-desktop-browser/appcast2.xml"
-SPARKLE_URL_ALPHA = "https://staticcdn.duckduckgo.com/macos-desktop-browser/alpha/appcast-alpha.xml"
+SPARKLE_URL_RELEASE = https:\/\/staticcdn.duckduckgo.com/macos-desktop-browser/appcast2.xml
+SPARKLE_URL_ALPHA = https:\/\/staticcdn.duckduckgo.com/macos-desktop-browser/alpha/appcast-alpha.xml
 
 SPARKLE_FEED_URL = $(SPARKLE_URL_RELEASE)
 SPARKLE_FEED_URL[config=Alpha] = $(SPARKLE_URL_ALPHA)

--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -820,6 +820,8 @@ final class MainMenu: NSMenu {
         }
 
         debugMenu.addItem(internalUserItem)
+        debugMenu.addItem(.separator())
+        debugMenu.addItem(NSMenuItem(title: "Download DuckDuckGo Alpha Build", action: #selector(downloadAlphaBuild), target: self))
         debugMenu.autoenablesItems = false
         return debugMenu
     }
@@ -874,6 +876,17 @@ final class MainMenu: NSMenu {
         AutofillPreferences().debugScriptEnabled = !AutofillPreferences().debugScriptEnabled
         NotificationCenter.default.post(name: .autofillScriptDebugSettingsDidChange, object: nil)
         updateAutofillDebugScriptMenuItem()
+    }
+
+    @MainActor
+    @objc private func downloadAlphaBuild() {
+        let url = URL(string: "https://staticcdn.duckduckgo.com/macos-desktop-browser/alpha/duckduckgo.dmg")!
+        Application.appDelegate.windowControllersManager.open(
+            url,
+            source: .userEntered(url.absoluteString, downloadRequested: true),
+            target: nil,
+            event: NSApp.currentEvent
+        )
     }
 }
 

--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -820,8 +820,10 @@ final class MainMenu: NSMenu {
         }
 
         debugMenu.addItem(internalUserItem)
+#if !ALPHA
         debugMenu.addItem(.separator())
         debugMenu.addItem(NSMenuItem(title: "Download DuckDuckGo Alpha Build", action: #selector(downloadAlphaBuild), target: self))
+#endif
         debugMenu.autoenablesItems = false
         return debugMenu
     }

--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -880,7 +880,7 @@ final class MainMenu: NSMenu {
 
     @MainActor
     @objc private func downloadAlphaBuild() {
-        let url = URL(string: "https://staticcdn.duckduckgo.com/macos-desktop-browser/alpha/duckduckgo.dmg")!
+        let url = URL(string: "https://staticcdn.duckduckgo.com/macos-desktop-browser/alpha/duckduckgo-alpha.dmg")!
         Application.appDelegate.windowControllersManager.open(
             url,
             source: .userEntered(url.absoluteString, downloadRequested: true),

--- a/macOS/Gemfile.lock
+++ b/macOS/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: c3f6b3ebbaa95e2121051ac6621e0fe65572b0b9
-  tag: 2.6.1
+  revision: dea711b1a7fce3b21da21849270d6c8b82a4190e
+  tag: 2.6.2
   specs:
     fastlane-plugin-ddg_apple_automation (2.6.0)
       asana
@@ -27,7 +27,7 @@ GEM
       oauth2 (>= 1.4, < 3)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1128.0)
+    aws-partitions (1.1129.0)
     aws-sdk-core (3.226.2)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)

--- a/macOS/Gemfile.lock
+++ b/macOS/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: f7e73eec227ced2af3057a400c5668aedfd9eb16
-  tag: 2.6.0
+  revision: c3f6b3ebbaa95e2121051ac6621e0fe65572b0b9
+  tag: 2.6.1
   specs:
     fastlane-plugin-ddg_apple_automation (2.6.0)
       asana

--- a/macOS/Gemfile.lock
+++ b/macOS/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: dea711b1a7fce3b21da21849270d6c8b82a4190e
+  revision: b469ad17cd89bc7515196d0065679e3754d0995f
   tag: 2.6.2
   specs:
     fastlane-plugin-ddg_apple_automation (2.6.0)

--- a/macOS/fastlane/Pluginfile
+++ b/macOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '2.6.0'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '2.6.1'

--- a/macOS/fastlane/Pluginfile
+++ b/macOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '2.6.1'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '2.6.2'

--- a/macOS/scripts/archive.sh
+++ b/macOS/scripts/archive.sh
@@ -310,7 +310,7 @@ compress_app_and_dsym() {
 
 	# Create tar archive of the versioned app bundle
 	echo "Creating tar archive..."
-	tar -cvf "DuckDuckGo-${version_identifier}.app.tar" "${versioned_app_name}"
+	tar -cf "DuckDuckGo-${version_identifier}.app.tar" "${versioned_app_name}"
 
 	# Rename app bundle back to original name for compatibility with other workflows
 	if [[ "${original_app_name}" != "${versioned_app_name}" ]]; then


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1210800425272850?focus=true

### Description
This change adds macos_alpha_release.yml workflow that builds and publishes
Alpha release to Sparkle and TestFlight.
Additionally, the regular app gets a Debug Menu option to get the Alpha build.
This change doesn’t cover enabling the alpha workflow in main branch.

### Testing Steps
1. Run the regular macOS Browser scheme.
2. Select Main Menu -> Debug -> Download DuckDuckGo Alpha Build.
3. Install downloaded Alpha DMG and launch it.
4. Run [macos_alpha_release.yml](https://github.com/duckduckgo/apple-browsers/actions/workflows/macos_alpha_release.yml) (this needs to happen via CLI: `gh workflow run macos_alpha_release.yml --ref dominik/macos-alpha-release-workflow`) and wait until it finishes (c.a. 20 minutes).
5. Check for updates in your Alpha DMG build. Verify than an update gets installed.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)