### PR TITLE
[iOS][AI Search Toggle] and paste and go support

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryViewController.swift
@@ -51,6 +51,7 @@ class SwitchBarTextEntryViewController: UIViewController {
         super.viewDidLoad()
         setupViews()
         setupConstraints()
+        setupPasteAndGo()
     }
 
     func focusTextField() {
@@ -96,7 +97,19 @@ class SwitchBarTextEntryViewController: UIViewController {
         ])
     }
 
+    private func setupPasteAndGo() {
+        let title = UserText.actionPasteAndGo
+        UIMenuController.shared.menuItems = [UIMenuItem(title: title, action: #selector(self.pasteURLAndGo))]
+    }
+
     // MARK: - Action Handlers
+    @objc private func pasteURLAndGo(sender: UIMenuItem) {
+        guard let pastedText = UIPasteboard.general.string,
+              !pastedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        handler.updateCurrentText(pastedText)
+        handleSend()
+    }
+
     private func handleSend() {
         let currentText = handler.currentText
         if !currentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1210882223417970?focus=true
Tech Design URL:
CC:

### Description
Adds paste and go support.   As per the existing omnibar - the edit menu now contains "Paste and Go" option which replaces the text and submits field. 

### Testing Steps
1. Copy some text into the pastbuffer
2. Tap on the search field and show the edit menu
3. Tap Paste and Go (might need to navigate to it initially, after this it should be more easily accessible)
4. Should submit the current view - search or duck.ai - so validate both

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)