### PR TITLE
Internal release of new tab page search box

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "0265bdf792cabae6f77af31ae5051becbe3235fe",
-        "version" : "10.14.0"
+        "revision" : "5e97cb0147dc8c89bace72826332c3e7dfd54bc3",
+        "version" : "10.15.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit.git", exact: "3.0.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.7.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "3.0.0"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "10.14.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "10.15.0"),
         .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "9.4.0"),
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
         .package(url: "https://github.com/1024jp/GzipSwift.git", exact: "6.0.1"),

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -310,7 +310,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .disableFireAnimation:
             return .remoteReleasable(.feature(.disableFireAnimation))
         case .newTabPageOmnibar:
-            return .disabled
+            return .internalOnly()
         case .newFeedbackForm:
             return .disabled
         case .vpnToolbarUpsell:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1210878121456915?focus=true

### Description
C-S-S version upgrade
Internal release of new tab page search box

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Set internal user state and make sure the search box is present on the New Tab Page
2. Remove internal user state and make sure the search box is NOT present on the New Tab Page
3. Smoke test the search and duck.ai from the search field

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)