### PR TITLE
Notify release task about a failed workflow

### DIFF
--- a/.github/workflows/ios_build_hotfix_release.yml
+++ b/.github/workflows/ios_build_hotfix_release.yml
@@ -33,13 +33,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    outputs:
+      asana_task_id: ${{ steps.task-id.outputs.asana_task_id }}
+
     steps:
       - name: Check out the code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Fetch all history and tags in order to extract Asana task URLs from git log
           ref: ${{ github.ref_name }}
-          submodules: recursive
 
       - name: Assert hotfix release branch
         run: |
@@ -47,6 +48,16 @@ jobs:
             refs/heads/hotfix/*) ;;
             *) echo "👎 Not a hotfix release branch"; exit 1 ;;
           esac
+
+      - name: Setup Ruby and dependencies
+        uses: ./.github/actions/setup-ruby
+        with:
+          working-directory: iOS
+          cache-key-prefix: ios-ruby
+
+      - name: Extract Asana Task ID
+        id: task-id
+        run: bundle exec fastlane run asana_extract_task_id task_url:"${{ github.event.inputs.asana-task-url }}"
 
   run_tests:
 
@@ -62,12 +73,11 @@ jobs:
 
     name: Update Asana tasks
 
-    needs: run_tests
+    needs: [assert_release_branch, run_tests]
     runs-on: macos-14-xlarge
     timeout-minutes: 10
 
     outputs:
-      asana_task_id: ${{ steps.task-id.outputs.asana_task_id }}
       commit_sha: ${{ steps.set-commit-sha.outputs.commit_sha }}
 
     steps:
@@ -90,10 +100,6 @@ jobs:
           working-directory: iOS
           cache-key-prefix: ios-ruby
 
-      - name: Extract Asana Task ID
-        id: task-id
-        run: bundle exec fastlane run asana_extract_task_id task_url:"${{ github.event.inputs.asana-task-url }}"
-
       - name: Update Asana for the release
         id: update-asana
         continue-on-error: true
@@ -107,7 +113,7 @@ jobs:
             release_type:internal \
             github_handle:"${{ github.actor }}" \
             is_scheduled_release:"${{ github.event_name == 'schedule' }}" \
-            release_task_id:"${{ steps.task-id.outputs.asana_task_id }}" \
+            release_task_id:"${{ needs.assert_release_branch.outputs.asana_task_id }}" \
             target_section_id:"${{ vars.IOS_APP_BOARD_VALIDATION_SECTION_ID }}"
 
   prepare_release:
@@ -134,11 +140,11 @@ jobs:
 
   report_failure:
     name: Report Failure
-    if: failure()
-    needs: [ update_asana, tag_and_merge ]
+    needs: [ assert_release_branch, run_tests, update_asana, prepare_release, tag_and_merge ]
+    if: always() && (needs.run_tests.result == 'failure' || needs.update_asana.result == 'failure' || needs.prepare_release.result == 'failure' || needs.tag_and_merge.result == 'failure')
     uses: ./.github/workflows/report_failed_release_workflow.yml
     with:
-      asana-task-id: ${{ needs.update_asana.outputs.asana_task_id }}
+      asana-task-id: ${{ needs.assert_release_branch.outputs.asana_task_id }}
       branch: ${{ github.ref_name }}
       commit-sha: ${{ needs.update_asana.outputs.commit_sha }}
       platform: ios

--- a/.github/workflows/ios_build_hotfix_release.yml
+++ b/.github/workflows/ios_build_hotfix_release.yml
@@ -67,6 +67,7 @@ jobs:
     timeout-minutes: 10
 
     outputs:
+      asana_task_id: ${{ steps.task-id.outputs.asana_task_id }}
       commit_sha: ${{ steps.set-commit-sha.outputs.commit_sha }}
 
     steps:
@@ -129,4 +130,17 @@ jobs:
       base-branch: ${{ github.event.inputs.current-internal-release-branch || 'main' }}
       commit-sha: ${{ needs.update_asana.outputs.commit_sha }}
       release-type: internal # Pre-release for now, after submitting to app store we will run ios-tag-release-update-asana again manually with 'hotfix' release type to finish up
+    secrets: inherit
+
+  report_failure:
+    name: Report Failure
+    if: failure()
+    needs: [ update_asana, tag_and_merge ]
+    uses: ./.github/workflows/report_failed_release_workflow.yml
+    with:
+      asana-task-id: ${{ needs.update_asana.outputs.asana_task_id }}
+      branch: ${{ github.ref_name }}
+      commit-sha: ${{ needs.update_asana.outputs.commit_sha }}
+      platform: ios
+      workflow-name: "build hotfix release"
     secrets: inherit

--- a/.github/workflows/ios_bump_internal_release.yml
+++ b/.github/workflows/ios_bump_internal_release.yml
@@ -153,8 +153,8 @@ jobs:
 
   report_failure:
     name: Report Failure
-    if: failure()
-    needs: [ validate_input_conditions, increment_build_number, tag_and_merge ]
+    needs: [ validate_input_conditions, run_tests, increment_build_number, prepare_release, tag_and_merge ]
+    if: always() && (needs.run_tests.result == 'failure' || needs.increment_build_number.result == 'failure' || needs.prepare_release.result == 'failure' || needs.tag_and_merge.result == 'failure')
     uses: ./.github/workflows/report_failed_release_workflow.yml
     with:
       asana-task-id: ${{ needs.validate_input_conditions.outputs.asana-task-id }}

--- a/.github/workflows/ios_bump_internal_release.yml
+++ b/.github/workflows/ios_bump_internal_release.yml
@@ -150,3 +150,16 @@ jobs:
       internal-release-bump: true
       release-type: internal
     secrets: inherit
+
+  report_failure:
+    name: Report Failure
+    if: failure()
+    needs: [ validate_input_conditions, increment_build_number, tag_and_merge ]
+    uses: ./.github/workflows/report_failed_release_workflow.yml
+    with:
+      asana-task-id: ${{ needs.validate_input_conditions.outputs.asana-task-id }}
+      branch: ${{ needs.validate_input_conditions.outputs.release-branch }}
+      commit-sha: ${{ needs.increment_build_number.outputs.commit_sha }}
+      platform: ios
+      workflow-name: "bump internal release"
+    secrets: inherit

--- a/.github/workflows/ios_code_freeze.yml
+++ b/.github/workflows/ios_code_freeze.yml
@@ -98,8 +98,8 @@ jobs:
 
   report_failure:
     name: Report Failure
-    if: failure()
-    needs: [ create_release_branch, tag_and_merge ]
+    needs: [ create_release_branch, run_tests, prepare_release, tag_and_merge ]
+    if: always() && (needs.run_tests.result == 'failure' || needs.prepare_release.result == 'failure' || needs.tag_and_merge.result == 'failure')
     uses: ./.github/workflows/report_failed_release_workflow.yml
     with:
       asana-task-id: ${{ needs.create_release_branch.outputs.asana_task_id }}

--- a/.github/workflows/ios_code_freeze.yml
+++ b/.github/workflows/ios_code_freeze.yml
@@ -27,6 +27,7 @@ jobs:
 
     outputs:
       release_branch_name: ${{ steps.make_release_branch.outputs.release_branch_name }}
+      asana_task_id: ${{ steps.make_release_branch.outputs.asana_task_id }}
       asana_task_url: ${{ steps.make_release_branch.outputs.asana_task_url }}
       commit_sha: ${{ steps.make_release_branch.outputs.commit_sha }}
 
@@ -93,4 +94,17 @@ jobs:
       branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
       commit-sha: ${{ needs.create_release_branch.outputs.commit_sha }}
       release-type: internal
+    secrets: inherit
+
+  report_failure:
+    name: Report Failure
+    if: failure()
+    needs: [ create_release_branch, tag_and_merge ]
+    uses: ./.github/workflows/report_failed_release_workflow.yml
+    with:
+      asana-task-id: ${{ needs.create_release_branch.outputs.asana_task_id }}
+      branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
+      commit-sha: ${{ needs.create_release_branch.outputs.commit_sha }}
+      platform: ios
+      workflow-name: "code freeze"
     secrets: inherit

--- a/.github/workflows/macos_build_hotfix_release.yml
+++ b/.github/workflows/macos_build_hotfix_release.yml
@@ -62,6 +62,7 @@ jobs:
     timeout-minutes: 10
 
     outputs:
+      asana-task-id: ${{ steps.task-id.outputs.asana_task_id }}
       commit_sha: ${{ steps.set-commit-sha.outputs.commit_sha }}
 
     steps:
@@ -124,4 +125,17 @@ jobs:
       base-branch: ${{ github.event.inputs.current-internal-release-branch || 'main' }}
       commit-sha: ${{ needs.update_asana.outputs.commit_sha }}
       prerelease: true # Pre-release for now, and the actual release will be done as part of publish_dmg_release that's called later
+    secrets: inherit
+
+  report_failure:
+    name: Report Failure
+    if: failure()
+    needs: [ update_asana, tag_and_merge ]
+    uses: ./.github/workflows/report_failed_release_workflow.yml
+    with:
+      asana-task-id: ${{ needs.update_asana.outputs.asana-task-id }}
+      branch: ${{ github.ref_name }}
+      commit-sha: ${{ needs.update_asana.outputs.commit_sha }}
+      platform: macos
+      workflow-name: "build hotfix release"
     secrets: inherit

--- a/.github/workflows/macos_build_hotfix_release.yml
+++ b/.github/workflows/macos_build_hotfix_release.yml
@@ -33,10 +33,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    outputs:
+      asana_task_id: ${{ steps.task-id.outputs.asana_task_id }}
+
     steps:
 
       - name: Check out the code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
 
       - name: Assert hotfix release branch
         run: |
@@ -44,6 +49,16 @@ jobs:
             refs/heads/hotfix/*) ;;
             *) echo "👎 Not a hotfix release branch"; exit 1 ;;
           esac
+
+      - name: Setup Ruby and dependencies
+        uses: ./.github/actions/setup-ruby
+        with:
+          working-directory: macOS
+          cache-key-prefix: macos-ruby
+
+      - name: Extract Asana Task ID
+        id: task-id
+        run: bundle exec fastlane run asana_extract_task_id task_url:"${{ github.event.inputs.asana-task-url }}"
 
   run_tests:
 
@@ -57,12 +72,11 @@ jobs:
 
     name: Update Asana tasks
 
-    needs: run_tests
+    needs: [assert_release_branch, run_tests]
     runs-on: macos-15
     timeout-minutes: 10
 
     outputs:
-      asana-task-id: ${{ steps.task-id.outputs.asana_task_id }}
       commit_sha: ${{ steps.set-commit-sha.outputs.commit_sha }}
 
     steps:
@@ -85,10 +99,6 @@ jobs:
           working-directory: macOS
           cache-key-prefix: macos-ruby
 
-      - name: Extract Asana Task ID
-        id: task-id
-        run: bundle exec fastlane run asana_extract_task_id task_url:"${{ github.event.inputs.asana-task-url }}"
-
       - name: Update Asana for the release
         id: update-asana
         continue-on-error: true
@@ -102,7 +112,7 @@ jobs:
             release_type:internal \
             github_handle:"${{ github.actor }}" \
             is_scheduled_release:"${{ github.event_name == 'schedule' }}" \
-            release_task_id:"${{ steps.task-id.outputs.asana_task_id }}" \
+            release_task_id:"${{ needs.assert_release_branch.outputs.asana_task_id }}" \
             target_section_id:"${{ vars.MACOS_APP_BOARD_VALIDATION_SECTION_ID }}"
 
   prepare_release:
@@ -129,11 +139,11 @@ jobs:
 
   report_failure:
     name: Report Failure
-    if: failure()
-    needs: [ update_asana, tag_and_merge ]
+    needs: [ assert_release_branch, run_tests, update_asana, prepare_release, tag_and_merge ]
+    if: always() && (needs.run_tests.result == 'failure' || needs.update_asana.result == 'failure' || needs.prepare_release.result == 'failure' || needs.tag_and_merge.result == 'failure')
     uses: ./.github/workflows/report_failed_release_workflow.yml
     with:
-      asana-task-id: ${{ needs.update_asana.outputs.asana-task-id }}
+      asana-task-id: ${{ needs.assert_release_branch.outputs.asana_task_id }}
       branch: ${{ github.ref_name }}
       commit-sha: ${{ needs.update_asana.outputs.commit_sha }}
       platform: macos

--- a/.github/workflows/macos_bump_internal_release.yml
+++ b/.github/workflows/macos_bump_internal_release.yml
@@ -170,8 +170,8 @@ jobs:
 
   report_failure:
     name: Report Failure
-    if: failure()
-    needs: [ validate_input_conditions, increment_build_number, tag_and_merge, publish_release ]
+    needs: [ validate_input_conditions, run_tests, increment_build_number, prepare_release, tag_and_merge, publish_release ]
+    if: always() && (needs.run_tests.result == 'failure' || needs.increment_build_number.result == 'failure' || needs.prepare_release.result == 'failure' || needs.tag_and_merge.result == 'failure' || needs.publish_release.result == 'failure')
     uses: ./.github/workflows/report_failed_release_workflow.yml
     with:
       asana-task-id: ${{ needs.validate_input_conditions.outputs.asana-task-id }}

--- a/.github/workflows/macos_bump_internal_release.yml
+++ b/.github/workflows/macos_bump_internal_release.yml
@@ -167,3 +167,16 @@ jobs:
       asana-task-url: ${{ needs.validate_input_conditions.outputs.asana-task-url }}
       branch: ${{ needs.validate_input_conditions.outputs.release-branch }}
     secrets: inherit
+
+  report_failure:
+    name: Report Failure
+    if: failure()
+    needs: [ validate_input_conditions, increment_build_number, tag_and_merge, publish_release ]
+    uses: ./.github/workflows/report_failed_release_workflow.yml
+    with:
+      asana-task-id: ${{ needs.validate_input_conditions.outputs.asana-task-id }}
+      branch: ${{ needs.validate_input_conditions.outputs.release-branch }}
+      commit-sha: ${{ needs.increment_build_number.outputs.commit_sha }}
+      platform: macos
+      workflow-name: "bump internal release"
+    secrets: inherit

--- a/.github/workflows/macos_code_freeze.yml
+++ b/.github/workflows/macos_code_freeze.yml
@@ -150,7 +150,7 @@ jobs:
     with:
       asana-task-id: "1211112466075936"
       branch: "dominik/report-workflow-failure"
-      commit-sha: "b642b649e165ac3a8c8a380de448ddaa99fb558d"
+      commit-sha: b642b649e165ac3a8c8a380de448ddaa99fb558d
+      platform: macos
       workflow-name: "code freeze"
-      working-directory: macOS
     secrets: inherit

--- a/.github/workflows/macos_code_freeze.yml
+++ b/.github/workflows/macos_code_freeze.yml
@@ -27,6 +27,7 @@ jobs:
 
     outputs:
       release_branch_name: ${{ steps.make_release_branch.outputs.release_branch_name }}
+      asana_task_id: ${{ steps.make_release_branch.outputs.asana_task_id }}
       asana_task_url: ${{ steps.make_release_branch.outputs.asana_task_url }}
 
     steps:
@@ -128,4 +129,16 @@ jobs:
       branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
       commit-sha: ${{ needs.increment_build_number.outputs.commit_sha }}
       prerelease: true
+    secrets: inherit
+
+  report_failure:
+    name: Report Failure
+    if: failure()
+    needs: [ create_release_branch, increment_build_number, tag_and_merge ]
+    uses: ./.github/workflows/report_failed_release_workflow.yml
+    with:
+      asana-task-id: ${{ needs.create_release_branch.outputs.asana_task_id }}
+      branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
+      commit-sha: ${{ needs.increment_build_number.outputs.commit_sha }}
+      workflow-name: "Code Freeze"
     secrets: inherit

--- a/.github/workflows/macos_code_freeze.yml
+++ b/.github/workflows/macos_code_freeze.yml
@@ -133,8 +133,8 @@ jobs:
 
   report_failure:
     name: Report Failure
-    if: failure()
-    needs: [ create_release_branch, increment_build_number, tag_and_merge ]
+    needs: [ create_release_branch, run_tests, increment_build_number, prepare_release, tag_and_merge ]
+    if: always() && (needs.run_tests.result == 'failure' || needs.increment_build_number.result == 'failure' || needs.prepare_release.result == 'failure' || needs.tag_and_merge.result == 'failure')
     uses: ./.github/workflows/report_failed_release_workflow.yml
     with:
       asana-task-id: ${{ needs.create_release_branch.outputs.asana_task_id }}

--- a/.github/workflows/macos_code_freeze.yml
+++ b/.github/workflows/macos_code_freeze.yml
@@ -141,5 +141,5 @@ jobs:
       branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
       commit-sha: ${{ needs.increment_build_number.outputs.commit_sha }}
       platform: macos
-      workflow-name: "Code Freeze"
+      workflow-name: "code freeze"
     secrets: inherit

--- a/.github/workflows/macos_code_freeze.yml
+++ b/.github/workflows/macos_code_freeze.yml
@@ -18,128 +18,139 @@ concurrency:
 
 jobs:
 
-  create_release_branch:
+  # create_release_branch:
 
-    name: Create Release Branch
+  #   name: Create Release Branch
 
-    runs-on: macos-15-xlarge
-    timeout-minutes: 10
+  #   runs-on: macos-15-xlarge
+  #   timeout-minutes: 10
 
-    outputs:
-      release_branch_name: ${{ steps.make_release_branch.outputs.release_branch_name }}
-      asana_task_id: ${{ steps.make_release_branch.outputs.asana_task_id }}
-      asana_task_url: ${{ steps.make_release_branch.outputs.asana_task_url }}
+  #   outputs:
+  #     release_branch_name: ${{ steps.make_release_branch.outputs.release_branch_name }}
+  #     asana_task_id: ${{ steps.make_release_branch.outputs.asana_task_id }}
+  #     asana_task_url: ${{ steps.make_release_branch.outputs.asana_task_url }}
 
-    steps:
-      - name: Check out the code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Fetch all history and tags in order to extract Asana task URLs from git log
-          submodules: recursive
+  #   steps:
+  #     - name: Check out the code
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0 # Fetch all history and tags in order to extract Asana task URLs from git log
+  #         submodules: recursive
 
-      - name: Assert main branch
-        run: |
-          if [ "${{ github.ref_name }}" != "main" ]; then
-            echo "👎 Not the main branch"
-            exit 1
-          fi
+  #     - name: Assert main branch
+  #       run: |
+  #         if [ "${{ github.ref_name }}" != "main" ]; then
+  #           echo "👎 Not the main branch"
+  #           exit 1
+  #         fi
 
-      - name: Setup Ruby and dependencies
-        uses: ./.github/actions/setup-ruby
-        with:
-          working-directory: macOS
-          cache-key-prefix: macos-ruby
+  #     - name: Setup Ruby and dependencies
+  #       uses: ./.github/actions/setup-ruby
+  #       with:
+  #         working-directory: macOS
+  #         cache-key-prefix: macos-ruby
 
-      - name: Make release branch
-        id: make_release_branch
-        env:
-          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          GITHUB_TOKEN: ${{ github.token }}
-          DBP_API_AUTH_TOKEN: ${{ secrets.DBP_API_AUTH_TOKEN }}
-        run: |
-          bundle exec fastlane run start_new_release \
-            platform:"macos" \
-            version:"${{ inputs.version }}" \
-            github_handle:"${{ github.actor }}" \
-            target_section_id:"${{ vars.MACOS_APP_BOARD_VALIDATION_SECTION_ID }}"
+  #     - name: Make release branch
+  #       id: make_release_branch
+  #       env:
+  #         ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+  #         GITHUB_TOKEN: ${{ github.token }}
+  #         DBP_API_AUTH_TOKEN: ${{ secrets.DBP_API_AUTH_TOKEN }}
+  #       run: |
+  #         bundle exec fastlane run start_new_release \
+  #           platform:"macos" \
+  #           version:"${{ inputs.version }}" \
+  #           github_handle:"${{ github.actor }}" \
+  #           target_section_id:"${{ vars.MACOS_APP_BOARD_VALIDATION_SECTION_ID }}"
 
-  run_tests:
+  # run_tests:
 
-    name: Run Tests
+  #   name: Run Tests
 
-    needs: create_release_branch
-    uses: ./.github/workflows/macos_pr_checks.yml
-    with:
-      branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
-    secrets: inherit
+  #   needs: create_release_branch
+  #   uses: ./.github/workflows/macos_pr_checks.yml
+  #   with:
+  #     branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
+  #   secrets: inherit
 
-  increment_build_number:
+  # increment_build_number:
 
-    name: Increment Build Number
+  #   name: Increment Build Number
 
-    needs: [ create_release_branch, run_tests ]
-    runs-on: macos-15-xlarge
-    timeout-minutes: 10
+  #   needs: [ create_release_branch, run_tests ]
+  #   runs-on: macos-15-xlarge
+  #   timeout-minutes: 10
 
-    outputs:
-      commit_sha: ${{ steps.increment-build-number.outputs.commit_sha }}
+  #   outputs:
+  #     commit_sha: ${{ steps.increment-build-number.outputs.commit_sha }}
 
-    steps:
+  #   steps:
 
-      - name: Check out the code
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          ref: ${{ needs.create_release_branch.outputs.release_branch_name }}
+  #     - name: Check out the code
+  #       uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
+  #         ref: ${{ needs.create_release_branch.outputs.release_branch_name }}
 
-      - name: Setup Ruby and dependencies
-        uses: ./.github/actions/setup-ruby
-        with:
-          working-directory: macOS
-          cache-key-prefix: macos-ruby
+  #     - name: Setup Ruby and dependencies
+  #       uses: ./.github/actions/setup-ruby
+  #       with:
+  #         working-directory: macOS
+  #         cache-key-prefix: macos-ruby
 
-      - name: Increment build number
-        id: increment-build-number
-        env:
-          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
-          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          bundle exec fastlane run bump_build_number platform:macos
+  #     - name: Increment build number
+  #       id: increment-build-number
+  #       env:
+  #         APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+  #         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+  #         APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
+  #         ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+  #         GITHUB_TOKEN: ${{ github.token }}
+  #       run: |
+  #         bundle exec fastlane run bump_build_number platform:macos
 
-  prepare_release:
-    name: Prepare Release
-    needs: [ create_release_branch, increment_build_number ]
-    uses: ./.github/workflows/macos_release.yml
-    with:
-      asana-task-url: ${{ needs.create_release_branch.outputs.asana_task_url }}
-      branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
-      commit-sha: ${{ needs.increment_build_number.outputs.commit_sha }}
-    secrets: inherit
+  # prepare_release:
+  #   name: Prepare Release
+  #   needs: [ create_release_branch, increment_build_number ]
+  #   uses: ./.github/workflows/macos_release.yml
+  #   with:
+  #     asana-task-url: ${{ needs.create_release_branch.outputs.asana_task_url }}
+  #     branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
+  #     commit-sha: ${{ needs.increment_build_number.outputs.commit_sha }}
+  #   secrets: inherit
 
-  tag_and_merge:
-    name: Tag and Merge Branch
-    needs: [ create_release_branch, increment_build_number, prepare_release ]
-    uses: ./.github/workflows/macos_tag_release.yml
-    with:
-      asana-task-url: ${{ needs.create_release_branch.outputs.asana_task_url }}
-      base-branch: ${{ github.ref_name }}
-      branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
-      commit-sha: ${{ needs.increment_build_number.outputs.commit_sha }}
-      prerelease: true
-    secrets: inherit
+  # tag_and_merge:
+  #   name: Tag and Merge Branch
+  #   needs: [ create_release_branch, increment_build_number, prepare_release ]
+  #   uses: ./.github/workflows/macos_tag_release.yml
+  #   with:
+  #     asana-task-url: ${{ needs.create_release_branch.outputs.asana_task_url }}
+  #     base-branch: ${{ github.ref_name }}
+  #     branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
+  #     commit-sha: ${{ needs.increment_build_number.outputs.commit_sha }}
+  #     prerelease: true
+  #   secrets: inherit
+
+  # report_failure:
+  #   name: Report Failure
+  #   if: failure()
+  #   needs: [ create_release_branch, increment_build_number, tag_and_merge ]
+  #   uses: ./.github/workflows/report_failed_release_workflow.yml
+  #   with:
+  #     asana-task-id: ${{ needs.create_release_branch.outputs.asana_task_id }}
+  #     branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
+  #     commit-sha: ${{ needs.increment_build_number.outputs.commit_sha }}
+  #     workflow-name: "Code Freeze"
+  #     working-directory: macOS
+  #   secrets: inherit
 
   report_failure:
     name: Report Failure
-    if: failure()
-    needs: [ create_release_branch, increment_build_number, tag_and_merge ]
     uses: ./.github/workflows/report_failed_release_workflow.yml
     with:
-      asana-task-id: ${{ needs.create_release_branch.outputs.asana_task_id }}
-      branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
-      commit-sha: ${{ needs.increment_build_number.outputs.commit_sha }}
-      workflow-name: "Code Freeze"
+      asana-task-id: "1211112466075936"
+      branch: "dominik/report-workflow-failure"
+      commit-sha: "b642b649e165ac3a8c8a380de448ddaa99fb558d"
+      workflow-name: "code freeze"
       working-directory: macOS
     secrets: inherit

--- a/.github/workflows/macos_code_freeze.yml
+++ b/.github/workflows/macos_code_freeze.yml
@@ -141,4 +141,5 @@ jobs:
       branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
       commit-sha: ${{ needs.increment_build_number.outputs.commit_sha }}
       workflow-name: "Code Freeze"
+      working-directory: macOS
     secrets: inherit

--- a/.github/workflows/macos_code_freeze.yml
+++ b/.github/workflows/macos_code_freeze.yml
@@ -18,139 +18,128 @@ concurrency:
 
 jobs:
 
-  # create_release_branch:
+  create_release_branch:
 
-  #   name: Create Release Branch
+    name: Create Release Branch
 
-  #   runs-on: macos-15-xlarge
-  #   timeout-minutes: 10
+    runs-on: macos-15-xlarge
+    timeout-minutes: 10
 
-  #   outputs:
-  #     release_branch_name: ${{ steps.make_release_branch.outputs.release_branch_name }}
-  #     asana_task_id: ${{ steps.make_release_branch.outputs.asana_task_id }}
-  #     asana_task_url: ${{ steps.make_release_branch.outputs.asana_task_url }}
+    outputs:
+      release_branch_name: ${{ steps.make_release_branch.outputs.release_branch_name }}
+      asana_task_id: ${{ steps.make_release_branch.outputs.asana_task_id }}
+      asana_task_url: ${{ steps.make_release_branch.outputs.asana_task_url }}
 
-  #   steps:
-  #     - name: Check out the code
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0 # Fetch all history and tags in order to extract Asana task URLs from git log
-  #         submodules: recursive
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history and tags in order to extract Asana task URLs from git log
+          submodules: recursive
 
-  #     - name: Assert main branch
-  #       run: |
-  #         if [ "${{ github.ref_name }}" != "main" ]; then
-  #           echo "👎 Not the main branch"
-  #           exit 1
-  #         fi
+      - name: Assert main branch
+        run: |
+          if [ "${{ github.ref_name }}" != "main" ]; then
+            echo "👎 Not the main branch"
+            exit 1
+          fi
 
-  #     - name: Setup Ruby and dependencies
-  #       uses: ./.github/actions/setup-ruby
-  #       with:
-  #         working-directory: macOS
-  #         cache-key-prefix: macos-ruby
+      - name: Setup Ruby and dependencies
+        uses: ./.github/actions/setup-ruby
+        with:
+          working-directory: macOS
+          cache-key-prefix: macos-ruby
 
-  #     - name: Make release branch
-  #       id: make_release_branch
-  #       env:
-  #         ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
-  #         GITHUB_TOKEN: ${{ github.token }}
-  #         DBP_API_AUTH_TOKEN: ${{ secrets.DBP_API_AUTH_TOKEN }}
-  #       run: |
-  #         bundle exec fastlane run start_new_release \
-  #           platform:"macos" \
-  #           version:"${{ inputs.version }}" \
-  #           github_handle:"${{ github.actor }}" \
-  #           target_section_id:"${{ vars.MACOS_APP_BOARD_VALIDATION_SECTION_ID }}"
+      - name: Make release branch
+        id: make_release_branch
+        env:
+          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+          DBP_API_AUTH_TOKEN: ${{ secrets.DBP_API_AUTH_TOKEN }}
+        run: |
+          bundle exec fastlane run start_new_release \
+            platform:"macos" \
+            version:"${{ inputs.version }}" \
+            github_handle:"${{ github.actor }}" \
+            target_section_id:"${{ vars.MACOS_APP_BOARD_VALIDATION_SECTION_ID }}"
 
-  # run_tests:
+  run_tests:
 
-  #   name: Run Tests
+    name: Run Tests
 
-  #   needs: create_release_branch
-  #   uses: ./.github/workflows/macos_pr_checks.yml
-  #   with:
-  #     branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
-  #   secrets: inherit
+    needs: create_release_branch
+    uses: ./.github/workflows/macos_pr_checks.yml
+    with:
+      branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
+    secrets: inherit
 
-  # increment_build_number:
+  increment_build_number:
 
-  #   name: Increment Build Number
+    name: Increment Build Number
 
-  #   needs: [ create_release_branch, run_tests ]
-  #   runs-on: macos-15-xlarge
-  #   timeout-minutes: 10
+    needs: [ create_release_branch, run_tests ]
+    runs-on: macos-15-xlarge
+    timeout-minutes: 10
 
-  #   outputs:
-  #     commit_sha: ${{ steps.increment-build-number.outputs.commit_sha }}
+    outputs:
+      commit_sha: ${{ steps.increment-build-number.outputs.commit_sha }}
 
-  #   steps:
+    steps:
 
-  #     - name: Check out the code
-  #       uses: actions/checkout@v4
-  #       with:
-  #         submodules: recursive
-  #         ref: ${{ needs.create_release_branch.outputs.release_branch_name }}
+      - name: Check out the code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          ref: ${{ needs.create_release_branch.outputs.release_branch_name }}
 
-  #     - name: Setup Ruby and dependencies
-  #       uses: ./.github/actions/setup-ruby
-  #       with:
-  #         working-directory: macOS
-  #         cache-key-prefix: macos-ruby
+      - name: Setup Ruby and dependencies
+        uses: ./.github/actions/setup-ruby
+        with:
+          working-directory: macOS
+          cache-key-prefix: macos-ruby
 
-  #     - name: Increment build number
-  #       id: increment-build-number
-  #       env:
-  #         APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
-  #         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-  #         APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
-  #         ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
-  #         GITHUB_TOKEN: ${{ github.token }}
-  #       run: |
-  #         bundle exec fastlane run bump_build_number platform:macos
+      - name: Increment build number
+        id: increment-build-number
+        env:
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
+          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          bundle exec fastlane run bump_build_number platform:macos
 
-  # prepare_release:
-  #   name: Prepare Release
-  #   needs: [ create_release_branch, increment_build_number ]
-  #   uses: ./.github/workflows/macos_release.yml
-  #   with:
-  #     asana-task-url: ${{ needs.create_release_branch.outputs.asana_task_url }}
-  #     branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
-  #     commit-sha: ${{ needs.increment_build_number.outputs.commit_sha }}
-  #   secrets: inherit
+  prepare_release:
+    name: Prepare Release
+    needs: [ create_release_branch, increment_build_number ]
+    uses: ./.github/workflows/macos_release.yml
+    with:
+      asana-task-url: ${{ needs.create_release_branch.outputs.asana_task_url }}
+      branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
+      commit-sha: ${{ needs.increment_build_number.outputs.commit_sha }}
+    secrets: inherit
 
-  # tag_and_merge:
-  #   name: Tag and Merge Branch
-  #   needs: [ create_release_branch, increment_build_number, prepare_release ]
-  #   uses: ./.github/workflows/macos_tag_release.yml
-  #   with:
-  #     asana-task-url: ${{ needs.create_release_branch.outputs.asana_task_url }}
-  #     base-branch: ${{ github.ref_name }}
-  #     branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
-  #     commit-sha: ${{ needs.increment_build_number.outputs.commit_sha }}
-  #     prerelease: true
-  #   secrets: inherit
-
-  # report_failure:
-  #   name: Report Failure
-  #   if: failure()
-  #   needs: [ create_release_branch, increment_build_number, tag_and_merge ]
-  #   uses: ./.github/workflows/report_failed_release_workflow.yml
-  #   with:
-  #     asana-task-id: ${{ needs.create_release_branch.outputs.asana_task_id }}
-  #     branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
-  #     commit-sha: ${{ needs.increment_build_number.outputs.commit_sha }}
-  #     workflow-name: "Code Freeze"
-  #     working-directory: macOS
-  #   secrets: inherit
+  tag_and_merge:
+    name: Tag and Merge Branch
+    needs: [ create_release_branch, increment_build_number, prepare_release ]
+    uses: ./.github/workflows/macos_tag_release.yml
+    with:
+      asana-task-url: ${{ needs.create_release_branch.outputs.asana_task_url }}
+      base-branch: ${{ github.ref_name }}
+      branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
+      commit-sha: ${{ needs.increment_build_number.outputs.commit_sha }}
+      prerelease: true
+    secrets: inherit
 
   report_failure:
     name: Report Failure
+    if: failure()
+    needs: [ create_release_branch, increment_build_number, tag_and_merge ]
     uses: ./.github/workflows/report_failed_release_workflow.yml
     with:
-      asana-task-id: "1211112466075936"
-      branch: "dominik/report-workflow-failure"
-      commit-sha: b642b649e165ac3a8c8a380de448ddaa99fb558d
+      asana-task-id: ${{ needs.create_release_branch.outputs.asana_task_id }}
+      branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
+      commit-sha: ${{ needs.increment_build_number.outputs.commit_sha }}
       platform: macos
-      workflow-name: "code freeze"
+      workflow-name: "Code Freeze"
     secrets: inherit

--- a/.github/workflows/report_failed_release_workflow.yml
+++ b/.github/workflows/report_failed_release_workflow.yml
@@ -73,7 +73,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           bundle exec fastlane run asana_report_failed_workflow \
-            platform: macos \
             branch:"${{ inputs.branch }}" \
             commit_sha:"${{ inputs.commit-sha }}" \
             github_handle:"${{ github.actor }}" \

--- a/.github/workflows/report_failed_release_workflow.yml
+++ b/.github/workflows/report_failed_release_workflow.yml
@@ -1,28 +1,6 @@
 name: Report Failed Release Workflow
 
 on:
-  workflow_dispatch:
-    inputs:
-      asana-task-id:
-        description: "Asana release task ID"
-        required: true
-        type: string
-      branch:
-        description: "Branch"
-        required: true
-        type: string
-      commit-sha:
-        description: "Commit SHA"
-        required: false
-        type: string
-      platform:
-        description: "Platform (ios/macos)"
-        required: true
-        type: string
-      workflow-name:
-        description: "Workflow name"
-        required: true
-        type: string
   workflow_call:
     inputs:
       asana-task-id:

--- a/.github/workflows/report_failed_release_workflow.yml
+++ b/.github/workflows/report_failed_release_workflow.yml
@@ -45,6 +45,9 @@ on:
         description: "Workflow name"
         required: true
         type: string
+    secrets:
+      ASANA_ACCESS_TOKEN:
+        required: true
 
 jobs:
   report_failure:

--- a/.github/workflows/report_failed_release_workflow.yml
+++ b/.github/workflows/report_failed_release_workflow.yml
@@ -15,12 +15,12 @@ on:
         description: "Commit SHA"
         required: false
         type: string
-      workflow-name:
-        description: "Workflow name"
+      platform:
+        description: "Platform (ios/macos)"
         required: true
         type: string
-      working-directory:
-        description: "Working directory (iOS/macOS)"
+      workflow-name:
+        description: "Workflow name"
         required: true
         type: string
   workflow_call:
@@ -37,12 +37,12 @@ on:
         description: "Commit SHA"
         required: false
         type: string
-      workflow-name:
-        description: "Workflow name"
+      platform:
+        description: "Platform (ios/macos)"
         required: true
         type: string
-      working-directory:
-        description: "Working directory (iOS/macOS)"
+      workflow-name:
+        description: "Workflow name"
         required: true
         type: string
 
@@ -54,6 +54,22 @@ jobs:
 
     steps:
 
+      - name: Set working directory
+        id: set-working-directory
+        run: |
+          case "${{ inputs.platform }}" in
+            ios)
+              echo "working_directory=iOS" >> $GITHUB_OUTPUT
+              ;;
+            macos)
+              echo "working_directory=macOS" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "::error::Invalid platform '${{ inputs.platform }}'."
+              exit 1
+            ;;
+          esac
+
       - name: Check out the code
         uses: actions/checkout@v4
         with:
@@ -63,16 +79,17 @@ jobs:
       - name: Setup Ruby and dependencies
         uses: ./.github/actions/setup-ruby
         with:
-          working-directory: ${{ inputs.working-directory }}
-          cache-key-prefix: macos-ruby
+          working-directory: ${{ steps.set-working-directory.outputs.working_directory }}
+          cache-key-prefix: ${{ inputs.platform }}-ruby
 
       - name: Report failed workflow
-        working-directory: ${{ inputs.working-directory }}
+        working-directory: ${{ steps.set-working-directory.outputs.working_directory }}
         env:
           ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           bundle exec fastlane run asana_report_failed_workflow \
+            platform:"${{ inputs.platform }}" \
             branch:"${{ inputs.branch }}" \
             commit_sha:"${{ inputs.commit-sha }}" \
             github_handle:"${{ github.actor }}" \

--- a/.github/workflows/report_failed_release_workflow.yml
+++ b/.github/workflows/report_failed_release_workflow.yml
@@ -1,0 +1,83 @@
+name: Report Failed Release Workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      asana-task-id:
+        description: "Asana release task ID"
+        required: true
+        type: string
+      branch:
+        description: "Branch"
+        required: true
+        type: string
+      commit-sha:
+        description: "Commit SHA"
+        required: false
+        type: string
+      workflow-name:
+        description: "Workflow name"
+        required: true
+        type: string
+      working-directory:
+        description: "Working directory (iOS/macOS)"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      asana-task-id:
+        description: "Asana release task ID"
+        required: true
+        type: string
+      branch:
+        description: "Branch"
+        required: true
+        type: string
+      commit-sha:
+        description: "Commit SHA"
+        required: false
+        type: string
+      workflow-name:
+        description: "Workflow name"
+        required: true
+        type: string
+      working-directory:
+        description: "Working directory (iOS/macOS)"
+        required: true
+        type: string
+
+jobs:
+  report_failure:
+    name: Report Failure
+
+    runs-on: macos-15
+
+    steps:
+
+      - name: Check out the code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          ref: ${{ inputs.branch }}
+
+      - name: Setup Ruby and dependencies
+        uses: ./.github/actions/setup-ruby
+        with:
+          working-directory: ${{ inputs.working-directory }}
+          cache-key-prefix: macos-ruby
+
+      - name: Report failed workflow
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          bundle exec fastlane run asana_report_failed_workflow \
+            platform: macos \
+            branch:"${{ inputs.branch }}" \
+            commit_sha:"${{ inputs.commit-sha }}" \
+            github_handle:"${{ github.actor }}" \
+            is_scheduled_release:"${{ github.event_name == 'schedule' }}" \
+            task_id:"${{ inputs.asana-task-id }}" \
+            workflow_name:"${{ inputs.workflow-name }}" \
+            workflow_url:"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"

--- a/iOS/Gemfile.lock
+++ b/iOS/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: db1ef2865dee9b4fc2d639c8b9290b134a677cf6
-  tag: 2.9.0
+  revision: 6cbc4f64bb74e7ba0a25d265b3f197f0a00dafc4
+  branch: dominik/report-workflow-failure
   specs:
     fastlane-plugin-ddg_apple_automation (2.9.0)
       asana
@@ -27,8 +27,8 @@ GEM
       oauth2 (>= 1.4, < 3)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1149.0)
-    aws-sdk-core (3.229.0)
+    aws-partitions (1.1150.0)
+    aws-sdk-core (3.230.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)

--- a/iOS/Gemfile.lock
+++ b/iOS/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: 7868ca07694180040978c4f8a7919f7a7585a18c
-  branch: dominik/report-workflow-failure
+  revision: e3d16afe384902170daf79716063692c8eea4566
+  tag: 2.10.0
   specs:
-    fastlane-plugin-ddg_apple_automation (2.9.0)
+    fastlane-plugin-ddg_apple_automation (2.10.0)
       asana
       climate_control
       httpparty

--- a/iOS/Gemfile.lock
+++ b/iOS/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: 6cbc4f64bb74e7ba0a25d265b3f197f0a00dafc4
+  revision: 7868ca07694180040978c4f8a7919f7a7585a18c
   branch: dominik/report-workflow-failure
   specs:
     fastlane-plugin-ddg_apple_automation (2.9.0)

--- a/iOS/fastlane/Pluginfile
+++ b/iOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '2.9.0'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', branch: 'dominik/report-workflow-failure'

--- a/iOS/fastlane/Pluginfile
+++ b/iOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', branch: 'dominik/report-workflow-failure'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '2.10.0'

--- a/macOS/Gemfile.lock
+++ b/macOS/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: a36348bd5b883e60c830d05f7256609532e0d356
+  revision: 84687089304d4eec9e25b83a03ec98ea259d6eec
   branch: dominik/report-workflow-failure
   specs:
     fastlane-plugin-ddg_apple_automation (2.9.0)

--- a/macOS/Gemfile.lock
+++ b/macOS/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: 570540c2e080a49ece617a1b3edacaa0c868a7a8
+  revision: 6cbc4f64bb74e7ba0a25d265b3f197f0a00dafc4
   branch: dominik/report-workflow-failure
   specs:
     fastlane-plugin-ddg_apple_automation (2.9.0)
@@ -27,8 +27,8 @@ GEM
       oauth2 (>= 1.4, < 3)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1149.0)
-    aws-sdk-core (3.229.0)
+    aws-partitions (1.1150.0)
+    aws-sdk-core (3.230.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)

--- a/macOS/Gemfile.lock
+++ b/macOS/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: 84687089304d4eec9e25b83a03ec98ea259d6eec
+  revision: 570540c2e080a49ece617a1b3edacaa0c868a7a8
   branch: dominik/report-workflow-failure
   specs:
     fastlane-plugin-ddg_apple_automation (2.9.0)

--- a/macOS/Gemfile.lock
+++ b/macOS/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: 7868ca07694180040978c4f8a7919f7a7585a18c
-  branch: dominik/report-workflow-failure
+  revision: e3d16afe384902170daf79716063692c8eea4566
+  tag: 2.10.0
   specs:
-    fastlane-plugin-ddg_apple_automation (2.9.0)
+    fastlane-plugin-ddg_apple_automation (2.10.0)
       asana
       climate_control
       httpparty

--- a/macOS/Gemfile.lock
+++ b/macOS/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: 6cbc4f64bb74e7ba0a25d265b3f197f0a00dafc4
+  revision: 7868ca07694180040978c4f8a7919f7a7585a18c
   branch: dominik/report-workflow-failure
   specs:
     fastlane-plugin-ddg_apple_automation (2.9.0)

--- a/macOS/Gemfile.lock
+++ b/macOS/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: 6f2eb34bda722f01b98fecb3bc9ac5f6123062d6
+  revision: a36348bd5b883e60c830d05f7256609532e0d356
   branch: dominik/report-workflow-failure
   specs:
     fastlane-plugin-ddg_apple_automation (2.9.0)

--- a/macOS/Gemfile.lock
+++ b/macOS/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: db1ef2865dee9b4fc2d639c8b9290b134a677cf6
-  tag: 2.9.0
+  revision: 6f2eb34bda722f01b98fecb3bc9ac5f6123062d6
+  branch: dominik/report-workflow-failure
   specs:
     fastlane-plugin-ddg_apple_automation (2.9.0)
       asana

--- a/macOS/fastlane/Pluginfile
+++ b/macOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '2.9.0'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', branch: 'dominik/report-workflow-failure'

--- a/macOS/fastlane/Pluginfile
+++ b/macOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', branch: 'dominik/report-workflow-failure'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '2.10.0'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1211100722861855?focus=true
Fastlane plugin PR: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation/pull/55

### Description
This change leverages a new action from the fastlane plugin to post a comment to the release task notifying
about a failed workflow run. It’s applied to code freeze, bump internal release and build hotfix release workflows
for iOS and macOS.

### Testing Steps
See [this workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/17139845872/job/48624681985) for an example of the action being triggered.
See [this task](https://app.asana.com/1/137249556945/project/1201621708115095/task/1211112466075936?focus=true) for example comments.

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Pretty low risk as the new workflow is called at the end of other workflows (and only on failure), so it can't fail them more.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)