### PR TITLE
Fix - Hitting "go" on the keyboard with empty input works as a return

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -313,6 +313,9 @@ extension SwitchBarTextEntryView: UITextViewDelegate {
             if !currentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 handler.submitText(currentText)
             }
+            /// Prevent adding newline when there's no content or just whitespace
+            /// https://app.asana.com/1/137249556945/project/72649045549333/task/1210989002857245?focus=true
+            return false
         }
         return true
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210989002857245?focus=true

### Description
Prevent keyboard return from adding new lines on empty input box

### Testing Steps
1. Enable experimental AI Chat under AI Chat features
2. Select the address bar, in both search and duck.ai mode press "go" with an empty input field
3. Make sure nothing happens (Same as current production address bar)
4. Type some text, validate that the text is submitted

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Text could not be correctly submitted