### PR TITLE
Set commit SHA in Info.plist for alpha builds

### DIFF
--- a/.github/workflows/macos_build_appstore.yml
+++ b/.github/workflows/macos_build_appstore.yml
@@ -119,11 +119,17 @@ jobs:
     - name: Select Xcode
       uses: ./.github/actions/select-xcode-version
 
-    - name: Override build number for Alpha release
-      if: ${{ env.destination == 'testflight_alpha' && inputs.build-number-override != '' }}
+    - name: Override version and build number for Alpha release
+      if: ${{ env.destination == 'testflight_alpha' }}
+      env:
+        ALPHA_VERSION: 9999.9.9
       run: |
-        echo "Overriding build number to ${{ inputs.build-number-override }}"
-        echo "CURRENT_PROJECT_VERSION = ${{ inputs.build-number-override }}" > Configuration/BuildNumber.xcconfig
+        echo "Overriding version number to ${ALPHA_VERSION}"
+        echo "MARKETING_VERSION = ${ALPHA_VERSION}" > Configuration/Version.xcconfig
+        if [[ "${{ inputs.build-number-override }}" != "" ]]; then
+          echo "Overriding build number to ${{ inputs.build-number-override }}"
+          echo "CURRENT_PROJECT_VERSION = ${{ inputs.build-number-override }}" > Configuration/BuildNumber.xcconfig
+        fi
 
     - name: Archive and Upload the App
       env:

--- a/.github/workflows/macos_build_appstore.yml
+++ b/.github/workflows/macos_build_appstore.yml
@@ -119,7 +119,7 @@ jobs:
     - name: Select Xcode
       uses: ./.github/actions/select-xcode-version
 
-    - name: Override version and build number for Alpha release
+    - name: Override version and build number for Alpha release and add commit SHA to plist
       if: ${{ env.destination == 'testflight_alpha' }}
       env:
         ALPHA_VERSION: 9999.9.9
@@ -130,6 +130,9 @@ jobs:
           echo "Overriding build number to ${{ inputs.build-number-override }}"
           echo "CURRENT_PROJECT_VERSION = ${{ inputs.build-number-override }}" > Configuration/BuildNumber.xcconfig
         fi
+        plist_path="DuckDuckGo/Info.plist"
+        /usr/libexec/PlistBuddy -c "Add :DDG_COMMIT_SHA string ${{ github.sha }}" "${plist_path}" \
+          || /usr/libexec/PlistBuddy -c "Set :DDG_COMMIT_SHA ${{ github.sha }}" "${plist_path}"
 
     - name: Archive and Upload the App
       env:

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -160,11 +160,17 @@ jobs:
     - name: Select Xcode
       uses: ./.github/actions/select-xcode-version
 
-    - name: Override build number for Alpha release
-      if: ${{ env.release-type == 'alpha' && inputs.build-number-override != '' }}
+    - name: Override version and build number for Alpha release
+      if: ${{ env.release-type == 'alpha' }}
+      env:
+        ALPHA_VERSION: 9999.9.9
       run: |
-        echo "Overriding build number to ${{ inputs.build-number-override }}"
-        echo "CURRENT_PROJECT_VERSION = ${{ inputs.build-number-override }}" > Configuration/BuildNumber.xcconfig
+        echo "Overriding version number to ${ALPHA_VERSION}"
+        echo "MARKETING_VERSION = ${ALPHA_VERSION}" > Configuration/Version.xcconfig
+        if [[ "${{ inputs.build-number-override }}" != "" ]]; then
+          echo "Overriding build number to ${{ inputs.build-number-override }}"
+          echo "CURRENT_PROJECT_VERSION = ${{ inputs.build-number-override }}" > Configuration/BuildNumber.xcconfig
+        fi
 
     - name: Archive and notarize the app
       id: archive

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -160,7 +160,7 @@ jobs:
     - name: Select Xcode
       uses: ./.github/actions/select-xcode-version
 
-    - name: Override version and build number for Alpha release
+    - name: Override version and build number for Alpha release and add commit SHA to plist
       if: ${{ env.release-type == 'alpha' }}
       env:
         ALPHA_VERSION: 9999.9.9
@@ -171,6 +171,9 @@ jobs:
           echo "Overriding build number to ${{ inputs.build-number-override }}"
           echo "CURRENT_PROJECT_VERSION = ${{ inputs.build-number-override }}" > Configuration/BuildNumber.xcconfig
         fi
+        plist_path="DuckDuckGo/Info.plist"
+        /usr/libexec/PlistBuddy -c "Add :DDG_COMMIT_SHA string ${{ github.sha }}" "${plist_path}" \
+          || /usr/libexec/PlistBuddy -c "Set :DDG_COMMIT_SHA ${{ github.sha }}" "${plist_path}"
 
     - name: Archive and notarize the app
       id: archive

--- a/SharedPackages/BrowserServicesKit/Sources/Common/AppVersion.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Common/AppVersion.swift
@@ -52,8 +52,8 @@ public struct AppVersion {
         return bundle.object(forInfoDictionaryKey: Bundle.Key.alphaBuildSuffix) as? String ?? ""
     }
 
-    public var commitSHA: String {
-        return bundle.object(forInfoDictionaryKey: Bundle.Key.commitSHA) as? String ?? ""
+    public var commitSHA: String? {
+        return bundle.object(forInfoDictionaryKey: Bundle.Key.commitSHA) as? String
     }
 
     public var versionAndBuildNumber: String {

--- a/SharedPackages/BrowserServicesKit/Sources/Common/AppVersion.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Common/AppVersion.swift
@@ -52,6 +52,10 @@ public struct AppVersion {
         return bundle.object(forInfoDictionaryKey: Bundle.Key.alphaBuildSuffix) as? String ?? ""
     }
 
+    public var commitSHA: String {
+        return bundle.object(forInfoDictionaryKey: Bundle.Key.commitSHA) as? String ?? ""
+    }
+
     public var versionAndBuildNumber: String {
         let baseVersion = "\(versionNumber).\(buildNumber)"
         let suffix = alphaBuildSuffix

--- a/SharedPackages/BrowserServicesKit/Sources/Common/Extensions/BundleExtension.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Common/Extensions/BundleExtension.swift
@@ -29,7 +29,8 @@ extension Bundle {
         static let displayName = "CFBundleDisplayName"
         /// Custom key that may be added by the adhoc build workflow to append a suffix to the build version
         static let alphaBuildSuffix = "DDG_ALPHA_BUILD_SUFFIX"
-
+        /// Custom key that may be added by the build workflow to indicate a commit of the build
+        static let commitSHA = "DDG_COMMIT_SHA"
     }
 
     public var releaseVersionNumber: String? { infoDictionary?[Key.versionNumber] as? String }

--- a/SharedPackages/BrowserServicesKit/Tests/CommonTests/AppVersionExtensionTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/CommonTests/AppVersionExtensionTests.swift
@@ -59,4 +59,9 @@ final class AppVersionExtensionTests: XCTestCase {
         mockBundle.add(name: Bundle.Key.alphaBuildSuffix, value: suffix)
         XCTAssertEqual("2.0.4.14-adhoc-test", testee.versionAndBuildNumber)
     }
+
+    func testThatCommitSHAReturnsValueFromTheBundle() {
+        mockBundle.add(name: Bundle.Key.commitSHA, value: "abcd0123")
+        XCTAssertEqual("abcd0123", testee.commitSHA)
+    }
 }

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -19,15 +19,6 @@
       }
     },
     {
-      "identity" : "bloom_cpp",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/duckduckgo/bloom_cpp.git",
-      "state" : {
-        "revision" : "8076199456290b61b4544bf2f4caf296759906a0",
-        "version" : "3.0.0"
-      }
-    },
-    {
       "identity" : "content-scope-scripts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",

--- a/macOS/DuckDuckGo/Application/AboutPanel.swift
+++ b/macOS/DuckDuckGo/Application/AboutPanel.swift
@@ -43,6 +43,12 @@ struct AboutPanelView: View {
         Bundle.main.object(forInfoDictionaryKey: "NSHumanReadableCopyright") as? String ?? ""
     }
 
+#if ALPHA
+    private let prereleaseLabel: String = "ALPHA"
+#else
+    private let prereleaseLabel: String = "BETA"
+#endif
+
     var body: some View {
         VStack(spacing: 8) {
             Image(nsImage: NSApp.applicationIconImage)
@@ -67,7 +73,7 @@ struct AboutPanelView: View {
                     .cursor(.pointingHand)
                     .help(UserText.clickToCopyVersion)
                 if isInternal {
-                    Text("BETA")
+                    Text(prereleaseLabel)
                         .font(.footnote)
                         .fontWeight(.bold)
                         .padding(.horizontal, 8)

--- a/macOS/DuckDuckGo/Preferences/Model/AboutPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AboutPreferences.swift
@@ -28,6 +28,12 @@ final class AboutPreferences: ObservableObject, PreferencesTabOpening {
 
     private let internalUserDecider: InternalUserDecider
     @Published var isInternalUser: Bool
+#if ALPHA
+    let prereleaseLabel: String = "ALPHA"
+#else
+    let prereleaseLabel: String = "BETA"
+#endif
+
     @Published var featureFlagOverrideToggle = false
     private var internalUserCancellable: AnyCancellable?
     private let featureFlagger: FeatureFlagger

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAboutView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAboutView.swift
@@ -116,7 +116,7 @@ extension Preferences {
                     Text(UserText.duckDuckGoForMacAppStore)
                         .font(.companyName)
                     if model.isInternalUser {
-                        Text("BETA")
+                        Text(model.prereleaseLabel)
                             .font(.caption2)
                             .fontWeight(.bold)
                             .padding(.horizontal, 6)
@@ -144,7 +144,7 @@ extension Preferences {
                     Text(UserText.duckDuckGo)
                         .font(.companyName)
                     if model.isInternalUser {
-                        Text("BETA")
+                        Text(model.prereleaseLabel)
                             .font(.caption2)
                             .fontWeight(.bold)
                             .padding(.horizontal, 6)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1210823981470909?focus=true

### Description
This change sets macOS Alpha builds version to 9999.9.9 and sets commit sha in the Info.plist to be displayed in the app.

### Testing Steps
1. Update internal build to 1.148.0.493
2. Download Alpha build via Debug Menu -> Download DuckDuckGo Alpha Build
3. Launch the Alpha build and verify that About settings look like this (ALPHA label will appear only after setting internal user state)
<img width="504" height="195" alt="Screenshot 2025-07-17 at 20 03 34" src="https://github.com/user-attachments/assets/d1a61c30-888b-4bc0-a6ea-6fbf5ed6adeb" />

4. Select Main Menu -> DuckDuckGo -> About DuckDuckGo and verify that the ALPHA label is present.
<img width="402" height="307" alt="Screenshot 2025-07-17 at 20 05 37" src="https://github.com/user-attachments/assets/70f1e0fa-fdff-4101-b6dc-8968def6b8c4" />

5. Run `plutil -extract DDG_COMMIT_SHA raw /Applications/DuckDuckGo\ Alpha.app/Contents/Info.plist` and verify that it outputs `bcf0a70aeed3ddc1584600910d0638d3f0acd9a8`

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)