### PR TITLE
Set concurrency requirements for CI workflows

### DIFF
--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -15,7 +15,11 @@ on:
       - '.xcode-version'
       - 'SharedPackages/BrowserServicesKit/**'
   schedule:
-    - cron: '10,35,50 4,5,6 * * *'
+    - cron: '10,30,50 4,5,6 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/dbp_pr_checks.yml
+++ b/.github/workflows/dbp_pr_checks.yml
@@ -17,6 +17,10 @@ on:
   schedule:
     - cron: '10,40 4,5,6 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   unit-tests:

--- a/.github/workflows/ios_build_hotfix_release.yml
+++ b/.github/workflows/ios_build_hotfix_release.yml
@@ -20,6 +20,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
 
   assert_release_branch:

--- a/.github/workflows/ios_bump_internal_release.yml
+++ b/.github/workflows/ios_bump_internal_release.yml
@@ -18,6 +18,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
 
   validate_input_conditions:

--- a/.github/workflows/ios_code_freeze.yml
+++ b/.github/workflows/ios_code_freeze.yml
@@ -12,6 +12,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
 
   create_release_branch:

--- a/.github/workflows/ios_end_to_end.yml
+++ b/.github/workflows/ios_end_to_end.yml
@@ -9,6 +9,10 @@ on:
     - cron: '0 4 * * *' # run at 4 AM UTC
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-end-to-end-tests:
     name: Build End to End Tests

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -50,6 +50,10 @@ on:
       SSH_PRIVATE_KEY_FASTLANE_MATCH:
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   shellcheck:
 

--- a/.github/workflows/ios_sync_end_to_end.yml
+++ b/.github/workflows/ios_sync_end_to_end.yml
@@ -9,6 +9,10 @@ on:
     - cron: '0 1 * * *' # run at 1 AM UTC
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-for-sync-end-to-end-tests:
     name: Build for Sync End To End Tests

--- a/.github/workflows/macos_build_hotfix_release.yml
+++ b/.github/workflows/macos_build_hotfix_release.yml
@@ -20,6 +20,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
 
   assert_release_branch:

--- a/.github/workflows/macos_bump_internal_release.yml
+++ b/.github/workflows/macos_bump_internal_release.yml
@@ -22,6 +22,10 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
 
   validate_input_conditions:
@@ -53,7 +57,7 @@ jobs:
             main) ;;
             *) echo "👎 Not a release or main branch"; exit 1 ;;
           esac
-          
+
       - name: Setup Ruby and dependencies
         uses: ./.github/actions/setup-ruby
         with:

--- a/.github/workflows/macos_code_freeze.yml
+++ b/.github/workflows/macos_code_freeze.yml
@@ -12,6 +12,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
 
   create_release_branch:

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -45,6 +45,10 @@ on:
       SSH_PRIVATE_KEY_FASTLANE_MATCH:
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   shellcheck:
 

--- a/.github/workflows/macos_sync_end_to_end.yml
+++ b/.github/workflows/macos_sync_end_to_end.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 5 * * *' # run at 5 AM UTC
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   create-notarized-app:
     name: Build Notarized Review app
@@ -140,7 +144,7 @@ jobs:
     - name: Extract and Copy app to /DerivedData
       run: |
         cd DuckDuckGo-review-*.app.tar.xz && tar -xf DuckDuckGo-*.app.tar.xz
-        
+
         # Find the extracted app bundle and rename if needed
         extracted_app=$(find . -maxdepth 1 -name "*.app" -type d | head -1)
         if [[ -n "${extracted_app}" ]]; then
@@ -150,7 +154,7 @@ jobs:
             mv "${extracted_app}" "DuckDuckGo Review.app"
           fi
         fi
-        
+
         mv -f "DuckDuckGo Review.app" "../DerivedData/Build/Products/Review/DuckDuckGo Review.app"
 
     - name: Run UI Tests

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -28,6 +28,10 @@ on:
       - '.github/**'
       - '.xcode-version'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   create-notarized-app:
     name: Build Notarized Review app
@@ -97,7 +101,7 @@ jobs:
         run: |
           # Check if a single test class was specified
           single_test_class="${{ inputs.single_test_class }}"
-          
+
           if [[ -n "$single_test_class" ]]; then
             echo "Running single test class: $single_test_class"
             test=$(jq -nc --arg class "$single_test_class" '[$class]')
@@ -107,7 +111,7 @@ jobs:
             test_names="$(find UITests -type f -maxdepth 1 -name *Tests.swift | xargs basename | sed 's/\.swift//')"
             test=$(echo $test_names | jq -cR 'split(" ")')
           fi
-          
+
           echo "test=${test}" >> $GITHUB_OUTPUT
 
   ui-tests:
@@ -206,7 +210,7 @@ jobs:
     - name: Extract and Copy app to /DerivedData
       run: |
         cd DuckDuckGo-review-*.app.tar.xz && tar -xf DuckDuckGo-*.app.tar.xz
-        
+
         # Find the extracted app bundle and rename if needed
         extracted_app=$(find . -maxdepth 1 -name "*.app" -type d | head -1)
         if [[ -n "${extracted_app}" ]]; then
@@ -216,7 +220,7 @@ jobs:
             mv "${extracted_app}" "DuckDuckGo Review.app"
           fi
         fi
-        
+
         mv -f "DuckDuckGo Review.app" "../DerivedData/Build/Products/Review/DuckDuckGo Review.app"
 
     - name: Run UI Tests
@@ -264,12 +268,12 @@ jobs:
         archive_name="BuildLogs ${{ matrix.test }} (macOS ${{ matrix.os-version }}) ${timestamp}"
         echo "Creating archive directory: $archive_name"
         mkdir -p "$archive_name"
-        
+
         # locate and copy all files, flattening the structure with verbose output
         cp "xcodebuild.log" "$archive_name/" || echo "No xcodebuild.log found"
         find DerivedData/Logs/Test -name "*.xcresult" -print -exec cp -rf {} "$archive_name/" \; 2>&1 || echo "No .xcresult files found"
         cp -rf ~/Library/Logs/DiagnosticReports "$archive_name/"
-        
+
         # Store archive name for upload step
         echo "ARCHIVE_NAME=$archive_name" >> $GITHUB_ENV
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1210878342031201?focus=true

### Description
This change sets up rules related to running various workflows concurrently, aiming to reduce the number
of unneeded workflow runs (e.g. made redundant by a new commit to a branch) and to guard us from errors
such as requesting internal release bump twice in a quick succession (e.g. by different team members that
haven’t communicated with each other).

### Testing Steps
1. Verify that these workflow runs have been cancelled (that’s because I pushed a commit while they were running):
  * [bsk_pr_checks](https://github.com/duckduckgo/apple-browsers/actions/runs/16497725260?pr=1479)
  * [dbp_pr_checks](https://github.com/duckduckgo/apple-browsers/actions/runs/16497725273?pr=1479)
  * [ios_pr_checks](https://github.com/duckduckgo/apple-browsers/actions/runs/16497725267?pr=1479)
  * [macos_pr_checks](https://github.com/duckduckgo/apple-browsers/actions/runs/16497725304?pr=1479)
2. Verify that concurrency definition for other workflows matches requirements in the linked Asana task. Release workflows use `cancel-in-progress: false` to allow current runs to finish before starting new runs.
 
### Impact and Risks
None: Internal tooling, documentation

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)