### PR TITLE
[Experimental AI Chat] Hide return button if keyboard is not visible

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/NavigationActionBarView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/NavigationActionBarView.swift
@@ -160,7 +160,6 @@ final class NavigationActionBarView: UIView {
     }
     
     private func setupBindings() {
-        // Observe view model changes
         viewModel.$isSearchMode
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
@@ -183,6 +182,13 @@ final class NavigationActionBarView: UIView {
             .store(in: &cancellables)
         
         viewModel.$isCurrentTextValidURL
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.updateUI()
+            }
+            .store(in: &cancellables)
+        
+        viewModel.$isKeyboardVisible
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.updateUI()
@@ -225,7 +231,6 @@ final class NavigationActionBarView: UIView {
         let isValidURL = viewModel.isCurrentTextValidURL
         let isSearchMode = viewModel.isSearchMode
         
-        // Determine icon
         let icon: UIImage? = {
             if isSearchMode && !isValidURL {
                 return DesignSystemImages.Glyphs.Size24.searchFind
@@ -241,18 +246,18 @@ final class NavigationActionBarView: UIView {
         )
         searchButton.isEnabled = hasText
         
-        // Animate changes
         UIView.animate(withDuration: 0.2) {
             self.searchButton.alpha = hasText ? 1.0 : 0.5
         }
     }
     
     private func updateButtonVisibility() {
-        // Update microphone button visibility
         let shouldShowMicButton = viewModel.shouldShowMicButton
         microphoneButton.isHidden = !shouldShowMicButton
         
-        // Update search button visibility
+        let shouldShowNewLineButton = viewModel.isKeyboardVisible
+        newLineButton.isHidden = !shouldShowNewLineButton
+        
         let shouldShowSearchButton = viewModel.hasText
         searchButton.isHidden = !shouldShowSearchButton
     }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/NavigationActionBarViewModel.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/NavigationActionBarViewModel.swift
@@ -32,6 +32,7 @@ final class NavigationActionBarViewModel: ObservableObject {
     @Published var isVoiceSearchEnabled: Bool = true
     @Published var hasUserInteractedWithText: Bool = false
     @Published var isCurrentTextValidURL: Bool = false
+    @Published var isKeyboardVisible: Bool = false
 
     // MARK: - Dependencies
     private let switchBarHandler: SwitchBarHandling
@@ -55,6 +56,7 @@ final class NavigationActionBarViewModel: ObservableObject {
 
         setupBindings()
         updateInitialState()
+        setupKeyboardObservers()
     }
 
     // MARK: - Private Methods
@@ -95,6 +97,22 @@ final class NavigationActionBarViewModel: ObservableObject {
         isVoiceSearchEnabled = switchBarHandler.isVoiceSearchEnabled
         hasUserInteractedWithText = false
         isCurrentTextValidURL = switchBarHandler.isCurrentTextValidURL
+    }
+    
+    private func setupKeyboardObservers() {
+        NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.isKeyboardVisible = true
+            }
+            .store(in: &cancellables)
+        
+        NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.isKeyboardVisible = false
+            }
+            .store(in: &cancellables)
     }
 
     // MARK: - Public Methods


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1210975209610639?\

### Description
Hide return button if keyboard is not visible

### Testing Steps
* Have enough favorites so the screen will scroll in the input view
* Start scrolling (when in input screen) in search mode
* Keyboard disappears, address bar is unfocused
* Return button should not be visible

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Hide the return button on situations where it shouldn't be hidden
