### PR TITLE
Use websearch keyboard for both modes

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -154,17 +154,17 @@ class SwitchBarTextEntryView: UIView {
     // MARK: - UI Updates
 
     private func updateForCurrentMode() {
+        textView.keyboardType = .webSearch
+
         switch currentMode {
         case .search:
             placeholderLabel.text = UserText.searchDuckDuckGo
-            textView.keyboardType = .webSearch
             textView.returnKeyType = .search
             textView.autocapitalizationType = .none
             textView.autocorrectionType = .no
             textView.spellCheckingType = .no
         case .aiChat:
             placeholderLabel.text = UserText.searchInputFieldPlaceholderDuckAI
-            textView.keyboardType = .default
             textView.returnKeyType = .go
             textView.autocapitalizationType = .sentences
             textView.autocorrectionType = .default


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1210949179434512?focus=true
Tech Design URL:
CC:

### Description
Use websearch keyboard for both modes in the experimental address bar

### Testing Steps
1. Enable experimental address bar
2. Go to search and duck.ai, make sure the keyboard don't change but only duck.ai has auto-correct and suggestions

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Wrong keyboard type
