### PR TITLE
re-add the drag drop delegate for tab switcher

### DIFF
--- a/iOS/DuckDuckGo/TabSwitcherViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController.swift
@@ -242,6 +242,8 @@ class TabSwitcherViewController: UIViewController {
         // These can be done more than once but don't need to
         decorate()
         becomeFirstResponder()
+        collectionView.dragDelegate = self
+        collectionView.dropDelegate = self
         collectionView.allowsSelection = true
         collectionView.allowsMultipleSelection = true
         collectionView.allowsMultipleSelectionDuringEditing = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1210907256770627?focus=true
Tech Design URL:
CC:

### Description
Fixes broken re-ordering

### Testing Steps
1. Open some tabs
2. Go to tab switcher
3. Check that re-ordering works when not in edit mode in both tile and list modes
4. Check that re-ordering doesn't work when editing 

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)