### PR TITLE
[iOS] Enhance logging of Set As Default manager

### DIFF
--- a/iOS/DuckDuckGo/DefaultBrowserPrompt/EventMappers/DefaultBrowserPromptManagerDebugPixelHandler.swift
+++ b/iOS/DuckDuckGo/DefaultBrowserPrompt/EventMappers/DefaultBrowserPromptManagerDebugPixelHandler.swift
@@ -25,7 +25,7 @@ import SetDefaultBrowserCore
 final class DefaultBrowserPromptManagerDebugPixelHandler: EventMapping<DefaultBrowserManagerDebugEvent>, DefaultBrowserPromptEventMapping {
 
     public init() {
-        super.init { event, _, _, _ in
+        super.init { event, error, _, _ in
             switch event {
             case .successfulResult:
                 DailyPixel.fireDailyAndCount(pixel: .debugSetAsDefaultBrowserSuccessfulResult)
@@ -34,7 +34,7 @@ final class DefaultBrowserPromptManagerDebugPixelHandler: EventMapping<DefaultBr
             case .rateLimitReachedNoExistingResultPersisted:
                 DailyPixel.fireDailyAndCount(pixel: .debugSetAsDefaultBrowserMaxNumberOfAttemptsNoExistingResultPersistedFailure)
             case .unknownError:
-                DailyPixel.fireDailyAndCount(pixel: .debugSetAsDefaultBrowserUnknownFailure)
+                DailyPixel.fireDailyAndCount(pixel: .debugSetAsDefaultBrowserUnknownFailure, error: error)
             }
         }
     }

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserCore/CheckDefaultBrowserService/CheckDefaultBrowserManager.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserCore/CheckDefaultBrowserService/CheckDefaultBrowserManager.swift
@@ -71,7 +71,7 @@ public final class DefaultBrowserManager: DefaultBrowserManaging {
             defaultBrowserEventMapper.fire(.rateLimitReached)
             return .failure(.rateLimitReached(updatedStoredInfo: defaultBrowserInfo))
         case let .failure(.unknownError(error)):
-            defaultBrowserEventMapper.fire(.unknownError)
+            defaultBrowserEventMapper.fire(.unknownError, error: error)
             return .failure(.unknownError(error))
         case .failure(.notSupportedOnThisOSVersion):
             return .failure(.notSupportedOnCurrentOSVersion)

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserCore/CheckDefaultBrowserService/Dependencies/DefaultBrowserPromptEventMapping.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserCore/CheckDefaultBrowserService/Dependencies/DefaultBrowserPromptEventMapping.swift
@@ -28,4 +28,8 @@ public extension DefaultBrowserPromptEventMapping {
         fire(event, error: nil, parameters: nil, onComplete: { _ in })
     }
 
+    func fire(_ event: Event, error: Error) {
+        fire(event, error: error, parameters: nil, onComplete: { _ in })
+    }
+
 }

--- a/iOS/LocalPackages/SetDefaultBrowser/Tests/SetDefaultBrowserTests/CheckDefaultBrowserManagerTests.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Tests/SetDefaultBrowserTests/CheckDefaultBrowserManagerTests.swift
@@ -79,6 +79,8 @@ final class DefaultBrowserManagerTests {
                 Issue.record("Success expected")
             }
         #expect(store.didSetDefaultBrowserInfo)
+        #expect(eventMapperMock.didCallFireEvent)
+        #expect(eventMapperMock.capturedEvent == .successfulResult)
     }
 
     @Test("Check Successful attempts update Browser Info data")
@@ -177,6 +179,8 @@ final class DefaultBrowserManagerTests {
             }
 
         #expect(store.didSetDefaultBrowserInfo)
+        #expect(eventMapperMock.didCallFireEvent)
+        #expect(eventMapperMock.capturedEvent == .rateLimitReached)
     }
 
     @Test("Check When Max Attempts Exceeded Failure and no Browser Info stored do not update info and return nil object")
@@ -199,6 +203,8 @@ final class DefaultBrowserManagerTests {
             }
 
         #expect(!store.didSetDefaultBrowserInfo)
+        #expect(eventMapperMock.didCallFireEvent)
+        #expect(eventMapperMock.capturedEvent == .rateLimitReachedNoExistingResultPersisted)
     }
 
     @Test("Check Default Browser Info is not stored when unknown error")
@@ -220,6 +226,9 @@ final class DefaultBrowserManagerTests {
             }
 
         #expect(!store.didSetDefaultBrowserInfo)
+        #expect(eventMapperMock.didCallFireEvent)
+        #expect(eventMapperMock.capturedEvent == .unknownError)
+        #expect(eventMapperMock.capturedError as? NSError == error)
     }
 
     @Test("Check Default Browser Info is not stored when notSupportedOnCurrentOSVersion error")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1210806442029210?focus=true
Tech Design URL:
CC:

### Description

This PR enhances the logging for the manager that checks if the browser is set as the default. If the API encounters an unknown error, we will log the error to gather more information about the cause.

### Testing Steps
1. Ensure tests pass.

Smoke Test
1. Put a breakpoint at Line 37 in ‘DefaultBrowserPromptManagerDebugPixelHandler.swift'
2.In DefaultBrowserManager defined in iOS/LocalPackages/SetDefaultBrowser replace line 50 with 'let defaultBrowserResult: Result<Bool, CheckDefaultBrowserServiceError> = .failure(.unknownError(NSError(domain: "test Alessandro", code: 0, userInfo: nil)))’
3. Fresh install the App
4. Skip Onboarding
5. Open Debug menu 
6. Set internal user state to On
7. Tap ‘Default Browser Prompt’
8. Change Today’s date to a couple of days in the future in ’Simulate Today’s Date’.
9. Close Settings.
10. Put the App in the background.
11. Bring the App to foreground. This should trigger prompting the modal, hence, checking if the browser is the default one.
12. Ensure breakpoint is fired and error is the expected one.

### Impact and Risks
Low: Improve logging of error

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)