### PR TITLE
Fixes an issue with cached updates showing an update button when they shouldn't

### DIFF
--- a/macOS/DuckDuckGo/Updates/ReleaseNotesTabExtension.swift
+++ b/macOS/DuckDuckGo/Updates/ReleaseNotesTabExtension.swift
@@ -162,12 +162,12 @@ extension ReleaseNotesValues {
                 formatter.dateFormat = "MMMM dd yyyy"
                 let releaseTitle = formatter.string(from: cached.date)
 
-                let cachedVersion = "\(cached.version) \(cached.build)"
+                let cachedVersion = "\(cached.version) (\(cached.build))"
                 let status = currentVersion == cachedVersion ? ReleaseNotesValues.Status.loaded : ReleaseNotesValues.Status.updateReady
 
                 self.init(status: status,
                           currentVersion: currentVersion,
-                          latestVersion: "\(cached.version) \(cached.build)",
+                          latestVersion: cachedVersion,
                           lastUpdate: lastUpdate,
                           releaseTitle: releaseTitle,
                           releaseNotes: cached.releaseNotes,
@@ -226,7 +226,7 @@ extension ReleaseNotesValues {
 
 private extension Update {
     var versionString: String? {
-        "\(version) \(build)"
+        "\(version) (\(build))"
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/276630244458377/task/1211161833367142?focus=true

### Description

Fixes an issue with cached updates showing an update button when they shouldn't

### Testing Steps

Before testing, run the app once and see what the latest version of the app is in the release notes page.  Take note of version and build.

1. Open Version.xcconfig and match the latest version
2. Open BuildNumber.xcconfig and match the latest version
3. Run the app once without modifications so it caches the correct last version.
4. Disconnect from internet.
5. Run the app, ensure you see the same as before.  There should be NO update button.
6. Open Version.xcconfig and be below the latest version
7. Open BuildNumber.xcconfig and be below the latest version
4. Disconnect from internet if necessary.
5. Run the app.  There should be an update button.

### Impact and Risks

Low.

#### What could go wrong?

Only showing / hiding a button.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)