### PR TITLE
New Tab Page default background color adjusted

### DIFF
--- a/macOS/DuckDuckGo/VisualRefresh/ColorsProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/ColorsProviding.swift
@@ -104,8 +104,8 @@ final class NewColorsProviding: ColorsProviding {
     var inactiveAddressBarBackgroundColor: NSColor { palette.surfaceTertiary }
     var suggestionsBackgroundColor: NSColor { palette.surfaceTertiary }
     var bannerBackgroundColor: NSColor { palette.surfacePrimary }
-    var ntpLightBackgroundColor: String { "#F2F2F2" }
-    var ntpDarkBackgroundColor: String { "#262626" }
+    var ntpLightBackgroundColor: String { "#FAFAFA" }
+    var ntpDarkBackgroundColor: String { "#1C1C1C" }
 
     init(palette: ColorPalette) {
         self.palette = palette


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1211135653720266?focus=true

### Description
New Tab Page default background color adjusted

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Open New Tab Page
2. If necessary, set the background color to "Default"
3. Make sure the colors are #FAFAFA for the Light mode and #1C1C1C for Dark mode

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)