### PR TITLE
Don't check for updates in macOS Debug builds

### DIFF
--- a/macOS/DuckDuckGo/Updates/UpdateController.swift
+++ b/macOS/DuckDuckGo/Updates/UpdateController.swift
@@ -221,14 +221,7 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
 
         _ = try? configureUpdater()
 
-#if DEBUG
-        if NSApp.delegateTyped.featureFlagger.isFeatureOn(.autoUpdateInDEBUG) {
-            checkForUpdateRespectingRollout()
-        }
-#else
         checkForUpdateRespectingRollout()
-#endif
-
         subscribeToResignKeyNotifications()
     }
 
@@ -268,6 +261,11 @@ final class UpdateController: NSObject, UpdateControllerProtocol {
     // Check for updates while adhering to the rollout schedule
     // This is the default behavior
     func checkForUpdateRespectingRollout() {
+#if DEBUG
+        guard NSApp.delegateTyped.featureFlagger.isFeatureOn(.autoUpdateInDEBUG) else {
+            return
+        }
+#endif
         Task { @UpdateCheckActor in
             await performUpdateCheck()
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1211168798749256?focus=true

### Description
This change adds a `#DEBUG` and `autoupdateInDEBUG` feature flag check to
`checkForUpdateRespectingRollout` that is now also called in response to
didResignKeyNotification event.

### Testing Steps
1. Set build number in BuildNumber.xcconfig to a value lower than the latest one (e.g. 500).
2. Launch the app
3. Make sure that `autoupdateInDEBUG` feature flag is disabled. If you had it enabled, relauch the app.
4. Launch the app and wait for a bit.
5. Quit the app and recompile and rerun.
6. Verify that it runs fine (and the compilation doesn’t fail on code signing issue).

### Impact and Risks
None: should only affect debug builds.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)