### PR TITLE
Fix the iOS debug menu's Configuration Info ETag viewer

### DIFF
--- a/iOS/DuckDuckGo/ConfigurationDebugViewController.swift
+++ b/iOS/DuckDuckGo/ConfigurationDebugViewController.swift
@@ -134,6 +134,7 @@ class ConfigurationDebugViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
+        cell.detailTextLabel?.text = nil
         switch Sections(rawValue: indexPath.section) {
         case .refreshInformation:
             switch RefreshInformationRows(rawValue: indexPath.row) {

--- a/iOS/DuckDuckGo/DebugEtagStorage.swift
+++ b/iOS/DuckDuckGo/DebugEtagStorage.swift
@@ -25,7 +25,7 @@ import os.log
 /// Only intended for use via Debug screens.
 class DebugEtagStorage {
 
-    lazy var defaults = UserDefaults(suiteName: "com.duckduckgo.blocker-list.etags")
+    private let defaults = UserDefaults(suiteName: "\(Global.groupIdPrefix).app-configuration")
 
     func loadEtag(for storeKey: String) -> String? {
         let etag = defaults?.string(forKey: storeKey)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1210976624719060?focus=true
Tech Design URL:
CC:

### Description

This PR fixes the debug menu in the iOS app to show the stored ETag version correctly. ETag storage was changed to use an app group but the debug menu wasn't updated too, so this PR fixes that.

It also fixes an issue where non-ETag rows were able to show the ETag, due to a cell reuse issue. Now the detail label value is set to nil right after fetching a cell, wiping out any reused state.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Open the debug menu's Configuration Info screen
2. Check that ETags are visible

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)