### PR TITLE
Call getConfig in various NTP user script clients on main actor

### DIFF
--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Favorites/NewTabPageFavoritesClient.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Favorites/NewTabPageFavoritesClient.swift
@@ -91,6 +91,7 @@ public final class NewTabPageFavoritesClient<FavoriteType, ActionHandler>: NewTa
         return nil
     }
 
+    @MainActor
     private func getConfig(params: Any, original: WKScriptMessage) async throws -> Encodable? {
         let expansion: NewTabPageUserScript.WidgetConfig.Expansion = favoritesModel.isViewExpanded ? .expanded : .collapsed
         return NewTabPageUserScript.WidgetConfig(animation: .viewTransitions, expansion: expansion)

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/NextStepsCards/NewTabPageNextStepsCardsClient.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/NextStepsCards/NewTabPageNextStepsCardsClient.swift
@@ -136,6 +136,7 @@ public final class NewTabPageNextStepsCardsClient: NewTabPageUserScriptClient {
         return nil
     }
 
+    @MainActor
     private func getConfig(params: Any, original: WKScriptMessage) async throws -> Encodable? {
         let expansion: NewTabPageUserScript.WidgetConfig.Expansion = model.isViewExpanded ? .expanded : .collapsed
 

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/ProtectionsReport/NewTabPageProtectionsReportClient.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/ProtectionsReport/NewTabPageProtectionsReportClient.swift
@@ -83,6 +83,7 @@ public final class NewTabPageProtectionsReportClient: NewTabPageUserScriptClient
         ])
     }
 
+    @MainActor
     private func getConfig(params: Any, original: WKScriptMessage) async throws -> Encodable? {
         let expansion: NewTabPageUserScript.WidgetConfig.Expansion = model.isViewExpanded ? .expanded : .collapsed
         return NewTabPageDataModel.ProtectionsConfig(expansion: expansion, feed: model.activeFeed, showBurnAnimation: model.shouldShowBurnAnimation)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1210897342897623?focus=true

### Description
This change ensures that getConfig message is always called on main actor.

### Testing Steps
Verify that CI is green.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)