### PR TITLE
Fix assertion failure during autoconsent tests.

### DIFF
--- a/iOS/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
+++ b/iOS/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
@@ -356,12 +356,9 @@ extension AutoconsentUserScript {
     func handleAutoconsentDone(message: WKScriptMessage, replyHandler: @escaping (Any?, String?) -> Void) {
         // report a managed popup
         guard let messageData: AutoconsentDoneMessage = decodeMessageBody(from: message.body),
-              let url = URL(string: messageData.url),
+              let url = URL(string: messageData.url.replacing(regex: "file://", with: "http://localhost")),
               let host = url.host else {
-            if ![.unitTests, .integrationTests, .xcPreviews].contains(AppVersion.runType) {
-                assertionFailure("Received a malformed message from autoconsent")
-            }
-
+            assertionFailure("Received a malformed message from autoconsent")
             replyHandler(nil, "cannot decode message")
             return
         }


### PR DESCRIPTION

Task/Issue URL: https://app.asana.com/1/137249556945/task/1210836027639389?focus=true
Tech Design URL:
CC:

### Description
Prevent decode error due to a file:// URL being used by the test runner.

### Testing Steps
1. Run AutoconsentBackgroundTests
2. Should no longer trigger an assertionFailure.
