### PR TITLE
Hide return button when there's no text

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/NavigationActionBarView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/NavigationActionBarView.swift
@@ -110,12 +110,14 @@ final class NavigationActionBarView: UIView {
         mainStackView.translatesAutoresizingMaskIntoConstraints = false
         backgroundGradientView.translatesAutoresizingMaskIntoConstraints = false
         
+        let mainStackMinHeightConstraint = mainStackView.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.buttonSize)
         NSLayoutConstraint.activate([
             // Main stack view constraints
             mainStackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: Constants.padding),
             mainStackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -Constants.padding),
             mainStackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: Constants.padding),
             mainStackView.bottomAnchor.constraint(equalTo: keyboardLayoutGuide.topAnchor, constant: -Constants.padding),
+            mainStackMinHeightConstraint,
 
             // Background gradient should align with the keyboard (or bottom safe area)
             backgroundGradientView.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -255,7 +257,7 @@ final class NavigationActionBarView: UIView {
         let shouldShowMicButton = viewModel.shouldShowMicButton
         microphoneButton.isHidden = !shouldShowMicButton
         
-        let shouldShowNewLineButton = viewModel.isKeyboardVisible
+        let shouldShowNewLineButton = viewModel.isKeyboardVisible && viewModel.hasText
         newLineButton.isHidden = !shouldShowNewLineButton
         
         let shouldShowSearchButton = viewModel.hasText


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1210987976823707?focus=true

### Description
Hide return button when there's no text

### Testing Steps
1. Enable experimental address bar
2. Select the address bar, make sure we don't display the return button
3. Add some text, the return button should now be visible 


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Incorrectly displaying the return button, or incorrectly hiding it
