### PR TITLE
Fix loc_export.sh scripts to properly isolate platform exports

### DIFF
--- a/iOS/scripts/loc_export.sh
+++ b/iOS/scripts/loc_export.sh
@@ -2,7 +2,7 @@
 
 # Get the directory where the script is stored
 script_dir=$(dirname "$(readlink -f "$0")")
-base_dir="${script_dir}/.."
+ios_dir="${script_dir}/.."
 
 echo "Updating..."
 "${script_dir}/loc_update.sh"
@@ -10,5 +10,22 @@ echo "Updating..."
 echo "Exporting..."
 loc_path="${script_dir}/assets/loc"
 rm -r "$loc_path"
-xcodebuild -exportLocalizations -project "${base_dir}/DuckDuckGo-iOS.xcodeproj" -localizationPath "$loc_path" -sdk iphoneos -exportLanguage en
+
+# Save current directory to return to it later
+current_dir=$(pwd)
+
+# Change to iOS directory and explicitly specify the iOS project
+# This ensures only iOS strings are exported when running from repository root
+# Only change directory if we're not already in the iOS directory
+if [ "$(pwd)" != "$ios_dir" ]; then
+    cd "$ios_dir"
+fi
+
+xcodebuild -exportLocalizations -project "DuckDuckGo-iOS.xcodeproj" -localizationPath "$loc_path" -sdk iphoneos -exportLanguage en
+
+# Return to original directory if we changed it
+if [ "$(pwd)" != "$current_dir" ]; then
+    cd "$current_dir"
+fi
+
 open "${loc_path}/en.xcloc/Localized Contents"

--- a/macOS/scripts/loc_export.sh
+++ b/macOS/scripts/loc_export.sh
@@ -8,7 +8,10 @@ show_help() {
     echo
     echo "Options:"
     echo "  -n, --name NAME    Specify the name for the exported xliff file"
-    echo "This script attempts to export an xliff file from the Xcode String Catalogue."
+    echo
+    echo "This script exports an xliff file from the macOS Xcode String Catalogue."
+    echo "It explicitly targets the macOS project to avoid including iOS strings"
+    echo "when run from the repository root directory."
     echo "--- ---"
     echo
     exit 0
@@ -47,11 +50,27 @@ script_dir=$(dirname "$(readlink -f "$0")")
 export_path="${script_dir}/TempLocalizationExport"
 final_xliff_path="${script_dir}/assets/loc"
 
+# Get the macOS directory (parent of scripts directory)
+macos_dir=$(dirname "$script_dir")
+
 # Ensure the final xliff directory exists
 mkdir -p "$final_xliff_path"
 
-# Export localizations
-xcodebuild -exportLocalizations -localizationPath "$export_path" -derivedDataPath "${script_dir}/DerivedData" -scheme "macOS Browser" APP_STORE_PRODUCT_MODULE_NAME_OVERRIDE=DuckDuckGo_Privacy_Browser_App_Store PRIVACY_PRO_PRODUCT_MODULE_NAME_OVERRIDE=DuckDuckGo_Privacy_Browser_Privacy_Pro
+# Export localizations - explicitly specify the macOS project and working directory
+# Save current directory to return to it later
+current_dir=$(pwd)
+
+# Only change directory if we're not already in the macOS directory
+if [ "$(pwd)" != "$macos_dir" ]; then
+    cd "$macos_dir"
+fi
+
+xcodebuild -exportLocalizations -localizationPath "$export_path" -derivedDataPath "${script_dir}/DerivedData" -project "DuckDuckGo-macOS.xcodeproj" -scheme "macOS Browser" APP_STORE_PRODUCT_MODULE_NAME_OVERRIDE=DuckDuckGo_Privacy_Browser_App_Store PRIVACY_PRO_PRODUCT_MODULE_NAME_OVERRIDE=DuckDuckGo_Privacy_Browser_Privacy_Pro
+
+# Return to original directory if we changed it
+if [ "$(pwd)" != "$current_dir" ]; then
+    cd "$current_dir"
+fi
 
 # Attempt to find the .xcloc package
 xcloc_package=$(find "$export_path" -type d -name "*.xcloc")


### PR DESCRIPTION
Task/Issue URL: N/A
Tech Design URL: N/A
CC: N/A

### Description
Fixed both iOS and macOS `loc_export.sh` scripts to ensure they only export strings from their respective platforms when run from the repository root directory.

The issue was that running these scripts from the root directory (e.g., `macOS/scripts/loc_export.sh`) could result in xcodebuild detecting and using the workspace file, which would export strings from both iOS and macOS platforms.

### Testing Steps
1. From the repository root, run `macOS/scripts/loc_export.sh`
2. Verify that only macOS strings are exported (no iOS phantom strings)
3. From the repository root, run `iOS/scripts/loc_export.sh`
4. Verify that only iOS strings are exported
5. Run the scripts from within their respective directories and verify they still work correctly

### Impact and Risks
**Low**: This is a build script improvement that ensures proper isolation of platform-specific localization exports.

#### What could go wrong?
- The scripts could fail if the directory structure changes, but the changes include checks to ensure we don't unnecessarily change directories if already in the correct location

### Quality Considerations
- Added directory change logic that checks current location before changing
- Both scripts now explicitly specify the project file to prevent workspace detection
- Scripts return to the original directory after completion to maintain expected behavior

### Notes to Reviewer
The key changes are:
1. Both scripts now change to their respective project directories before running xcodebuild
2. The macOS script now explicitly specifies `-project "DuckDuckGo-macOS.xcodeproj"`
3. Directory changes are conditional to avoid unnecessary operations