### PR TITLE
Enable duck player and duck.ai reload buttons

### DIFF
--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -755,9 +755,11 @@ protocol NewWindowPolicyDecisionMaker {
         let canGoForward = webView.canGoForward
         let canReload = {
             switch content {
-            case .url(let url, _, _):
-                return !(url.isDuckPlayer || url.isDuckURLScheme)
+            case .url:
+                return true
             case .history:
+                return true
+            case .aiChat:
                 return true
             default:
                 return false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1210820344467736?focus=true

### Description
Allow duck.ai and duck player to be refreshed

### Testing Steps
1. Open duck.ai, verify you can use the reload button
2. Open a video in duck player (i.e: duck://player/0qanF-91aJo), verify you can use the reload button

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Disable or enable reload on places we shouldn't
