### PR TITLE
Fix content appearing when foregrounding app and before authentication

### DIFF
--- a/iOS/DuckDuckGo/AppServices/AuthenticationService.swift
+++ b/iOS/DuckDuckGo/AppServices/AuthenticationService.swift
@@ -56,7 +56,7 @@ extension AuthenticationService: AuthenticationServiceProtocol {
         guard shouldAuthenticate else {
             return
         }
-        overlayWindowManager.removeBlankSnapshotWindow(for: .authentication)
+        overlayWindowManager.removeAnyOverlay()
         let authenticationViewController = showAuthenticationScreen()
         await authenticate(with: authenticationViewController)
     }

--- a/iOS/DuckDuckGo/AppServices/AuthenticationService.swift
+++ b/iOS/DuckDuckGo/AppServices/AuthenticationService.swift
@@ -43,7 +43,7 @@ final class AuthenticationService {
 
     func suspend() {
         if privacyStore.authenticationEnabled {
-            overlayWindowManager.displayBlankSnapshotWindow()
+            overlayWindowManager.displayBlankSnapshotWindow(for: .authentication)
         }
     }
 
@@ -56,7 +56,7 @@ extension AuthenticationService: AuthenticationServiceProtocol {
         guard shouldAuthenticate else {
             return
         }
-        overlayWindowManager.removeOverlay()
+        overlayWindowManager.removeBlankSnapshotWindow(for: .authentication)
         let authenticationViewController = showAuthenticationScreen()
         await authenticate(with: authenticationViewController)
     }
@@ -69,7 +69,7 @@ extension AuthenticationService: AuthenticationServiceProtocol {
     private func authenticate(with authenticationViewController: AuthenticationViewController) async {
         let didAuthenticate = await authenticator.authenticate(reason: UserText.appUnlock)
         if didAuthenticate {
-            overlayWindowManager.removeOverlay()
+            overlayWindowManager.removeAnyOverlay()
             authenticationViewController.dismiss(animated: true)
         } else {
             authenticationViewController.showUnlockInstructions()

--- a/iOS/DuckDuckGo/AppServices/AutoClearService.swift
+++ b/iOS/DuckDuckGo/AppServices/AutoClearService.swift
@@ -59,7 +59,7 @@ final class AutoClearService: AutoClearServiceProtocol {
                 await autoClear.clearDataDueToTimeExpired(applicationState: .active)
             }
         } else {
-            overlayWindowManager.removeNonAuthenticationOverlay()
+            overlayWindowManager.removeBlankSnapshotWindow(for: .autoClearing)
         }
     }
 
@@ -67,7 +67,7 @@ final class AutoClearService: AutoClearServiceProtocol {
 
     func suspend() {
         if autoClear.isClearingEnabled {
-            overlayWindowManager.displayBlankSnapshotWindow()
+            overlayWindowManager.displayBlankSnapshotWindow(for: .autoClearing)
         }
         autoClear.startClearingTimer(Date().timeIntervalSince1970)
     }
@@ -77,7 +77,7 @@ final class AutoClearService: AutoClearServiceProtocol {
     @MainActor
     func waitForDataCleared() async {
         await autoClearTask?.value
-        overlayWindowManager.removeNonAuthenticationOverlay()
+        overlayWindowManager.removeBlankSnapshotWindow(for: .autoClearing)
     }
 
 }

--- a/iOS/DuckDuckGo/UICoordination/OverlayWindowManager.swift
+++ b/iOS/DuckDuckGo/UICoordination/OverlayWindowManager.swift
@@ -88,6 +88,7 @@ final class OverlayWindowManager: OverlayWindowManaging {
         overlay.isHidden = true
         overlayWindow = nil
         window.makeKeyAndVisible()
+        activeReasons = []
     }
 
     func removeBlankSnapshotWindow(for reason: BlankSnapshotOverlayReason) {

--- a/iOS/DuckDuckGo/UICoordination/OverlayWindowManager.swift
+++ b/iOS/DuckDuckGo/UICoordination/OverlayWindowManager.swift
@@ -22,16 +22,27 @@ import BrowserServicesKit
 
 protocol OverlayWindowManaging {
 
-    func displayBlankSnapshotWindow()
+    func displayBlankSnapshotWindow(for reason: BlankSnapshotOverlayReason)
+    func removeBlankSnapshotWindow(for reason: BlankSnapshotOverlayReason)
+
     func displayOverlay(with viewController: UIViewController)
-    func removeOverlay()
-    func removeNonAuthenticationOverlay()
+    func removeAnyOverlay()
+
+}
+
+struct BlankSnapshotOverlayReason: OptionSet {
+
+    let rawValue: Int
+
+    static let autoClearing   = BlankSnapshotOverlayReason(rawValue: 1 << 0)
+    static let authentication = BlankSnapshotOverlayReason(rawValue: 1 << 1)
 
 }
 
 final class OverlayWindowManager: OverlayWindowManaging {
 
     private var overlayWindow: UIWindow?
+    private var activeReasons: BlankSnapshotOverlayReason = []
 
     private let window: UIWindow
     private let appSettings: AppSettings
@@ -51,7 +62,8 @@ final class OverlayWindowManager: OverlayWindowManaging {
         self.aiChatSettings = aiChatSettings
     }
 
-    func displayBlankSnapshotWindow() {
+    func displayBlankSnapshotWindow(for reason: BlankSnapshotOverlayReason) {
+        activeReasons.insert(reason)
         let blankSnapshotViewController = BlankSnapshotViewController(addressBarPosition: appSettings.currentAddressBarPosition,
                                                                       aiChatSettings: aiChatSettings,
                                                                       voiceSearchHelper: voiceSearchHelper,
@@ -63,7 +75,6 @@ final class OverlayWindowManager: OverlayWindowManaging {
 
     func displayOverlay(with viewController: UIViewController) {
         guard overlayWindow == nil else { return }
-
         overlayWindow = UIWindow(frame: window.frame)
         overlayWindow?.windowLevel = .alert
         overlayWindow?.rootViewController = viewController
@@ -72,28 +83,24 @@ final class OverlayWindowManager: OverlayWindowManaging {
         window.isHidden = true
     }
 
-    func removeOverlay() {
-        if overlayWindow == nil {
-            tryToObtainOverlayWindow()
-        }
+    func removeAnyOverlay() {
+        guard let overlay = overlayWindow ?? obtainOverlayWindow() else { return }
+        overlay.isHidden = true
+        overlayWindow = nil
+        window.makeKeyAndVisible()
+    }
 
-        if let overlay = overlayWindow {
-            overlay.isHidden = true
-            overlayWindow = nil
-            window.makeKeyAndVisible()
+    func removeBlankSnapshotWindow(for reason: BlankSnapshotOverlayReason) {
+        guard !(overlayWindow?.rootViewController is AuthenticationViewController) else { return }
+        activeReasons.remove(reason)
+        if activeReasons.isEmpty {
+            removeAnyOverlay()
         }
     }
 
-    func removeNonAuthenticationOverlay() {
-        if !(overlayWindow?.rootViewController is AuthenticationViewController) {
-            removeOverlay()
-        }
-    }
-
-    private func tryToObtainOverlayWindow() {
-        for window in UIApplication.shared.foregroundSceneWindows where window.rootViewController is BlankSnapshotViewController {
-            overlayWindow = window
-            return
+    private func obtainOverlayWindow() -> UIWindow? {
+        UIApplication.shared.foregroundSceneWindows.first {
+            $0.rootViewController is BlankSnapshotViewController
         }
     }
 
@@ -102,7 +109,7 @@ final class OverlayWindowManager: OverlayWindowManaging {
 extension OverlayWindowManager: BlankSnapshotViewRecoveringDelegate {
 
     func recoverFromPresenting(controller: BlankSnapshotViewController) {
-        removeOverlay()
+        removeAnyOverlay()
     }
 
 }

--- a/iOS/DuckDuckGoTests/AuthenticationServiceTests.swift
+++ b/iOS/DuckDuckGoTests/AuthenticationServiceTests.swift
@@ -70,6 +70,7 @@ final class AuthenticationServiceTests {
         await authenticationService.authenticate()
 
         // Then
+        #expect(mockOverlayWindowManager.removeNonAuthenticationOverlayCalled)
         #expect(mockOverlayWindowManager.removeOverlayCalled)
         #expect(mockOverlayWindowManager.displayOverlayCalled)
         #expect(mockAuthenticator.authenticateCalled)
@@ -86,6 +87,7 @@ final class AuthenticationServiceTests {
         await authenticationService.authenticate()
 
         // Then
+        #expect(!mockOverlayWindowManager.removeNonAuthenticationOverlayCalled)
         #expect(!mockOverlayWindowManager.removeOverlayCalled)
         #expect(!mockOverlayWindowManager.displayOverlayCalled)
         #expect(!mockAuthenticator.authenticateCalled)
@@ -101,6 +103,7 @@ final class AuthenticationServiceTests {
         await authenticationService.authenticate()
 
         // Then
+        #expect(!mockOverlayWindowManager.removeNonAuthenticationOverlayCalled)
         #expect(!mockOverlayWindowManager.removeOverlayCalled)
         #expect(!mockOverlayWindowManager.displayOverlayCalled)
         #expect(!mockAuthenticator.authenticateCalled)

--- a/iOS/DuckDuckGoTests/AuthenticationServiceTests.swift
+++ b/iOS/DuckDuckGoTests/AuthenticationServiceTests.swift
@@ -70,7 +70,6 @@ final class AuthenticationServiceTests {
         await authenticationService.authenticate()
 
         // Then
-        #expect(mockOverlayWindowManager.removeNonAuthenticationOverlayCalled)
         #expect(mockOverlayWindowManager.removeOverlayCalled)
         #expect(mockOverlayWindowManager.displayOverlayCalled)
         #expect(mockAuthenticator.authenticateCalled)
@@ -87,7 +86,6 @@ final class AuthenticationServiceTests {
         await authenticationService.authenticate()
 
         // Then
-        #expect(!mockOverlayWindowManager.removeNonAuthenticationOverlayCalled)
         #expect(!mockOverlayWindowManager.removeOverlayCalled)
         #expect(!mockOverlayWindowManager.displayOverlayCalled)
         #expect(!mockAuthenticator.authenticateCalled)
@@ -103,7 +101,6 @@ final class AuthenticationServiceTests {
         await authenticationService.authenticate()
 
         // Then
-        #expect(!mockOverlayWindowManager.removeNonAuthenticationOverlayCalled)
         #expect(!mockOverlayWindowManager.removeOverlayCalled)
         #expect(!mockOverlayWindowManager.displayOverlayCalled)
         #expect(!mockAuthenticator.authenticateCalled)

--- a/iOS/DuckDuckGoTests/Mocks/MockOverlayWindowManager.swift
+++ b/iOS/DuckDuckGoTests/Mocks/MockOverlayWindowManager.swift
@@ -29,7 +29,7 @@ final class MockOverlayWindowManager: OverlayWindowManaging {
 
     var lastDisplayedViewController: UIViewController?
 
-    func displayBlankSnapshotWindow() {
+    func displayBlankSnapshotWindow(for reason: DuckDuckGo.BlankSnapshotOverlayReason) {
         displayBlankSnapshotWindowCalled = true
     }
 
@@ -38,11 +38,11 @@ final class MockOverlayWindowManager: OverlayWindowManaging {
         lastDisplayedViewController = viewController
     }
 
-    func removeOverlay() {
+    func removeAnyOverlay() {
         removeOverlayCalled = true
     }
 
-    func removeNonAuthenticationOverlay() {
+    func removeBlankSnapshotWindow(for reason: DuckDuckGo.BlankSnapshotOverlayReason) {
         removeNonAuthenticationOverlayCalled = true
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201392122292466/task/1211024438380986?focus=true

### Description

### Testing Steps
1. Open any site.
2. Have authentication and data clearing turned off.
3. Background the app.
4. Open App Switcher and notice the site is visible.
5. Open the app and notice the site is immediately visible.

## Authentication ON
1. Turn on authentication.
2. Background the app.
3. Open App Switcher and notice the site is NOT visible.
4. Open the app and notice the site is NOT visible until authenticated.

## Data Clearing ON
1. Turn off authentication and turn on data clearing (5 minutes). You can change this line of code  `return elapsedTime > 5 * 60` to `return elapsedTime > 2` and wait 2 seconds instead of 5 minutes.
2. Also, add this line: `try? await Task.sleep(nanoseconds: 5_000_000_000)` under `await autoClear.clearDataDueToTimeExpired(applicationState: .active)` in AutoClearService.swift to simulate long data clearing process.
3. Background the app.
4. Open App Switcher and notice the site is NOT visible.
5. Open the app and notice the site is NOT visible until data clearing completes (5 seconds).

## Authentication ON and Data Clearing ON
1. Turn on authentication and turn on data clearing (5 minutes). You can change this line of code  `return elapsedTime > 5 * 60` to `return elapsedTime > 2` and wait 2 seconds instead of 5 minutes.
2. Also, add this line: `try? await Task.sleep(nanoseconds: 5_000_000_000)` under `await autoClear.clearDataDueToTimeExpired(applicationState: .active)` in AutoClearService.swift to simulate long data clearing process.
3. Background the app.
4. Open App Switcher and notice the site is NOT visible.
5. Open the app and notice the site is NOT visible until data clearing completes (5 seconds) and until user authenticates.

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Overlay screen not being dismissed/not appearing in some scenarios.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)