### PR TITLE
Update autofill to 18.3.0

### DIFF
--- a/SharedPackages/BrowserServicesKit/Package.resolved
+++ b/SharedPackages/BrowserServicesKit/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "21abb6f36a0cefc238c7366c50144ca792ada305",
-        "version" : "18.2.0"
+        "revision" : "252082be808ece0ab91d60a27e18bfcf10dcec1b",
+        "version" : "18.3.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         .library(name: "WKAbstractions", targets: ["WKAbstractions"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "18.2.0"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "18.3.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit.git", exact: "3.0.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.7.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "3.0.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211053700302155
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.3.0
Apple PR: 

## Description
Updates Autofill to version [18.3.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.3.0).

### Autofill 18.3.0 release notes
## What's Changed
* [Form] Don't reset value, if the target input is non-ddg or unknown by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/748
* add qobuz.com example and fix it's cardName skip issue by @borgateo in https://github.com/duckduckgo/duckduckgo-autofill/pull/882
* [Matching] Tweak regex to match "access settings" string to login by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/883
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/886
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/888
* [Scanner] Check if target is in shadow root for forced form by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/885
* [Windows prompt] set auto height on windows by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/893
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/894
* [Bundle size] GH Action for reporting bundle size by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/896


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/18.2.0...18.3.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).