### PR TITLE
[macOS][Tab Previews] Enable rendering content for Duck Player urls

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabSnapshotExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabSnapshotExtension.swift
@@ -173,7 +173,7 @@ final class TabSnapshotExtension {
             return
         }
 
-        guard let snapshot = await webViewSnapshotRenderer.renderSnapshot(webView: webView) else {
+        guard let snapshot = await webViewSnapshotRenderer.renderSnapshot(webView: webView, delay: snapshotDelay(forURL: url)) else {
             return
         }
 
@@ -207,6 +207,12 @@ final class TabSnapshotExtension {
         default:
             true
         }
+    }
+
+    private func snapshotDelay(forURL url: URL) -> TimeInterval {
+        // If DuckPlayer URL delay screenshot rendering to give time to load the video
+        // Otherwise wait a bit to allow super-fast loading pages (e.g. localhost and special pages) get rendered in the webView
+        url.navigationalScheme == .duck && url.host == URL.duckPlayerHost ? 1.0 : 0.1
     }
 }
 

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabSnapshotExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabSnapshotExtension.swift
@@ -154,7 +154,7 @@ final class TabSnapshotExtension {
     func renderWebViewSnapshot() async {
         guard let webView, let tabContent,
               let url = tabContent.userEditableUrl,
-              url.navigationalScheme != .duck || url == .onboarding || url.isHistory else {
+              isAllowedURL(url) else {
             // Previews of native views are rendered in renderNativePreview()
             return
         }
@@ -199,6 +199,15 @@ final class TabSnapshotExtension {
         Logger.tabSnapshots.debug("Snapshot of native page rendered")
     }
 
+    private func isAllowedURL(_ url: URL) -> Bool {
+        // If duck url allow exception only if it's DuckPlayer or Onboarding or History.
+        switch url {
+        case let url where url.navigationalScheme == .duck:
+            url.host == URL.duckPlayerHost || url == .onboarding || url.isHistory
+        default:
+            true
+        }
+    }
 }
 
 extension TabSnapshotExtension: WebViewInteractionEventsDelegate {

--- a/macOS/DuckDuckGo/TabPreview/Model/WebViewSnapshotRenderer.swift
+++ b/macOS/DuckDuckGo/TabPreview/Model/WebViewSnapshotRenderer.swift
@@ -24,22 +24,21 @@ import os.log
 protocol WebViewSnapshotRendering {
 
     @MainActor
-    func renderSnapshot(webView: WKWebView) async -> NSImage?
+    func renderSnapshot(webView: WKWebView, delay: TimeInterval) async -> NSImage?
 
 }
 
 final class WebViewSnapshotRenderer: WebViewSnapshotRendering {
 
     @MainActor
-    func renderSnapshot(webView: WKWebView) async -> NSImage? {
+    func renderSnapshot(webView: WKWebView, delay: TimeInterval) async -> NSImage? {
         dispatchPrecondition(condition: .onQueue(.main))
         Logger.tabSnapshots.debug("Preview rendering started for \(String(describing: webView.url))")
 
         let configuration = WKSnapshotConfiguration.makePreviewSnapshotConfiguration()
 
         do {
-            // Wait a bit to allow super-fast loading pages (e.g. localhost and special pages) get rendered in the webView
-            try? await Task.sleep(nanoseconds: 100000000)
+            try? await Task.sleep(interval: delay)
             let image = try await webView.takeSnapshot(configuration: configuration)
             Logger.tabSnapshots.debug("Preview rendered for \(String(describing: webView.url))")
 

--- a/macOS/UnitTests/TabExtensionsTests/TabSnapshotExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/TabSnapshotExtensionTests.swift
@@ -203,6 +203,78 @@ class TabSnapshotExtensionTests: XCTestCase {
         XCTAssert(mockTabSnapshotStore.persistedSnapshotIDs.count == 0)
     }
 
+    @MainActor
+    func testWhenURLIsDuckPlayerURL_ThenSnapshotIsRendered() async throws {
+        // GIVEN
+        let url = try XCTUnwrap(URL(string: "duck://player/12345"))
+        let webView = WebView(frame: .zero, configuration: WKWebViewConfiguration())
+        mockWebViewPublisher.send(webView)
+        let content = Tab.TabContent.contentFromURL(url, source: .ui)
+        mockContentPublisher.send(content)
+        let snapshot = NSImage()
+        mockWebViewSnapshotRenderer.nextSnapshot = snapshot
+
+        // WHEN
+        await tabSnapshotExtension.renderWebViewSnapshot()
+
+        // THEN
+        XCTAssertEqual(tabSnapshotExtension.snapshot, snapshot)
+    }
+
+    @MainActor
+    func testWhenURLIsOnboardingURL_ThenSnapshotIsRendered() async throws {
+        // GIVEN
+        let url = try XCTUnwrap(URL(string: "duck://onboarding"))
+        let webView = WebView(frame: .zero, configuration: WKWebViewConfiguration())
+        mockWebViewPublisher.send(webView)
+        let content = Tab.TabContent.contentFromURL(url, source: .ui)
+        mockContentPublisher.send(content)
+        let snapshot = NSImage()
+        mockWebViewSnapshotRenderer.nextSnapshot = snapshot
+
+        // WHEN
+        await tabSnapshotExtension.renderWebViewSnapshot()
+
+        // THEN
+        XCTAssertEqual(tabSnapshotExtension.snapshot, snapshot)
+    }
+
+    @MainActor
+    func testWhenURLIsHistoryURL_ThenSnapshotIsRendered() async throws {
+        // GIVEN
+        let url = try XCTUnwrap(URL(string: "duck://history"))
+        let webView = WebView(frame: .zero, configuration: WKWebViewConfiguration())
+        mockWebViewPublisher.send(webView)
+        let content = Tab.TabContent.contentFromURL(url, source: .ui)
+        mockContentPublisher.send(content)
+        let snapshot = NSImage()
+        mockWebViewSnapshotRenderer.nextSnapshot = snapshot
+
+        // WHEN
+        await tabSnapshotExtension.renderWebViewSnapshot()
+
+        // THEN
+        XCTAssertEqual(tabSnapshotExtension.snapshot, snapshot)
+    }
+
+    @MainActor
+    func testWhenURLHasDuckScheme_AndIsNotDuckPlayerOrHistoryOrOnboardingURL_ThenSnapshotIsNotRendered() async throws {
+        // GIVEN
+        let url = try XCTUnwrap(URL(string: "duck://\(#function)"))
+        let webView = WebView(frame: .zero, configuration: WKWebViewConfiguration())
+        mockWebViewPublisher.send(webView)
+        let content = Tab.TabContent.contentFromURL(url, source: .ui)
+        mockContentPublisher.send(content)
+        let snapshot = NSImage()
+        mockWebViewSnapshotRenderer.nextSnapshot = snapshot
+
+        // WHEN
+        await tabSnapshotExtension.renderWebViewSnapshot()
+
+        // THEN
+        XCTAssertNil(tabSnapshotExtension.snapshot)
+    }
+
 }
 
 fileprivate extension URL {

--- a/macOS/UnitTests/TabExtensionsTests/TabSnapshotExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/TabSnapshotExtensionTests.swift
@@ -275,6 +275,39 @@ class TabSnapshotExtensionTests: XCTestCase {
         XCTAssertNil(tabSnapshotExtension.snapshot)
     }
 
+    @MainActor
+    func testWhenURLIsDuckPlayerURL_ThenWait1SecondToRenderSnapshot() async throws {
+        // GIVEN
+        let url = try XCTUnwrap(URL(string: "duck://player/12345"))
+        let webView = WebView(frame: .zero, configuration: WKWebViewConfiguration())
+        mockWebViewPublisher.send(webView)
+        let content = Tab.TabContent.contentFromURL(url, source: .ui)
+        mockContentPublisher.send(content)
+        XCTAssertNil(mockWebViewSnapshotRenderer.lastDelay)
+
+        // WHEN
+        await tabSnapshotExtension.renderWebViewSnapshot()
+
+        // THEN
+        XCTAssertEqual(mockWebViewSnapshotRenderer.lastDelay, 1.0)
+    }
+
+    @MainActor
+    func testWhenURLIsNotDuckPlayerURL_ThenWait1SecondToRenderSnapshot() async throws {
+        // GIVEN
+        let webView = WebView(frame: .zero, configuration: WKWebViewConfiguration())
+        mockWebViewPublisher.send(webView)
+        let content = Tab.TabContent.contentFromURL(URL.aURL, source: .ui)
+        mockContentPublisher.send(content)
+        XCTAssertNil(mockWebViewSnapshotRenderer.lastDelay)
+
+        // WHEN
+        await tabSnapshotExtension.renderWebViewSnapshot()
+
+        // THEN
+        XCTAssertEqual(mockWebViewSnapshotRenderer.lastDelay, 0.1)
+    }
+
 }
 
 fileprivate extension URL {

--- a/macOS/UnitTests/TabPreview/Mocks/MockWebViewSnapshotRenderer.swift
+++ b/macOS/UnitTests/TabPreview/Mocks/MockWebViewSnapshotRenderer.swift
@@ -26,10 +26,12 @@ class MockWebViewSnapshotRenderer: WebViewSnapshotRendering {
 
     var nextSnapshot: NSImage?
     var lastWebView: WKWebView?
+    var lastDelay: TimeInterval?
 
     @MainActor
-    func renderSnapshot(webView: WKWebView) async -> NSImage? {
+    func renderSnapshot(webView: WKWebView, delay: TimeInterval) async -> NSImage? {
         lastWebView = webView
+        lastDelay = delay
         return nextSnapshot
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1210929137641345?focus=true
Tech Design URL:
CC:

### Description

This PR enables tab previews for DuckPlayer. Previously, tab previews were not rendering the content of DuckPlayer tabs because we were blocking all URLs with the 'duck' scheme, allowing only onboarding and history exceptions. I have now included DuckPlayer URLs as well.

**Screenshots**
<img width="1166" height="851" alt="Screenshot 2025-08-01 at 2 18 00 pm" src="https://github.com/user-attachments/assets/36077da5-3722-4cd5-9c4c-f359512a0baf" />

### Testing Steps
1. Load Youtube in the browser.
2. Select a video and choose to open in DuckPlayer.
3. Wait for the video to load.
4. Change Tab and hover DuckPlayer tab.
5. Ensure the Tab preview is displaying and the content of DuckPlayer. 

### Impact and Risks
Low: DuckPlayer previews are not currently displaying player content. 

#### What could go wrong?
The delay set for capturing a snapshot of the tab content for DuckPlayer URLs may not be long enough for videos that take a significant amount of time to load. If this happens, the DuckPlayer preview may display a black video player instead of the actual content.
The old behaviour will still apply as a safety net; if the users interact with the webview we will take another screenshot to ensure the content is accurately captured.

### Quality Considerations
I've written unit tests to ensure that the current logic functions correctly and to validate the new behavior.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)