### PR TITLE
Global AI Switch 4. Pixels

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -39,6 +39,12 @@ enum AIChatPixel: PixelKitEventV2 {
     /// - Check if this is not a widespread issue. Sometimes users can change config data manually on macOS which could cause this
     case aichatNoRemoteSettingsFound(AIChatRemoteSettings.SettingsValue)
 
+    /// Event Trigger: Global toggle for all AI Chat features is turned on
+    case aiChatSettingsGlobalToggleTurnedOn
+
+    /// Event Trigger: Global toggle for all AI Chat features is turned off
+    case aiChatSettingsGlobalToggleTurnedOff
+
     /// Event Trigger: New Tab Page shortcut for AI Chat is turned on
     case aiChatSettingsNewTabPageShortcutTurnedOn
 
@@ -100,6 +106,10 @@ enum AIChatPixel: PixelKitEventV2 {
             return "aichat_application-menu-file-clicked"
         case .aichatNoRemoteSettingsFound(let settings):
             return "aichat_no_remote_settings_found-\(settings.rawValue.lowercased())"
+        case .aiChatSettingsGlobalToggleTurnedOn:
+            return "aichat_settings_global-toggle_on"
+        case .aiChatSettingsGlobalToggleTurnedOff:
+            return "aichat_settings_global-toggle_off"
         case .aiChatSettingsNewTabPageShortcutTurnedOn:
             return "aichat_settings_new-tab-page_on"
         case .aiChatSettingsNewTabPageShortcutTurnedOff:
@@ -136,6 +146,8 @@ enum AIChatPixel: PixelKitEventV2 {
         case .aichatApplicationMenuAppClicked,
                 .aichatApplicationMenuFileClicked,
                 .aichatNoRemoteSettingsFound,
+                .aiChatSettingsGlobalToggleTurnedOn,
+                .aiChatSettingsGlobalToggleTurnedOff,
                 .aiChatSettingsNewTabPageShortcutTurnedOn,
                 .aiChatSettingsNewTabPageShortcutTurnedOff,
                 .aiChatSettingsAddressBarShortcutTurnedOn,

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
@@ -59,6 +59,9 @@ extension Preferences {
                                     isShowingDisableAIChatDialog = true
                                 } else {
                                     model.isAIFeaturesEnabled = true
+                                    PixelKit.fire(AIChatPixel.aiChatSettingsGlobalToggleTurnedOn,
+                                                  frequency: .dailyAndCount,
+                                                  includeAppVersionParameter: true)
                                 }
                             }
                             .accessibilityIdentifier("Preferences.AIChat.aiFeaturesToggle")
@@ -264,7 +267,10 @@ extension Preferences {
                 Button(UserText.cancel) { isShowingDisableAIChatDialog = false }
                 Button(action: {
                     isShowingDisableAIChatDialog = false
-                    model.isAIFeaturesEnabled.toggle()
+                    model.isAIFeaturesEnabled = false
+                    PixelKit.fire(AIChatPixel.aiChatSettingsGlobalToggleTurnedOff,
+                                  frequency: .dailyAndCount,
+                                  includeAppVersionParameter: true)
                 }, label: {
                     Text(UserText.aiChatDisableDialogConfirmButton)
                 })

--- a/macOS/PixelDefinitions/pixels/aichat_settings_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/aichat_settings_pixels.json5
@@ -1,0 +1,31 @@
+// See https://app.asana.com/0/72649045549333/1208001118995887/f.
+{
+    'm_mac_aichat_settings_global-toggle_on': {
+        description: 'Fired when the global toggle for all AI Chat features is turned on',
+        owners: ['miasma13'],
+        triggers: ['other'],
+        suffixes: ['first_daily_count'],
+        parameters: ['appVersion', 'pixelSource'],
+    },
+    'm_mac_aichat_settings_global-toggle_off': {
+        description: 'Fired when the global toggle for all AI Chat features is turned off',
+        owners: ['miasma13'],
+        triggers: ['other'],
+        suffixes: ['first_daily_count'],
+        parameters: ['appVersion', 'pixelSource'],
+    },
+    'm_mac_aichat_settings_new-tab-page_on': {
+        description: 'Fired when the New Tab Page shortcut for AI Chat is turned on',
+        owners: ['miasma13'],
+        triggers: ['other'],
+        suffixes: ['first_daily_count'],
+        parameters: ['appVersion', 'pixelSource'],
+    },
+    'm_mac_aichat_settings_new-tab-page_off': {
+        description: 'Fired when the New Tab Page shortcut for AI Chat is turned off',
+        owners: ['miasma13'],
+        triggers: ['other'],
+        suffixes: ['first_daily_count'],
+        parameters: ['appVersion', 'pixelSource'],
+    },
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210702047347360?focus=true
Tech Design URL:
CC:

### Description
Pixels and pixel definitions

### Testing Steps
1. Open "AI Feature" settings
2. Click "Disable Duck.ai..." and confirm the dialog.
3. Verify that `m_mac_aichat_settings_global-toggle_off_daily` and `m_mac_aichat_settings_global-toggle_off_count` were fired.
4. Click "Enable Duck.ai"
5. Verify that `m_mac_aichat_settings_global-toggle_on_daily` and `m_mac_aichat_settings_global-toggle_on_count` were fired.

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Pixels being fired in wrong use case

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)