### PR TITLE
Reload Search Input's input views only after text change

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -157,7 +157,6 @@ class SwitchBarTextEntryView: UIView {
             textView.spellCheckingType = .default
         }
 
-        textView.reloadInputViews()
         updatePlaceholderVisibility()
         updateButtonState()
         updateTextViewHeight()
@@ -281,6 +280,8 @@ extension SwitchBarTextEntryView: UITextViewDelegate {
         updateTextViewHeight()
         handler.updateCurrentText(textView.text ?? "")
         handler.markUserInteraction()
+
+        textView.reloadInputViews()
     }
 
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1210916875279073?focus=true
Tech Design URL:
CC:

### Description

Prevents showing unpopulated predictive text suggestions and in the same time prevents Dax logo from jumping up during mode toggle.

### Testing Steps
1. Enable Search Input under AI Features settings.
2. Enter Search Input and toggle back and forth between two modes. Verify y location is not changing when doing that.
3. Type anything and switch to other mode, do any interaction with the text view (e.g. change caret position). Verify the accessoryView is updated to a proper value, which is no suggestions for Search, suggestions for Duck.ai.
4. Repeat pt 3 starting with other mode.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Suggestions are not working as expected or not visible when then should be.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)