### PR TITLE
Prevent TabSwitcher collection inconsistency when adding new tab

### DIFF
--- a/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
@@ -121,16 +121,6 @@ extension TabSwitcherViewController {
         presentForgetDataAlert()
     }
 
-    func addNewTab() {
-        guard !isProcessingUpdates else { return }
-        // Will be dismissed, so no need to process incoming updates
-        canUpdateCollection = false
-
-        Pixel.fire(pixel: .tabSwitcherNewTab)
-        delegate.tabSwitcherDidRequestNewTab(tabSwitcher: self)
-        dismiss()
-    }
-
     func transitionToMultiSelect() {
         self.isEditing = true
         collectionView.reloadData()

--- a/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
@@ -123,6 +123,8 @@ extension TabSwitcherViewController {
 
     func addNewTab() {
         guard !isProcessingUpdates else { return }
+        // Will be dismissed, so no need to process incoming updates
+        canUpdateCollection = false
 
         Pixel.fire(pixel: .tabSwitcherNewTab)
         delegate.tabSwitcherDidRequestNewTab(tabSwitcher: self)

--- a/iOS/DuckDuckGo/TabSwitcherViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController.swift
@@ -107,7 +107,7 @@ class TabSwitcherViewController: UIViewController {
 
     var tabSwitcherSettings: TabSwitcherSettings = DefaultTabSwitcherSettings()
     var isProcessingUpdates = false
-    private var canUpdateCollection = true
+    var canUpdateCollection = true
 
     let favicons: Favicons
 

--- a/iOS/DuckDuckGo/TabSwitcherViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController.swift
@@ -107,7 +107,7 @@ class TabSwitcherViewController: UIViewController {
 
     var tabSwitcherSettings: TabSwitcherSettings = DefaultTabSwitcherSettings()
     var isProcessingUpdates = false
-    var canUpdateCollection = true
+    private var canUpdateCollection = true
 
     let favicons: Favicons
 
@@ -327,6 +327,16 @@ class TabSwitcherViewController: UIViewController {
     func editBookmark(_ url: URL?) {
         guard let url else { return }
         delegate?.tabSwitcher(self, editBookmarkForUrl: url)
+    }
+
+    func addNewTab() {
+        guard !isProcessingUpdates else { return }
+        // Will be dismissed, so no need to process incoming updates
+        canUpdateCollection = false
+
+        Pixel.fire(pixel: .tabSwitcherNewTab)
+        delegate.tabSwitcherDidRequestNewTab(tabSwitcher: self)
+        dismiss()
     }
 
     func bookmarkTabs(withIndexPaths indexPaths: [IndexPath], viewModel: MenuBookmarksInteracting) -> BookmarkAllResult {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1210977113880963
Tech Design URL:
CC:

### Description

Prevents performing batch updates with invalid internal state after the model has been modified by adding a new tab. 

This is a **speculative fix**, as I couldn't reproduce it manually. It can be reproduced by adding the following code at the very top of `TabSwitcherViewController.didChange(tab:)` and closing all of new tabs in tab switcher:
```
let hasNewTab = tabsModel.tabs.contains { $0.link == nil }
if !hasNewTab {
    addNewTab()
}
```

What it does is it's modifying data model just before the batch updates caused by notifying observer is performed (e.g. after refresh or redirect happens for one of tabs), simulating the specific events timing that triggers the inconsistency.

The assumption is that the flow which is causing the crash is as follows:
1. Have a tab (or a bunch of tabs) which are reloading in background. This may be http://privacy-test-pages.site/features/auto-refresh.html.
2. When user is on `TabSwitcherViewController`, the `didChange(tab:)` is being called every time the link is updated.
3. Pressing New Tab button on tab switcher, so calling `TabSwitcherViewController.addHomeTab()` just before the batch updates in `didChange(tab:)` causes the model to update and diverge from the internal state of UICollectionView. 

### Testing Steps
1. Smoke test around tab switcher and adding a new tab specifically.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Batch updates are not done after one of background tabs is being refreshed, but that should be negligible as we're about to dismiss the tab switcher anyway.

### Notes to Reviewer
I've considered doing a more robust fix with using `performBatchUpdates` in the `addNewTab` function, but this has negative side effects like introducing unnecessary animation. Given the fact we already have `canUpdateCollection` in place using it seemed like the easiest and safest solution.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)