### PR TITLE
Don’t show Duck.ai to people stuck in Auth V1

### DIFF
--- a/iOS/DuckDuckGo/SettingsSubscriptionView.swift
+++ b/iOS/DuckDuckGo/SettingsSubscriptionView.swift
@@ -151,7 +151,7 @@ struct SettingsSubscriptionView: View {
             )
         }
 
-        if subscriptionFeatures.contains(.paidAIChat) && settingsViewModel.isPaidAIChatEnabled {
+        if subscriptionFeatures.contains(.paidAIChat) && settingsViewModel.isPaidAIChatEnabled && settingsViewModel.isAuthV2Enabled {
             SettingsCellView(
                 label: UserText.settingsSubscriptionAiChatTitle,
                 image: Image(uiImage: DesignSystemImages.Color.Size24.aiChat),


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1211151096924816?focus=true
Tech Design URL:
CC:

### Description
Don’t show Duck.ai to people stuck in Auth V1

### Testing Steps
1. Turn Auth V2 FF off and restart the app twice
2. Subscribe and check that Duck.ai is not shown in the settings menu and in the more options menu
3. Turn Auth V2 FF on and restart the app twice
4. Before subscribing check that the least of feature in the subscription menu shows Duck.ai

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)