### PR TITLE
Trim whitespace before submitting a query

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
@@ -116,8 +116,9 @@ final class SwitchBarHandler: SwitchBarHandling {
     }
 
     func submitText(_ text: String) {
-        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-        textSubmissionSubject.send((text: text, mode: currentToggleState))
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        textSubmissionSubject.send((text: trimmed, mode: currentToggleState))
     }
 
     func setToggleState(_ state: TextEntryMode) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1210989002857246?focus=true

### Description
Trim whitespace before submitting a query

### Testing Steps
1. Enable the experimental address bar under AI Features
2. Type search queries like "      lala.     " 
3. Check that the actual query submitted doesn't have the whitespace on it
4. Check if the history item when you start typing "la" doesn't have the whitespace on it

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Incorrectly trim the whitespace