### PR TITLE
VPN Upsell: Delay feature flag evaluation until the trigger

### DIFF
--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNUpsellVisibilityManager.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNUpsellVisibilityManager.swift
@@ -100,7 +100,7 @@ final class VPNUpsellVisibilityManager: ObservableObject {
 
         updateState(.notEligible)
 
-        guard isUserEligible, isFeatureOn else {
+        guard isUserEligible else {
             return
         }
 
@@ -312,27 +312,29 @@ final class VPNUpsellVisibilityManager: ObservableObject {
     // MARK: - Upsell Visibility
 
     private func updateState(_ newState: State) {
-        guard isFeatureOn, isUserEligible else {
-            state = .notEligible
-            return
-        }
-
         guard !shouldDismiss else {
             state = .dismissed
             return
         }
 
+        guard newState == .visible else {
+            state = newState
+            return
+        }
+
+        guard isFeatureOn, isUserEligible else {
+            state = .notEligible
+            return
+        }
+
         let previousState = state
-        state = newState
 
         // Fire pixel when transitioning to visible state
-        if previousState != .visible && newState == .visible {
+        if previousState != .visible {
             pixelHandler(.privacyProToolbarButtonShown)
         }
 
-        guard newState == .visible else {
-            return
-        }
+        state = newState
 
         shouldShowNotificationDot = !persistor.vpnUpsellPopoverViewed
     }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1211006882189186?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1210649122070619?focus=true
CC:

### Description

This PR fixes an important edge case in the following scenario:
1. eligible user launches the app for the first time
2. they go through the onboarding and set the browser as default
3. upsell button won’t show up

Before this PR, `setup` also evaluated `isFeatureOn`, but that was prone to timing issues - the remote config might not update before we get to this evaluation. I fixed that by moving `isFeatureOn` evaluation directly before setting the upsell state to `.visible`. Since this only affects the first launch, it gives more than enough breathing room for a remote config refresh.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app —>
1. Make sure `vpnToolbarUpsell` flag is disabled (so remove the override)
2. Reset upsell state via `Debug > VPN > Upsell > Reset Upsell State`
3. Relaunch the browser
4. Skip onboarding
5. Now use the debug menu to change the remote config url to this: https://jsonblob.com/api/jsonBlob/1403306814828896256 (no restart required)
6. Now set the browser as default
7. The upsell shortcut should appear within 10 seconds.

### Impact and Risks
None, feature-flagged

#### What could go wrong?
N/A

### Quality Considerations
* I’ve added a dedicated test for this edge case

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)