### PR TITLE
[iOS] Add Pixel definition and implement logging

### DIFF
--- a/iOS/Core/DailyPixelFiring.swift
+++ b/iOS/Core/DailyPixelFiring.swift
@@ -34,6 +34,11 @@ public protocol DailyPixelFiring {
                                   onDailyComplete: @escaping (Swift.Error?) -> Void,
                                   onCountComplete: @escaping (Swift.Error?) -> Void)
 
+    static func fireDailyAndCount(_ pixel: Pixel.Event,
+                                  error: Swift.Error?,
+                                  withAdditionalParameters params: [String: String])
+
+
     static func fireDaily(_ pixel: Pixel.Event)
 }
 
@@ -45,4 +50,9 @@ extension DailyPixel: DailyPixelFiring {
     public static func fireDaily(_ pixel: Pixel.Event) {
         fire(pixel: pixel)
     }
+
+    public static func fireDailyAndCount(_ pixel: Pixel.Event, error: Swift.Error?, withAdditionalParameters params: [String: String]) {
+        fireDailyAndCount(pixel: pixel, error: error, withAdditionalParameters: params)
+    }
+
 }

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1324,6 +1324,9 @@ extension Pixel {
         case duckPlayerNativePrimingModalCTA
         /// Settings gear icon is tapped from Duck Player UI
         case duckPlayerNativeDuckPlayerSettingsOpened
+
+        // MARK: - System Settings Picture-in-Picture Video Tutorial
+        case systemSettingsPiPTutorialFailedToLoadVideo
     }
 
 }
@@ -2589,6 +2592,9 @@ extension Pixel.Event {
         /// Settings gear icon is tapped from Duck Player UI
         case .duckPlayerNativeDuckPlayerSettingsOpened:
             return "duckplayer_native_duckplayer_settings_opened"
+
+        // MARK: System Settings PiP Video Tutorial
+        case .systemSettingsPiPTutorialFailedToLoadVideo: return "m_picture-in-picture-tutorial_failed-to-load-video"
         }
     }
 }

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1283,6 +1283,7 @@
 		9FE59CDD2E31AD9D00C4B65D /* DefaultBrowserPiPTutorialURLProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE59CDC2E31AD8D00C4B65D /* DefaultBrowserPiPTutorialURLProviderTests.swift */; };
 		9FE59CE22E31E5A500C4B65D /* SystemSettingsPiPTutorialPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE59CE12E31E59D00C4B65D /* SystemSettingsPiPTutorialPixelHandler.swift */; };
 		9FE59CE42E31E5F300C4B65D /* VideoPlayerCoordinator+SystemSettingsPiPTutorial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE59CE32E31E5E700C4B65D /* VideoPlayerCoordinator+SystemSettingsPiPTutorial.swift */; };
+		9FE59CE72E3307AD00C4B65D /* SystemSettingsPiPTutorialPixelHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE59CE62E3307A000C4B65D /* SystemSettingsPiPTutorialPixelHandlerTests.swift */; };
 		9FE7CD592E13C40E006691AB /* DefaultBrowserPromptUserActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE7CD572E13C40E006691AB /* DefaultBrowserPromptUserActivityManager.swift */; };
 		9FE7CD5C2E14C6CD006691AB /* DefaultBrowserPromptUserActivityManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE7CD5B2E14C6BA006691AB /* DefaultBrowserPromptUserActivityManagerTests.swift */; };
 		9FE7CD5E2E14C81A006691AB /* MockDefaultBrowserPromptUserActivityStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE7CD5D2E14C80B006691AB /* MockDefaultBrowserPromptUserActivityStorage.swift */; };
@@ -3435,6 +3436,7 @@
 		9FE59CDC2E31AD8D00C4B65D /* DefaultBrowserPiPTutorialURLProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserPiPTutorialURLProviderTests.swift; sourceTree = "<group>"; };
 		9FE59CE12E31E59D00C4B65D /* SystemSettingsPiPTutorialPixelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemSettingsPiPTutorialPixelHandler.swift; sourceTree = "<group>"; };
 		9FE59CE32E31E5E700C4B65D /* VideoPlayerCoordinator+SystemSettingsPiPTutorial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoPlayerCoordinator+SystemSettingsPiPTutorial.swift"; sourceTree = "<group>"; };
+		9FE59CE62E3307A000C4B65D /* SystemSettingsPiPTutorialPixelHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemSettingsPiPTutorialPixelHandlerTests.swift; sourceTree = "<group>"; };
 		9FE7CD572E13C40E006691AB /* DefaultBrowserPromptUserActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserPromptUserActivityManager.swift; sourceTree = "<group>"; };
 		9FE7CD5B2E14C6BA006691AB /* DefaultBrowserPromptUserActivityManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserPromptUserActivityManagerTests.swift; sourceTree = "<group>"; };
 		9FE7CD5D2E14C80B006691AB /* MockDefaultBrowserPromptUserActivityStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDefaultBrowserPromptUserActivityStorage.swift; sourceTree = "<group>"; };
@@ -6756,6 +6758,14 @@
 			path = SystemSettingsPiPTutorial;
 			sourceTree = "<group>";
 		};
+		9FE59CE52E33078B00C4B65D /* SystemSettingsPiPTutorial */ = {
+			isa = PBXGroup;
+			children = (
+				9FE59CE62E3307A000C4B65D /* SystemSettingsPiPTutorialPixelHandlerTests.swift */,
+			);
+			path = SystemSettingsPiPTutorial;
+			sourceTree = "<group>";
+		};
 		9FE7CD562E13BF74006691AB /* UserActivityManager */ = {
 			isa = PBXGroup;
 			children = (
@@ -8000,6 +8010,7 @@
 				9F254AC92CF5CA860063B308 /* SpecialErrorPage */,
 				F1BDDBFC2C340D9C00459306 /* Subscription */,
 				569437222BDD402600C0881B /* Sync */,
+				9FE59CE52E33078B00C4B65D /* SystemSettingsPiPTutorial */,
 				F13B4BF71F18C9E800814661 /* Tabs */,
 				859DB8192CE6265F001F7210 /* TextZoom */,
 				98EA2C3A218B9A880023E1DC /* Themes */,
@@ -10769,6 +10780,7 @@
 				98E564092DE8B32D00E6E75F /* ContextualOnboardingPresenterMock.swift in Sources */,
 				9F4CC5172C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift in Sources */,
 				F1A83D872E0AB27E00054B03 /* MockFeatureFlagger.swift in Sources */,
+				9FE59CE72E3307AD00C4B65D /* SystemSettingsPiPTutorialPixelHandlerTests.swift in Sources */,
 				F13B4BFB1F18E3D900814661 /* TabsModelPersistenceTests.swift in Sources */,
 				9FD6E61B2DFA739200C2B032 /* MockAVPictureInPictureController.swift in Sources */,
 				8528AE7E212EF5FF00D0BD74 /* AppRatingPromptTests.swift in Sources */,

--- a/iOS/DuckDuckGo/SystemSettingsPiPTutorial/SystemSettingsPiPTutorialPixelHandler.swift
+++ b/iOS/DuckDuckGo/SystemSettingsPiPTutorial/SystemSettingsPiPTutorialPixelHandler.swift
@@ -21,9 +21,27 @@ import Core
 import SystemSettingsPiPTutorial
 
 final class SystemSettingsPiPTutorialPixelHandler: SystemSettingsPiPTutorialEventMapper {
+    private static let regex = #"([a-zA-Z\-]+\.lproj/[^/]+)$"#
+
+    private let dailyPixelFiring: DailyPixelFiring.Type
+
+    init(dailyPixelFiring: DailyPixelFiring.Type = DailyPixel.self) {
+        self.dailyPixelFiring = dailyPixelFiring
+    }
 
     func fireFailedToLoadPiPTutorialEvent(error: (any Error)?, urlPath: String?) {
-        Logger.pipTutorial.error("[PiP Tutorial Video] Failed To Load video: \(String(describing: error)) \(String(describing: urlPath))")
+        let parameters = extractVideoUrlPath(from: urlPath).flatMap { ["video_url_path": $0] } ?? [:]
+        dailyPixelFiring.fireDailyAndCount(.systemSettingsPiPTutorialFailedToLoadVideo, error: error, withAdditionalParameters: parameters)
+    }
+
+    private func extractVideoUrlPath(from path: String?) -> String? {
+        guard
+            let path,
+            let range = path.range(of: Self.regex, options: .regularExpression)
+        else {
+            return nil
+        }
+        return String(path[range])
     }
 
 }

--- a/iOS/DuckDuckGoTests/SystemSettingsPiPTutorial/SystemSettingsPiPTutorialPixelHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/SystemSettingsPiPTutorial/SystemSettingsPiPTutorialPixelHandlerTests.swift
@@ -1,0 +1,89 @@
+//
+//  SystemSettingsPiPTutorialPixelHandlerTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Core
+import Testing
+@testable import DuckDuckGo
+
+@Suite("System Settings PiP Tutorial - Pixel Handler Tests")
+final class SystemSettingsPiPTutorialPixelHandlerTests {
+    private let pixelFiringMock: PixelFiringMock.Type
+
+    init() {
+        pixelFiringMock = PixelFiringMock.self
+    }
+
+    deinit {
+        pixelFiringMock.tearDown()
+    }
+
+    @Test(
+        "Check parameter is extracted properly from URL",
+        arguments: zip(
+            [
+                "file:///private/var/containers/Bundle/Application/6CB3B838-5751-46A8-A148-C5A6C2F85C71/DuckDuckGo.app/en.lproj/default-browser-tutorial.mp4",
+                "file:///private/var/containers/Bundle/Application/6CB3B838-5751-46A8-A148-C5A6C2F85C71/DuckDuckGo.app/de.lproj/default-browser-tutorial.mp4",
+                "file:///private/var/containers/Bundle/Application/6CB3B838-5751-46A8-A148-C5A6C2F85C71/DuckDuckGo.app/es.lproj/default-browser-tutorial.mp4",
+                "file:///private/var/containers/Bundle/Application/6CB3B838-5751-46A8-A148-C5A6C2F85C71/DuckDuckGo.app/fr.lproj/default-browser-tutorial.mp4",
+                "file:///private/var/containers/Bundle/Application/6CB3B838-5751-46A8-A148-C5A6C2F85C71/DuckDuckGo.app/it.lproj/default-browser-tutorial.mp4",
+                "file:///private/var/containers/Bundle/Application/6CB3B838-5751-46A8-A148-C5A6C2F85C71/DuckDuckGo.app/nl.lproj/default-browser-tutorial.mp4",
+                "file:///private/var/containers/Bundle/Application/6CB3B838-5751-46A8-A148-C5A6C2F85C71/DuckDuckGo.app/pt.lproj/default-browser-tutorial.mp4",
+            ],
+            [
+                "en.lproj/default-browser-tutorial.mp4",
+                "de.lproj/default-browser-tutorial.mp4",
+                "es.lproj/default-browser-tutorial.mp4",
+                "fr.lproj/default-browser-tutorial.mp4",
+                "it.lproj/default-browser-tutorial.mp4",
+                "nl.lproj/default-browser-tutorial.mp4",
+                "pt.lproj/default-browser-tutorial.mp4",
+            ]
+        )
+    )
+    func whenURLPathIsNotNilThenParametersIsSetCorrectly(urlPath: String, expectedResult: String) async throws {
+        // GIVEN
+        let error = NSError(domain: #function, code: 0)
+        let sut = SystemSettingsPiPTutorialPixelHandler(dailyPixelFiring: pixelFiringMock)
+
+        // WHEN
+        sut.fireFailedToLoadPiPTutorialEvent(error: error, urlPath: urlPath)
+
+        // THEN
+        #expect(pixelFiringMock.lastDailyPixelInfo?.pixelName == Pixel.Event.systemSettingsPiPTutorialFailedToLoadVideo.name)
+        #expect(pixelFiringMock.lastDailyPixelInfo?.params == ["video_url_path": expectedResult])
+        #expect(pixelFiringMock.lastDailyPixelInfo?.error as? NSError == error)
+    }
+
+    @Test("Check parameter is extracted properly from URL ")
+    func whenURLPathIsNilThenParametersIsNotSet() async throws {
+        // GIVEN
+        let error = NSError(domain: #function, code: 0)
+        let sut = SystemSettingsPiPTutorialPixelHandler(dailyPixelFiring: pixelFiringMock)
+
+        // WHEN
+        sut.fireFailedToLoadPiPTutorialEvent(error: error, urlPath: nil)
+
+        // THEN
+        #expect(pixelFiringMock.lastDailyPixelInfo?.pixelName == Pixel.Event.systemSettingsPiPTutorialFailedToLoadVideo.name)
+        #expect(pixelFiringMock.lastDailyPixelInfo?.params == [:])
+        #expect(pixelFiringMock.lastDailyPixelInfo?.error as? NSError == error)
+    }
+
+}

--- a/iOS/PixelDefinitions/pixels/system-settings-pip-tutorial.json5
+++ b/iOS/PixelDefinitions/pixels/system-settings-pip-tutorial.json5
@@ -1,0 +1,35 @@
+// See https://app.asana.com/0/72649045549333/1208001118995887/f.
+{
+    pixel_name: {
+        description: 'Fires when the the Picture-in-Picture video tutorial Fails to load.',
+        owners: ['alessandroboron'],
+        triggers: ['other'],
+        suffixes: [
+            'form_factor',
+            'daily',
+            'count',
+        ],
+        parameters: [
+            // Commonly used param, defined in params_dictionary.json.
+            'appVersion',
+            'pixelSource',
+            // Path of the embedded video. E.g. 'es.lproj/default-browser-tutorial.mp4'
+            {
+                key: 'url',
+                description: 'The local path of the embedded video that failed.',
+                type: 'string',
+            },
+            // Default Parameters for errors "e" and "d"
+            {
+                key: 'e',
+                description: 'The error code if present.',
+                type: 'string',
+            },
+            {
+                key: 'd',
+                description: 'The domain of the error. e.g. AVFoundationErrorDomain',
+                type: 'string',
+            },
+        ],
+    },
+}

--- a/iOS/SharedTestUtils/Mocks/MockPixelFiring.swift
+++ b/iOS/SharedTestUtils/Mocks/MockPixelFiring.swift
@@ -138,6 +138,10 @@ final actor PixelFiringMock: PixelFiring, PixelFiringAsync, DailyPixelFiring {
         onCountComplete(expectedCountPixelFireError)
     }
 
+    static func fireDailyAndCount(_ pixel: Core.Pixel.Event, error: (any Error)?, withAdditionalParameters params: [String: String]) {
+        lastDailyPixelInfo = PixelInfo(pixelName: pixel.name, error: error, params: params, includedParams: nil)
+    }
+
     // -
 
     static func tearDown() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1210886579244439?focus=true
Tech Design URL:
CC:

### Description

Adds the Pixel definition and implementation that fires when an embedded video tutorial fails to load.

### Testing Steps
1. Change `DefaultBrowserPiPTutorialURLProvider` pipTutorialURL() to return a URL for a video that does not exist.
2. Trigger the DefaultBrowser PiP video from one of the entry points.
3. Ensure that `m.picture-in-picture-tutorial.failed-to-load-video` fires and the `video_url_path` parameter is equal to “en.lproj/<name_of_the_file>"

### Impact and Risks
Low

#### What could go wrong?
Path to the local resource could be wrong.

### Quality Considerations
The logic to parse and check that the pixel is sent has been tested.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)