### PR TITLE
disable testWhenSyncGetsDisabledBeforeStartingOperationThenOperationReturnsEarly

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -422,6 +422,7 @@ final class DDGSyncTests: XCTestCase {
     }
 
     func testWhenSyncGetsDisabledBeforeStartingOperationThenOperationReturnsEarly() throws {
+        throw XCTSkip("Flakey test")
         let dataProvider = DataProvidingMock(feature: .init(name: "bookmarks"))
         setUpDataProviderCallbacks(for: dataProvider)
         setUpExpectations(started: 1, fetch: 1, handleResponse: 1, finished: 1)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1210924861103056?focus=true
Tech Design URL:
CC:

### Description
- disable testWhenSyncGetsDisabledBeforeStartingOperationThenOperationReturnsEarly

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
- ensure CI is green

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
No

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
Nothing

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)