### PR TITLE
Remove the assertion

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "a382fa493c5309a5399b35ef5c49cf2895dcf367",
-        "version" : "10.6.0"
+        "revision" : "4935471fe659cad802f0fe3d4c51c8cf1318ae86",
+        "version" : "10.13.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "7532135989abb6ddbde48632b7222e0abed7d253",
-        "version" : "18.1.0"
+        "revision" : "21abb6f36a0cefc238c7366c50144ca792ada305",
+        "version" : "18.2.0"
       }
     },
     {
@@ -248,8 +248,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/sync_crypto",
       "state" : {
-        "revision" : "4e383fa27d3386a48e01a43fd890540a7d8656aa",
-        "version" : "0.5.0"
+        "revision" : "8dfdea29e325c6611d9b2b556e1d380252d54ba6",
+        "version" : "0.7.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Sources/Navigation/Extensions/WKNavigationActionExtension.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Navigation/Extensions/WKNavigationActionExtension.swift
@@ -187,19 +187,10 @@ extension WKNavigationAction: WebViewNavigationAction {
 
         switch navigationType {
         case .linkActivated, .other:
-            let isSameDocumentNavigation = self.isRedirect != true && newURL.absoluteString.hashedSuffix != nil && currentURL.isSameDocument(newURL)
-            if #available(iOS 18.5, macOS 15.5, *) {
-                assert(!isSameDocumentNavigation || targetFrame?.webView?.committedURL?.absoluteString != targetFrame?.safeRequest?.url?.absoluteString,
-                """
-                If the issue is fixed in the future macOS/iOS versions,
-                please add version check to only use `targetFrame.webView?.committedURL`
-                in the `currentURL` property above when macOS >= 15.5 and less than the one where this was fixed
-                and iOS >= 18.5 and less than with the same WebKit version.
-                Otherwise we should just use `targetFrame.safeRequest?.url` which got broken for same-document navigations.
-                This assertion should be removed afterwards.
-                Also update NavigationAction.init checking source/target frames urls.
-                """)
-            }
+            let isSameDocumentNavigation = self.isRedirect != true
+            && newURL.absoluteString.hashedSuffix != nil
+            && currentURL.isSameDocument(newURL)
+
             return isSameDocumentNavigation
         case .backForward:
             return (newURL.absoluteString.hashedSuffix != nil || currentURL.absoluteString.hashedSuffix != nil) && currentURL.isSameDocument(newURL)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1210800458942617?focus=true

### Description
- disable the assertion warning when doing anchored same-doc navigations

### Testing Steps
1. Navigate to an anchored link (`<a href="#link"><br><br><br><a id="navlink">a navlink</a>`), validate everything's fine and the address bar is updated

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
The assertion removal brings no risks

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
Nothing

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)