### PR TITLE
Use external feature flag for experimental address bar

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -194,6 +194,9 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
 
     // Adds capability to load AI Chat in a sidebar
     case sidebar
+
+    /// Experimental address bar with duck.ai
+    case experimentalAddressBar
 }
 
 public enum NetworkProtectionSubfeature: String, Equatable, PrivacySubfeature {

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -102,10 +102,8 @@ public enum FeatureFlag: String {
     case june2025TabManagerLayoutChanges
 
     /// https://app.asana.com/1/137249556945/project/72649045549333/task/1210055762484807?focus=true
-    case experimentalAIChat
-
     /// https://app.asana.com/1/137249556945/task/1210496258241813
-    case experimentalSwitcherBarTransition
+    case experimentalAIChat
 
     /// https://app.asana.com/1/137249556945/task/1210139454006070
     case privacyProOnboardingPromotion
@@ -197,7 +195,6 @@ extension FeatureFlag: FeatureFlagDescribing {
              .paidAIChat,
              .canInterceptSyncSetupUrls,
              .exchangeKeysToSyncWithAnotherDevice,
-             .experimentalSwitcherBarTransition,
              .subscriptionRebranding,
              .june2025TabManagerLayoutChanges,
              .canPromoteImportPasswordsInPasswordManagement,
@@ -313,9 +310,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .june2025TabManagerLayoutChanges:
             return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.june2025TabManagerLayoutChanges))
         case .experimentalAIChat:
-            return .internalOnly()
-        case .experimentalSwitcherBarTransition:
-            return .internalOnly()
+            return .remoteReleasable(.subfeature(AIChatSubfeature.experimentalAddressBar))
         case .privacyProOnboardingPromotion:
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.privacyProOnboardingPromotion))
         case .syncSetupBarcodeIsUrlBased:

--- a/iOS/DuckDuckGo/AIChat/AIChatSettings.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatSettings.swift
@@ -119,7 +119,7 @@ struct AIChatSettings: AIChatSettingsProvider {
     }
 
     var isAIChatSearchInputUserSettingsEnabled: Bool {
-        userDefaults.showAIChatSearchInputInternal && isAIChatEnabled && featureFlagger.isFeatureOn(.experimentalSwitcherBarTransition)
+        userDefaults.showAIChatExperimentalSearchInput && isAIChatEnabled && featureFlagger.isFeatureOn(.experimentalAIChat)
     }
 
     func enableAIChat(enable: Bool) {
@@ -156,7 +156,7 @@ struct AIChatSettings: AIChatSettingsProvider {
     }
 
     func enableAIChatSearchInputUserSettings(enable: Bool) {
-        userDefaults.showAIChatSearchInputInternal = enable
+        userDefaults.showAIChatExperimentalSearchInput = enable
         triggerSettingsChangedNotification()
 
         if enable {
@@ -210,9 +210,7 @@ private extension UserDefaults {
         static let showAIChatAddressBar = "aichat.settings.showAIChatAddressBar"
         static let showAIChatVoiceSearch = "aichat.settings.showAIChatVoiceSearch"
         static let showAIChatTabSwitcher = "aichat.settings.showAIChatTabSwitcher"
-
-        /// We are using a specific flag for internal purposes because when we ship this to external users, the default value will be different, and we don't want to set the default before the feature is ready
-        static let showAIChatSearchInputInternal = "aichat.settings.showAIChatSearchInputInternal"
+        static let showAIChatExperimentalSearchInput = "aichat.settings.showAIChatExperimentalSearchInput"
     }
 
     static let isAIChatEnabledDefaultValue = true
@@ -220,7 +218,7 @@ private extension UserDefaults {
     static let showAIChatAddressBarDefaultValue = true
     static let showAIChatVoiceSearchDefaultValue = true
     static let showAIChatTabSwitcherDefaultValue = true
-    static let showAIChatSearchInputDefaultValueInternal = false
+    static let showAIChatExperimentalSearchInputDefaultValue = false
 
     @objc dynamic var isAIChatEnabled: Bool {
         get {
@@ -266,14 +264,14 @@ private extension UserDefaults {
         }
     }
 
-    @objc dynamic var showAIChatSearchInputInternal: Bool {
+    @objc dynamic var showAIChatExperimentalSearchInput: Bool {
         get {
-            value(forKey: Keys.showAIChatSearchInputInternal) as? Bool ?? Self.showAIChatSearchInputDefaultValueInternal
+            value(forKey: Keys.showAIChatExperimentalSearchInput) as? Bool ?? Self.showAIChatExperimentalSearchInputDefaultValue
         }
 
         set {
-            guard newValue != showAIChatSearchInputInternal else { return }
-            set(newValue, forKey: Keys.showAIChatSearchInputInternal)
+            guard newValue != showAIChatExperimentalSearchInput else { return }
+            set(newValue, forKey: Keys.showAIChatExperimentalSearchInput)
         }
     }
 

--- a/iOS/DuckDuckGo/AIChat/ExperimentalAIChatManager.swift
+++ b/iOS/DuckDuckGo/AIChat/ExperimentalAIChatManager.swift
@@ -33,11 +33,7 @@ struct ExperimentalAIChatManager {
     }
 
     var isExperimentalAIChatFeatureFlagEnabled: Bool {
-        featureFlagger.isFeatureOn(for: FeatureFlag.experimentalAIChat)
-    }
-
-    var isExperimentalTransitionEnabled: Bool {
-        featureFlagger.isFeatureOn(for: FeatureFlag.experimentalSwitcherBarTransition, allowOverride: true)
+        featureFlagger.isFeatureOn(for: FeatureFlag.experimentalAIChat, allowOverride: true)
     }
 
     var isExperimentalAIChatSettingsEnabled: Bool {
@@ -54,6 +50,6 @@ struct ExperimentalAIChatManager {
     }
 
     mutating func toggleExperimentalTransition() {
-        featureFlagger.localOverrides?.toggleOverride(for: FeatureFlag.experimentalSwitcherBarTransition)
+        featureFlagger.localOverrides?.toggleOverride(for: FeatureFlag.experimentalAIChat)
     }
 }

--- a/iOS/DuckDuckGo/SettingsState.swift
+++ b/iOS/DuckDuckGo/SettingsState.swift
@@ -65,7 +65,6 @@ struct SettingsState {
     var addressBar: AddressBar
     var showsFullURL: Bool
     var isExperimentalAIChatEnabled: Bool
-    var isExperimentalAIChatTransitionEnabled: Bool
 
     // Privacy properties
     var sendDoNotSell: Bool
@@ -125,7 +124,6 @@ struct SettingsState {
             addressBar: AddressBar(enabled: false, position: .top),
             showsFullURL: false,
             isExperimentalAIChatEnabled: false,
-            isExperimentalAIChatTransitionEnabled: false,
             sendDoNotSell: true,
             autoconsentEnabled: false,
             autoclearDataEnabled: false,

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -570,7 +570,6 @@ extension SettingsViewModel {
             addressBar: SettingsState.AddressBar(enabled: !isPad, position: appSettings.currentAddressBarPosition),
             showsFullURL: appSettings.showFullSiteAddress,
             isExperimentalAIChatEnabled: experimentalAIChatManager.isExperimentalAIChatSettingsEnabled,
-            isExperimentalAIChatTransitionEnabled: experimentalAIChatManager.isExperimentalTransitionEnabled,
             sendDoNotSell: appSettings.sendDoNotSell,
             autoconsentEnabled: appSettings.autoconsentEnabled,
             autoclearDataEnabled: AutoClearSettingsModel(settings: appSettings) != nil,
@@ -1302,15 +1301,6 @@ extension SettingsViewModel {
             set: { _ in
                 self.experimentalAIChatManager.toggleExperimentalTheming()
                 self.state.isExperimentalAIChatEnabled = self.experimentalAIChatManager.isExperimentalAIChatSettingsEnabled
-            })
-    }
-
-    var aiChatExperimentalTransitionBinding: Binding<Bool> {
-        Binding<Bool>(
-            get: { self.state.isExperimentalAIChatTransitionEnabled },
-            set: { _ in
-                self.experimentalAIChatManager.toggleExperimentalTransition()
-                self.state.isExperimentalAIChatTransitionEnabled = self.experimentalAIChatManager.isExperimentalTransitionEnabled
             })
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1210947460017660?focus=true
Tech Design URL:
CC:

### Description
Use external feature flag for experimental address bar

### Testing Steps
1. The new config should be published, but in case it's not, use [this](https://duckduckgo.github.io/privacy-configuration/pr-3548/v4/ios-config.json) for testing
2. Open the app as external user, make sure the experimental address bar under AI Features is not visible
3. Make sure that tapping the omnibar brings the current production address bar experience
4. Set yourself as internal user, make sure the experimental address bar under AI Features is visible and **disabled**
5. Make sure that tapping the omnibar brings the current production address bar experience
6. Enable the settings and make sure that tapping the omnibar brings the new address bar experience

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)