### PR TITLE
Switch NTP Omnibar to Search mode when AI is disabled

### DIFF
--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
@@ -93,6 +93,9 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
     var mode: NewTabPageDataModel.OmnibarMode {
         get {
             do {
+                guard isAIChatShortcutEnabled && isAIChatSettingVisible else {
+                    return .search
+                }
                 if let rawValue = try keyValueStore.object(forKey: Key.newTabPageOmnibarMode.rawValue) as? String,
                    let mode = NewTabPageDataModel.OmnibarMode(rawValue: rawValue) {
                     return mode

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarConfigProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarConfigProviderTests.swift
@@ -68,6 +68,24 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
     }
 
     @MainActor
+    func testModeFallBackToSearchWhenAIFeaturesAreDisabled() throws {
+        let store = try makeStore(underlying: [storageKey: "ai"])
+        let settingProvider = MockNewTabPageAIChatShortcutSettingProvider()
+        let provider = NewTabPageOmnibarConfigProvider(keyValueStore: store, aiChatShortcutSettingProvider: settingProvider)
+        settingProvider.isAIChatSettingVisible = false
+        XCTAssertEqual(provider.mode, .search)
+    }
+
+    @MainActor
+    func testModeFallBackToSearchWhenAIChatShortcutIsHidden() throws {
+        let store = try makeStore(underlying: [storageKey: "ai"])
+        let settingProvider = MockNewTabPageAIChatShortcutSettingProvider()
+        let provider = NewTabPageOmnibarConfigProvider(keyValueStore: store, aiChatShortcutSettingProvider: settingProvider)
+        settingProvider.isAIChatShortcutEnabled = false
+        XCTAssertEqual(provider.mode, .search)
+    }
+
+    @MainActor
     func testModeDefaultsToSearchOnInvalidRawValue() throws {
         let store = try makeStore(underlying: [storageKey: "invalid"])
         let provider = NewTabPageOmnibarConfigProvider(keyValueStore: store, aiChatShortcutSettingProvider: MockNewTabPageAIChatShortcutSettingProvider())


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210888877150441?focus=true

### Description
When Duck.ai was selected as current mode of NTP Omnibar and use decided to hide Duck.ai on NTP
or disable Duck.ai in AI Features settings, revert to Search mode.

### Testing Steps
1. Launch the app and select Duck.ai in NTP Omnibar
2. Open NTP Customization Panel and click Hide Duck.ai. Verify that the segmented control disappears and the Omnibar enters Search mode.
3. Click Show Duck.ai and verify that the segmented control reappears (Omnibar remains in Search mode).
4. Select Duck.ai and go to Settings -> AI Features
5. Click Disable Duck.ai and confirm the dialog. Go back to NTP and verify that the segmented control disappears and the Omnibar enters Search mode.
6. Click Enable Duck.ai in AI Features settings, go back to NTP and verify that the segmented control reappears (Omnibar remains in Search mode).

### Impact and Risks
<!— 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
—>

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)