### PR TITLE
Mitigate chances of showing no release notes

### DIFF
--- a/macOS/DuckDuckGo/Updates/UpdateController.swift
+++ b/macOS/DuckDuckGo/Updates/UpdateController.swift
@@ -186,6 +186,10 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
 
         _ = try? configureUpdater()
 
+        // Proactively check for update information to ensure release notes are available
+        // This helps prevent the "no release notes" issue when caching logic prevents normal update checks
+        updater?.checkForUpdateInformation()
+
 #if DEBUG
         if NSApp.delegateTyped.featureFlagger.isFeatureOn(.autoUpdateInDEBUG) {
             checkForUpdateRespectingRollout()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1210940767613141?focus=true

### Description

Mitigate chances of showing no release notes.  This is a tentative improvement.

### Testing Steps

No reproduction steps are known, this is a tentative improvement.
Starting the app without a connection will show no release notes - this is a pre-existing issue this PR won't fix.
Please review the logic makes sense.

### Impact and Risks

Low.

#### What could go wrong?

NA

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)