### PR TITLE
NTP feature flags connected to Privacy Configuration

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -81,6 +81,7 @@ public enum PrivacyFeature: String {
     case delayedWebviewPresentation
     case disableFireAnimation
     case feedbackForm
+    case htmlNewTabPage
 }
 
 /// An abstraction to be implemented by any "subfeature" of a given `PrivacyConfiguration` feature.
@@ -201,6 +202,18 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
 
     /// Global switch to disable all AI Chat related functionality
     case globalToggle
+}
+
+public enum HtmlNewTabPageSubfeature: String, Equatable, PrivacySubfeature {
+    public var parent: PrivacyFeature {
+        .htmlNewTabPage
+    }
+
+    /// Global switch to disable New Tab Page search box
+    case omnibar
+
+    /// Global switch to control shared or independent New Tab Page
+    case newTabPagePerTab
 }
 
 public enum NetworkProtectionSubfeature: String, Equatable, PrivacySubfeature {

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -341,7 +341,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .disableFireAnimation:
             return .remoteReleasable(.feature(.disableFireAnimation))
         case .newTabPageOmnibar:
-            return .internalOnly()
+            return .remoteReleasable(.subfeature(HtmlNewTabPageSubfeature.omnibar))
         case .subscriptionRebranding:
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.subscriptionRebranding))
         case .newFeedbackForm:
@@ -349,7 +349,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .vpnToolbarUpsell:
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.vpnToolbarUpsell))
         case .newTabPagePerTab:
-            return .internalOnly()
+            return .remoteReleasable(.subfeature(HtmlNewTabPageSubfeature.newTabPagePerTab))
         case .supportsAlternateStripePaymentFlow:
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.supportsAlternateStripePaymentFlow))
         case .openFireWindowByDefault:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1211121799241568?focus=true

### Description
Internal feature flags related to NTP search box replaced with remote feature flags

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Run the app and make sure the NTP search box is visible only for internal users
2. Also, make sure the NTP for internal users is independent for each tab (you can have separate states of New Tab Page on each tab)

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
NTP search box will be visible for external users sooner than planned

### Notes to Reviewer
-

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)