### PR TITLE
fix flaky MaliciousSiteProtectionUpdateManagerTests

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/Services/UpdateManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/Services/UpdateManager.swift
@@ -117,6 +117,9 @@ public struct UpdateManager: InternalUpdateManaging {
         Task.detached {
             // run update jobs in background for every data type
             try await withThrowingTaskGroup(of: Never.self) { group in
+                defer {
+                    Logger.updateManager.info("Periodic updates cancelled")
+                }
                 let supportedThreats = supportedThreatsProvider()
                 let filteredDataTypes = DataManager.StoredDataType.allCases.filter { supportedThreats.contains($0.threatKind) }
                 for dataType in filteredDataTypes {

--- a/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/MaliciousSiteProtectionUpdateManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/MaliciousSiteProtectionUpdateManagerTests.swift
@@ -55,6 +55,7 @@ class MaliciousSiteProtectionUpdateManagerTests: XCTestCase {
     }
 
     override func tearDown() async throws {
+        clock = nil
         updateManager = nil
         updateManagerInfoStore = nil
         dataManager = nil
@@ -62,6 +63,13 @@ class MaliciousSiteProtectionUpdateManagerTests: XCTestCase {
         updateIntervalProvider = nil
         mockEventMapping = nil
         updateTask?.cancel()
+        do {
+            try await withTimeout(1) { [updateTask] in
+                try await updateTask?.value
+            }
+        } catch is CancellationError {
+        }
+        updateTask = nil
     }
 
     func testUpdateHashPrefixes() async throws {
@@ -308,29 +316,38 @@ class MaliciousSiteProtectionUpdateManagerTests: XCTestCase {
         isScamProtectionSupported = false
         self.updateIntervalProvider = { _ in 0.9 }
 
-        let eHashPrefixesNotUpdated = expectation(description: "Hash prefixes for scam should not be updated")
-        eHashPrefixesNotUpdated.isInverted = true
-
+        // Data for both hash prefixes and filter set should not be updated when scam protection is disabled
         let c1 = await dataManager.publisher(for: .hashPrefixes(threatKind: .scam))
             .dropFirst()
-            .sink { _ in
-                eHashPrefixesNotUpdated.fulfill()
+            .sink { data in
+                XCTFail("Unexpected hash prefixes update received: \(data)")
             }
-
-        let eFilterSetNotUpdated = expectation(description: "Filter set for scam should not be updated")
-        eFilterSetNotUpdated.isInverted = true
 
         let c2 = await dataManager.publisher(for: .filterSet(threatKind: .scam))
             .dropFirst()
-            .sink { _ in
-                eFilterSetNotUpdated.fulfill()
+            .sink { data in
+                XCTFail("Unexpected filter set update received: \(data)")
             }
 
+        // Set up sleep expectations to synchronize with the mock clock
+        var sleepIndex = 0
+        let sleepExpectations = [
+            XCTestExpectation(description: "Will Sleep 1"),
+            XCTestExpectation(description: "Will Sleep 2"),
+        ]
+        self.willSleep = { _ in
+            DispatchQueue.main.async {
+                sleepExpectations[safe: sleepIndex]?.fulfill()
+                sleepIndex += 1
+            }
+        }
+
         updateTask = updateManager.startPeriodicUpdates()
+        await fulfillment(of: [sleepExpectations[0]], timeout: 1)
 
-        try await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
-
-        await fulfillment(of: [eHashPrefixesNotUpdated, eFilterSetNotUpdated], timeout: 1, enforceOrder: false)
+        // Advance the clock to trigger the next sleep interval
+        await self.clock.advance(by: .seconds(1))
+        await fulfillment(of: [sleepExpectations[1]], timeout: 1)
 
         withExtendedLifetime((c1, c2)) {}
     }
@@ -474,7 +491,12 @@ class MaliciousSiteProtectionUpdateManagerTests: XCTestCase {
 
         // Cancel the update task
         updateTask!.cancel()
-        await Task.megaYield(count: 10)
+        do {
+            try await withTimeout(1) { [updateTask=updateTask!] in
+                try await updateTask.value
+            }
+        } catch is CancellationError {
+        }
 
         // Reset expectations for further updates
         let c = await dataManager.$store.dropFirst().sink { data in


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1209019077143944?focus=true

### Description
- Fix testWhenPeriodicUpdatesAreCancelled_noFurtherUpdatesReceived flakiness by awaiting for `Task.value` after the update task cancellation
- Refactor `testWhenPeriodicUpdatesStart_forScam_andFlagOff_dataSetsAreNotUpdated` so it doesn't actually sleeps for 1sec since we're using mock clock in the tests but instead rely on sleep interval expectations

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Validate CI is green
2. Run `MaliciousSiteProtectionUpdateManagerTests` locally for 1000 times (right click the TestCase in the Tests inspector and choose Test repeatedly), validate the tests pass

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
No

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
Nothing

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)