### PR TITLE
[QWD][iOS] Autogenerate app size report and fire pixels for release build

### DIFF
--- a/.github/actions/measure-app-size/action.yml
+++ b/.github/actions/measure-app-size/action.yml
@@ -1,0 +1,40 @@
+name: 'Measure iOS App Size'
+description: 'Extract download and installation sizes from iOS App Thinning Size Report and send pixel metrics'
+author: 'DuckDuckGo'
+
+inputs:
+  report-file:
+    description: 'Path to the App Thinning Size Report.txt file'
+    required: true
+  download-pixel-name:
+    description: 'Pixel name for download size metric'
+    required: false
+  installation-pixel-name:
+    description: 'Pixel name for installation size metric'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Parse App Thinning Size Report
+      id: parse
+      shell: bash
+      run: |
+        echo "Parsing App Thinning Size Report..."
+        ${{ github.action_path }}/parse_app_size.sh "${{ inputs.report-file }}"
+
+    - name: Send Download Size Pixel
+      if: ${{ inputs.download-pixel-name != '' }}
+      uses: ./.github/actions/send-pixel
+      with:
+        pixel-name: ${{ inputs.download-pixel-name }}
+        query-params: |
+          size_mb: ${{ steps.parse.outputs.download_size }}
+
+    - name: Send Installation Size Pixel
+      if: ${{ inputs.installation-pixel-name != '' }}
+      uses: ./.github/actions/send-pixel
+      with:
+        pixel-name: ${{ inputs.installation-pixel-name }}
+        query-params: |
+          size_mb: ${{ steps.parse.outputs.installation_size }}

--- a/.github/actions/measure-app-size/action.yml
+++ b/.github/actions/measure-app-size/action.yml
@@ -6,10 +6,10 @@ inputs:
   report-file:
     description: 'Path to the App Thinning Size Report.txt file'
     required: true
-  download-pixel-name:
+  download-size-pixel-name:
     description: 'Pixel name for download size metric'
     required: false
-  installation-pixel-name:
+  installation-size-pixel-name:
     description: 'Pixel name for installation size metric'
     required: false
   app-version:
@@ -30,20 +30,20 @@ runs:
         ${{ github.action_path }}/parse_app_size.sh "${{ inputs.report-file }}"
 
     - name: Send Download Size Pixel
-      if: ${{ inputs.download-pixel-name != '' }}
+      if: ${{ inputs.download-size-pixel-name != '' }}
       uses: ./.github/actions/send-pixel
       with:
-        pixel-name: ${{ inputs.download-pixel-name }}
+        pixel-name: ${{ inputs.download-size-pixel-name }}
         query-params: |
           size: ${{ steps.parse.outputs.download_size }}
           app_version: ${{ inputs.app-version }}
           build_number: ${{ inputs.build-number }}
 
     - name: Send Installation Size Pixel
-      if: ${{ inputs.installation-pixel-name != '' }}
+      if: ${{ inputs.installation-size-pixel-name != '' }}
       uses: ./.github/actions/send-pixel
       with:
-        pixel-name: ${{ inputs.installation-pixel-name }}
+        pixel-name: ${{ inputs.installation-size-pixel-name }}
         query-params: |
           size: ${{ steps.parse.outputs.installation_size }}
           app_version: ${{ inputs.app-version }}

--- a/.github/actions/measure-app-size/action.yml
+++ b/.github/actions/measure-app-size/action.yml
@@ -36,8 +36,7 @@ runs:
         pixel-name: ${{ inputs.download-size-pixel-name }}
         query-params: |
           size: ${{ steps.parse.outputs.download_size }}
-          app_version: ${{ inputs.app-version }}
-          build_number: ${{ inputs.build-number }}
+          appVersion: ${{ inputs.app-version }}.${{ inputs.build-number }}
 
     - name: Send Installation Size Pixel
       if: ${{ inputs.installation-size-pixel-name != '' }}
@@ -46,5 +45,4 @@ runs:
         pixel-name: ${{ inputs.installation-size-pixel-name }}
         query-params: |
           size: ${{ steps.parse.outputs.installation_size }}
-          app_version: ${{ inputs.app-version }}
-          build_number: ${{ inputs.build-number }}
+          appVersion: ${{ inputs.app-version }}.${{ inputs.build-number }}

--- a/.github/actions/measure-app-size/action.yml
+++ b/.github/actions/measure-app-size/action.yml
@@ -12,6 +12,12 @@ inputs:
   installation-pixel-name:
     description: 'Pixel name for installation size metric'
     required: false
+  app-version:
+    description: 'App version to include in pixel data'
+    required: false
+  build-number:
+    description: 'Build number to include in pixel data'
+    required: false
 
 runs:
   using: 'composite'
@@ -30,6 +36,8 @@ runs:
         pixel-name: ${{ inputs.download-pixel-name }}
         query-params: |
           size: ${{ steps.parse.outputs.download_size }}
+          app_version: ${{ inputs.app-version }}
+          build_number: ${{ inputs.build-number }}
 
     - name: Send Installation Size Pixel
       if: ${{ inputs.installation-pixel-name != '' }}
@@ -38,3 +46,5 @@ runs:
         pixel-name: ${{ inputs.installation-pixel-name }}
         query-params: |
           size: ${{ steps.parse.outputs.installation_size }}
+          app_version: ${{ inputs.app-version }}
+          build_number: ${{ inputs.build-number }}

--- a/.github/actions/measure-app-size/action.yml
+++ b/.github/actions/measure-app-size/action.yml
@@ -29,7 +29,7 @@ runs:
       with:
         pixel-name: ${{ inputs.download-pixel-name }}
         query-params: |
-          size_mb: ${{ steps.parse.outputs.download_size }}
+          size: ${{ steps.parse.outputs.download_size }}
 
     - name: Send Installation Size Pixel
       if: ${{ inputs.installation-pixel-name != '' }}
@@ -37,4 +37,4 @@ runs:
       with:
         pixel-name: ${{ inputs.installation-pixel-name }}
         query-params: |
-          size_mb: ${{ steps.parse.outputs.installation_size }}
+          size: ${{ steps.parse.outputs.installation_size }}

--- a/.github/actions/measure-app-size/action.yml
+++ b/.github/actions/measure-app-size/action.yml
@@ -18,6 +18,9 @@ inputs:
   build-number:
     description: 'Build number to include in pixel data'
     required: false
+  suffix:
+    description: 'Optional suffix to append to version (applies only for ad-hoc builds)'
+    required: false
 
 runs:
   using: 'composite'
@@ -29,6 +32,14 @@ runs:
         echo "Parsing App Thinning Size Report..."
         ${{ github.action_path }}/parse_app_size.sh "${{ inputs.report-file }}"
 
+    - name: Build app version string
+      id: app-version
+      shell: bash
+      run: |
+        # Concatenate app version, build number, and optional suffix (e.g., 7.10.15.5 or 7.10.15.5.adhoc)
+        VERSION="${{ inputs.app-version }}.${{ inputs.build-number }}${{ inputs.suffix != '' && format('.{0}', inputs.suffix) || '' }}"
+        echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
     - name: Send Download Size Pixel
       if: ${{ inputs.download-size-pixel-name != '' }}
       uses: ./.github/actions/send-pixel
@@ -36,7 +47,7 @@ runs:
         pixel-name: ${{ inputs.download-size-pixel-name }}
         query-params: |
           size: ${{ steps.parse.outputs.download_size }}
-          appVersion: ${{ inputs.app-version }}.${{ inputs.build-number }}
+          appVersion: ${{ steps.app-version.outputs.version }}
 
     - name: Send Installation Size Pixel
       if: ${{ inputs.installation-size-pixel-name != '' }}
@@ -45,4 +56,4 @@ runs:
         pixel-name: ${{ inputs.installation-size-pixel-name }}
         query-params: |
           size: ${{ steps.parse.outputs.installation_size }}
-          appVersion: ${{ inputs.app-version }}.${{ inputs.build-number }}
+          appVersion: ${{ steps.app-version.outputs.version }}

--- a/.github/actions/measure-app-size/parse_app_size.sh
+++ b/.github/actions/measure-app-size/parse_app_size.sh
@@ -95,17 +95,6 @@ parse_app_size_from_line() {
         echo "Download size (compressed): $DOWNLOAD_SIZE"
         echo "Installation size (uncompressed): $INSTALLATION_SIZE"
         
-        # Extract numeric values without units for backward compatibility
-        DOWNLOAD_SIZE_VALUE=$(echo "$DOWNLOAD_SIZE" | sed 's/[A-Z]*//')
-        INSTALLATION_SIZE_VALUE=$(echo "$INSTALLATION_SIZE" | sed 's/[A-Z]*//')
-        
-        echo ""
-        echo "Environment variables:"
-        echo "DOWNLOAD_SIZE=$DOWNLOAD_SIZE"
-        echo "INSTALLATION_SIZE=$INSTALLATION_SIZE"
-        echo "DOWNLOAD_SIZE_MB=$DOWNLOAD_SIZE_VALUE"
-        echo "INSTALLATION_SIZE_MB=$INSTALLATION_SIZE_VALUE"
-        
         return 0
     else
         echo "Error: Could not extract size values from line: $app_size_line"

--- a/.github/actions/measure-app-size/parse_app_size.sh
+++ b/.github/actions/measure-app-size/parse_app_size.sh
@@ -85,6 +85,10 @@ parse_app_size_from_line() {
     INSTALLATION_SIZE=$(echo "$app_size_line" | sed -n "s/$UNCOMPRESSED_SIZE_REGEX/\1/p")
     
     if [ -n "$DOWNLOAD_SIZE" ] && [ -n "$INSTALLATION_SIZE" ]; then
+        # Remove spaces from sizes to avoid URL encoding issues (space becomes +)
+        DOWNLOAD_SIZE=$(echo "$DOWNLOAD_SIZE" | sed 's/ //')
+        INSTALLATION_SIZE=$(echo "$INSTALLATION_SIZE" | sed 's/ //')
+        
         echo ""
         echo "Results:"
         echo "--------"
@@ -92,8 +96,8 @@ parse_app_size_from_line() {
         echo "Installation size (uncompressed): $INSTALLATION_SIZE"
         
         # Extract numeric values without units for backward compatibility
-        DOWNLOAD_SIZE_VALUE=$(echo "$DOWNLOAD_SIZE" | sed 's/ [A-Z]*//')
-        INSTALLATION_SIZE_VALUE=$(echo "$INSTALLATION_SIZE" | sed 's/ [A-Z]*//')
+        DOWNLOAD_SIZE_VALUE=$(echo "$DOWNLOAD_SIZE" | sed 's/[A-Z]*//')
+        INSTALLATION_SIZE_VALUE=$(echo "$INSTALLATION_SIZE" | sed 's/[A-Z]*//')
         
         echo ""
         echo "Environment variables:"

--- a/.github/actions/measure-app-size/parse_app_size.sh
+++ b/.github/actions/measure-app-size/parse_app_size.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+# Script to parse App Thinning Size Report and extract app sizes
+# Usage: ./parse_app_size.sh "App Thinning Size Report.txt"
+
+# =============================================================================
+# CONSTANTS AND REGEX PATTERNS
+# =============================================================================
+VARIANT_PATTERN="^Variant:.*DuckDuckGo(-Alpha)?\.ipa$"
+APP_SIZE_PATTERN="^App size:"
+COMPRESSED_SIZE_REGEX="^App size: \([0-9.]* [A-Z]*\) compressed.*"
+UNCOMPRESSED_SIZE_REGEX="^.*compressed, \([0-9.]* [A-Z]*\) uncompressed.*"
+
+# =============================================================================
+# FUNCTION: Validate script inputs
+# Returns: 0 if valid, exits with 1 if invalid
+# Sets global variable: REPORT_FILE
+# =============================================================================
+validate_inputs() {
+    if [ $# -eq 0 ]; then
+        echo "Usage: $0 <path_to_app_thinning_size_report.txt>"
+        exit 1
+    fi
+
+    REPORT_FILE="$1"
+
+    if [ ! -f "$REPORT_FILE" ]; then
+        echo "Error: File '$REPORT_FILE' not found"
+        exit 1
+    fi
+
+    return 0
+}
+
+# =============================================================================
+# FUNCTION: Find the App size line for the universal variant
+# Parses from bottom up to find the first (universal) variant encountered
+# Returns: Outputs the App size line to stdout, returns 0 if found, 1 if not found
+# =============================================================================
+find_universal_app_size_line() {
+    # Read file into array (from bottom up)
+    local lines=()
+    while IFS= read -r line; do
+        lines=("$line" "${lines[@]}")
+    done < "$REPORT_FILE"
+    
+    local target_app_size_line=""
+    
+    # Parse from bottom (which is now top of array)
+    for line in "${lines[@]}"; do
+        # If we find an App size line first, store it
+        if [[ "$line" =~ $APP_SIZE_PATTERN ]]; then
+            target_app_size_line="$line"
+        fi
+        
+        # If we then find the universal variant, this App size line belongs to it
+        if [[ "$line" =~ $VARIANT_PATTERN ]]; then
+            echo "Found universal variant: $line" >&2
+            if [ -n "$target_app_size_line" ]; then
+                echo "$target_app_size_line"  # Output the line to stdout
+                return 0
+            fi
+        fi
+    done
+    
+    echo "Error: Universal variant App size line not found" >&2
+    return 1
+}
+
+# =============================================================================
+# FUNCTION: Parse app size values from a given App size line
+# Input: App size line as parameter
+# Returns: 0 if successfully parsed, 1 if parsing failed
+# Outputs: Sets DOWNLOAD_SIZE and INSTALLATION_SIZE variables
+# =============================================================================
+parse_app_size_from_line() {
+    local app_size_line="$1"
+    
+    echo "Parsing app size line: $app_size_line"
+    
+    # Extract compressed size (download size) with unit
+    DOWNLOAD_SIZE=$(echo "$app_size_line" | sed -n "s/$COMPRESSED_SIZE_REGEX/\1/p")
+    
+    # Extract uncompressed size (installation size) with unit
+    INSTALLATION_SIZE=$(echo "$app_size_line" | sed -n "s/$UNCOMPRESSED_SIZE_REGEX/\1/p")
+    
+    if [ -n "$DOWNLOAD_SIZE" ] && [ -n "$INSTALLATION_SIZE" ]; then
+        echo ""
+        echo "Results:"
+        echo "--------"
+        echo "Download size (compressed): $DOWNLOAD_SIZE"
+        echo "Installation size (uncompressed): $INSTALLATION_SIZE"
+        
+        # Extract numeric values without units for backward compatibility
+        DOWNLOAD_SIZE_VALUE=$(echo "$DOWNLOAD_SIZE" | sed 's/ [A-Z]*//')
+        INSTALLATION_SIZE_VALUE=$(echo "$INSTALLATION_SIZE" | sed 's/ [A-Z]*//')
+        
+        echo ""
+        echo "Environment variables:"
+        echo "DOWNLOAD_SIZE=$DOWNLOAD_SIZE"
+        echo "INSTALLATION_SIZE=$INSTALLATION_SIZE"
+        echo "DOWNLOAD_SIZE_MB=$DOWNLOAD_SIZE_VALUE"
+        echo "INSTALLATION_SIZE_MB=$INSTALLATION_SIZE_VALUE"
+        
+        return 0
+    else
+        echo "Error: Could not extract size values from line: $app_size_line"
+        return 1
+    fi
+}
+
+# =============================================================================
+# FUNCTION: Save values to GitHub Actions output
+# =============================================================================
+save_to_github_output() {
+    if [ -n "$GITHUB_OUTPUT" ]; then
+        echo "download_size=$DOWNLOAD_SIZE" >> "$GITHUB_OUTPUT"
+        echo "installation_size=$INSTALLATION_SIZE" >> "$GITHUB_OUTPUT"
+        echo "Values saved to GitHub Actions output"
+    else
+        echo "Note: GITHUB_OUTPUT not set (not running in GitHub Actions)"
+    fi
+}
+
+# =============================================================================
+# MAIN EXECUTION
+# =============================================================================
+
+# Step 1: Validate inputs
+validate_inputs "$@"
+
+# Step 2: Find the universal variant App size line (parsing from bottom)
+echo "Parsing App Thinning Size Report: $REPORT_FILE"
+echo "============================================="
+echo "Searching for universal variant App size line..."
+APP_SIZE_LINE=$(find_universal_app_size_line)
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+
+# Step 3: Parse the app size values from that line
+if ! parse_app_size_from_line "$APP_SIZE_LINE"; then
+    exit 1
+fi
+
+# Step 4: Save to GitHub Actions output
+save_to_github_output
+
+echo ""
+echo "Parsing completed successfully!"

--- a/.github/workflows/ios_adhoc.yml
+++ b/.github/workflows/ios_adhoc.yml
@@ -84,6 +84,15 @@ jobs:
             bundle exec fastlane ${lane_to_use}
           fi
 
+      - name: Check App Thinning Size Report
+        run: |
+          if [[ -f "App Thinning Size Report.txt" ]]; then
+            echo "=== App Thinning Size Report ==="
+            cat "App Thinning Size Report.txt"
+          else
+            echo "App Thinning Size Report.txt not found"
+          fi
+
       - name: Report job duration
         if: success() || (always() && steps.archive-and-upload.outcome == 'failure')
         uses: ./.github/actions/measure-duration

--- a/.github/workflows/ios_adhoc.yml
+++ b/.github/workflows/ios_adhoc.yml
@@ -90,8 +90,9 @@ jobs:
         uses: ./.github/actions/measure-app-size
         with:
           report-file: "iOS/App Thinning Size Report.txt"
-          download-pixel-name: "m_ci_apple_ios_adhoc_download_size"
-          installation-pixel-name: "m_ci_apple_ios_adhoc_installation_size"
+          download-size-pixel-name: "m_ci_apple_ios_adhoc_download_size"
+          installation-size-pixel-name: "m_ci_apple_ios_adhoc_installation_size"
+          app-version: ${{ env.output_name }}
 
       - name: Report job duration
         if: success() || (always() && steps.archive-and-upload.outcome == 'failure')

--- a/.github/workflows/ios_adhoc.yml
+++ b/.github/workflows/ios_adhoc.yml
@@ -84,14 +84,14 @@ jobs:
             bundle exec fastlane ${lane_to_use}
           fi
 
-      - name: Check App Thinning Size Report
-        run: |
-          if [[ -f "App Thinning Size Report.txt" ]]; then
-            echo "=== App Thinning Size Report ==="
-            cat "App Thinning Size Report.txt"
-          else
-            echo "App Thinning Size Report.txt not found"
-          fi
+      - name: Measure App Size
+        if: steps.archive-and-upload.outcome == 'success'
+        continue-on-error: true
+        uses: ./.github/actions/measure-app-size
+        with:
+          report-file: "App Thinning Size Report.txt"
+          download-pixel-name: "m_ci_apple_ios_adhoc_download_size"
+          installation-pixel-name: "m_ci_apple_ios_adhoc_installation_size"
 
       - name: Report job duration
         if: success() || (always() && steps.archive-and-upload.outcome == 'failure')

--- a/.github/workflows/ios_adhoc.yml
+++ b/.github/workflows/ios_adhoc.yml
@@ -89,7 +89,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/measure-app-size
         with:
-          report-file: "App Thinning Size Report.txt"
+          report-file: "iOS/App Thinning Size Report.txt"
           download-pixel-name: "m_ci_apple_ios_adhoc_download_size"
           installation-pixel-name: "m_ci_apple_ios_adhoc_installation_size"
 

--- a/.github/workflows/ios_adhoc.yml
+++ b/.github/workflows/ios_adhoc.yml
@@ -73,6 +73,11 @@ jobs:
           APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
         run: |
+          app_version="$(cut -d ' ' -f 3 < Configuration/Version.xcconfig)"
+          build_number="$(cut -d ' ' -f 3 < Configuration/BuildNumber.xcconfig)"
+          echo "app_version=${app_version}" >> $GITHUB_ENV
+          echo "build_number=${build_number}" >> $GITHUB_ENV
+          
           lane_to_use="adhoc"
           if [[ "${{ github.event.inputs.build-type }}" == "Release" ]]; then
             lane_to_use="release_adhoc"
@@ -92,7 +97,9 @@ jobs:
           report-file: "iOS/App Thinning Size Report.txt"
           download-size-pixel-name: "m_ci_apple_ios_adhoc_download_size"
           installation-size-pixel-name: "m_ci_apple_ios_adhoc_installation_size"
-          app-version: ${{ env.output_name }}
+          app-version: ${{ env.app_version }}
+          build-number: ${{ env.build_number }}
+          suffix: ${{ github.event.inputs.suffix }}
 
       - name: Report job duration
         if: success() || (always() && steps.archive-and-upload.outcome == 'failure')

--- a/.github/workflows/ios_bump_internal_release.yml
+++ b/.github/workflows/ios_bump_internal_release.yml
@@ -136,6 +136,7 @@ jobs:
       asana-task-url: ${{ needs.validate_input_conditions.outputs.asana-task-url }}
       branch: ${{ needs.validate_input_conditions.outputs.release-branch }}
       commit-sha: ${{ needs.increment_build_number.outputs.commit_sha }}
+      measure-app-size: true
     secrets: inherit
 
   tag_and_merge:

--- a/.github/workflows/ios_code_freeze.yml
+++ b/.github/workflows/ios_code_freeze.yml
@@ -81,6 +81,7 @@ jobs:
       asana-task-url: ${{ needs.create_release_branch.outputs.asana_task_url }}
       branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
       commit-sha: ${{ needs.create_release_branch.outputs.commit_sha }}
+      measure-app-size: true
     secrets: inherit
 
   tag_and_merge:

--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -36,6 +36,11 @@ on:
         description: "Upload destination (TestFlight or App Store)"
         default: testflight
         type: string
+      measure-app-size:
+        description: "Whether to measure and track app sizes"
+        required: false
+        default: false
+        type: boolean
     secrets:
       APPLE_API_KEY_BASE64:
         required: true
@@ -119,6 +124,18 @@ jobs:
         echo "build_number=${build_number}" >> $GITHUB_ENV
         bundle exec fastlane release_${{ steps.destination.outputs.destination }}
         mv -f "$original_dsyms_path" "$dsyms_path"
+
+    - name: Measure App Size
+      id: measure-app-size
+      if: success() && inputs.measure-app-size == true
+      continue-on-error: true
+      uses: ./.github/actions/measure-app-size
+      with:
+        report-file: "iOS/App Thinning Size Report.txt"
+        download-pixel-name: "m_ci_apple_ios_release_download_size"
+        installation-pixel-name: "m_ci_apple_ios_release_installation_size"
+        app-version: ${{ env.app_version }}
+        build-number: ${{ env.build_number }}
 
     - name: Upload dSYMs artifact
       if: always()

--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -132,8 +132,8 @@ jobs:
       uses: ./.github/actions/measure-app-size
       with:
         report-file: "iOS/App Thinning Size Report.txt"
-        download-pixel-name: "m_ci_apple_ios_release_download_size"
-        installation-pixel-name: "m_ci_apple_ios_release_installation_size"
+        download-size-pixel-name: "m_ci_apple_ios_release_download_size"
+        installation-size-pixel-name: "m_ci_apple_ios_release_installation_size"
         app-version: ${{ env.app_version }}
         build-number: ${{ env.build_number }}
 

--- a/iOS/adhocExportOptions.plist
+++ b/iOS/adhocExportOptions.plist
@@ -29,6 +29,9 @@
         <key>com.duckduckgo.mobile.ios.CredentialExtension</key>
 		<string>match AdHoc com.duckduckgo.mobile.ios.CredentialExtension</string>
     </dict>
+    
+    <key>thinning</key>
+    <string>&lt;thin-for-all-variants&gt;</string>
 
 </dict>
 </plist>

--- a/iOS/alphaAdhocExportOptions.plist
+++ b/iOS/alphaAdhocExportOptions.plist
@@ -23,5 +23,7 @@
 		<key>com.duckduckgo.mobile.ios.alpha.CredentialExtension</key>
 		<string>match AdHoc com.duckduckgo.mobile.ios.alpha.CredentialExtension</string>
 	</dict>
+    <key>thinning</key>
+    <string>&lt;thin-for-all-variants&gt;</string>
 </dict>
 </plist>

--- a/iOS/alphaExportOptions.plist
+++ b/iOS/alphaExportOptions.plist
@@ -21,5 +21,7 @@
 		<key>com.duckduckgo.mobile.ios.alpha.CredentialExtension</key>
 		<string>match AppStore com.duckduckgo.mobile.ios.alpha.CredentialExtension</string>
 	</dict>
+    <key>thinning</key>
+    <string>&lt;thin-for-all-variants&gt;</string>
 </dict>
 </plist>

--- a/iOS/appStoreExportOptions.plist
+++ b/iOS/appStoreExportOptions.plist
@@ -21,5 +21,7 @@
 		<key>com.duckduckgo.mobile.ios.CredentialExtension</key>
 		<string>match AppStore com.duckduckgo.mobile.ios.CredentialExtension</string>
 	</dict>
+    <key>thinning</key>
+    <string>&lt;thin-for-all-variants&gt;</string>
 </dict>
 </plist>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1211098882149655
Tech Design URL:
CC:

### Description

Add iOS App Size Tracking to CI Workflows

**Summary**
  - Implemented app size measurement for iOS ad-hoc builds and release builds
  - Created reusable GitHub Action to parse App Thinning Size Reports and send pixel metrics
  - Integrated with existing workflows

**Changes Made**

New GitHub Action: measure-app-size
- Script: Parses "App Thinning Size Report.txt" to extract universal variant sizes
- Outputs: Download size (compressed) and installation size (uncompressed)
- Pixels: Automatically sends pixel metrics to improving.duckduckgo.com/t/ with app version and build number parameters

Workflows Integrations

 ios_release.yml
  - Added: Optional measure-app-size boolean input (default: false) for different workflows (ios_bump_internal_release.yml & ios_code_freeze.yml) to use.
  - Conditional: Only measures when explicitly requested
  - Use: measure-app-size custom github action with the following parameters:
     - m_ci_apple_ios_release_download_size 
     - m_ci_apple_ios_release_installation_size
     - app_version 
     - build_number

 ios_bump_internal_release.yml & ios_code_freeze.yml
  - Added: measure-app-size: true when calling ios_release.yml
  - Coverage: This will ensure we will send the pixel metrics on a Monday when the internal release is created and on subsequent internal bumps if neeeded

ios_adhoc.yml
  - Added: App size measurement after successful archive for testing purposes.

### Testing Steps
**Test Script works**
1. Save the content of the [App Thinning Size Report.txt](https://github.com/user-attachments/files/21927962/App.Thinning.Size.Report.txt) locally.
2. In terminal run ./.github/actions/measure-app-size/parse_app_size.sh <path_to_file> and ensure the values printed are the expected ones.

**Test Ad Hoc Build**
1. Run the ios_adhoc workflow pointing at this branch with the following command:
`gh workflow run ios_adhoc.yml --ref alessandro/qwd-ci-app-size-ios --field suffix="app-size-test-6" --field asana-task-url="https://app.asana.com/1/137249556945/project/1203301625297703/task/1211098882149664\?focus\=true" --field build-type=Release`
You can probably omit the `asana-task-url` and can pick your `suffix`
 
**Ensure Pixels are sent with right parameters**
- In Kibana check for m_ci_apple_ios_release_download_size & m_ci_apple_ios_release_installation_size pixels and ensure they have the expected parameters.

### Impact and Risks
None: Uses `continue-on-error: true` to prevent workflow failures.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)