### PR TITLE
Don't show favorites border when Search Input active

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
@@ -94,7 +94,7 @@ final class SuggestionTrayManager: NSObject {
         }
 
         controller.coversFullScreen = true
-        controller.isUsingNTPCompatibleStyling = true
+        controller.isUsingSearchInputCustomStyling = true
         controller.additionalFavoritesOverlayInsets = UIEdgeInsets(top: 0, left: 6, bottom: 0, right: 6)
 
         parentViewController.addChild(controller)

--- a/iOS/DuckDuckGo/FavoriteHomeCell.swift
+++ b/iOS/DuckDuckGo/FavoriteHomeCell.swift
@@ -35,7 +35,7 @@ class FavoriteHomeCell: UICollectionViewCell {
     @IBOutlet weak var iconSize: NSLayoutConstraint!
     @IBOutlet weak var deleteButton: UIButton!
 
-    var isUsingNTPCompatibleStyling: Bool = false {
+    var isUsingSearchInputCustomStyling: Bool = false {
         didSet {
             decorate()
         }
@@ -131,7 +131,7 @@ class FavoriteHomeCell: UICollectionViewCell {
         iconSize.constant = border ? -24 : 0
         iconImage.layer.masksToBounds = !border
 
-        let defaultCornerRadius = isUsingNTPCompatibleStyling ? Constant.cornerRadiusNTPCompatible : Constant.cornerRadius
+        let defaultCornerRadius = isUsingSearchInputCustomStyling ? Constant.cornerRadiusNTPCompatible : Constant.cornerRadius
         iconImage.layer.cornerRadius = border ? 3 : defaultCornerRadius
     }
   
@@ -179,7 +179,7 @@ private extension BookmarkEntity {
 extension FavoriteHomeCell {
     
     private func decorate() {
-        if isUsingNTPCompatibleStyling {
+        if isUsingSearchInputCustomStyling {
             titleLabel.textColor = UIColor(designSystemColor: .textPrimary)
             titleLabel.font = .systemFont(ofSize: 12, weight: .regular)
             

--- a/iOS/DuckDuckGo/FavoritesHomeViewSectionRenderer.swift
+++ b/iOS/DuckDuckGo/FavoritesHomeViewSectionRenderer.swift
@@ -56,7 +56,7 @@ class FavoritesHomeViewSectionRenderer {
     private weak var reorderingCell: FavoriteHomeCell?
 
     var isEditing = false
-    var isUsingNTPCompatibleStyling = false
+    var isUsingSearchInputCustomStyling = false
 
     var onFaviconMissing: ((String) -> Void)?
 
@@ -151,7 +151,7 @@ class FavoritesHomeViewSectionRenderer {
             self?.onFaviconMissing?(domain)
         })
         cell.isEditing = isEditing
-        cell.isUsingNTPCompatibleStyling = isUsingNTPCompatibleStyling
+        cell.isUsingSearchInputCustomStyling = isUsingSearchInputCustomStyling
         
         return cell
 

--- a/iOS/DuckDuckGo/FavoritesOverlay.swift
+++ b/iOS/DuckDuckGo/FavoritesOverlay.swift
@@ -73,8 +73,11 @@ class FavoritesOverlay: UIViewController {
         collectionView.backgroundColor = .clear
 
         view.addSubview(collectionView)
-        borderView.insertSelf(into: view)
-        borderView.updateForAddressBarPosition(appSettings.currentAddressBarPosition)
+
+        if !isUsingSearchInputCustomStyling {
+            borderView.insertSelf(into: view)
+            borderView.updateForAddressBarPosition(appSettings.currentAddressBarPosition)
+        }
 
         renderer.install(into: self)
         

--- a/iOS/DuckDuckGo/FavoritesOverlay.swift
+++ b/iOS/DuckDuckGo/FavoritesOverlay.swift
@@ -43,9 +43,9 @@ class FavoritesOverlay: UIViewController {
 
     private lazy var borderView = StyledTopBottomBorderView()
 
-    var isUsingNTPCompatibleStyling: Bool {
-        get { renderer.isUsingNTPCompatibleStyling }
-        set { renderer.isUsingNTPCompatibleStyling = newValue }
+    var isUsingSearchInputCustomStyling: Bool {
+        get { renderer.isUsingSearchInputCustomStyling }
+        set { renderer.isUsingSearchInputCustomStyling = newValue }
     }
 
     weak var delegate: FavoritesOverlayDelegate?
@@ -99,7 +99,7 @@ class FavoritesOverlay: UIViewController {
             layout.minimumInteritemSpacing = 32
         } else {
             layout.minimumInteritemSpacing = 10
-            if isUsingNTPCompatibleStyling {
+            if isUsingSearchInputCustomStyling {
                 layout.minimumLineSpacing = 12
             }
         }
@@ -189,7 +189,7 @@ extension FavoritesOverlay: UICollectionViewDelegateFlowLayout {
             
             var insets = renderer.collectionView(collectionView, layout: collectionViewLayout, insetForSectionAt: section) ?? UIEdgeInsets.zero
             
-            insets.top += isUsingNTPCompatibleStyling ? Constants.ntpCompatibleMargin : Constants.margin
+            insets.top += isUsingSearchInputCustomStyling ? Constants.ntpCompatibleMargin : Constants.margin
             return insets
     }
 }

--- a/iOS/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/iOS/DuckDuckGo/SuggestionTrayViewController.swift
@@ -53,9 +53,9 @@ class SuggestionTrayViewController: UIViewController {
         isShowingAutocompleteSuggestions || isShowingFavoritesOverlay
     }
 
-    var isUsingNTPCompatibleStyling: Bool = false {
+    var isUsingSearchInputCustomStyling: Bool = false {
         didSet {
-            favoritesOverlay?.isUsingNTPCompatibleStyling = isUsingNTPCompatibleStyling
+            favoritesOverlay?.isUsingSearchInputCustomStyling = isUsingSearchInputCustomStyling
         }
     }
 
@@ -255,7 +255,7 @@ class SuggestionTrayViewController: UIViewController {
     private func installFavoritesOverlay(animated: Bool, onInstall: @escaping () -> Void = {}) {
         let controller = FavoritesOverlay(viewModel: favoritesModel)
         controller.delegate = favoritesOverlayDelegate
-        controller.isUsingNTPCompatibleStyling = isUsingNTPCompatibleStyling
+        controller.isUsingSearchInputCustomStyling = isUsingSearchInputCustomStyling
         install(controller: controller,
                 animated: animated,
                 additionalInsets: additionalFavoritesOverlayInsets,


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210830406472517?focus=true
Tech Design URL:
CC:

### Description

* Prevents adding the border around FavoritesOverlay when styled for Search Input.
* Renames the variable to avoid confusion, as the border is part of NTP styling right now.

### Testing Steps
1. Enable Search Input in AI Features.
2. Having Favorites, start search.
3. Make sure there's no top/bottom border around favorites.
4. Make sure the border is still visible when Search Input is disabled.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)