### PR TITLE
Global AI Switch 5. Settings update

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
@@ -111,7 +111,15 @@ final class AIChatMenuConfiguration: AIChatMenuVisibilityConfigurable {
     }
 
     var shouldOpenAIChatInSidebar: Bool {
-        shouldDisplayAnyAIChatFeature && storage.openAIChatInSidebar
+        // Can be removed after `.aiChatGlobalSwitch` is fully rolled out.
+        // Additionally all current `shouldOpenAIChatInSidebar` calls should be reviewed cleaning up obsolete code paths.
+        guard featureFlagger.isFeatureOn(.aiChatGlobalSwitch) else {
+            return shouldDisplayAnyAIChatFeature && storage.openAIChatInSidebar
+        }
+
+        // When using global AI Chat switch is enabled there is no separate setting for the sidebar and sidebar use is made a new defult
+        // so we ignore previous setting value.
+        return true
     }
 
     init(storage: AIChatPreferencesStorage, remoteSettings: AIChatRemoteSettingsProvider, featureFlagger: FeatureFlagger) {

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
@@ -118,25 +118,6 @@ extension Preferences {
                     }
                     .visibility(model.shouldShowAIFeatures ? .visible : .gone)
 
-                    PreferencePaneSection(UserText.aiChatOpenNewChatsSectionTitle,
-                                          spacing: 6) {
-                        Picker(selection: $model.openAIChatInSidebar, content: {
-                            Text(UserText.aiChatOpenInSidebarOption).tag(true)
-                                .padding(.bottom, 4).accessibilityIdentifier("Preferences.AIChat.openNewChatsPicker.inSidebar")
-                            Text(UserText.aiChatOpenInFullPageOption).tag(false)
-                                .accessibilityIdentifier("Preferences.AIChat.openNewChatsPicker.fullPage")
-                        }, label: {})
-                        .pickerStyle(.radioGroup)
-                        .offset(x: PreferencesUI_macOS.Const.pickerHorizontalOffset)
-                        .accessibilityIdentifier("Preferences.AIChat.openNewChatsPicker")
-                        .onChange(of: model.openAIChatInSidebar) { _ in
-                            PixelKit.fire(AIChatPixel.aiChatSidebarSettingChanged,
-                                          frequency: .uniqueByName,
-                                          includeAppVersionParameter: true)
-                        }
-                    }
-                    .visibility(model.shouldShowAIFeatures && model.shouldShowOpenAIChatInSidebarToggle ? .visible : .gone)
-
                     Divider()
                         .padding(.bottom, 8)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210702047347360?focus=true
Tech Design URL:
CC:

### Description
This PR implements change to "AI Features" settings discussed in https://app.asana.com/1/137249556945/task/1210881343994632/comment/1210999247146358?focus=true :
- removing the "Open New Chats" section
- for all users using the global AI toggle default to the "sidebar enabled" experience

### Testing Steps
1. Disable the `aiChatGlobalSwitch` flag
2. Open settings -> AI Features
3. Uncheck "Open Duck.ai in the sidebar" option.
4. Open a new tab and navigate to a website
5. Click "Duck.ai" in the address bar to ensure full page "Duck.ai" navigation happens.
--
1. Enable the `aiChatGlobalSwitch` flag
2. Open settings -> AI Features
3. Ensure that the "Open New Chats" section with radio buttons from old designs is no longer present
4. Open a new tab and navigate to a website
5. Click "Duck.ai" in the address bar to ensure that sidebar is toggled

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
We break the sidebar showing logic.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)