### PR TITLE
Remove the return button from the search mode [Experimental address bar]

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/NavigationActionBarView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/NavigationActionBarView.swift
@@ -257,7 +257,7 @@ final class NavigationActionBarView: UIView {
         let shouldShowMicButton = viewModel.shouldShowMicButton
         microphoneButton.isHidden = !shouldShowMicButton
         
-        let shouldShowNewLineButton = viewModel.isKeyboardVisible && viewModel.hasText
+        let shouldShowNewLineButton = viewModel.isKeyboardVisible && viewModel.hasText && !viewModel.isSearchMode
         newLineButton.isHidden = !shouldShowNewLineButton
         
         let shouldShowSearchButton = viewModel.hasText


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1211142604441314?focus=true

### Description
Remove the return button from the search mode on the new experimental bar experience

### Testing Steps
1. Enable AI Features experimental address bar
2. Select the address bar, make sure we don't display the return key on search mode, only on duck.ai


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Don't display the return key on duck.ai