### PR TITLE
Make default browser PiP tutorial feature flag overridable

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -195,7 +195,8 @@ extension FeatureFlag: FeatureFlagDescribing {
              .subscriptionRebranding,
              .june2025TabManagerLayoutChanges,
              .canPromoteImportPasswordsInPasswordManagement,
-             .canPromoteImportPasswordsInBrowser:
+             .canPromoteImportPasswordsInBrowser,
+             .setAsDefaultBrowserPiPVideoTutorial:
             return true
         case .showSettingsCompleteSetupSection:
             if #available(iOS 18.2, *) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1210903469838658?focus=true
Tech Design URL:
CC:

### Description

Enable feature flag override for Set As Default browser PiP tutorial

### Testing Steps
1. Check Feature Flag in Debug menu supports override as per attached screenshot
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-28 at 21 07 13" src="https://github.com/user-attachments/assets/8710b998-4546-4399-9e0a-1ff1e427d859" />

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)