### PR TITLE
Skip failing DuckPlayer UI tests on macOS 13

### DIFF
--- a/macOS/UITests/DuckPlayerTests.swift
+++ b/macOS/UITests/DuckPlayerTests.swift
@@ -139,6 +139,11 @@ class DuckPlayerTests: UITestCase {
     }
 
     func test_DuckPlayer_AlwaysEnabled_Opens_FromSERPOrganic() throws {
+        // Skip this test on macOS 13
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        if version.majorVersion == 13 {
+            throw XCTSkip("Test disabled on macOS 13")
+        }
 
         // Settings
         openDuckPlayerSettings()
@@ -162,6 +167,11 @@ class DuckPlayerTests: UITestCase {
     }
 
     func test_DuckPlayer_AlwaysEnabled_Opens_FromSERPVideos() throws {
+        // Skip this test on macOS 13
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        if version.majorVersion == 13 {
+            throw XCTSkip("Test disabled on macOS 13")
+        }
 
         // Settings
         openDuckPlayerSettings()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1211075306410488
Tech Design URL: N/A
CC: 

### Description
Skip two failing DuckPlayer UI tests specifically on macOS 13 while keeping them enabled for macOS 14+. The tests `test_DuckPlayer_AlwaysEnabled_Opens_FromSERPOrganic` and `test_DuckPlayer_AlwaysEnabled_Opens_FromSERPVideos` are failing consistently on macOS 13 but pass on newer versions.

### Testing Steps
1. Run the DuckPlayer UI tests on macOS 13 - the two tests will be skipped with message "Test disabled on macOS 13"
2. Run the same tests on macOS 14+ - tests should execute normally

### Impact and Risks
**Low**: This only affects test coverage on macOS 13. No production code changes.

#### What could go wrong?
- We lose test coverage for DuckPlayer functionality on macOS 13
- If these features break on macOS 13, we won't catch it automatically
- Mitigated by: Tests still run on macOS 14+, and macOS 13 is becoming less common

### Quality Considerations
- Tests use the established pattern of `ProcessInfo.processInfo.operatingSystemVersion` to detect OS version
- Uses `XCTSkip` which is the standard way to conditionally skip tests
- Clear skip message indicates why the test was skipped
- No performance impact as check happens at test start

### Notes to Reviewer
This follows the existing pattern used in other test files for version-specific test skipping (e.g., using `@available` or `if #available` checks).

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)