### PR TITLE
Firefox login import JSON decoding bug

### DIFF
--- a/macOS/DuckDuckGo/DataImport/Logins/Firefox/FirefoxLoginReader.swift
+++ b/macOS/DuckDuckGo/DataImport/Logins/Firefox/FirefoxLoginReader.swift
@@ -164,7 +164,7 @@ final class FirefoxLoginReader {
             case .deleted:
                 return nil // Filter out deleted entries
             case .unparsed:
-                return nil // Filter out unparsed entries and send an error
+                return nil // Filter out unparsed entries and TODO: send an error
             }
         }
 
@@ -241,23 +241,15 @@ private enum FirefoxLoginEntry: Decodable {
     }
 
     init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-
+        // Try to decode as active login - this will fail if required fields are missing
         if let activeLogin = try? ActiveLogin(from: decoder) {
-            // Try to decode as active login - this will fail if required fields are missing
-            let activeLogin = try ActiveLogin(from: decoder)
             self = .active(activeLogin)
-        } else if let deleted = try container.decodeIfPresent(Bool.self, forKey: .deleted), deleted {
             // Check if this is a deleted entry
-            let deletedLogin = try DeletedLogin(from: decoder)
+        } else if let deletedLogin = try? DeletedLogin(from: decoder), deletedLogin.deleted {
             self = .deleted(deletedLogin)
         } else {
             self = .unparsed
         }
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case deleted
     }
 }
 

--- a/macOS/DuckDuckGo/DataImport/Logins/Firefox/FirefoxLoginReader.swift
+++ b/macOS/DuckDuckGo/DataImport/Logins/Firefox/FirefoxLoginReader.swift
@@ -164,7 +164,7 @@ final class FirefoxLoginReader {
             case .deleted:
                 return nil // Filter out deleted entries
             case .unparsed:
-                return nil // Filter out unparsed entries and TODO: send an error
+                return nil // Filter out unparsed entries
             }
         }
 

--- a/macOS/DuckDuckGo/DataImport/Logins/Firefox/FirefoxLoginReader.swift
+++ b/macOS/DuckDuckGo/DataImport/Logins/Firefox/FirefoxLoginReader.swift
@@ -153,7 +153,22 @@ final class FirefoxLoginReader {
     private func readLoginsFile(from loginsFilePath: String) throws -> EncryptedFirefoxLogins {
         let loginsFileData = try Data(contentsOf: URL(fileURLWithPath: loginsFilePath))
 
-        return try JSONDecoder().decode(EncryptedFirefoxLogins.self, from: loginsFileData)
+        // Decode all entries using type-safe enum approach
+        let allEntries = try JSONDecoder().decode(FirefoxLoginsFile.self, from: loginsFileData)
+
+        // Extract only active logins using type-safe filtering
+        let activeLogins = allEntries.logins.compactMap { entry in
+            switch entry {
+            case .active(let login):
+                return login
+            case .deleted:
+                return nil // Filter out deleted entries
+            case .unparsed:
+                return nil // Filter out unparsed entries and send an error
+            }
+        }
+
+        return EncryptedFirefoxLogins(logins: activeLogins)
     }
 
     private func decrypt(logins: EncryptedFirefoxLogins, with key: Data, currentOperationType: inout ImportError.OperationType) throws -> [ImportedLoginCredential] {
@@ -203,14 +218,50 @@ final class FirefoxLoginReader {
 }
 
 /// Represents the logins.json file found in the Firefox profile directory
-private struct EncryptedFirefoxLogins: Decodable {
+private struct FirefoxLoginsFile: Decodable {
+    let logins: [FirefoxLoginEntry]
+}
 
-    struct Login: Decodable {
+/// Type-safe enum representing either an active or deleted Firefox login entry
+private enum FirefoxLoginEntry: Decodable {
+    case active(ActiveLogin)
+    case deleted(DeletedLogin)
+    case unparsed
+
+    /// Active login with all required fields for import
+    struct ActiveLogin: Decodable {
         let hostname: String
         let encryptedUsername: String
         let encryptedPassword: String
     }
 
-    let logins: [Login]
+    /// Deleted login entry (tombstone record for sync)
+    struct DeletedLogin: Decodable {
+        let deleted: Bool
+    }
 
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        if let activeLogin = try? ActiveLogin(from: decoder) {
+            // Try to decode as active login - this will fail if required fields are missing
+            let activeLogin = try ActiveLogin(from: decoder)
+            self = .active(activeLogin)
+        } else if let deleted = try container.decodeIfPresent(Bool.self, forKey: .deleted), deleted {
+            // Check if this is a deleted entry
+            let deletedLogin = try DeletedLogin(from: decoder)
+            self = .deleted(deletedLogin)
+        } else {
+            self = .unparsed
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case deleted
+    }
+}
+
+/// Legacy structure for compatibility with existing decrypt logic
+private struct EncryptedFirefoxLogins {
+    let logins: [FirefoxLoginEntry.ActiveLogin]
 }

--- a/macOS/DuckDuckGo/DataImport/Logins/Firefox/FirefoxLoginReader.swift
+++ b/macOS/DuckDuckGo/DataImport/Logins/Firefox/FirefoxLoginReader.swift
@@ -242,11 +242,12 @@ private enum FirefoxLoginEntry: Decodable {
 
     init(from decoder: Decoder) throws {
         // Try to decode as active login - this will fail if required fields are missing
-        if let activeLogin = try? ActiveLogin(from: decoder) {
-            self = .active(activeLogin)
-            // Check if this is a deleted entry
-        } else if let deletedLogin = try? DeletedLogin(from: decoder), deletedLogin.deleted {
+
+        // Check if this is a deleted entry
+        if let deletedLogin = try? DeletedLogin(from: decoder), deletedLogin.deleted {
             self = .deleted(deletedLogin)
+        } else if let activeLogin = try? ActiveLogin(from: decoder) {
+            self = .active(activeLogin)
         } else {
             self = .unparsed
         }

--- a/macOS/UnitTests/DataImport/DataImportResources/TestFirefoxData/No Primary Password/logins-all-deleted.json
+++ b/macOS/UnitTests/DataImport/DataImportResources/TestFirefoxData/No Primary Password/logins-all-deleted.json
@@ -1,0 +1,36 @@
+{
+  "nextId": 10,
+  "logins": [
+    {
+      "id": 1,
+      "guid": "{a92b5f8d-125f-fc46-ba57-e90bbc4fa47e}",
+      "timePasswordChanged": 1740745502197,
+      "syncCounter": 0,
+      "everSynced": true,
+      "deleted": true
+    },
+    {
+      "id": 2,
+      "guid": "{b3c4d8e9-234f-5a67-ba89-f01c23d4e567}",
+      "timePasswordChanged": 1740745502198,
+      "syncCounter": 0,
+      "everSynced": true,
+      "deleted": true
+    },
+    {
+      "id": 3,
+      "guid": "{c4d5e9f0-345g-6b78-cb90-g12d34e5f678}",
+      "timePasswordChanged": 1740745502199,
+      "syncCounter": 0,
+      "everSynced": true,
+      "deleted": true
+    }
+  ],
+  "potentiallyVulnerablePasswords": [],
+  "dismissedBreachAlertsByLoginGUID": {},
+  "version": 3,
+  "sync": {
+    "syncID": "MDoEEPgAAAAAAAAAAAAAAAAAAAEwFAYIKoZIhvcNAwcECLOmtnS0A6fGBBB3ROXhw32H6r9ipiBEbGJL",
+    "lastSync": 1627668886.4
+  }
+} 

--- a/macOS/UnitTests/DataImport/DataImportResources/TestFirefoxData/No Primary Password/logins-with-deleted-entries.json
+++ b/macOS/UnitTests/DataImport/DataImportResources/TestFirefoxData/No Primary Password/logins-with-deleted-entries.json
@@ -1,0 +1,47 @@
+{
+  "nextId": 516,
+  "logins": [
+    {
+      "id": 1,
+      "guid": "{a92b5f8d-125f-fc46-ba57-e90bbc4fa47e}",
+      "timePasswordChanged": 1740745502197,
+      "syncCounter": 0,
+      "everSynced": true,
+      "deleted": true
+    },
+    {
+      "id": 2,
+      "guid": "{b3c4d8e9-234f-5a67-ba89-f01c23d4e567}",
+      "timePasswordChanged": 1740745502198,
+      "syncCounter": 0,
+      "everSynced": true,
+      "deleted": true
+    },
+    {
+      "id": 515,
+      "hostname": "https://example.com",
+      "httpRealm": null,
+      "formSubmitURL": "",
+      "usernameField": "",
+      "passwordField": "",
+      "encryptedUsername": "MDoEEPgAAAAAAAAAAAAAAAAAAAEwFAYIKoZIhvcNAwcECAiEdyNqsLTWBBDdYwpiVMU7gcL/HFoQBplh",
+      "encryptedPassword": "MDoEEPgAAAAAAAAAAAAAAAAAAAEwFAYIKoZIhvcNAwcECPNfACq4KeojBBCffD6qgSAbS3DwaCBwrWtF",
+      "guid": "{7c7fa80b-b58c-4088-aec5-793d3df33edc}",
+      "encType": 1,
+      "timeCreated": 1752511876304,
+      "timeLastUsed": 1752511876304,
+      "timePasswordChanged": 1752511987727,
+      "timesUsed": 1,
+      "syncCounter": 0,
+      "everSynced": true,
+      "encryptedUnknownFields": null
+    }
+  ],
+  "potentiallyVulnerablePasswords": [],
+  "dismissedBreachAlertsByLoginGUID": {},
+  "version": 3,
+  "sync": {
+    "syncID": "MDoEEPgAAAAAAAAAAAAAAAAAAAEwFAYIKoZIhvcNAwcECLOmtnS0A6fGBBB3ROXhw32H6r9ipiBEbGJL",
+    "lastSync": 1627668886.4
+  }
+} 

--- a/macOS/UnitTests/DataImport/DataImportResources/TestFirefoxData/No Primary Password/logins-with-malformed-entries.json
+++ b/macOS/UnitTests/DataImport/DataImportResources/TestFirefoxData/No Primary Password/logins-with-malformed-entries.json
@@ -1,0 +1,44 @@
+{
+  "nextId": 10,
+  "logins": [
+    {
+      "id": 1,
+      "guid": "{a92b5f8d-125f-fc46-ba57-e90bbc4fa47e}",
+      "timePasswordChanged": 1740745502197,
+      "syncCounter": 0,
+      "everSynced": true
+    },
+    {
+      "id": 2,
+      "hostname": "https://example.com",
+      "encryptedUsername": "MDoEEPgAAAAAAAAAAAAAAAAAAAEwFAYIKoZIhvcNAwcECAiEdyNqsLTWBBDdYwpiVMU7gcL/HFoQBplh",
+      "guid": "{b3c4d8e9-234f-5a67-ba89-f01c23d4e567}"
+    },
+    {
+      "id": 3,
+      "hostname": "https://example.com",
+      "httpRealm": null,
+      "formSubmitURL": "",
+      "usernameField": "",
+      "passwordField": "",
+      "encryptedUsername": "MDoEEPgAAAAAAAAAAAAAAAAAAAEwFAYIKoZIhvcNAwcECAiEdyNqsLTWBBDdYwpiVMU7gcL/HFoQBplh",
+      "encryptedPassword": "MDoEEPgAAAAAAAAAAAAAAAAAAAEwFAYIKoZIhvcNAwcECPNfACq4KeojBBCffD6qgSAbS3DwaCBwrWtF",
+      "guid": "{c4d5e9f0-345g-6b78-cb90-g12d34e5f678}",
+      "encType": 1,
+      "timeCreated": 1752511876305,
+      "timeLastUsed": 1752511876305,
+      "timePasswordChanged": 1752511987728,
+      "timesUsed": 1,
+      "syncCounter": 0,
+      "everSynced": true,
+      "encryptedUnknownFields": null
+    }
+  ],
+  "potentiallyVulnerablePasswords": [],
+  "dismissedBreachAlertsByLoginGUID": {},
+  "version": 3,
+  "sync": {
+    "syncID": "MDoEEPgAAAAAAAAAAAAAAAAAAAEwFAYIKoZIhvcNAwcECLOmtnS0A6fGBBB3ROXhw32H6r9ipiBEbGJL",
+    "lastSync": 1627668886.4
+  }
+} 

--- a/macOS/UnitTests/DataImport/DataImportResources/TestFirefoxData/Primary Password/logins-all-deleted.json
+++ b/macOS/UnitTests/DataImport/DataImportResources/TestFirefoxData/Primary Password/logins-all-deleted.json
@@ -1,0 +1,36 @@
+{
+  "nextId": 10,
+  "logins": [
+    {
+      "id": 1,
+      "guid": "{a92b5f8d-125f-fc46-ba57-e90bbc4fa47e}",
+      "timePasswordChanged": 1740745502197,
+      "syncCounter": 0,
+      "everSynced": true,
+      "deleted": true
+    },
+    {
+      "id": 2,
+      "guid": "{b3c4d8e9-234f-5a67-ba89-f01c23d4e567}",
+      "timePasswordChanged": 1740745502198,
+      "syncCounter": 0,
+      "everSynced": true,
+      "deleted": true
+    },
+    {
+      "id": 3,
+      "guid": "{c4d5e9f0-345g-6b78-cb90-g12d34e5f678}",
+      "timePasswordChanged": 1740745502199,
+      "syncCounter": 0,
+      "everSynced": true,
+      "deleted": true
+    }
+  ],
+  "potentiallyVulnerablePasswords": [],
+  "dismissedBreachAlertsByLoginGUID": {},
+  "version": 3,
+  "sync": {
+    "syncID": "MDoEEPgAAAAAAAAAAAAAAAAAAAEwFAYIKoZIhvcNAwcECLOmtnS0A6fGBBB3ROXhw32H6r9ipiBEbGJL",
+    "lastSync": 1627668886.4
+  }
+} 

--- a/macOS/UnitTests/DataImport/DataImportResources/TestFirefoxData/Primary Password/logins-with-deleted-entries.json
+++ b/macOS/UnitTests/DataImport/DataImportResources/TestFirefoxData/Primary Password/logins-with-deleted-entries.json
@@ -1,0 +1,47 @@
+{
+  "nextId": 516,
+  "logins": [
+    {
+      "id": 1,
+      "guid": "{a92b5f8d-125f-fc46-ba57-e90bbc4fa47e}",
+      "timePasswordChanged": 1740745502197,
+      "syncCounter": 0,
+      "everSynced": true,
+      "deleted": true
+    },
+    {
+      "id": 2,
+      "guid": "{b3c4d8e9-234f-5a67-ba89-f01c23d4e567}",
+      "timePasswordChanged": 1740745502198,
+      "syncCounter": 0,
+      "everSynced": true,
+      "deleted": true
+    },
+    {
+      "id": 515,
+      "hostname": "https://example.com",
+      "httpRealm": null,
+      "formSubmitURL": "",
+      "usernameField": "",
+      "passwordField": "",
+      "encryptedUsername": "MDoEEPgAAAAAAAAAAAAAAAAAAAEwFAYIKoZIhvcNAwcECAiEdyNqsLTWBBDdYwpiVMU7gcL/HFoQBplh",
+      "encryptedPassword": "MDoEEPgAAAAAAAAAAAAAAAAAAAEwFAYIKoZIhvcNAwcECPNfACq4KeojBBCffD6qgSAbS3DwaCBwrWtF",
+      "guid": "{7c7fa80b-b58c-4088-aec5-793d3df33edc}",
+      "encType": 1,
+      "timeCreated": 1752511876304,
+      "timeLastUsed": 1752511876304,
+      "timePasswordChanged": 1752511987727,
+      "timesUsed": 1,
+      "syncCounter": 0,
+      "everSynced": true,
+      "encryptedUnknownFields": null
+    }
+  ],
+  "potentiallyVulnerablePasswords": [],
+  "dismissedBreachAlertsByLoginGUID": {},
+  "version": 3,
+  "sync": {
+    "syncID": "MDoEEPgAAAAAAAAAAAAAAAAAAAEwFAYIKoZIhvcNAwcECLOmtnS0A6fGBBB3ROXhw32H6r9ipiBEbGJL",
+    "lastSync": 1627668886.4
+  }
+} 

--- a/macOS/UnitTests/DataImport/DataImportResources/TestFirefoxData/Primary Password/logins-with-malformed-entries.json
+++ b/macOS/UnitTests/DataImport/DataImportResources/TestFirefoxData/Primary Password/logins-with-malformed-entries.json
@@ -1,0 +1,44 @@
+{
+  "nextId": 10,
+  "logins": [
+    {
+      "id": 1,
+      "guid": "{a92b5f8d-125f-fc46-ba57-e90bbc4fa47e}",
+      "timePasswordChanged": 1740745502197,
+      "syncCounter": 0,
+      "everSynced": true
+    },
+    {
+      "id": 2,
+      "hostname": "https://example.com",
+      "encryptedUsername": "MDoEEPgAAAAAAAAAAAAAAAAAAAEwFAYIKoZIhvcNAwcECAiEdyNqsLTWBBDdYwpiVMU7gcL/HFoQBplh",
+      "guid": "{b3c4d8e9-234f-5a67-ba89-f01c23d4e567}"
+    },
+    {
+      "id": 3,
+      "hostname": "https://example.com",
+      "httpRealm": null,
+      "formSubmitURL": "",
+      "usernameField": "",
+      "passwordField": "",
+      "encryptedUsername": "MDoEEPgAAAAAAAAAAAAAAAAAAAEwFAYIKoZIhvcNAwcECAiEdyNqsLTWBBDdYwpiVMU7gcL/HFoQBplh",
+      "encryptedPassword": "MDoEEPgAAAAAAAAAAAAAAAAAAAEwFAYIKoZIhvcNAwcECPNfACq4KeojBBCffD6qgSAbS3DwaCBwrWtF",
+      "guid": "{c4d5e9f0-345g-6b78-cb90-g12d34e5f678}",
+      "encType": 1,
+      "timeCreated": 1752511876305,
+      "timeLastUsed": 1752511876305,
+      "timePasswordChanged": 1752511987728,
+      "timesUsed": 1,
+      "syncCounter": 0,
+      "everSynced": true,
+      "encryptedUnknownFields": null
+    }
+  ],
+  "potentiallyVulnerablePasswords": [],
+  "dismissedBreachAlertsByLoginGUID": {},
+  "version": 3,
+  "sync": {
+    "syncID": "MDoEEPgAAAAAAAAAAAAAAAAAAAEwFAYIKoZIhvcNAwcECLOmtnS0A6fGBBB3ROXhw32H6r9ipiBEbGJL",
+    "lastSync": 1627668886.4
+  }
+} 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202926619870900/task/1210798627853091?focus=true

### Description

Firefox password import is failing with DecodingError.keyNotFound for hostname field during JSON parsing. This is because the import code attempts to decode deleted login entries that lack required fields like hostname. These are common entries for users who have synced.

I've fixed this by excluding "deleted": true entries as well as skipping over any entries that don't parse rather than failing the whole import.

### Testing Steps
1. Download Firefox https://download.mozilla.org/?product=firefox-stub&os=win&lang=en-US
2. Save some logins (Nav menu -> Passwords)
3. Click Sign In to Sync
4. Either sign up yourself or ask me for my test credentials
5. Delete >=1 login
6. Open DuckDuckGo
7. Go to File -> Import Bookmarks and Passwords
8. Import from Firefox (making sure you select the synced profile if you have multiple. If you have one, the profile picker will not show)
9. **Import should complete with the number of non-deleted logins**

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
More complicated parsing could be more brittle. However, I've kept the parsing the same and only parsed what is absolutely needed.

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)