### PR TITLE
Open summarization source links in new tab when Duck.ai chat is in a full-size tab

### DIFF
--- a/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebar.swift
+++ b/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebar.swift
@@ -60,7 +60,7 @@ final class AIChatSidebar: NSObject {
     /// Creates a sidebar wrapper with the specified initial AI chat URL.
     /// - Parameter initialAIChatURL: The initial AI chat URL to load. If nil, defaults to the URL from AIChatRemoteSettings.
     init(initialAIChatURL: URL? = nil, burnerMode: BurnerMode) {
-        self.initialAIChatURL = initialAIChatURL ?? aiChatRemoteSettings.aiChatURL.forSidebar()
+        self.initialAIChatURL = initialAIChatURL ?? aiChatRemoteSettings.aiChatURL.forAIChatSidebar()
         self.burnerMode = burnerMode
     }
 }
@@ -87,22 +87,25 @@ extension AIChatSidebar: NSSecureCoding {
     }
 }
 
-fileprivate extension URL {
-
-    enum PlacementParameter {
-        static let name = "placement"
-        static let sidebar = "sidebar"
-    }
-
-    func forSidebar() -> URL {
-        self.appendingParameter(name: PlacementParameter.name, value: PlacementParameter.sidebar)
-    }
-
-}
-
 extension URL {
 
-    public func removingPlacementParameter() -> URL {
-        self.removingParameters(named: [PlacementParameter.name])
+    enum AIChatPlacementParameter {
+        public static let name = "placement"
+        public static let sidebar = "sidebar"
+    }
+
+    public func forAIChatSidebar() -> URL {
+        appendingParameter(name: AIChatPlacementParameter.name, value: AIChatPlacementParameter.sidebar)
+    }
+
+    public func removingAIChatPlacementParameter() -> URL {
+        removingParameters(named: [AIChatPlacementParameter.name])
+    }
+
+    public var hasAIChatSidebarPlacementParameter: Bool {
+        guard let parameter = self.getParameter(named: AIChatPlacementParameter.name) else {
+            return false
+        }
+        return parameter == AIChatPlacementParameter.sidebar
     }
 }

--- a/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarViewController.swift
+++ b/macOS/DuckDuckGo/Tab/AIChatSidebar/AIChatSidebarViewController.swift
@@ -273,7 +273,7 @@ final class AIChatSidebarViewController: NSViewController {
     @objc private func openInNewTabButtonClicked() {
         let aiChatRestorationData = aiTab.aiChat?.aiChatUserScript?.handler.messageHandling.getDataForMessageType(.chatRestorationData) as? AIChatRestorationData
 
-        delegate?.didClickOpenInNewTabButton(currentAIChatURL: currentAIChatURL.removingPlacementParameter(), aiChatRestorationData: aiChatRestorationData)
+        delegate?.didClickOpenInNewTabButton(currentAIChatURL: currentAIChatURL.removingAIChatPlacementParameter(), aiChatRestorationData: aiChatRestorationData)
     }
 
     @objc private func closeButtonClicked() {

--- a/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -207,9 +207,10 @@ struct AIChatUserScriptHandlerTests {
 
     @Test("openSummarizationSourceLink doesn't call windowControllersManager when invalid URL is passed")
     @MainActor
-    func testThatOpenSummarizationSourceLinkDoesNotCallWindowControllersManagerWhenInvalidURLIsPassed() async {
+    func testThatOpenSummarizationSourceLinkDoesNotCallWindowControllersManagerWhenInvalidURLIsPassed() async throws {
         let urlString = "invalid"
-        let params = [AIChatUserScriptHandler.AIChatKeys.url: urlString]
+        let openLinkPayload = AIChatUserScriptHandler.OpenLink(url: urlString, target: .sameTab)
+        let params = try #require(DecodableHelper.encode(openLinkPayload).flatMap { try JSONSerialization.jsonObject(with: $0, options: []) })
 
         _ = await handler.openSummarizationSourceLink(params: params, message: WKScriptMessage())
 

--- a/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -17,8 +17,10 @@
 //
 
 import Combine
+import Common
 import PixelKitTestingUtilities
 import Testing
+import UserScript
 import WebKit
 @testable import DuckDuckGo_Privacy_Browser
 
@@ -167,11 +169,31 @@ struct AIChatUserScriptHandlerTests {
         #expect(messageHandler.setDataCalls.first?.data == nil)
     }
 
-    @Test("openSummarizationSourceLink calls windowControllersManager when valid URL is passed")
+    @Test("openSummarizationSourceLink calls windowControllersManager show when valid URL is passed with same tab target")
     @MainActor
-    func testThatOpenSummarizationSourceLinkCallsWindowControllersManager() async throws {
+    func testThatOpenSummarizationSourceLinkCallsWindowControllersManagerShow() async throws {
         let urlString = "https://example.com"
-        let params = [AIChatUserScriptHandler.AIChatKeys.url: urlString]
+        let openLinkPayload = AIChatUserScriptHandler.OpenLink(url: urlString, target: .sameTab)
+        let params = try #require(DecodableHelper.encode(openLinkPayload).flatMap { try JSONSerialization.jsonObject(with: $0, options: []) })
+        pixelFiring.expectedFireCalls = [.init(pixel: AIChatPixel.aiChatSummarizeSourceLinkClicked, frequency: .dailyAndStandard)]
+
+        _ = await handler.openSummarizationSourceLink(params: params, message: WKScriptMessage())
+
+        let showCall = try #require(windowControllersManager.showCalled)
+        #expect(showCall.url?.absoluteString == urlString)
+        #expect(showCall.source == .switchToOpenTab)
+        #expect(showCall.newTab == true)
+        #expect(showCall.selected == true)
+        #expect(pixelFiring.expectedFireCalls == pixelFiring.actualFireCalls)
+    }
+
+    static let targets: [AIChatUserScriptHandler.OpenLink.OpenTarget] = [.newTab, .newWindow]
+    @Test("openSummarizationSourceLink calls windowControllersManager open when valid URL is passed with non-same-tab target", arguments: targets)
+    @MainActor
+    func testThatOpenSummarizationSourceLinkCallsWindowControllersManagerOpen(_ target: AIChatUserScriptHandler.OpenLink.OpenTarget) async throws {
+        let urlString = "https://example.com"
+        let openLinkPayload = AIChatUserScriptHandler.OpenLink(url: urlString, target: target)
+        let params = try #require(DecodableHelper.encode(openLinkPayload).flatMap { try JSONSerialization.jsonObject(with: $0, options: []) })
         pixelFiring.expectedFireCalls = [.init(pixel: AIChatPixel.aiChatSummarizeSourceLinkClicked, frequency: .dailyAndStandard)]
 
         _ = await handler.openSummarizationSourceLink(params: params, message: WKScriptMessage())


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210855725388312?focus=true

### Description
This change changes behavior of the summarization source link when in a full-size tab.
The link will now open in a new tab instead of the current tab, and when such tab is already open,
it will switch to the open tab instead.
The behavior for sidebar chats is the same and clicking the link will open the website in the current tab.

### Testing Steps
1. Have sidebar enabled
2. Summarize some text (it happens in the sidebar).
3. Navigate to another website in the same tab.
4. Click Summarization source link in the summarize chat bubble and verify that the source website is opened in the current tab.
5. Expand the sidebar to a full-size tab.
6. Click Summarization source link and verify that you’re redirected to an already open tab with the source website.
7. Close that tab and click the Summarization source link again. Verify that it opens a new tab.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

### Quality Considerations
Tests are updated but I couldn’t test isSidebar logic because UserScriptMessage requires WKWebView and
WKWebView.url is read-only. We’d need a better mocking for the UserScriptMessage and/or for the WebView itself.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)