### PR TITLE
[QWD][iOS] Remove unit from sizes before sending the pixels for easier transformation

### DIFF
--- a/.github/actions/measure-app-size/action.yml
+++ b/.github/actions/measure-app-size/action.yml
@@ -40,13 +40,23 @@ runs:
         VERSION="${{ inputs.app-version }}.${{ inputs.build-number }}${{ inputs.suffix != '' && format('.{0}', inputs.suffix) || '' }}"
         echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
+    - name: Sanitize sizes
+      id: sanitize-sizes
+      shell: bash
+      run: |
+        # Remove unit suffixes (MB, GB, etc.) to get clean numeric values for easier metric transformations
+        SANITIZED_DOWNLOAD_SIZE=$(echo "${{ steps.parse.outputs.download_size }}" | sed 's/[A-Z]*$//')
+        SANITIZED_INSTALLATION_SIZE=$(echo "${{ steps.parse.outputs.installation_size }}" | sed 's/[A-Z]*$//')
+        echo "download_size=${SANITIZED_DOWNLOAD_SIZE}" >> $GITHUB_OUTPUT
+        echo "installation_size=${SANITIZED_INSTALLATION_SIZE}" >> $GITHUB_OUTPUT
+
     - name: Send Download Size Pixel
       if: ${{ inputs.download-size-pixel-name != '' }}
       uses: ./.github/actions/send-pixel
       with:
         pixel-name: ${{ inputs.download-size-pixel-name }}
         query-params: |
-          size: ${{ steps.parse.outputs.download_size }}
+          size: ${{ steps.sanitize-sizes.outputs.download_size }}
           appVersion: ${{ steps.app-version.outputs.version }}
 
     - name: Send Installation Size Pixel
@@ -55,5 +65,5 @@ runs:
       with:
         pixel-name: ${{ inputs.installation-size-pixel-name }}
         query-params: |
-          size: ${{ steps.parse.outputs.installation_size }}
+          size: ${{ steps.sanitize-sizes.outputs.installation_size }}
           appVersion: ${{ steps.app-version.outputs.version }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1211119966980600?focus=true
Tech Design URL:
CC:

### Description

Remove unit from app size to make Grafana transformations easier. 

<img width="2246" height="385" alt="Screenshot 2025-08-22 at 6 09 03 pm" src="https://github.com/user-attachments/assets/7839d8d2-9150-4a97-a33f-8231687cf75d" />

<img width="2254" height="385" alt="Screenshot 2025-08-22 at 6 08 39 pm" src="https://github.com/user-attachments/assets/df179328-e1bc-4587-ba39-9904035490b2" />

### Testing Steps
Check CI Run https://github.com/duckduckgo/apple-browsers/actions/runs/17149525701

### Impact and Risks
None: Internal tooling

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)