### PR TITLE
Improve navigation pixel logic for anchor navigations

### DIFF
--- a/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -32,7 +32,7 @@ enum GeneralPixel: PixelKitEventV2 {
     case launch
     case dailyActiveUser(isDefault: Bool, isAddedToDock: Bool?)
 
-    case navigation
+    case navigation(NavigationKind)
     case serp
     case serpInitial
 
@@ -1262,6 +1262,10 @@ enum GeneralPixel: PixelKitEventV2 {
             }
 
             return params
+
+        case .navigation(let kind):
+            return ["kind": kind.description]
+
         case .dataImportFailed(source: _, sourceVersion: let version, error: let error):
             var params = error.pixelParameters
 
@@ -1418,6 +1422,13 @@ enum GeneralPixel: PixelKitEventV2 {
         case attributed = "attributed"
         case unknown = "unknown"
 
+    }
+
+    enum NavigationKind: String, CustomStringConvertible {
+        var description: String { rawValue }
+
+        case regular
+        case client
     }
 
     enum OnboardingShown: String, CustomStringConvertible {

--- a/macOS/DuckDuckGo/Tab/Model/Tab+Navigation.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab+Navigation.swift
@@ -45,7 +45,7 @@ extension Tab: NavigationResponder {
             .weak(nullable: self.aiChat),
 
             .weak(nullable: self.navigationHotkeyHandler),
-            .struct(NavigationPixelNavigationResponder()),
+            .strong(NavigationPixelNavigationResponder()),
             .weak(nullable: self.brokenSiteInfo),
             .weak(nullable: self.tabCrashRecovery),
 

--- a/macOS/DuckDuckGo/Tab/TabExtensions/NavigationPixelNavigationResponder.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/NavigationPixelNavigationResponder.swift
@@ -24,18 +24,32 @@ import WebKit
 /**
  * This responder is responsible for firing navigation pixel on regular and same-tab navigations.
  */
-struct NavigationPixelNavigationResponder {
+final class NavigationPixelNavigationResponder {
 
     private let pixelFiring: PixelFiring?
+    fileprivate var previousSameDocumentNavigation: SameDocumentNavigation?
 
     init(pixelFiring: PixelFiring? = PixelKit.shared) {
         self.pixelFiring = pixelFiring
+    }
+
+    struct SameDocumentNavigation: Equatable {
+        let url: URL
+        let type: WKSameDocumentNavigationType
+
+        func isAnchorFollowingStatePop(_ previous: SameDocumentNavigation?) -> Bool {
+            return previous?.url == url && type == .anchorNavigation && previous?.type == .sessionStatePop
+        }
     }
 }
 
 extension NavigationPixelNavigationResponder: NavigationResponder {
 
     func didStart(_ navigation: Navigation) {
+        guard navigation.navigationAction.isForMainFrame else {
+            return
+        }
+
         let shouldFireNavigationPixel: Bool = {
             /// Fire navigation pixel on all navigations except for loading error pages
             if navigation.navigationAction.navigationType == .alternateHtmlLoad {
@@ -51,13 +65,24 @@ extension NavigationPixelNavigationResponder: NavigationResponder {
         }()
 
         if shouldFireNavigationPixel {
-            pixelFiring?.fire(GeneralPixel.navigation)
+            pixelFiring?.fire(GeneralPixel.navigation(.regular))
         }
     }
 
     func navigation(_ navigation: Navigation, didSameDocumentNavigationOf navigationType: WKSameDocumentNavigationType) {
-        if navigationType != .sessionStateReplace {
-            PixelKit.fire(GeneralPixel.navigation)
+        guard navigation.navigationAction.isForMainFrame, navigationType != .sessionStateReplace else {
+            return
         }
+
+        /// Some anchor navigations call `pop state` before, so there are 2 same-page navigations:
+        /// `pop state` and `hash change`. We only want to send 1 pixel for this, so we're firing it
+        /// on the `pop state` event and then we filter out the `hash change` if it happens immediately
+        /// after `pop state` for the same URL.
+        let sameDocumentNavigation = SameDocumentNavigation(url: navigation.url, type: navigationType)
+        if sameDocumentNavigation.isAnchorFollowingStatePop(previousSameDocumentNavigation) {
+            return
+        }
+        previousSameDocumentNavigation = sameDocumentNavigation
+        PixelKit.fire(GeneralPixel.navigation(.client))
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1210812990564440?focus=true

### Description
This change adds a parameter to the navigation pixel to distinguish regular from same-page navigations,
and fixes double pixel fired on some anchor navigations.

### Testing Steps
1. Launch the app and filter logs for `m_mac_navigation [`
2. Go to https://privacy-test-pages.site/features/web-telemetry/url-changed.html.
3. Click all the buttons on the page and verify that each button fires at most 1 pixel with “kind": “client” or “regular”, as specified on the website.
4. Go to [a GitHub repo](https://github.com/duckduckgo/apple-browsers/pulls) and verify that switching between tabs (Code, Issues, Pull requests, etc.) fires 1 pixel.
5. Go to [a Wikipedia article](https://en.wikipedia.org/wiki/Constans_II_(son_of_Constantine_III)) and verify that jumping between sections fires 1 pixel.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Some edge-case anchor navigations may not be reported.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)