### PR TITLE
Fix state restoration E2E test

### DIFF
--- a/.maestro/browser_features/state_restoration.yaml
+++ b/.maestro/browser_features/state_restoration.yaml
@@ -15,24 +15,27 @@ tags:
     id: "searchEntry"
 - tapOn:
     id: "searchEntry"
-- inputText: "https://www.wikipedia.org/"
+- inputText: "https://duckduckgo.com"
 - pressKey: Enter
 
 # Create navigation stack
-- assertVisible: 'English.*'
-- tapOn: 
-    text: 'English.*'
-    childOf: "Top languages, navigation"
-- assertVisible: "Welcome to Wikipedia.*"
-- tapOn: "Wikipedia" 
-- assertVisible: "Article"
+- assertVisible: 'DuckDuckGo.*'
 - scrollUntilVisible:
-    element: "United States"
+    element: "Terms of Service"
+    timeout: 50000
+    speed: 100
+- tapOn: 
+    text: 'Terms of Service'
+- assertVisible: "DuckDuckGo Terms of Service"
+- scrollUntilVisible:
+    element: "Privacy Policy"
+    timeout: 50000
+    speed: 100
 # Make sure bottom bar is visible
 - tapOn:
     point: 80%, 99%
 - tapOn: "Browse Back"
-- assertVisible: "Welcome to Wikipedia.*"
+- assertVisible: "DuckDuckGo.*"
 
 # Load a new tab
 - longPressOn: "Tab Switcher"
@@ -53,6 +56,6 @@ tags:
     point: 20%, 25%
 
 # Check if state from previous session was restored
-- assertVisible: "Welcome to Wikipedia.*"
+- assertVisible: "DuckDuckGo.*"
 - tapOn: "Browse Forward"
-- assertVisible: "United States"
+- assertVisible: "DuckDuckGo Terms of Service"


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1210995171100910
Tech Design URL:
CC:

### Description

Wikipedia got a popup which was breaking the test flow. Used DuckDuckGo website instead.

### Testing Steps
1. Make sure state_restoration E2E test passes (https://github.com/duckduckgo/apple-browsers/actions/runs/16814136030)

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)