### PR TITLE
[iOS][Picture In Picture] Attempt Fix crash

### DIFF
--- a/iOS/DuckDuckGo/AppServices/SystemSettingsPiPTutorialService.swift
+++ b/iOS/DuckDuckGo/AppServices/SystemSettingsPiPTutorialService.swift
@@ -24,24 +24,22 @@ import SystemSettingsPiPTutorial
 
 @MainActor
 final class SystemSettingsPiPTutorialService {
-    let manager: SystemSettingsPiPTutorialManager
+    lazy var manager: SystemSettingsPiPTutorialManager = SystemSettingsPiPTutorialManager(
+        playerView: self.videoPlayerComponents.playerView,
+        videoPlayer: self.videoPlayerComponents.playerCoordinator,
+        eventMapper: SystemSettingsPiPTutorialPixelHandler()
+    )
 
-    init(featureFlagger: FeatureFlagger) {
-        // Initialises the Video Player Coordinator and assign the avPlayerLayer to PiP controller.
+    // PlayerView and VideoPlayerCoordinator are injected as autoclosure var so they're initialisation will be deferred till they're needed
+    // https://app.asana.com/1/137249556945/project/1206329551987282/task/1211011039245367?focus=true
+    private lazy var videoPlayerComponents: (playerView: PlayerUIView, playerCoordinator: VideoPlayerCoordinator) = {
         let videoPlayerCoordinator = VideoPlayerCoordinator(configuration: .init(allowsPictureInPicturePlayback: true, requiresLinearPlayback: true))
         let playerView = PlayerUIView(player: videoPlayerCoordinator.player)
         videoPlayerCoordinator.setupPictureInPicture(playerLayer: playerView.playerLayer)
+        return (playerView, videoPlayerCoordinator)
+    }()
 
-        let isFeatureEnabled = {
-            true
-        }
-
-        manager = SystemSettingsPiPTutorialManager(
-            playerView: playerView,
-            videoPlayer: videoPlayerCoordinator,
-            eventMapper: SystemSettingsPiPTutorialPixelHandler()
-        )
-
+    init(featureFlagger: FeatureFlagger) {
         // Register PiP Video URL providers
         registerAllURLProviders(featureFlagger: featureFlagger)
     }

--- a/iOS/LocalPackages/SystemSettingsPiPTutorial/Sources/SystemSettingsPiPTutorial/SystemSettingsPiPTutorialManager.swift
+++ b/iOS/LocalPackages/SystemSettingsPiPTutorial/Sources/SystemSettingsPiPTutorial/SystemSettingsPiPTutorialManager.swift
@@ -28,8 +28,12 @@ import Combine
 public final class SystemSettingsPiPTutorialManager {
     weak var presenter: SystemSettingsPiPTutorialPresenting?
 
-    private let playerView: () -> UIView
-    private let videoPlayer: () -> SystemSettingsPiPTutorialPlayer
+    private let playerViewProvider: () -> UIView
+    private let videoPlayerProvider: () -> SystemSettingsPiPTutorialPlayer
+
+    private lazy var playerView: UIView = playerViewProvider()
+    private lazy var videoPlayer: SystemSettingsPiPTutorialPlayer = videoPlayerProvider()
+
     private let pipTutorialURLProvider: SystemSettingsPiPTutorialURLManaging
     private let urlOpener: SystemSettingsPiPURLOpener
     private let eventMapper: SystemSettingsPiPTutorialEventMapper
@@ -62,8 +66,8 @@ public final class SystemSettingsPiPTutorialManager {
         eventMapper: SystemSettingsPiPTutorialEventMapper,
         urlOpener: SystemSettingsPiPURLOpener
     ) {
-        self.playerView = playerView
-        self.videoPlayer = videoPlayer
+        self.playerViewProvider = playerView
+        self.videoPlayerProvider = videoPlayer
         self.pipTutorialURLProvider = pipTutorialURLProvider
         self.urlOpener = urlOpener
         self.eventMapper = eventMapper
@@ -76,7 +80,7 @@ private extension SystemSettingsPiPTutorialManager {
 
     func loadAndPlayPiPTutorialIfEnabled(for destination: SystemSettingsPiPTutorialDestination) {
         // If PiP is supported, otherwise load the URL without loading the video.
-        guard videoPlayer().isPictureInPictureSupported() else {
+        guard videoPlayer.isPictureInPictureSupported() else {
             urlOpener.open(destination.url)
             return
         }
@@ -85,7 +89,7 @@ private extension SystemSettingsPiPTutorialManager {
             let pipTutorialURL = try pipTutorialURLProvider.url(for: destination)
 
             // Observe status before loading
-            playerItemStatusCancellable = videoPlayer().playerItemStatusPublisher
+            playerItemStatusCancellable = videoPlayer.playerItemStatusPublisher
                 .receive(on: DispatchQueue.main)
                 .filter { $0 == .readyToPlay || $0 == .failed } // We're only interested if the item is ready to play or can't be played.
                 .prefix(1) // If video loops `.readyToPlay` is emitted multiple times. We're only interested in the first event when the asset finished loading.
@@ -93,12 +97,12 @@ private extension SystemSettingsPiPTutorialManager {
                     guard let self else { return }
                     switch status {
                     case .readyToPlay:
-                        self.videoPlayer().play()
+                        self.videoPlayer.play()
                         Logger.pipTutorial.debug("[PiP Tutorial Video] Opening Default Browser Settings")
                         self.urlOpener.open(destination.url)
                     case .failed:
                         Logger.pipTutorial.error("[PiP Tutorial Video] Could not play PiP video. Opening Default Browser Settings")
-                        eventMapper.fireFailedToLoadPiPTutorialEvent(error: videoPlayer().currentItemError, urlPath: videoPlayer().currentItemURL?.absoluteString)
+                        eventMapper.fireFailedToLoadPiPTutorialEvent(error: videoPlayer.currentItemError, urlPath: videoPlayer.currentItemURL?.absoluteString)
                         self.urlOpener.open(destination.url)
                     default:
                         break
@@ -108,8 +112,8 @@ private extension SystemSettingsPiPTutorialManager {
             // Attach the player before call loading.
             // The player view is removed when the app comes to foreground so there's no need to remove it if the player fails to load the asset.
             // There are intermittent issues when attaching the player view just before playing causing PiP not to show. This ensure PiP will be always visible when we play the video.
-            presenter?.attachPlayerView(playerView())
-            videoPlayer().load(url: pipTutorialURL)
+            presenter?.attachPlayerView(playerView)
+            videoPlayer.load(url: pipTutorialURL)
 
         } catch {
             logError(error)
@@ -125,7 +129,7 @@ private extension SystemSettingsPiPTutorialManager {
             Logger.pipTutorial.error("Provider failed to resolve URL. Error: \(error.localizedDescription)")
         default:
             Logger.pipTutorial.error("An unexpected error occurred: \(error.localizedDescription)")
-            eventMapper.fireFailedToLoadPiPTutorialEvent(error: error, urlPath: videoPlayer().currentItemURL?.absoluteString)
+            eventMapper.fireFailedToLoadPiPTutorialEvent(error: error, urlPath: videoPlayer.currentItemURL?.absoluteString)
         }
     }
 
@@ -150,8 +154,8 @@ extension SystemSettingsPiPTutorialManager: SystemSettingsPiPTutorialManaging {
 
     public func stopPiPTutorialIfNeeded() {
         // Do not check for feature enabled here as it may be turned off when the video is already playing and we may never stop the video.
-        videoPlayer().stop()
-        presenter?.detachPlayerView(playerView())
+        videoPlayer.stop()
+        presenter?.detachPlayerView(playerView)
     }
 
     public func playPiPTutorialAndNavigateTo(destination: SystemSettingsPiPTutorialDestination) {

--- a/iOS/LocalPackages/SystemSettingsPiPTutorial/Sources/SystemSettingsPiPTutorial/SystemSettingsPiPTutorialManager.swift
+++ b/iOS/LocalPackages/SystemSettingsPiPTutorial/Sources/SystemSettingsPiPTutorial/SystemSettingsPiPTutorialManager.swift
@@ -28,8 +28,8 @@ import Combine
 public final class SystemSettingsPiPTutorialManager {
     weak var presenter: SystemSettingsPiPTutorialPresenting?
 
-    private let playerView: UIView
-    private let videoPlayer: SystemSettingsPiPTutorialPlayer
+    private let playerView: () -> UIView
+    private let videoPlayer: () -> SystemSettingsPiPTutorialPlayer
     private let pipTutorialURLProvider: SystemSettingsPiPTutorialURLManaging
     private let urlOpener: SystemSettingsPiPURLOpener
     private let eventMapper: SystemSettingsPiPTutorialEventMapper
@@ -42,8 +42,8 @@ public final class SystemSettingsPiPTutorialManager {
     ///   - playerView: The view that will display the video content.
     ///   - videoPlayer: The player responsible for video playback and PiP functionality.
     public convenience init(
-        playerView: UIView,
-        videoPlayer: SystemSettingsPiPTutorialPlayer,
+        playerView: @escaping @autoclosure () -> UIView,
+        videoPlayer: @escaping @autoclosure () -> SystemSettingsPiPTutorialPlayer,
         eventMapper: SystemSettingsPiPTutorialEventMapper
     ) {
         self.init(
@@ -56,8 +56,8 @@ public final class SystemSettingsPiPTutorialManager {
     }
 
     init(
-        playerView: UIView,
-        videoPlayer: SystemSettingsPiPTutorialPlayer,
+        playerView: @escaping () -> UIView,
+        videoPlayer: @escaping () -> SystemSettingsPiPTutorialPlayer,
         pipTutorialURLProvider: SystemSettingsPiPTutorialURLManaging,
         eventMapper: SystemSettingsPiPTutorialEventMapper,
         urlOpener: SystemSettingsPiPURLOpener
@@ -76,7 +76,7 @@ private extension SystemSettingsPiPTutorialManager {
 
     func loadAndPlayPiPTutorialIfEnabled(for destination: SystemSettingsPiPTutorialDestination) {
         // If PiP is supported, otherwise load the URL without loading the video.
-        guard videoPlayer.isPictureInPictureSupported() else {
+        guard videoPlayer().isPictureInPictureSupported() else {
             urlOpener.open(destination.url)
             return
         }
@@ -85,7 +85,7 @@ private extension SystemSettingsPiPTutorialManager {
             let pipTutorialURL = try pipTutorialURLProvider.url(for: destination)
 
             // Observe status before loading
-            playerItemStatusCancellable = videoPlayer.playerItemStatusPublisher
+            playerItemStatusCancellable = videoPlayer().playerItemStatusPublisher
                 .receive(on: DispatchQueue.main)
                 .filter { $0 == .readyToPlay || $0 == .failed } // We're only interested if the item is ready to play or can't be played.
                 .prefix(1) // If video loops `.readyToPlay` is emitted multiple times. We're only interested in the first event when the asset finished loading.
@@ -93,12 +93,12 @@ private extension SystemSettingsPiPTutorialManager {
                     guard let self else { return }
                     switch status {
                     case .readyToPlay:
-                        self.videoPlayer.play()
+                        self.videoPlayer().play()
                         Logger.pipTutorial.debug("[PiP Tutorial Video] Opening Default Browser Settings")
                         self.urlOpener.open(destination.url)
                     case .failed:
                         Logger.pipTutorial.error("[PiP Tutorial Video] Could not play PiP video. Opening Default Browser Settings")
-                        eventMapper.fireFailedToLoadPiPTutorialEvent(error: videoPlayer.currentItemError, urlPath: videoPlayer.currentItemURL?.absoluteString)
+                        eventMapper.fireFailedToLoadPiPTutorialEvent(error: videoPlayer().currentItemError, urlPath: videoPlayer().currentItemURL?.absoluteString)
                         self.urlOpener.open(destination.url)
                     default:
                         break
@@ -108,8 +108,8 @@ private extension SystemSettingsPiPTutorialManager {
             // Attach the player before call loading.
             // The player view is removed when the app comes to foreground so there's no need to remove it if the player fails to load the asset.
             // There are intermittent issues when attaching the player view just before playing causing PiP not to show. This ensure PiP will be always visible when we play the video.
-            presenter?.attachPlayerView(playerView)
-            videoPlayer.load(url: pipTutorialURL)
+            presenter?.attachPlayerView(playerView())
+            videoPlayer().load(url: pipTutorialURL)
 
         } catch {
             logError(error)
@@ -125,7 +125,7 @@ private extension SystemSettingsPiPTutorialManager {
             Logger.pipTutorial.error("Provider failed to resolve URL. Error: \(error.localizedDescription)")
         default:
             Logger.pipTutorial.error("An unexpected error occurred: \(error.localizedDescription)")
-            eventMapper.fireFailedToLoadPiPTutorialEvent(error: error, urlPath: videoPlayer.currentItemURL?.absoluteString)
+            eventMapper.fireFailedToLoadPiPTutorialEvent(error: error, urlPath: videoPlayer().currentItemURL?.absoluteString)
         }
     }
 
@@ -150,8 +150,8 @@ extension SystemSettingsPiPTutorialManager: SystemSettingsPiPTutorialManaging {
 
     public func stopPiPTutorialIfNeeded() {
         // Do not check for feature enabled here as it may be turned off when the video is already playing and we may never stop the video.
-        videoPlayer.stop()
-        presenter?.detachPlayerView(playerView)
+        videoPlayer().stop()
+        presenter?.detachPlayerView(playerView())
     }
 
     public func playPiPTutorialAndNavigateTo(destination: SystemSettingsPiPTutorialDestination) {

--- a/iOS/LocalPackages/SystemSettingsPiPTutorial/Tests/SystemSettingsPiPTutorialTests/SystemSettingsPiPTutorialManagerTests.swift
+++ b/iOS/LocalPackages/SystemSettingsPiPTutorial/Tests/SystemSettingsPiPTutorialTests/SystemSettingsPiPTutorialManagerTests.swift
@@ -34,8 +34,8 @@ struct SystemSettingsPiPTutorialManagerTests {
     func checkRegisteringProviderForDestinationAsksURLProviderToRegisterProvider() async throws {
         // GIVEN
         let sut = SystemSettingsPiPTutorialManager(
-            playerView: UIView(),
-            videoPlayer: videoPlayerMock,
+            playerView: { UIView() },
+            videoPlayer: { videoPlayerMock },
             pipTutorialURLProvider: urlProviderMock,
             eventMapper: eventMapperMock,
             urlOpener: urlOpenerMock
@@ -60,8 +60,8 @@ struct SystemSettingsPiPTutorialManagerTests {
         // GIVEN
         let playerView = UIView()
         let sut = SystemSettingsPiPTutorialManager(
-            playerView: playerView,
-            videoPlayer: videoPlayerMock,
+            playerView: { playerView },
+            videoPlayer: { videoPlayerMock },
             pipTutorialURLProvider: urlProviderMock,
             eventMapper: eventMapperMock,
             urlOpener: urlOpenerMock
@@ -87,8 +87,8 @@ struct SystemSettingsPiPTutorialManagerTests {
         // GIVEN
         videoPlayerMock.isPiPSupported = false
         let sut = SystemSettingsPiPTutorialManager(
-            playerView: UIView(),
-            videoPlayer: videoPlayerMock,
+            playerView: { UIView() },
+            videoPlayer: { videoPlayerMock },
             pipTutorialURLProvider: urlProviderMock,
             eventMapper: eventMapperMock,
             urlOpener: urlOpenerMock
@@ -111,8 +111,8 @@ struct SystemSettingsPiPTutorialManagerTests {
         // GIVEN
         urlProviderMock.urlForDestinationResult = .failure(.noProviderAvailable(destination: .mock))
         let sut = SystemSettingsPiPTutorialManager(
-            playerView: UIView(),
-            videoPlayer: videoPlayerMock,
+            playerView: { UIView() },
+            videoPlayer: { videoPlayerMock },
             pipTutorialURLProvider: urlProviderMock,
             eventMapper: eventMapperMock,
             urlOpener: urlOpenerMock
@@ -136,8 +136,8 @@ struct SystemSettingsPiPTutorialManagerTests {
         // GIVEN
         let playerView = UIView()
         let sut = SystemSettingsPiPTutorialManager(
-            playerView: playerView,
-            videoPlayer: videoPlayerMock,
+            playerView: { playerView },
+            videoPlayer: { videoPlayerMock },
             pipTutorialURLProvider: urlProviderMock,
             eventMapper: eventMapperMock,
             urlOpener: urlOpenerMock
@@ -175,8 +175,8 @@ struct SystemSettingsPiPTutorialManagerTests {
         // GIVEN
         let playerView = UIView()
         let sut = SystemSettingsPiPTutorialManager(
-            playerView: playerView,
-            videoPlayer: videoPlayerMock,
+            playerView: { playerView },
+            videoPlayer: { videoPlayerMock },
             pipTutorialURLProvider: urlProviderMock,
             eventMapper: eventMapperMock,
             urlOpener: urlOpenerMock
@@ -217,8 +217,8 @@ struct SystemSettingsPiPTutorialManagerTests {
         videoPlayerMock.currentItemError = error
         videoPlayerMock.currentItemURL = url
         let sut = SystemSettingsPiPTutorialManager(
-            playerView: UIView(),
-            videoPlayer: videoPlayerMock,
+            playerView: { UIView() },
+            videoPlayer: { videoPlayerMock },
             pipTutorialURLProvider: urlProviderMock,
             eventMapper: eventMapperMock,
             urlOpener: urlOpenerMock


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1211011039245367?focus=true
Tech Design URL:
CC:

### Description

The [stack trace](https://errors.duckduckgo.com/organizations/ddg/issues/506092/?project=8&query=is%3Aunresolved+firstSeen%3A-9d&referrer=issue-stream&sort=freq&statsPeriod=14d&stream_index=0) shows that the service introduced to show the PiP video crashes for several users when the app launches. The crash happens in AVPictureInPictureController.init. This PR attempts to fix the crash by deferring the initialisation of the video components till they’re needed.

### Testing Steps
Prerequisites:
- Ensure to test on a physical device. PiP is not supported on iOS simulator

**Scenario 1 - “Onboarding"**
1. Open Debug Menu.
2. Select ‘Onboarding’.
3. Tap ‘Preview Onboarding Intro’ button.
4. Progress linear onboarding till ‘Protections Activated!’ screen.
5. Tap ‘Choose Your Browser’ button.
6. Ensure that the app deeplinks to the settings and PiP Video is playing.
7. Go back to the App.
8. Ensure that the PiP video is not playing anymore and the onboarding flow has progressed to:
  a. Add me to your Dock’ screen for iPhone.
  b. 'Choose App Icon color’ screen for iPad.
9. On the 'Add me to your Dock’ screen tap the ’Shoe Me How’ button.
10. Ensure the 'Add to Dock' video plays fine.
11. Send the app to the background and ensure NO pip video plays.

**Scenario 2 - “Settings"**
1. Open Settings Menu.
2. Tap ‘Default Browser’ button from ‘Privacy Protections’ section.
3. Ensure that the app deeplinks to the settings and PiP Video is playing.
4. Go back to the App.
5. Ensure that the PiP video is not playing anymore.

**Scenario 3 - “Promo Modal”**
1. Delete and re-install the app.
2. Open the Debug menu and select ‘Default Browser Prompt’.
3. Select 'New' or ‘Returning’ user.
4. In the 'Activity Log’ section you should see when the first modal will show. (1 day after installation date)
5. Override current date by tapping on in ’Simulate Today’s Date’ and select a date in the future. E.g 2 days in the future. Do not worry about time.
6. Dismiss the Debug and Setting Menu.
7. Send the app to background and bring it back to foreground.
8. Bring the app to foreground.
9. Once the modal show tap ’Set Default Browser’ button.
10. Ensure that the app deeplinks to the settings and PiP Video is playing.
11. Go back to the App.
12. Ensure that the PiP video is not playing anymore.

### Impact and Risks
Low: Crash already exist

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)