### PR TITLE
Open subscriptions landing page on Duck.ai emphasised page

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL.swift
@@ -115,6 +115,31 @@ extension SubscriptionURL {
             .appendingParameter(name: AttributionParameter.origin, value: origin)
         return URLComponents(url: url, resolvingAgainstBaseURL: false)
     }
+
+    /**
+     * Creates URL components for a subscription purchase URL with the specified origin and featurePage parameters.
+     *
+     * - Parameters:
+     *   - origin: A string identifying where the subscription request originated from (optional)
+     *   - featurePage: The feature page to highlight (optional)
+     *   - environment: The subscription environment to use (defaults to production)
+     *
+     * - Returns: URLComponents containing the subscription URL with the origin and featurePage parameters, or nil if the URL could not be parsed
+     */
+    public static func purchaseURLComponentsWithOriginAndFeaturePage(
+        origin: String?,
+        featurePage: String?,
+        environment: SubscriptionEnvironment.ServiceEnvironment = .production
+    ) -> URLComponents? {
+        var url = SubscriptionURL.purchase.subscriptionURL(environment: environment)
+        if let origin = origin {
+            url = url.appendingParameter(name: AttributionParameter.origin, value: origin)
+        }
+        if let featurePage = featurePage {
+            url = url.appendingParameter(name: "featurePage", value: featurePage)
+        }
+        return URLComponents(url: url, resolvingAgainstBaseURL: false)
+    }
 }
 
 fileprivate extension URL {

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionUserScript/SubscriptionUserScript.swift
@@ -59,7 +59,7 @@ protocol SubscriptionUserScriptHandling {
 public protocol SubscriptionUserScriptNavigationDelegate: AnyObject {
     @MainActor func navigateToSettings()
     @MainActor func navigateToSubscriptionActivation()
-    @MainActor func navigateToSubscriptionPurchase(origin: String?)
+    @MainActor func navigateToSubscriptionPurchase(origin: String?, featurePage: String?)
 }
 
 protocol UserScriptMessagePushing: AnyObject {
@@ -152,7 +152,7 @@ final class SubscriptionUserScriptHandler: SubscriptionUserScriptHandling {
             return nil
         }()
 
-        navigationDelegate?.navigateToSubscriptionPurchase(origin: purchaseParams?.origin)
+        navigationDelegate?.navigateToSubscriptionPurchase(origin: purchaseParams?.origin, featurePage: "duckai")
         return nil
     }
 

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
@@ -212,4 +212,84 @@ final class SubscriptionURLTests: XCTestCase {
         XCTAssertNotNil(components)
         XCTAssertEqual(components?.url, expectedURL)
     }
+
+    func testPurchaseURLComponentsWithOriginAndFeaturePageForProduction() throws {
+        // Given
+        let origin = "funnel_appsettings_ios"
+        let featurePage = "duckai"
+        let expectedURL = URL(string: "https://duckduckgo.com/subscriptions?origin=funnel_appsettings_ios&featurePage=duckai")!
+
+        // When
+        let components = SubscriptionURL.purchaseURLComponentsWithOriginAndFeaturePage(origin: origin, featurePage: featurePage, environment: .production)
+
+        // Then
+        XCTAssertNotNil(components)
+        XCTAssertEqual(components?.url, expectedURL)
+    }
+
+    func testPurchaseURLComponentsWithOriginAndFeaturePageForStaging() throws {
+        // Given
+        let origin = "funnel_appsettings_ios"
+        let featurePage = "duckai"
+        let expectedURL = URL(string: "https://duckduckgo.com/subscriptions?environment=staging&origin=funnel_appsettings_ios&featurePage=duckai")!
+
+        // When
+        let components = SubscriptionURL.purchaseURLComponentsWithOriginAndFeaturePage(origin: origin, featurePage: featurePage, environment: .staging)
+
+        // Then
+        XCTAssertNotNil(components)
+        XCTAssertEqual(components?.url, expectedURL)
+    }
+
+    func testPurchaseURLComponentsWithNilOriginAndFeaturePage() throws {
+        // Given
+        let expectedURL = URL(string: "https://duckduckgo.com/subscriptions")!
+
+        // When
+        let components = SubscriptionURL.purchaseURLComponentsWithOriginAndFeaturePage(origin: nil, featurePage: nil, environment: .production)
+
+        // Then
+        XCTAssertNotNil(components)
+        XCTAssertEqual(components?.url, expectedURL)
+    }
+
+    func testPurchaseURLComponentsWithOnlyFeaturePage() throws {
+        // Given
+        let featurePage = "duckai"
+        let expectedURL = URL(string: "https://duckduckgo.com/subscriptions?featurePage=duckai")!
+
+        // When
+        let components = SubscriptionURL.purchaseURLComponentsWithOriginAndFeaturePage(origin: nil, featurePage: featurePage, environment: .production)
+
+        // Then
+        XCTAssertNotNil(components)
+        XCTAssertEqual(components?.url, expectedURL)
+    }
+
+    func testPurchaseURLComponentsWithOnlyOrigin() throws {
+        // Given
+        let origin = "funnel_appsettings_ios"
+        let expectedURL = URL(string: "https://duckduckgo.com/subscriptions?origin=funnel_appsettings_ios")!
+
+        // When
+        let components = SubscriptionURL.purchaseURLComponentsWithOriginAndFeaturePage(origin: origin, featurePage: nil, environment: .production)
+
+        // Then
+        XCTAssertNotNil(components)
+        XCTAssertEqual(components?.url, expectedURL)
+    }
+
+    func testPurchaseURLComponentsWithEmptyOriginAndFeaturePage() throws {
+        // Given
+        let origin = ""
+        let featurePage = ""
+        let expectedURL = URL(string: "https://duckduckgo.com/subscriptions?origin=&featurePage=")!
+
+        // When
+        let components = SubscriptionURL.purchaseURLComponentsWithOriginAndFeaturePage(origin: origin, featurePage: featurePage, environment: .production)
+
+        // Then
+        XCTAssertNotNil(components)
+        XCTAssertEqual(components?.url, expectedURL)
+    }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionUserScript/SubscriptionUserScriptHandlerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionUserScript/SubscriptionUserScriptHandlerTests.swift
@@ -187,6 +187,7 @@ final class SubscriptionUserScriptHandlerTests: XCTestCase {
         XCTAssertNil(response)
         XCTAssertTrue(mockNavigationDelegate.navigateToSubscriptionPurchaseCalled)
         XCTAssertEqual(mockNavigationDelegate.purchaseOrigin, origin)
+        XCTAssertEqual(mockNavigationDelegate.purchaseFeaturePage, "duckai")
     }
 
     @MainActor
@@ -195,6 +196,7 @@ final class SubscriptionUserScriptHandlerTests: XCTestCase {
         XCTAssertNil(response)
         XCTAssertTrue(mockNavigationDelegate.navigateToSubscriptionPurchaseCalled)
         XCTAssertNil(mockNavigationDelegate.purchaseOrigin)
+        XCTAssertEqual(mockNavigationDelegate.purchaseFeaturePage, "duckai")
     }
 
     // MARK: - Auth Update Push Tests
@@ -261,6 +263,7 @@ class MockNavigationDelegate: SubscriptionUserScriptNavigationDelegate {
     var navigateToSubscriptionActivationCalled = false
     var navigateToSubscriptionPurchaseCalled = false
     var purchaseOrigin: String?
+    var purchaseFeaturePage: String?
 
     func navigateToSettings() {
         navigateToSettingsCalled = true
@@ -270,9 +273,10 @@ class MockNavigationDelegate: SubscriptionUserScriptNavigationDelegate {
         navigateToSubscriptionActivationCalled = true
     }
 
-    func navigateToSubscriptionPurchase(origin: String?) {
+    func navigateToSubscriptionPurchase(origin: String?, featurePage: String?) {
         navigateToSubscriptionPurchaseCalled = true
         purchaseOrigin = origin
+        purchaseFeaturePage = featurePage
     }
 }
 

--- a/iOS/DuckDuckGo/Subscription/SubscriptionURLNavigationHandler.swift
+++ b/iOS/DuckDuckGo/Subscription/SubscriptionURLNavigationHandler.swift
@@ -57,12 +57,13 @@ final class SubscriptionURLNavigationHandler: SubscriptionUserScriptNavigationDe
     func navigateToSubscriptionPurchase(origin: String?) {
         let settingsDeepLink: SettingsViewModel.SettingsDeepLinkSection
 
+        var url = SubscriptionURL.purchase.subscriptionURL(environment: .production)
+        url = url.appendingParameter(name: "featurePage", value: "duckai")
         if let origin = origin {
-            let redirectURLComponents = SubscriptionURL.purchaseURLComponentsWithOrigin(origin)
-            settingsDeepLink = .subscriptionFlow(redirectURLComponents: redirectURLComponents)
-        } else {
-            settingsDeepLink = .subscriptionFlow()
+            url = url.appendingParameter(name: AttributionParameter.origin, value: origin)
         }
+        let redirectURLComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        settingsDeepLink = .subscriptionFlow(redirectURLComponents: redirectURLComponents)
 
         NotificationCenter.default.post(
             name: .settingsDeepLinkNotification,

--- a/iOS/DuckDuckGo/Subscription/SubscriptionURLNavigationHandler.swift
+++ b/iOS/DuckDuckGo/Subscription/SubscriptionURLNavigationHandler.swift
@@ -55,16 +55,11 @@ final class SubscriptionURLNavigationHandler: SubscriptionUserScriptNavigationDe
     /// Navigates to the subscription purchase flow.
     /// Called when Duck.ai need to start a new subscription purchase.
     func navigateToSubscriptionPurchase(origin: String?) {
-        let settingsDeepLink: SettingsViewModel.SettingsDeepLinkSection
-
-        var url = SubscriptionURL.purchase.subscriptionURL(environment: .production)
-        url = url.appendingParameter(name: "featurePage", value: "duckai")
-        if let origin = origin {
-            url = url.appendingParameter(name: AttributionParameter.origin, value: origin)
-        }
-        let redirectURLComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
-        settingsDeepLink = .subscriptionFlow(redirectURLComponents: redirectURLComponents)
-
+        let components = SubscriptionURL.purchaseURLComponentsWithOriginAndFeaturePage(
+            origin: origin,
+            featurePage: "duckai"
+        )
+        let settingsDeepLink = SettingsViewModel.SettingsDeepLinkSection.subscriptionFlow(redirectURLComponents: components)
         NotificationCenter.default.post(
             name: .settingsDeepLinkNotification,
             object: settingsDeepLink

--- a/iOS/DuckDuckGo/Subscription/SubscriptionURLNavigationHandler.swift
+++ b/iOS/DuckDuckGo/Subscription/SubscriptionURLNavigationHandler.swift
@@ -54,10 +54,10 @@ final class SubscriptionURLNavigationHandler: SubscriptionUserScriptNavigationDe
 
     /// Navigates to the subscription purchase flow.
     /// Called when Duck.ai need to start a new subscription purchase.
-    func navigateToSubscriptionPurchase(origin: String?) {
+    func navigateToSubscriptionPurchase(origin: String?, featurePage: String?) {
         let components = SubscriptionURL.purchaseURLComponentsWithOriginAndFeaturePage(
             origin: origin,
-            featurePage: "duckai"
+            featurePage: featurePage
         )
         let settingsDeepLink = SettingsViewModel.SettingsDeepLinkSection.subscriptionFlow(redirectURLComponents: components)
         NotificationCenter.default.post(

--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionURLNavigationHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionURLNavigationHandlerTests.swift
@@ -105,7 +105,7 @@ final class SubscriptionURLNavigationHandlerTests: XCTestCase {
         }
 
         // When
-        handler.navigateToSubscriptionPurchase(origin: nil)
+        handler.navigateToSubscriptionPurchase(origin: nil, featurePage: "duckai")
 
         // Then
         wait(for: [expectation], timeout: 1.0)
@@ -143,7 +143,7 @@ final class SubscriptionURLNavigationHandlerTests: XCTestCase {
         }
 
         // When
-        handler.navigateToSubscriptionPurchase(origin: testOrigin)
+        handler.navigateToSubscriptionPurchase(origin: testOrigin, featurePage: "duckai")
 
         // Then
         wait(for: [expectation], timeout: 1.0)

--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionURLNavigationHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionURLNavigationHandlerTests.swift
@@ -88,9 +88,18 @@ final class SubscriptionURLNavigationHandlerTests: XCTestCase {
                 return false
             }
 
-            // Check if it's subscriptionFlow with no redirect components
+            // Check if it's subscriptionFlow with redirect components
             if case .subscriptionFlow(let components) = deepLinkTarget {
-                return components == nil
+                guard let urlComponents = components,
+                      let url = urlComponents.url,
+                      let queryItems = urlComponents.queryItems else {
+                    XCTFail("URLComponents should contain URL and query items")
+                    return false
+                }
+                // Verify the featurePage=duckai parameter is present
+                let hasFeaturePage = queryItems.contains { $0.name == "featurePage" && $0.value == "duckai" }
+                let urlContainsFeaturePage = url.absoluteString.contains("featurePage=duckai")
+                return hasFeaturePage && urlContainsFeaturePage
             }
             return false
         }
@@ -125,8 +134,10 @@ final class SubscriptionURLNavigationHandlerTests: XCTestCase {
                 // Verify the origin parameter is present in the URL
                 let hasOriginParameter = queryItems.contains { $0.name == "origin" && $0.value == testOrigin }
                 let urlContainsOrigin = url.absoluteString.contains("origin=\(testOrigin)")
-
-                return hasOriginParameter && urlContainsOrigin
+                // Verify the featurePage=duckai parameter is present
+                let hasFeaturePage = queryItems.contains { $0.name == "featurePage" && $0.value == "duckai" }
+                let urlContainsFeaturePage = url.absoluteString.contains("featurePage=duckai")
+                return hasOriginParameter && urlContainsOrigin && hasFeaturePage && urlContainsFeaturePage
             }
             return false
         }

--- a/macOS/DuckDuckGo/Subscription/SubscriptionNavigationCoordinator.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionNavigationCoordinator.swift
@@ -69,9 +69,9 @@ extension SubscriptionNavigationCoordinator: SubscriptionUserScriptNavigationDel
 
     /// Opens the subscription purchase flow in a new tab.
     /// Called when Duck.ai need to start a new subscription purchase.
-    func navigateToSubscriptionPurchase(origin: String?) {
+    func navigateToSubscriptionPurchase(origin: String?, featurePage: String?) {
         var url = subscriptionManager.url(for: .purchase)
-        url = url.appendingParameter(name: "featurePage", value: "duckai")
+        url = url.appendingParameter(name: "featurePage", value: featurePage)
         if let origin {
             url = url.appendingParameter(name: AttributionParameter.origin, value: origin)
         }

--- a/macOS/DuckDuckGo/Subscription/SubscriptionNavigationCoordinator.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionNavigationCoordinator.swift
@@ -71,7 +71,7 @@ extension SubscriptionNavigationCoordinator: SubscriptionUserScriptNavigationDel
     /// Called when Duck.ai need to start a new subscription purchase.
     func navigateToSubscriptionPurchase(origin: String?) {
         var url = subscriptionManager.url(for: .purchase)
-
+        url = url.appendingParameter(name: "featurePage", value: "duckai")
         if let origin {
             url = url.appendingParameter(name: AttributionParameter.origin, value: origin)
         }

--- a/macOS/DuckDuckGo/Subscription/SubscriptionNavigationCoordinator.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionNavigationCoordinator.swift
@@ -71,7 +71,9 @@ extension SubscriptionNavigationCoordinator: SubscriptionUserScriptNavigationDel
     /// Called when Duck.ai need to start a new subscription purchase.
     func navigateToSubscriptionPurchase(origin: String?, featurePage: String?) {
         var url = subscriptionManager.url(for: .purchase)
-        url = url.appendingParameter(name: "featurePage", value: featurePage)
+        if let featurePage {
+            url = url.appendingParameter(name: "featurePage", value: featurePage)
+        }
         if let origin {
             url = url.appendingParameter(name: AttributionParameter.origin, value: origin)
         }

--- a/macOS/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/Resources/Localizable.xcstrings
+++ b/macOS/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/Resources/Localizable.xcstrings
@@ -5406,7 +5406,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Privacy Pro is now just called the DuckDuckGo subscription."
+            "value" : "Privacy Pro is now just called the DuckDuckGo subscription"
           }
         }
       }

--- a/macOS/UnitTests/Subscription/SubscriptionNavigationCoordinatorTests.swift
+++ b/macOS/UnitTests/Subscription/SubscriptionNavigationCoordinatorTests.swift
@@ -74,7 +74,7 @@ struct SubscriptionNavigationCoordinatorTests {
         let expectedURL = URL(string: "https://duckduckgo.com/pro/purchase")!
         mockSubscriptionManager.urls[.purchase] = expectedURL
 
-        coordinator.navigateToSubscriptionPurchase(origin: nil)
+        coordinator.navigateToSubscriptionPurchase(origin: nil, featurePage: "duckai")
 
         // Verify tab shower was called to show tab with subscription content
         #expect(mockTabShower.capturedContent != nil)
@@ -95,7 +95,7 @@ struct SubscriptionNavigationCoordinatorTests {
         let origin = "funnel_duckai_macos__modelpicker"
         mockSubscriptionManager.urls[.purchase] = baseURL
 
-        coordinator.navigateToSubscriptionPurchase(origin: origin)
+        coordinator.navigateToSubscriptionPurchase(origin: origin, featurePage: "duckai")
 
         // Verify tab shower was called to show tab with subscription content
         #expect(mockTabShower.capturedContent != nil)

--- a/macOS/UnitTests/Subscription/SubscriptionNavigationCoordinatorTests.swift
+++ b/macOS/UnitTests/Subscription/SubscriptionNavigationCoordinatorTests.swift
@@ -84,8 +84,8 @@ struct SubscriptionNavigationCoordinatorTests {
             return
         }
 
-        // Verify the URL matches exactly what was returned from subscription manager
-        #expect(url == expectedURL)
+        // Verify the URL contains the featurePage=duckai parameter
+        #expect(url.absoluteString.contains("featurePage=duckai"))
     }
 
     @Test("navigateToSubscriptionPurchase fetches purchase URL and shows subscription tab with origin")
@@ -107,6 +107,8 @@ struct SubscriptionNavigationCoordinatorTests {
 
         // Verify the URL contains the origin parameter
         #expect(url.absoluteString.contains("origin=\(origin)"))
+        // Verify the URL contains the featurePage=duckai parameter
+        #expect(url.absoluteString.contains("featurePage=duckai"))
     }
 
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210891403305046

### Description Adds parameter to URL when navigating to subscription flow from Duck.ai

### Testing Steps
On both iOS and macOS
1. Make sure paidAiChat feature flag is on and you are not subscribed
2. Go to Duck.ai
3. Go to Duck.ai settings and click on “Subscribe to DuckDuckGo"
4. On macOS you should see the landing page with Duck.ai as first item also the URL in the address bar should contain featurePage=duckai parameter
5. on iOS from the debugger look for "HeadlessWebViewCoordinator - webView(_:decidePolicyFor:decisionHandler:) .allow: https://duckduckgo.com/subscriptions” and check it has the featurePage=duckai parameter parameter

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)