### PR TITLE
Prevent capturing touch events by Dax logo

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/DaxLogoManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/DaxLogoManager.swift
@@ -42,6 +42,7 @@ final class DaxLogoManager {
     func installInViewController(_ viewController: UIViewController, belowView topView: UIView) {
 
         logoContainerView.translatesAutoresizingMaskIntoConstraints = false
+        logoContainerView.isUserInteractionEnabled = false
         viewController.view.addSubview(logoContainerView)
 
         logoContainerView.addSubview(homeDaxLogoView)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1210980392990014?focus=true
Tech Design URL:
CC:

### Description

Disables interactions on logo, so it does not capture swipe gestures.

### Testing Steps
1. Enable Experimental Address Bar
2. Open search, type something and try to tap on rows where the logo would normally be.
3. Try to swipe between modes swiping in the area where the logo would be displayed.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)