### PR TITLE
make subscription rebranding message semibold

### DIFF
--- a/iOS/DuckDuckGo/SettingsCell.swift
+++ b/iOS/DuckDuckGo/SettingsCell.swift
@@ -143,36 +143,38 @@ struct SettingsCellView: View, Identifiable {
     private var defaultView: some View {
         Group {
             HStack(alignment: .center) {
-                HStack(alignment: .top) {
-                    // Image
-                    if let image {
-                        if isGreyedOut {
-                            image
-                                .padding(.top, -2)
-                                .saturation(0)
-                                .opacity(0.5)
-                        } else {
-                            image
-                                .padding(.top, -2)
+                HStack(alignment: .center) {
+                    HStack(alignment: .top) {
+                        // Image
+                        if let image {
+                            if isGreyedOut {
+                                image
+                                    .padding(.top, -2)
+                                    .saturation(0)
+                                    .opacity(0.5)
+                            } else {
+                                image
+                                    .padding(.top, -2)
+                            }
                         }
-                    }
-                    VStack(alignment: .leading) {
-                        // Title
-                        Text(label)
-                            .daxBodyRegular()
-                            .foregroundColor(Color(designSystemColor: isGreyedOut == true ? .textSecondary : .textPrimary))
-                        // Subtitle
-                        if let subtitleText = subtitle {
-                            Text(subtitleText)
-                                .daxFootnoteRegular()
-                                .foregroundColor(Color(designSystemColor: .textSecondary))
-                        }
-                    }.fixedSize(horizontal: false, vertical: true)
-                        .layoutPriority(0.7)
+                        VStack(alignment: .leading) {
+                            // Title
+                            Text(label)
+                                .daxBodyRegular()
+                                .foregroundColor(Color(designSystemColor: isGreyedOut == true ? .textSecondary : .textPrimary))
+                            // Subtitle
+                            if let subtitleText = subtitle {
+                                Text(subtitleText)
+                                    .daxFootnoteRegular()
+                                    .foregroundColor(Color(designSystemColor: .textSecondary))
+                            }
+                        }.fixedSize(horizontal: false, vertical: true)
+                            .layoutPriority(0.7)
+                    }.scaledToFit()
                     if isNew {
                         BadgeView(text: UserText.settingsItemNewBadge)
                     }
-                }.scaledToFit()
+                }
 
                 Spacer(minLength: 8)
 

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
@@ -694,7 +694,9 @@ struct SubscriptionSettingsViewV2: View {
         if viewModel.showRebrandingMessage {
             HStack(alignment: .top) {
                 Text(UserText.subscriptionRebrandingMessage)
-                    .font(.headline)
+                    .font(
+                        Font(uiFont: UIFont.daxSubheadSemibold())
+                    )
                 Spacer()
                 Button(action: {
                     viewModel.dismissRebrandingMessage()
@@ -703,6 +705,7 @@ struct SubscriptionSettingsViewV2: View {
                         .foregroundColor(.secondary)
                 }
             }
+            .padding(.vertical, 2)
         }
     }
 

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
@@ -484,10 +484,9 @@ struct SubscriptionSettingsViewV2: View {
             if let email = viewModel.state.subscriptionEmail, !email.isEmpty {
                 SettingsCellView(label: UserText.subscriptionEditEmailButton,
                                  subtitle: email,
-                                 disclosureIndicator: true)
-                .onTapGesture {
-                    isShowingManageEmailView = true
-                }
+                                 action: { isShowingManageEmailView = true },
+                                 disclosureIndicator: true,
+                                 isButton: true)
             }
 
             SettingsCustomCell(content: {

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
@@ -39,7 +39,6 @@ struct SubscriptionSettingsView: View {
     @StateObject var settingsViewModel: SettingsViewModel
     @EnvironmentObject var subscriptionNavigationCoordinator: SubscriptionNavigationCoordinator
     var viewPlans: (() -> Void)?
-
     @State var isShowingStripeView = false
     @State var isShowingGoogleView = false
     @State var isShowingRemovalNotice = false
@@ -123,7 +122,7 @@ struct SubscriptionSettingsView: View {
                     .foregroundColor(Color.init(designSystemColor: .accent)) },
                                    disclosureIndicator: false)
             }.isDetailLink(false)
-        }
+        }.listRowBackground(Color(designSystemColor: .surface))
     }
 
     private var devicesSectionFooter: some View {

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
@@ -702,6 +702,7 @@ struct SubscriptionSettingsViewV2: View {
                 }),
             isActive: $isShowingManageEmailView
         ) { EmptyView() }
+            .isDetailLink(false)
             .hidden()
 
         NavigationLink(
@@ -718,6 +719,7 @@ struct SubscriptionSettingsViewV2: View {
                 }),
             isActive: $isShowingActivationView
         ) { EmptyView() }
+            .isDetailLink(false)
             .hidden()
 
         NavigationLink(destination: SubscriptionGoogleView(),

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
@@ -39,7 +39,7 @@ struct SubscriptionSettingsView: View {
     @StateObject var settingsViewModel: SettingsViewModel
     @EnvironmentObject var subscriptionNavigationCoordinator: SubscriptionNavigationCoordinator
     var viewPlans: (() -> Void)?
-    
+
     @State var isShowingStripeView = false
     @State var isShowingGoogleView = false
     @State var isShowingRemovalNotice = false
@@ -123,7 +123,7 @@ struct SubscriptionSettingsView: View {
                     .foregroundColor(Color.init(designSystemColor: .accent)) },
                                    disclosureIndicator: false)
             }.isDetailLink(false)
-        }.listRowBackground(Color(designSystemColor: .surface))
+        }
     }
 
     private var devicesSectionFooter: some View {
@@ -302,10 +302,10 @@ struct SubscriptionSettingsView: View {
         }.hidden()
 
         NavigationLink(destination: UnifiedFeedbackRootView(viewModel: UnifiedFeedbackFormViewModel(subscriptionManager: AppDependencyProvider.shared.subscriptionAuthV1toV2Bridge,
-                                                                                                    apiService: DefaultAPIService(),
-                                                                                                    vpnMetadataCollector: DefaultVPNMetadataCollector(),
-                                                                                                    isPaidAIChatFeatureEnabled: { settingsViewModel.subscriptionFeatureAvailability.isPaidAIChatEnabled },
-                                                                                                    source: .ppro)),
+                                                                                                apiService: DefaultAPIService(),
+                                                                                                vpnMetadataCollector: DefaultVPNMetadataCollector(),
+                                                                                                isPaidAIChatFeatureEnabled: { settingsViewModel.subscriptionFeatureAvailability.isPaidAIChatEnabled },
+                                                                                                source: .ppro)),
                        isActive: $isShowingSupportView) {
             EmptyView()
         }.hidden()
@@ -483,41 +483,20 @@ struct SubscriptionSettingsViewV2: View {
                 footer: devicesSectionFooter) {
 
             if let email = viewModel.state.subscriptionEmail, !email.isEmpty {
-                NavigationLink(destination: SubscriptionContainerViewFactory.makeEmailFlowV2(
-                    navigationCoordinator: subscriptionNavigationCoordinator,
-                    subscriptionManager: AppDependencyProvider.shared.subscriptionManagerV2!,
-                    subscriptionFeatureAvailability: settingsViewModel.subscriptionFeatureAvailability,
-                    internalUserDecider: AppDependencyProvider.shared.internalUserDecider,
-                    emailFlow: .manageEmailFlow,
-                    onDisappear: {
-                        Task {
-                            await viewModel.fetchAndUpdateAccountEmail(cachePolicy: .remoteFirst)
-                        }
-                    }),
-                               isActive: $isShowingManageEmailView) {
-                    SettingsCellView(label: UserText.subscriptionEditEmailButton,
-                                     subtitle: email)
-                }.isDetailLink(false)
+                SettingsCellView(label: UserText.subscriptionEditEmailButton,
+                                 subtitle: email,
+                                 disclosureIndicator: true)
+                .onTapGesture {
+                    isShowingManageEmailView = true
+                }
             }
 
-            NavigationLink(destination: SubscriptionContainerViewFactory.makeEmailFlowV2(
-                navigationCoordinator: subscriptionNavigationCoordinator,
-                subscriptionManager: AppDependencyProvider.shared.subscriptionManagerV2!,
-                subscriptionFeatureAvailability: settingsViewModel.subscriptionFeatureAvailability,
-                internalUserDecider: AppDependencyProvider.shared.internalUserDecider,
-                emailFlow: .activationFlow,
-                onDisappear: {
-                    Task {
-                        await viewModel.fetchAndUpdateAccountEmail(cachePolicy: .remoteFirst)
-                    }
-                }),
-                           isActive: $isShowingActivationView) {
-                SettingsCustomCell(content: {
-                    Text(UserText.subscriptionAddToDeviceButton)
-                        .daxBodyRegular()
-                    .foregroundColor(Color.init(designSystemColor: .accent)) },
-                                   disclosureIndicator: false)
-            }.isDetailLink(false)
+            SettingsCustomCell(content: {
+                Text(UserText.subscriptionAddToDeviceButton)
+                    .daxBodyRegular()
+                    .foregroundColor(Color.init(designSystemColor: .accent))
+            }, action: { isShowingActivationView = true },
+                               disclosureIndicator: true, isButton: true)
         }
     }
 
@@ -711,6 +690,38 @@ struct SubscriptionSettingsViewV2: View {
 
     @ViewBuilder
     private var optionsView: some View {
+        NavigationLink(
+            destination: SubscriptionContainerViewFactory.makeEmailFlowV2(
+                navigationCoordinator: subscriptionNavigationCoordinator,
+                subscriptionManager: AppDependencyProvider.shared.subscriptionManagerV2!,
+                subscriptionFeatureAvailability: settingsViewModel.subscriptionFeatureAvailability,
+                internalUserDecider: AppDependencyProvider.shared.internalUserDecider,
+                emailFlow: .manageEmailFlow,
+                onDisappear: {
+                    Task {
+                        await viewModel.fetchAndUpdateAccountEmail(cachePolicy: .remoteFirst)
+                    }
+                }),
+            isActive: $isShowingManageEmailView
+        ) { EmptyView() }
+            .hidden()
+
+        NavigationLink(
+            destination: SubscriptionContainerViewFactory.makeEmailFlowV2(
+                navigationCoordinator: subscriptionNavigationCoordinator,
+                subscriptionManager: AppDependencyProvider.shared.subscriptionManagerV2!,
+                subscriptionFeatureAvailability: settingsViewModel.subscriptionFeatureAvailability,
+                internalUserDecider: AppDependencyProvider.shared.internalUserDecider,
+                emailFlow: .activationFlow,
+                onDisappear: {
+                    Task {
+                        await viewModel.fetchAndUpdateAccountEmail(cachePolicy: .remoteFirst)
+                    }
+                }),
+            isActive: $isShowingActivationView
+        ) { EmptyView() }
+            .hidden()
+
         NavigationLink(destination: SubscriptionGoogleView(),
                        isActive: $isShowingGoogleView) {
             EmptyView()


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1210964598062836?focus=true

### Description Makes the Rebranding message semibold

### Testing Steps
1. Turn SubscriptionRebranding feature flag on
2. Go to Subscription settings and check the rebranding message appears semibold (Igor checked and approved the ship review)
3. Check Edit email and add to device look like the other cell (Igor checked and approved the ship review)
4. Test both link work
5. Check duck.ai “New” badge is centered (Igor checked and approved the ship review)

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)