### PR TITLE
[iOS][Set As Default Browser] Increase the minimum version to check if the browser is the default to 18.3

### DIFF
--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserCore/CheckDefaultBrowserService/CheckDefaultBrowserService.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserCore/CheckDefaultBrowserService/CheckDefaultBrowserService.swift
@@ -38,9 +38,11 @@ public protocol CheckDefaultBrowserService: AnyObject {
 // Usually we would make an interface with the same method and have UIApplication conform to it.
 // The issue with the above approach is that it requires marking the protocol `@available(iOS 18.2, *)`.
 // That will cause issues with injecting the parameter as it is available only for iOS 18.2.
+// [2025-07-30] Changed min required version to 18.3 due to some user experiencing crashes only on 18.2.
+// For more info: https://app.asana.com/1/137249556945/project/1206329551987282/task/1210878147492704?focus=true
 @MainActor
 public protocol ApplicationDefaultCategoryChecking: AnyObject {
-    @available(iOS 18.2, *)
+    @available(iOS 18.3, *)
     func isDefault(_ category: UIApplication.Category) throws -> Bool
 }
 
@@ -55,7 +57,9 @@ public final class SystemCheckDefaultBrowserService: CheckDefaultBrowserService 
     }
 
     public func isDefaultWebBrowser() -> Result<Bool, CheckDefaultBrowserServiceError> {
-        guard #available(iOS 18.2, *) else { return .failure(.notSupportedOnThisOSVersion) }
+        // The feature is available since iOS 18.2 but users experienced a few crashes only in iOS 18.2.
+        // Bumping min required version to 18.3. For more info: https://app.asana.com/1/137249556945/project/1206329551987282/task/1210878147492704?focus=true
+        guard #available(iOS 18.3, *) else { return .failure(.notSupportedOnThisOSVersion) }
 
         do {
             let isDefaultBrowser = try application.isDefault(.webBrowser)

--- a/iOS/LocalPackages/SetDefaultBrowser/Tests/SetDefaultBrowserTests/CheckDefaultBrowserServiceTests.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Tests/SetDefaultBrowserTests/CheckDefaultBrowserServiceTests.swift
@@ -25,8 +25,8 @@ import SetDefaultBrowserTestSupport
 
 @Suite("Set Default Browser - Check Default Browser Service")
 struct CheckDefaultBrowserServiceTests {
-    private static let isLowerThanIOS18PointTwo: Bool = {
-        if #available(iOS 18.2, *) {
+    private static let isLowerThanPermittedVersion: Bool = {
+        if #available(iOS 18.3, *) {
             false
         } else {
             true
@@ -41,7 +41,7 @@ struct CheckDefaultBrowserServiceTests {
             false
         ]
     )
-    @available(iOS 18.2, *)
+    @available(iOS 18.3, *)
     func checkDefaultBrowserReturnsSuccess(_ expectedDefaultBrowserValue: Bool) throws {
         // GIVEN
         let application = MockApplication()
@@ -57,7 +57,7 @@ struct CheckDefaultBrowserServiceTests {
 
     @MainActor
     @Test("Check is Default Browser returns maxNumberOfAttemptsExceeded when rateLimited error")
-    @available(iOS 18.2, *)
+    @available(iOS 18.3, *)
     func checkDefaultBrowserReturnsMaxNumberOfAttemptsExceededFailure() throws {
         // GIVEN
         let timestamp: TimeInterval = 1773122108000 // 10th of March 2026
@@ -87,7 +87,7 @@ struct CheckDefaultBrowserServiceTests {
 
     @MainActor
     @Test("Check is Default Browser returns unknown failure when generic error")
-    @available(iOS 18.2, *)
+    @available(iOS 18.3, *)
     func checkDefaultBrowserReturnsUnknownFailure() throws {
         // GIVEN
         let systemError = NSError(
@@ -112,7 +112,7 @@ struct CheckDefaultBrowserServiceTests {
     }
 
     @MainActor
-    @Test(.enabled(if: CheckDefaultBrowserServiceTests.isLowerThanIOS18PointTwo))
+    @Test(.enabled(if: CheckDefaultBrowserServiceTests.isLowerThanPermittedVersion))
     func legacyCheckDefaultBrowserReturnsNotSupportedFailure() throws {
         // GIVEN
         let sut = SystemCheckDefaultBrowserService()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1210878147492704?focus=true
Tech Design URL:
CC:

### Description

We observed a few crashes happening in SystemCheckDefaultBrowserService. This is a wrapper on Apple [isDefault(.webBrowser)](https://developer.apple.com/documentation/uikit/uiapplication/isdefault(_:)). 
The crashes are occurring only for users on iOS 18.2, which leads us to believe that they may be caused by an internal Apple issue with this framework in that version.
This PR defensively address the issue by ensuring the API can be queried only by users running iOS 18.3+ as discussed in [Asana](https://app.asana.com/1/137249556945/task/1210878147492704/comment/1210903471317985?focus=true).

### Testing Steps
1. Ensure CI pass.

### Impact and Risks
Low: While this fix will prevent showing the Default Browser Prompt to users running iOS 18.2 it will  

#### What could go wrong?
It could impact the Default Browser conversion as it won’t show for users running iOS 18.2. I can’t currently quantify it.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)