### PR TITLE
Apple VPN: Adds useful information to controller start failures

### DIFF
--- a/SharedPackages/VPN/Sources/VPN/NetworkProtectionOptionKey.swift
+++ b/SharedPackages/VPN/Sources/VPN/NetworkProtectionOptionKey.swift
@@ -26,8 +26,10 @@ public enum NetworkProtectionOptionKey {
     public static let dnsSettings = "dnsSettings"
     public static let excludeLocalNetworks = "excludeLocalNetworks"
     public static let isAuthV2Enabled = "isAuthV2Enabled"
+#if os(macOS)
     public static let authToken = "authToken"
     public static let tokenContainer = "tokenContainer"
+#endif
     public static let isOnDemand = "is-on-demand"
     public static let activationAttemptId = "activationAttemptId"
     public static let tunnelFailureSimulation = "tunnelFailureSimulation"

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
@@ -509,6 +509,7 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
         case connectionAlreadyStarted
         case simulateControllerFailureError
         case startTunnelFailure(_ error: Error)
+        case failedToFetchAuthToken(_ error: Error)
 
         var errorDescription: String? {
             switch self {
@@ -531,7 +532,8 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
 #endif
             case .simulateControllerFailureError:
                 return "Simulated a controller error as requested"
-            case .startTunnelFailure(let error):
+            case .startTunnelFailure(let error),
+                    .failedToFetchAuthToken(let error):
                 return error.localizedDescription
             }
         }
@@ -546,6 +548,8 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
             case .simulateControllerFailureError: return 4
                 // MARK: Actual connection attempt issues
             case .startTunnelFailure: return 100
+                // MARK: Auth errors
+            case .failedToFetchAuthToken: return 201
             }
         }
 
@@ -557,7 +561,8 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
                     .connectionAlreadyStarted,
                     .simulateControllerFailureError:
                 return [:]
-            case .startTunnelFailure(let error):
+            case .startTunnelFailure(let error),
+                    .failedToFetchAuthToken(let error):
                 return [NSUnderlyingErrorKey: error]
             }
         }
@@ -888,13 +893,18 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
         }
     }
 
-    private func fetchAuthToken() throws -> NSString {
-        if let accessToken = try? accessTokenStorage.getAccessToken() {
+    private func fetchAuthToken() throws -> NSString? {
+        do {
+            guard let accessToken = try accessTokenStorage.getAccessToken() else {
+                Logger.networkProtection.error("🔴 TunnelController found no token")
+                throw StartError.noAuthToken
+            }
+
             Logger.networkProtection.log("🟢 TunnelController found token")
             return Self.adaptAccessTokenForVPN(accessToken) as NSString
-        } else {
-            Logger.networkProtection.error("🔴 TunnelController found no token")
-            throw StartError.noAuthToken
+        } catch {
+            Logger.networkProtection.fault("🔴 TunnelController failed to fetch token: \(error.localizedDescription)")
+            throw StartError.failedToFetchAuthToken(error)
         }
     }
 
@@ -904,8 +914,14 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
             Logger.networkProtection.log("🟢 TunnelController found token container")
             return tokenContainer
         } catch {
-            Logger.networkProtection.fault("🔴 TunnelController found no token container")
-            throw StartError.noAuthToken
+            switch error {
+            case SubscriptionManagerError.noTokenAvailable:
+                Logger.networkProtection.fault("🔴 TunnelController found no token container")
+                throw StartError.noAuthToken
+            default:
+                Logger.networkProtection.fault("🔴 TunnelController failed to fetch token container: \(error.localizedDescription)")
+                throw StartError.failedToFetchAuthToken(error)
+            }
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206580121312550/task/1210845165145900?focus=true

### Description

Adds useful information to controller start failures

## Testing Steps

### Test regular behavior:

Test the VPN works fine in auth v1 and v2 for both macOS and iOS - or at least if it's not, that you don't see errors in the `controller_start` pixels.

### Force failures:

Force failures in the iOS and macOS tunnel controllers and check that you see the correct error information in the pixels depending on which error you're forcing.

### Impact and Risks

Medium.

#### What could go wrong?

I could've made a mistake in the logic, causing the tunnel not to start in either macOS or iOS.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)