### PR TITLE
[iOS] CBR Crash Fix

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentBlocking/ContentBlockingRulesCompilationTask.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentBlocking/ContentBlockingRulesCompilationTask.swift
@@ -90,6 +90,10 @@ extension ContentBlockerRulesManager {
 
                 // Delegate querying to main thread - crashes were observed in background.
                 DispatchQueue.main.async {
+
+                    // https://app.asana.com/1/137249556945/project/949243614371883/task/1210912586079501?focus=true
+                    _ = WKWebView()
+
                     let identifier = model.rulesIdentifier.stringValue
                     Logger.contentBlocking.debug("Lookup CBR with \(identifier, privacy: .public)")
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/949243614371883/task/1210912586079501?focus=true
Tech Design URL:
CC:

### Description
Call WebView init before CBR compilation.

### Testing Steps
1. Add `_ = WKWebView()` to `func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: ` before anything else
2. Comment out `_ = WKWebView()` in `ContentBlockingRulesCompilationTask` at line 95
3. Clean install and run the app with above code
4. App should crash
5. Remove line from app delegate
6. Comment back in the line in `ContentBlockingRulesCompilationTask`
7. Run the app - it should launch
8. Smoke test the app

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Unexpected consequences of init WebView in this location

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)