### PR TITLE
Remove flaky DuckPlayer tests

### DIFF
--- a/iOS/DuckDuckGoTests/DuckPlayer/DuckPlayerNativeUIPresenterTests.swift
+++ b/iOS/DuckDuckGoTests/DuckPlayer/DuckPlayerNativeUIPresenterTests.swift
@@ -1900,52 +1900,6 @@ final class DuckPlayerNativeUIPresenterTests: XCTestCase {
     }
 
     @MainActor
-    func testRoundedPageSheetDismissal_TriggersReEntryPill() {
-        // Given
-        let videoID = "test123"
-        let source: DuckPlayer.VideoNavigationSource = .youtube
-        let timestamp: TimeInterval = 30
-        mockDuckPlayerSettings.welcomeMessageShown = true
-        mockDuckPlayerSettings.primingMessagePresented = true
-
-        // Present the DuckPlayer
-        _ = sut.presentDuckPlayer(
-            videoID: videoID,
-            source: source,
-            in: mockHostViewController,
-            title: nil,
-            timestamp: timestamp
-        )
-
-        // Verify initial state
-        XCTAssertTrue(sut.state.hasBeenShown, "State should indicate DuckPlayer has been shown")
-        XCTAssertNil(sut.containerViewController, "Pill container should not exist while DuckPlayer is shown")
-
-        // Ensure hostView reference is maintained
-        XCTAssertNotNil(sut.hostView, "Host view should be maintained")
-
-        // When - Simulate DuckPlayer dismissal by triggering the dismiss publisher
-        guard let playerViewModel = sut.playerViewModel else {
-            XCTFail("Player view model should exist")
-            return
-        }
-
-        // Simulate the view disappearing and dismiss publisher firing
-        playerViewModel.dismissPublisher.send(timestamp)
-        
-        // Wait for pill presentation using helper method
-        waitForCondition(
-            condition: { [weak sut] in sut?.containerViewController != nil },
-            description: "Pill should be presented after dismissal"
-        )
-
-        // Then - Should present re-entry pill 
-        XCTAssertNotNil(sut.containerViewController, "Pill container should be created after dismissal")
-        XCTAssertEqual(sut.state.timestamp, timestamp, "State should preserve the timestamp")
-        XCTAssertTrue(sut.duckPlayerSettings.welcomeMessageShown, "Welcome message should be marked as shown")
-    }
-
-    @MainActor
     func testDuckPlayerDismissal_UpdatesStateAndSettings() {
         // Given
         let videoID = "test123"

--- a/iOS/DuckDuckGoTests/DuckPlayer/DuckPlayerViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/DuckPlayer/DuckPlayerViewModelTests.swift
@@ -276,40 +276,6 @@ final class DuckPlayerViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testHandleYouTubeNavigation_SameVideo_NoPublisherEvents() {
-        // Given
-        let sameVideoURL = URL(string: "https://www.youtube.com/watch?v=\(viewModel.videoID)")!
-        var dismissPublisherFired = false
-        var navigationPublisherFired = false
-
-        // Subscribe to both publishers to ensure neither fires
-        viewModel.dismissPublisher
-            .sink { _ in
-                dismissPublisherFired = true
-            }
-            .store(in: &cancellables)
-            
-        viewModel.youtubeNavigationRequestPublisher
-            .sink { _ in
-                navigationPublisherFired = true
-            }
-            .store(in: &cancellables)
-
-        // When
-        viewModel.handleYouTubeNavigation(sameVideoURL)
-
-        // Then - Wait a brief moment to ensure no publishers fire
-        let expectation = XCTestExpectation(description: "Brief wait")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 0.2)
-        
-        XCTAssertFalse(dismissPublisherFired, "Dismiss publisher should not fire for same video")
-        XCTAssertFalse(navigationPublisherFired, "Navigation publisher should not fire for same video")
-    }
-
-    @MainActor
     func testHandleYouTubeNavigation_DifferentVideo_SendsNavigationRequest() {
         // Given
         let differentVideoURL = URL(string: "https://www.youtube.com/watch?v=differentVideoID")!


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204099484721401/task/1210917586418509?focus=true
Tech Design URL: N/A
CC: N/A

### Description
Removed two flaky tests from the DuckPlayer test suite to improve test reliability:
- `testRoundedPageSheetDismissal_TriggersReEntryPill` from DuckPlayerNativeUIPresenterTests
- `testHandleYouTubeNavigation_SameVideo_NoPublisherEvents` from DuckPlayerViewModelTests

### Testing Steps
CI should be 🥬 

### Impact and Risks
**Impact Level: None**

