### PR TITLE
macOS: Failed update checks no longer count towards the update rate-limiting quota

### DIFF
--- a/macOS/DuckDuckGo/Updates/UpdateCheckState.swift
+++ b/macOS/DuckDuckGo/Updates/UpdateCheckState.swift
@@ -34,14 +34,14 @@ actor UpdateCheckState {
     /// Determines whether a new update check can be started.
     ///
     /// - Parameters:
-    ///   - updater: The SPUUpdater instance to check for active sessions
+    ///   - updater: The SPUUpdater instance to check for availability
     ///   - minimumInterval: Minimum time interval that must pass between checks.
     ///     Defaults to `UpdateCheckState.defaultMinimumCheckInterval`.
-    /// - Returns: `true` if no session is active and enough time has passed since the last check, `false` otherwise.
+    /// - Returns: `true` if Sparkle allows checks and enough time has passed since the last check, `false` otherwise.
     ///
     func canStartNewCheck(updater: SPUUpdater?, minimumInterval: TimeInterval = UpdateCheckState.defaultMinimumCheckInterval) -> Bool {
-        // Check if Sparkle is already checking
-        if let updater = updater, updater.sessionInProgress {
+        // Check if Sparkle allows checking for updates
+        if let updater = updater, !updater.canCheckForUpdates {
             return false
         }
 

--- a/macOS/DuckDuckGo/Updates/UpdateCheckState.swift
+++ b/macOS/DuckDuckGo/Updates/UpdateCheckState.swift
@@ -17,10 +17,11 @@
 //
 
 import Foundation
+import Sparkle
 
-/// Actor responsible for managing update check state and task coordination.
+/// Actor responsible for managing update check state and rate limiting.
 ///
-/// Handles rate limiting, task lifecycle management, and prevents concurrent update checks.
+/// Handles rate limiting to prevent concurrent update checks.
 /// Each UpdateController instance has its own UpdateCheckState for isolated state management.
 /// 
 actor UpdateCheckState {
@@ -28,18 +29,19 @@ actor UpdateCheckState {
     /// Default minimum interval between update checks
     static let defaultMinimumCheckInterval: TimeInterval = .minutes(5)
 
-    private var activeUpdateTask: Task<Void, Never>?
     private var lastUpdateCheckTime: Date?
 
     /// Determines whether a new update check can be started.
     ///
-    /// - Parameter minimumInterval: Minimum time interval that must pass between checks.
-    ///   Defaults to `UpdateCheckState.defaultMinimumCheckInterval`.
-    /// - Returns: `true` if no task is active and enough time has passed since the last check, `false` otherwise.
+    /// - Parameters:
+    ///   - updater: The SPUUpdater instance to check for active sessions
+    ///   - minimumInterval: Minimum time interval that must pass between checks.
+    ///     Defaults to `UpdateCheckState.defaultMinimumCheckInterval`.
+    /// - Returns: `true` if no session is active and enough time has passed since the last check, `false` otherwise.
     ///
-    func canStartNewCheck(minimumInterval: TimeInterval = UpdateCheckState.defaultMinimumCheckInterval) -> Bool {
-        // Check if there's an active task
-        if let task = activeUpdateTask, !task.isCancelled {
+    func canStartNewCheck(updater: SPUUpdater?, minimumInterval: TimeInterval = UpdateCheckState.defaultMinimumCheckInterval) -> Bool {
+        // Check if Sparkle is already checking
+        if let updater = updater, updater.sessionInProgress {
             return false
         }
 
@@ -50,24 +52,6 @@ actor UpdateCheckState {
         }
 
         return true
-    }
-
-    /// Cancels any currently active update task.
-    ///
-    /// This method immediately cancels the active task and clears the task reference.
-    /// Used when user-initiated update checks need to take priority over automatic checks.
-    ///
-    internal func cancelActiveTask() {
-        activeUpdateTask?.cancel()
-        activeUpdateTask = nil
-    }
-
-    /// Sets or clears the currently active update task.
-    ///
-    /// - Parameter task: The task to track as active, or `nil` to clear the active task.
-    ///
-    internal func setActiveTask(_ task: Task<Void, Never>?) {
-        activeUpdateTask = task
     }
 
     /// Records the current time as the last update check time.

--- a/macOS/DuckDuckGo/Updates/UpdateController.swift
+++ b/macOS/DuckDuckGo/Updates/UpdateController.swift
@@ -309,7 +309,7 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
             Logger.updates.debug("User-initiated update check skipped - not allowed by Sparkle")
             return
         }
-        
+
         Logger.updates.debug("User-initiated update check starting")
 
         if case .updaterError = userDriver?.updateProgress {

--- a/macOS/DuckDuckGo/Updates/UpdateController.swift
+++ b/macOS/DuckDuckGo/Updates/UpdateController.swift
@@ -246,9 +246,6 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
             return
         }
 
-        // Record that we're starting a check
-        await updateCheckState.recordCheckTime()
-
         if case .updaterError = userDriver?.updateProgress {
             userDriver?.cancelAndDismissCurrentUpdate()
         }
@@ -268,10 +265,6 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
 
         // Store the task reference
         await updateCheckState.setActiveTask(updateTask)
-
-        // Wait for the task to complete and clean up
-        await updateTask.value
-        await updateCheckState.setActiveTask(nil)
     }
 
     private var isBuildExpired: Bool {
@@ -318,9 +311,6 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
         await updateCheckState.cancelActiveTask()
         Logger.updates.debug("User-initiated update check - cancelled any active task")
 
-        // Record that we're starting a check (no rate limiting for user-initiated)
-        await updateCheckState.recordCheckTime()
-
         if case .updaterError = userDriver?.updateProgress {
             userDriver?.cancelAndDismissCurrentUpdate()
         }
@@ -340,10 +330,6 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
 
         // Store the task reference
         await updateCheckState.setActiveTask(updateTask)
-
-        // Wait for the task to complete and clean up
-        await updateTask.value
-        await updateCheckState.setActiveTask(nil)
     }
 
     // MARK: - Private
@@ -553,12 +539,18 @@ extension UpdateController: SPUUpdaterDelegate {
     }
 
     func updater(_ updater: SPUUpdater, didFinishUpdateCycleFor updateCheck: SPUUpdateCheck, error: (any Error)?) {
+        defer {
+            Task { await updateCheckState.setActiveTask(nil) }
+        }
+
         if error == nil {
             Logger.updates.log("Updater did finish update cycle with no error")
             updateProgress = .updateCycleDone(.finishedWithNoError)
+            Task { await updateCheckState.recordCheckTime() }
         } else if let errorCode = (error as? NSError)?.code, errorCode == Int(Sparkle.SUError.noUpdateError.rawValue) {
             Logger.updates.log("Updater did finish update cycle with no update found")
             updateProgress = .updateCycleDone(.finishedWithNoUpdateFound)
+            Task { await updateCheckState.recordCheckTime() }
         } else if let error {
             Logger.updates.log("Updater did finish update cycle with error: \(error.localizedDescription, privacy: .public) (\(error.pixelParameters, privacy: .public))")
         }

--- a/macOS/DuckDuckGo/Updates/UpdateController.swift
+++ b/macOS/DuckDuckGo/Updates/UpdateController.swift
@@ -540,11 +540,11 @@ extension UpdateController: SPUUpdaterDelegate {
         if error == nil {
             Logger.updates.log("Updater did finish update cycle with no error")
             updateProgress = .updateCycleDone(.finishedWithNoError)
-            Task { await updateCheckState.recordCheckTime() }
+            Task { @UpdateCheckActor in await updateCheckState.recordCheckTime() }
         } else if let errorCode = (error as? NSError)?.code, errorCode == Int(Sparkle.SUError.noUpdateError.rawValue) {
             Logger.updates.log("Updater did finish update cycle with no update found")
             updateProgress = .updateCycleDone(.finishedWithNoUpdateFound)
-            Task { await updateCheckState.recordCheckTime() }
+            Task { @UpdateCheckActor in await updateCheckState.recordCheckTime() }
         } else if let error {
             Logger.updates.log("Updater did finish update cycle with error: \(error.localizedDescription, privacy: .public) (\(error.pixelParameters, privacy: .public))")
         }

--- a/macOS/DuckDuckGo/Updates/UpdateController.swift
+++ b/macOS/DuckDuckGo/Updates/UpdateController.swift
@@ -240,9 +240,9 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
 
     @UpdateCheckActor
     private func performUpdateCheck() async {
-        // Check if we can start a new check (no active task + rate limiting)
-        guard await updateCheckState.canStartNewCheck() else {
-            Logger.updates.debug("Update check skipped - task already running or rate limited")
+        // Check if we can start a new check (no active session + rate limiting)
+        guard await updateCheckState.canStartNewCheck(updater: updater) else {
+            Logger.updates.debug("Update check skipped - already checking or rate limited")
             return
         }
 
@@ -251,7 +251,7 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
         }
 
         // Create the actual update task
-        let updateTask = Task { @MainActor in
+        Task { @MainActor in
             // Handle expired builds first (critical path)
             guard !discardCurrentUpdateIfExpiredAndCheckAgain(skipRollout: false) else {
                 return
@@ -262,9 +262,6 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
             Logger.updates.log("Checking for updates respecting rollout")
             updater.checkForUpdatesInBackground()
         }
-
-        // Store the task reference
-        await updateCheckState.setActiveTask(updateTask)
     }
 
     private var isBuildExpired: Bool {
@@ -307,16 +304,20 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
 
     @UpdateCheckActor
     private func performUpdateCheckSkippingRollout() async {
-        // Cancel any active task (user-initiated takes priority)
-        await updateCheckState.cancelActiveTask()
-        Logger.updates.debug("User-initiated update check - cancelled any active task")
+        // User-initiated checks skip rate limiting but still respect active sessions
+        guard await updateCheckState.canStartNewCheck(updater: updater, minimumInterval: 0) else {
+            Logger.updates.debug("User-initiated update check skipped - session already in progress")
+            return
+        }
+        
+        Logger.updates.debug("User-initiated update check starting")
 
         if case .updaterError = userDriver?.updateProgress {
             userDriver?.cancelAndDismissCurrentUpdate()
         }
 
         // Create the actual update task
-        let updateTask = Task { @MainActor in
+        Task { @MainActor in
             // Handle expired builds first (critical path)
             guard !discardCurrentUpdateIfExpiredAndCheckAgain(skipRollout: true) else {
                 return
@@ -327,9 +328,6 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
             Logger.updates.log("Checking for updates skipping rollout")
             updater.checkForUpdates()
         }
-
-        // Store the task reference
-        await updateCheckState.setActiveTask(updateTask)
     }
 
     // MARK: - Private
@@ -539,10 +537,6 @@ extension UpdateController: SPUUpdaterDelegate {
     }
 
     func updater(_ updater: SPUUpdater, didFinishUpdateCycleFor updateCheck: SPUUpdateCheck, error: (any Error)?) {
-        defer {
-            Task { await updateCheckState.setActiveTask(nil) }
-        }
-
         if error == nil {
             Logger.updates.log("Updater did finish update cycle with no error")
             updateProgress = .updateCycleDone(.finishedWithNoError)

--- a/macOS/DuckDuckGo/Updates/UpdateController.swift
+++ b/macOS/DuckDuckGo/Updates/UpdateController.swift
@@ -240,9 +240,9 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
 
     @UpdateCheckActor
     private func performUpdateCheck() async {
-        // Check if we can start a new check (no active session + rate limiting)
+        // Check if we can start a new check (Sparkle availability + rate limiting)
         guard await updateCheckState.canStartNewCheck(updater: updater) else {
-            Logger.updates.debug("Update check skipped - already checking or rate limited")
+            Logger.updates.debug("Update check skipped - not allowed by Sparkle or rate limited")
             return
         }
 
@@ -304,9 +304,9 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
 
     @UpdateCheckActor
     private func performUpdateCheckSkippingRollout() async {
-        // User-initiated checks skip rate limiting but still respect active sessions
+        // User-initiated checks skip rate limiting but still respect Sparkle availability
         guard await updateCheckState.canStartNewCheck(updater: updater, minimumInterval: 0) else {
-            Logger.updates.debug("User-initiated update check skipped - session already in progress")
+            Logger.updates.debug("User-initiated update check skipped - not allowed by Sparkle")
             return
         }
         

--- a/macOS/UnitTests/Updates/UpdateCheckStateTests.swift
+++ b/macOS/UnitTests/Updates/UpdateCheckStateTests.swift
@@ -27,6 +27,54 @@ class MockSPUUpdater: SPUUpdater {
     override var canCheckForUpdates: Bool {
         return mockCanCheckForUpdates
     }
+
+    convenience init() {
+        // Create a minimal mock user driver for testing
+        let mockUserDriver = MockUserDriver()
+        self.init(hostBundle: Bundle.main,
+                  applicationBundle: Bundle.main,
+                  userDriver: mockUserDriver,
+                  delegate: nil)
+        // Note: We intentionally don't call start() here since:
+        // 1. It might throw and we don't need it for these tests
+        // 2. We're only testing UpdateCheckState rate limiting, not SPUUpdater functionality
+    }
+}
+
+// Mock user driver to satisfy SPUUpdater requirements
+class MockUserDriver: NSObject, SPUUserDriver {
+    func showCanCheckForUpdatesNow(_ canCheckForUpdatesNow: Bool) {}
+    func showUserInitiatedUpdateCheck(cancellation: @escaping () -> Void) {}
+    func dismissUserInitiatedUpdateCheck() {}
+    func show(_ request: SPUUpdatePermissionRequest) async -> SUUpdatePermissionResponse {
+        return SUUpdatePermissionResponse(automaticUpdateChecks: false, sendSystemProfile: false)
+    }
+    func showUpdateFound(with appcastItem: SUAppcastItem, state: SPUUserUpdateState, reply: @escaping (SPUUserUpdateChoice) -> Void) {
+        reply(.dismiss)
+    }
+    func showUpdateReleaseNotes(with downloadData: SPUDownloadData) {}
+    func showUpdateReleaseNotesFailedToDownloadWithError(_ error: any Error) {}
+    func showUpdateNotFoundWithError(_ error: any Error, acknowledgement: @escaping () -> Void) {
+        acknowledgement()
+    }
+    func showUpdaterError(_ error: any Error, acknowledgement: @escaping () -> Void) {
+        acknowledgement()
+    }
+    func showDownloadInitiated(cancellation: @escaping () -> Void) {}
+    func showDownloadDidReceiveExpectedContentLength(_ expectedContentLength: UInt64) {}
+    func showDownloadDidReceiveData(ofLength length: UInt64) {}
+    func showDownloadDidStartExtractingUpdate() {}
+    func showExtractionReceivedProgress(_ progress: Double) {}
+    func showReady(toInstallAndRelaunch reply: @escaping (SPUUserUpdateChoice) -> Void) {
+        reply(.dismiss)
+    }
+    func showInstallingUpdate(withApplicationTerminated applicationTerminated: Bool, retryTerminatingApplication: @escaping () -> Void) {}
+    func showSendingTerminationSignal() {}
+    func showUpdateInstalledAndRelaunched(_ relaunched: Bool, acknowledgement: @escaping () -> Void) {
+        acknowledgement()
+    }
+    func showUpdateInFocus() {}
+    func dismissUpdateInstallation() {}
 }
 
 /// Tests for UpdateCheckState actor that manages update check rate limiting.

--- a/macOS/UnitTests/Updates/UpdateCheckStateTests.swift
+++ b/macOS/UnitTests/Updates/UpdateCheckStateTests.swift
@@ -18,31 +18,41 @@
 
 import XCTest
 @testable import DuckDuckGo_Privacy_Browser
+import Sparkle
 
-/// Tests for UpdateCheckState actor that manages update check coordination and rate limiting.
+// Mock SPUUpdater for testing
+class MockSPUUpdater: SPUUpdater {
+    var mockCanCheckForUpdates: Bool = true
+
+    override var canCheckForUpdates: Bool {
+        return mockCanCheckForUpdates
+    }
+}
+
+/// Tests for UpdateCheckState actor that manages update check rate limiting.
 ///
-/// This test suite validates two critical behaviors:
-/// 1. **Rate Limiting**: Prevents excessive update checks that could impact performance or server load
-/// 2. **Task Coordination**: Ensures only one update check runs at a time to prevent resource conflicts
+/// This test suite validates rate limiting behavior that prevents excessive update checks
+/// which could impact performance or server load.
 ///
 /// These behaviors are essential for:
 /// - Maintaining app responsiveness during update checks
 /// - Preventing server abuse from rapid-fire update requests
-/// - Ensuring user-initiated checks take priority over automatic background checks
-/// - Handling edge cases like cancelled tasks and concurrent access safely
+/// - Ensuring user-initiated checks can bypass rate limiting when needed
 @available(macOS 10.15.0, *)
 final class UpdateCheckStateTests: XCTestCase {
 
     var updateCheckState: UpdateCheckState!
+    var mockUpdater: MockSPUUpdater!
 
     override func setUp() async throws {
         try await super.setUp()
         updateCheckState = UpdateCheckState()
+        mockUpdater = MockSPUUpdater()
     }
 
     override func tearDown() async throws {
-        await updateCheckState.cancelActiveTask()
         updateCheckState = nil
+        mockUpdater = nil
         try await super.tearDown()
     }
 
@@ -50,41 +60,15 @@ final class UpdateCheckStateTests: XCTestCase {
 
     /// Tests that update checks are allowed when the system is in its initial state.
     func testAllowsUpdateChecksInInitialState() async {
-        let canStart = await updateCheckState.canStartNewCheck()
+        let canStart = await updateCheckState.canStartNewCheck(updater: mockUpdater)
         XCTAssertTrue(canStart, "Should be able to start check in initial state")
-    }
-
-    /// Tests that concurrent update checks are prevented when one is already running.
-    func testPreventsConcurrentUpdateChecks() async {
-        let activeTask = Task<Void, Never> { @MainActor in
-            try? await Task.sleep(nanoseconds: 200 * NSEC_PER_MSEC)
-        }
-        await updateCheckState.setActiveTask(activeTask)
-
-        let canStart = await updateCheckState.canStartNewCheck()
-        XCTAssertFalse(canStart, "Should not be able to start check with active task")
-
-        activeTask.cancel()
-        await updateCheckState.setActiveTask(nil)
-    }
-
-    /// Tests that cancelled update tasks don't block new update checks.
-    func testCancelledTasksDontBlockNewChecks() async {
-        let cancelledTask = Task<Void, Never> { @MainActor in
-            try? await Task.sleep(nanoseconds: 200 * NSEC_PER_MSEC)
-        }
-        cancelledTask.cancel()
-        await updateCheckState.setActiveTask(cancelledTask)
-
-        let canStart = await updateCheckState.canStartNewCheck()
-        XCTAssertTrue(canStart, "Should be able to start check with cancelled task")
     }
 
     /// Tests that update checks are rate limited to prevent excessive requests.
     func testRateLimitingPreventsExcessiveRequests() async {
         await updateCheckState.recordCheckTime()
 
-        let canStart = await updateCheckState.canStartNewCheck()
+        let canStart = await updateCheckState.canStartNewCheck(updater: mockUpdater)
         XCTAssertFalse(canStart, "Should be rate limited when checking too soon")
     }
 
@@ -92,126 +76,112 @@ final class UpdateCheckStateTests: XCTestCase {
     func testRateLimitingCanBeBypassed() async {
         await updateCheckState.recordCheckTime()
 
-        let canStart = await updateCheckState.canStartNewCheck(minimumInterval: 0)
+        let canStart = await updateCheckState.canStartNewCheck(updater: mockUpdater, minimumInterval: 0)
         XCTAssertTrue(canStart, "Should be able to start check when rate limit is disabled")
     }
 
-    /// Tests that rate limiting intervals can be configured for different scenarios.
+    /// Tests that rate limiting intervals are configurable for different scenarios.
     func testRateLimitingIntervalsAreConfigurable() async {
         await updateCheckState.recordCheckTime()
 
-        let canStart = await updateCheckState.canStartNewCheck(minimumInterval: 0.1)
+        let canStart = await updateCheckState.canStartNewCheck(updater: mockUpdater, minimumInterval: 0.1)
         XCTAssertFalse(canStart, "Should respect custom minimum interval")
     }
 
-    // MARK: - cancelActiveTask Tests
+    /// Tests that checks are blocked when Sparkle doesn't allow updates.
+    func testChecksAreBlockedWhenSparkleDoesntAllow() async {
+        mockUpdater.mockCanCheckForUpdates = false
 
-    /// Tests that running update checks can be cancelled to allow new ones to start.
-    func testRunningChecksCanBeCancelled() async {
-        let activeTask = Task<Void, Never> { @MainActor in
-            try? await Task.sleep(nanoseconds: 200 * NSEC_PER_MSEC)
-        }
-        await updateCheckState.setActiveTask(activeTask)
-
-        await updateCheckState.cancelActiveTask()
-
-        XCTAssertTrue(activeTask.isCancelled, "Task should be cancelled")
-
-        let canStart = await updateCheckState.canStartNewCheck()
-        XCTAssertTrue(canStart, "Should be able to start new check after cancellation")
+        let canStart = await updateCheckState.canStartNewCheck(updater: mockUpdater)
+        XCTAssertFalse(canStart, "Should not be able to start check when Sparkle doesn't allow it")
     }
 
-    /// Tests that cancelling update checks is safe even when none are running.
-    func testCancellingIsSafeWhenNoneRunning() async {
-        await updateCheckState.cancelActiveTask()
+    /// Tests that checks are allowed when Sparkle allows updates.
+    func testChecksAreAllowedWhenSparkleAllows() async {
+        mockUpdater.mockCanCheckForUpdates = true
 
-        let canStart = await updateCheckState.canStartNewCheck()
-        XCTAssertTrue(canStart, "Should still be able to start check")
+        let canStart = await updateCheckState.canStartNewCheck(updater: mockUpdater)
+        XCTAssertTrue(canStart, "Should be able to start check when Sparkle allows it")
     }
 
-    // MARK: - setActiveTask Tests
-
-    /// Tests that update checks are blocked while another check is tracked as active.
-    func testChecksAreBlockedWhileAnotherIsActive() async {
-        let task = Task<Void, Never> { @MainActor in
-        }
-
-        await updateCheckState.setActiveTask(task)
-
-        let canStart = await updateCheckState.canStartNewCheck()
-        XCTAssertFalse(canStart, "Should not be able to start check with active task set")
-
-        task.cancel()
-        await updateCheckState.setActiveTask(nil)
+    /// Tests that nil updater allows update checks (doesn't block them).
+    func testNilUpdaterAllowsChecks() async {
+        let canStart = await updateCheckState.canStartNewCheck(updater: nil)
+        XCTAssertTrue(canStart, "Should be able to start check with nil updater")
     }
 
-    /// Tests that update checks are unblocked when the active check is cleared.
-    func testChecksAreUnblockedWhenActiveCheckCleared() async {
-        let task = Task<Void, Never> { @MainActor in
-            try? await Task.sleep(nanoseconds: 200 * NSEC_PER_MSEC)
-        }
-        await updateCheckState.setActiveTask(task)
+    /// Tests that nil updater still respects rate limiting.
+    func testNilUpdaterRespectsRateLimiting() async {
+        await updateCheckState.recordCheckTime()
 
-        await updateCheckState.setActiveTask(nil)
-
-        let canStart = await updateCheckState.canStartNewCheck()
-        XCTAssertTrue(canStart, "Should be able to start check after clearing active task")
-
-        task.cancel()
+        let canStart = await updateCheckState.canStartNewCheck(updater: nil)
+        XCTAssertFalse(canStart, "Should still be rate limited with nil updater")
     }
 
     // MARK: - recordCheckTime Tests
 
     /// Tests that recording check timestamps enables rate limiting behavior.
     func testRecordingTimestampsEnablesRateLimiting() async {
-        let initialCanStart = await updateCheckState.canStartNewCheck()
+        let initialCanStart = await updateCheckState.canStartNewCheck(updater: mockUpdater)
         XCTAssertTrue(initialCanStart, "Should initially be able to start check")
 
         await updateCheckState.recordCheckTime()
 
-        let canStartAfterRecord = await updateCheckState.canStartNewCheck()
+        let canStartAfterRecord = await updateCheckState.canStartNewCheck(updater: mockUpdater)
         XCTAssertFalse(canStartAfterRecord, "Should be rate limited after recording check time")
+    }
+
+    /// Tests that rate limiting expires after sufficient time passes.
+    func testRateLimitingExpiresAfterTime() async {
+        await updateCheckState.recordCheckTime()
+
+        // Check immediately after recording - should be rate limited
+        let canStartImmediately = await updateCheckState.canStartNewCheck(updater: mockUpdater, minimumInterval: 0.01)
+        XCTAssertFalse(canStartImmediately, "Should be rate limited immediately after recording")
+
+        // Wait for rate limit to expire
+        try? await Task.sleep(nanoseconds: 20_000_000) // 20ms
+
+        let canStartAfterWait = await updateCheckState.canStartNewCheck(updater: mockUpdater, minimumInterval: 0.01)
+        XCTAssertTrue(canStartAfterWait, "Should be able to start check after rate limit expires")
     }
 
     // MARK: - Integration Tests
 
-    /// Tests the complete update check workflow from start to finish including rate limiting.
-    func testCompleteUpdateCheckWorkflow() async {
-        let initialCanStart = await updateCheckState.canStartNewCheck()
+    /// Tests the basic rate limiting workflow.
+    func testBasicRateLimitingWorkflow() async {
+        // Initial state - should allow checks
+        let initialCanStart = await updateCheckState.canStartNewCheck(updater: mockUpdater)
         XCTAssertTrue(initialCanStart, "Should initially be able to start check")
 
+        // Record check time - should now be rate limited
         await updateCheckState.recordCheckTime()
-        let task = Task<Void, Never> { @MainActor in
-            try? await Task.sleep(nanoseconds: 200 * NSEC_PER_MSEC)
-        }
-        await updateCheckState.setActiveTask(task)
+        let canStartAfterRecord = await updateCheckState.canStartNewCheck(updater: mockUpdater)
+        XCTAssertFalse(canStartAfterRecord, "Should be rate limited after recording check time")
 
-        let canStartDuringTask = await updateCheckState.canStartNewCheck()
-        XCTAssertFalse(canStartDuringTask, "Should not be able to start with active task and rate limit")
-
-        await task.value
-        await updateCheckState.setActiveTask(nil)
-
-        let canStartAfterTask = await updateCheckState.canStartNewCheck()
-        XCTAssertFalse(canStartAfterTask, "Should still be rate limited after task completion")
-
-        let canStartWithoutRateLimit = await updateCheckState.canStartNewCheck(minimumInterval: 0)
-        XCTAssertTrue(canStartWithoutRateLimit, "Should be able to start when rate limit is disabled")
+        // User-initiated check can bypass rate limit
+        let canStartUserInitiated = await updateCheckState.canStartNewCheck(updater: mockUpdater, minimumInterval: 0)
+        XCTAssertTrue(canStartUserInitiated, "User-initiated check should bypass rate limit")
     }
 
-    /// Tests that user-initiated update checks can override automatic rate limiting.
-    func testUserInitiatedChecksOverrideRateLimiting() async {
+    /// Tests behavior with different Sparkle states and rate limiting.
+    func testSparkleStateAndRateLimitingInteraction() async {
+        // Record a check time to enable rate limiting
         await updateCheckState.recordCheckTime()
-        let automaticTask = Task<Void, Never> { @MainActor in
-            try? await Task.sleep(nanoseconds: 200 * NSEC_PER_MSEC)
-        }
-        await updateCheckState.setActiveTask(automaticTask)
 
-        await updateCheckState.cancelActiveTask()
+        // Even if rate limited, Sparkle state should still be respected
+        mockUpdater.mockCanCheckForUpdates = false
+        let canStartWithBlockedSparkle = await updateCheckState.canStartNewCheck(updater: mockUpdater, minimumInterval: 0)
+        XCTAssertFalse(canStartWithBlockedSparkle, "Should not be able to start even when bypassing rate limit if Sparkle blocks")
 
-        let canStartUserInitiated = await updateCheckState.canStartNewCheck(minimumInterval: 0)
-        XCTAssertTrue(canStartUserInitiated, "User-initiated check should be able to start immediately")
-        XCTAssertTrue(automaticTask.isCancelled, "Automatic task should be cancelled")
+        // When Sparkle allows but we're rate limited
+        mockUpdater.mockCanCheckForUpdates = true
+        let canStartWithAllowedSparkle = await updateCheckState.canStartNewCheck(updater: mockUpdater)
+        XCTAssertFalse(canStartWithAllowedSparkle, "Should still be rate limited even when Sparkle allows")
+
+        // When both Sparkle allows and rate limit is bypassed
+        let canStartBothAllowed = await updateCheckState.canStartNewCheck(updater: mockUpdater, minimumInterval: 0)
+        XCTAssertTrue(canStartBothAllowed, "Should be able to start when both conditions are met")
     }
 
     // MARK: - Constants Tests


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210873627461949?focus=true

### Description

Failed update checks no longer count towards the update rate-limiting quota.

### Testing Steps

1. Launch the app without a connection.
2. Open release notes.
3. You'll see empty release notes - this is a known issue that's unrelated to rate-limiting.
4. Reconnect to internet
5. Go to Settings > About, click check for updates
6. Ensure the release notes are showing

### Impact and Risks

Low.

#### What could go wrong?

Nothing I can think of.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)