### PR TITLE
iOS: Stripe Checkout Back Navigation Bug

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1326,6 +1326,8 @@
 		BDFF03262BA3DA4900F324C9 /* NetworkProtectionFeatureVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFF03242BA3D92E00F324C9 /* NetworkProtectionFeatureVisibilityTests.swift */; };
 		C1056A562E253D98003220BA /* AutofillCredentialsImportPresentationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1056A552E253D98003220BA /* AutofillCredentialsImportPresentationManagerTests.swift */; };
 		C10CB5F32A1A5BDF0048E503 /* AutofillViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10CB5F22A1A5BDF0048E503 /* AutofillViews.swift */; };
+		C10E0A362E5CB1E4009CAE1B /* URL+QueryParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10E0A352E5CB1E4009CAE1B /* URL+QueryParameters.swift */; };
+		C10E0A382E5CB269009CAE1B /* URL+QueryParametersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10E0A372E5CB269009CAE1B /* URL+QueryParametersTests.swift */; };
 		C111B26927F579EF006558B1 /* BookmarkOrFolderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C111B26827F579EF006558B1 /* BookmarkOrFolderTests.swift */; };
 		C111F9512DC3CC2D00FABCA8 /* SaveCreditCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C111F9502DC3CC2D00FABCA8 /* SaveCreditCardViewModelTests.swift */; };
 		C12324C32C4697C900FBB26B /* AutofillBreakageReportTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1836CE42C35A0EA0016D057 /* AutofillBreakageReportTableViewCell.swift */; };
@@ -3444,6 +3446,8 @@
 		BDFF03242BA3D92E00F324C9 /* NetworkProtectionFeatureVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionFeatureVisibilityTests.swift; sourceTree = "<group>"; };
 		C1056A552E253D98003220BA /* AutofillCredentialsImportPresentationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillCredentialsImportPresentationManagerTests.swift; sourceTree = "<group>"; };
 		C10CB5F22A1A5BDF0048E503 /* AutofillViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillViews.swift; sourceTree = "<group>"; };
+		C10E0A352E5CB1E4009CAE1B /* URL+QueryParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+QueryParameters.swift"; sourceTree = "<group>"; };
+		C10E0A372E5CB269009CAE1B /* URL+QueryParametersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+QueryParametersTests.swift"; sourceTree = "<group>"; };
 		C111B26827F579EF006558B1 /* BookmarkOrFolderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkOrFolderTests.swift; sourceTree = "<group>"; };
 		C111F9502DC3CC2D00FABCA8 /* SaveCreditCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveCreditCardViewModelTests.swift; sourceTree = "<group>"; };
 		C1193F602D08642900CB3239 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -7494,6 +7498,7 @@
 		D664C7962B289AA000CBFA76 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				C10E0A352E5CB1E4009CAE1B /* URL+QueryParameters.swift */,
 				BD10B8A92C7629740033115D /* Logger+Subscription.swift */,
 				F1FDC9342BF51E41006B1435 /* VPNSettings+Environment.swift */,
 				D664C7982B289AA000CBFA76 /* WKUserContentController+Handler.swift */,
@@ -8280,6 +8285,7 @@
 				56A3CDE42DF2F37F00DDE757 /* SubscriptionPagesUseSubscriptionFeatureV2Tests.swift */,
 				56940C742E0AA4F60007741D /* UnifiedFeedbackFormViewModelTests.swift */,
 				56B3310E2E0E92B200D4D3BA /* SubscriptionURLNavigationHandlerTests.swift */,
+				C10E0A372E5CB269009CAE1B /* URL+QueryParametersTests.swift */,
 			);
 			path = Subscription;
 			sourceTree = "<group>";
@@ -9802,6 +9808,7 @@
 				C185ED612BD4329700BAE9DC /* ImportPasswordsViaSyncStatusHandler.swift in Sources */,
 				F1849C6B2D6E3C98000589A4 /* DebugScreen.swift in Sources */,
 				F1849C6C2D6E3C98000589A4 /* DebugScreensViewModel.swift in Sources */,
+				C10E0A362E5CB1E4009CAE1B /* URL+QueryParameters.swift in Sources */,
 				F1849C6D2D6E3C98000589A4 /* DebugScreensViewController.swift in Sources */,
 				F1849C6E2D6E3C98000589A4 /* DebugScreensViewModel+Screens.swift in Sources */,
 				65BD16392D8DA439000795DE /* DuckPlayerDebugSettingsView.swift in Sources */,
@@ -10416,6 +10423,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C10E0A382E5CB269009CAE1B /* URL+QueryParametersTests.swift in Sources */,
 				8528AE84212FF9A100D0BD74 /* AppRatingPromptStorageTests.swift in Sources */,
 				569437312BE3F64400C0881B /* SyncErrorHandlerSyncPausedAlertsTests.swift in Sources */,
 				563A3D012D37BF83001966FD /* ConfigurationManagerTests.swift in Sources */,

--- a/iOS/DuckDuckGo/Subscription/Extensions/URL+QueryParameters.swift
+++ b/iOS/DuckDuckGo/Subscription/Extensions/URL+QueryParameters.swift
@@ -1,0 +1,47 @@
+//
+//  URL+QueryParameters.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension URL {
+    
+    enum QueryParameterKeys {
+        static let preventBackNavigation = "preventBackNavigation"
+    }
+    
+    enum QueryParameterValues {
+        static let trueValue = "true"
+    }
+    
+    /// Checks if the URL contains a specific query parameter with the given name and value.
+    func hasQueryParameter(name: String, value: String) -> Bool {
+        guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false),
+              let queryItems = components.queryItems else {
+            return false
+        }
+        
+        return queryItems.contains { $0.name == name && $0.value == value }
+    }
+    
+    /// Returns true if the URL contains the query parameter `preventBackNavigation=true`.
+    var shouldPreventBackNavigation: Bool {
+        return hasQueryParameter(name: QueryParameterKeys.preventBackNavigation,
+                                value: QueryParameterValues.trueValue)
+    }
+}

--- a/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
+++ b/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
@@ -242,6 +242,7 @@ final class SubscriptionFlowViewModel: ObservableObject {
     }
 
     private func shouldAllowWebViewBackNavigationForURL(currentURL: URL) -> Bool {
+        return !currentURL.shouldPreventBackNavigation &&
         !isCurrentURL(matching: .purchase) &&
         !isCurrentURL(matching: .welcome) &&
         !isCurrentURL(matching: .activationFlowSuccess) &&

--- a/iOS/DuckDuckGoTests/Subscription/URL+QueryParametersTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/URL+QueryParametersTests.swift
@@ -1,0 +1,70 @@
+//
+//  URL+QueryParametersTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo
+
+final class URL_QueryParametersTests: XCTestCase {
+
+    func testHasQueryParameterWithMatchingNameAndValue() {
+        let url = URL(string: "https://example.com?preventBackNavigation=true")!
+        XCTAssertTrue(url.hasQueryParameter(name: "preventBackNavigation", value: "true"))
+    }
+    
+    func testHasQueryParameterWithMatchingNameButDifferentValue() {
+        let url = URL(string: "https://example.com?preventBackNavigation=false")!
+        XCTAssertFalse(url.hasQueryParameter(name: "preventBackNavigation", value: "true"))
+    }
+    
+    func testHasQueryParameterWithDifferentNameButMatchingValue() {
+        let url = URL(string: "https://example.com?someOtherParam=true")!
+        XCTAssertFalse(url.hasQueryParameter(name: "preventBackNavigation", value: "true"))
+    }
+    
+    func testHasQueryParameterWithNoQueryParameters() {
+        let url = URL(string: "https://example.com")!
+        XCTAssertFalse(url.hasQueryParameter(name: "preventBackNavigation", value: "true"))
+    }
+    
+    func testHasQueryParameterWithMultipleParameters() {
+        let url = URL(string: "https://example.com?foo=bar&preventBackNavigation=true&baz=qux")!
+        XCTAssertTrue(url.hasQueryParameter(name: "preventBackNavigation", value: "true"))
+    }
+    
+    func testShouldPreventBackNavigationWhenParameterIsTrue() {
+        let url = URL(string: "https://example.com?preventBackNavigation=true")!
+        XCTAssertTrue(url.shouldPreventBackNavigation)
+    }
+    
+    func testShouldPreventBackNavigationWhenParameterIsFalse() {
+        let url = URL(string: "https://example.com?preventBackNavigation=false")!
+        XCTAssertFalse(url.shouldPreventBackNavigation)
+    }
+    
+    func testShouldPreventBackNavigationWhenParameterIsMissing() {
+        let url = URL(string: "https://example.com?someOtherParam=value")!
+        XCTAssertFalse(url.shouldPreventBackNavigation)
+    }
+    
+    func testShouldPreventBackNavigationWhenNoQueryParameters() {
+        let url = URL(string: "https://example.com")!
+        XCTAssertFalse(url.shouldPreventBackNavigation)
+    }
+
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1211073283656162?focus=true

### Description
We will soon offer Stripe Payments on iOS. In our Stripe purchase flow, there was a bug where after a successful purchase, a user could not navigate directly back to app settings. Instead it would navigate to Stripe checkout again. This fixes that and now after successful purchase the user can navigate directly back to settings. 

### Testing Prerequisites
1. Set device VPN to US

### Testing Steps
#### Core changes
1. Run the alpha version of the app on your device. Ensure you have no active subscription in this build
2. Via debug menu, set https://charmston.duckduckgo.com/subscriptions as your custom base subscription URL (under `Debug` -> `Subscriptions`)
3. Enter https://charmston.duckduckgo.com/pro?featurePage=stripe in the address bar, which will deeplink to in-app purchase via Stripe
4. Complete a monthly subscription purchase via Stripe ([instructions](https://app.asana.com/1/137249556945/project/1206488453854252/task/1209553319142622?focus=true))
5. After purchase the left navigation button should say ’Settings” and tapping it should bring you directly back to app Settings
6. Ensure the device now has a active subscription

#### Smoke test
1. Remove the subscription from device
2. Purchase a test subscription via the app store using a sandbox user
3. Ensure it completes successfully and the subscription is active on device

### Impact and Risks
Medium: Subscription purchase flow changes

#### What could go wrong?
Broken Subscription flows

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)