### PR TITLE
[iOS] Enable feature flag for duck.ai SERP settings

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -361,7 +361,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .aiFeaturesSettingsUpdate:
             return .enabled
         case .duckAISearchParameter:
-            return .internalOnly()
+            return .enabled
         case .inactivityNotification:
             return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.inactivityNotification))
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1199230911884351/task/1211143145900569?focus=true

### Description
Enable Feature Flag for the duck.ai SERP settings

### Testing Steps
1. Already tested here https://github.com/duckduckgo/apple-browsers/pull/1758

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features
