### PR TITLE
VPN Upsell: Target users who can purchase

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionAuthV1toV2BridgeMock.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionAuthV1toV2BridgeMock.swift
@@ -45,7 +45,8 @@ public final class SubscriptionAuthV1toV2BridgeMock: SubscriptionAuthV1toV2Bridg
     }
 
     public var canPurchase: Bool = true
-    public var canPurchasePublisher: AnyPublisher<Bool, Never> = .init(Empty())
+    public var canPurchasePublisher: AnyPublisher<Bool, Never> { canPurchaseSubject.eraseToAnyPublisher() }
+    public var canPurchaseSubject: PassthroughSubject<Bool, Never> = .init()
     public var returnSubscription: Result<PrivacyProSubscription, Error>!
     public func getSubscription(cachePolicy: SubscriptionCachePolicy) async throws -> PrivacyProSubscription {
         switch returnSubscription! {

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -687,6 +687,7 @@ extension AppDelegate {
 
     @objc func resetVPNUpsell() {
         // Clear VPN upsell state
+        vpnUpsellUserDefaultsPersistor.vpnUpsellPopoverViewed = false
         vpnUpsellUserDefaultsPersistor.vpnUpsellDismissed = false
         vpnUpsellUserDefaultsPersistor.vpnUpsellFirstPinnedDate = nil
         // Store a user defaults flag so that AppDelegate initializes VPNUpsellVisibilityManager with a 10 second timer instead of 10 minutes

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -1220,6 +1220,7 @@ final class NavigationBarViewController: NSViewController {
     private func toggleNetworkProtectionPopover() {
         guard Application.appDelegate.subscriptionAuthV1toV2Bridge.isUserAuthenticated else {
             popovers.toggleVPNUpsellPopover(from: networkProtectionButton)
+            vpnUpsellVisibilityManager.dismissNotificationDot()
             return
         }
 
@@ -1717,10 +1718,10 @@ extension NavigationBarViewController: NSMenuDelegate {
             .store(in: &cancellables)
 
         // Show notification dot when VPN upsell should be shown
-        networkProtectionButtonModel.$shouldShowUpsell
+        networkProtectionButtonModel.$shouldShowNotificationDot
             .receive(on: RunLoop.main)
-            .sink { [weak self] shouldShowUpsell in
-                self?.networkProtectionButton.isNotificationVisible = shouldShowUpsell
+            .sink { [weak self] shouldShowNotificationDot in
+                self?.networkProtectionButton.isNotificationVisible = shouldShowNotificationDot
             }
             .store(in: &cancellables)
     }

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionNavBarButtonModel.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionNavBarButtonModel.swift
@@ -72,6 +72,9 @@ final class NetworkProtectionNavBarButtonModel: NSObject, ObservableObject {
     @Published
     private(set) var shouldShowUpsell = false
 
+    @Published
+    private(set) var shouldShowNotificationDot = false
+
     // MARK: - Initialization
 
     init(popoverManager: NetPPopoverManager,
@@ -149,6 +152,16 @@ final class NetworkProtectionNavBarButtonModel: NSObject, ObservableObject {
             Task { @MainActor in
                 self.shouldShowUpsell = state == .visible
                 self.updateVisibility()
+            }
+        }.store(in: &cancellables)
+
+        vpnUpsellVisibilityManager.$shouldShowNotificationDot.sink { [weak self] shouldShowNotificationDot in
+            guard let self = self else {
+                return
+            }
+
+            Task { @MainActor in
+                self.shouldShowNotificationDot = shouldShowNotificationDot
             }
         }.store(in: &cancellables)
     }

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNUpsellPopover.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNUpsellPopover.swift
@@ -147,7 +147,7 @@ struct VPNUpsellPopoverView: View {
             Button {
                 viewModel.showSubscriptionLandingPage()
             } label: {
-                Text(viewModel.featureSet.mainCTATitle)
+                Text(viewModel.featureSet.mainCTATitle.capitalized)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
             .buttonStyle(DefaultActionButtonStyle(enabled: true, shouldBeFixedVertical: false))

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNUpsellPopover.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNUpsellPopover.swift
@@ -27,10 +27,12 @@ import SwiftUIExtensions
 // MARK: - Constants
 
 private enum Constants {
+    static let popoverMaxWidth: CGFloat = 380
     static let outerVerticalSpacing: CGFloat = 16
     static let innerVerticalSpacing: CGFloat = 28
     static let headerHorizontalPadding: CGFloat = 48
     static let titleAndSubtitleHorizontalPadding: CGFloat = 36
+    static let titleAndSubtitleMaxWidth: CGFloat = 280
     static let titleAndSubtitleVerticalSpacing: CGFloat = 8
     static let featuresHorizontalPadding: CGFloat = 48
     static let featuresVerticalSpacing: CGFloat = 12
@@ -69,6 +71,7 @@ struct VPNUpsellPopoverView: View {
 
             VStack(spacing: Constants.innerVerticalSpacing) {
                 titleAndSubtitle
+                    .frame(width: Constants.titleAndSubtitleMaxWidth)
                     .padding(.horizontal, Constants.titleAndSubtitleHorizontalPadding)
                 features
                     .padding(.horizontal, Constants.featuresHorizontalPadding)
@@ -77,6 +80,7 @@ struct VPNUpsellPopoverView: View {
             actionButtons
                 .padding(.top, Constants.actionButtonsTopPadding)
         }
+        .frame(width: Constants.popoverMaxWidth)
         .padding(.top, Constants.topPadding)
         .padding(.horizontal, Constants.horizontalPadding)
         .padding(.bottom, Constants.bottomPadding)

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNUpsellUserDefaultsPersistor.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNUpsellUserDefaultsPersistor.swift
@@ -21,6 +21,7 @@ import Persistence
 
 protocol VPNUpsellUserDefaultsPersisting {
     var vpnUpsellDismissed: Bool { get set }
+    var vpnUpsellPopoverViewed: Bool { get set }
     var vpnUpsellFirstPinnedDate: Date? { get set }
     var expectedUpsellTimeInterval: TimeInterval { get set }
 }
@@ -29,6 +30,7 @@ struct VPNUpsellUserDefaultsPersistor: VPNUpsellUserDefaultsPersisting {
 
     enum Key: String {
         case vpnUpsellDismissed = "vpn.upsell.dismissed"
+        case vpnUpsellPopoverViewed = "vpn.upsell.popover.viewed"
         case vpnUpsellFirstPinnedDate = "vpn.upsell.first-pinned-date"
         case expectedUpsellTimeInterval = "vpn.upsell.expected.time.interval"
     }
@@ -42,6 +44,11 @@ struct VPNUpsellUserDefaultsPersistor: VPNUpsellUserDefaultsPersisting {
     var vpnUpsellDismissed: Bool {
         get { (try? keyValueStore.object(forKey: Key.vpnUpsellDismissed.rawValue) as? Bool) ?? false }
         set { try? keyValueStore.set(newValue, forKey: Key.vpnUpsellDismissed.rawValue) }
+    }
+
+    var vpnUpsellPopoverViewed: Bool {
+        get { (try? keyValueStore.object(forKey: Key.vpnUpsellPopoverViewed.rawValue) as? Bool) ?? false }
+        set { try? keyValueStore.set(newValue, forKey: Key.vpnUpsellPopoverViewed.rawValue) }
     }
 
     var vpnUpsellFirstPinnedDate: Date? {

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNUpsellVisibilityManager.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNUpsellVisibilityManager.swift
@@ -64,6 +64,7 @@ final class VPNUpsellVisibilityManager: ObservableObject {
 
     // MARK: - State
     private let isDefaultBrowserSubject = PassthroughSubject<Bool, Never>()
+    private let canUserPurchaseSubject = PassthroughSubject<Bool, Never>()
     private var cancellables = Set<AnyCancellable>()
     private var defaultBrowserPollingTimer: Timer?
     private var timer: Timer?
@@ -102,6 +103,22 @@ final class VPNUpsellVisibilityManager: ObservableObject {
             return
         }
 
+        canUserPurchaseSubject
+            .sink { [weak self] canPurchase in
+                guard let self else { return }
+                guard canPurchase else {
+                    self.updateState(.notEligible)
+                    return
+                }
+
+                self.start(isFirstLaunch: isFirstLaunch)
+            }
+            .store(in: &cancellables)
+
+        checkPurchaseEligibility()
+    }
+
+    private func start(isFirstLaunch: Bool) {
         if isFirstLaunch {
             monitorFirstLaunchConditions()
         } else {
@@ -131,6 +148,19 @@ final class VPNUpsellVisibilityManager: ObservableObject {
         }
 
         return firstPinnedDate.daysSinceNow() >= autoDismissDays
+    }
+
+    private func checkPurchaseEligibility() {
+        switch subscriptionManager.currentEnvironment.purchasePlatform {
+        case .appStore:
+            subscriptionManager.canPurchasePublisher
+                .sink { [weak self] canPurchase in
+                    self?.canUserPurchaseSubject.send(canPurchase)
+                }
+                .store(in: &cancellables)
+        case .stripe:
+            canUserPurchaseSubject.send(true)
+        }
     }
 
     // MARK: - Monitoring Setup

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNUpsellVisibilityManager.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNUpsellVisibilityManager.swift
@@ -49,6 +49,7 @@ extension VPNUpsellVisibilityManager {
 final class VPNUpsellVisibilityManager: ObservableObject {
     // MARK: - Output
     @Published private(set) var state: State = .uninitialized
+    @Published private(set) var shouldShowNotificationDot: Bool = false
 
     // MARK: - Dependencies
     private let isFirstLaunch: Bool
@@ -218,6 +219,11 @@ final class VPNUpsellVisibilityManager: ObservableObject {
         }
     }
 
+    public func dismissNotificationDot() {
+        persistor.vpnUpsellPopoverViewed = true
+        shouldShowNotificationDot = false
+    }
+
     private func startTimerIfNeeded() {
         guard state == .waitingForConditions else {
             return
@@ -323,6 +329,12 @@ final class VPNUpsellVisibilityManager: ObservableObject {
         if previousState != .visible && newState == .visible {
             pixelHandler(.privacyProToolbarButtonShown)
         }
+
+        guard newState == .visible else {
+            return
+        }
+
+        shouldShowNotificationDot = !persistor.vpnUpsellPopoverViewed
     }
 
     deinit {

--- a/macOS/UnitTests/NetworkProtection/Mocks/VPNMocks.swift
+++ b/macOS/UnitTests/NetworkProtection/Mocks/VPNMocks.swift
@@ -24,6 +24,7 @@ import NetworkProtectionUI
 
 final class MockVPNUpsellUserDefaultsPersistor: VPNUpsellUserDefaultsPersisting {
     var vpnUpsellDismissed: Bool = false
+    var vpnUpsellPopoverViewed: Bool = false
     var vpnUpsellFirstPinnedDate: Date?
     var expectedUpsellTimeInterval: TimeInterval = 0
 }

--- a/macOS/UnitTests/NetworkProtection/NetworkProtectionNavBarButtonModelTests.swift
+++ b/macOS/UnitTests/NetworkProtection/NetworkProtectionNavBarButtonModelTests.swift
@@ -202,6 +202,29 @@ final class NetworkProtectionNavBarButtonModelTests: XCTestCase {
         XCTAssertFalse(mockPersistor.vpnUpsellDismissed)
         XCTAssertFalse(sut.showVPNButton)
     }
+
+    func testItUpdatesBlueDotVisibility() {
+        // Given
+        let upsellManager = createUpsellManager(shouldShowUpsell: true)
+        sut = createButtonModel(with: upsellManager)
+
+        let expectation = XCTestExpectation(description: "shouldShowNotificationDot should become false")
+
+        cancellable = sut.$shouldShowNotificationDot
+            .dropFirst()
+            .sink { shouldShowNotificationDot in
+                if !shouldShowNotificationDot {
+                    expectation.fulfill()
+                }
+            }
+
+        // When
+        upsellManager.dismissNotificationDot()
+
+        // Then
+        wait(for: [expectation], timeout: 2.0)
+        XCTAssertFalse(sut.shouldShowNotificationDot)
+    }
 }
 
 // MARK: - Helpers

--- a/macOS/UnitTests/NetworkProtection/NetworkProtectionNavBarButtonModelTests.swift
+++ b/macOS/UnitTests/NetworkProtection/NetworkProtectionNavBarButtonModelTests.swift
@@ -37,6 +37,7 @@ final class NetworkProtectionNavBarButtonModelTests: XCTestCase {
         super.setUp()
         mockPersistor = MockVPNUpsellUserDefaultsPersistor()
         mockSubscriptionManager = SubscriptionAuthV1toV2BridgeMock()
+        mockSubscriptionManager.currentEnvironment = .init(serviceEnvironment: .staging, purchasePlatform: .stripe)
     }
 
     override func tearDown() {

--- a/macOS/UnitTests/NetworkProtection/VPNUpsellPopoverViewModelTests.swift
+++ b/macOS/UnitTests/NetworkProtection/VPNUpsellPopoverViewModelTests.swift
@@ -46,6 +46,7 @@ final class VPNUpsellPopoverViewModelTests: XCTestCase {
         firedPixels = []
 
         mockFeatureFlagger.enabledFeatureFlags = [.vpnToolbarUpsell]
+        mockSubscriptionManager.currentEnvironment = .init(serviceEnvironment: .staging, purchasePlatform: .stripe)
 
         vpnUpsellVisibilityManager = VPNUpsellVisibilityManager(
             isFirstLaunch: false,

--- a/macOS/UnitTests/NetworkProtection/VPNUpsellVisibilityManagerTests.swift
+++ b/macOS/UnitTests/NetworkProtection/VPNUpsellVisibilityManagerTests.swift
@@ -39,6 +39,7 @@ final class VPNUpsellVisibilityManagerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         mockSubscriptionManager = SubscriptionAuthV1toV2BridgeMock()
+        mockSubscriptionManager.currentEnvironment = .init(serviceEnvironment: .staging, purchasePlatform: .stripe)
         mockFeatureFlagger = MockFeatureFlagger()
         mockDefaultBrowserProvider = MockDefaultBrowserProvider()
         mockPersistor = MockVPNUpsellUserDefaultsPersistor()
@@ -356,6 +357,34 @@ final class VPNUpsellVisibilityManagerTests: XCTestCase {
 
         // Then
         XCTAssertEqual(sut.state, .notEligible)
+    }
+
+    // MARK: - Purchase Eligibility Tests
+
+    func testWhenUserCannotPurchaseSubscription_ItDoesNotShowTheUpsell() {
+        // Given
+        mockSubscriptionManager.currentEnvironment = .init(serviceEnvironment: .staging, purchasePlatform: .appStore)
+        sut = createUpsellManager(isFirstLaunch: false, isNewUser: true)
+        XCTAssertEqual(sut.state, .notEligible)
+
+        // When
+        mockSubscriptionManager.canPurchaseSubject.send(false)
+
+        // Then
+        XCTAssertEqual(sut.state, .notEligible)
+    }
+
+    func testWhenUserCanPurchaseSubscription_ItShowsTheUpsell() {
+        // Given
+        mockSubscriptionManager.currentEnvironment = .init(serviceEnvironment: .staging, purchasePlatform: .appStore)
+        sut = createUpsellManager(isFirstLaunch: false, isNewUser: true)
+        XCTAssertEqual(sut.state, .notEligible)
+
+        // When
+        mockSubscriptionManager.canPurchaseSubject.send(true)
+
+        // Then
+        XCTAssertEqual(sut.state, .visible)
     }
 }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1210977189442464?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/1210594645229050/task/1210649122070619?focus=true
CC:

### Description
This PR contains the following improvements for the VPN Upsell:
* [Only target users who can purchase a subscription](https://app.asana.com/1/137249556945/project/414235014887631/task/1210977112631758?focus=true)
* [Remove notification dot from upsell shortcut once popover is opened](https://app.asana.com/1/137249556945/task/1210995213964980)
* [Limit popover width to make sure non-English languages don’t break the UI](https://app.asana.com/1/137249556945/task/1210995213964985)
* [Capitalize CTA title to avoid shouting at users in non-English languages](https://app.asana.com/1/137249556945/task/1210996456012325)

### Testing Steps
* Reset upsell state and make the shortcut appear (refer to [instructions here](https://app.asana.com/1/137249556945/project/1142021229838617/task/1210985001384919?focus=true))
* Click the upsell shortcut -> Blue dot should disappear, and never appear again (unless you reset and restart again)
* Launch the app in a non-English language (German is always a good candidate)
* Bring up the upsell popover -> Title should fit vertically, and CTA should use `Title Casing` instead of `ALL CAPS`

| before | after |
| ------ | ------ | 
| <img width="1160" height="1012" alt="Screenshot 2025-08-07 at 12 36 16" src="https://github.com/user-attachments/assets/97d9d7f5-1828-4815-9ba7-f9bb9b65bb3f" /> |   <img width="968" height="1108" alt="Screenshot 2025-08-07 at 12 52 30" src="https://github.com/user-attachments/assets/27ff824e-c47b-45d3-aac1-8599fe485a06" /> |

### Impact and Risks
None: Feature-flagged

#### What could go wrong?
N/A

### Quality Considerations
* I’ve added tests to account for purchase eligibility

### Notes to Reviewer
@aataraxiaa I couldn’t really find a good manual testing steps `canPurchase` logic.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)