### PR TITLE
Don't offer text summarization on Duck.ai

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
@@ -175,6 +175,7 @@ extension TabExtensionsBuilder {
         }
         add {
             ContextMenuManager(contextMenuScriptPublisher: userScripts.map(\.?.contextMenuScript),
+                               contentPublisher: args.contentPublisher,
                                isLoadedInSidebar: args.isTabLoadedInSidebar,
                                featureFlagger: dependencies.featureFlagger)
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1210860639120454?focus=true

### Description
Don’t show "Summarize with Duck.ai" context menu option on Duck.ai tabs.

### Testing Steps
1. Open Duck.ai chat and start a conversation (you can do it by summarizing text on some website)
2. If Duck.ai is in the sidebar, expand the sidebar to a full tab.
3. Select some text on Duck.ai, open context menu and verify that “Summarize with Duck.ai” option is not present.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)