### PR TITLE
Fix flaky address bar test

### DIFF
--- a/macOS/IntegrationTests/Tab/AddressBarTests.swift
+++ b/macOS/IntegrationTests/Tab/AddressBarTests.swift
@@ -905,7 +905,7 @@ class AddressBarTests: XCTestCase {
         let firstResponderChangeExpectation = window2.responderDidChangeExpectation(to: tab.webView)
         viewModel2.select(at: .pinned(0))
 
-        await fulfillment(of: [firstResponderChangeExpectation], timeout: 1)
+        await fulfillment(of: [firstResponderChangeExpectation], timeout: 2)
 
         XCTAssertEqual(window.firstResponder, window)
         XCTAssertEqual(window2.firstResponder, tab.webView)
@@ -913,10 +913,20 @@ class AddressBarTests: XCTestCase {
         // when activating a Pinned Tab in another window when its Address Bar is active, it should be kept active
         _=window.makeFirstResponder(addressBarTextField)
         window.makeKeyAndOrderFront(nil)
-        try await Task.sleep(interval: 0.01)
+
+        let becomesOwnFirstResponder = expectation(
+            for: NSPredicate { [weak window2] _, _ in
+                guard let window2 else { return false }
+                return window2.firstResponder === window2
+            },
+            evaluatedWith: nil,
+            handler: nil
+        )
+
+        let result = await XCTWaiter().fulfillment(of: [becomesOwnFirstResponder], timeout: 5.0)
 
         XCTAssertTrue(isAddressBarFirstResponder)
-        XCTAssertEqual(window2.firstResponder, window2)
+        XCTAssertEqual(result, .completed, "window2 never became its own first-responder")
     }
 
     @MainActor

--- a/macOS/IntegrationTests/Tab/AddressBarTests.swift
+++ b/macOS/IntegrationTests/Tab/AddressBarTests.swift
@@ -926,7 +926,7 @@ class AddressBarTests: XCTestCase {
         let result = await XCTWaiter().fulfillment(of: [becomesOwnFirstResponder], timeout: 5.0)
 
         XCTAssertTrue(isAddressBarFirstResponder)
-        XCTAssertEqual(result, .completed, "window2 never became its own first-responder")
+        XCTAssertEqual(result, .completed, "window2 never became its own first responder")
     }
 
     @MainActor


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1210837193154122?focus=true
Tech Design URL: 
CC:

### Description

This PR fixes a flaky address bar test. The previous implementation was sleeping for a short time before asserting its conditions, but I was able to reproduce this failing consistently using the Run Repeatedly feature.

Increasing the sleep duration helped, suggesting that this was simply not waiting long enough, so the implementation has been replaced with XCTWaiter with a generous timeout instead.

After this change, I wasn't able to reproduce the failure even after running the test for 1000 iterations - previously I would always hit a failure within the first 100.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Run this test repeatedly locally and verify that it doesn't fail

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)