### PR TITLE
Fix loc_export.sh scripts to properly isolate platform exports

### DIFF
--- a/.maestro/common.sh
+++ b/.maestro/common.sh
@@ -50,9 +50,19 @@ build_app() {
     fi
 
     echo "⏲️ Building the app"
+    
+    # Use specific device UUID if provided, otherwise fall back to name-based destination
+    if [ -n "$MAESTRO_DEVICE_UUID" ]; then
+        destination="platform=iOS Simulator,id=$MAESTRO_DEVICE_UUID"
+        echo "ℹ️ Building for specific simulator: $MAESTRO_DEVICE_UUID"
+    else
+        destination="platform=iOS Simulator,name=$destination_device,OS=$destination_os_version"
+        echo "ℹ️ Building for simulator: $destination_device with OS $destination_os_version"
+    fi
+    
     set -o pipefail && xcodebuild -project "$project_root"/iOS/DuckDuckGo-iOS.xcodeproj \
                                   -scheme "iOS Browser" \
-                                  -destination "platform=iOS Simulator,name=$destination_device,OS=$destination_os_version" \
+                                  -destination "$destination" \
                                   -derivedDataPath "$derived_data_path" \
                                   -skipPackagePluginValidation \
                                   -skipMacroValidation \

--- a/.maestro/duckplayer.native/01_serp_navigation_enabled.yaml
+++ b/.maestro/duckplayer.native/01_serp_navigation_enabled.yaml
@@ -1,0 +1,36 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - duckplayer.native
+
+---
+
+
+# Set up 
+- runFlow: 
+    file: ../shared/setup.yaml
+
+# Load Site
+- assertVisible:
+    id: "searchEntry"
+- tapOn: 
+    id: "searchEntry"
+- inputText: "https://duckduckgo.com/?q=%22DuckDuckGo+vs+Google%3A+5+Reasons+You+Should+Switch%E2%80%9D+site%3Ayoutube.com&atb=v469-1-wb&ia=web"
+- pressKey: Enter
+
+# Open Specific Video
+- assertVisible: "DuckDuckGo vs Google: 5 Reasons You Should Switch"
+- tapOn: "DuckDuckGo vs Google: 5 Reasons You Should Switch"
+
+# Validate Duck Player opens
+- assertVisible: "Duck Player"
+- assertVisible:
+    id: "xmark"
+- assertVisible: "Watch on YouTube"
+- assertVisible: "DuckPlayerOpenSettings"
+- assertVisible:
+    id: "chevron.up"
+
+# Validate Duck Player Closes
+- tapOn: 
+    id: "xmark"
+- assertVisible: "DuckDuckGo vs Google: 5 Reasons You Should Switch"

--- a/.maestro/duckplayer.native/01_serp_navigation_enabled.yaml
+++ b/.maestro/duckplayer.native/01_serp_navigation_enabled.yaml
@@ -4,33 +4,25 @@ tags:
 
 ---
 
-
 # Set up 
 - runFlow: 
     file: ../shared/setup.yaml
 
 # Load Site
-- assertVisible:
-    id: "searchEntry"
-- tapOn: 
-    id: "searchEntry"
-- inputText: "https://duckduckgo.com/?q=%22DuckDuckGo+vs+Google%3A+5+Reasons+You+Should+Switch%E2%80%9D+site%3Ayoutube.com&atb=v469-1-wb&ia=web"
-- pressKey: Enter
+- runFlow: 
+    file: shared/load_serp_url.yaml
 
 # Open Specific Video
 - assertVisible: "DuckDuckGo vs Google: 5 Reasons You Should Switch"
 - tapOn: "DuckDuckGo vs Google: 5 Reasons You Should Switch"
 
-# Validate Duck Player opens
-- assertVisible: "Duck Player"
-- assertVisible:
-    id: "xmark"
+# Validate Duck Player is Visible
+- runFlow: 
+    file: shared/duckplayer_is_visible.yaml
+
+# Validate this is SERP View
 - assertVisible: "Watch on YouTube"
-- assertVisible: "DuckPlayerOpenSettings"
-- assertVisible:
-    id: "chevron.up"
 
 # Validate Duck Player Closes
-- tapOn: 
-    id: "xmark"
-- assertVisible: "DuckDuckGo vs Google: 5 Reasons You Should Switch"
+- runFlow: 
+    file: shared/close_player.yaml

--- a/.maestro/duckplayer.native/02_serp_navigation_disabled.yaml
+++ b/.maestro/duckplayer.native/02_serp_navigation_disabled.yaml
@@ -1,0 +1,37 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - duckplayer.native
+
+---
+
+
+# Set up 
+- runFlow: 
+    file: ../shared/setup.yaml
+
+# Turn SERP off
+- tapOn: "Browsing Menu"
+- tapOn: "Settings"
+- scrollUntilVisible: 
+    element: "Duck Player"
+    direction: DOWN
+- tapOn: "Duck Player"
+- tapOn:
+    text: "1"
+    index: 0
+- tapOn: "Settings"
+- tapOn: "Done"
+
+
+# Navigate to a video
+- assertVisible:
+    id: "searchEntry"
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://duckduckgo.com/?q=%22DuckDuckGo+vs+Google%3A+5+Reasons+You+Should+Switch%E2%80%9D+site%3Ayoutube.com&atb=v469-1-wb&ia=web"
+- pressKey: Enter
+- assertVisible: "DuckDuckGo vs Google: 5 Reasons You Should Switch"
+- tapOn: "DuckDuckGo vs Google: 5 Reasons You Should Switch"
+
+# Validate YouTube opens
+- assertVisible: "m.youtube.com"

--- a/.maestro/duckplayer.native/03_youtube_navigation_let_me_choose.yaml
+++ b/.maestro/duckplayer.native/03_youtube_navigation_let_me_choose.yaml
@@ -1,0 +1,89 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - duckplayer.native
+
+---
+
+# Load constants
+- runFlow:
+    file: shared/constants.yaml
+
+# Set up 
+- runFlow: 
+    file: ../shared/setup.yaml
+
+# Navigate to a video
+# Load Site
+- runFlow: 
+    file: shared/load_youtube_url.yaml
+
+  # Assert Youtube Search Page opens and open the video
+- assertVisible: ${output.videoTitle}
+- tapOn: ${output.videoTitle}
+
+# Validate YouTube opens
+- assertVisible: ${output.youtubeMobileDomain}
+
+# Assert Duck Player Welcome Pill is present
+- assertVisible:
+    id: duckPlayerWelcomePill
+
+- tapOn:
+    id: duckPlayerWelcomeButton
+
+# Validate Duck Player is Visible
+- runFlow: 
+    file: shared/duckplayer_is_visible.yaml
+
+# Ensure the player is correct
+- assertVisible: ${output.openVideosHereLabel}
+
+# Close Duck Player
+- runFlow: 
+    file: shared/close_player.yaml
+
+# Assert Duck Player Welcome Pill is not present
+- assertVisible: "Resume in Duck Player"
+
+- tapOn: "Resume in Duck Player"
+
+# Assert Duck Player is Visible
+- runFlow: 
+    file: shared/duckplayer_is_visible.yaml
+
+# Close Duck Player
+- runFlow: 
+    file: shared/close_player.yaml
+
+# Check for the pill
+- assertVisible: "Resume in Duck Player"
+- tapOn: Resume in Duck Player
+
+# Assert Duck Player is Visible
+- runFlow: 
+    file: shared/duckplayer_is_visible.yaml
+
+# Close Duck Player
+- runFlow: 
+    file: shared/close_player.yaml
+
+# Hit fire button
+- tapOn: "Close Tabs and Clear Data"
+- tapOn:
+    id: alert.forget-data.confirm
+
+# Load YouTube URL
+- runFlow: 
+    file: shared/load_youtube_url.yaml
+
+  # Assert Youtube Search Page opens and open the video
+- assertVisible: ${output.videoTitle}
+- tapOn: ${output.videoTitle}
+
+# Assert Pill is present
+- assertVisible: "Play this video in Duck Player"
+- tapOn: "Play this video in Duck Player"
+
+# Assert Duck Player is Visible
+- runFlow: 
+    file: shared/duckplayer_is_visible.yaml

--- a/.maestro/duckplayer.native/04_youtube_navigation_let_me_choose.yaml
+++ b/.maestro/duckplayer.native/04_youtube_navigation_let_me_choose.yaml
@@ -12,10 +12,9 @@ tags:
 - runFlow: 
     file: shared/open_settings.yaml
 
-# Turn SERP off
-- tapOn:
-    text: "1"
-    index: 0
+# Turn DuckPlayer off
+- tapOn: "Let me choose"
+- tapOn: "Don't Show"
 
 # Close Settings
 - runFlow: 
@@ -24,7 +23,7 @@ tags:
 # Navigate to a video
 # Load Site
 - runFlow: 
-    file: shared/load_serp_url.yaml
+    file: shared/load_youtube_url.yaml
 
   # Assert Youtube Search Page opens and open the video
 - assertVisible: "DuckDuckGo vs Google: 5 Reasons You Should Switch"
@@ -32,3 +31,13 @@ tags:
 
 # Validate YouTube opens
 - assertVisible: "m.youtube.com"
+
+# Assert Duck Player Welcome Pill is present
+- assertNotVisible:
+    id: duckPlayerWelcomePill
+
+- runFlow: 
+    file: shared/load_youtube_url.yaml
+
+# Assert Duck Player Welcome Pill is not present
+- assertNotVisible: "Resume in Duck Player"

--- a/.maestro/duckplayer.native/shared/close_player.yaml
+++ b/.maestro/duckplayer.native/shared/close_player.yaml
@@ -1,0 +1,7 @@
+appId: com.duckduckgo.mobile.ios
+---
+
+# Validate Duck Player Closes
+- tapOn: 
+    id: "xmark"
+- assertVisible: "DuckDuckGo vs Google: 5 Reasons You Should Switch"

--- a/.maestro/duckplayer.native/shared/close_settings.yaml
+++ b/.maestro/duckplayer.native/shared/close_settings.yaml
@@ -1,0 +1,5 @@
+appId: com.duckduckgo.mobile.ios
+---
+
+- tapOn: "Settings"
+- tapOn: "Done"

--- a/.maestro/duckplayer.native/shared/constants.yaml
+++ b/.maestro/duckplayer.native/shared/constants.yaml
@@ -1,0 +1,18 @@
+# Shared constants for DuckPlayer tests
+appId: com.duckduckgo.mobile.ios
+
+# Define variables that can be used across tests
+- evalScript: ${output.videoTitle = "DuckDuckGo vs Google: 5 Reasons You Should Switch"}
+- evalScript: ${output.videoSearchUrl = "https://duckduckgo.com/?q=%22DuckDuckGo+vs+Google%3A+5+Reasons+You+Should+Switch%E2%80%9D+site%3Ayoutube.com&atb=v469-1-wb&ia=web"}
+- evalScript: ${output.youtubeSearchUrl = "https://www.youtube.com/results?search_query=%22DuckDuckGo+vs+Google%3A+5+Reasons+You+Should+Switch%22&sp=EgIQAQ%253D%253D"}
+- evalScript: ${output.searchEntryId = "searchEntry"}
+- evalScript: ${output.closeButtonId = "xmark"}
+- evalScript: ${output.chevronUpId = "chevron.up"}
+- evalScript: ${output.duckPlayerSettingsId = "DuckPlayerOpenSettings"}
+- evalScript: ${output.duckPlayerLabel = "Duck Player"}
+- evalScript: ${output.settingsLabel = "Settings"}
+- evalScript: ${output.doneLabel = "Done"}
+- evalScript: ${output.browsingMenuLabel = "Browsing Menu"}
+- evalScript: ${output.watchOnYoutubeLabel = "Watch on YouTube"}
+- evalScript: ${output.openVideosHereLabel = "Open YouTube videos here"}
+- evalScript: ${output.youtubeMobileDomain = "m.youtube.com"}

--- a/.maestro/duckplayer.native/shared/duckplayer_is_visible.yaml
+++ b/.maestro/duckplayer.native/shared/duckplayer_is_visible.yaml
@@ -1,0 +1,12 @@
+# duckplayer_is_visible.yaml
+
+appId: com.duckduckgo.mobile.ios
+---
+
+# Validate Duck Player is Visible
+- assertVisible: "Duck Player"
+- assertVisible:
+    id: "xmark"
+- assertVisible: "DuckPlayerOpenSettings"
+- assertVisible:
+    id: "chevron.up"

--- a/.maestro/duckplayer.native/shared/load_serp_url.yaml
+++ b/.maestro/duckplayer.native/shared/load_serp_url.yaml
@@ -1,0 +1,9 @@
+appId: com.duckduckgo.mobile.ios
+---
+
+- assertVisible:
+    id: "searchEntry"
+- tapOn: 
+    id: "searchEntry"
+- inputText: "https://duckduckgo.com/?q=%22DuckDuckGo+vs+Google%3A+5+Reasons+You+Should+Switch%E2%80%9D+site%3Ayoutube.com&atb=v469-1-wb&ia=web"
+- pressKey: Enter

--- a/.maestro/duckplayer.native/shared/load_youtube_url.yaml
+++ b/.maestro/duckplayer.native/shared/load_youtube_url.yaml
@@ -1,0 +1,12 @@
+appId: com.duckduckgo.mobile.ios
+---
+
+- assertVisible:
+    id: "searchEntry"
+- tapOn: 
+    id: "searchEntry"
+- inputText: "https://www.youtube.com/results?search_query=%22DuckDuckGo+vs+Google%3A+5+Reasons+You+Should+Switch%22&sp=EgIQAQ%253D%253D"
+- pressKey: Enter
+
+# Refresh the page to ensure the cookies are handled
+- tapOn: Refresh page

--- a/.maestro/duckplayer.native/shared/open_settings.yaml
+++ b/.maestro/duckplayer.native/shared/open_settings.yaml
@@ -1,0 +1,9 @@
+appId: com.duckduckgo.mobile.ios
+---
+
+- tapOn: "Browsing Menu"
+- tapOn: "Settings"
+- scrollUntilVisible: 
+    element: "Duck Player"
+    direction: DOWN
+- tapOn: "Duck Player"

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "782c3fdd5c96d978e7eae5b9734be40abcfdfa50",
-        "version" : "10.8.0"
+        "revision" : "40e84974805a910979961ded1d5003584d9d94b5",
+        "version" : "10.12.0"
       }
     },
     {

--- a/iOS/scripts/loc_export.sh
+++ b/iOS/scripts/loc_export.sh
@@ -2,7 +2,7 @@
 
 # Get the directory where the script is stored
 script_dir=$(dirname "$(readlink -f "$0")")
-base_dir="${script_dir}/.."
+ios_dir="${script_dir}/.."
 
 echo "Updating..."
 "${script_dir}/loc_update.sh"
@@ -10,5 +10,22 @@ echo "Updating..."
 echo "Exporting..."
 loc_path="${script_dir}/assets/loc"
 rm -r "$loc_path"
-xcodebuild -exportLocalizations -project "${base_dir}/DuckDuckGo-iOS.xcodeproj" -localizationPath "$loc_path" -sdk iphoneos -exportLanguage en
+
+# Save current directory to return to it later
+current_dir=$(pwd)
+
+# Change to iOS directory and explicitly specify the iOS project
+# This ensures only iOS strings are exported when running from repository root
+# Only change directory if we're not already in the iOS directory
+if [ "$(pwd)" != "$ios_dir" ]; then
+    cd "$ios_dir"
+fi
+
+xcodebuild -exportLocalizations -project "DuckDuckGo-iOS.xcodeproj" -localizationPath "$loc_path" -sdk iphoneos -exportLanguage en
+
+# Return to original directory if we changed it
+if [ "$(pwd)" != "$current_dir" ]; then
+    cd "$current_dir"
+fi
+
 open "${loc_path}/en.xcloc/Localized Contents"

--- a/macOS/scripts/loc_export.sh
+++ b/macOS/scripts/loc_export.sh
@@ -8,7 +8,10 @@ show_help() {
     echo
     echo "Options:"
     echo "  -n, --name NAME    Specify the name for the exported xliff file"
-    echo "This script attempts to export an xliff file from the Xcode String Catalogue."
+    echo
+    echo "This script exports an xliff file from the macOS Xcode String Catalogue."
+    echo "It explicitly targets the macOS project to avoid including iOS strings"
+    echo "when run from the repository root directory."
     echo "--- ---"
     echo
     exit 0
@@ -47,11 +50,27 @@ script_dir=$(dirname "$(readlink -f "$0")")
 export_path="${script_dir}/TempLocalizationExport"
 final_xliff_path="${script_dir}/assets/loc"
 
+# Get the macOS directory (parent of scripts directory)
+macos_dir=$(dirname "$script_dir")
+
 # Ensure the final xliff directory exists
 mkdir -p "$final_xliff_path"
 
-# Export localizations
-xcodebuild -exportLocalizations -localizationPath "$export_path" -derivedDataPath "${script_dir}/DerivedData" -scheme "macOS Browser" APP_STORE_PRODUCT_MODULE_NAME_OVERRIDE=DuckDuckGo_Privacy_Browser_App_Store PRIVACY_PRO_PRODUCT_MODULE_NAME_OVERRIDE=DuckDuckGo_Privacy_Browser_Privacy_Pro
+# Export localizations - explicitly specify the macOS project and working directory
+# Save current directory to return to it later
+current_dir=$(pwd)
+
+# Only change directory if we're not already in the macOS directory
+if [ "$(pwd)" != "$macos_dir" ]; then
+    cd "$macos_dir"
+fi
+
+xcodebuild -exportLocalizations -localizationPath "$export_path" -derivedDataPath "${script_dir}/DerivedData" -project "DuckDuckGo-macOS.xcodeproj" -scheme "macOS Browser" APP_STORE_PRODUCT_MODULE_NAME_OVERRIDE=DuckDuckGo_Privacy_Browser_App_Store PRIVACY_PRO_PRODUCT_MODULE_NAME_OVERRIDE=DuckDuckGo_Privacy_Browser_Privacy_Pro
+
+# Return to original directory if we changed it
+if [ "$(pwd)" != "$current_dir" ]; then
+    cd "$current_dir"
+fi
 
 # Attempt to find the .xcloc package
 xcloc_package=$(find "$export_path" -type d -name "*.xcloc")


### PR DESCRIPTION
Task/Issue URL: N/A
Tech Design URL: N/A
CC: N/A

### Description
Fixed both iOS and macOS `loc_export.sh` scripts to ensure they only export strings from their respective platforms when run from the repository root directory.

The issue was that running these scripts from the root directory (e.g., `macOS/scripts/loc_export.sh`) could result in xcodebuild detecting and using the workspace file, which would export strings from both iOS and macOS platforms.

### Testing Steps
1. From the repository root, run `macOS/scripts/loc_export.sh`
2. Verify that only macOS strings are exported (no iOS phantom strings)
3. From the repository root, run `iOS/scripts/loc_export.sh`
4. Verify that only iOS strings are exported
5. Run the scripts from within their respective directories and verify they still work correctly

### Impact and Risks
**Low**: This is a build script improvement that ensures proper isolation of platform-specific localization exports.

#### What could go wrong?
- The scripts could fail if the directory structure changes, but the changes include checks to ensure we don't unnecessarily change directories if already in the correct location

### Quality Considerations
- Added directory change logic that checks current location before changing
- Both scripts now explicitly specify the project file to prevent workspace detection
- Scripts return to the original directory after completion to maintain expected behavior

### Notes to Reviewer
The key changes are:
1. Both scripts now change to their respective project directories before running xcodebuild
2. The macOS script now explicitly specifies `-project "DuckDuckGo-macOS.xcodeproj"`
3. Directory changes are conditional to avoid unnecessary operations