### PR TITLE
Fix autoconsent self-test triggering.

### DIFF
--- a/iOS/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
+++ b/iOS/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
@@ -51,7 +51,7 @@ final class AutoconsentUserScript: NSObject, WKScriptMessageHandlerWithReply, Us
     var forMainFrameOnly: Bool { false }
     
     weak var selfTestWebView: WKWebView?
-    weak var selfTestFrameInfo: WKFrameInfo?
+    var selfTestFrameInfo: WKFrameInfo?
     
     var topUrl: URL?
     var preferences: AutoconsentPreferences

--- a/macOS/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
+++ b/macOS/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
@@ -44,7 +44,7 @@ final class AutoconsentUserScript: NSObject, WKScriptMessageHandlerWithReply, Us
     var forMainFrameOnly: Bool { false }
 
     private weak var selfTestWebView: WKWebView?
-    private weak var selfTestFrameInfo: WKFrameInfo?
+    private var selfTestFrameInfo: WKFrameInfo?
 
     private var topUrl: URL?
     private let preferences = CookiePopupProtectionPreferences.shared


### PR DESCRIPTION

<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201844467387842/task/1210902061380084?focus=true
Tech Design URL:
CC:

### Description
weak ref to WKFrameInfo disappears immediately after the message is processed, causing the reference to be null when the 'autoconsentDone' message is triggered shortly after. Instead we can safely make selfTestFrameInfo not weak, as it's own reference to WKWebView is weak.


### Testing Steps
1. Put a breakpoint in `handleSelfTestResult`. 
2. Visit http://privacy-test-pages.site/features/autoconsent/index.html
3. Breakpoint should be triggered.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)