### PR TITLE
Fix regex for checking tasks in last internal release

### DIFF
--- a/iOS/scripts/get_tasks_in_last_internal_release.sh
+++ b/iOS/scripts/get_tasks_in_last_internal_release.sh
@@ -30,7 +30,7 @@ get_task_id() {
 	local url="$1"
 	local task_id
 	task_id="$(perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?.*|\1|; \
-                s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?.*|\1|; \
+                s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(?:/[0-9a-z/]*)?(?:\?focus=true)?.*|\1|; \
                 s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?.*|\1|' <<< "$url")"
 	if [[ -n "$task_id" ]]; then
 		local http_code

--- a/iOS/scripts/get_tasks_in_last_internal_release.sh
+++ b/iOS/scripts/get_tasks_in_last_internal_release.sh
@@ -29,9 +29,9 @@ find_task_urls_in_git_log() {
 get_task_id() {
 	local url="$1"
 	local task_id
-	task_id="$(perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?|\1|; \
-                s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?|\1|; \
-                s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?|\1|' <<< "$url")"
+	task_id="$(perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?.*|\1|; \
+                s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?.*|\1|; \
+                s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?.*|\1|' <<< "$url")"
 	if [[ -n "$task_id" ]]; then
 		local http_code
 		http_code="$(curl -fLSs "${asana_api_url}/tasks/${task_id}?opt_fields=gid" \

--- a/macOS/scripts/get_tasks_in_last_internal_release.sh
+++ b/macOS/scripts/get_tasks_in_last_internal_release.sh
@@ -30,7 +30,7 @@ get_task_id() {
 	local url="$1"
 	local task_id
 	task_id="$(perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?.*|\1|; \
-                s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?.*|\1|; \
+                s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(?:/[0-9a-z/]*)?(?:\?focus=true)?.*|\1|; \
                 s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?.*|\1|' <<< "$url")"
 	if [[ -n "$task_id" ]]; then
 		local http_code

--- a/macOS/scripts/get_tasks_in_last_internal_release.sh
+++ b/macOS/scripts/get_tasks_in_last_internal_release.sh
@@ -29,9 +29,9 @@ find_task_urls_in_git_log() {
 get_task_id() {
 	local url="$1"
 	local task_id
-	task_id="$(perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?|\1|; \
-                s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?|\1|; \
-                s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?|\1|' <<< "$url")"
+	task_id="$(perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?.*|\1|; \
+                s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?.*|\1|; \
+                s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?.*|\1|' <<< "$url")"
 	if [[ -n "$task_id" ]]; then
 		local http_code
 		http_code="$(curl -fLSs "${asana_api_url}/tasks/${task_id}?opt_fields=gid" \


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1211022602360101?focus=true

### Description
Drop characters after matched task ID.

### Testing Steps
Run this and verify that it returns `1210975209610639`:
```
perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?.*|\1|; \
                s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?.*|\1|; \
                s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?.*|\1|' \
    <<< 'https://app.asana.com/1/137249556945/project/1204167627774280/task/1210975209610639?\'
```

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)