### PR TITLE
Prevent switcher hang by using UIKit for logo

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/DaxLogoManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/DaxLogoManager.swift
@@ -26,25 +26,16 @@ final class DaxLogoManager {
     
     // MARK: - Properties
 
-    private var daxLogoHostingController: UIHostingController<FullHeightLogoView>?
-
-    var logoView: UIView? {
-        daxLogoHostingController?.view
-    }
+    var logoView = DaxLogoView()
     
     // MARK: - Public Methods
     
-    func installInViewController(_ viewController: UIViewController, belowView topView: UIView) {
-        let daxLogoView = FullHeightLogoView()
-        let hostingController = UIHostingController(rootView: daxLogoView)
-        daxLogoHostingController = hostingController
-        
-        hostingController.view.backgroundColor = .clear
-        viewController.addChild(hostingController)
-        viewController.view.addSubview(hostingController.view)
-        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+    func installInViewController(_ viewController: UIViewController, belowView topView: UIView) {        viewController.view.addSubview(logoView)
+        logoView.translatesAutoresizingMaskIntoConstraints = false
+        logoView.setContentHuggingPriority(.defaultHigh, for: .vertical)
 
         let centeringGuide = UILayoutGuide()
+        centeringGuide.identifier = "DaxLogoCenteringGuide"
         viewController.view.addLayoutGuide(centeringGuide)
 
         NSLayoutConstraint.activate([
@@ -53,31 +44,60 @@ final class DaxLogoManager {
             topView.bottomAnchor.constraint(equalTo: centeringGuide.topAnchor),
             viewController.view.keyboardLayoutGuide.topAnchor.constraint(equalTo: centeringGuide.bottomAnchor),
 
-            hostingController.view.centerXAnchor.constraint(equalTo: centeringGuide.centerXAnchor),
-            hostingController.view.centerYAnchor.constraint(equalTo: centeringGuide.centerYAnchor),
-            hostingController.view.topAnchor.constraint(greaterThanOrEqualTo: centeringGuide.topAnchor),
-            hostingController.view.bottomAnchor.constraint(lessThanOrEqualTo: centeringGuide.bottomAnchor)
+            logoView.topAnchor.constraint(greaterThanOrEqualTo: centeringGuide.topAnchor),
+            logoView.bottomAnchor.constraint(lessThanOrEqualTo: centeringGuide.bottomAnchor),
+            logoView.leadingAnchor.constraint(greaterThanOrEqualTo: centeringGuide.leadingAnchor),
+            logoView.trailingAnchor.constraint(lessThanOrEqualTo: centeringGuide.trailingAnchor),
+            logoView.centerXAnchor.constraint(equalTo: centeringGuide.centerXAnchor),
+            logoView.centerYAnchor.constraint(equalTo: centeringGuide.centerYAnchor)
         ])
 
-        viewController.view.sendSubviewToBack(hostingController.view)
-        hostingController.didMove(toParent: viewController)
-    }
-    
-    func removeFromParent() {
-        daxLogoHostingController?.willMove(toParent: nil)
-        daxLogoHostingController?.view.removeFromSuperview()
-        daxLogoHostingController?.removeFromParent()
-        daxLogoHostingController = nil
+        viewController.view.sendSubviewToBack(logoView)
     }
 }
 
+final class DaxLogoView: UIView {
+    let logoImage = UIImageView(image: UIImage(resource: .home))
+    let textImage = UIImageView(image: UIImage(resource: .textDuckDuckGo))
 
-// Makes the logo view expand to fill the full height,
-// allowing to automatically adjust for keyboard.
-private struct FullHeightLogoView: View {
-    var body: some View {
-        NewTabPageDaxLogoView()
-            .padding(24)
-            .scaledToFit()
+    private let stackView = UIStackView()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setUpView()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setUpView() {
+        stackView.addArrangedSubview(logoImage)
+        stackView.addArrangedSubview(textImage)
+
+        textImage.tintColor = UIColor(designSystemColor: .textPrimary)
+
+        stackView.spacing = 12
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+
+        addSubview(stackView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            logoImage.heightAnchor.constraint(lessThanOrEqualToConstant: 96),
+            logoImage.heightAnchor.constraint(equalToConstant: 96).withPriority(.defaultHigh)
+        ])
+
+        logoImage.contentMode = .scaleAspectFit
+        textImage.contentMode = .center
+
     }
 }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/DaxLogoManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/DaxLogoManager.swift
@@ -26,8 +26,8 @@ final class DaxLogoManager {
     
     // MARK: - Properties
 
-    var logoView = DaxLogoView()
-    
+    private(set) var logoView: UIView = DaxLogoView()
+
     // MARK: - Public Methods
     
     func installInViewController(_ viewController: UIViewController, belowView topView: UIView) {        viewController.view.addSubview(logoView)
@@ -39,11 +39,14 @@ final class DaxLogoManager {
         viewController.view.addLayoutGuide(centeringGuide)
 
         NSLayoutConstraint.activate([
+
+            // Position layout centering guide vertically between top view and keyboard
             viewController.view.leadingAnchor.constraint(equalTo: centeringGuide.leadingAnchor),
             viewController.view.trailingAnchor.constraint(equalTo: centeringGuide.trailingAnchor),
             topView.bottomAnchor.constraint(equalTo: centeringGuide.topAnchor),
             viewController.view.keyboardLayoutGuide.topAnchor.constraint(equalTo: centeringGuide.bottomAnchor),
 
+            // Center within the layout guide
             logoView.topAnchor.constraint(greaterThanOrEqualTo: centeringGuide.topAnchor),
             logoView.bottomAnchor.constraint(lessThanOrEqualTo: centeringGuide.bottomAnchor),
             logoView.leadingAnchor.constraint(greaterThanOrEqualTo: centeringGuide.leadingAnchor),
@@ -56,7 +59,7 @@ final class DaxLogoManager {
     }
 }
 
-final class DaxLogoView: UIView {
+private final class DaxLogoView: UIView {
     let logoImage = UIImageView(image: UIImage(resource: .home))
     let textImage = UIImageView(image: UIImage(resource: .textDuckDuckGo))
 
@@ -65,7 +68,7 @@ final class DaxLogoView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        setUpView()
+        setUpSubviews()
     }
 
     @available(*, unavailable)
@@ -73,16 +76,14 @@ final class DaxLogoView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func setUpView() {
+    private func setUpSubviews() {
         stackView.addArrangedSubview(logoImage)
         stackView.addArrangedSubview(textImage)
 
         textImage.tintColor = UIColor(designSystemColor: .textPrimary)
 
-        stackView.spacing = 12
+        stackView.spacing = Metrics.spacing
         stackView.axis = .vertical
-        stackView.alignment = .fill
-        stackView.distribution = .fill
 
         addSubview(stackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -92,12 +93,17 @@ final class DaxLogoView: UIView {
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
             stackView.topAnchor.constraint(equalTo: topAnchor),
             stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            logoImage.heightAnchor.constraint(lessThanOrEqualToConstant: 96),
-            logoImage.heightAnchor.constraint(equalToConstant: 96).withPriority(.defaultHigh)
+            logoImage.heightAnchor.constraint(lessThanOrEqualToConstant: Metrics.maxLogoSize),
+            logoImage.heightAnchor.constraint(equalToConstant: Metrics.maxLogoSize).withPriority(.defaultHigh)
         ])
 
         logoImage.contentMode = .scaleAspectFit
         textImage.contentMode = .center
 
+    }
+
+    private struct Metrics {
+        static let maxLogoSize: CGFloat = 96
+        static let spacing: CGFloat = 12
     }
 }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/DaxLogoManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/DaxLogoManager.swift
@@ -30,7 +30,9 @@ final class DaxLogoManager {
 
     // MARK: - Public Methods
     
-    func installInViewController(_ viewController: UIViewController, belowView topView: UIView) {        viewController.view.addSubview(logoView)
+    func installInViewController(_ viewController: UIViewController, belowView topView: UIView) {
+
+        viewController.view.addSubview(logoView)
         logoView.translatesAutoresizingMaskIntoConstraints = false
         logoView.setContentHuggingPriority(.defaultHigh, for: .vertical)
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1210818370845271?focus=true
Tech Design URL:
CC:

### Description

Prevents conflicting SwiftUI / UIKit layout by converting logo view into UIView.

### Testing Steps
1. Enable Search Input under AI Features
2. Focus in Search Input while browsing and on NTP.
3. In each case switch between Search and Duck.ai using toggle and swiping
4. Repeat pt. 3 with autocomplete visible and favorites visible (empty search term)
5. Rotate the device while Search Input is active.

### Impact and Risks
Medium/High: Could not remove the UI hang entirely making app unusable (only for internal feature)

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
The hang was most likely caused by using keyboardLayoutGuide to layout and implicitly size a SwiftUI view. I tried applying `ignoresSafeArea` modifier but while it was not adjusting for the safe area, the hang was still present.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)