### PR TITLE
[macOS] Enable feature flag for duck.ai SERP settings

### DIFF
--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -363,7 +363,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .openFileMenuAction:
             return .internalOnly()
         case .duckAISearchParameter:
-            return .internalOnly()
+            return .enabled
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211141466427685?focus=true

### Description
Enable Feature Flag for the duck.ai SERP settings

### Testing Steps
1. Already tested here https://github.com/duckduckgo/apple-browsers/pull/1760

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features
