### PR TITLE
Vpn macos pass entire vpn settings on tunnel start

### DIFF
--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -516,12 +516,12 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     open func load(options: StartupOptions) async throws {
         Logger.networkProtection.log("Loading startup options")
         loadKeyValidity(from: options)
+        loadTesterEnabled(from: options)
+#if os(macOS)
         loadSelectedEnvironment(from: options)
         loadSelectedServer(from: options)
         loadSelectedLocation(from: options)
         loadDNSSettings(from: options)
-        loadTesterEnabled(from: options)
-#if os(macOS)
         loadAuthVersion(from: options)
         if !Self.isUsingAuthV2 {
             try await loadAuthToken(from: options)
@@ -550,6 +550,18 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
+    private func loadTesterEnabled(from options: StartupOptions) {
+        switch options.enableTester {
+        case .set(let value):
+            isConnectionTesterEnabled = value
+        case .useExisting:
+            break
+        case .reset:
+            isConnectionTesterEnabled = true
+        }
+    }
+
+#if os(macOS)
     private func loadSelectedEnvironment(from options: StartupOptions) {
         switch options.selectedEnvironment {
         case .set(let selectedEnvironment):
@@ -594,18 +606,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
-    private func loadTesterEnabled(from options: StartupOptions) {
-        switch options.enableTester {
-        case .set(let value):
-            isConnectionTesterEnabled = value
-        case .useExisting:
-            break
-        case .reset:
-            isConnectionTesterEnabled = true
-        }
-    }
-
-#if os(macOS)
     private func loadAuthVersion(from options: StartupOptions) {
         switch options.isAuthV2Enabled {
         case .set(let newAuthVersion):

--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -522,15 +522,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         Logger.networkProtection.log("Loading startup options")
         loadKeyValidity(from: options)
         loadTesterEnabled(from: options)
-#if os(macOS)
-        try loadVPNSettings(from: options)
-        loadAuthVersion(from: options)
-        if !Self.isUsingAuthV2 {
-            try await loadAuthToken(from: options)
-        } else {
-            try await loadTokenContainer(from: options)
-        }
-#endif
     }
 
     open func loadVendorOptions(from provider: NETunnelProviderProtocol?) throws {
@@ -569,89 +560,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
-#if os(macOS)
-    private func loadVPNSettings(from options: StartupOptions) throws {
-        switch options.vpnSettings {
-        case .set(let settingsSnapshot):
-            settingsSnapshot.applyTo(settings)
-        case .useExisting:
-            break
-        case .reset:
-            // VPN settings are required - if we're in reset case, it means they were missing or invalid
-            throw TunnelError.settingsMissing
-        }
-    }
 
-    private func loadAuthVersion(from options: StartupOptions) {
-        switch options.isAuthV2Enabled {
-        case .set(let newAuthVersion):
-            Logger.networkProtection.log("Set new isAuthV2Enabled")
-            Self.isUsingAuthV2 = newAuthVersion
-        case .useExisting:
-            Logger.networkProtection.log("Use existing isAuthV2Enabled")
-        case .reset:
-            Logger.networkProtection.log("Reset isAuthV2Enabled")
-        }
-        Logger.networkProtection.log("Load isAuthV2Enabled: \(Self.isUsingAuthV2, privacy: .public)")
-    }
-
-    private func loadAuthToken(from options: StartupOptions) async throws {
-        let tokenHandlerProvider = tokenHandlerProvider()
-        Logger.networkProtection.log("Load auth token")
-        switch options.authToken {
-        case .set(let newAuthToken):
-            Logger.networkProtection.log("Set new token")
-            if let currentAuthToken = try? await tokenHandlerProvider.getToken(), currentAuthToken == newAuthToken {
-                Logger.networkProtection.log("Token unchanged, using the current one")
-                return
-            }
-
-            try await tokenHandlerProvider.adoptToken(newAuthToken)
-        case .useExisting:
-            Logger.networkProtection.log("Use existing token")
-            do {
-                try await tokenHandlerProvider.getToken()
-            } catch {
-                throw TunnelError.startingTunnelWithoutAuthToken(internalError: error)
-            }
-        case .reset:
-            Logger.networkProtection.log("Reset token")
-            // This case should in theory not be possible, but it's ideal to have this in place
-            // in case an error in the controller on the client side allows it.
-            try? await tokenHandlerProvider.removeToken()
-            throw TunnelError.tokenReset
-        }
-    }
-
-    private func loadTokenContainer(from options: StartupOptions) async throws {
-        let tokenHandlerProvider = tokenHandlerProvider()
-        Logger.networkProtection.log("Load token container")
-        switch options.tokenContainer {
-        case .set(let newTokenContainer):
-            Logger.networkProtection.log("Set new token container")
-            do {
-                try await tokenHandlerProvider.adoptToken(newTokenContainer)
-            } catch {
-                Logger.networkProtection.fault("Error adopting token container: \(error, privacy: .public)")
-                throw TunnelError.startingTunnelWithoutAuthToken(internalError: error)
-            }
-        case .useExisting:
-            Logger.networkProtection.log("Use existing token container")
-            do {
-                try await tokenHandlerProvider.getToken()
-            } catch {
-                Logger.networkProtection.fault("Error loading token container: \(error, privacy: .public)")
-                throw TunnelError.startingTunnelWithoutAuthToken(internalError: error)
-            }
-        case .reset:
-            Logger.networkProtection.log("Reset token")
-            // This case should in theory not be possible, but it's ideal to have this in place
-            // in case an error in the controller on the client side allows it.
-            try await tokenHandlerProvider.removeToken()
-            throw TunnelError.tokenReset
-        }
-    }
-#endif
 
     // MARK: - Observing Changes
 

--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -102,6 +102,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         case startingTunnelWithoutAuthToken(internalError: Error?)
         case couldNotGenerateTunnelConfiguration(internalError: Error)
         case simulateTunnelFailureError
+        case settingsMissing
         case simulateSubscriptionExpiration
         case tokenReset
 
@@ -122,6 +123,8 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 return "Failed to generate a tunnel configuration: \(internalError.localizedDescription)"
             case .simulateTunnelFailureError:
                 return "Simulated a tunnel error as requested"
+            case .settingsMissing:
+                return "VPN settings are missing or invalid"
             case .simulateSubscriptionExpiration:
                 return nil
             case .tokenReset:
@@ -137,8 +140,9 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             case .startingTunnelWithoutAuthToken: return 0
             case .couldNotGenerateTunnelConfiguration: return 1
             case .simulateTunnelFailureError: return 2
-            case .simulateSubscriptionExpiration: return 3
-            case .tokenReset: return 4
+            case .settingsMissing: return 3
+            case .simulateSubscriptionExpiration: return 4
+            case .tokenReset: return 5
                 // Subscription Errors - 100+
             case .vpnAccessRevoked: return 100
             case .vpnAccessRevokedDetectedByMonitorCheck: return 101
@@ -150,6 +154,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         public var errorUserInfo: [String: Any] {
             switch self {
             case .simulateTunnelFailureError,
+                    .settingsMissing,
                     .vpnAccessRevokedDetectedByMonitorCheck,
                     .simulateSubscriptionExpiration,
                     .tokenReset,
@@ -518,10 +523,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
         loadKeyValidity(from: options)
         loadTesterEnabled(from: options)
 #if os(macOS)
-        loadSelectedEnvironment(from: options)
-        loadSelectedServer(from: options)
-        loadSelectedLocation(from: options)
-        loadDNSSettings(from: options)
+        try loadVPNSettings(from: options)
         loadAuthVersion(from: options)
         if !Self.isUsingAuthV2 {
             try await loadAuthToken(from: options)
@@ -536,10 +538,16 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     private func loadKeyValidity(from options: StartupOptions) {
-        switch options.keyValidity {
-        case .set(let validity):
-            Task { @MainActor in
-                await keyExpirationTester.setKeyValidity(validity)
+        switch options.vpnSettings {
+        case .set(let settingsSnapshot):
+            if case .custom(let validity) = settingsSnapshot.registrationKeyValidity {
+                Task { @MainActor in
+                    await keyExpirationTester.setKeyValidity(validity)
+                }
+            } else {
+                Task { @MainActor in
+                    await keyExpirationTester.setKeyValidity(nil)
+                }
             }
         case .useExisting:
             break
@@ -562,47 +570,15 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
 #if os(macOS)
-    private func loadSelectedEnvironment(from options: StartupOptions) {
-        switch options.selectedEnvironment {
-        case .set(let selectedEnvironment):
-            settings.selectedEnvironment = selectedEnvironment
+    private func loadVPNSettings(from options: StartupOptions) throws {
+        switch options.vpnSettings {
+        case .set(let settingsSnapshot):
+            settingsSnapshot.applyTo(settings)
         case .useExisting:
             break
         case .reset:
-            settings.selectedEnvironment = .default
-        }
-    }
-
-    private func loadSelectedServer(from options: StartupOptions) {
-        switch options.selectedServer {
-        case .set(let selectedServer):
-            settings.selectedServer = selectedServer
-        case .useExisting:
-            break
-        case .reset:
-            settings.selectedServer = .automatic
-        }
-    }
-
-    private func loadSelectedLocation(from options: StartupOptions) {
-        switch options.selectedLocation {
-        case .set(let selectedLocation):
-            settings.selectedLocation = selectedLocation
-        case .useExisting:
-            break
-        case .reset:
-            settings.selectedServer = .automatic
-        }
-    }
-
-    private func loadDNSSettings(from options: StartupOptions) {
-        switch options.dnsSettings {
-        case .set(let dnsSettings):
-            settings.dnsSettings = dnsSettings
-        case .useExisting:
-            break
-        case .reset:
-            settings.dnsSettings = .ddg(blockRiskyDomains: settings.isBlockRiskyDomainsOn)
+            // VPN settings are required - if we're in reset case, it means they were missing or invalid
+            throw TunnelError.settingsMissing
         }
     }
 

--- a/SharedPackages/VPN/Sources/VPN/StartupOptions.swift
+++ b/SharedPackages/VPN/Sources/VPN/StartupOptions.swift
@@ -151,11 +151,11 @@ public struct StartupOptions {
     let simulateError: Bool
     let simulateCrash: Bool
     let simulateMemoryCrash: Bool
-    let vpnSettings: StoredOption<VPNSettingsSnapshot>
+    public let vpnSettings: StoredOption<VPNSettingsSnapshot>
 #if os(macOS)
-    let isAuthV2Enabled: StoredOption<Bool>
-    let authToken: StoredOption<String>
-    let tokenContainer: StoredOption<TokenContainer>
+    public let isAuthV2Enabled: StoredOption<Bool>
+    public let authToken: StoredOption<String>
+    public let tokenContainer: StoredOption<TokenContainer>
 #endif
     let enableTester: StoredOption<Bool>
 

--- a/SharedPackages/VPN/Sources/VPN/StartupOptions.swift
+++ b/SharedPackages/VPN/Sources/VPN/StartupOptions.swift
@@ -21,6 +21,52 @@ import Common
 import Networking
 import os.log
 
+/// Codable representation of VPN settings that can be passed to the packet tunnel
+///
+public struct VPNSettingsSnapshot: Codable, Equatable {
+    let registrationKeyValidity: VPNSettings.RegistrationKeyValidity
+    let selectedEnvironment: VPNSettings.SelectedEnvironment
+    let selectedServer: VPNSettings.SelectedServer
+    let selectedLocation: VPNSettings.SelectedLocation
+    let dnsSettings: NetworkProtectionDNSSettings
+    let excludeLocalNetworks: Bool
+
+    /// Create a snapshot of the current VPN settings
+    public init(from settings: VPNSettings) {
+        self.registrationKeyValidity = settings.registrationKeyValidity
+        self.selectedEnvironment = settings.selectedEnvironment
+        self.selectedServer = settings.selectedServer
+        self.selectedLocation = settings.selectedLocation
+        self.dnsSettings = settings.dnsSettings
+        self.excludeLocalNetworks = settings.excludeLocalNetworks
+    }
+
+    /// Create a snapshot with explicit values
+    public init(registrationKeyValidity: VPNSettings.RegistrationKeyValidity,
+         selectedEnvironment: VPNSettings.SelectedEnvironment,
+         selectedServer: VPNSettings.SelectedServer,
+         selectedLocation: VPNSettings.SelectedLocation,
+         dnsSettings: NetworkProtectionDNSSettings,
+         excludeLocalNetworks: Bool) {
+        self.registrationKeyValidity = registrationKeyValidity
+        self.selectedEnvironment = selectedEnvironment
+        self.selectedServer = selectedServer
+        self.selectedLocation = selectedLocation
+        self.dnsSettings = dnsSettings
+        self.excludeLocalNetworks = excludeLocalNetworks
+    }
+
+    /// Apply these settings to a VPNSettings instance
+    public func applyTo(_ settings: VPNSettings) {
+        settings.registrationKeyValidity = registrationKeyValidity
+        settings.selectedEnvironment = selectedEnvironment
+        settings.selectedServer = selectedServer
+        settings.selectedLocation = selectedLocation
+        settings.dnsSettings = dnsSettings
+        settings.excludeLocalNetworks = excludeLocalNetworks
+    }
+}
+
 /// This class handles the proper parsing of the startup options for our tunnel.
 ///
 public struct StartupOptions {
@@ -105,12 +151,7 @@ public struct StartupOptions {
     let simulateError: Bool
     let simulateCrash: Bool
     let simulateMemoryCrash: Bool
-    let keyValidity: StoredOption<TimeInterval>
-    let selectedEnvironment: StoredOption<VPNSettings.SelectedEnvironment>
-    let selectedServer: StoredOption<VPNSettings.SelectedServer>
-    let selectedLocation: StoredOption<VPNSettings.SelectedLocation>
-    let dnsSettings: StoredOption<NetworkProtectionDNSSettings>
-    public let excludeLocalNetworks: StoredOption<Bool>
+    let vpnSettings: StoredOption<VPNSettingsSnapshot>
 #if os(macOS)
     let isAuthV2Enabled: StoredOption<Bool>
     let authToken: StoredOption<String>
@@ -142,12 +183,7 @@ public struct StartupOptions {
         tokenContainer = Self.readTokenContainer(from: options, resetIfNil: resetStoredOptionsIfNil)
 #endif
         enableTester = Self.readEnableTester(from: options, resetIfNil: resetStoredOptionsIfNil)
-        keyValidity = Self.readKeyValidity(from: options, resetIfNil: resetStoredOptionsIfNil)
-        selectedEnvironment = Self.readSelectedEnvironment(from: options, resetIfNil: resetStoredOptionsIfNil)
-        selectedServer = Self.readSelectedServer(from: options, resetIfNil: resetStoredOptionsIfNil)
-        selectedLocation = Self.readSelectedLocation(from: options, resetIfNil: resetStoredOptionsIfNil)
-        dnsSettings = Self.readDNSSettings(from: options, resetIfNil: resetStoredOptionsIfNil)
-        excludeLocalNetworks = Self.readExcludeLocalNetworks(from: options, resetIfNil: resetStoredOptionsIfNil)
+        vpnSettings = Self.readVPNSettings(from: options, resetIfNil: resetStoredOptionsIfNil)
     }
 
     var description: String {
@@ -157,13 +193,8 @@ public struct StartupOptions {
             simulateError: \(self.simulateError.description),
             simulateCrash: \(self.simulateCrash.description),
             simulateMemoryCrash: \(self.simulateMemoryCrash.description),
-            keyValidity: \(self.keyValidity.description),
-            selectedEnvironment: \(self.selectedEnvironment.description),
-            selectedServer: \(self.selectedServer.description),
-            selectedLocation: \(self.selectedLocation.description),
-            dnsSettings: \(self.dnsSettings.description),
+            vpnSettings: \(self.vpnSettings.description),
             enableTester: \(self.enableTester),
-            excludeLocalNetworks: \(self.excludeLocalNetworks),
         """
 #if os(macOS)
         result += """
@@ -213,59 +244,14 @@ public struct StartupOptions {
     }
 #endif
 
-    private static func readKeyValidity(from options: [String: Any], resetIfNil: Bool) -> StoredOption<TimeInterval> {
+    private static func readVPNSettings(from options: [String: Any], resetIfNil: Bool) -> StoredOption<VPNSettingsSnapshot> {
         StoredOption(resetIfNil: resetIfNil) {
-            guard let keyValidityString = options[NetworkProtectionOptionKey.keyValidity] as? String,
-                  let keyValidity = TimeInterval(keyValidityString) else {
-
+            guard let data = options[NetworkProtectionOptionKey.settings] as? Data,
+                  let vpnSettings = try? JSONDecoder().decode(VPNSettingsSnapshot.self, from: data) else {
                 return nil
             }
 
-            return keyValidity
-        }
-    }
-
-    private static func readSelectedEnvironment(from options: [String: Any], resetIfNil: Bool) -> StoredOption<VPNSettings.SelectedEnvironment> {
-        StoredOption(resetIfNil: resetIfNil) {
-            guard let environment = options[NetworkProtectionOptionKey.selectedEnvironment] as? String else {
-                return nil
-            }
-
-            return VPNSettings.SelectedEnvironment(rawValue: environment) ?? .default
-        }
-    }
-
-    private static func readSelectedServer(from options: [String: Any], resetIfNil: Bool) -> StoredOption<VPNSettings.SelectedServer> {
-        StoredOption(resetIfNil: resetIfNil) {
-            guard let serverName = options[NetworkProtectionOptionKey.selectedServer] as? String else {
-                return nil
-            }
-
-            return .endpoint(serverName)
-        }
-    }
-
-    private static func readSelectedLocation(from options: [String: Any], resetIfNil: Bool) -> StoredOption<VPNSettings.SelectedLocation> {
-        StoredOption(resetIfNil: resetIfNil) {
-            guard
-                let data = options[NetworkProtectionOptionKey.selectedLocation] as? Data,
-                let selectedLocation = try? JSONDecoder().decode(VPNSettings.SelectedLocation.self, from: data)
-            else {
-                return nil
-            }
-
-            return selectedLocation
-        }
-    }
-
-    private static func readDNSSettings(from options: [String: Any], resetIfNil: Bool) -> StoredOption<NetworkProtectionDNSSettings> {
-        StoredOption(resetIfNil: resetIfNil) {
-            guard let data = options[NetworkProtectionOptionKey.dnsSettings] as? Data,
-                  let dnsSettings = try? JSONDecoder().decode(NetworkProtectionDNSSettings.self, from: data) else {
-                return nil
-            }
-
-            return dnsSettings
+            return vpnSettings
         }
     }
 
@@ -279,13 +265,4 @@ public struct StartupOptions {
         }
     }
 
-    private static func readExcludeLocalNetworks(from options: [String: Any], resetIfNil: Bool) -> StoredOption<Bool> {
-        StoredOption(resetIfNil: resetIfNil) {
-            guard let value = options[NetworkProtectionOptionKey.excludeLocalNetworks] as? Bool else {
-                return nil
-            }
-
-            return value
-        }
-    }
 }

--- a/iOS/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -293,12 +293,7 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
             }
         }
 
-        options[NetworkProtectionOptionKey.selectedEnvironment] = settings.selectedEnvironment.rawValue as NSString
 
-        var dnsSettings = settings.dnsSettings
-        if let data = try? JSONEncoder().encode(dnsSettings) {
-            options[NetworkProtectionOptionKey.dnsSettings] = NSData(data: data)
-        }
 
         do {
             try tunnelManager.connection.startVPNTunnel(options: options)

--- a/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
+++ b/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
@@ -415,7 +415,7 @@ final class SubscriptionDebugViewController: UITableViewController {
 
     private func clearAuthDataV2() {
         Task {
-            await subscriptionManagerV1.signOut(notifyUI: true)
+            await subscriptionManagerV2.signOut(notifyUI: true)
             showAlert(title: "Data cleared!")
         }
     }

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
@@ -689,22 +689,10 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
             try await subscriptionManagerV2.getTokenContainer(policy: .localForceRefresh)
         }
 
-        options[NetworkProtectionOptionKey.selectedEnvironment] = settings.selectedEnvironment.rawValue as NSString
-        options[NetworkProtectionOptionKey.selectedServer] = settings.selectedServer.stringValue as? NSString
-
-        options[NetworkProtectionOptionKey.excludeLocalNetworks] = NSNumber(value: settings.excludeLocalNetworks)
-
-        if let data = try? JSONEncoder().encode(settings.selectedLocation) {
-            options[NetworkProtectionOptionKey.selectedLocation] = NSData(data: data)
-        }
-
-        var dnsSettings = settings.dnsSettings
-        if let data = try? JSONEncoder().encode(dnsSettings) {
-            options[NetworkProtectionOptionKey.dnsSettings] = NSData(data: data)
-        }
-
-        if case .custom(let keyValidity) = settings.registrationKeyValidity {
-            options[NetworkProtectionOptionKey.keyValidity] = String(describing: keyValidity) as NSString
+        // Encode entire VPN settings as one unit
+        let settingsSnapshot = VPNSettingsSnapshot(from: settings)
+        if let data = try? JSONEncoder().encode(settingsSnapshot) {
+            options[NetworkProtectionOptionKey.settings] = NSData(data: data)
         }
 
         if Self.simulationOptions.isEnabled(.tunnelFailure) {

--- a/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
@@ -535,27 +535,6 @@ final class MacPacketTunnelProvider: PacketTunnelProvider {
         Logger.networkProtectionMemory.log("[-] MacPacketTunnelProvider")
     }
 
-    // MARK: - NEPacketTunnelProvider
-
-    public override func load(options: StartupOptions) async throws {
-        try await super.load(options: options)
-
-#if NETP_SYSTEM_EXTENSION
-        loadExcludeLocalNetworks(from: options)
-#endif
-    }
-
-    private func loadExcludeLocalNetworks(from options: StartupOptions) {
-        switch options.excludeLocalNetworks {
-        case .set(let exclude):
-            settings.excludeLocalNetworks = exclude
-        case .useExisting:
-            break
-        case .reset:
-            settings.excludeLocalNetworks = true
-        }
-    }
-
     enum ConfigurationError: Error {
         case missingProviderConfiguration
         case missingPixelHeaders

--- a/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/MacPacketTunnelProvider.swift
@@ -535,6 +535,101 @@ final class MacPacketTunnelProvider: PacketTunnelProvider {
         Logger.networkProtectionMemory.log("[-] MacPacketTunnelProvider")
     }
 
+    public override func load(options: StartupOptions) async throws {
+        try await super.load(options: options)
+        
+        // macOS-specific options
+        try loadVPNSettings(from: options)
+        loadAuthVersion(from: options)
+        if !Self.isUsingAuthV2 {
+            try await loadAuthToken(from: options)
+        } else {
+            try await loadTokenContainer(from: options)
+        }
+    }
+
+    private func loadVPNSettings(from options: StartupOptions) throws {
+        switch options.vpnSettings {
+        case .set(let settingsSnapshot):
+            settingsSnapshot.applyTo(settings)
+        case .useExisting:
+            break
+        case .reset:
+            // VPN settings are required - if we're in reset case, it means they were missing or invalid
+            throw TunnelError.settingsMissing
+        }
+    }
+
+    private func loadAuthVersion(from options: StartupOptions) {
+        switch options.isAuthV2Enabled {
+        case .set(let newAuthVersion):
+            Logger.networkProtection.log("Set new isAuthV2Enabled")
+            Self.isUsingAuthV2 = newAuthVersion
+        case .useExisting:
+            Logger.networkProtection.log("Use existing isAuthV2Enabled")
+        case .reset:
+            Logger.networkProtection.log("Reset isAuthV2Enabled")
+        }
+        Logger.networkProtection.log("Load isAuthV2Enabled: \(Self.isUsingAuthV2, privacy: .public)")
+    }
+
+    private func loadAuthToken(from options: StartupOptions) async throws {
+        let tokenHandler = tokenHandlerProvider()
+        Logger.networkProtection.log("Load auth token")
+        switch options.authToken {
+        case .set(let newAuthToken):
+            Logger.networkProtection.log("Set new token")
+            if let currentAuthToken = try? await tokenHandler.getToken(), currentAuthToken == newAuthToken {
+                Logger.networkProtection.log("Token unchanged, using the current one")
+                return
+            }
+
+            try await tokenHandler.adoptToken(newAuthToken)
+        case .useExisting:
+            Logger.networkProtection.log("Use existing token")
+            do {
+                try await tokenHandler.getToken()
+            } catch {
+                throw TunnelError.startingTunnelWithoutAuthToken(internalError: error)
+            }
+        case .reset:
+            Logger.networkProtection.log("Reset token")
+            // This case should in theory not be possible, but it's ideal to have this in place
+            // in case an error in the controller on the client side allows it.
+            try? await tokenHandler.removeToken()
+            throw TunnelError.tokenReset
+        }
+    }
+
+    private func loadTokenContainer(from options: StartupOptions) async throws {
+        let tokenHandler = tokenHandlerProvider()
+        Logger.networkProtection.log("Load token container")
+        switch options.tokenContainer {
+        case .set(let newTokenContainer):
+            Logger.networkProtection.log("Set new token container")
+            do {
+                try await tokenHandler.adoptToken(newTokenContainer)
+            } catch {
+                Logger.networkProtection.fault("Error adopting token container: \(error, privacy: .public)")
+                throw TunnelError.startingTunnelWithoutAuthToken(internalError: error)
+            }
+        case .useExisting:
+            Logger.networkProtection.log("Use existing token container")
+            do {
+                try await tokenHandler.getToken()
+            } catch {
+                Logger.networkProtection.fault("Error loading token container: \(error, privacy: .public)")
+                throw TunnelError.startingTunnelWithoutAuthToken(internalError: error)
+            }
+        case .reset:
+            Logger.networkProtection.log("Reset token")
+            // This case should in theory not be possible, but it's ideal to have this in place
+            // in case an error in the controller on the client side allows it.
+            try await tokenHandler.removeToken()
+            throw TunnelError.tokenReset
+        }
+    }
+
     enum ConfigurationError: Error {
         case missingProviderConfiguration
         case missingPixelHeaders


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207603085593419/task/1211125360935005?focus=true

### Description

Encode the VPN settings when starting the tunnel in NetworkTunnelController, rather than encoding individual values from it.
Decode the VPN settings entirely in PacketTunnelProvider and fail starting the tunnel if settings aren't present.

### Testing Steps

Test the macOS VPN, changing servers, changing environment, killing the extension to trigger on-demand.

### Impact and Risks

Medium.

#### What could go wrong?

Changing sensitive code.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)