### PR TITLE
Don't switch to open tab when activating summarization source website link in the sidebar

### DIFF
--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -129,10 +129,11 @@ struct AIChatUserScriptHandler: AIChatUserScriptHandling {
         guard let openLinkParams: OpenLink = DecodableHelper.decode(from: params), let url = openLinkParams.url.url
         else { return nil }
 
+        let isSidebar = message.messageWebView?.url?.hasAIChatSidebarPlacementParameter == true
+
         switch openLinkParams.target {
-        case .sameTab:
-            let isSidebar = message.messageWebView?.url?.hasAIChatSidebarPlacementParameter == true
-            windowControllersManager.show(url: url, source: .switchToOpenTab, newTab: !isSidebar, selected: true)
+        case .sameTab where isSidebar == false: // for same tab outside of sidebar we force opening new tab to keep the AI chat tab
+            windowControllersManager.show(url: url, source: .switchToOpenTab, newTab: true, selected: true)
         default:
             windowControllersManager.open(url, source: .link, target: nil, event: NSApp.currentEvent)
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1199230911884351/task/1210855725388312?focus=true

### Description
Ensure that when opening a link from the sidebar always opens the URL in the current tab.

### Testing Steps
1. Make sure that sidebar is enabled in AI Features settings.
2. Open a website, select text, and activate “Summarize with Duck.ai” option from context menu.
3. Duplicate current website.
4. In the tab with the sidebar, navigate to another website.
5. Click the link in the summarization chat bubble and verify that the URL loads in the current tab.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)