### PR TITLE
Fix a crash when opening new fire tab when newTabPagePerTab is enabled

### DIFF
--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
@@ -435,7 +435,7 @@ final class TabCollectionViewModel: NSObject {
     }
 
     private func makeTab(for content: Tab.TabContent) -> Tab {
-        if content == .newtab, let preloaded = newTabPageTabPreloader?.newTab() {
+        if !isBurner, content == .newtab, let preloaded = newTabPageTabPreloader?.newTab() {
             return preloaded
         }
         return Tab(content: content, shouldLoadInBackground: true, burnerMode: burnerMode)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1211054479138273?focus=true

### Description
Ignore tab preloader in Fire Windows, as they don’t use HTML New Tab Page and don’t need preloading.

### Testing Steps
1. Launch the app
2. Enable `newTabPagePerTab` feature flag if disabled
3. Open Fire Window
4. Open new tab in the Fire Window
5. Verify that it doesn’t crash.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)