### PR TITLE
[iOS] Add Provisional Push Notification Local Config

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -123,6 +123,10 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     case defaultBrowserTutorial
 
     case widgetReporting
+
+    // Local inactivity provisional notifications delivered to Notification Center.
+    // https://app.asana.com/1/137249556945/project/72649045549333/task/1211003501974970?focus=true
+    case inactivityNotification
 }
 
 public enum TabManagerSubfeature: String, PrivacySubfeature {

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -155,6 +155,10 @@ public enum FeatureFlag: String {
 
     /// https://app.asana.com/1/137249556945/project/1204167627774280/task/1210926332858859?focus=true
     case aiFeaturesSettingsUpdate
+    
+    /// Local inactivity provisional notifications delivered to Notification Center.
+    /// https://app.asana.com/1/137249556945/project/72649045549333/task/1211003501974970?focus=true
+    case inactivityNotification
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -211,7 +215,8 @@ extension FeatureFlag: FeatureFlagDescribing {
              .personalInformationRemoval,
              .createFireproofFaviconUpdaterSecureVaultInBackground,
              .scheduledSetDefaultBrowserPrompts,
-             .scheduledSetDefaultBrowserPromptsForInactiveUsers:
+             .scheduledSetDefaultBrowserPromptsForInactiveUsers,
+             .inactivityNotification:
             return true
         case .showSettingsCompleteSetupSection:
             if #available(iOS 18.2, *) {
@@ -354,6 +359,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(AutofillSubfeature.createFireproofFaviconUpdaterSecureVaultInBackground))
         case .aiFeaturesSettingsUpdate:
             return .enabled
+        case .inactivityNotification:
+            return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.inactivityNotification))
         }
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1211003501974970?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1211032403913073?focus=true

### Description
Following up on https://github.com/duckduckgo/privacy-configuration/pull/3623, add the subfeature `inactivityNotification` to `BrowserServicesKit` and `FeatureFlag`

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Build app and run

### Impact and Risks

None. The subfeature is not used anywhere. 

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

None. The subfeature is not used anywhere. 

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)