### PR TITLE
[iOS][Duck.ai input] fix multi-line text clearing in new search experience

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -226,6 +226,11 @@ class SwitchBarTextEntryView: UIView {
         }
     }
 
+    /// https://app.asana.com/1/137249556945/project/392891325557410/task/1210835160047733?focus=true
+    private func isUnexpandedURL() -> Bool {
+        return !hasBeenInteractedWith && isURL
+    }
+
     private func updateTextViewHeight() {
 
         let size = textView.systemLayoutSizeFitting(CGSize(width: textView.frame.width, height: CGFloat.greatestFiniteMagnitude))
@@ -234,7 +239,10 @@ class SwitchBarTextEntryView: UIView {
         // Reset defaults
         textView.textContainer.lineBreakMode = .byWordWrapping
 
-        if !hasBeenInteractedWith && isURL { // https://app.asana.com/1/137249556945/project/392891325557410/task/1210835160047733?focus=true
+        if isUnexpandedURL() ||
+            // https://app.asana.com/1/137249556945/project/392891325557410/task/1210916875279070?focus=true
+            textView.text.isBlank {
+            
             heightConstraint?.constant = Constants.minHeight
             textView.isScrollEnabled = false
             textView.showsVerticalScrollIndicator = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1210916875279070?focus=true
Tech Design URL:
CC: @Bunn 

### Description
Fixes multi-line text clearing in the experimental search experience.

### Testing Steps
1. Enable the new experience (Settings > AI Features > Experimental)
2. Perform a search for Lorem Ipsem and either use the SERP or DuckAi to generate some for you
3. Copy and paste a large chunk of text into the field and scroll it
4. Tap the clear button, the field should return to a single line height
5. Visit a web site
6. Tap the url, the field should populate to a single line
7. Smoke test around entering URLs / searches, browsing and asking Duck.ai

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Could break the input field

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)