### PR TITLE
[iOS] Add Push Notification Pixel Definition

### DIFF
--- a/iOS/PixelDefinitions/pixels/push-notification.json5
+++ b/iOS/PixelDefinitions/pixels/push-notification.json5
@@ -13,11 +13,6 @@
                 description: 'Number of days the user has been inactive',
                 type: 'integer',
             },
-            {
-                key: 'copyNumber',
-                description: 'The number of copy variant shown to the user',
-                type: 'integer',
-            },
         ],
     },
 }

--- a/iOS/PixelDefinitions/pixels/push-notification.json5
+++ b/iOS/PixelDefinitions/pixels/push-notification.json5
@@ -2,7 +2,7 @@
 {
     'm_push-notification_local-provisional_inactive-user-tap': {
         description: 'Fires when a user taps a local provisional push notification that was scheduled due to inactivity.',
-        owners: ['htang'],
+        owners: ['hanyutang-sandra'],
         triggers: ['other'],
         suffixes: ['form_factor'],
         parameters: [

--- a/iOS/PixelDefinitions/pixels/push-notification.json5
+++ b/iOS/PixelDefinitions/pixels/push-notification.json5
@@ -1,0 +1,23 @@
+// Push Notification-related pixel definitions
+{
+    'm_push-notification_local-provisional_inactive-user-tap': {
+        description: 'Fires when a user taps a local provisional push notification that was scheduled due to inactivity.',
+        owners: ['htang'],
+        triggers: ['other'],
+        suffixes: ['form_factor'],
+        parameters: [
+            'appVersion',
+            'pixelSource',
+            {
+                key: 'daysInactive',
+                description: 'Number of days the user has been inactive',
+                type: 'integer',
+            },
+            {
+                key: 'copyNumber',
+                description: 'The number of copy variant shown to the user',
+                type: 'integer',
+            },
+        ],
+    },
+}


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1211003501974958?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1211032403913073?focus=true

### Description

Added a new pixel definition: `m_push-notification_local-provisional_inactive-user-tap`
- Fires when a user taps a local provisional push notification scheduled due to inactivity to measure engagement with provisional push notifications on iOS
- Captures: appVersion, pixelSource, daysInactive, copyNumber, and form_factor.

### Testing Steps

1. Build and run the app.
2. Confirm parameters are correctly defined.

### Impact and Risks

No risks — pixel definition only

#### What could go wrong?

Likely none. Incorrect parameter type definitions could lead to dropped events.

### Quality Considerations

Definition follows schema conventions

### Notes to Reviewer
- Added param `daysInactive` due to https://app.asana.com/1/137249556945/project/481882893211075/task/1211032403913073?focus=true showing a possibility of changing this value on the fly
- Added param `copyNumber` due to product asking about multiple copies https://app.asana.com/1/137249556945/task/1211041375427085/comment/1211100532889037?focus=true

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)