### PR TITLE
Change duck.ai button to a globe when there's a valid URL

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/NavigationActionBarView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/NavigationActionBarView.swift
@@ -128,7 +128,7 @@ struct NavigationActionBarView: View {
 
     private var searchButton: some View {
         let icon: Image = {
-            if viewModel.isSearchMode && viewModel.isCurrentTextValidURL {
+            if viewModel.isCurrentTextValidURL {
                 return Image(uiImage: DesignSystemImages.Glyphs.Size24.globe)
             } else if viewModel.isSearchMode {
                 return Image(uiImage: DesignSystemImages.Glyphs.Size24.searchFind)

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -223,17 +223,23 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
             .receive(on: DispatchQueue.main)
             .sink { [weak self] submission in
                 guard let self = self else { return }
+                defer { self.switchBarHandler.clearText() }
+
+                let text = submission.text
+
+                if self.switchBarHandler.isCurrentTextValidURL {
+                    self.delegate?.onQuerySubmitted(text)
+                    return
+                }
+
                 switch submission.mode {
                 case .search:
-                    self.delegate?.onQuerySubmitted(submission.text)
+                    self.delegate?.onQuerySubmitted(text)
+
                 case .aiChat:
-                    if self.switchBarHandler.forceWebSearch {
-                        self.delegate?.onPromptSubmitted(submission.text, tools: [.webSearch])
-                    } else {
-                        self.delegate?.onPromptSubmitted(submission.text, tools: nil)
-                    }
+                    let tools: [AIChatRAGTool]? = self.switchBarHandler.forceWebSearch ? [.webSearch] : nil
+                    self.delegate?.onPromptSubmitted(text, tools: tools)
                 }
-                self.switchBarHandler.clearText()
             }
             .store(in: &cancellables)
 

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
@@ -120,7 +120,8 @@ final class SwitchBarHandler: SwitchBarHandling {
     // MARK: - SwitchBarHandling Implementation
     func updateCurrentText(_ text: String) {
         currentText = text
-        isCurrentTextValidURL = URL.webUrl(from: text) != nil
+        /// URL.webUrl converts spaces to %20, but this is not a concern in this context, as we are validating the user's input in the address bar to ensure it is a valid URL.
+        isCurrentTextValidURL = !text.contains(where: { $0.isWhitespace }) && URL.webUrl(from: text) != nil
     }
 
     func submitText(_ text: String) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1210823147637787?focus=true

### Description
When on duck.ai mode, if you type a valid URL (or the URL is already present) in the text field, the submit button should change to a globe, and pressing it should open the website instead of going to duck.ai

### Testing Steps
1. Enable the new input field on AI Features -> Search input
2. Type random queries on both search mode and duck.ai modes, check if they go to their respective options
3. Type a valid URL on both modes, check if we display a globe button in the FAB regardless of which mode you have selected, tapping on it (or go in the keyboard) should open the website


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
Incorrectly display the globe button when it shouldn't
