### PR TITLE
Diego/vpn ios no longer passing settings

### DIFF
--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -516,12 +516,12 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     open func load(options: StartupOptions) async throws {
         Logger.networkProtection.log("Loading startup options")
         loadKeyValidity(from: options)
+        loadTesterEnabled(from: options)
+#if os(macOS)
         loadSelectedEnvironment(from: options)
         loadSelectedServer(from: options)
         loadSelectedLocation(from: options)
         loadDNSSettings(from: options)
-        loadTesterEnabled(from: options)
-#if os(macOS)
         loadAuthVersion(from: options)
         if !Self.isUsingAuthV2 {
             try await loadAuthToken(from: options)
@@ -550,6 +550,18 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
+    private func loadTesterEnabled(from options: StartupOptions) {
+        switch options.enableTester {
+        case .set(let value):
+            isConnectionTesterEnabled = value
+        case .useExisting:
+            break
+        case .reset:
+            isConnectionTesterEnabled = true
+        }
+    }
+
+#if os(macOS)
     private func loadSelectedEnvironment(from options: StartupOptions) {
         switch options.selectedEnvironment {
         case .set(let selectedEnvironment):
@@ -594,18 +606,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
-    private func loadTesterEnabled(from options: StartupOptions) {
-        switch options.enableTester {
-        case .set(let value):
-            isConnectionTesterEnabled = value
-        case .useExisting:
-            break
-        case .reset:
-            isConnectionTesterEnabled = true
-        }
-    }
-
-#if os(macOS)
     private func loadAuthVersion(from options: StartupOptions) {
         switch options.isAuthV2Enabled {
         case .set(let newAuthVersion):

--- a/iOS/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -293,12 +293,7 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
             }
         }
 
-        options[NetworkProtectionOptionKey.selectedEnvironment] = settings.selectedEnvironment.rawValue as NSString
 
-        var dnsSettings = settings.dnsSettings
-        if let data = try? JSONEncoder().encode(dnsSettings) {
-            options[NetworkProtectionOptionKey.dnsSettings] = NSData(data: data)
-        }
 
         do {
             try tunnelManager.connection.startVPNTunnel(options: options)

--- a/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
+++ b/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
@@ -415,7 +415,7 @@ final class SubscriptionDebugViewController: UITableViewController {
 
     private func clearAuthDataV2() {
         Task {
-            await subscriptionManagerV1.signOut(notifyUI: true)
+            await subscriptionManagerV2.signOut(notifyUI: true)
             showAlert(title: "Data cleared!")
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207603085593419/task/1211125360934988?focus=true

### Description

When running the VPN in iOS there's no need to pass startup options, or decode them in the packet tunnel because VPN settings are in the shared user defaults.

### Testing Steps

1. Start the VPN in iOS.
2. Change servers.
3. Disconnect
4. Reconnect
5. Ensure it all works well.

### Impact and Risks

Medium.

#### What could go wrong?

Unexpected side effect of this change.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)