### PR TITLE
Auto select the keyboard on duck.ai

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -169,6 +169,12 @@ class SwitchBarTextEntryView: UIView {
             textView.autocapitalizationType = .sentences
             textView.autocorrectionType = .default
             textView.spellCheckingType = .default
+            
+            /// Auto-focus the text field when switching to duck.ai mode
+            /// https://app.asana.com/1/137249556945/project/72649045549333/task/1210975209610640?focus=true
+            DispatchQueue.main.async { [weak self] in
+                self?.textView.becomeFirstResponder()
+            }
         }
 
         updatePlaceholderVisibility()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210975209610640?focus=true

### Description
Auto select the keyboard on duck.ai

### Testing Steps
1. Enable Experimental address bar for duck.ai (AI Features -> Experimental)
2. Add at least one favorite
3. Select the address bar, scroll the favorites to dismiss the keyboard
4. Go to duck.ai, validate that the keyboard is automatically selected

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features
