### PR TITLE
Fix X on rebranding message and adjust new badge

### DIFF
--- a/macOS/DuckDuckGo/Preferences/View/PreferencesSidebar.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesSidebar.swift
@@ -70,7 +70,7 @@ extension Preferences {
 
         var body: some View {
             Button(action: action) {
-                HStack(spacing: 6) {
+                HStack(alignment: .center, spacing: 6) {
                     Image(nsImage: pane.preferenceIconName(for: settingsIconProvider, isSubscriptionRebrandingOn: isSubscriptionRebrandingOn))
                         .frame(width: 16, height: 16)
                         .if(!isEnabled) {
@@ -83,7 +83,7 @@ extension Preferences {
                         }
 
                     if isNew {
-                        BadgeView(text: UserText.newBadge.uppercased())
+                        NewBadgeView()
                     }
 
                     Spacer()
@@ -100,6 +100,18 @@ extension Preferences {
             .buttonStyle(SidebarItemButtonStyle(isSelected: isSelected))
             .accessibilityIdentifier("PreferencesSidebar.\(pane.id.rawValue)Button")
             .disabled(!isEnabled)
+        }
+    }
+
+    struct NewBadgeView: View {
+        var body: some View {
+            Text(UserText.newBadge.uppercased())
+                .font(.custom("SFProText-Bold", size: 11))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 2)
+                .background(Color(designSystemColor: .alertYellow))
+                .foregroundColor(.black)
+                .cornerRadius(4)
         }
     }
 

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesSidebar.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesSidebar.swift
@@ -106,7 +106,7 @@ extension Preferences {
     struct NewBadgeView: View {
         var body: some View {
             Text(UserText.newBadge.uppercased())
-                .font(.custom("SFProText-Bold", size: 11))
+                .font(.system(size: 11, weight: .bold))
                 .padding(.horizontal, 8)
                 .padding(.vertical, 2)
                 .background(Color(designSystemColor: .alertYellow))

--- a/macOS/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/Resources/Subscription.xcassets/Icons/Close-16.imageset/Contents.json
+++ b/macOS/LocalPackages/SubscriptionUI/Sources/SubscriptionUI/Resources/Subscription.xcassets/Icons/Close-16.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1210977456754447?focus=true

### Description

### Testing Steps
1. Make sure paidAiChat and subscriptionRebranding feature flags are on
2. Test the app in dark mode and in Subscription Settings and check the X of the rebranding message is visible
3. Check the New badge next to Duck.ai in settings items is like in https://www.figma.com/design/uLcRB1C1ifps7pwQv6Mnkb/Subscription-Settings---Rename-from-Privacy-Pro-to-DuckDuckGo-Subscription?node-id=0-1&p=f&m=dev 
Note: Stephen has already looked at screenshots and said they are ok

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)