### PR TITLE
Sanitize VPN errors before emitting them

### DIFF
--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -104,6 +104,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         case simulateTunnelFailureError
         case simulateSubscriptionExpiration
         case tokenReset
+        case xpcIncompatibleError(underlyingError: Error)
 
         // Subscription Errors - 100+
         case vpnAccessRevoked(_ underlyingError: Error)
@@ -128,6 +129,8 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 return "Abnormal situation caused the token to be reset"
             case .appRequestedCancellation:
                 return nil
+            case .xpcIncompatibleError(let underlyingError):
+                return "Error contained XPC-incompatible data: \(underlyingError.localizedDescription)"
             }
         }
 
@@ -139,6 +142,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             case .simulateTunnelFailureError: return 2
             case .simulateSubscriptionExpiration: return 3
             case .tokenReset: return 4
+            case .xpcIncompatibleError: return 5
                 // Subscription Errors - 100+
             case .vpnAccessRevoked: return 100
             case .vpnAccessRevokedDetectedByMonitorCheck: return 101
@@ -164,6 +168,13 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 } else {
                     return [:]
                 }
+            case .xpcIncompatibleError(let underlyingError):
+                let ns = underlyingError as NSError
+                return [
+                    "OriginalErrorDomain": ns.domain,
+                    "OriginalErrorCode": ns.code,
+                    "OriginalErrorDescription": ns.localizedDescription
+                ]
             }
         }
 
@@ -724,6 +735,15 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
     @MainActor
     open override func startTunnel(options: [String: NSObject]? = nil) async throws {
+        do {
+            try await startTunnelInternal(options: options)
+        } catch {
+            throw error.sanitizedForXPC()
+        }
+    }
+
+    @MainActor
+    private func startTunnelInternal(options: [String: NSObject]? = nil) async throws {
         Logger.networkProtection.log("🚀 Starting tunnel")
 
         // It's important to have this as soon as possible since it helps setup PixelKit

--- a/SharedPackages/VPN/Sources/VPN/XPCErrorSanitizer.swift
+++ b/SharedPackages/VPN/Sources/VPN/XPCErrorSanitizer.swift
@@ -1,6 +1,5 @@
 //
 //  XPCErrorSanitizer.swift
-//  VPN
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
 //

--- a/SharedPackages/VPN/Sources/VPN/XPCErrorSanitizer.swift
+++ b/SharedPackages/VPN/Sources/VPN/XPCErrorSanitizer.swift
@@ -1,0 +1,60 @@
+//
+//  XPCErrorSanitizer.swift
+//  VPN
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public struct XPCErrorSanitizer {
+    
+    public static func sanitize(_ error: Error) -> Error {
+        let nsError = error as NSError
+        return isXPCSafe(nsError) ? error : PacketTunnelProvider.TunnelError.xpcIncompatibleError(underlyingError: error)
+    }
+
+    static func isXPCSafe(_ error: NSError) -> Bool {
+        do {
+            _ = try NSKeyedArchiver.archivedData(withRootObject: error, requiringSecureCoding: true)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+}
+
+extension Error {
+    func sanitizedForXPC() -> Error {
+        return XPCErrorSanitizer.sanitize(self)
+    }
+}
+
+extension PacketTunnelProvider.TunnelError {
+    var sanitizedForXPC: PacketTunnelProvider.TunnelError {
+        switch self {
+        case .couldNotGenerateTunnelConfiguration(let internalError):
+            return .couldNotGenerateTunnelConfiguration(internalError: internalError.sanitizedForXPC())
+        case .vpnAccessRevoked(let underlyingError):
+            return .vpnAccessRevoked(underlyingError.sanitizedForXPC())
+        case .startingTunnelWithoutAuthToken(let internalError):
+            return .startingTunnelWithoutAuthToken(internalError: internalError?.sanitizedForXPC())
+        default:
+            let nsError = self as NSError
+            return XPCErrorSanitizer.isXPCSafe(nsError) ? self : .xpcIncompatibleError(underlyingError: self)
+        }
+    }
+}

--- a/SharedPackages/VPN/Tests/VPNTests/XPCErrorSanitizerTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/XPCErrorSanitizerTests.swift
@@ -1,0 +1,193 @@
+//
+//  XPCErrorSanitizerTests.swift
+//  VPN
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import VPN
+
+final class XPCErrorSanitizerTests: XCTestCase {
+
+    func testSanitizeSimpleError() {
+        let safeError = NSError(domain: "TestError", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Test error"
+        ])
+
+        let sanitized = XPCErrorSanitizer.sanitize(safeError)
+
+        XCTAssertEqual((sanitized as NSError).domain, "TestError")
+        XCTAssertEqual((sanitized as NSError).code, 1)
+        XCTAssertEqual((sanitized as NSError).localizedDescription, "Test error")
+    }
+
+    func testSanitizingTunnelErrorThatDoesNotNeedSanitizingDoesNotModifyIt() {
+        let safeError = NSError(domain: "TestError", code: 1)
+        let tunnelError = PacketTunnelProvider.TunnelError.vpnAccessRevoked(safeError)
+        let sanitized = XPCErrorSanitizer.sanitize(tunnelError)
+
+        XCTAssert(sanitized is PacketTunnelProvider.TunnelError)
+        XCTAssertEqual((sanitized as NSError).domain, "VPN.PacketTunnelProvider.TunnelError")
+        XCTAssertEqual((sanitized as NSError).code, 100)
+        XCTAssertEqual((sanitized as NSError).localizedDescription, "VPN disconnected due to expired subscription")
+    }
+
+    func testVpnAccessRevokedWithUnsafeUnderlyingIsWrapped() {
+        let unsafeUnderlying = NSError(domain: "SubscriptionDomain", code: 42, userInfo: [
+            NSLocalizedDescriptionKey: "Access revoked",
+            "object": UnsafeTestClass()
+        ])
+
+        let tunnelError = PacketTunnelProvider.TunnelError.vpnAccessRevoked(unsafeUnderlying)
+        let sanitized = tunnelError.sanitizedForXPC
+
+        if case .vpnAccessRevoked(let sanitizedUnderlying) = sanitized {
+            if case PacketTunnelProvider.TunnelError.xpcIncompatibleError(let original) = sanitizedUnderlying {
+                let nsError = original as NSError
+                XCTAssertEqual(nsError.domain, "SubscriptionDomain")
+                XCTAssertEqual(nsError.code, 42)
+            } else {
+                XCTFail("Expected xpcIncompatibleError for underlying")
+            }
+        } else {
+            XCTFail("Expected vpnAccessRevoked case")
+        }
+    }
+
+    func testStartingTunnelWithoutAuthTokenWithUnsafeInternalErrorIsWrapped() {
+        let internalError = NSError(domain: "TestError", code: 1, userInfo: [
+            "unsafe": UnsafeTestClass()
+        ])
+
+        let tunnelError = PacketTunnelProvider.TunnelError.startingTunnelWithoutAuthToken(internalError: internalError)
+        let sanitized = tunnelError.sanitizedForXPC
+
+        if case .startingTunnelWithoutAuthToken(let maybeError) = sanitized {
+            guard let error = maybeError else { return XCTFail("Expected internal error present") }
+            if case PacketTunnelProvider.TunnelError.xpcIncompatibleError(let original) = error {
+                let ns = original as NSError
+                XCTAssertEqual(ns.domain, "TestError")
+                XCTAssertEqual(ns.code, 1)
+            } else {
+                XCTFail("Expected xpcIncompatibleError for internal error")
+            }
+        } else {
+            XCTFail("Expected startingTunnelWithoutAuthToken case")
+        }
+    }
+
+    func testSanitizeTunnelErrorWithUnderlyingError() {
+        let underlyingError = NSError(domain: "TestError", code: 1, userInfo: [
+            "unsafe": UnsafeTestClass()
+        ])
+
+        let tunnelError = PacketTunnelProvider.TunnelError.couldNotGenerateTunnelConfiguration(
+            internalError: underlyingError
+        )
+
+        let sanitizedTunnelError = tunnelError.sanitizedForXPC
+
+        if case .couldNotGenerateTunnelConfiguration(let sanitizedInternal) = sanitizedTunnelError {
+            if case PacketTunnelProvider.TunnelError.xpcIncompatibleError(let underlying) = sanitizedInternal {
+                let underlyingNSError = underlying as NSError
+                XCTAssertEqual(underlyingNSError.domain, "TestError")
+                XCTAssertEqual(underlyingNSError.code, 1)
+            } else {
+                XCTFail("Expected xpcIncompatibleError wrapper for underlying")
+            }
+        } else {
+            XCTFail("Expected couldNotGenerateTunnelConfiguration case")
+        }
+    }
+
+    func testSanitizedTunnelErrorIsXPCSafe() {
+        let internalError = NSError(domain: "TestError", code: 1, userInfo: [
+            "unsafe": UnsafeTestClass()
+        ])
+
+        let error = PacketTunnelProvider.TunnelError.couldNotGenerateTunnelConfiguration(internalError: internalError)
+        let sanitized = error.sanitizedForXPC as NSError
+        XCTAssertNoThrow(try NSKeyedArchiver.archivedData(withRootObject: sanitized, requiringSecureCoding: true))
+    }
+
+    func testXpcIncompatibleErrorUserInfoIsMinimal() {
+        let unsafeError = NSError(domain: "TestError", code: 1, userInfo: [
+            "unsafe": UnsafeTestClass()
+        ])
+
+        let wrapped = PacketTunnelProvider.TunnelError.xpcIncompatibleError(underlyingError: unsafeError)
+        let ns = wrapped as NSError
+        let keys = Set(ns.userInfo.keys.map { String(describing: $0) })
+        XCTAssertEqual(keys, ["OriginalErrorDomain", "OriginalErrorCode", "OriginalErrorDescription"])
+    }
+
+    func testNestedUnderlyingUnsafeCausesWrapper() {
+        let bottom = NSError(domain: "BottomDomain", code: 3, userInfo: [
+            "unsafe": UnsafeTestClass()
+        ])
+
+        let middle = NSError(domain: "MiddleDomain", code: 2, userInfo: [
+            NSUnderlyingErrorKey: bottom
+        ])
+
+        let top = NSError(domain: "TopDomain", code: 1, userInfo: [
+            NSUnderlyingErrorKey: middle
+        ])
+
+        let sanitized = XPCErrorSanitizer.sanitize(top)
+
+        if case PacketTunnelProvider.TunnelError.xpcIncompatibleError(let underlying) = sanitized {
+            let underlyingNSError = underlying as NSError
+            XCTAssertEqual(underlyingNSError.domain, "TopDomain")
+            XCTAssertEqual(underlyingNSError.code, 1)
+            let ns = sanitized as NSError
+            XCTAssertNoThrow(try NSKeyedArchiver.archivedData(withRootObject: ns, requiringSecureCoding: true))
+        } else {
+            XCTFail("Expected xpcIncompatibleError for nested underlying chain")
+        }
+    }
+
+    func testErrorExtensionSanitizedForXPC() {
+        let error = NSError(domain: "TestError", code: 1, userInfo: [
+            "unsafeKey": UnsafeTestClass()
+        ])
+
+        let sanitized = error.sanitizedForXPC()
+        let directSanitized = XPCErrorSanitizer.sanitize(error)
+
+        XCTAssertEqual((sanitized as NSError).domain, (directSanitized as NSError).domain)
+        XCTAssertEqual((sanitized as NSError).code, (directSanitized as NSError).code)
+    }
+
+    func testCouldNotGenerateTunnelConfigurationWithUnsafeInternalErrorIsArchivable() {
+        let underlyingError = NSError(domain: "TestError", code: 1, userInfo: [
+            "object": UnsafeTestClass()
+        ])
+
+        let tunnelError = PacketTunnelProvider.TunnelError.couldNotGenerateTunnelConfiguration(
+            internalError: underlyingError
+        )
+
+        let error = tunnelError.sanitizedForXPC as NSError
+        XCTAssertNoThrow(try NSKeyedArchiver.archivedData(withRootObject: error, requiringSecureCoding: true))
+    }
+}
+
+private class UnsafeTestClass: NSObject {
+    override var description: String {
+        return "UnsafeTestClass instance"
+    }
+}

--- a/SharedPackages/VPN/Tests/VPNTests/XPCErrorSanitizerTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/XPCErrorSanitizerTests.swift
@@ -1,6 +1,5 @@
 //
 //  XPCErrorSanitizerTests.swift
-//  VPN
 //
 //  Copyright © 2024 DuckDuckGo. All rights reserved.
 //


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1211073812765067?focus=true
Tech Design URL:
CC:

### Description

This PR updates the VPN error handling chain to avoid emitting those with issues encoding for XPC.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that the method of XPC encoding is good enough
2. Check that the tests are looking for the right conditions

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)