### PR TITLE
Add `check_retries` to unit test jobs that are missing it

### DIFF
--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -291,6 +291,7 @@ jobs:
           check_name: BSK Test Report (iOS)
           report_paths: SharedPackages/BrowserServicesKit/bsk-ios-unittests.xml
           require_tests: true
+          check_retries: true
 
       - name: Update Asana with failed unit tests
         if: always() && steps.run-unit-tests-ios.outcome == 'failure'

--- a/.github/workflows/dbp_pr_checks.yml
+++ b/.github/workflows/dbp_pr_checks.yml
@@ -267,6 +267,7 @@ jobs:
           check_name: DBP Test Report (iOS)
           report_paths: SharedPackages/DataBrokerProtectionCore/dbp-ios-unittests.xml
           require_tests: true
+          check_retries: true
 
       - name: Send Unit Tests Status Pixel
         if: always() && github.ref_name == 'main'

--- a/.github/workflows/ios_nightly.yml
+++ b/.github/workflows/ios_nightly.yml
@@ -67,6 +67,7 @@ jobs:
       uses: mikepenz/action-junit-report@v3
       with:
         report_paths: iOS/unittests.xml
+        check_retries: true
 
   fingerprinting-ui-tests:
     name: Fingerprinting UI Tests
@@ -96,6 +97,7 @@ jobs:
       uses: mikepenz/action-junit-report@v3
       with:
         report_paths: iOS/unittests.xml
+        check_retries: true
 
   notify-failure:
     name: Notify on failure


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1210905604852698?focus=true
Tech Design URL:
CC:

### Description

This PR updates unit test workflows to use `check_retries`, in cases where we are using the retry iterations feature. Without this change, a retry can succeed but the test summary will show as a failure.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI is green

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)