### PR TITLE
macOS: Fix dragging space after tabs

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -585,10 +585,10 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
 
     private func updateEmptyTabArea() {
         let totalTabWidth = self.totalTabWidth
-        let plusButtonWidth = footerCurrentWidthDimension
+        let plusButtonWidth: CGFloat = 44
 
         // Window dragging
-        let leadingSpace = min(totalTabWidth, scrollView.frame.size.width)
+        let leadingSpace = min(totalTabWidth + plusButtonWidth, scrollView.frame.size.width)
         windowDraggingViewLeadingConstraint.constant = leadingSpace
     }
 

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -588,7 +588,7 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
         let plusButtonWidth = footerCurrentWidthDimension
 
         // Window dragging
-        let leadingSpace = min(totalTabWidth + plusButtonWidth, scrollView.frame.size.width)
+        let leadingSpace = min(totalTabWidth, scrollView.frame.size.width)
         windowDraggingViewLeadingConstraint.constant = leadingSpace
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1210891681561459?focus=true
Tech Design URL:
CC:

### Description
When we added the new visuals, we introduced a new way of calculating the size and position of the add tab button, which caused an issue when calculating the dragging space after the tab bar. Now, by removing the size of the add button, the drag space is okay again.

### Testing Steps
1. Grab the area that is just next to the add tab button (the +) in the tab bar.
2. Check that it is possible to drag the window when doing that.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)