### PR TITLE
VPN Upsell - targeting logic

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -3264,6 +3264,8 @@
 		BB960BCE2DD77A0B002C46DD /* SettingsIconsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB960BCC2DD77A02002C46DD /* SettingsIconsProviding.swift */; };
 		BB960BD32DD7890B002C46DD /* BookmarksIconsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB960BD22DD788FD002C46DD /* BookmarksIconsProviding.swift */; };
 		BB960BD42DD7890B002C46DD /* BookmarksIconsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB960BD22DD788FD002C46DD /* BookmarksIconsProviding.swift */; };
+		BB9851922E3102ED00FED56A /* NetworkProtectionNavBarButtonModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9851912E3102ED00FED56A /* NetworkProtectionNavBarButtonModelTests.swift */; };
+		BB9851932E3102ED00FED56A /* NetworkProtectionNavBarButtonModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9851912E3102ED00FED56A /* NetworkProtectionNavBarButtonModelTests.swift */; };
 		BB9BA2202D10BC72009229F3 /* TabBarRemoteMessageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9BA21F2D10BC6B009229F3 /* TabBarRemoteMessageViewModelTests.swift */; };
 		BB9BA2212D10BC72009229F3 /* TabBarRemoteMessageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9BA21F2D10BC6B009229F3 /* TabBarRemoteMessageViewModelTests.swift */; };
 		BB9BA2262D10C08F009229F3 /* TabBarRemoteMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9BA2252D10C089009229F3 /* TabBarRemoteMessage.swift */; };
@@ -5473,6 +5475,7 @@
 		BB8D1FD62DF9C0E4007F2834 /* RemoteMessagingConfigMatcherProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteMessagingConfigMatcherProviderTests.swift; sourceTree = "<group>"; };
 		BB960BCC2DD77A02002C46DD /* SettingsIconsProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsIconsProviding.swift; sourceTree = "<group>"; };
 		BB960BD22DD788FD002C46DD /* BookmarksIconsProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksIconsProviding.swift; sourceTree = "<group>"; };
+		BB9851912E3102ED00FED56A /* NetworkProtectionNavBarButtonModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionNavBarButtonModelTests.swift; sourceTree = "<group>"; };
 		BB9BA21F2D10BC6B009229F3 /* TabBarRemoteMessageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarRemoteMessageViewModelTests.swift; sourceTree = "<group>"; };
 		BB9BA2252D10C089009229F3 /* TabBarRemoteMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarRemoteMessage.swift; sourceTree = "<group>"; };
 		BB9BA2282D10C0A3009229F3 /* TabBarActiveRemoteMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarActiveRemoteMessage.swift; sourceTree = "<group>"; };
@@ -7855,6 +7858,7 @@
 		4BCF15E32ABB987F0083F6DF /* NetworkProtection */ = {
 			isa = PBXGroup;
 			children = (
+				BB9851912E3102ED00FED56A /* NetworkProtectionNavBarButtonModelTests.swift */,
 				BBD31EA92E2FB46E0045551C /* VPNUpsellVisibilityManagerTests.swift */,
 				BDA7648F2BC4E56200D0400C /* Mocks */,
 				7B09CBA72BA4BE7000CF245B /* NetworkProtectionPixelEventTests.swift */,
@@ -13455,6 +13459,7 @@
 				3706FDE4293F661700E42796 /* TabLazyLoaderTests.swift in Sources */,
 				84AECC512DFBFADC00438ACC /* AutoClearHandlerTests.swift in Sources */,
 				3706FDE5293F661700E42796 /* URLEventHandlerTests.swift in Sources */,
+				BB9851932E3102ED00FED56A /* NetworkProtectionNavBarButtonModelTests.swift in Sources */,
 				3706FDE6293F661700E42796 /* BookmarkOutlineViewDataSourceTests.swift in Sources */,
 				BBC063E92C5A9E4B007BDC18 /* BookmarkManagementDetailViewModelTests.swift in Sources */,
 				3706FDE8293F661700E42796 /* TemporaryFileHandlerTests.swift in Sources */,
@@ -15348,6 +15353,7 @@
 				37697D802D4A0D12004C0CBB /* NewTabPageShownPixelSenderTests.swift in Sources */,
 				9F97B31F2DE8311000653C0D /* DefaultBrowserAndDockPromptFeatureFlaggerTests.swift in Sources */,
 				4B9DB05A2A983B55000927DB /* MockWaitlistRequest.swift in Sources */,
+				BB9851922E3102ED00FED56A /* NetworkProtectionNavBarButtonModelTests.swift in Sources */,
 				1D9EB31B2D43C2F7004B7270 /* WebExtensionLoaderMock.swift in Sources */,
 				37D2377C287EBDA300BCE03B /* TabIndexTests.swift in Sources */,
 				37EC314D2D8C02C00026C348 /* FaviconTests.swift in Sources */,

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -3292,6 +3292,10 @@
 		BBC7BDAC2D5BB0890037A4AE /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC7BDAB2D5BB0720037A4AE /* BannerView.swift */; };
 		BBC7BDAD2D5BB0890037A4AE /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC7BDAB2D5BB0720037A4AE /* BannerView.swift */; };
 		BBCD467A2C8643EC004DB483 /* XCUIApplicationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBCD46792C8643EC004DB483 /* XCUIApplicationExtension.swift */; };
+		BBD31EA72E2FB3B20045551C /* VPNUpsellVisibilityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD31EA62E2FB3B20045551C /* VPNUpsellVisibilityManager.swift */; };
+		BBD31EA82E2FB3B20045551C /* VPNUpsellVisibilityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD31EA62E2FB3B20045551C /* VPNUpsellVisibilityManager.swift */; };
+		BBD31EAA2E2FB46E0045551C /* VPNUpsellVisibilityManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD31EA92E2FB46E0045551C /* VPNUpsellVisibilityManagerTests.swift */; };
+		BBD31EAB2E2FB46E0045551C /* VPNUpsellVisibilityManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD31EA92E2FB46E0045551C /* VPNUpsellVisibilityManagerTests.swift */; };
 		BBD798AD2DF213B100575051 /* AddressBarPermissionButtonsIconsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD798AC2DF213AF00575051 /* AddressBarPermissionButtonsIconsProviding.swift */; };
 		BBD798AE2DF213B100575051 /* AddressBarPermissionButtonsIconsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD798AC2DF213AF00575051 /* AddressBarPermissionButtonsIconsProviding.swift */; };
 		BBDAA91A2DAD4E7400555E1E /* CurrentVPNNavigationBarIconProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBDAA9192DAD4E5C00555E1E /* CurrentVPNNavigationBarIconProvider.swift */; };
@@ -5484,6 +5488,8 @@
 		BBC7BDA82D5B82A20037A4AE /* DefaultBrowserAndDockPromptCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserAndDockPromptCoordinator.swift; sourceTree = "<group>"; };
 		BBC7BDAB2D5BB0720037A4AE /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
 		BBCD46792C8643EC004DB483 /* XCUIApplicationExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIApplicationExtension.swift; sourceTree = "<group>"; };
+		BBD31EA62E2FB3B20045551C /* VPNUpsellVisibilityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNUpsellVisibilityManager.swift; sourceTree = "<group>"; };
+		BBD31EA92E2FB46E0045551C /* VPNUpsellVisibilityManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNUpsellVisibilityManagerTests.swift; sourceTree = "<group>"; };
 		BBD798AC2DF213AF00575051 /* AddressBarPermissionButtonsIconsProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBarPermissionButtonsIconsProviding.swift; sourceTree = "<group>"; };
 		BBDAA9192DAD4E5C00555E1E /* CurrentVPNNavigationBarIconProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentVPNNavigationBarIconProvider.swift; sourceTree = "<group>"; };
 		BBDAA91C2DAD6DAD00555E1E /* fire-button-mouse-over-new.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "fire-button-mouse-over-new.json"; sourceTree = "<group>"; };
@@ -7313,6 +7319,7 @@
 		4B4D60632A0B29FA00BCD287 /* BothAppTargets */ = {
 			isa = PBXGroup;
 			children = (
+				BBD31EA62E2FB3B20045551C /* VPNUpsellVisibilityManager.swift */,
 				7BB4BC692C5CD96200E06FC8 /* ActiveDomainPublisher.swift */,
 				7BB4BC622C5BC13D00E06FC8 /* ActiveSiteInfoPublisher.swift */,
 				4B4D60722A0B29FA00BCD287 /* EventMapping+NetworkProtectionError.swift */,
@@ -7848,6 +7855,7 @@
 		4BCF15E32ABB987F0083F6DF /* NetworkProtection */ = {
 			isa = PBXGroup;
 			children = (
+				BBD31EA92E2FB46E0045551C /* VPNUpsellVisibilityManagerTests.swift */,
 				BDA7648F2BC4E56200D0400C /* Mocks */,
 				7B09CBA72BA4BE7000CF245B /* NetworkProtectionPixelEventTests.swift */,
 				BDA7648C2BC4E4EF00D0400C /* DefaultVPNLocationFormatterTests.swift */,
@@ -12627,6 +12635,7 @@
 				37C7493A2D55FE710065B48B /* HistoryViewActionsHandler.swift in Sources */,
 				3706FEC3293F6F0600E42796 /* NativeMessagingCommunicator.swift in Sources */,
 				3706FAFA293F65D500E42796 /* CleanThisHistoryMenuItem.swift in Sources */,
+				BBD31EA82E2FB3B20045551C /* VPNUpsellVisibilityManager.swift in Sources */,
 				1DA6D0FE2A1FF9A100540406 /* HTTPCookie.swift in Sources */,
 				3706FAFC293F65D500E42796 /* DownloadListItem.swift in Sources */,
 				3706FAFD293F65D500E42796 /* DownloadsPopover.swift in Sources */,
@@ -13803,6 +13812,7 @@
 				B6CA4825298CE4B70067ECCE /* AdClickAttributionTabExtensionTests.swift in Sources */,
 				1D2EE7092E267D6B00F51C57 /* NewTabPageModeProviderTests.swift in Sources */,
 				3707C72D294B5D4100682A9F /* EmptyAttributionRulesProver.swift in Sources */,
+				BBD31EAA2E2FB46E0045551C /* VPNUpsellVisibilityManagerTests.swift in Sources */,
 				376E2D2629428353001CD31B /* PrivacyReferenceTestHelper.swift in Sources */,
 				1D8C2FF12B70F751005E4BBD /* MockTabSnapshotStore.swift in Sources */,
 				3706FE7D293F661700E42796 /* WKDownloadMock.swift in Sources */,
@@ -14412,6 +14422,7 @@
 				7BDBAD182CBFF633000379B7 /* TipKitAppEventHandling.swift in Sources */,
 				7BDBAD192CBFF633000379B7 /* TipKitController+ConvenienceInitializers.swift in Sources */,
 				9F1556722DDC0D2D00A35DBA /* DefaultBrowserAndDockPromptTypeDeciding.swift in Sources */,
+				BBD31EA72E2FB3B20045551C /* VPNUpsellVisibilityManager.swift in Sources */,
 				7BDBAD1A2CBFF633000379B7 /* TipKitDebugOptionsUIActionHandling.swift in Sources */,
 				845B43312DB699D300D46001 /* SwiftUIContextMenuRetainCycleFix.swift in Sources */,
 				7BDBAD1B2CBFF633000379B7 /* Logger+TipKit.swift in Sources */,
@@ -15634,6 +15645,7 @@
 				4B8AC93D26B49BE600879451 /* FirefoxLoginReaderTests.swift in Sources */,
 				3714B1E728EDB7FA0056C57A /* DuckPlayerPreferencesTests.swift in Sources */,
 				9F1556822DDC41E600A35DBA /* MockDefaultBrowserAndDockPromptStorage.swift in Sources */,
+				BBD31EAB2E2FB46E0045551C /* VPNUpsellVisibilityManagerTests.swift in Sources */,
 				5681ED402BDB955100F59729 /* SyncCredentialsAdapterTests.swift in Sources */,
 				5681ED432BDBA5F900F59729 /* SyncBookmarksAdapterTests.swift in Sources */,
 				4BBF09232830812900EE1418 /* FileSystemDSL.swift in Sources */,

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -204,6 +204,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         VPNControllerXPCClient.shared
     }
 
+    lazy var vpnUpsellVisibilityManager: VPNUpsellVisibilityManager = {
+        return VPNUpsellVisibilityManager(
+            isFirstLaunch: AppDelegate.isFirstLaunch,
+            isNewUser: AppDelegate.isNewUser,
+            subscriptionManager: subscriptionAuthV1toV2Bridge,
+            defaultBrowserPublisher: DefaultBrowserPreferences.shared.$isDefault.eraseToAnyPublisher(),
+            contextualOnboardingPublisher: onboardingContextualDialogsManager.isContextualOnboardingCompletedPublisher.eraseToAnyPublisher(),
+            featureFlagger: featureFlagger
+        )
+    }()
+
     // MARK: - DBP
 
     private lazy var dataBrokerProtectionSubscriptionEventHandler: DataBrokerProtectionSubscriptionEventHandler = {
@@ -229,6 +240,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     static var isNewUser: Bool {
         return firstLaunchDate >= Date.weekAgo
     }
+
+    static var isFirstLaunch = false
 
     static var twoDaysPassedSinceFirstLaunch: Bool {
         return firstLaunchDate.daysSinceNow() >= 2
@@ -840,6 +853,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         _ = RecentlyClosedCoordinator.shared
 
         if LocalStatisticsStore().atb == nil {
+            AppDelegate.isFirstLaunch = true
             AppDelegate.firstLaunchDate = Date()
         }
         AtbAndVariantCleanup.cleanup()

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionNavBarButtonModel.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionNavBarButtonModel.swift
@@ -30,6 +30,7 @@ final class NetworkProtectionNavBarButtonModel: NSObject, ObservableObject {
     private let networkProtectionStatusReporter: NetworkProtectionStatusReporter
     private var status: VPN.ConnectionStatus = .default
     private let popoverManager: NetPPopoverManager
+    private let vpnUpsellVisibilityManager: VPNUpsellVisibilityManager
 
     // MARK: - Subscriptions
 
@@ -66,13 +67,18 @@ final class NetworkProtectionNavBarButtonModel: NSObject, ObservableObject {
 
     private var isHavingConnectivityIssues = false
 
+    // MARK: - Upsell
+
+    private var shouldShowUpsell = false
+
     // MARK: - Initialization
 
     init(popoverManager: NetPPopoverManager,
          pinningManager: PinningManager = LocalPinningManager.shared,
          vpnGatekeeper: VPNFeatureGatekeeper = DefaultVPNFeatureGatekeeper(subscriptionManager: Application.appDelegate.subscriptionAuthV1toV2Bridge),
          statusReporter: NetworkProtectionStatusReporter,
-         iconProvider: IconProvider) {
+         iconProvider: IconProvider,
+         vpnUpsellVisibilityManager: VPNUpsellVisibilityManager = Application.appDelegate.vpnUpsellVisibilityManager) {
 
         self.popoverManager = popoverManager
         self.vpnGatekeeper = vpnGatekeeper
@@ -80,6 +86,7 @@ final class NetworkProtectionNavBarButtonModel: NSObject, ObservableObject {
         self.iconPublisher = NetworkProtectionIconPublisher(statusReporter: networkProtectionStatusReporter, iconProvider: iconProvider)
         self.pinningManager = pinningManager
         self.shortcutTitle = pinningManager.shortcutTitle(for: .networkProtection)
+        self.vpnUpsellVisibilityManager = vpnUpsellVisibilityManager
 
         isHavingConnectivityIssues = networkProtectionStatusReporter.connectivityIssuesObserver.recentValue
         buttonImage = .image(for: iconPublisher.icon)
@@ -95,6 +102,7 @@ final class NetworkProtectionNavBarButtonModel: NSObject, ObservableObject {
         setupIconSubscription()
         setupStatusSubscription()
         setupInterruptionSubscription()
+        setupUpsellSubscription()
     }
 
     private func setupIconSubscription() {
@@ -131,6 +139,19 @@ final class NetworkProtectionNavBarButtonModel: NSObject, ObservableObject {
         }.store(in: &cancellables)
     }
 
+    private func setupUpsellSubscription() {
+        vpnUpsellVisibilityManager.$shouldShowUpsell.sink { [weak self] shouldShowUpsell in
+            guard let self = self else {
+                return
+            }
+
+            Task { @MainActor in
+                self.shouldShowUpsell = shouldShowUpsell
+                self.updateVisibility()
+            }
+        }.store(in: &cancellables)
+    }
+
     @MainActor
     func updateVisibility() {
         Task { @MainActor in
@@ -147,7 +168,7 @@ final class NetworkProtectionNavBarButtonModel: NSObject, ObservableObject {
                 return
             }
 
-            showVPNButton = isPinned || popoverManager.isShown || isHavingConnectivityIssues
+            showVPNButton = isPinned || popoverManager.isShown || isHavingConnectivityIssues || shouldShowUpsell
         }
     }
 

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellVisibilityManager.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellVisibilityManager.swift
@@ -59,6 +59,10 @@ final class VPNUpsellVisibilityManager: ObservableObject {
         self.featureFlagger = featureFlagger
         self.timerDuration = timerDuration
 
+        guard featureFlagger.isFeatureOn(.vpnToolbarUpsell) else {
+            return
+        }
+
         guard isNewUser && !subscriptionManager.isUserAuthenticated else {
             return
         }

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellVisibilityManager.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellVisibilityManager.swift
@@ -59,10 +59,6 @@ final class VPNUpsellVisibilityManager: ObservableObject {
         self.featureFlagger = featureFlagger
         self.timerDuration = timerDuration
 
-        guard featureFlagger.isFeatureOn(.vpnToolbarUpsell) else {
-            return
-        }
-
         guard isNewUser && !subscriptionManager.isUserAuthenticated else {
             return
         }
@@ -124,7 +120,7 @@ final class VPNUpsellVisibilityManager: ObservableObject {
     // MARK: - Upsell Visibility
 
     private func updateUpsellVisibility() {
-        guard !subscriptionManager.isUserAuthenticated else {
+        guard featureFlagger.isFeatureOn(.vpnToolbarUpsell), !subscriptionManager.isUserAuthenticated else {
             shouldShowUpsell = false
             return
         }

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellVisibilityManager.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellVisibilityManager.swift
@@ -1,0 +1,134 @@
+//
+//  VPNUpsellVisibilityManager.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import BrowserServicesKit
+import Combine
+import Common
+import Foundation
+import Subscription
+import VPN
+
+/// Manages the visibility and state of VPN upsell messaging based on user onboarding flow.
+///
+final class VPNUpsellVisibilityManager: ObservableObject {
+    @Published private(set) var shouldShowUpsell = false
+
+    // MARK: - Dependencies
+
+    private let isFirstLaunch: Bool
+    private let isNewUser: Bool
+    private let subscriptionManager: any SubscriptionAuthV1toV2Bridge
+    private let defaultBrowserPublisher: AnyPublisher<Bool, Never>
+    private let contextualOnboardingPublisher: AnyPublisher<Bool, Never>
+    private let featureFlagger: FeatureFlagger
+    private let timerDuration: TimeInterval
+
+    // MARK: - State
+    private var cancellables = Set<AnyCancellable>()
+    private var timer: Timer?
+    private var timerCompleted = false
+
+    init(isFirstLaunch: Bool,
+         isNewUser: Bool,
+         subscriptionManager: any SubscriptionAuthV1toV2Bridge,
+         defaultBrowserPublisher: AnyPublisher<Bool, Never>,
+         contextualOnboardingPublisher: AnyPublisher<Bool, Never>,
+         featureFlagger: FeatureFlagger,
+         timerDuration: TimeInterval = 600)
+    {
+        self.isFirstLaunch = isFirstLaunch
+        self.isNewUser = isNewUser
+        self.subscriptionManager = subscriptionManager
+        self.defaultBrowserPublisher = defaultBrowserPublisher
+        self.contextualOnboardingPublisher = contextualOnboardingPublisher
+        self.featureFlagger = featureFlagger
+        self.timerDuration = timerDuration
+
+        guard isNewUser && !subscriptionManager.isUserAuthenticated else {
+            return
+        }
+
+        guard isFirstLaunch else {
+            shouldShowUpsell = true
+            return
+        }
+
+        setupMonitoring()
+    }
+
+    // MARK: - Monitoring Setup
+
+    private func setupMonitoring() {
+        Publishers.CombineLatest(
+            contextualOnboardingPublisher,
+            defaultBrowserPublisher
+        )
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] onboardingDone, isDefault in
+            self?.startTimerIfNeeded(onboardingCompleted: onboardingDone, defaultBrowserSet: isDefault)
+        }
+        .store(in: &cancellables)
+
+        NotificationCenter.default
+            .publisher(for: .entitlementsDidChange)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.handleSubscriptionChange()
+            }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Event Handling
+
+    private func startTimerIfNeeded(onboardingCompleted: Bool, defaultBrowserSet: Bool) {
+        guard onboardingCompleted, defaultBrowserSet, timer == nil, !timerCompleted else {
+            return
+        }
+
+        timer = Timer.scheduledTimer(withTimeInterval: timerDuration, repeats: false) { [weak self] _ in
+            self?.handleTimerCompletion()
+        }
+    }
+
+    private func handleTimerCompletion() {
+        timerCompleted = true
+        updateUpsellVisibility()
+    }
+
+    private func handleSubscriptionChange() {
+        timer?.invalidate()
+        timer = nil
+        timerCompleted = false
+        updateUpsellVisibility()
+    }
+
+    // MARK: - Upsell Visibility
+
+    private func updateUpsellVisibility() {
+        guard !subscriptionManager.isUserAuthenticated else {
+            shouldShowUpsell = false
+            return
+        }
+
+        shouldShowUpsell = timerCompleted
+    }
+
+    deinit {
+        timer?.invalidate()
+    }
+}

--- a/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/ContextualDialogsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/ContextualDialogsManager.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import Combine
 import PrivacyDashboard
 
 /// Represents the current state of onboarding.
@@ -87,7 +88,7 @@ public class ContextualOnboardingStateStorage: ContextualOnboardingStateStoring 
 }
 
 /// Main manager responsible for deciding which onboarding dialog to display based on the current state and tab.
-public class ContextualDialogsManager: ContextualOnboardingDialogTypeProviding, ContextualOnboardingStateUpdater {
+public class ContextualDialogsManager: ObservableObject, ContextualOnboardingDialogTypeProviding, ContextualOnboardingStateUpdater {
 
     private let trackerMessageProvider: TrackerMessageProviding
     private var stateStorage: ContextualOnboardingStateStoring
@@ -98,6 +99,9 @@ public class ContextualDialogsManager: ContextualOnboardingDialogTypeProviding, 
     // The last tab for which a dialog was provided.
     private weak var lastTab: Tab?
 
+    // Publisher for contextual onboarding completion
+    @Published private(set) var isContextualOnboardingCompleted: Bool = true
+
     // Computed property for managing state.
     var state: ContextualOnboardingState {
         get {
@@ -106,6 +110,13 @@ public class ContextualDialogsManager: ContextualOnboardingDialogTypeProviding, 
         set {
             // Update persistent state.
             stateStorage.stateString = newValue.rawValue
+
+            // Publish completion status
+            let isCompleted = newValue == .onboardingCompleted
+            if isContextualOnboardingCompleted != isCompleted {
+                isContextualOnboardingCompleted = isCompleted
+            }
+
             // If onboarding is restarted, clear all stored dialogs and flags.
             if state == ContextualOnboardingState.notStarted {
                 stateStorage.contextualDialogsSeen = []

--- a/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/ContextualDialogsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/ContextualDialogsManager.swift
@@ -52,6 +52,7 @@ protocol ContextualOnboardingDialogTypeProviding {
 /// Protocol to update the onboarding state (e.g., when the user uses the fire button or the feature is turned off).
 protocol ContextualOnboardingStateUpdater: AnyObject {
     var state: ContextualOnboardingState { get set }
+    var isContextualOnboardingCompletedPublisher: Published<Bool>.Publisher { get }
     func gotItPressed()
     func fireButtonUsed()
     func turnOffFeature()
@@ -101,6 +102,7 @@ public class ContextualDialogsManager: ObservableObject, ContextualOnboardingDia
 
     // Publisher for contextual onboarding completion
     @Published private(set) var isContextualOnboardingCompleted: Bool = true
+    var isContextualOnboardingCompletedPublisher: Published<Bool>.Publisher { $isContextualOnboardingCompleted }
 
     // Computed property for managing state.
     var state: ContextualOnboardingState {

--- a/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
+++ b/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
@@ -373,6 +373,8 @@ class MockDialogsProvider: ContextualOnboardingDialogTypeProviding, ContextualOn
     var lastDialog: DuckDuckGo_Privacy_Browser.ContextualDialogType?
 
     var state: ContextualOnboardingState = .onboardingCompleted
+    @Published var isContextualOnboardingCompleted: Bool = true
+    var isContextualOnboardingCompletedPublisher: Published<Bool>.Publisher { $isContextualOnboardingCompleted }
     var turnOffFeatureCalledExpectation: XCTestExpectation?
 
     func updateStateFor(tab: DuckDuckGo_Privacy_Browser.Tab) {}

--- a/macOS/UnitTests/Fire/FirePopoverViewModelTests.swift
+++ b/macOS/UnitTests/Fire/FirePopoverViewModelTests.swift
@@ -71,6 +71,9 @@ class CapturingContextualOnboardingStateUpdater: ContextualOnboardingStateUpdate
 
     var state: ContextualOnboardingState = .onboardingCompleted
 
+    @Published var isContextualOnboardingCompleted: Bool = true
+    var isContextualOnboardingCompletedPublisher: Published<Bool>.Publisher { $isContextualOnboardingCompleted }
+
     var updatedForTab: Tab?
     var gotItPressedCalled = false
     var fireButtonUsedCalled = false

--- a/macOS/UnitTests/NetworkProtection/NetworkProtectionNavBarButtonModelTests.swift
+++ b/macOS/UnitTests/NetworkProtection/NetworkProtectionNavBarButtonModelTests.swift
@@ -1,0 +1,148 @@
+//
+//  NetworkProtectionNavBarButtonModelTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Combine
+import VPN
+import NetworkProtectionUI
+import BrowserServicesKit
+import SubscriptionTestingUtilities
+@testable import DuckDuckGo_Privacy_Browser
+
+@MainActor
+final class NetworkProtectionNavBarButtonModelTests: XCTestCase {
+
+    var sut: NetworkProtectionNavBarButtonModel!
+    var cancellable: AnyCancellable?
+
+    override func tearDown() {
+        sut = nil
+        cancellable?.cancel()
+        cancellable = nil
+        super.tearDown()
+    }
+
+    func testWhenUpsellManagerNeedsToShowVPNButton_ItShowsButton() {
+        // Given
+        let upsellManager = createUpsellManager(shouldShowUpsell: true)
+        sut = createButtonModel(with: upsellManager)
+        let expectation = XCTestExpectation(description: "showVPNButton should become true")
+
+        cancellable = sut.$showVPNButton
+            .sink { showButton in
+                if showButton {
+                    expectation.fulfill()
+                }
+            }
+
+        // When
+        sut.updateVisibility()
+
+        // Then
+        wait(for: [expectation], timeout: 2.0)
+        XCTAssertTrue(sut.showVPNButton)
+    }
+
+    func testWhenUpsellManagerDoesNotNeedToShowVPNButton_ItFallsBackToRegularLogic() {
+        // Given
+        let upsellManager = createUpsellManager(shouldShowUpsell: false)
+        sut = createButtonModel(with: upsellManager)
+        let expectation = XCTestExpectation(description: "showVPNButton should become false")
+
+        cancellable = sut.$showVPNButton
+            .sink { showButton in
+                if !showButton {
+                    expectation.fulfill()
+                }
+            }
+
+        // When
+        sut.updateVisibility()
+
+        // Then
+        wait(for: [expectation], timeout: 2.0)
+        XCTAssertFalse(sut.showVPNButton)
+    }
+}
+
+// MARK: - Helpers
+
+extension NetworkProtectionNavBarButtonModelTests {
+    private func createUpsellManager(shouldShowUpsell: Bool) -> VPNUpsellVisibilityManager {
+        let mockSubscriptionManager = SubscriptionAuthV1toV2BridgeMock()
+        let mockFeatureFlagger = MockFeatureFlagger()
+
+        if shouldShowUpsell {
+            mockFeatureFlagger.enabledFeatureFlags = [.vpnToolbarUpsell]
+        }
+
+        return VPNUpsellVisibilityManager(
+            isFirstLaunch: false,
+            isNewUser: true,
+            subscriptionManager: mockSubscriptionManager,
+            defaultBrowserPublisher: Just(true).eraseToAnyPublisher(),
+            contextualOnboardingPublisher: Just(true).eraseToAnyPublisher(),
+            featureFlagger: mockFeatureFlagger
+        )
+    }
+
+    private func createButtonModel(with upsellManager: VPNUpsellVisibilityManager) -> NetworkProtectionNavBarButtonModel {
+        let popoverManager = NetPPopoverManagerMock()
+        let pinningManager = TestPinningManager()
+        let vpnGatekeeper = MockVPNFeatureGatekeeper(
+            canStartVPN: true,
+            isInstalled: true,
+            isVPNVisible: true,
+            onboardStatusPublisher: Just(.completed).eraseToAnyPublisher()
+        )
+        let statusReporter = TestNetworkProtectionStatusReporter()
+        let iconProvider = NavigationBarIconProvider()
+
+        return NetworkProtectionNavBarButtonModel(
+            popoverManager: popoverManager,
+            pinningManager: pinningManager,
+            vpnGatekeeper: vpnGatekeeper,
+            statusReporter: statusReporter,
+            iconProvider: iconProvider,
+            vpnUpsellVisibilityManager: upsellManager
+        )
+    }
+}
+
+// MARK: - Mocks
+
+private final class TestPinningManager: PinningManager {
+    func togglePinning(for view: PinnableView) {}
+    func isPinned(_ view: PinnableView) -> Bool { false }
+    func wasManuallyToggled(_ view: PinnableView) -> Bool { false }
+    func pin(_ view: PinnableView) {}
+    func unpin(_ view: PinnableView) {}
+    func shortcutTitle(for view: PinnableView) -> String { "" }
+}
+
+private final class TestNetworkProtectionStatusReporter: NetworkProtectionStatusReporter {
+    private let ipcClient = IPCClientMock()
+
+    var statusObserver: ConnectionStatusObserver { ipcClient.ipcStatusObserver }
+    var serverInfoObserver: ConnectionServerInfoObserver { ipcClient.ipcServerInfoObserver }
+    var connectionErrorObserver: ConnectionErrorObserver { ipcClient.ipcConnectionErrorObserver }
+    var connectivityIssuesObserver: ConnectivityIssueObserver { ipcClient.ipcConnectivityIssuesObserver }
+    var controllerErrorMessageObserver: ControllerErrorMesssageObserver { ipcClient.ipcControllerErrorMessageObserver }
+    var dataVolumeObserver: DataVolumeObserver { ipcClient.ipcDataVolumeObserver }
+    var knownFailureObserver: KnownFailureObserver { ipcClient.ipcKnownFailureObserver }
+}

--- a/macOS/UnitTests/NetworkProtection/VPNUpsellVisibilityManagerTests.swift
+++ b/macOS/UnitTests/NetworkProtection/VPNUpsellVisibilityManagerTests.swift
@@ -42,6 +42,7 @@ final class VPNUpsellVisibilityManagerTests: XCTestCase {
         defaultBrowserSubject = CurrentValueSubject<Bool, Never>(false)
         contextualOnboardingSubject = CurrentValueSubject<Bool, Never>(false)
         cancellables = Set<AnyCancellable>()
+        mockFeatureFlagger.enabledFeatureFlags = [.vpnToolbarUpsell]
     }
 
     override func tearDown() {
@@ -193,6 +194,17 @@ final class VPNUpsellVisibilityManagerTests: XCTestCase {
         defaultBrowserSubject.send(true)
 
         wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testWhenFeatureFlagIsDisabled_ItDoesNotShowUpsell() {
+        // Given
+        mockFeatureFlagger.enabledFeatureFlags = []
+
+        // When
+        sut = createSUT(isFirstLaunch: false, isNewUser: true, isUserAuthenticated: false)
+
+        // Then
+        XCTAssertFalse(sut.shouldShowUpsell)
     }
 }
 

--- a/macOS/UnitTests/NetworkProtection/VPNUpsellVisibilityManagerTests.swift
+++ b/macOS/UnitTests/NetworkProtection/VPNUpsellVisibilityManagerTests.swift
@@ -163,7 +163,17 @@ final class VPNUpsellVisibilityManagerTests: XCTestCase {
     }
 
     func testWhenSubscriptionChanges_ItHidesUpsellAndCancelsTimer() {
-        sut = createSUT(isFirstLaunch: true, isNewUser: true, isUserAuthenticated: false, timerDuration: 10.0)
+        let expectation = XCTestExpectation(description: "Visibility should be false")
+        sut = createSUT(isFirstLaunch: true, isNewUser: true, isUserAuthenticated: false, timerDuration: 0.1)
+
+        sut.$shouldShowUpsell
+            .dropFirst()
+            .sink { (shouldShow: Bool) in
+                // Then
+                XCTAssertFalse(shouldShow)
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
 
         contextualOnboardingSubject.send(true)
         defaultBrowserSubject.send(true)
@@ -173,7 +183,7 @@ final class VPNUpsellVisibilityManagerTests: XCTestCase {
         NotificationCenter.default.post(name: .entitlementsDidChange, object: nil)
 
         // Then
-        XCTAssertFalse(sut.shouldShowUpsell)
+        wait(for: [expectation], timeout: 1.0)
     }
 
     func testWhenTimerCompletes_ItUpdatesVisibility() {
@@ -199,12 +209,24 @@ final class VPNUpsellVisibilityManagerTests: XCTestCase {
     func testWhenFeatureFlagIsDisabled_ItDoesNotShowUpsell() {
         // Given
         mockFeatureFlagger.enabledFeatureFlags = []
+        let expectation = XCTestExpectation(description: "Should not show upsell")
+
+        sut = createSUT(isFirstLaunch: true, isNewUser: true, isUserAuthenticated: false, timerDuration: 0.1)
+
+        sut.$shouldShowUpsell
+            .dropFirst()
+            .sink { (shouldShow: Bool) in
+                // Then
+                XCTAssertFalse(shouldShow)
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
 
         // When
-        sut = createSUT(isFirstLaunch: false, isNewUser: true, isUserAuthenticated: false)
+        contextualOnboardingSubject.send(true)
+        defaultBrowserSubject.send(true)
 
-        // Then
-        XCTAssertFalse(sut.shouldShowUpsell)
+        wait(for: [expectation], timeout: 1.0)
     }
 }
 

--- a/macOS/UnitTests/NetworkProtection/VPNUpsellVisibilityManagerTests.swift
+++ b/macOS/UnitTests/NetworkProtection/VPNUpsellVisibilityManagerTests.swift
@@ -1,0 +1,220 @@
+//
+//  VPNUpsellVisibilityManagerTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Combine
+import BrowserServicesKit
+import Common
+import Subscription
+import SubscriptionTestingUtilities
+@testable import DuckDuckGo_Privacy_Browser
+
+@MainActor
+final class VPNUpsellVisibilityManagerTests: XCTestCase {
+
+    var sut: VPNUpsellVisibilityManager!
+    var mockSubscriptionManager: SubscriptionAuthV1toV2BridgeMock!
+    var mockFeatureFlagger: MockFeatureFlagger!
+    var defaultBrowserSubject: CurrentValueSubject<Bool, Never>!
+    var contextualOnboardingSubject: CurrentValueSubject<Bool, Never>!
+    var cancellables: Set<AnyCancellable>!
+
+    override func setUp() {
+        super.setUp()
+
+        mockSubscriptionManager = SubscriptionAuthV1toV2BridgeMock()
+        mockFeatureFlagger = MockFeatureFlagger()
+        defaultBrowserSubject = CurrentValueSubject<Bool, Never>(false)
+        contextualOnboardingSubject = CurrentValueSubject<Bool, Never>(false)
+        cancellables = Set<AnyCancellable>()
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockSubscriptionManager = nil
+        mockFeatureFlagger = nil
+        defaultBrowserSubject = nil
+        contextualOnboardingSubject = nil
+        cancellables = nil
+        super.tearDown()
+    }
+
+    func testWhenUserIsSubscribed_ItDoesNotShowUpsell() {
+        sut = createSUT(isFirstLaunch: true, isNewUser: true, isUserAuthenticated: true)
+
+        XCTAssertFalse(sut.shouldShowUpsell)
+    }
+
+    func testWhenUserIsNotNew_ItDoesNotShowUpsell() {
+        sut = createSUT(isFirstLaunch: true, isNewUser: false, isUserAuthenticated: false)
+
+        XCTAssertFalse(sut.shouldShowUpsell)
+    }
+
+    func testWhenNotFirstLaunch_ItShowsUpsellImmediately() {
+        sut = createSUT(isFirstLaunch: false, isNewUser: true, isUserAuthenticated: false)
+
+        XCTAssertTrue(sut.shouldShowUpsell)
+    }
+
+    func testWhenContextualOnboardingIsComplete_AndDefaultBrowserIsSet_ItStartsTimer() {
+        let expectation = XCTestExpectation(description: "Timer should complete")
+        sut = createSUT(isFirstLaunch: true, isNewUser: true, isUserAuthenticated: false, timerDuration: 0.1)
+
+        sut.$shouldShowUpsell
+            .dropFirst()
+            .sink { (shouldShow: Bool) in
+                if shouldShow {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        // When
+        contextualOnboardingSubject.send(true)
+        defaultBrowserSubject.send(true)
+
+        wait(for: [expectation], timeout: 1.0)
+        // Then
+        XCTAssertTrue(sut.shouldShowUpsell)
+    }
+
+    func testWhenOnlyContextualOnboardingIsComplete_ItDoesNotStartTimer() {
+        sut = createSUT(isFirstLaunch: true, isNewUser: true, isUserAuthenticated: false, timerDuration: 0.1)
+
+        let expectation = XCTestExpectation(description: "Should not show upsell")
+        expectation.isInverted = true
+
+        sut.$shouldShowUpsell
+            .dropFirst()
+            .sink { _ in
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        // When
+        contextualOnboardingSubject.send(true)
+
+        wait(for: [expectation], timeout: 1.0)
+        // Then
+        XCTAssertFalse(sut.shouldShowUpsell)
+    }
+
+    func testWhenOnlyDefaultBrowserIsSet_ItDoesNotStartTimer() {
+        sut = createSUT(isFirstLaunch: true, isNewUser: true, isUserAuthenticated: false, timerDuration: 0.1)
+
+        let expectation = XCTestExpectation(description: "Should not show upsell")
+        expectation.isInverted = true
+
+        sut.$shouldShowUpsell
+            .dropFirst()
+            .sink { _ in
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        // When
+        defaultBrowserSubject.send(true)
+
+        wait(for: [expectation], timeout: 1.0)
+        // Then
+        XCTAssertFalse(sut.shouldShowUpsell)
+    }
+
+    func testWhenMultipleTimerStartAttempts_OnlyOneTimerRuns() {
+        let expectation = XCTestExpectation(description: "Timer should complete once")
+        expectation.expectedFulfillmentCount = 1
+        sut = createSUT(isFirstLaunch: true, isNewUser: true, isUserAuthenticated: false, timerDuration: 0.1)
+
+        sut.$shouldShowUpsell
+            .dropFirst()
+            .sink { (shouldShow: Bool) in
+                if shouldShow {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        // When
+        contextualOnboardingSubject.send(true)
+        defaultBrowserSubject.send(true)
+        contextualOnboardingSubject.send(true)
+        defaultBrowserSubject.send(true)
+
+        wait(for: [expectation], timeout: 1.0)
+        // Then
+        XCTAssertTrue(sut.shouldShowUpsell)
+    }
+
+    func testWhenSubscriptionChanges_ItHidesUpsellAndCancelsTimer() {
+        sut = createSUT(isFirstLaunch: true, isNewUser: true, isUserAuthenticated: false, timerDuration: 10.0)
+
+        contextualOnboardingSubject.send(true)
+        defaultBrowserSubject.send(true)
+
+        // When
+        mockSubscriptionManager.accessTokenResult = .success("mock-token")
+        NotificationCenter.default.post(name: .entitlementsDidChange, object: nil)
+
+        // Then
+        XCTAssertFalse(sut.shouldShowUpsell)
+    }
+
+    func testWhenTimerCompletes_ItUpdatesVisibility() {
+        let expectation = XCTestExpectation(description: "Timer completion updates visibility")
+        sut = createSUT(isFirstLaunch: true, isNewUser: true, isUserAuthenticated: false, timerDuration: 0.1)
+
+        sut.$shouldShowUpsell
+            .dropFirst()
+            .sink { (shouldShow: Bool) in
+                // Then
+                XCTAssertTrue(shouldShow)
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        // When
+        contextualOnboardingSubject.send(true)
+        defaultBrowserSubject.send(true)
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+}
+
+// MARK: - Helpers
+
+extension VPNUpsellVisibilityManagerTests {
+    private func createSUT(
+        isFirstLaunch: Bool,
+        isNewUser: Bool,
+        isUserAuthenticated: Bool,
+        timerDuration: TimeInterval = 0.1
+    ) -> VPNUpsellVisibilityManager {
+        mockSubscriptionManager.accessTokenResult = isUserAuthenticated ? .success("mock-token") : .failure(SubscriptionManagerError.noTokenAvailable)
+
+        return VPNUpsellVisibilityManager(
+            isFirstLaunch: isFirstLaunch,
+            isNewUser: isNewUser,
+            subscriptionManager: mockSubscriptionManager,
+            defaultBrowserPublisher: defaultBrowserSubject.eraseToAnyPublisher(),
+            contextualOnboardingPublisher: contextualOnboardingSubject.eraseToAnyPublisher(),
+            featureFlagger: mockFeatureFlagger,
+            timerDuration: timerDuration
+        )
+    }
+}

--- a/macOS/UnitTests/Onboarding/ContextualOnboarding/ContextualDialogsManagerTests.swift
+++ b/macOS/UnitTests/Onboarding/ContextualOnboarding/ContextualDialogsManagerTests.swift
@@ -39,6 +39,20 @@ class ContextualDialogsManagerTests {
         XCTAssertEqual(manager.state, .onboardingCompleted)
     }
 
+    @Test("Contextual onboarding completion is published")
+    func testContextualOnboardingCompletedPublisher() {
+        // Given
+        XCTAssertTrue(manager.isContextualOnboardingCompleted)
+
+        // When
+        manager.state = .ongoing
+        XCTAssertFalse(manager.isContextualOnboardingCompleted)
+        manager.state = .onboardingCompleted
+
+        // Then
+        XCTAssertTrue(manager.isContextualOnboardingCompleted)
+    }
+
     // MARK: - NewTab
 
     @Test("The first time New Tab is shown will show tryASearch dialog")

--- a/macOS/UnitTests/Onboarding/ContextualOnboarding/OnboardingPixelReporterTests.swift
+++ b/macOS/UnitTests/Onboarding/ContextualOnboarding/OnboardingPixelReporterTests.swift
@@ -183,6 +183,9 @@ class MockContextualOnboardingState: ContextualOnboardingStateUpdater, Contextua
 
     var state: ContextualOnboardingState = .onboardingCompleted
 
+    @Published var isContextualOnboardingCompleted: Bool = true
+    var isContextualOnboardingCompletedPublisher: Published<Bool>.Publisher { $isContextualOnboardingCompleted }
+
     func updateStateFor(tab: Tab) {
     }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210594645229050/task/1210649122070618?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/1210594645229050/task/1210649122070619?focus=true
CC: @SabrinaTardio 

### Description

This PR adds targeting/appearance logic for the VPN upsell button.

* `VPNUpsellVisibilityManager` will decide whether to show the upsell button or not
* `NetworkProtectionNavBarButtonModel` subscribes to the manager’s output and refresh visibility of the button
* Added a publisher to `ContextualDialogsManager`

### Testing Steps
Since the feature is not ready yet, just make sure the regular flow works as expected:
1. Launch the app without a subscription -> VPN button should not show
2. Launch the app as subscriber -> VPN button should show

### Impact and Risks
None: New logic is behind feature flag

#### What could go wrong?
N/A

### Quality Considerations
I’ve added tests to `VPNUpsellVisibilityManager` and `NetworkProtectionNavBarButtonModel`

### Notes to Reviewer
Removal logic is not yet implemented, and will come in a follow-up PR as I work on [these](https://app.asana.com/1/137249556945/task/1210649122070626) [tasks](https://app.asana.com/1/137249556945/task/1210649122070627).

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)