### PR TITLE
Global AI Switch 1. Add feature flag and improve logic

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "revision" : "4935471fe659cad802f0fe3d4c51c8cf1318ae86",
-        "version" : "10.13.0"
+        "branch" : "10.15.0",
+        "revision" : "5e97cb0147dc8c89bace72826332c3e7dfd54bc3"
       }
     },
     {

--- a/SharedPackages/AIChat/Sources/AIChat/macOS/PublicAPI/AIChatRemoteSettingsProvider.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/macOS/PublicAPI/AIChatRemoteSettingsProvider.swift
@@ -26,6 +26,5 @@ public protocol AIChatRemoteSettingsProvider {
     var aiChatURLIdentifiableQueryValue: String { get }
     var aiChatURL: URL { get }
     var isAIChatEnabled: Bool { get }
-    var isTextSummarizationEnabled: Bool { get }
 }
 #endif

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit.git", exact: "3.0.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.7.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "3.0.0"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts", branch: "pr-releases/pr-1845"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts", branch: "10.15.0"),
         .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "9.4.0"),
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
         .package(url: "https://github.com/1024jp/GzipSwift.git", exact: "6.0.1"),

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit.git", exact: "3.0.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.7.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "3.0.0"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts", branch: "10.15.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts", exact: "10.15.0"),
         .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "9.4.0"),
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
         .package(url: "https://github.com/1024jp/GzipSwift.git", exact: "6.0.1"),

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts",
       "state" : {
-        "branch" : "pr-releases/pr-1845",
-        "revision" : "c5826af657abc072128f4bd95f1051c135f1effc"
+        "revision" : "5e97cb0147dc8c89bace72826332c3e7dfd54bc3",
+        "version" : "10.15.0"
       }
     },
     {

--- a/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
@@ -44,7 +44,7 @@ protocol AIChatMenuVisibilityConfigurable {
     /// This property determines whether AI Chat should open in the sidebar.
     ///
     /// - Returns: `true` if AI Chat should open in the sidebar; otherwise, `false`.
-    var openAIChatInSidebar: Bool { get }
+    var shouldOpenAIChatInSidebar: Bool { get }
 
     /// This property validates user settings to determine if the text summarization
     /// feature should be presented to the user.
@@ -90,7 +90,7 @@ final class AIChatMenuConfiguration: AIChatMenuVisibilityConfigurable {
         remoteSettings.isAIChatEnabled && storage.isAIFeaturesEnabled && storage.showShortcutInAddressBar
     }
 
-    var openAIChatInSidebar: Bool {
+    var shouldOpenAIChatInSidebar: Bool {
         remoteSettings.isAIChatEnabled && storage.isAIFeaturesEnabled && storage.openAIChatInSidebar
     }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
@@ -75,19 +75,19 @@ final class AIChatMenuConfiguration: AIChatMenuVisibilityConfigurable {
 
     var valuesChangedPublisher = PassthroughSubject<Void, Never>()
 
-    private var shouldAllowAIChatFeatures: Bool {
-        let isRemoteAIChatEnabled = remoteSettings.isAIChatEnabled
-        let isLocalAIChatEnabled = storage.isAIFeaturesEnabled
+    var shouldAllowAIChatFeatures: Bool {
+        let isAIChatEnabledRemotely = remoteSettings.isAIChatEnabled
+        let isAIChatEnabledLocally = storage.isAIFeaturesEnabled
 
         if featureFlagger.isFeatureOn(.aiChatGlobalSwitch) {
-            return isRemoteAIChatEnabled && isLocalAIChatEnabled
+            return isAIChatEnabledRemotely && isAIChatEnabledLocally
         } else {
-            return isRemoteAIChatEnabled
+            return isAIChatEnabledRemotely
         }
     }
 
     var shouldDisplayNewTabPageShortcut: Bool {
-        remoteSettings.isAIChatEnabled && storage.isAIFeaturesEnabled && storage.showShortcutOnNewTabPage
+        shouldAllowAIChatFeatures && storage.showShortcutOnNewTabPage
     }
 
     var shouldDisplaySummarizationMenuItem: Bool {

--- a/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
@@ -114,9 +114,7 @@ final class AIChatMenuConfiguration: AIChatMenuVisibilityConfigurable {
         shouldDisplayAnyAIChatFeature && storage.openAIChatInSidebar
     }
 
-    init(storage: AIChatPreferencesStorage = DefaultAIChatPreferencesStorage(),
-         remoteSettings: AIChatRemoteSettingsProvider = AIChatRemoteSettings(),
-         featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger) {
+    init(storage: AIChatPreferencesStorage, remoteSettings: AIChatRemoteSettingsProvider, featureFlagger: FeatureFlagger) {
         self.storage = storage
         self.remoteSettings = remoteSettings
         self.featureFlagger = featureFlagger

--- a/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
@@ -23,6 +23,14 @@ import Combine
 
 protocol AIChatMenuVisibilityConfigurable {
 
+    /// Indicates whether any AI Chat feature should be displayed to the user.
+    ///
+    /// This property checks both remote setting and local global switch value to determine
+    /// if any of the AI Chat-related features should be visible in the UI.
+    ///
+    /// - Returns: `true` if any AI Chat feature should be shown; otherwise, `false`.
+    var shouldDisplayAnyAIChatFeature: Bool { get }
+
     /// This property validates user settings to determine if the shortcut
     /// should be presented to the user.
     ///
@@ -75,7 +83,7 @@ final class AIChatMenuConfiguration: AIChatMenuVisibilityConfigurable {
 
     var valuesChangedPublisher = PassthroughSubject<Void, Never>()
 
-    var shouldAllowAIChatFeatures: Bool {
+    var shouldDisplayAnyAIChatFeature: Bool {
         let isAIChatEnabledRemotely = remoteSettings.isAIChatEnabled
         let isAIChatEnabledLocally = storage.isAIFeaturesEnabled
 
@@ -87,23 +95,23 @@ final class AIChatMenuConfiguration: AIChatMenuVisibilityConfigurable {
     }
 
     var shouldDisplayNewTabPageShortcut: Bool {
-        shouldAllowAIChatFeatures && storage.showShortcutOnNewTabPage
+        shouldDisplayAnyAIChatFeature && storage.showShortcutOnNewTabPage
     }
 
     var shouldDisplaySummarizationMenuItem: Bool {
-        shouldAllowAIChatFeatures && featureFlagger.isFeatureOn(.aiChatTextSummarization) && shouldDisplayApplicationMenuShortcut
+        shouldDisplayAnyAIChatFeature && featureFlagger.isFeatureOn(.aiChatTextSummarization) && shouldDisplayApplicationMenuShortcut
     }
 
     var shouldDisplayApplicationMenuShortcut: Bool {
-        shouldAllowAIChatFeatures && storage.showShortcutInApplicationMenu
+        shouldDisplayAnyAIChatFeature && storage.showShortcutInApplicationMenu
     }
 
     var shouldDisplayAddressBarShortcut: Bool {
-        shouldAllowAIChatFeatures && storage.showShortcutInAddressBar
+        shouldDisplayAnyAIChatFeature && storage.showShortcutInAddressBar
     }
 
     var shouldOpenAIChatInSidebar: Bool {
-        shouldAllowAIChatFeatures && storage.openAIChatInSidebar
+        shouldDisplayAnyAIChatFeature && storage.openAIChatInSidebar
     }
 
     init(storage: AIChatPreferencesStorage = DefaultAIChatPreferencesStorage(),

--- a/macOS/DuckDuckGo/AIChat/AIChatRemoteSettings.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatRemoteSettings.swift
@@ -42,7 +42,6 @@ struct AIChatRemoteSettings: AIChatRemoteSettingsProvider {
         }
     }
 
-    private let featureFlagger: FeatureFlagger
     private let privacyConfigurationManager: PrivacyConfigurationManaging
     private let debugURLSettings: AIChatDebugURLSettingsRepresentable
     private var settings: PrivacyConfigurationData.PrivacyFeature.FeatureSettings {
@@ -50,11 +49,9 @@ struct AIChatRemoteSettings: AIChatRemoteSettingsProvider {
     }
 
     init(
-        featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger,
         privacyConfigurationManager: PrivacyConfigurationManaging = Application.appDelegate.privacyFeatures.contentBlocking.privacyConfigurationManager,
         debugURLSettings: AIChatDebugURLSettingsRepresentable = AIChatDebugURLSettings()
     ) {
-        self.featureFlagger = featureFlagger
         self.privacyConfigurationManager = privacyConfigurationManager
         self.debugURLSettings = debugURLSettings
     }
@@ -82,10 +79,6 @@ struct AIChatRemoteSettings: AIChatRemoteSettingsProvider {
 
     var isAIChatEnabled: Bool {
         privacyConfigurationManager.privacyConfig.isEnabled(featureKey: .aiChat)
-    }
-
-    var isTextSummarizationEnabled: Bool {
-        isAIChatEnabled && featureFlagger.isFeatureOn(.aiChatTextSummarization)
     }
 
     // MARK: - Private

--- a/macOS/DuckDuckGo/AIChat/AIChatSummarizer.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatSummarizer.swift
@@ -80,7 +80,7 @@ final class AIChatSummarizer: AIChatSummarizing {
         let prompt = AIChatNativePrompt.summaryPrompt(request.text, url: request.websiteURL, title: request.websiteTitle)
         pixelFiring?.fire(AIChatPixel.aiChatSummarizeText(source: request.source), frequency: .dailyAndStandard)
 
-        if aiChatMenuConfig.openAIChatInSidebar {
+        if aiChatMenuConfig.shouldOpenAIChatInSidebar {
             if !aiChatSidebarPresenter.isSidebarOpenForCurrentTab() {
                 pixelFiring?.fire(AIChatPixel.aiChatSidebarOpened(source: .summarization), frequency: .dailyAndStandard)
             }

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -387,9 +387,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         aiChatMenuConfiguration = AIChatMenuConfiguration(
             storage: DefaultAIChatPreferencesStorage(),
             remoteSettings: AIChatRemoteSettings(
-                featureFlagger: featureFlagger,
                 privacyConfigurationManager: privacyConfigurationManager
-            )
+            ),
+            featureFlagger: featureFlagger
         )
 
         appearancePreferences = AppearancePreferences(

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -388,7 +388,7 @@ final class AddressBarButtonsViewController: NSViewController {
 
         // Close the sidebar if it's currently open and the user preference is set to open AI chat in new tabs
         // This ensures consistent behavior when the sidebar is unexpectedly open but shouldn't be the default action
-        if !aiChatMenuConfig.openAIChatInSidebar && aiChatSidebarPresenter.isSidebarOpen(for: tab.uuid) {
+        if !aiChatMenuConfig.shouldOpenAIChatInSidebar && aiChatSidebarPresenter.isSidebarOpen(for: tab.uuid) {
             aiChatSidebarPresenter.toggleSidebar()
 
             if aiChatButton == sender as? AddressBarMenuButton {
@@ -399,7 +399,7 @@ final class AddressBarButtonsViewController: NSViewController {
         let behavior = createAIChatLinkOpenBehavior(for: tab)
 
         if featureFlagger.isFeatureOn(.aiChatSidebar),
-           aiChatMenuConfig.openAIChatInSidebar,
+           aiChatMenuConfig.shouldOpenAIChatInSidebar,
            !isTextFieldEditorFirstResponder,
            case .url = tab.content,
            behavior == .currentTab {
@@ -719,7 +719,7 @@ final class AddressBarButtonsViewController: NSViewController {
     @objc func openAIChatContextMenuAction(_ sender: NSMenuItem) {
         // Open AI Chat action implementation - behavior opposite to default setting
 
-        if aiChatMenuConfig.openAIChatInSidebar {
+        if aiChatMenuConfig.shouldOpenAIChatInSidebar {
             // Default is sidebar, menu action forces new tab
             let behavior = LinkOpenBehavior(
                 event: NSApp.currentEvent,
@@ -1214,7 +1214,7 @@ final class AddressBarButtonsViewController: NSViewController {
 
             if isSidebarOpen {
                 aiChatButton.toolTip = UserText.aiChatCloseSidebarButton
-            } else if aiChatMenuConfig.openAIChatInSidebar, case .url = tab.content {
+            } else if aiChatMenuConfig.shouldOpenAIChatInSidebar, case .url = tab.content {
                 aiChatButton.toolTip = UserText.aiChatOpenSidebarButton
             } else {
                 aiChatButton.toolTip = isTextFieldEditorFirstResponder ? ShortcutTooltip.askAIChat.value : ShortcutTooltip.newAIChatTab.value
@@ -1291,7 +1291,7 @@ final class AddressBarButtonsViewController: NSViewController {
         let contextMenu = NSMenu {
             if shouldShowOpenAIChatButton {
                 let contextMenuTitle: String = {
-                    if aiChatMenuConfig.openAIChatInSidebar {
+                    if aiChatMenuConfig.shouldOpenAIChatInSidebar {
                         return UserText.aiChatOpenNewTabButton
                     } else {
                         // Check if sidebar is currently open for this tab

--- a/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
@@ -83,6 +83,10 @@ final class AIChatPreferences: ObservableObject {
             .store(in: &cancellables)
     }
 
+    var shouldShowAIFeaturesToggle: Bool {
+        featureFlagger.isFeatureOn(.aiChatGlobalSwitch)
+    }
+
     var shouldShowOpenAIChatInSidebarToggle: Bool {
         featureFlagger.isFeatureOn(.aiChatSidebar)
     }

--- a/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
@@ -29,16 +29,16 @@ final class AIChatPreferences: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private let learnMoreURL = URL(string: "https://duckduckgo.com/duckduckgo-help-pages/duckai/approach-to-ai")!
     private let searchAssistSettingsURL = URL(string: "https://duckduckgo.com/settings#aifeatures")!
-    private let remoteSettings: AIChatRemoteSettingsProvider
+    private let aiChatMenuConfiguration: AIChatMenuVisibilityConfigurable
     private var windowControllersManager: WindowControllersManager
     private let featureFlagger: FeatureFlagger
 
     init(storage: AIChatPreferencesStorage = DefaultAIChatPreferencesStorage(),
-         remoteSettings: AIChatRemoteSettingsProvider = AIChatRemoteSettings(),
+         aiChatMenuConfiguration: AIChatMenuVisibilityConfigurable = Application.appDelegate.aiChatMenuConfiguration,
          windowControllersManager: WindowControllersManager = Application.appDelegate.windowControllersManager,
          featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger) {
         self.storage = storage
-        self.remoteSettings = remoteSettings
+        self.aiChatMenuConfiguration = aiChatMenuConfiguration
         self.windowControllersManager = windowControllersManager
         self.featureFlagger = featureFlagger
 
@@ -83,6 +83,12 @@ final class AIChatPreferences: ObservableObject {
             .store(in: &cancellables)
     }
 
+    // Options visibility
+
+    var shouldShowAIFeatures: Bool {
+        aiChatMenuConfiguration.shouldDisplayAnyAIChatFeature
+    }
+
     var shouldShowAIFeaturesToggle: Bool {
         featureFlagger.isFeatureOn(.aiChatGlobalSwitch)
     }
@@ -94,6 +100,8 @@ final class AIChatPreferences: ObservableObject {
     var shouldShowNewTabPageToggle: Bool {
         featureFlagger.isFeatureOn(.newTabPageOmnibar)
     }
+
+    // Properties for managing the current state of AI Chat preference options
 
     @Published var isAIFeaturesEnabled: Bool {
         didSet { storage.isAIFeaturesEnabled = isAIFeaturesEnabled }

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
@@ -38,10 +38,12 @@ extension Preferences {
                     }
                 }
 
-                PreferencePaneSubSection {
-                    ToggleMenuItem("Enable Duck.ai",
-                                   isOn: $model.isAIFeaturesEnabled)
-                    .accessibilityIdentifier("Preferences.AIChat.aiFeaturesToggle")
+                if model.shouldShowAIFeaturesToggle {
+                    PreferencePaneSubSection {
+                        ToggleMenuItem("Enable Duck.ai",
+                                       isOn: $model.isAIFeaturesEnabled)
+                        .accessibilityIdentifier("Preferences.AIChat.aiFeaturesToggle")
+                    }
                 }
 
                 PreferencePaneSection(UserText.duckAIShortcuts) {

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
@@ -106,7 +106,7 @@ extension Preferences {
                         }
                     }
                 }
-                .visibility(model.isAIFeaturesEnabled ? .visible : .gone)
+                .visibility(model.shouldShowAIFeatures ? .visible : .gone)
 
                 PreferencePaneSection(UserText.searchAssistSettings) {
                     TextMenuItemCaption(UserText.searchAssistSettingsDescription)

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -108,7 +108,7 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1201048563534612/task/1210702047347360?focus=true
     case aiFeatures
 
-    /// https://app.asana.com/1/137249556945/project/1209671977594486/task/1210410403692636?focus=true
+    /// https://app.asana.com/1/137249556945/project/1209671977594486/task/1210012482760771?focus=true
     case aiChatSidebar
 
     /// https://app.asana.com/1/137249556945/project/1201899738287924/task/1210012162616039?focus=true

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -106,7 +106,7 @@ public enum FeatureFlag: String, CaseIterable {
     case removeWWWInCanonicalizationInThreatProtection
 
     /// https://app.asana.com/1/137249556945/project/1201048563534612/task/1210702047347360?focus=true
-    case aiFeatures
+    case aiChatGlobalSwitch
 
     /// https://app.asana.com/1/137249556945/project/1209671977594486/task/1210012482760771?focus=true
     case aiChatSidebar
@@ -204,7 +204,7 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .osSupportForceUnsupportedMessage,
                 .osSupportForceWillSoonDropSupportMessage,
                 .willSoonDropBigSurSupport,
-                .aiFeatures,
+                .aiChatGlobalSwitch,
 				.aiChatSidebar,
                 .aiChatTextSummarization,
                 .shortHistoryMenu,
@@ -302,8 +302,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.paidAIChat))
         case .removeWWWInCanonicalizationInThreatProtection:
             return .remoteReleasable(.subfeature(MaliciousSiteProtectionSubfeature.removeWWWInCanonicalization))
-        case .aiFeatures:
-            return .remoteReleasable(.feature(.aiChat))
+        case .aiChatGlobalSwitch:
+            return .internalOnly()
         case .aiChatSidebar:
             return .remoteReleasable(.subfeature(AIChatSubfeature.sidebar))
         case .aiChatTextSummarization:

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlagCategory.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlagCategory.swift
@@ -45,7 +45,7 @@ public protocol FeatureFlagCategorization {
 extension FeatureFlag: FeatureFlagCategorization {
     public var category: FeatureFlagCategory {
         switch self {
-        case .aiFeatures,
+        case .aiChatGlobalSwitch,
                 .aiChatSidebar,
                 .aiChatTextSummarization:
             return .duckAI

--- a/macOS/UnitTests/AIChat/AIChatMenuConfigurationTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatMenuConfigurationTests.swift
@@ -172,7 +172,7 @@ class AIChatMenuConfigurationTests: XCTestCase {
     func testShouldOpenAIChatInSidebarPublisherWhenStorageAreTrue() {
         mockStorage.openAIChatInSidebar = true
 
-        let result = configuration.openAIChatInSidebar
+        let result = configuration.shouldOpenAIChatInSidebar
 
         XCTAssertTrue(result, "Open AI Chat in sidebar should be displayed when storage is true.")
     }

--- a/macOS/UnitTests/AIChat/AIChatMenuConfigurationTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatMenuConfigurationTests.swift
@@ -29,7 +29,7 @@ class AIChatMenuConfigurationTests: XCTestCase {
         super.setUp()
         mockStorage = MockAIChatPreferencesStorage()
         remoteSettings = MockRemoteAISettings()
-        configuration = AIChatMenuConfiguration(storage: mockStorage, remoteSettings: remoteSettings)
+        configuration = AIChatMenuConfiguration(storage: mockStorage, remoteSettings: remoteSettings, featureFlagger: MockFeatureFlagger())
     }
 
     override func tearDown() {

--- a/macOS/UnitTests/AIChat/AIChatMenuConfigurationTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatMenuConfigurationTests.swift
@@ -272,7 +272,6 @@ final class MockRemoteAISettings: AIChatRemoteSettingsProvider {
     var isAIChatEnabled: Bool
     var isAddressBarShortcutEnabled: Bool
     var isApplicationMenuShortcutEnabled: Bool
-    var isTextSummarizationEnabled: Bool
 
     init(onboardingCookieName: String = "defaultCookie",
          onboardingCookieDomain: String = "defaultdomain.com",
@@ -281,8 +280,7 @@ final class MockRemoteAISettings: AIChatRemoteSettingsProvider {
          aiChatURL: URL = URL(string: "https://duck.com/chat")!,
          isAIChatEnabled: Bool = true,
          isAddressBarShortcutEnabled: Bool = true,
-         isApplicationMenuShortcutEnabled: Bool = true,
-         isTextSummarizationEnabled: Bool = true) {
+         isApplicationMenuShortcutEnabled: Bool = true) {
         self.onboardingCookieName = onboardingCookieName
         self.onboardingCookieDomain = onboardingCookieDomain
         self.aiChatURLIdentifiableQuery = aiChatURLIdentifiableQuery
@@ -291,6 +289,5 @@ final class MockRemoteAISettings: AIChatRemoteSettingsProvider {
         self.isAIChatEnabled = isAIChatEnabled
         self.isAddressBarShortcutEnabled = isAddressBarShortcutEnabled
         self.isApplicationMenuShortcutEnabled = isApplicationMenuShortcutEnabled
-        self.isTextSummarizationEnabled = isTextSummarizationEnabled
     }
 }

--- a/macOS/UnitTests/Menus/MainMenuTests.swift
+++ b/macOS/UnitTests/Menus/MainMenuTests.swift
@@ -328,7 +328,8 @@ private class DummyAIChatConfig: AIChatMenuVisibilityConfigurable {
     var shouldDisplayNewTabPageShortcut = false
     var shouldDisplayApplicationMenuShortcut = false
     var shouldDisplayAddressBarShortcut = false
-    var openAIChatInSidebar = false
+    var shouldDisplayAnyAIChatFeature = false
+    var shouldOpenAIChatInSidebar = false
     var shouldDisplaySummarizationMenuItem = false
 
     var valuesChangedPublisher: PassthroughSubject<Void, Never> {

--- a/macOS/UnitTests/Menus/MoreOptionsMenuTests.swift
+++ b/macOS/UnitTests/Menus/MoreOptionsMenuTests.swift
@@ -131,7 +131,8 @@ final class MoreOptionsMenuTests: XCTestCase {
                                           dataBrokerProtectionFreemiumPixelHandler: mockPixelHandler,
                                           aiChatMenuConfiguration: AIChatMenuConfiguration(
                                             storage: aiChatPreferencesStorage,
-                                            remoteSettings: MockRemoteAISettings()
+                                            remoteSettings: MockRemoteAISettings(),
+                                            featureFlagger: mockFeatureFlagger
                                           ))
 
         moreOptionsMenu.actionDelegate = capturingActionDelegate

--- a/macOS/UnitTests/NewTabPage/NewTabPageAIChatShortcutSettingProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageAIChatShortcutSettingProviderTests.swift
@@ -27,12 +27,15 @@ final class NewTabPageAIChatShortcutSettingProviderTests: XCTestCase {
     private var userDefaults: UserDefaults!
     private var configuration: AIChatMenuConfiguration!
     private var storage: DefaultAIChatPreferencesStorage!
+    private var featureFlagger: MockFeatureFlagger!
 
     override func setUp() async throws {
         suiteName = UUID().uuidString
         userDefaults = UserDefaults(suiteName: suiteName)
         storage = DefaultAIChatPreferencesStorage(userDefaults: userDefaults)
-        configuration = AIChatMenuConfiguration(storage: storage, remoteSettings: MockRemoteAISettings())
+        featureFlagger = MockFeatureFlagger()
+        featureFlagger.enabledFeatureFlags = [.aiChatGlobalSwitch]
+        configuration = AIChatMenuConfiguration(storage: storage, remoteSettings: MockRemoteAISettings(), featureFlagger: featureFlagger)
 
         provider = NewTabPageAIChatShortcutSettingProvider(
             aiChatMenuConfiguration: configuration,
@@ -45,6 +48,7 @@ final class NewTabPageAIChatShortcutSettingProviderTests: XCTestCase {
         provider = nil
         configuration = nil
         userDefaults = nil
+        featureFlagger = nil
     }
 
     func testWhenFlagIsTrueThenGetterReturnsTrue() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210702047347360?focus=true
Tech Design URL:
CC:

### Description
Adds feature flag for the global AI switch and improves the logic used to show/hide elements based on its value.

### Testing Steps
1. Ensure `aiChatGlobalSwitch` feature flag is disabled.
2. Open settings -> AI Features
3. Verify that section options should be unchanged as in production build
--
4. Enable `aiChatGlobalSwitch` feature flag.
5. Open settings -> AI Features
6. "Enable Duck.ai" check box should be visible and toggled
7. Uncheck "Enable Duck.ai" option
8. Verify that all Duck.ai related options and in the app all AI related features are hidden (sidebar, Duck.AI menu and address bar shortcuts, summarisation)
--
9. Disable `aiChatGlobalSwitch` feature flag.
10. Verify if original state o the app is restored
--
11. Enable `aiChatGlobalSwitch` feature flag.
12. Open settings -> AI Features
13. Check "Enable Duck.ai" 
14. AI features should again be available in the app


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Access to AI features or settings is hidden in wrong conditions.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)