### PR TITLE
Prevent favicon background from scaling down

### DIFF
--- a/iOS/DuckDuckGo/FavoriteIconView.swift
+++ b/iOS/DuckDuckGo/FavoriteIconView.swift
@@ -42,6 +42,7 @@ struct FavoriteIconView: View {
                     $0.shadow(color: .shade(0.12), radius: 0.5, y: 1)
                 }
                 .aspectRatio(1, contentMode: .fit)
+                .frame(width: Constant.faviconSize, height: Constant.faviconSize)
 
             Image(uiImage: favicon.image)
                 .resizable()
@@ -75,6 +76,7 @@ struct FavoriteIconView: View {
 
 private struct Constant {
     static let faviconSize: CGFloat = 64
+    static let fakeFaviconSize: CGFloat = 40
     static let borderSize: CGFloat = 12
     static let cornerRadiusExperimental: CGFloat = 12
     static let cornerRadius: CGFloat = 8
@@ -97,7 +99,7 @@ private extension Favorite {
 extension FavoriteIconView {
     init(favorite: Favorite, isExperimentalAppearanceEnabled: Bool, faviconLoading: FavoritesFaviconLoading? = nil) {
         let favicon = faviconLoading?.existingFavicon(for: favorite, size: Constant.faviconSize)
-        ?? faviconLoading?.fakeFavicon(for: favorite, size: Constant.faviconSize)
+        ?? faviconLoading?.fakeFavicon(for: favorite, size: Constant.fakeFaviconSize)
         ?? .empty
         self.init(favicon: favicon, favorite: favorite, faviconLoading: faviconLoading, isExperimentalAppearanceEnabled: isExperimentalAppearanceEnabled)
     }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1210844584732074?focus=true
Tech Design URL:
CC: @amddg44 

### Description

* Fixes the size of the favicon background to prevent it from becoming smaller than required.
* Enforces the fake favicon size to match the NTP.

### Testing Steps
1. Add favorites for the following:
    1. https://dummyimage.com/100/100/fff?text=page98
    2. https://api.dicebear.com/9.x/adventurer/svg?seed=page98
    3. Any SERP result
    4. https://robohash.org/page81
    5. https://hello.com/
2. Verify if they all look fine on NTP.
3. Enable Search Input
4. Focus on input, check if the favorite icons look the same as on NTP.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Sizing of the favorites on NTP may be off or they can be misaligned.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)