### PR TITLE
kill web content process after each Navigation test

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/NavigationTests/Helpers/DistributedNavigationDelegateTestsHelpers.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/NavigationTests/Helpers/DistributedNavigationDelegateTestsHelpers.swift
@@ -27,10 +27,6 @@ import XCTest
 
 @testable import Navigation
 
-@objc private protocol WebProcessPoolPrivate: AnyObject {
-    @objc(_setWebProcessCountLimit:) static func setWebProcessCountLimit(_ webProcessCountLimit: UInt)
-}
-
 @available(macOS 12.0, iOS 15.0, *)
 class DistributedNavigationDelegateTestsBase: XCTestCase {
 
@@ -72,8 +68,6 @@ class DistributedNavigationDelegateTestsBase: XCTestCase {
                 XCTFail("[\(testName)] unexpected event received: \($0)")
             })
         }
-
-        unsafeBitCast(WKProcessPool.self, to: WebProcessPoolPrivate.Type.self).setWebProcessCountLimit(5)
     }
 
     override func tearDown() {
@@ -90,6 +84,7 @@ class DistributedNavigationDelegateTestsBase: XCTestCase {
                 let navigationDelegateProxyKey = UnsafeRawPointer(bitPattern: "navigationDelegateProxyKey".hashValue)!
                 objc_setAssociatedObject(_webView, navigationDelegateProxyKey, navigationDelegateProxy, .OBJC_ASSOCIATION_RETAIN)
             }
+            _webView.killWebContentProcess()
             self._webView = nil
         }
         navigationDelegateProxy = nil

--- a/SharedPackages/BrowserServicesKit/Tests/NavigationTests/Helpers/NavigationTestHelpers.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/NavigationTests/Helpers/NavigationTestHelpers.swift
@@ -527,7 +527,7 @@ extension URLRequest: TestComparable {
         ?? compare("httpMethod", lhs.httpMethod, rhs.httpMethod)
         ?? compare("allHTTPHeaderFields", Headers(lhs.allHTTPHeaderFields), Headers(rhs.allHTTPHeaderFields))
         ?? compare("cachePolicy", lhs.cachePolicy, rhs.cachePolicy)
-        ?? compare("timeoutInterval", lhs.timeoutInterval, rhs.timeoutInterval)
+        // not comparing timeout since it may be 0 for local resources or cached pages on macOS Tahoe
     }
 
 }

--- a/SharedPackages/BrowserServicesKit/Tests/NavigationTests/Helpers/WKWebView+KillWebContentProcess.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/NavigationTests/Helpers/WKWebView+KillWebContentProcess.swift
@@ -22,9 +22,9 @@ extension WKWebView {
 
     func killWebContentProcess() {
         let webContentProcessInfo = (WKProcessPool.perform(Selector(("_webContentProcessInfo"))).takeUnretainedValue() as? [NSObject])!
-        let processInfo = webContentProcessInfo.first {
-            ($0.value(forKey: "webViews") as? [WKWebView])!.contains(self)
-        }!
+        guard let processInfo = webContentProcessInfo.first(where: {
+            ($0.value(forKey: "webViews") as? [WKWebView])?.contains(self) == true
+        }) else { return }
         let pid = processInfo.value(forKey: "pid") as! pid_t
 
         kill(pid, SIGTERM)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1211041653522693?focus=true

### Description
- Terminate web content process after each Navigation test run to reduce the resource consumption

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Validate CI is green

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)