### PR TITLE
Make the test fulfill the expectation after capturing the expected va…

### DIFF
--- a/macOS/UnitTests/FileDownload/Helpers/DownloadsTabExtensionMock.swift
+++ b/macOS/UnitTests/FileDownload/Helpers/DownloadsTabExtensionMock.swift
@@ -50,12 +50,11 @@ class DownloadsTabExtensionMock: NSObject, DownloadsTabExtensionProtocol {
     }
 
     func saveDownloadedData(_ data: Data?, suggestedFilename: String, mimeType: String, originatingURL: URL) async throws -> URL? {
-        didCallSaveDownloadedData = true
         capturedSavedDownloadData = data
         capturedSuggestedFilename = suggestedFilename
         capturedMimeType = mimeType
         capturedOriginatingURL = originatingURL
-
+        didCallSaveDownloadedData = true
         return nil
     }
 

--- a/macOS/UnitTests/FileDownload/Tab+WKUIDelegateTests.swift
+++ b/macOS/UnitTests/FileDownload/Tab+WKUIDelegateTests.swift
@@ -26,13 +26,11 @@ final class TabWKUIDelegateTests: XCTestCase {
     private var testData: Data!
     private var originatingURL: URL!
     private let filename = "Document.pdf"
-    private let fileManager = FileManager.default
     private var testDirectory: URL!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         testData = try XCTUnwrap("test".data(using: .utf8))
-        testDirectory = fileManager.temporaryDirectory
         originatingURL = URL(string: "https://www.duckduckgo.com")!
     }
 
@@ -42,7 +40,6 @@ final class TabWKUIDelegateTests: XCTestCase {
 
     override func tearDown() {
         testData = nil
-        testDirectory = nil
         originatingURL = nil
     }
 
@@ -74,7 +71,7 @@ final class TabWKUIDelegateTests: XCTestCase {
         // THEN
         waitForExpectations(timeout: 1)
         XCTAssertEqual(downloadExtensionMock.capturedSavedDownloadData, testData)
-        XCTAssertNotNil(downloadExtensionMock.capturedMimeType, "application/pdf")
+        XCTAssertEqual(downloadExtensionMock.capturedMimeType, "application/pdf")
 
         withExtendedLifetime(c) {}
     }

--- a/macOS/UnitTests/FileDownload/Tab+WKUIDelegateTests.swift
+++ b/macOS/UnitTests/FileDownload/Tab+WKUIDelegateTests.swift
@@ -34,10 +34,6 @@ final class TabWKUIDelegateTests: XCTestCase {
         originatingURL = URL(string: "https://www.duckduckgo.com")!
     }
 
-    override var allowedNonNilVariables: Set<String> {
-        ["fileManager"]
-    }
-
     override func tearDown() {
         testData = nil
         originatingURL = nil


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1211004949060394?focus=true
Tech Design URL:
CC:

### Description

Attempt to fix flaky TabWKUIDelegate test. I could not get it to fail locally.

We had few [occasions](https://github.com/duckduckgo/apple-browsers/actions/runs/16822581385/attempts/1) where the test failed at line 76: XCTAssertEqual failed: ("nil") is not equal to ("Optional(4 bytes)”).

The test expectation was fulfilled before the async function finished setting values. Moved the publisher signal to the end of the mock's async function.

### Testing Steps
Ensure CI is green.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)