### PR TITLE
Revert "Fix Duck Player audio continuing in background tabs"

### DIFF
--- a/iOS/DuckDuckGo/DuckPlayer/WebUI/WebDuckPlayerNavigationHandler.swift
+++ b/iOS/DuckDuckGo/DuckPlayer/WebUI/WebDuckPlayerNavigationHandler.swift
@@ -1050,22 +1050,14 @@ extension WebDuckPlayerNavigationHandler: DuckPlayerNavigationHandling {
     ///
     /// - Parameter hostViewController: The `TabViewController` to set as the host.
     func updateDuckPlayerForWebViewAppearance(_ hostViewController: TabViewController) {
-        guard let webView = hostViewController.webView else { return }
-        
-        // Resume media playback capability when tab appears (user switches back to tab)
-        // This allows media to play again when the tab becomes active
-        webView.setAllMediaPlaybackSuspended(false) { }
+        // NOOP
     }
 
     /// Update DuckPlayer for WebView Disappearance
     ///
     /// - Parameter hostViewController: The `TabViewController` to set as the host.
     func updateDuckPlayerForWebViewDisappearance(_ hostViewController: TabViewController) {
-        guard let webView = hostViewController.webView else { return }
-        
-        // Pause all media playback when tab disappears (user switches to another tab)
-        // This matches normal browser behavior where background tabs pause media
-        webView.setAllMediaPlaybackSuspended(true) { }
+        // NOOP
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210379416433601/task/1210922940139837?focus=true

## Description
This PR reverts the changes from #1310 that prevented Duck Player audio from continuing in background tabs.

## What changed?
- Removed media playback suspension when tabs become inactive
- Removed media playback resumption when tabs become active  
- Reverted `WebDuckPlayerNavigationHandler.swift` to allow audio to continue playing when switching between tabs

## Why?
The previous implementation that paused media when switching tabs was causing issues with the intended Duck Player experience. Users expect audio to continue playing in background tabs, similar to standard web video players.

## Testing:
Make sure CI is green.  No new functionality added.

--
