### PR TITLE
Fix flaky NewTabPageProtectionsReportModelTests

### DIFF
--- a/macOS/DuckDuckGo/InfoPlist.xcstrings
+++ b/macOS/DuckDuckGo/InfoPlist.xcstrings
@@ -61,18 +61,6 @@
         }
       }
     },
-    "NSAppDataUsageDescription" : {
-      "comment" : "Privacy - Other Application Data Usage Description",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DuckDuckGo will securely access your Bitwarden vault to autofill your passwords. To prevent this dialog in the future, go to Mac System Settings > Privacy & Security > Full Disk Access and toggle DuckDuckGo on, or switch back to the built-in password manager."
-          }
-        }
-      }
-    },
     "NSCameraUsageDescription" : {
       "comment" : "Privacy - Camera Usage Description",
       "extractionState" : "extracted_with_value",

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageProtectionsReportModelTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageProtectionsReportModelTests.swift
@@ -170,7 +170,7 @@ final class NewTabPageProtectionsReportModelTests: XCTestCase {
         XCTAssertFalse(model.shouldShowBurnAnimation)
     }
 
-    func testWhenBurnAnimationSettingChangesToTrueThenShouldShowBurnAnimationIsTrue() async {
+    func testWhenBurnAnimationSettingChangesToTrueThenShouldShowBurnAnimationIsTrue() async throws {
         let burnAnimationSubject = PassthroughSubject<Bool, Never>()
         model = NewTabPageProtectionsReportModel(
             privacyStats: privacyStats,
@@ -179,26 +179,13 @@ final class NewTabPageProtectionsReportModelTests: XCTestCase {
             showBurnAnimation: false
         )
 
-        let expectation = expectation(description: "shouldShowBurnAnimation should be updated")
-        let cancellable = model.$shouldShowBurnAnimation
-            .dropFirst()
-            .sink { shouldShow in
-                if shouldShow {
-                    expectation.fulfill()
-                }
-            }
-
-        // Ensure subscription is established before sending
-        await Task.yield()
-
+        try makeShouldShowBurnAnimationStream()
         burnAnimationSubject.send(true)
-
-        await fulfillment(of: [expectation], timeout: 2.0)
-        XCTAssertTrue(model.shouldShowBurnAnimation)
-        cancellable.cancel()
+        let shouldShowBurnAnimation = try await getShouldShowBurnAnimationValue()
+        XCTAssertTrue(shouldShowBurnAnimation)
     }
 
-    func testWhenBurnAnimationSettingChangesToFalseThenShouldShowBurnAnimationIsFalse() async {
+    func testWhenBurnAnimationSettingChangesToFalseThenShouldShowBurnAnimationIsFalse() async throws {
         let burnAnimationSubject = PassthroughSubject<Bool, Never>()
         model = NewTabPageProtectionsReportModel(privacyStats: privacyStats,
                                                  settingsPersistor: settingsPersistor,
@@ -207,47 +194,70 @@ final class NewTabPageProtectionsReportModelTests: XCTestCase {
 
         XCTAssertTrue(model.shouldShowBurnAnimation)
 
-        let expectation = expectation(description: "shouldShowBurnAnimation should be updated")
-        let cancellable = model.$shouldShowBurnAnimation
-            .dropFirst()
-            .sink { shouldShow in
-                if !shouldShow {
-                    expectation.fulfill()
-                }
-            }
-
+        try makeShouldShowBurnAnimationStream()
         burnAnimationSubject.send(false)
-
-        await fulfillment(of: [expectation], timeout: 1.0)
-        XCTAssertFalse(model.shouldShowBurnAnimation)
-        cancellable.cancel()
+        let shouldShowBurnAnimation = try await getShouldShowBurnAnimationValue()
+        XCTAssertFalse(shouldShowBurnAnimation)
     }
 
-    func testWhenBurnAnimationSettingChangesMultipleTimesThenShouldShowBurnAnimationFollowsChanges() async {
+    func testWhenBurnAnimationSettingChangesMultipleTimesThenShouldShowBurnAnimationFollowsChanges() async throws {
         let burnAnimationSubject = PassthroughSubject<Bool, Never>()
         model = NewTabPageProtectionsReportModel(privacyStats: privacyStats,
                                                  settingsPersistor: settingsPersistor,
                                                  burnAnimationSettingChanges: burnAnimationSubject.eraseToAnyPublisher(),
                                                  showBurnAnimation: true)
 
-        var receivedValues: [Bool] = []
-        let expectation = expectation(description: "shouldShowBurnAnimation should receive multiple updates")
-        expectation.expectedFulfillmentCount = 3
-
-        let cancellable = model.$shouldShowBurnAnimation
-            .dropFirst()
-            .sink { shouldShow in
-                receivedValues.append(shouldShow)
-                expectation.fulfill()
-            }
+        try makeShouldShowBurnAnimationStream()
 
         burnAnimationSubject.send(false)
         burnAnimationSubject.send(true)
         burnAnimationSubject.send(false)
 
-        await fulfillment(of: [expectation], timeout: 1.0)
-        XCTAssertEqual(receivedValues, [false, true, false])
+        let shouldShowBurnAnimationValues = try await getShouldShowBurnAnimationValues(3)
+        XCTAssertEqual(shouldShowBurnAnimationValues, [false, true, false])
         XCTAssertFalse(model.shouldShowBurnAnimation)
-        cancellable.cancel()
+    }
+
+    // MARK: - Helpers
+
+    private var shouldShowBurnAnimationStream: AsyncStream<Bool>!
+    private struct ShouldShowBurnAnimationNotReceivedError: Error {}
+
+    /// Creates AsyncStream that emits updates to `testSettingSyncHandler.syncedValue`.
+    private func makeShouldShowBurnAnimationStream() throws {
+        shouldShowBurnAnimationStream = AsyncStream { continuation in
+            let cancellable = model.$shouldShowBurnAnimation.dropFirst()
+                .sink { value in
+                    continuation.yield(value)
+                }
+
+            continuation.onTermination = { _ in
+                cancellable.cancel()
+            }
+        }
+    }
+
+    /// Awaits first event emitted by the shouldShowBurnAnimation AsyncStream.
+    private func getShouldShowBurnAnimationValue() async throws -> Bool {
+        let values = try await getShouldShowBurnAnimationValues(1)
+        guard let value = values.first else {
+            throw ShouldShowBurnAnimationNotReceivedError()
+        }
+        return value
+    }
+
+    /// Awaits first `count` events emitted by the shouldShowBurnAnimation AsyncStream.
+    private func getShouldShowBurnAnimationValues(_ count: Int) async throws -> [Bool] {
+        var iterator = shouldShowBurnAnimationStream.makeAsyncIterator()
+        var values: [Bool] = []
+
+        for _ in 0..<count {
+            guard let value = await iterator.next() else {
+                throw ShouldShowBurnAnimationNotReceivedError()
+            }
+            values.append(value)
+        }
+
+        return values
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1210878230234168?focus=true

### Description
Use AsyncStream to listen to value updates for shouldShowBurnAnimation.

### Testing Steps
Verify that CI is green.

### Impact and Risks
None: Internal tooling, documentation

### Quality Considerations
I’ve run tests repeatedly locally with no failures.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)