### PR TITLE
Fix onboarding on the new omnibar

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3322,7 +3322,9 @@ extension MainViewController: AutoClearWorker {
                 self.newTabPageViewController?.showNextDaxDialog()
             } else if KeyboardSettings().onNewTab {
                 let showKeyboardAfterFireButton = DispatchWorkItem {
-                    self.enterSearch()
+                    if !self.aiChatSettings.isAIChatSearchInputUserSettingsEnabled {
+                        self.enterSearch()
+                    }
                 }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: showKeyboardAfterFireButton)
                 self.showKeyboardAfterFireButton = showKeyboardAfterFireButton


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1210975282087890?focus=true

### Description
Do not automatically select the omnibar in the last onboarding step if the new omnibar is enabled

### Testing Steps
1. Start the onboarding
2. When available, go to settings and enable the AI Features experimental address bar
3. Continue the onboarding 
4. Check if the last step (high five) doesn't automatically select the omnibar

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Regression in the omnibar
