### PR TITLE
Fixes an issue where cached update information doesn't allow updating

### DIFF
--- a/macOS/DuckDuckGo/Updates/ReleaseNotesTabExtension.swift
+++ b/macOS/DuckDuckGo/Updates/ReleaseNotesTabExtension.swift
@@ -162,14 +162,17 @@ extension ReleaseNotesValues {
                 formatter.dateFormat = "MMMM dd yyyy"
                 let releaseTitle = formatter.string(from: cached.date)
 
-                self.init(status: .loaded,
+                let cachedVersion = "\(cached.version) \(cached.build)"
+                let status = currentVersion == cachedVersion ? ReleaseNotesValues.Status.loaded : ReleaseNotesValues.Status.updateReady
+
+                self.init(status: status,
                           currentVersion: currentVersion,
                           latestVersion: "\(cached.version) \(cached.build)",
                           lastUpdate: lastUpdate,
                           releaseTitle: releaseTitle,
                           releaseNotes: cached.releaseNotes,
                           releaseNotesPrivacyPro: cached.releaseNotesPrivacyPro,
-                          downloadProgress: nil,
+                          downloadProgress: 0.00,
                           automaticUpdate: updateController.areAutomaticUpdatesEnabled)
                 return
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1211096471236167?focus=true

### Description

Shows the "Update DuckDuckGo" blue button when the latest update is loaded from cache.

### Testing Steps

**Preparation:**
The steps described below can be used to both reproduce the original issue in the release branch and test it's fixed in this branch.

1. Make sure we get an update while testing:
   1. Edit `macOS/Configuration/BuildNumber.xcconfig` and set the build number to 400.
   2. Edit `macOS/Configuration/Version.xcconfig` and set the marketing version to 1.151.0
   3. Run the app once in debug mode, and enable  the `autoUpdateInDebug` feature flag.
2. Make sure we set-up the exact conditions that make the bug show up.  Add the following two lines of code [here](https://github.com/duckduckgo/apple-browsers/blob/bd5cab09e7deb5b1a796ec44c16fdf7779075772/macOS/DuckDuckGo/Updates/UpdateController.swift#L475):

```swift
updateValidityStartDate = Date.distantPast
atestUpdate = nil
```

**Testing steps:**
1. Run the app.
2. You'll see the "Install now" message in the "more" menu.
3. Click on it.
4. You should be brought to the release notes page and see an "Update DuckDuckGo" button.  The button was missing before, which was the bug.
<img width="621" height="458" alt="Screenshot 2025-08-21 at 10 53 51" src="https://github.com/user-attachments/assets/f8d8b095-3547-4d50-8e51-e8e54d9b8ff0" />
6. Clicking on it should show the update execute (if you have a connection).

### Impact and Risks

Medium.

#### What could go wrong?

The update logic is tricky to get right.

### Quality Considerations

NA

### Notes to Reviewer

Let me know if you have any questions.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)