### PR TITLE
[iOS] fix auto suggestions in new toggle

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
@@ -70,9 +70,16 @@ final class SuggestionTrayManager: NSObject {
 
     var shouldDisplaySuggestionTray: Bool {
         let query = switchBarHandler.currentText
-        let hasUserInteracted = switchBarHandler.hasUserInteractedWithText
+        // No text so don't show suggestins
+        guard !query.isBlank else { return false }
 
-        return !(query.isEmpty || !hasUserInteracted)
+        // For URLs, only show suggestions if the user has interacted with the text
+        if switchBarHandler.isCurrentTextValidURL {
+            return switchBarHandler.hasUserInteractedWithText
+        }
+
+        // For all other cases just show suggestions
+        return true
     }
 
     // MARK: - Initialization
@@ -177,12 +184,11 @@ final class SuggestionTrayManager: NSObject {
     }
     
     private func updateSuggestionTrayForCurrentState() {
-        let query = switchBarHandler.currentText
-
-        if !shouldDisplaySuggestionTray {
-            showSuggestionTray(.favorites)
-        } else {
+        if shouldDisplaySuggestionTray {
+            let query = switchBarHandler.currentText
             showSuggestionTray(.autocomplete(query: query))
+        } else {
+            showSuggestionTray(.favorites)
         }
     }
     


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1210977117977431?focus=true
Tech Design URL:
CC:

### Description
Shows suggestions when tapping on text in the address bar, but not for URLs which are shown as fixed height still.

### Testing Steps
1. Type something in that has suggestions (e.g. music)
2. Perform the search
3. Tap on the text in the address bar
4. The suggestions should show
5. Cancel that and click on a link in the serp
6. After website loads tap the address bar
7. URL should be shown (with logo or favorites below) on a single line which expands when tapped (as before).

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)