### PR TITLE
iOS: Ensure Legacy Omnibar Pixel is Only Sent When Input is Legacy Mode

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2613,7 +2613,9 @@ extension MainViewController: OmniBarDelegate {
             }
         )
 
-        DailyPixel.fireDailyAndCount(pixel: .aiChatLegacyOmnibarAichatButtonPressed)
+        if !aiChatSettings.isAIChatSearchInputUserSettingsEnabled {
+            DailyPixel.fireDailyAndCount(pixel: .aiChatLegacyOmnibarAichatButtonPressed)
+        }
         fireAIChatUsagePixelAndSetFeatureUsed(.openAIChatFromAddressBar)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211121614418052?focus=true

### Description
Ensure Legacy Omnibar Pixel is Only Sent When Input is Legacy Mode

### Testing Steps
1. Launch and set input to legacy mode
2. Tap the ai chat button in the omnibar when the omnibar is unfocused
3. Ensure `m.aichat.legacy.omnibar.aichat.button.pressed.count` is sent
4. Tap the ai chat button in the omnibar when the omnibar is focused
5. Ensure `m.aichat.legacy.omnibar.aichat.button.pressed.count` is sent
6. Switch to new input mode
7. Tap the ai chat button in the omnibar when the omnibar is unfocused
8. Ensure `m.aichat.legacy.omnibar.aichat.button.pressed.count` is **NOT** sent

### Impact and Risks
Low, minor bug fix

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)