### PR TITLE
Fix - NTP address bar click pixel is not sent when using experimental search bar

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -37,6 +37,7 @@ protocol OmniBarEditingStateViewControllerDelegate: AnyObject {
     func onSelectFavorite(_ favorite: BookmarkEntity)
     func onSelectSuggestion(_ suggestion: Suggestion)
     func onVoiceSearchRequested(from mode: TextEntryMode)
+    func onDismissRequested()
 }
 
 /// Main coordinator for the OmniBar editing state, managing multiple specialized components
@@ -242,6 +243,7 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
 
     @objc private func dismissButtonTapped(_ sender: UIButton) {
         switchBarVC.unfocusTextField()
+        delegate?.onDismissRequested()
         dismissAnimated()
     }
 

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
@@ -42,6 +42,7 @@ protocol SwitchBarHandling: AnyObject {
     var toggleStatePublisher: AnyPublisher<TextEntryMode, Never> { get }
     var textSubmissionPublisher: AnyPublisher<(text: String, mode: TextEntryMode), Never> { get }
     var microphoneButtonTappedPublisher: AnyPublisher<Void, Never> { get }
+    var clearButtonTappedPublisher: AnyPublisher<Void, Never> { get }
     var hasUserInteractedWithTextPublisher: AnyPublisher<Bool, Never> { get }
     var isCurrentTextValidURLPublisher: AnyPublisher<Bool, Never> { get }
 
@@ -52,6 +53,7 @@ protocol SwitchBarHandling: AnyObject {
     func clearText()
     func microphoneButtonTapped()
     func markUserInteraction()
+    func clearButtonTapped()
 }
 
 // MARK: - SwitchBarHandler Implementation
@@ -100,8 +102,13 @@ final class SwitchBarHandler: SwitchBarHandling {
         microphoneButtonTappedSubject.eraseToAnyPublisher()
     }
 
+    var clearButtonTappedPublisher: AnyPublisher<Void, Never> {
+        clearButtonTappedSubject.eraseToAnyPublisher()
+    }
+
     private let textSubmissionSubject = PassthroughSubject<(text: String, mode: TextEntryMode), Never>()
     private let microphoneButtonTappedSubject = PassthroughSubject<Void, Never>()
+    private let clearButtonTappedSubject = PassthroughSubject<Void, Never>()
 
     init(voiceSearchHelper: VoiceSearchHelperProtocol, storage: KeyValueStoring) {
         self.voiceSearchHelper = voiceSearchHelper
@@ -136,6 +143,10 @@ final class SwitchBarHandler: SwitchBarHandling {
 
     func markUserInteraction() {
         hasUserInteractedWithText = true
+    }
+
+    func clearButtonTapped() {
+        clearButtonTappedSubject.send(())
     }
 
     func saveToggleState() {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -131,6 +131,7 @@ class SwitchBarTextEntryView: UIView {
     private func setupButtonsView() {
         buttonsView.onClearTapped = { [weak self] in
             self?.handler.clearText()
+            self?.handler.clearButtonTapped()
         }
     }
 

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -60,7 +60,7 @@ final class DefaultOmniBarViewController: OmniBarViewController {
 
     override func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
         if aiChatSettings.isAIChatSearchInputUserSettingsEnabled {
-            omniDelegate?.onExperimentalAddressBarTappedForPixelsOnly()
+            omniDelegate?.onExperimentalAddressBarTapped()
             presentExperimentalEditingState(for: textField)
             return false
         }
@@ -189,7 +189,7 @@ final class DefaultOmniBarViewController: OmniBarViewController {
         switchBarHandler.clearButtonTappedPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
-                self?.omniDelegate?.onExperimentalAddressBarClearPressedForPixelsOnly()
+                self?.omniDelegate?.onExperimentalAddressBarClearPressed()
             }
             .store(in: &cancellables)
         
@@ -263,7 +263,7 @@ extension DefaultOmniBarViewController: OmniBarEditingStateViewControllerDelegat
 
     func onDismissRequested() {
         // Fire cancel pixel only (no other side effects) when experimental bar is dismissed via back button
-        omniDelegate?.onExperimentalAddressBarCancelPressedForPixelsOnly()
+        omniDelegate?.onExperimentalAddressBarCancelPressed()
     }
 }
 

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -18,6 +18,7 @@
 //
 
 import UIKit
+import Combine
 import PrivacyDashboard
 import Suggestions
 import Bookmarks
@@ -32,6 +33,7 @@ final class DefaultOmniBarViewController: OmniBarViewController {
     private lazy var omniBarView = DefaultOmniBarView.create()
     private let aiChatSettings = AIChatSettings()
     private weak var editingStateViewController: OmniBarEditingStateViewController?
+    private var cancellables = Set<AnyCancellable>()
 
 //    let editModeTransitioningDelegate = OmniBarEditingStateTransitioningDelegate()
 
@@ -58,6 +60,7 @@ final class DefaultOmniBarViewController: OmniBarViewController {
 
     override func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
         if aiChatSettings.isAIChatSearchInputUserSettingsEnabled {
+            omniDelegate?.onExperimentalAddressBarTappedForPixelsOnly()
             presentExperimentalEditingState(for: textField)
             return false
         }
@@ -183,6 +186,13 @@ final class DefaultOmniBarViewController: OmniBarViewController {
         editingStateViewController.suggestionTrayDependencies = suggestionsDependencies
         editingStateViewController.automaticallySelectsTextOnAppear = shouldAutoSelectText
         
+        switchBarHandler.clearButtonTappedPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                self?.omniDelegate?.onExperimentalAddressBarClearPressedForPixelsOnly()
+            }
+            .store(in: &cancellables)
+        
         self.editingStateViewController = editingStateViewController
 
         present(editingStateViewController, animated: true)
@@ -249,6 +259,11 @@ extension DefaultOmniBarViewController: OmniBarEditingStateViewControllerDelegat
             let voiceSearchTarget: VoiceSearchTarget = (mode == .aiChat) ? .AIChat : .SERP
             self.omniDelegate?.onVoiceSearchPressed(preferredTarget: voiceSearchTarget)
         }
+    }
+
+    func onDismissRequested() {
+        // Fire cancel pixel only (no other side effects) when experimental bar is dismissed via back button
+        omniDelegate?.onExperimentalAddressBarCancelPressedForPixelsOnly()
     }
 }
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2651,6 +2651,23 @@ extension MainViewController: OmniBarDelegate {
     func onDidEndEditing() {
         omniBar.updateAccessoryType(omnibarAccessoryHandler.omnibarAccessory(for: currentTab?.url))
     }
+
+    // MARK: - Experimental Address Bar (pixels only)
+    func onExperimentalAddressBarTappedForPixelsOnly() {
+        fireControllerAwarePixel(ntp: .addressBarClickOnNTP, serp: .addressBarClickOnSERP, website: .addressBarClickOnWebsite)
+    }
+
+    func onExperimentalAddressBarClearPressedForPixelsOnly() {
+        fireControllerAwarePixel(ntp: .addressBarClearPressedOnNTP,
+                                 serp: .addressBarClearPressedOnSERP,
+                                 website: .addressBarClearPressedOnWebsite)
+    }
+
+    func onExperimentalAddressBarCancelPressedForPixelsOnly() {
+        fireControllerAwarePixel(ntp: .addressBarCancelPressedOnNTP,
+                                 serp: .addressBarCancelPressedOnSERP,
+                                 website: .addressBarCancelPressedOnWebsite)
+    }
 }
 
 extension MainViewController: FavoritesOverlayDelegate {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2653,17 +2653,17 @@ extension MainViewController: OmniBarDelegate {
     }
 
     // MARK: - Experimental Address Bar (pixels only)
-    func onExperimentalAddressBarTappedForPixelsOnly() {
+    func onExperimentalAddressBarTapped() {
         fireControllerAwarePixel(ntp: .addressBarClickOnNTP, serp: .addressBarClickOnSERP, website: .addressBarClickOnWebsite)
     }
 
-    func onExperimentalAddressBarClearPressedForPixelsOnly() {
+    func onExperimentalAddressBarClearPressed() {
         fireControllerAwarePixel(ntp: .addressBarClearPressedOnNTP,
                                  serp: .addressBarClearPressedOnSERP,
                                  website: .addressBarClearPressedOnWebsite)
     }
 
-    func onExperimentalAddressBarCancelPressedForPixelsOnly() {
+    func onExperimentalAddressBarCancelPressed() {
         fireControllerAwarePixel(ntp: .addressBarCancelPressedOnNTP,
                                  serp: .addressBarCancelPressedOnSERP,
                                  website: .addressBarCancelPressedOnWebsite)

--- a/iOS/DuckDuckGo/OmniBarDelegate.swift
+++ b/iOS/DuckDuckGo/OmniBarDelegate.swift
@@ -92,9 +92,9 @@ protocol OmniBarDelegate: AnyObject {
     func isSuggestionTrayVisible() -> Bool
 
     // MARK: - Experimental Address Bar (pixels only)
-    func onExperimentalAddressBarTappedForPixelsOnly()
-    func onExperimentalAddressBarClearPressedForPixelsOnly()
-    func onExperimentalAddressBarCancelPressedForPixelsOnly()
+    func onExperimentalAddressBarTapped()
+    func onExperimentalAddressBarClearPressed()
+    func onExperimentalAddressBarCancelPressed()
 }
 
 extension OmniBarDelegate {
@@ -153,7 +153,7 @@ extension OmniBarDelegate {
     }
 
     // Default no-op implementations for experimental address bar pixel hooks
-    func onExperimentalAddressBarTappedForPixelsOnly() {}
-    func onExperimentalAddressBarClearPressedForPixelsOnly() {}
-    func onExperimentalAddressBarCancelPressedForPixelsOnly() {}
+    func onExperimentalAddressBarTapped() {}
+    func onExperimentalAddressBarClearPressed() {}
+    func onExperimentalAddressBarCancelPressed() {}
 }

--- a/iOS/DuckDuckGo/OmniBarDelegate.swift
+++ b/iOS/DuckDuckGo/OmniBarDelegate.swift
@@ -90,6 +90,11 @@ protocol OmniBarDelegate: AnyObject {
     func didRequestCurrentURL() -> URL?
 
     func isSuggestionTrayVisible() -> Bool
+
+    // MARK: - Experimental Address Bar (pixels only)
+    func onExperimentalAddressBarTappedForPixelsOnly()
+    func onExperimentalAddressBarClearPressedForPixelsOnly()
+    func onExperimentalAddressBarCancelPressedForPixelsOnly()
 }
 
 extension OmniBarDelegate {
@@ -146,4 +151,9 @@ extension OmniBarDelegate {
     func onVoiceSearchPressed(preferredTarget: VoiceSearchTarget) {
         onVoiceSearchPressed()
     }
+
+    // Default no-op implementations for experimental address bar pixel hooks
+    func onExperimentalAddressBarTappedForPixelsOnly() {}
+    func onExperimentalAddressBarClearPressedForPixelsOnly() {}
+    func onExperimentalAddressBarCancelPressedForPixelsOnly() {}
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1211080567413562?focus=true
Tech Design URL:
CC:

### Description
Fix - NTP address bar click pixel is not sent when using experimental search bar

### Testing Steps
1. Enable the experimental address bar under AI Features
2. Check if the correct pixels are sent on these actions on NTP, SERP and website:
3. Select the address bar
4. Dismiss the address bar
5. Clear the text in the address bar

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Send the wrong pixels
