### PR TITLE
Add NewTabPage AI shortcut setting

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/macOS/PublicAPI/AIChatPreferencesStorage.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/macOS/PublicAPI/AIChatPreferencesStorage.swift
@@ -24,6 +24,9 @@ public protocol AIChatPreferencesStorage {
     var isAIFeaturesEnabled: Bool { get set }
     var isAIFeaturesEnabledPublisher: AnyPublisher<Bool, Never> { get }
 
+    var showOnNewTabPage: Bool { get set }
+    var showOnNewTabPagePublisher: AnyPublisher<Bool, Never> { get }
+
     var showShortcutInApplicationMenu: Bool { get set }
     var showShortcutInApplicationMenuPublisher: AnyPublisher<Bool, Never> { get }
 
@@ -42,6 +45,10 @@ public struct DefaultAIChatPreferencesStorage: AIChatPreferencesStorage {
 
     public var isAIFeaturesEnabledPublisher: AnyPublisher<Bool, Never> {
         userDefaults.isAIFeaturesEnabledPublisher
+    }
+
+    public var showOnNewTabPagePublisher: AnyPublisher<Bool, Never> {
+        userDefaults.showAIChatOnNewTabPagePublisher
     }
 
     public var showShortcutInApplicationMenuPublisher: AnyPublisher<Bool, Never> {
@@ -67,6 +74,11 @@ public struct DefaultAIChatPreferencesStorage: AIChatPreferencesStorage {
         set { userDefaults.isAIFeaturesEnabled = newValue }
     }
 
+    public var showOnNewTabPage: Bool {
+        get { userDefaults.showAIChatOnNewTabPage }
+        set { userDefaults.showAIChatOnNewTabPage = newValue }
+    }
+
     public var showShortcutInApplicationMenu: Bool {
         get { userDefaults.showAIChatShortcutInApplicationMenu }
         set { userDefaults.showAIChatShortcutInApplicationMenu = newValue }
@@ -84,6 +96,7 @@ public struct DefaultAIChatPreferencesStorage: AIChatPreferencesStorage {
 
     public func reset() {
         userDefaults.isAIFeaturesEnabled = UserDefaults.isAIFeaturesEnabledDefaultValue
+        userDefaults.showAIChatOnNewTabPage = UserDefaults.showAIChatOnNewTabPageDefaultValue
         userDefaults.showAIChatShortcutInApplicationMenu = UserDefaults.showAIChatShortcutInApplicationMenuDefaultValue
         userDefaults.showAIChatShortcutInAddressBar = UserDefaults.showAIChatShortcutInAddressBarDefaultValue
         userDefaults.openAIChatInSidebar = UserDefaults.openAIChatInSidebarDefaultValue
@@ -93,12 +106,14 @@ public struct DefaultAIChatPreferencesStorage: AIChatPreferencesStorage {
 private extension UserDefaults {
     enum Keys {
         static let aiFeatures = "aichat.enabled"
+        static let showAIChatOnNewTabPage = "aichat.showAIChatOnNewTabPage"
         static let showAIChatShortcutInApplicationMenu = "aichat.showAIChatShortcutInApplicationMenu"
         static let showAIChatShortcutInAddressBar = "aichat.showAIChatShortcutInAddressBar"
         static let openAIChatInSidebar = "aichat.openAIChatInSidebar"
     }
 
     static let isAIFeaturesEnabledDefaultValue = true
+    static let showAIChatOnNewTabPageDefaultValue = true
     static let showAIChatShortcutInApplicationMenuDefaultValue = true
     static let showAIChatShortcutInAddressBarDefaultValue = true
     static let openAIChatInSidebarDefaultValue = true
@@ -111,6 +126,17 @@ private extension UserDefaults {
         set {
             guard newValue != isAIFeaturesEnabled else { return }
             set(newValue, forKey: Keys.aiFeatures)
+        }
+    }
+
+    @objc dynamic var showAIChatOnNewTabPage: Bool {
+        get {
+            value(forKey: Keys.showAIChatOnNewTabPage) as? Bool ?? Self.showAIChatOnNewTabPageDefaultValue
+        }
+
+        set {
+            guard newValue != showAIChatOnNewTabPage else { return }
+            set(newValue, forKey: Keys.showAIChatOnNewTabPage)
         }
     }
 
@@ -149,6 +175,10 @@ private extension UserDefaults {
 
     var isAIFeaturesEnabledPublisher: AnyPublisher<Bool, Never> {
         publisher(for: \.isAIFeaturesEnabled).eraseToAnyPublisher()
+    }
+
+    var showAIChatOnNewTabPagePublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.showAIChatOnNewTabPage).eraseToAnyPublisher()
     }
 
     var showAIChatShortcutInApplicationMenuPublisher: AnyPublisher<Bool, Never> {

--- a/SharedPackages/AIChat/Sources/AIChat/macOS/PublicAPI/AIChatPreferencesStorage.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/macOS/PublicAPI/AIChatPreferencesStorage.swift
@@ -24,8 +24,8 @@ public protocol AIChatPreferencesStorage {
     var isAIFeaturesEnabled: Bool { get set }
     var isAIFeaturesEnabledPublisher: AnyPublisher<Bool, Never> { get }
 
-    var showOnNewTabPage: Bool { get set }
-    var showOnNewTabPagePublisher: AnyPublisher<Bool, Never> { get }
+    var showShortcutOnNewTabPage: Bool { get set }
+    var showShortcutOnNewTabPagePublisher: AnyPublisher<Bool, Never> { get }
 
     var showShortcutInApplicationMenu: Bool { get set }
     var showShortcutInApplicationMenuPublisher: AnyPublisher<Bool, Never> { get }
@@ -47,7 +47,7 @@ public struct DefaultAIChatPreferencesStorage: AIChatPreferencesStorage {
         userDefaults.isAIFeaturesEnabledPublisher
     }
 
-    public var showOnNewTabPagePublisher: AnyPublisher<Bool, Never> {
+    public var showShortcutOnNewTabPagePublisher: AnyPublisher<Bool, Never> {
         userDefaults.showAIChatOnNewTabPagePublisher
     }
 
@@ -74,7 +74,7 @@ public struct DefaultAIChatPreferencesStorage: AIChatPreferencesStorage {
         set { userDefaults.isAIFeaturesEnabled = newValue }
     }
 
-    public var showOnNewTabPage: Bool {
+    public var showShortcutOnNewTabPage: Bool {
         get { userDefaults.showAIChatOnNewTabPage }
         set { userDefaults.showAIChatOnNewTabPage = newValue }
     }

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit.git", exact: "3.0.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.7.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "3.0.0"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "10.13.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "10.14.0"),
         .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "9.4.0"),
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
         .package(url: "https://github.com/1024jp/GzipSwift.git", exact: "6.0.1"),

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "4935471fe659cad802f0fe3d4c51c8cf1318ae86",
-        "version" : "10.13.0"
+        "revision" : "0265bdf792cabae6f77af31ae5051becbe3235fe",
+        "version" : "10.14.0"
       }
     },
     {

--- a/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
@@ -75,7 +75,7 @@ final class AIChatMenuConfiguration: AIChatMenuVisibilityConfigurable {
     var valuesChangedPublisher = PassthroughSubject<Void, Never>()
 
     var shouldDisplayNewTabPageShortcut: Bool {
-        remoteSettings.isAIChatEnabled && storage.isAIFeaturesEnabled && storage.showOnNewTabPage
+        remoteSettings.isAIChatEnabled && storage.isAIFeaturesEnabled && storage.showShortcutOnNewTabPage
     }
 
     var shouldDisplaySummarizationMenuItem: Bool {
@@ -105,7 +105,7 @@ final class AIChatMenuConfiguration: AIChatMenuVisibilityConfigurable {
     private func subscribeToValuesChanged() {
         Publishers.Merge5(
             storage.isAIFeaturesEnabledPublisher.removeDuplicates(),
-            storage.showOnNewTabPagePublisher.removeDuplicates(),
+            storage.showShortcutOnNewTabPagePublisher.removeDuplicates(),
             storage.showShortcutInApplicationMenuPublisher.removeDuplicates(),
             storage.showShortcutInAddressBarPublisher.removeDuplicates(),
             storage.openAIChatInSidebarPublisher.removeDuplicates()

--- a/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
@@ -26,6 +26,12 @@ protocol AIChatMenuVisibilityConfigurable {
     /// This property validates user settings to determine if the shortcut
     /// should be presented to the user.
     ///
+    /// - Returns: `true` if the New Tab Page omnibar shortcut should be displayed; otherwise, `false`.
+    var shouldDisplayNewTabPageShortcut: Bool { get }
+
+    /// This property validates user settings to determine if the shortcut
+    /// should be presented to the user.
+    ///
     /// - Returns: `true` if the address bar shortcut should be displayed; otherwise, `false`.
     var shouldDisplayAddressBarShortcut: Bool { get }
 
@@ -68,6 +74,10 @@ final class AIChatMenuConfiguration: AIChatMenuVisibilityConfigurable {
 
     var valuesChangedPublisher = PassthroughSubject<Void, Never>()
 
+    var shouldDisplayNewTabPageShortcut: Bool {
+        remoteSettings.isAIChatEnabled && storage.isAIFeaturesEnabled && storage.showOnNewTabPage
+    }
+
     var shouldDisplaySummarizationMenuItem: Bool {
         remoteSettings.isTextSummarizationEnabled && storage.isAIFeaturesEnabled && shouldDisplayApplicationMenuShortcut
     }
@@ -93,8 +103,9 @@ final class AIChatMenuConfiguration: AIChatMenuVisibilityConfigurable {
     }
 
     private func subscribeToValuesChanged() {
-        Publishers.Merge4(
+        Publishers.Merge5(
             storage.isAIFeaturesEnabledPublisher.removeDuplicates(),
+            storage.showOnNewTabPagePublisher.removeDuplicates(),
             storage.showShortcutInApplicationMenuPublisher.removeDuplicates(),
             storage.showShortcutInAddressBarPublisher.removeDuplicates(),
             storage.openAIChatInSidebarPublisher.removeDuplicates()

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -39,6 +39,12 @@ enum AIChatPixel: PixelKitEventV2 {
     /// - Check if this is not a widespread issue. Sometimes users can change config data manually on macOS which could cause this
     case aichatNoRemoteSettingsFound(AIChatRemoteSettings.SettingsValue)
 
+    /// Event Trigger: New Tab Page shortcut for AI Chat is turned on
+    case aiChatSettingsNewTabPageShortcutTurnedOn
+
+    /// Event Trigger: New Tab Page shortcut for AI Chat is turned off
+    case aiChatSettingsNewTabPageShortcutTurnedOff
+
     /// Event Trigger: Address bar shortcut for AI Chat is turned on
     case aiChatSettingsAddressBarShortcutTurnedOn
 
@@ -94,6 +100,10 @@ enum AIChatPixel: PixelKitEventV2 {
             return "aichat_application-menu-file-clicked"
         case .aichatNoRemoteSettingsFound(let settings):
             return "aichat_no_remote_settings_found-\(settings.rawValue.lowercased())"
+        case .aiChatSettingsNewTabPageShortcutTurnedOn:
+            return "aichat_settings_new-tab-page_on"
+        case .aiChatSettingsNewTabPageShortcutTurnedOff:
+            return "aichat_settings_new-tab-page_off"
         case .aiChatSettingsAddressBarShortcutTurnedOn:
             return "aichat_settings_addressbar_on"
         case .aiChatSettingsAddressBarShortcutTurnedOff:
@@ -126,6 +136,8 @@ enum AIChatPixel: PixelKitEventV2 {
         case .aichatApplicationMenuAppClicked,
                 .aichatApplicationMenuFileClicked,
                 .aichatNoRemoteSettingsFound,
+                .aiChatSettingsNewTabPageShortcutTurnedOn,
+                .aiChatSettingsNewTabPageShortcutTurnedOff,
                 .aiChatSettingsAddressBarShortcutTurnedOn,
                 .aiChatSettingsAddressBarShortcutTurnedOff,
                 .aiChatSettingsApplicationMenuShortcutTurnedOff,

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -439,6 +439,7 @@ struct UserText {
 
     // Misc
 
+    static let aiChatShowOnNewTabPageBarToggle = NSLocalizedString("duckai.show-on-new-tab-page.toggle", value: "Show on New Tab Page", comment: "A checkbox to control AI Chat shortcut visibility on the New Tab Page")
     static let aiChatShowInAddressBarToggle = NSLocalizedString("duckai.show-in-address-bar.toggle", value: "Show Duck.ai shortcut in the address bar", comment: "Show AI Chat in the address bar")
     static let aiChatShowInApplicationMenuToggle = NSLocalizedString("duckai.show-in-application-menu.toggle-setting", value: "Show Duck.ai shortcuts in menus", comment: "Show Duck.ai in application menus")
     static let aiChatOpenInSidebarToggle = NSLocalizedString("duckai.open-in-sidebar.toggle-setting", value: "Open Duck.ai in the sidebar", comment: "Settings option to open Duck.ai in the sidebar")

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -22932,6 +22932,18 @@
         }
       }
     },
+    "duckai.show-on-new-tab-page.toggle" : {
+      "comment" : "A checkbox to control AI Chat shortcut visibility on the New Tab Page",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show on New Tab Page"
+          }
+        }
+      }
+    },
     "duckai.summarize.context-menu-action" : {
       "comment" : "Context menu option that triggers Duck.ai-assisted summarization of selected text",
       "extractionState" : "extracted_with_value",

--- a/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
@@ -43,6 +43,7 @@ final class AIChatPreferences: ObservableObject {
         self.featureFlagger = featureFlagger
 
         isAIFeaturesEnabled = storage.isAIFeaturesEnabled
+        showOnNewTabPage = storage.showOnNewTabPage
         showShortcutInApplicationMenu = storage.showShortcutInApplicationMenu
         showShortcutInAddressBar = storage.showShortcutInAddressBar
         openAIChatInSidebar = storage.openAIChatInSidebar
@@ -55,6 +56,12 @@ final class AIChatPreferences: ObservableObject {
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .assign(to: \.isAIFeaturesEnabled, onWeaklyHeld: self)
+            .store(in: &cancellables)
+
+        storage.showOnNewTabPagePublisher
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .assign(to: \.showOnNewTabPage, onWeaklyHeld: self)
             .store(in: &cancellables)
 
         storage.showShortcutInApplicationMenuPublisher
@@ -80,8 +87,16 @@ final class AIChatPreferences: ObservableObject {
         featureFlagger.isFeatureOn(.aiChatSidebar)
     }
 
+    var shouldShowNewTabPageToggle: Bool {
+        featureFlagger.isFeatureOn(.newTabPageOmnibar)
+    }
+
     @Published var isAIFeaturesEnabled: Bool {
         didSet { storage.isAIFeaturesEnabled = isAIFeaturesEnabled }
+    }
+
+    @Published var showOnNewTabPage: Bool {
+        didSet { storage.showOnNewTabPage = showOnNewTabPage }
     }
 
     @Published var showShortcutInApplicationMenu: Bool {

--- a/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
@@ -43,7 +43,7 @@ final class AIChatPreferences: ObservableObject {
         self.featureFlagger = featureFlagger
 
         isAIFeaturesEnabled = storage.isAIFeaturesEnabled
-        showOnNewTabPage = storage.showOnNewTabPage
+        showShortcutOnNewTabPage = storage.showShortcutOnNewTabPage
         showShortcutInApplicationMenu = storage.showShortcutInApplicationMenu
         showShortcutInAddressBar = storage.showShortcutInAddressBar
         openAIChatInSidebar = storage.openAIChatInSidebar
@@ -58,10 +58,10 @@ final class AIChatPreferences: ObservableObject {
             .assign(to: \.isAIFeaturesEnabled, onWeaklyHeld: self)
             .store(in: &cancellables)
 
-        storage.showOnNewTabPagePublisher
+        storage.showShortcutOnNewTabPagePublisher
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
-            .assign(to: \.showOnNewTabPage, onWeaklyHeld: self)
+            .assign(to: \.showShortcutOnNewTabPage, onWeaklyHeld: self)
             .store(in: &cancellables)
 
         storage.showShortcutInApplicationMenuPublisher
@@ -95,8 +95,8 @@ final class AIChatPreferences: ObservableObject {
         didSet { storage.isAIFeaturesEnabled = isAIFeaturesEnabled }
     }
 
-    @Published var showOnNewTabPage: Bool {
-        didSet { storage.showOnNewTabPage = showOnNewTabPage }
+    @Published var showShortcutOnNewTabPage: Bool {
+        didSet { storage.showShortcutOnNewTabPage = showShortcutOnNewTabPage }
     }
 
     @Published var showShortcutInApplicationMenu: Bool {

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
@@ -45,6 +45,24 @@ extension Preferences {
                 }
 
                 PreferencePaneSection(UserText.duckAIShortcuts) {
+
+                    if model.shouldShowNewTabPageToggle {
+                        ToggleMenuItem(UserText.aiChatShowOnNewTabPageBarToggle,
+                                       isOn: $model.showOnNewTabPage)
+                        .accessibilityIdentifier("Preferences.AIChat.showOnNewTabPageToggle")
+                        .onChange(of: model.showOnNewTabPage) { newValue in
+                            if newValue {
+                                PixelKit.fire(AIChatPixel.aiChatSettingsNewTabPageShortcutTurnedOn,
+                                              frequency: .dailyAndCount,
+                                              includeAppVersionParameter: true)
+                            } else {
+                                PixelKit.fire(AIChatPixel.aiChatSettingsNewTabPageShortcutTurnedOff,
+                                              frequency: .dailyAndCount,
+                                              includeAppVersionParameter: true)
+                            }
+                        }
+                    }
+
                     ToggleMenuItem(UserText.aiChatShowInAddressBarToggle,
                                    isOn: $model.showShortcutInAddressBar)
                     .accessibilityIdentifier("Preferences.AIChat.showInAddressBarToggle")

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
@@ -48,9 +48,9 @@ extension Preferences {
 
                     if model.shouldShowNewTabPageToggle {
                         ToggleMenuItem(UserText.aiChatShowOnNewTabPageBarToggle,
-                                       isOn: $model.showOnNewTabPage)
+                                       isOn: $model.showShortcutOnNewTabPage)
                         .accessibilityIdentifier("Preferences.AIChat.showOnNewTabPageToggle")
-                        .onChange(of: model.showOnNewTabPage) { newValue in
+                        .onChange(of: model.showShortcutOnNewTabPage) { newValue in
                             if newValue {
                                 PixelKit.fire(AIChatPixel.aiChatSettingsNewTabPageShortcutTurnedOn,
                                               frequency: .dailyAndCount,

--- a/macOS/UnitTests/AIChat/AIChatMenuConfigurationTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatMenuConfigurationTests.swift
@@ -39,6 +39,28 @@ class AIChatMenuConfigurationTests: XCTestCase {
         super.tearDown()
     }
 
+    func testShouldDisplayNewTabPageShortcut() {
+        mockStorage.showOnNewTabPage = true
+        let result = configuration.shouldDisplayNewTabPageShortcut
+
+        XCTAssertTrue(result, "New Tab Page shortcut should be displayed when enabled.")
+    }
+
+    func testNewTabPageValuesChangedPublisher() {
+        let expectation = self.expectation(description: "Values changed publisher should emit a value.")
+
+        let cancellable = configuration.valuesChangedPublisher.sink {
+            expectation.fulfill()
+        }
+
+        mockStorage.updateNewTabPageShortcutDisplay(to: true)
+
+        waitForExpectations(timeout: 1) { error in
+            XCTAssertNil(error, "Values changed publisher did not emit a value in time.")
+        }
+        cancellable.cancel()
+    }
+
     func testShouldDisplayApplicationMenuShortcut() {
         mockStorage.showShortcutInApplicationMenu = true
         let result = configuration.shouldDisplayApplicationMenuShortcut
@@ -106,6 +128,7 @@ class AIChatMenuConfigurationTests: XCTestCase {
     }
 
     func testReset() {
+        mockStorage.showOnNewTabPage = true
         mockStorage.showShortcutInApplicationMenu = true
         mockStorage.showShortcutInAddressBar = true
         mockStorage.openAIChatInSidebar = true
@@ -113,6 +136,7 @@ class AIChatMenuConfigurationTests: XCTestCase {
 
         mockStorage.reset()
 
+        XCTAssertFalse(mockStorage.showOnNewTabPage, "New Tab Page shortcut should be reset to false.")
         XCTAssertFalse(mockStorage.showShortcutInApplicationMenu, "Application menu shortcut should be reset to false.")
         XCTAssertFalse(mockStorage.showShortcutInAddressBar, "Address bar shortcut should be reset to false.")
         XCTAssertFalse(mockStorage.openAIChatInSidebar, "Open AI Chat in sidebar should be reset to false.")
@@ -137,6 +161,14 @@ class AIChatMenuConfigurationTests: XCTestCase {
         XCTAssertTrue(result, "Application menu shortcut should be displayed when both remote flag and storage are true.")
     }
 
+    func testShouldDisplayNewTabPageShortcutWhenStorageIsTrue() {
+        mockStorage.showOnNewTabPage = true
+
+        let result = configuration.shouldDisplayNewTabPageShortcut
+
+        XCTAssertTrue(result, "New Tab Page shortcut should be displayed when storage is true.")
+    }
+
     func testShouldOpenAIChatInSidebarPublisherWhenStorageAreTrue() {
         mockStorage.openAIChatInSidebar = true
 
@@ -154,6 +186,12 @@ class MockAIChatPreferencesStorage: AIChatPreferencesStorage {
     }
 
     var didDisplayAIChatAddressBarOnboarding: Bool = false
+
+    var showOnNewTabPage: Bool = false {
+        didSet {
+            showOnNewTabPageSubject.send(showShortcutInApplicationMenu)
+        }
+    }
 
     var showShortcutInApplicationMenu: Bool = false {
         didSet {
@@ -174,12 +212,17 @@ class MockAIChatPreferencesStorage: AIChatPreferencesStorage {
     }
 
     private var isAIFeaturesEnabledSubject = PassthroughSubject<Bool, Never>()
+    private var showOnNewTabPageSubject = PassthroughSubject<Bool, Never>()
     private var showShortcutInApplicationMenuSubject = PassthroughSubject<Bool, Never>()
     private var showShortcutInAddressBarSubject = PassthroughSubject<Bool, Never>()
     private var openAIChatInSidebarSubject = PassthroughSubject<Bool, Never>()
 
     var isAIFeaturesEnabledPublisher: AnyPublisher<Bool, Never> {
         isAIFeaturesEnabledSubject.eraseToAnyPublisher()
+    }
+
+    var showOnNewTabPagePublisher: AnyPublisher<Bool, Never> {
+        showOnNewTabPageSubject.eraseToAnyPublisher()
     }
 
     var showShortcutInApplicationMenuPublisher: AnyPublisher<Bool, Never> {
@@ -196,10 +239,15 @@ class MockAIChatPreferencesStorage: AIChatPreferencesStorage {
 
     func reset() {
         isAIFeaturesEnabled = true
+        showOnNewTabPage = false
         showShortcutInApplicationMenu = false
         showShortcutInAddressBar = false
         didDisplayAIChatAddressBarOnboarding = false
         openAIChatInSidebar = false
+    }
+
+    func updateNewTabPageShortcutDisplay(to value: Bool) {
+        showOnNewTabPage = value
     }
 
     func updateApplicationMenuShortcutDisplay(to value: Bool) {

--- a/macOS/UnitTests/AIChat/AIChatMenuConfigurationTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatMenuConfigurationTests.swift
@@ -40,7 +40,7 @@ class AIChatMenuConfigurationTests: XCTestCase {
     }
 
     func testShouldDisplayNewTabPageShortcut() {
-        mockStorage.showOnNewTabPage = true
+        mockStorage.showShortcutOnNewTabPage = true
         let result = configuration.shouldDisplayNewTabPageShortcut
 
         XCTAssertTrue(result, "New Tab Page shortcut should be displayed when enabled.")
@@ -128,7 +128,7 @@ class AIChatMenuConfigurationTests: XCTestCase {
     }
 
     func testReset() {
-        mockStorage.showOnNewTabPage = true
+        mockStorage.showShortcutOnNewTabPage = true
         mockStorage.showShortcutInApplicationMenu = true
         mockStorage.showShortcutInAddressBar = true
         mockStorage.openAIChatInSidebar = true
@@ -136,7 +136,7 @@ class AIChatMenuConfigurationTests: XCTestCase {
 
         mockStorage.reset()
 
-        XCTAssertFalse(mockStorage.showOnNewTabPage, "New Tab Page shortcut should be reset to false.")
+        XCTAssertFalse(mockStorage.showShortcutOnNewTabPage, "New Tab Page shortcut should be reset to false.")
         XCTAssertFalse(mockStorage.showShortcutInApplicationMenu, "Application menu shortcut should be reset to false.")
         XCTAssertFalse(mockStorage.showShortcutInAddressBar, "Address bar shortcut should be reset to false.")
         XCTAssertFalse(mockStorage.openAIChatInSidebar, "Open AI Chat in sidebar should be reset to false.")
@@ -162,7 +162,7 @@ class AIChatMenuConfigurationTests: XCTestCase {
     }
 
     func testShouldDisplayNewTabPageShortcutWhenStorageIsTrue() {
-        mockStorage.showOnNewTabPage = true
+        mockStorage.showShortcutOnNewTabPage = true
 
         let result = configuration.shouldDisplayNewTabPageShortcut
 
@@ -187,9 +187,9 @@ class MockAIChatPreferencesStorage: AIChatPreferencesStorage {
 
     var didDisplayAIChatAddressBarOnboarding: Bool = false
 
-    var showOnNewTabPage: Bool = false {
+    var showShortcutOnNewTabPage: Bool = false {
         didSet {
-            showOnNewTabPageSubject.send(showShortcutInApplicationMenu)
+            showShortcutOnNewTabPageSubject.send(showShortcutInApplicationMenu)
         }
     }
 
@@ -212,7 +212,7 @@ class MockAIChatPreferencesStorage: AIChatPreferencesStorage {
     }
 
     private var isAIFeaturesEnabledSubject = PassthroughSubject<Bool, Never>()
-    private var showOnNewTabPageSubject = PassthroughSubject<Bool, Never>()
+    private var showShortcutOnNewTabPageSubject = PassthroughSubject<Bool, Never>()
     private var showShortcutInApplicationMenuSubject = PassthroughSubject<Bool, Never>()
     private var showShortcutInAddressBarSubject = PassthroughSubject<Bool, Never>()
     private var openAIChatInSidebarSubject = PassthroughSubject<Bool, Never>()
@@ -221,8 +221,8 @@ class MockAIChatPreferencesStorage: AIChatPreferencesStorage {
         isAIFeaturesEnabledSubject.eraseToAnyPublisher()
     }
 
-    var showOnNewTabPagePublisher: AnyPublisher<Bool, Never> {
-        showOnNewTabPageSubject.eraseToAnyPublisher()
+    var showShortcutOnNewTabPagePublisher: AnyPublisher<Bool, Never> {
+        showShortcutOnNewTabPageSubject.eraseToAnyPublisher()
     }
 
     var showShortcutInApplicationMenuPublisher: AnyPublisher<Bool, Never> {
@@ -239,7 +239,7 @@ class MockAIChatPreferencesStorage: AIChatPreferencesStorage {
 
     func reset() {
         isAIFeaturesEnabled = true
-        showOnNewTabPage = false
+        showShortcutOnNewTabPage = false
         showShortcutInApplicationMenu = false
         showShortcutInAddressBar = false
         didDisplayAIChatAddressBarOnboarding = false
@@ -247,7 +247,7 @@ class MockAIChatPreferencesStorage: AIChatPreferencesStorage {
     }
 
     func updateNewTabPageShortcutDisplay(to value: Bool) {
-        showOnNewTabPage = value
+        showShortcutOnNewTabPage = value
     }
 
     func updateApplicationMenuShortcutDisplay(to value: Bool) {

--- a/macOS/UnitTests/Menus/MainMenuTests.swift
+++ b/macOS/UnitTests/Menus/MainMenuTests.swift
@@ -325,6 +325,7 @@ private class DummyFeatureFlagger: FeatureFlagger {
 }
 
 private class DummyAIChatConfig: AIChatMenuVisibilityConfigurable {
+    var shouldDisplayNewTabPageShortcut = false
     var shouldDisplayApplicationMenuShortcut = false
     var shouldDisplayAddressBarShortcut = false
     var openAIChatInSidebar = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1210867847393823?focus=true

### Description
This change displays New Tab Page shortcut setting in AI Features preferences.
Storage is provided but the flag is not yet connected to the New Tab Page.

### Testing Steps
1. Launch the app, disable `newTabPageOmnibar` feature flag.
2. Go to AI Features settings and verify that “Show on New Tab Page” is not present
3. Enable `newTabPageOmnibar` feature flag.
4. Select other settings pane and back to AI Features, verify that “Show on New Tab Page” is present.
5. Verify that the value of “Show on New Tab Page” setting is stored between Settings page views and app launches.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)