### PR TITLE
iOS: Add checkout.stripe.com to Async Web View Allowed Domains

### DIFF
--- a/iOS/DuckDuckGo/Subscription/AsyncHeadlessWebview/AsyncHeadlessWebView.swift
+++ b/iOS/DuckDuckGo/Subscription/AsyncHeadlessWebview/AsyncHeadlessWebView.swift
@@ -47,6 +47,9 @@ struct AsyncHeadlessWebViewSettings {
         // Allow navigation to baseURLs domain
         allowedDomains.insert(baseURL.host ?? "duckduckgo.com")
 
+        // Always allow Stripe checkout domain
+        allowedDomains.insert("checkout.stripe.com")
+
         // For internal user allow these domains as required for DUO based authentication flow
         if isInternalUser {
             allowedDomains.formUnion(duoAuthenticationDomains)

--- a/iOS/DuckDuckGoTests/Subscription/AsyncHeadlessWebViewSettingsTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/AsyncHeadlessWebViewSettingsTests.swift
@@ -33,7 +33,9 @@ final class AsyncHeadlessWebViewSettingsTests: XCTestCase {
         let result = AsyncHeadlessWebViewSettings.makeAllowedDomains(baseURL: baseURL, isInternalUser: isInternalUser)
 
         // Then
-        XCTAssertEqual([baseURL.host!], result)
+        XCTAssertTrue(result.contains(baseURL.host!))
+        XCTAssertTrue(result.contains("checkout.stripe.com"))
+        XCTAssertEqual(2, result.count)
     }
 
     func testAllowedDomainsContainsCustomBaseURLHostWhenInternalUserModeDisabled() async throws {
@@ -45,7 +47,9 @@ final class AsyncHeadlessWebViewSettingsTests: XCTestCase {
         let result = AsyncHeadlessWebViewSettings.makeAllowedDomains(baseURL: baseURL, isInternalUser: isInternalUser)
 
         // Then
-        XCTAssertEqual([baseURL.host!], result)
+        XCTAssertTrue(result.contains(baseURL.host!))
+        XCTAssertTrue(result.contains("checkout.stripe.com"))
+        XCTAssertEqual(2, result.count)
     }
 
     func testAllowedDomainsContainsBaseURLHostAndDUORequiredHostsWhenInternalUserModeEnabled() async throws {
@@ -59,6 +63,7 @@ final class AsyncHeadlessWebViewSettingsTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.contains(baseURL.host!))
+        XCTAssertTrue(result.contains("checkout.stripe.com"))
 
         domainsRequiredForDUOAuthentication.forEach { duoDomain in
             XCTAssertTrue(result.contains(duoDomain))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210857545758178
Security Triage: https://app.asana.com/1/137249556945/project/1199892415909552/task/1210867225045705

### Description
To enable purchase of Subscriptions via Stripe in our modal web view, we are adding `checkout.stripe.com` to the list of allowed domains. See [related security triage](https://app.asana.com/1/137249556945/project/1199892415909552/task/1210867225045705).

**Note:** E2E testing of actual Stripe purchase will be done once FE changes are in place.

### Testing Steps
1. Ensure you have no active subscription
2. Launch, navigate to the Subscription landing page, and purchase a subscription via the app store
3. Ensure it succeeds as expected and the subscription is active on the device

### Impact and Risks
Low

#### What could go wrong?
Subscription purchase is impacted. 

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)