### PR TITLE
[macOS] Add feature flag for session restoration prompt

### DIFF
--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -156,6 +156,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Note: 'Failsafe' feature flag. See https://app.asana.com/1/137249556945/project/1202500774821704/task/1210572145398078?focus=true
     case supportsAlternateStripePaymentFlow
 
+    /// https://app.asana.com/1/137249556945/project/72649045549333/task/1208994157946492?focus=true
+    case restoreSessionPrompt
+
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -226,7 +229,8 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .newTabPagePerTab,
                 .newFeedbackForm,
                 .vpnToolbarUpsell,
-                .supportsAlternateStripePaymentFlow:
+                .supportsAlternateStripePaymentFlow,
+                .restoreSessionPrompt:
             return true
         case .debugMenu,
                 .sslCertificatesBypass,
@@ -348,6 +352,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .internalOnly()
         case .supportsAlternateStripePaymentFlow:
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.supportsAlternateStripePaymentFlow))
+        case .restoreSessionPrompt:
+            return .disabled
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211047835568340
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1211047835568335
CC: @tomasstrba 

### Description

Adds a feature flag for the prompt to restore a session after the app closes unexpectedly.

### Testing Steps

None - The feature flag is not used yet.

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing

### Quality Considerations
None

### Notes to Reviewer
None

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)