### PR TITLE
Fix pixel firing for experimental address bar

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -439,8 +439,6 @@ class MainViewController: UIViewController {
         if daxDialogsManager.shouldShowFireButtonPulse {
             showFireButtonPulse()
         }
-
-        fireExperimentalAddressBarPixel()
     }
 
     override func performSegue(withIdentifier identifier: String, sender: Any?) {
@@ -1079,6 +1077,7 @@ class MainViewController: UIViewController {
     }
     
     func onForeground() {
+        fireExperimentalAddressBarPixel()
         skipSERPFlow = true
         
         // Show Fire Pulse only if Privacy button pulse should not be shown. In control group onboarding `shouldShowPrivacyButtonPulse` is always false.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211034739440613?focus=true

### Description
Fix pixel firing for experimental address bar

### Testing Steps
1. Add a breakpoint on fireExperimentalAddressBarPixel
2. Make sure it's called on a cold boot
3. Make sure it's called if the app goes to the background and then foreground

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Firing the pixel multiple times instead of daily
