### PR TITLE
[iOS][Set As Default Browser] Fix prompt presentation when other modals are on screen

### DIFF
--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/DefaultBrowserPromptPresenter.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/DefaultBrowserPromptPresenter.swift
@@ -77,25 +77,29 @@ private extension DefaultBrowserModalPresenter {
     }
 
     func presentDefaultBrowserPromptForInactiveUser(from viewController: UIViewController) {
+        // Present the full screen from the root controller or from the presented screen if any. (E.g. settings)
+        let presentingViewController = viewController.presentedViewController ?? viewController
+
         let rootView = DefaultBrowserPromptInactiveUserView(
             background: AnyView(uiProvider.makeBackground()),
             browserComparisonChart: AnyView(uiProvider.makeBrowserComparisonChart()),
-            closeAction: { [weak viewController, weak coordinator] in
+            closeAction: { [weak presentingViewController, weak coordinator] in
                 coordinator?.dismissAction(forPrompt: .inactiveUserModal, shouldDismissPromptPermanently: false)
-                viewController?.dismiss(animated: true)
+                presentingViewController?.dismiss(animated: true)
             },
-            setAsDefaultAction: { [weak viewController, weak coordinator] in
+            setAsDefaultAction: { [weak presentingViewController, weak coordinator] in
                 coordinator?.setDefaultBrowserAction(forPrompt: .inactiveUserModal)
-                viewController?.dismiss(animated: false)
+                presentingViewController?.dismiss(animated: false)
             },
-            onMoreProtectionsTapped: { [weak viewController, weak coordinator] in
+            onMoreProtectionsTapped: { [weak presentingViewController, weak coordinator] in
                 coordinator?.moreProtectionsAction()
-                viewController?.presentedViewController?.present(UINavigationController(rootViewController: MoreProtectionsViewController()), animated: true)
+                presentingViewController?.presentedViewController?.present(UINavigationController(rootViewController: MoreProtectionsViewController()), animated: true)
             }
         )
         let hostingController = PortraitHostingController(rootView: rootView)
         hostingController.modalPresentationStyle = .overFullScreen
-        viewController.present(hostingController, animated: true)
+
+        presentingViewController.present(hostingController, animated: true)
     }
 
     func configurePresentationStyle(hostingController: UIHostingController<DefaultBrowserPromptActiveUserView>, presentingController: UIViewController) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211030690383959?focus=true
Tech Design URL:
CC:

### Description

The inactive modal will not be presented if any other modal is on the screen. This affects monitoring, as we will report showing the prompt, but since the prompt is only displayed once, the user may never see it.

This PR addresses the issue by presenting the full-screen prompt on top of any currently displayed modal, preserving the user's ongoing operation. When the prompt is dismissed, we will ensure that only the prompt is removed, and any previous modal remains on the screen.

### Testing Steps

1. In `DefaultBrowserModalPresenter` comment lines 43-48 and 50 to force inactive modal to appear when the app comes to foreground.
2. Open settings menu.
3. Background and foreground the app.
4. Ensure prompt for inactive users is presented.
5. Tap “Even More Protections…” button and check the webpage is presented correctly.
6. Dismiss the webpage.
7. Close the prompt.
8. Ensure Settings is still on screen.

Repeat the steps by tapping the “Open Links With DuckDuckGo” button.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)