### PR TITLE
Prevent scale animation when Search Input enabled

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3022,7 +3022,7 @@ extension MainViewController: TabSwitcherDelegate {
 
     func tabSwitcherDidRequestNewTab(tabSwitcher: TabSwitcherViewController) {
         newTab()
-        if newTabPageViewController != nil {
+        if newTabPageViewController?.isShowingLogo == true, !aiChatSettings.isAIChatSearchInputUserSettingsEnabled {
             animateLogoAppearance()
         }
         themeColorManager.updateThemeColor()


### PR DESCRIPTION
Also show the scale animation only when Logo is visible

<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210775687930269?focus=true
Tech Design URL:
CC:

### Description

* Prevents the scale animation from running when logo is not visible on NTP (fixes a production bug).
* Turns of the scale animation completely if the Search Input feature is enabled.

### Testing Steps
1. Enable Search Input in AI Features
2. Open Tab Switcher, press + to add new tab
3. No scale animation should run, just the regular input field expansion animation
5. Disable Search Input
6. Having no favorites, add a new tab from Tab Switcher. Dax logo should scale up animated.
7. Add a favorite, add a new tab from Tab Switcher. There should be no scale animation.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)