### PR TITLE
macOS: Add Open File feature

### DIFF
--- a/macOS/DuckDuckGo/Common/Extensions/NSOpenPanelExtensions.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/NSOpenPanelExtensions.swift
@@ -41,4 +41,15 @@ extension NSOpenPanel {
         canChooseDirectories = false
     }
 
+    static func openFilePanel() -> NSOpenPanel {
+        let panel = NSOpenPanel()
+
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.html, .plainText, .pdf]
+
+        return panel
+    }
+
 }

--- a/macOS/DuckDuckGo/Common/Extensions/NSOpenPanelExtensions.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/NSOpenPanelExtensions.swift
@@ -47,7 +47,7 @@ extension NSOpenPanel {
         panel.canChooseFiles = true
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
-        panel.allowedContentTypes = [.html, .plainText, .pdf]
+        panel.allowedContentTypes = [.text, .pdf, .image, .webArchive]
 
         return panel
     }

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -86,6 +86,7 @@ struct UserText {
     static let mainMenuFile = NSLocalizedString("main-menu.file", value: "File", comment: "Main Menu File")
     static let mainMenuFileNewTab = NSLocalizedString("main-menu.file.new-tab", value: "New Tab", comment: "Main Menu File item")
     static let mainMenuFileOpenLocation = NSLocalizedString("main-menu.file.open-location", value: "Open Location…", comment: "Main Menu File item- Menu option that allows the user to connect to an address (type an address) on click the address bar of the browser is selected and the user can type.")
+    static let mainMenuFileOpenFile = NSLocalizedString("main-menu.file.open-file", value: "Open File…", comment: "Main Menu File item")
     static let mainMenuFileCloseWindow = NSLocalizedString("main-menu.file.close-window", value: "Close Window", comment: "Main Menu File item")
     static let mainMenuFileCloseAllWindows = NSLocalizedString("main-menu.file.close-all-windows", value: "Close All Windows", comment: "Main Menu File item")
     static let mainMenuFileSaveAs = NSLocalizedString("main-menu.file.save-as", value: "Save As…", comment: "Main Menu File item")

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -44223,6 +44223,18 @@
         }
       }
     },
+    "main-menu.file.open-file" : {
+      "comment" : "Main Menu File item",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Open File…"
+          }
+        }
+      }
+    },
     "main-menu.file.open-location" : {
       "comment" : "Main Menu File item- Menu option that allows the user to connect to an address (type an address) on click the address bar of the browser is selected and the user can type.",
       "extractionState" : "extracted_with_value",

--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -219,7 +219,7 @@ final class MainMenu: NSMenu {
 
             aiChatMenu
 
-            if featureFlagger.isFeatureOn(.openFileFeature) {
+            if featureFlagger.isFeatureOn(.openFileMenuAction) {
                 openFileMenuItem
             }
 

--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -45,6 +45,7 @@ final class MainMenu: NSMenu {
     let newBurnerWindowMenuItem = NSMenuItem(title: UserText.newBurnerWindowMenuItem, action: #selector(AppDelegate.newBurnerWindow), keyEquivalent: "")
     let newTabMenuItem = NSMenuItem(title: UserText.mainMenuFileNewTab, action: #selector(AppDelegate.newTab), keyEquivalent: "t")
     let openLocationMenuItem = NSMenuItem(title: UserText.mainMenuFileOpenLocation, action: #selector(AppDelegate.openLocation), keyEquivalent: "l")
+    let openFileMenuItem = NSMenuItem(title: UserText.mainMenuFileOpenFile, action: #selector(AppDelegate.openFile), keyEquivalent: "o")
     let closeWindowMenuItem = NSMenuItem(title: UserText.mainMenuFileCloseWindow, action: #selector(NSWindow.performClose), keyEquivalent: "W")
     let closeAllWindowsMenuItem = NSMenuItem(title: UserText.mainMenuFileCloseAllWindows, action: #selector(AppDelegate.closeAllWindows), keyEquivalent: [.option, .command, "W"])
     let closeTabMenuItem = NSMenuItem(title: UserText.closeTab, action: #selector(MainViewController.closeTab), keyEquivalent: "w")
@@ -217,6 +218,10 @@ final class MainMenu: NSMenu {
             }
 
             aiChatMenu
+
+            if featureFlagger.isFeatureOn(.openFileFeature) {
+                openFileMenuItem
+            }
 
             openLocationMenuItem
             NSMenuItem.separator()

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -88,6 +88,31 @@ extension AppDelegate {
         }
     }
 
+    @objc func openFile(_ sender: Any?) {
+        DispatchQueue.main.async {
+            var window: NSWindow?
+
+            // If no window is opened, we open one when the user taps to open a file.
+            if Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.window == nil {
+                window = Application.appDelegate.windowControllersManager.openNewWindow()
+            } else {
+                window = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.window
+            }
+
+            guard let window = window else {
+                Logger.general.error("No key window available for file picker")
+                return
+            }
+
+            let openPanel = NSOpenPanel.openFilePanel()
+            openPanel.beginSheetModal(for: window) { response in
+                guard response == .OK, let selectedURL = openPanel.url else { return }
+
+                Application.appDelegate.windowControllersManager.show(url: selectedURL, source: .ui, newTab: true)
+            }
+        }
+    }
+
     @objc func closeAllWindows(_ sender: Any?) {
         DispatchQueue.main.async {
             WindowsManager.closeWindows()

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -93,10 +93,10 @@ extension AppDelegate {
             var window: NSWindow?
 
             // If no window is opened, we open one when the user taps to open a file.
-            if Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.window == nil {
-                window = Application.appDelegate.windowControllersManager.openNewWindow()
+            if self.windowControllersManager.lastKeyMainWindowController?.window == nil {
+                window = self.windowControllersManager.openNewWindow()
             } else {
-                window = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.window
+                window = self.windowControllersManager.lastKeyMainWindowController?.window
             }
 
             guard let window = window else {
@@ -105,10 +105,10 @@ extension AppDelegate {
             }
 
             let openPanel = NSOpenPanel.openFilePanel()
-            openPanel.beginSheetModal(for: window) { response in
+            openPanel.beginSheetModal(for: window) { [weak self] response in
                 guard response == .OK, let selectedURL = openPanel.url else { return }
 
-                Application.appDelegate.windowControllersManager.show(url: selectedURL, source: .ui, newTab: true)
+                self?.windowControllersManager.show(url: selectedURL, source: .ui, newTab: true)
             }
         }
     }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -160,7 +160,7 @@ public enum FeatureFlag: String, CaseIterable {
     case restoreSessionPrompt
 
     /// https://app.asana.com/1/137249556945/project/276630244458377/task/1211090698913983?focus=true
-    case openFileFeature
+    case openFileMenuAction
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -233,7 +233,7 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .supportsAlternateStripePaymentFlow,
                 .openFireWindowByDefault,
                 .restoreSessionPrompt,
-                .openFileFeature:
+                .openFileMenuAction:
             return true
         case .debugMenu,
                 .sslCertificatesBypass,
@@ -356,7 +356,7 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .internalOnly()
         case .restoreSessionPrompt:
             return .disabled
-        case .openFileFeature:
+        case .openFileMenuAction:
             return .internalOnly()
         }
     }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -158,6 +158,9 @@ public enum FeatureFlag: String, CaseIterable {
 
     /// https://app.asana.com/1/137249556945/project/72649045549333/task/1208994157946492?focus=true
     case restoreSessionPrompt
+
+    /// https://app.asana.com/1/137249556945/project/276630244458377/task/1211090698913983?focus=true
+    case openFileFeature
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -229,7 +232,8 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .vpnToolbarUpsell,
                 .supportsAlternateStripePaymentFlow,
                 .openFireWindowByDefault,
-                .restoreSessionPrompt:
+                .restoreSessionPrompt,
+                .openFileFeature:
             return true
         case .debugMenu,
                 .sslCertificatesBypass,
@@ -352,6 +356,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .internalOnly()
         case .restoreSessionPrompt:
             return .disabled
+        case .openFileFeature:
+            return .internalOnly()
         }
     }
 }

--- a/macOS/UnitTests/Menus/MainMenuTests.swift
+++ b/macOS/UnitTests/Menus/MainMenuTests.swift
@@ -321,7 +321,7 @@ class MainMenuTests: XCTestCase {
         let isFireWindowDefault = true
 
         let sut = MainMenu(
-            featureFlagger: DummyFeatureFlagger(),
+            featureFlagger: MockFeatureFlagger(),
             bookmarkManager: MockBookmarkManager(),
             historyCoordinator: HistoryCoordinatingMock(),
             faviconManager: FaviconManagerMock(),
@@ -337,6 +337,31 @@ class MainMenuTests: XCTestCase {
 
         XCTAssertEqual(fileMenu.submenu?.item(at: 1)?.title, UserText.newBurnerWindowMenuItem)
         XCTAssertEqual(fileMenu.submenu?.item(at: 2)?.title, UserText.newWindowMenuItem)
+    }
+
+    @MainActor
+    func testMainMenuInitializedWithTrueOpenFileFlag_ThenOpenFileMenuItemIsVisible() throws {
+        let featureFlagger = MockFeatureFlagger()
+        featureFlagger.enabledFeatureFlags = [.openFileFeature]
+
+        let sut = MainMenu(
+            featureFlagger: featureFlagger,
+            bookmarkManager: MockBookmarkManager(),
+            historyCoordinator: HistoryCoordinatingMock(),
+            faviconManager: FaviconManagerMock(),
+            aiChatMenuConfig: DummyAIChatConfig(),
+            internalUserDecider: MockInternalUserDecider(),
+            appearancePreferences: appearancePreferences,
+            privacyConfigurationManager: MockPrivacyConfigurationManager(),
+            isFireWindowDefault: false,
+            configurationURLProvider: MockCustomURLProvider()
+        )
+
+        let fileMenu = try XCTUnwrap(sut.item(withTitle: UserText.mainMenuFile))
+        let openFileMenuItem = fileMenu.submenu?.item(withTitle: UserText.mainMenuFileOpenFile)
+
+        XCTAssertNotNil(openFileMenuItem, "Open File menu item should exist in the file menu.")
+        XCTAssertFalse(openFileMenuItem?.isHidden ?? true, "Open File menu item should be visible when the openFileFeature feature flag is enabled.")
     }
 
     @MainActor

--- a/macOS/UnitTests/Menus/MainMenuTests.swift
+++ b/macOS/UnitTests/Menus/MainMenuTests.swift
@@ -342,7 +342,7 @@ class MainMenuTests: XCTestCase {
     @MainActor
     func testMainMenuInitializedWithTrueOpenFileFlag_ThenOpenFileMenuItemIsVisible() throws {
         let featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags = [.openFileFeature]
+        featureFlagger.enabledFeatureFlags = [.openFileMenuAction]
 
         let sut = MainMenu(
             featureFlagger: featureFlagger,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/276630244458377/task/1211090698913983?focus=true
Tech Design URL:
CC:

### Description
Adds a new menu item to the `File` menu that allows users to open PDFs, TXTs, and HTML files. The shortcut will be CMD+O (like other browsers)

### Testing Steps
1. Open the application, make sure you are an internal user and the feature flag `openFileFeature` is ON (it should be ON by default for internal users)
2. Check that if you go to the menu `File`, you see the `Open File` menu item above the `Open Location`.
3. Tap CMD+O, or tap the menu item
4. A picker should be opened
5. Select a pdf, txt or html file
6. Make sure the file is opened in a new tab
7. Close all the windows (but do not close the app)
8. Tap File -> Open File (or CMD+O)
9. A new window should be opened, and the file picker should be presented.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The change is behind a feature flag

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)