### PR TITLE
Don't adjust scroll position when typing

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -316,13 +316,13 @@ class SwitchBarTextEntryView: UIView {
 extension SwitchBarTextEntryView: UITextViewDelegate {
 
     func textViewDidChange(_ textView: UITextView) {
+        hasBeenInteractedWith = true
+        
         updatePlaceholderVisibility()
         updateButtonState()
         updateTextViewHeight()
         handler.updateCurrentText(textView.text ?? "")
         handler.markUserInteraction()
-
-        hasBeenInteractedWith = true
 
         textView.reloadInputViews()
     }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1210987986595470?focus=true
Tech Design URL:
CC:

### Description

Prevent adjusting scroll position while typing, but keep existing behavior based on the input type (url / non-url).

* Adjusted the variable to account for typing interaction - this allowed to adjust scroll on entry based on input type.
* Added height adjustment after layout, making sure the automatic scroll is performed on up-to-date frame content size.

### Testing Steps
1. Enable Experimental Address Bar
2. Start typing text and add newlines, move the caret to beginning and the center, verify the new text is visible and text is not being scrolled uncontrollably.
3. Enter a long search term that exceeds 6 lines without newlines (e.g. lorem ipsum) and perform the search.
4. Tap on search field. Verify the text area is expanded and last line is visible.
5. Browse to a website with a long url, that exceeds 6 lines (e.g. random amazon product page).
6. Tap on search field. Verify text area is 1 line and beginning of the URL is visible.
7. Tap on search field again. Verify text area has expanded and the beginning of the URL is visible.

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
TextView scroll is behaving erratically and does unexpected UI actions.

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)