### PR TITLE
[macOS][Flaky Tests] Disable onboarding test to check the highglight view is dismissed correctly

### DIFF
--- a/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
+++ b/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
@@ -291,6 +291,7 @@ final class BrowserTabViewControllerOnboardingTests: XCTestCase {
     }
 
     func testWhenGotItButtonPressedThenAskDelegateToRemoveViewHighlights() throws {
+        throw XCTSkip("Flaky Test")
         // GIVEN
         let expectation = self.expectation(description: "Wait for webViewDidFinishNavigationPublisher to emit")
         let delegate = BrowserTabViewControllerDelegateSpy()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210912369794512
Tech Design URL:
CC:

### Description

Disable an onboarding test that causes test suite flakiness 

### Testing Steps
1. Ensure CI pass.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)