### PR TITLE
pass origin to subscription purchase url from duck.ai

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
@@ -59,7 +59,7 @@ protocol SubscriptionUserScriptHandling {
 public protocol SubscriptionUserScriptNavigationDelegate: AnyObject {
     @MainActor func navigateToSettings()
     @MainActor func navigateToSubscriptionActivation()
-    @MainActor func navigateToSubscriptionPurchase()
+    @MainActor func navigateToSubscriptionPurchase(origin: String?)
 }
 
 protocol UserScriptMessagePushing: AnyObject {
@@ -139,7 +139,20 @@ final class SubscriptionUserScriptHandler: SubscriptionUserScriptHandling {
 
     @MainActor
     func openSubscriptionPurchase(params: Any, message: any UserScriptMessage) async throws -> Encodable? {
-        navigationDelegate?.navigateToSubscriptionPurchase()
+        struct PurchaseParams: Decodable {
+            let origin: String?
+        }
+
+        let purchaseParams: PurchaseParams? = {
+            if let paramsDict = params as? [String: Any] {
+                if let jsonData = try? JSONSerialization.data(withJSONObject: paramsDict, options: []) {
+                    return try? JSONDecoder().decode(PurchaseParams.self, from: jsonData)
+                }
+            }
+            return nil
+        }()
+
+        navigationDelegate?.navigateToSubscriptionPurchase(origin: purchaseParams?.origin)
         return nil
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/SubscriptionUserScript/MockSubscriptionUserScriptHandler.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/SubscriptionUserScript/MockSubscriptionUserScriptHandler.swift
@@ -32,6 +32,10 @@ public final class MockSubscriptionUserScriptHandler: SubscriptionUserScriptHand
     public var openSubscriptionActivationCallCount = 0
     public var openSubscriptionPurchaseCallCount = 0
 
+    // Parameter tracking
+    public var lastOpenSubscriptionPurchaseParams: Any?
+    public var lastOpenSubscriptionPurchaseMessage: (any UserScriptMessage)?
+
     // Setter method tracking
     public var lastSetBroker: UserScriptMessagePushing?
     public var lastSetWebView: WKWebView?
@@ -77,6 +81,8 @@ public final class MockSubscriptionUserScriptHandler: SubscriptionUserScriptHand
 
     public func openSubscriptionPurchase(params: Any, message: any UserScriptMessage) async throws -> Encodable? {
         openSubscriptionPurchaseCallCount += 1
+        lastOpenSubscriptionPurchaseParams = params
+        lastOpenSubscriptionPurchaseMessage = message
         return try await openSubscriptionPurchase(params, message)
     }
 

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionUserScript/SubscriptionUserScriptHandlerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionUserScript/SubscriptionUserScriptHandlerTests.swift
@@ -181,9 +181,20 @@ final class SubscriptionUserScriptHandlerTests: XCTestCase {
 
     @MainActor
     func testOpenSubscriptionPurchaseCallsNavigationDelegate() async throws {
-        let response = try await handler.openSubscriptionPurchase(params: [], message: WKScriptMessage())
+        let origin = "some_origin"
+        let params = ["origin": origin]
+        let response = try await handler.openSubscriptionPurchase(params: params, message: WKScriptMessage())
         XCTAssertNil(response)
         XCTAssertTrue(mockNavigationDelegate.navigateToSubscriptionPurchaseCalled)
+        XCTAssertEqual(mockNavigationDelegate.purchaseOrigin, origin)
+    }
+
+    @MainActor
+    func testOpenSubscriptionPurchaseWithoutOriginCallsNavigationDelegate() async throws {
+        let response = try await handler.openSubscriptionPurchase(params: [:], message: WKScriptMessage())
+        XCTAssertNil(response)
+        XCTAssertTrue(mockNavigationDelegate.navigateToSubscriptionPurchaseCalled)
+        XCTAssertNil(mockNavigationDelegate.purchaseOrigin)
     }
 
     // MARK: - Auth Update Push Tests
@@ -249,6 +260,7 @@ class MockNavigationDelegate: SubscriptionUserScriptNavigationDelegate {
     var navigateToSettingsCalled = false
     var navigateToSubscriptionActivationCalled = false
     var navigateToSubscriptionPurchaseCalled = false
+    var purchaseOrigin: String?
 
     func navigateToSettings() {
         navigateToSettingsCalled = true
@@ -258,8 +270,9 @@ class MockNavigationDelegate: SubscriptionUserScriptNavigationDelegate {
         navigateToSubscriptionActivationCalled = true
     }
 
-    func navigateToSubscriptionPurchase() {
+    func navigateToSubscriptionPurchase(origin: String?) {
         navigateToSubscriptionPurchaseCalled = true
+        purchaseOrigin = origin
     }
 }
 

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionUserScript/SubscriptionUserScriptTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionUserScript/SubscriptionUserScriptTests.swift
@@ -111,14 +111,23 @@ final class SubscriptionUserScriptTests: XCTestCase {
     }
 
     func testThatOpenSubscriptionPurchaseMessageIsPassedToHandler() async throws {
-        try await handleMessageIgnoringResponse(named: SubscriptionUserScript.MessageName.openSubscriptionPurchase)
-        XCTAssertEqual(handler.handshakeCallCount, 0)
-        XCTAssertEqual(handler.subscriptionDetailsCallCount, 0)
-        XCTAssertEqual(handler.getAuthAccessTokenCallCount, 0)
-        XCTAssertEqual(handler.getFeatureConfigCallCount, 0)
-        XCTAssertEqual(handler.backToSettingsCallCount, 0)
-        XCTAssertEqual(handler.openSubscriptionActivationCallCount, 0)
-        XCTAssertEqual(handler.openSubscriptionPurchaseCallCount, 1)
+        let origin = "some_origin"
+        let params = ["origin": origin]
+        let handler = try XCTUnwrap(userScript.handler(forMethodNamed: SubscriptionUserScript.MessageName.openSubscriptionPurchase.rawValue))
+        _ = try await handler(params, WKScriptMessage())
+
+        let mockHandler = try XCTUnwrap(self.handler)
+        XCTAssertEqual(mockHandler.handshakeCallCount, 0)
+        XCTAssertEqual(mockHandler.subscriptionDetailsCallCount, 0)
+        XCTAssertEqual(mockHandler.getAuthAccessTokenCallCount, 0)
+        XCTAssertEqual(mockHandler.getFeatureConfigCallCount, 0)
+        XCTAssertEqual(mockHandler.backToSettingsCallCount, 0)
+        XCTAssertEqual(mockHandler.openSubscriptionActivationCallCount, 0)
+        XCTAssertEqual(mockHandler.openSubscriptionPurchaseCallCount, 1)
+
+        // Verify parameters were passed through
+        let passedParams = try XCTUnwrap(mockHandler.lastOpenSubscriptionPurchaseParams as? [String: String])
+        XCTAssertEqual(passedParams["origin"], origin)
     }
 
     func testThatHandshakeIncludesAuthUpdateInAvailableMessages() async throws {

--- a/iOS/DuckDuckGo/Subscription/SubscriptionURLNavigationHandler.swift
+++ b/iOS/DuckDuckGo/Subscription/SubscriptionURLNavigationHandler.swift
@@ -54,10 +54,19 @@ final class SubscriptionURLNavigationHandler: SubscriptionUserScriptNavigationDe
 
     /// Navigates to the subscription purchase flow.
     /// Called when Duck.ai need to start a new subscription purchase.
-    func navigateToSubscriptionPurchase() {
+    func navigateToSubscriptionPurchase(origin: String?) {
+        let settingsDeepLink: SettingsViewModel.SettingsDeepLinkSection
+
+        if let origin = origin {
+            let redirectURLComponents = SubscriptionURL.purchaseURLComponentsWithOrigin(origin)
+            settingsDeepLink = .subscriptionFlow(redirectURLComponents: redirectURLComponents)
+        } else {
+            settingsDeepLink = .subscriptionFlow()
+        }
+
         NotificationCenter.default.post(
             name: .settingsDeepLinkNotification,
-            object: SettingsViewModel.SettingsDeepLinkSection.subscriptionFlow()
+            object: settingsDeepLink
         )
     }
 }

--- a/macOS/DuckDuckGo/Subscription/SubscriptionNavigationCoordinator.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionNavigationCoordinator.swift
@@ -69,8 +69,13 @@ extension SubscriptionNavigationCoordinator: SubscriptionUserScriptNavigationDel
 
     /// Opens the subscription purchase flow in a new tab.
     /// Called when Duck.ai need to start a new subscription purchase.
-    func navigateToSubscriptionPurchase() {
-        let url = subscriptionManager.url(for: .purchase)
+    func navigateToSubscriptionPurchase(origin: String?) {
+        var url = subscriptionManager.url(for: .purchase)
+
+        if let origin {
+            url = url.appendingParameter(name: AttributionParameter.origin, value: origin)
+        }
+
         tabShower.showTab(with: .subscription(url))
     }
 }

--- a/macOS/UnitTests/Subscription/SubscriptionNavigationCoordinatorTests.swift
+++ b/macOS/UnitTests/Subscription/SubscriptionNavigationCoordinatorTests.swift
@@ -74,7 +74,7 @@ struct SubscriptionNavigationCoordinatorTests {
         let expectedURL = URL(string: "https://duckduckgo.com/pro/purchase")!
         mockSubscriptionManager.urls[.purchase] = expectedURL
 
-        coordinator.navigateToSubscriptionPurchase()
+        coordinator.navigateToSubscriptionPurchase(origin: nil)
 
         // Verify tab shower was called to show tab with subscription content
         #expect(mockTabShower.capturedContent != nil)
@@ -86,6 +86,27 @@ struct SubscriptionNavigationCoordinatorTests {
 
         // Verify the URL matches exactly what was returned from subscription manager
         #expect(url == expectedURL)
+    }
+
+    @Test("navigateToSubscriptionPurchase fetches purchase URL and shows subscription tab with origin")
+    func navigateToSubscriptionPurchaseWithOrigin() async throws {
+        let (coordinator, mockTabShower, mockSubscriptionManager) = createCoordinator()
+        let baseURL = URL(string: "https://duckduckgo.com/pro/purchase")!
+        let origin = "funnel_duckai_macos__modelpicker"
+        mockSubscriptionManager.urls[.purchase] = baseURL
+
+        coordinator.navigateToSubscriptionPurchase(origin: origin)
+
+        // Verify tab shower was called to show tab with subscription content
+        #expect(mockTabShower.capturedContent != nil)
+
+        guard case let .subscription(url) = mockTabShower.capturedContent else {
+            Issue.record("Expected .subscription tab content")
+            return
+        }
+
+        // Verify the URL contains the origin parameter
+        #expect(url.absoluteString.contains("origin=\(origin)"))
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1210821475040699?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1210810535079321

### Description When navigating from duck.ai to purchase flow we pass the origin to the url

### Testing Steps
On both platforms
1. "Debug" → "Feature Flag Overrides” → Others, check that paidAIChat feature flag is enabled if not then select it
2. "Debug" → "Feature Flag Overrides” → Others, check that PrivacyProAuthV2 feature flag is enabled if not then select it
3. “Debug” → “AI Chat” → "Web Communication” → “Set custom URL” set URL to https://euw-serp-dev-testing10.duck.co/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=1
4. Make sure you are NOT subscribed
5. Go to Duck.ai settings
6. Click on Subscribe to DuckDuckGo
7. Check it navigates to the subscription flow and the url contains the origin (e.g. origin=funnel_duckai_macOS__settings) (on macOS you can check from the address bar on iOS in the debugger you can look for "HeadlessWebViewCoordinator - webView(_:decidePolicyFor:decisionHandler:) .allow: https://duckduckgo.com/subscriptions?environment=staging&origin=funnel_duckai_ios__settings"

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)