### PR TITLE
Global AI Switch 6. Move sidebar setting as a nested option

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatMenuVisibilityConfigurable.swift
@@ -111,15 +111,7 @@ final class AIChatMenuConfiguration: AIChatMenuVisibilityConfigurable {
     }
 
     var shouldOpenAIChatInSidebar: Bool {
-        // Can be removed after `.aiChatGlobalSwitch` is fully rolled out.
-        // Additionally all current `shouldOpenAIChatInSidebar` calls should be reviewed cleaning up obsolete code paths.
-        guard featureFlagger.isFeatureOn(.aiChatGlobalSwitch) else {
-            return shouldDisplayAnyAIChatFeature && storage.openAIChatInSidebar
-        }
-
-        // When using global AI Chat switch is enabled there is no separate setting for the sidebar and sidebar use is made a new defult
-        // so we ignore previous setting value.
-        return true
+        shouldDisplayAnyAIChatFeature && storage.openAIChatInSidebar
     }
 
     init(storage: AIChatPreferencesStorage, remoteSettings: AIChatRemoteSettingsProvider, featureFlagger: FeatureFlagger) {

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
@@ -115,27 +115,20 @@ extension Preferences {
                                               includeAppVersionParameter: true)
                             }
                         }
-                    }
-                    .visibility(model.shouldShowAIFeatures ? .visible : .gone)
 
-                    PreferencePaneSection(UserText.aiChatOpenNewChatsSectionTitle,
-                                          spacing: 6) {
-                        Picker(selection: $model.openAIChatInSidebar, content: {
-                            Text(UserText.aiChatOpenInSidebarOption).tag(true)
-                                .padding(.bottom, 4).accessibilityIdentifier("Preferences.AIChat.openNewChatsPicker.inSidebar")
-                            Text(UserText.aiChatOpenInFullPageOption).tag(false)
-                                .accessibilityIdentifier("Preferences.AIChat.openNewChatsPicker.fullPage")
-                        }, label: {})
-                        .pickerStyle(.radioGroup)
-                        .offset(x: PreferencesUI_macOS.Const.pickerHorizontalOffset)
-                        .accessibilityIdentifier("Preferences.AIChat.openNewChatsPicker")
-                        .onChange(of: model.openAIChatInSidebar) { _ in
-                            PixelKit.fire(AIChatPixel.aiChatSidebarSettingChanged,
-                                          frequency: .uniqueByName,
-                                          includeAppVersionParameter: true)
+                        if model.shouldShowOpenAIChatInSidebarToggle {
+                            ToggleMenuItem(UserText.aiChatOpenInSidebarToggle,
+                                           isOn: $model.openAIChatInSidebar)
+                            .accessibilityIdentifier("Preferences.AIChat.openInSidebarToggle")
+                            .onChange(of: model.openAIChatInSidebar) { _ in
+                                PixelKit.fire(AIChatPixel.aiChatSidebarSettingChanged,
+                                              frequency: .uniqueByName,
+                                              includeAppVersionParameter: true)
+                            }
+                            .padding(.leading, 19)
                         }
                     }
-                    .visibility(model.shouldShowAIFeatures && model.shouldShowOpenAIChatInSidebarToggle ? .visible : .gone)
+                    .visibility(model.shouldShowAIFeatures ? .visible : .gone)
 
                     Divider()
                         .padding(.bottom, 8)

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
@@ -125,6 +125,7 @@ extension Preferences {
                                               frequency: .uniqueByName,
                                               includeAppVersionParameter: true)
                             }
+                            .disabled(!model.showShortcutInAddressBar)
                             .padding(.leading, 19)
                         }
                     }

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
@@ -118,6 +118,25 @@ extension Preferences {
                     }
                     .visibility(model.shouldShowAIFeatures ? .visible : .gone)
 
+                    PreferencePaneSection(UserText.aiChatOpenNewChatsSectionTitle,
+                                          spacing: 6) {
+                        Picker(selection: $model.openAIChatInSidebar, content: {
+                            Text(UserText.aiChatOpenInSidebarOption).tag(true)
+                                .padding(.bottom, 4).accessibilityIdentifier("Preferences.AIChat.openNewChatsPicker.inSidebar")
+                            Text(UserText.aiChatOpenInFullPageOption).tag(false)
+                                .accessibilityIdentifier("Preferences.AIChat.openNewChatsPicker.fullPage")
+                        }, label: {})
+                        .pickerStyle(.radioGroup)
+                        .offset(x: PreferencesUI_macOS.Const.pickerHorizontalOffset)
+                        .accessibilityIdentifier("Preferences.AIChat.openNewChatsPicker")
+                        .onChange(of: model.openAIChatInSidebar) { _ in
+                            PixelKit.fire(AIChatPixel.aiChatSidebarSettingChanged,
+                                          frequency: .uniqueByName,
+                                          includeAppVersionParameter: true)
+                        }
+                    }
+                    .visibility(model.shouldShowAIFeatures && model.shouldShowOpenAIChatInSidebarToggle ? .visible : .gone)
+
                     Divider()
                         .padding(.bottom, 8)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210702047347360?focus=true
Tech Design URL:
CC:

### Description
This PR implements change to "AI Features" settings screen as discussed in https://app.asana.com/1/137249556945/task/1210881343994632/comment/1211022228644970?focus=true with the major changes being:
- keep the sidebar setting and nest it under "Show in address bar"
- when "Show in address bar" is unchecked then render nested sidebar setting in disabled (greyed out) state
- don't introduce any changes to sidebar/new conversation logic as part of the global switch feature


### Testing Steps
1. Open Settings -> AI Features
2. Ensure "Open Duck.ai in the sidebar" is rendered as a nested setting under "Show in address bar"
3. Disabling "Show in address bar" should also make "Open Duck.ai in the sidebar" option disabled
4. Enable both "Show in address bar" and "Open Duck.ai in the sidebar"
5. Open a new tab and navigate to a website
6. Click "Duck.ai" in the address bar to ensure that sidebar is toggled
7. Open Settings -> AI Features
8. Disable "Open Duck.ai in the sidebar"
9. Open a new tab and navigate to a website
10. Click "Duck.ai" in the address bar to ensure full page "Duck.ai" navigation happens

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Sidebar logic not working

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)