### PR TITLE
[iOS][new search input] fix bug to show RMF when there's no favorites

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
@@ -64,8 +64,9 @@ final class SuggestionTrayManager: NSObject {
 
     var shouldDisplayFavoritesOverlay: Bool {
         let canDisplayFavorites = suggestionTrayViewController?.canShow(for: .favorites) ?? false
+        let hasRemoteMessages = suggestionTrayViewController?.hasRemoteMessages ?? false
 
-        return !shouldDisplaySuggestionTray && canDisplayFavorites
+        return !shouldDisplaySuggestionTray && (canDisplayFavorites || hasRemoteMessages)
     }
 
     var shouldDisplaySuggestionTray: Bool {
@@ -189,7 +190,9 @@ final class SuggestionTrayManager: NSObject {
     private func showSuggestionTray(_ type: SuggestionTrayViewController.SuggestionType) {
         guard let suggestionTray = suggestionTrayViewController else { return }
         
-        let canShowSuggestion = suggestionTray.canShow(for: type)
+        let canShowSuggestion =
+            suggestionTray.canShow(for: type) ||
+            (type == .favorites && suggestionTray.hasRemoteMessages)
 
         if canShowSuggestion {
             suggestionTray.fill()

--- a/iOS/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/iOS/DuckDuckGo/SuggestionTrayViewController.swift
@@ -255,7 +255,12 @@ class SuggestionTrayViewController: UIViewController {
     private var canDisplayFavorites: Bool {
         favoritesModel.favorites.count > 0
     }
-    
+
+    var hasRemoteMessages: Bool {
+        guard let newTabPageDependencies else { return false }
+        return !newTabPageDependencies.homePageMessagesConfiguration.homeMessages.isEmpty
+    }
+
     private func displayFavoritesIfNeeded(animated: Bool, onInstall: @escaping () -> Void = {}) {
         if isUsingSearchInputCustomStyling && newTabPage == nil {
             installNewTabPage(animated: animated, onInstall: onInstall)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1210957466937448?focus=true
Tech Design URL:
CC:

### Description
RMF would only show on new input when there were favourites.  Use this config https://gist.githubusercontent.com/amddg44/1977131b538d02d25e980d135a304f2a/raw/387b82315639443133a10599f475de088244007d/gistfile1.json

### Testing Steps
1. Use the following confirm and ensure RMF shows on New tab page
3. Make sure no favorites
2. Enable the new input 
4. Ensure the RMF shows when tapping on the address bar

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)