### PR TITLE
[iOS][App Intent & App Shortcut] Add Intent Pixel Definition

### DIFF
--- a/iOS/PixelDefinitions/pixels/app_intent.json5
+++ b/iOS/PixelDefinitions/pixels/app_intent.json5
@@ -1,0 +1,19 @@
+// App Intent related pixel definitions
+{
+    'm_app-intent_intent-performed': {
+        description: 'Fires when an App Intent successfully executes, regardless of where it was invoked from (App Shortcut, Siri, Spotlight, Shortcuts app).',
+        owners: ['hanyutang-sandra'],
+        triggers: ['other'],
+        suffixes: ['platform', 'form_factor'],
+        parameters: [
+            'appVersion',
+            'pixelSource',
+            {
+                key: 'type',
+                description: 'Type of the app intent performed: search for general search intents, duckai for AI chat intents.',
+                type: 'string',
+                enum: ['search', 'duckai'],
+            },
+        ],
+    },
+}


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL:  https://app.asana.com/1/137249556945/task/1211152077380452?focus=true
CC:

### Description
Added a new pixel definition: m_app-intent_intent-performed

Fires when an App Intent successfully executes, regardless of where it was invoked from (App Shortcut, Siri, Spotlight, Shortcuts app).
Captures: appVersion, pixelSource, type, platform and form_factor.

For more context of App Intent & App Shortcut, see parent task: https://app.asana.com/1/137249556945/project/276630244458377/task/1211107420315000?focus=true

### Testing Steps
1. Build and run the app.
2. Confirm parameters are correctly defined.

### Impact and Risks
No risks — pixel definition only

#### What could go wrong?
Likely none. Incorrect parameter type definitions could lead to dropped events.

### Quality Considerations
Definition follows schema conventions
### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)