### PR TITLE
Refactor urlsToRemove to use Set for O(1) lookups

### DIFF
--- a/iOS/DuckDuckGo/TabInteractionStateDiskSource.swift
+++ b/iOS/DuckDuckGo/TabInteractionStateDiskSource.swift
@@ -123,9 +123,9 @@ final class TabInteractionStateDiskSource: TabInteractionStateSource, TabInterac
         guard let allCacheFiles = try? allCacheFiles() else {
             return []
         }
+        let excludedUIDs = Set(excludedTabs.compactMap { $0.uid })
         return allCacheFiles.filter { file in
-            let isExcluded = excludedTabs.contains { $0.uid == file.lastPathComponent }
-            return !isExcluded
+            !excludedUIDs.contains(file.lastPathComponent)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201392122292466/task/1210977112671092?focus=true
CC: @dus7

### Description
This PR refactors urlsToRemove(excluding:) to replace the nested .contains calls with a Set lookup.
Previously the function performed in O(N × M) time (files × tabs), which could cause high CPU usage or memory pressure for large datasets.
With a Set of excluded UIDs, lookups are now O(1), making the operation significantly faster and reducing the risk of watchdog/jetsam kills.

### Testing Steps
1. Unit tests should not fail.

### Impact and Risks
What's the impact on users if something goes wrong?
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Potentially removing wrong or not removing cached interaction states.