### PR TITLE
Add translations for inactive default browser prompt

### DIFF
--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/bg.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/bg.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Затваряне";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Отваряй връзки с DuckDuckGo";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Може би по-късно";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo има защити, които другите браузъри нямат.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Направете ни браузър по подразбиране, за да отваряте връзките към сайтове в DuckDuckGo.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/cs.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/cs.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Zavřít";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Otevírat odkazy prohlížečem DuckDuckGo";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Možná později";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo má ochranné funkce, jaké jiné prohlížeče nemají.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Nastav si nás jako výchozí prohlížeč, aby se všechny odkazy na stránky otevíraly v DuckDuckGo.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/da.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/da.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Luk";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Åbn links med DuckDuckGo";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Måske senere";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo har beskyttelser, som andre browsere ikke har.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Gør os til din standardbrowser, så alle links åbner i DuckDuckGo.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/de.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/de.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Schließen";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Links mit DuckDuckGo öffnen";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Vielleicht später";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo bietet Schutzmaßnahmen, die andere Browser nicht bieten.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Mach uns zu deinem Standardbrowser, damit alle Links in DuckDuckGo geöffnet werden.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/el.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/el.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Κλείσιμο";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Άνοιγμα συνδέσμων με το DuckDuckGo";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Ισως αργότερα";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "Το DuckDuckGo έχει προστασίες τις οποίες δεν διαθέτουν άλλα προγράμματα περιήγησης.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Ορίστε μας ως το προεπιλεγμένο πρόγραμμα περιήγησής σας ώστε όλοι οι σύνδεσμοι του ιστότοπου να ανοίγουν στο DuckDuckGo.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/es.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/es.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Cerrar";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Abrir enlaces con DuckDuckGo";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Quizá más tarde";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo tiene protecciones de las que carecen otros navegadores.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Haznos tu navegador predeterminado para que todos los enlaces a sitios se abran en DuckDuckGo.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/et.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/et.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Sulge";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Ava lingid DuckDuckGo abil";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Võib-olla hiljem";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo pakub kaitseid, mida teistel brauseritel pole.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Muutke meid oma vaikebrauseriks, et kõik saidilingid avaneksid DuckDuckGos.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/fi.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/fi.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Sulje";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Avaa linkit DuckDuckGo:ssa";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Ehkä myöhemmin";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo tarjoaa suojauksia, joita muilla selaimilla ei ole.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Tee meistä oletusselaimesi, niin kaikki sivustolinkit avautuvat DuckDuckGo-selaimessa.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/fr.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/fr.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Fermer";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Ouvrir les liens avec DuckDuckGo";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Peut-être plus tard";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo offre des protections que d’autres navigateurs n’ont pas.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Choisissez-nous comme navigateur par défaut afin que tous les liens de site s'ouvrent dans DuckDuckGo.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/hr.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/hr.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Zatvori";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Otvori veze s DuckDuckGo";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Možda kasnije";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo sadrži zaštite koje drugi preglednici nemaju.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Postavi nas kao svoj zadani preglednik kako bi se sve poveznice otvorile u DuckDuckGou.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/hu.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/hu.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Bezárás";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Linkek megnyitása DuckDuckGóban";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Talán később";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "A DuckDuckGo olyan védelmet kínál, amilyet más böngészők nem.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Legyen a DuckDuckGo az alapértelmezett böngésződ, hogy minden weboldal linkje a DuckDuckGóban nyíljon meg.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/it.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/it.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Chiudi";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Apri i collegamenti con DuckDuckGo";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Forse più tardi";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo offre protezioni che gli altri browser non hanno.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Imposta DuckDuckGo come browser predefinito in modo che apra tutti i link dei siti.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/lt.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/lt.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Uždaryti";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Atidarykite nuorodas su „DuckDuckGo“";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Galbūt vėliau";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "„DuckDuckGo“ turi apsaugos priemones, kurių neturi kitos naršyklės.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Nustatykite „DuckDuckGo“ kaip numatytąją naršyklę, kad visos svetainių nuorodos atsidarytų su ja.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/lv.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/lv.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Aizvērt";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Atvērt saites vietnē DuckDuckGo";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Varbūt vēlāk";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo piedāvā aizsardzību, kādas nav citās pārlūkprogrammās.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Iestati mūs kā savu noklusējuma pārlūku, lai visas vietņu saites atvērtos DuckDuckGo.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/nb.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/nb.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Lukk";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Åpne lenker med DuckDuckGo";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Kanskje senere";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo har beskyttelser som andre nettlesere ikke har.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Gjør oss til standardnettleseren din slik at alle nettstedslenker åpnes i DuckDuckGo.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/nl.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/nl.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Sluiten";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Links openen met DuckDuckGo";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Later misschien";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo heeft beveiligingen die andere browsers niet hebben.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Maak ons je standaardbrowser zodat alle sitelinks in DuckDuckGo worden geopend.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/pl.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/pl.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Zamknij";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Otwieraj linki w DuckDuckGo";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Może później";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo ma zabezpieczenia, których nie mają inne przeglądarki.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Ustaw naszą przeglądarkę jako domyślną, aby wszystkie linki były otwierane w DuckDuckGo.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/pt.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/pt.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Fechar";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Abrir links com o DuckDuckGo";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Talvez mais tarde";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "O DuckDuckGo tem proteções que outros navegadores não têm.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Torna-nos o teu navegador predefinido para que todos os links dos sites sejam abertos no DuckDuckGo.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/ro.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/ro.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Închidere";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Deschide linkuri cu DuckDuckGo";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Poate mai târziu";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo oferă instrumente de protecție pe care alte browsere nu le au.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Transformă-ne în browserul tău implicit, astfel încât toate linkurile de pe site să se deschidă în DuckDuckGo.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/ru.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/ru.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Закрыть";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Открывать ссылки в DuckDuckGo";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Позже";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo — защита, которой нет в других браузерах";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Сделайте его браузером по умолчанию, чтобы все ссылки на сайты открывались в DuckDuckGo.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/sk.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/sk.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Zatvoriť";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Otvárať odkazy pomocou DuckDuckGo";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Možno neskôr";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo má ochrany, ktoré iné prehliadače nemajú.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Nastav si nás ako svoj predvolený prehliadač, aby sa všetky odkazy na stránky otvárali v DuckDuckGo.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/sl.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/sl.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Zapri";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Odpri povezave z DuckDuckGo";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Mogoče kasneje";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo ima zaščite, ki jih drugi brskalniki nimajo.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Nastavite nas kot privzeti brskalnik, da se vse povezave do spletnih mest odprejo v DuckDuckGo.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/sv.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/sv.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Stäng";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Öppna länkar med DuckDuckGo";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Kanske senare";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo har skydd som andra webbläsare saknar.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Gör oss till din standardwebbläsare så att alla webbplatslänkar öppnas i DuckDuckGo.";
 

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/tr.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/Resources/tr.lproj/Localizable.strings
@@ -7,6 +7,15 @@
 /* (No Comment) */
 "setDefaultBrowser.modal.cta.cancel" = "Kapat";
 
+/* The tile of the button the user can use to set the browser as default. */
+"setDefaultBrowser.modal.inactive-user.cta.primary.title" = "Bağlantıları DuckDuckGo ile Aç";
+
+/* The title of the button to dismiss the prompt. */
+"setDefaultBrowser.modal.inactive-user.cta.secondary.title" = "Belki Sonra";
+
+/* Title of the a page inviting the inactive user to use the DuckDuckGo browser as default browser */
+"setDefaultBrowser.modal.inactive-user.title" = "DuckDuckGo diğer tarayıcılarda olmayan koruma özellikleri sunar.";
+
 /* Set Default Browser Modal Sheet Message. */
 "setDefaultBrowser.modal.message" = "Tüm site bağlantılarının DuckDuckGo'da açılması için bizi varsayılan tarayıcınız yapın.";
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1210723746045883?focus=true
Tech Design URL:
CC:

### Description

Import Translations for Default Browser Prompt for Inactive Users

### Testing Steps
Smoke test prompt to ensure UI translations are reflected.
1. Edit 'iOS Browser’ scheme -> Options -> App Language and pick one of the languages we support (E.g. Italian)
2. In “DefaultBrowserModalPresenter.swift” comment lines 43-48 and 50 to always show the prompt.
3. Run the app and ensure the prompt is showing translated strings.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)