### PR TITLE
Fix jerky animation on scroll for experimental address bar

### DIFF
--- a/SharedPackages/UIComponents/Sources/UIComponents/iOS/ImageSegmentedPickerView.swift
+++ b/SharedPackages/UIComponents/Sources/UIComponents/iOS/ImageSegmentedPickerView.swift
@@ -158,7 +158,7 @@ public struct ImageSegmentedPickerView: View {
                     .frame(width: geo.size.width / CGFloat(viewModel.items.count), height: Constants.innerHeight)
                     .offset(x: currentOffset)
                     .shadow(color: Color(designSystemColor: .shadowPrimary), radius: 0.5, x: 0, y: 0.5)
-                    .animation(.easeInOut(duration: 0.2), value: currentOffset)
+                    .animation(viewModel.scrollProgress == nil ? .easeInOut(duration: 0.2) : nil, value: currentOffset)
 
                 HStack(spacing: 0) {
                     ForEach(Array(viewModel.items.enumerated()), id: \.element.id) { index, item in
@@ -178,11 +178,6 @@ public struct ImageSegmentedPickerView: View {
                 var transaction = Transaction()
                 transaction.disablesAnimations = true
                 withTransaction(transaction) {
-                    currentOffset = calculateCurrentOffset(geometry: geo)
-                }
-            }
-            .onChange(of: viewModel.selectedItem.id) { _ in
-                if viewModel.scrollProgress == nil {
                     currentOffset = calculateCurrentOffset(geometry: geo)
                 }
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210947460017654?focus=true

### Description
Fix jerky animation on scroll for experimental address bar

### Testing Steps
1. Enable the Experimental address bar under AI Features
2. Add a bunch of favorites (not required but it makes easier to reproduce the issue)
3. Select the address bar and tap on duck.ai, make sure the animation is smooth
4. Swipe left/right in the content area to see if it's still working

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Regression on selecting the mode by tapping on it, or scrolling in the content area