### PR TITLE
Fix AI features to still work when protections are off

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/ContentScopeScripts/Resources/contentScope.js
+++ b/SharedPackages/BrowserServicesKit/Sources/ContentScopeScripts/Resources/contentScope.js
@@ -1311,7 +1311,7 @@
   function isGloballyDisabled(args) {
     return args.site.allowlisted || args.site.isBroken;
   }
-  var platformSpecificFeatures = ["windowsPermissionUsage", "messageBridge", "favicon"];
+  var platformSpecificFeatures = ["navigatorInterface", "windowsPermissionUsage", "messageBridge", "favicon"];
   function isPlatformSpecificFeature(featureName) {
     return platformSpecificFeatures.includes(featureName);
   }

--- a/SharedPackages/BrowserServicesKit/Sources/ContentScopeScripts/Resources/contentScopeIsolated.js
+++ b/SharedPackages/BrowserServicesKit/Sources/ContentScopeScripts/Resources/contentScopeIsolated.js
@@ -2016,7 +2016,7 @@
   function isGloballyDisabled(args) {
     return args.site.allowlisted || args.site.isBroken;
   }
-  var platformSpecificFeatures = ["windowsPermissionUsage", "messageBridge", "favicon"];
+  var platformSpecificFeatures = ["navigatorInterface", "windowsPermissionUsage", "messageBridge", "favicon"];
   function isPlatformSpecificFeature(featureName) {
     return platformSpecificFeatures.includes(featureName);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "SharedPackages/BrowserServicesKit"
       ],
       "dependencies": {
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.9.0"
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.10.0"
       }
     },
     "iOS": {
@@ -81,7 +81,7 @@
       }
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#2e62c54b95a1875804eec4f0c8711c672cc81df3",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#c235c51d2854b02ee7abf9a4fc0a55d007d11413",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "postinstall": "npm run build-content-scope-scripts"
   },
   "dependencies": {
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.9.0"
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.10.0"
   }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1211161923991524

### Description
This change updates C-S-S to the version that allows disabling protections on duck.ai
without disabling AI features at the same time.

### Testing Steps
1. Navigate to duck.ai
2. Disable protections
3. Open some website, select text and select “Summarize with Duck.ai”
4. Verify that summarization worked.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)