### PR TITLE
iOS: Remove unreliable Dax Easter Egg JS Test

### DIFF
--- a/iOS/DuckDuckGoTests/DaxEasterEggLogos/DaxEasterEggHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/DaxEasterEggLogos/DaxEasterEggHandlerTests.swift
@@ -103,60 +103,6 @@ final class DaxEasterEggHandlerTests: XCTestCase {
         // This verifies the new direct JavaScript execution architecture works
         XCTAssertTrue(originalCallCount <= self.mockDelegate.callCount, "Should have attempted JavaScript execution")
     }
-    
-    func testJavaScriptLogic_ReturnsNilWhenNoLogoFound() {
-        // This test verifies the embedded JavaScript logic returns nil appropriately
-        // Testing the JavaScript string that gets executed directly
-        
-        // Given - the JavaScript logic embedded in the handler
-        let jsLogic = """
-        (function() {
-            try {
-                function findLogo() {
-                    var ddgLogo = document.querySelector('.js-logo-ddg');
-                    
-                    if (!ddgLogo) {
-                        ddgLogo = document.querySelector('.logo-dynamic');
-                    }
-                    if (!ddgLogo) {
-                        ddgLogo = document.querySelector('[data-dynamic-logo]');
-                    }
-                    
-                    if (!ddgLogo) {
-                        return null;
-                    }
-                    
-                    if (ddgLogo.dataset && ddgLogo.dataset.dynamicLogo) {
-                        return 'themed|' + ddgLogo.dataset.dynamicLogo;
-                    }
-                    
-                    return null;
-                }
-                
-                return findLogo();
-            } catch (error) {
-                return null;
-            }
-        })();
-        """
-        
-        let expectation = XCTestExpectation(description: "JavaScript returns nil for empty page")
-        
-        // When - execute JavaScript on empty webview (no logo elements)
-        mockWebView.evaluateJavaScript(jsLogic) { result, error in
-            // Then
-            if let error = error {
-                XCTFail("JavaScript execution failed: \(error)")
-            } else {
-                // Should return nil/null for empty page
-                let logoURL = result as? String
-                XCTAssertNil(logoURL, "Should return nil when no logo elements found")
-            }
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: 2.0)
-    }
 }
 
 // MARK: - Mock Classes


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1211171157662850

### Description
Remove unreliable Dax Easter Egg JS Test. This relates to quick win days changes. If needed I’ll investigate/re-add the test in future quick win/hack days. I’ve added a subtask for this test [here](https://app.asana.com/1/137249556945/task/1211168694842948).

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Green CI

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)