### PR TITLE
Fire pixel with settings status

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1263,6 +1263,7 @@ extension Pixel {
         case aiChatMetricOpenMostRecentHistoryChat
         case aiChatMetricSentPromptOngoingChat
         case aiChatInternalSwitchBarDisplayed
+        case aiChatExperimentalAddressBarIsEnabledDaily
 
         // MARK: Lifecycle
         case appDidTransitionToUnexpectedState
@@ -2475,6 +2476,7 @@ extension Pixel.Event {
         case .aiChatMetricOpenMostRecentHistoryChat: return "m_aichat_open_most_recent_history_chat"
         case .aiChatMetricSentPromptOngoingChat: return "m_aichat_sent_prompt_ongoing_chat"
         case .aiChatInternalSwitchBarDisplayed: return "m_aichat_internal_switch_bar_displayed"
+        case .aiChatExperimentalAddressBarIsEnabledDaily: return "m_aichat_experimental_address_bar_is_enabled_daily"
 
         // MARK: Lifecycle
         case .appDidTransitionToUnexpectedState: return "m_debug_app-did-transition-to-unexpected-state-4"

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -435,11 +435,22 @@ class MainViewController: UIViewController {
         if DaxDialogs.shared.shouldShowFireButtonPulse {
             showFireButtonPulse()
         }
+
+        fireExperimentalAddressBarPixel()
     }
 
     override func performSegue(withIdentifier identifier: String, sender: Any?) {
         assertionFailure()
         super.performSegue(withIdentifier: identifier, sender: sender)
+    }
+
+    private func fireExperimentalAddressBarPixel() {
+        let isEnabledParam = "is_enabled"
+        let isEnableValue = "\(aiChatSettings.isAIChatSearchInputUserSettingsEnabled)"
+
+        DailyPixel.fireDaily(.aiChatExperimentalAddressBarIsEnabledDaily,
+                             withAdditionalParameters: [isEnabledParam: isEnableValue])
+        
     }
 
     private func installSwipeTabs() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1210948199732010?focus=true 

### Description
Add daily pixel for experimental bar
Triage done [here](https://app.asana.com/1/137249556945/project/69071770703008/task/1210952435072843?focus=true)

### Testing Steps
1. Run app with the experimental address bar enabled, check if the pixel fire with the param as true
2. Run app with the experimental address bar enabled, check if the pixel fire with the param as false

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Not send the pixel or send the pixel multiple times