### PR TITLE
macOS: Limit file types in Open File menu item

### DIFF
--- a/macOS/DuckDuckGo/Common/Extensions/NSOpenPanelExtensions.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/NSOpenPanelExtensions.swift
@@ -47,7 +47,17 @@ extension NSOpenPanel {
         panel.canChooseFiles = true
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
-        panel.allowedContentTypes = [.text, .pdf, .image, .webArchive]
+        panel.allowedContentTypes = [
+            .plainText,     // Plain text files
+            .html,          // HTML files  
+            .pdf,           // PDF files
+            .webArchive,    // Web archive files
+            .jpeg,          // JPEG images
+            .png,           // PNG images
+            .gif,           // GIF images
+            .svg,           // SVG images
+            .webP           // WebP images
+        ]
 
         return panel
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211126561190944?focus=true
Tech Design URL:
CC:

### Description
Limit the file types we can open from the `Open File` menu item. The main problem before was that if we used the whole range of images, some types of files (like .psd) would open as a download instead of opening the file in the browser.

### Testing Steps
1. Open the app
2. Tap CMD+O, or go to File -> Open File
3. Make sure that only PNG, GIF, JPEG, SVG, and WebP images can be opened.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)