### PR TITLE
Adjust scroll content offset and size along rotation transition

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SwipeContainerManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SwipeContainerManager.swift
@@ -71,8 +71,9 @@ final class SwipeContainerManager: NSObject {
     /// Updates the scroll view position and content size when bounds change
     func updateLayout(viewBounds: CGRect) {
         guard swipeScrollView != nil else { return }
-        swipeScrollView.contentSize = CGSize(width: viewBounds.width * 2, height: 0)
-        updateScrollViewPosition(animated: false)
+        let pageWidth = viewBounds.width
+        swipeScrollView.contentSize = CGSize(width: pageWidth * 2, height: 0)
+        updateScrollViewPosition(pageWidth: pageWidth, animated: false)
     }
     
     // MARK: - Private Methods
@@ -140,14 +141,18 @@ final class SwipeContainerManager: NSObject {
     
     private func configureInitialPosition() {
         guard let parentView = swipeScrollView.superview else { return }
-        
-        swipeScrollView.contentSize = CGSize(width: parentView.bounds.width * 2, height: 0)
-        updateScrollViewPosition(animated: false)
+
+        let pageWidth = parentView.bounds.width
+        swipeScrollView.contentSize = CGSize(width: pageWidth * 2, height: 0)
+        updateScrollViewPosition(pageWidth: pageWidth, animated: false)
     }
     
-    private func updateScrollViewPosition(animated: Bool) {
+    private func updateScrollViewPosition(pageWidth: CGFloat? = nil, animated: Bool) {
         guard let parentView = swipeScrollView.superview else { return }
-        let targetX: CGFloat = switchBarHandler.currentToggleState == .search ? 0 : parentView.bounds.width
+
+        let pageWidth = pageWidth ?? parentView.bounds.width
+
+        let targetX: CGFloat = switchBarHandler.currentToggleState == .search ? 0 : pageWidth
         swipeScrollView.setContentOffset(CGPoint(x: targetX, y: 0), animated: animated)
     }
     

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -140,6 +140,14 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
         delegate?.onDismiss()
     }
 
+    override func viewWillTransition(to size: CGSize, with coordinator: any UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+
+        coordinator.animate { _ in
+            self.swipeContainerManager?.updateLayout(viewBounds: CGRect(origin: .zero, size: size))
+        }
+    }
+
     // MARK: - Private Methods
     
     private func setupView() {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1210809108643490?focus=true
Tech Design URL:
CC:

### Description

Recalculates ScrollView size and offset based on the target size and runs the change alongside the rotation transition.

### Testing Steps
1. Enable Search Input in AI Features
2. Select Duck.ai mode.
3. Rotate to landscape.
4. Verify the mode selection and offset is valid.
5. Verify selected mode is used to process the query.
6. Rotate back to portrait, revalidate steps 4 - 5
7. Select search, validate steps 3 - 6

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Scroll offset may be not aligned to a page.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)