### PR TITLE
replace assumeMainActor usages with custom implementation

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Common/Concurrency/MainActorExtension.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Common/Concurrency/MainActorExtension.swift
@@ -1,0 +1,34 @@
+//
+//  MainActorExtension.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension MainActor {
+
+    /// - Note: https://github.com/swiftlang/swift/blob/dbf7fe6aa01c958fa6711df30423e88ff22c0b75/stdlib/public/Concurrency/MainActor.swift#L128
+    @available(*, noasync)
+    public nonisolated static func assumeMainThread<T: Sendable>(_ operation: @MainActor () throws -> T) rethrows -> T {
+        precondition(Thread.isMainThread)
+
+        return try withoutActuallyEscaping(operation) {
+            return try unsafeBitCast($0, to: (() throws -> T).self)()
+        }
+
+    }
+
+}

--- a/SharedPackages/BrowserServicesKit/Sources/Navigation/Navigation.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Navigation/Navigation.swift
@@ -394,7 +394,7 @@ extension Navigation: CustomDebugStringConvertible {
             assertionFailure("Accessing Navigation from background thread")
             return "<ExpectedNavigation ?>"
         }
-        return MainActor.assumeIsolated {
+        return MainActor.assumeMainThread {
             "<\(identity) #\(navigationAction.identifier): url:\(url.absoluteString) state:\(state)\(isCommitted ? "(committed)" : "") type:\(navigationActions.last?.navigationType.debugDescription ?? "<nil>")\(isCurrent ? "" : " non-current")>"
         }
     }

--- a/SharedPackages/BrowserServicesKit/Sources/Navigation/Navigator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Navigation/Navigator.swift
@@ -155,7 +155,7 @@ extension ExpectedNavigation: CustomDebugStringConvertible {
             assertionFailure("Accessing ExpectedNavigation from background thread")
             return "<ExpectedNavigation ?>"
         }
-        return MainActor.assumeIsolated {
+        return MainActor.assumeMainThread {
             "<ExpectedNavigation \(navigation.identity) \(navigation.navigationActions.last != nil ? "from_redirected: #\(navigation.navigationActions.last!.identifier)" : "")>"
         }
     }

--- a/macOS/.swiftlint.yml
+++ b/macOS/.swiftlint.yml
@@ -36,6 +36,13 @@ custom_rules:
       - keyword
     message: "Classes should be `final` by default, use explicit `internal` or `public` for non-final classes."
     severity: error
+  
+  use_main_actor_assume_main_thread:
+    included: ".*\\.swift"
+    name: "Use MainActor.assumeMainThread instead of assumeIsolated"
+    regex: "MainActor\\.assumeIsolated"
+    message: "`MainActor.assumeIsolated` may crash on the main thread."
+    severity: error
 
 # Rule Config
 cyclomatic_complexity:

--- a/macOS/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
@@ -559,7 +559,7 @@ final class KnownBookmarkFolderIdList {
     }
 
     deinit {
-        MainActor.assumeIsolated {
+        MainActor.assumeMainThread {
             for id in knownIds {
                 Self.restorableFolders[id] = nil
             }

--- a/macOS/DuckDuckGo/Common/Extensions/DispatchQueueExtensions.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/DispatchQueueExtensions.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import Common
 import Foundation
 
 extension DispatchQueue {
@@ -32,7 +33,7 @@ extension DispatchQueue {
     func asyncOrNow(execute workItem: @escaping @MainActor () -> Void) {
         assert(self == .main)
         if Thread.isMainThread {
-            MainActor.assumeIsolated(workItem)
+            MainActor.assumeMainThread(workItem)
         } else {
             DispatchQueue.main.async {
                 workItem()

--- a/macOS/DuckDuckGo/Common/Extensions/NSSizeExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/NSSizeExtension.swift
@@ -16,8 +16,9 @@
 //  limitations under the License.
 //
 
-import Foundation
+import Common
 import DeveloperToolsSupport
+import Foundation
 
 extension NSSize {
 
@@ -38,7 +39,7 @@ extension CGSize {
     /// #Preview helper to convert CGSize to Preview Traits
     @available(macOS 14.0, *)
     var fixedLayout: PreviewTrait<Preview.ViewTraits> {
-        MainActor.assumeIsolated {
+        MainActor.assumeMainThread {
             .fixedLayout(width: width, height: height)
         }
     }

--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -457,7 +457,7 @@ protocol NewWindowPolicyDecisionMaker {
     /// Publishes currently active main frame Navigation state
     var navigationStatePublisher: some Publisher<NavigationState?, Never> {
         navigationDelegate.$currentNavigation.map { currentNavigation -> AnyPublisher<NavigationState?, Never> in
-            MainActor.assumeIsolated {
+            MainActor.assumeMainThread {
                 currentNavigation?.$state.map { $0 }.eraseToAnyPublisher() ?? Just(nil).eraseToAnyPublisher()
             }
         }.switchToLatest()
@@ -480,7 +480,7 @@ protocol NewWindowPolicyDecisionMaker {
                 guard let currentNavigation = currentNavigation else {
                     return false
                 }
-                return MainActor.assumeIsolated {
+                return MainActor.assumeMainThread {
                     let isSameDocumentNavigation = (currentNavigation.redirectHistory.first ?? currentNavigation.navigationAction).navigationType.isSameDocumentNavigation
                     return !isSameDocumentNavigation
                 }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/SpecialErrorPageTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/SpecialErrorPageTabExtension.swift
@@ -65,12 +65,12 @@ final class SpecialErrorPageTabExtension {
         self.closeTab = closeTab
 
         webViewPublisher.sink { [weak self] webView in
-            MainActor.assumeIsolated {
+            MainActor.assumeMainThread {
                 self?.webView = webView
             }
         }.store(in: &cancellables)
         scriptsPublisher.sink { [weak self] scripts in
-            MainActor.assumeIsolated {
+            MainActor.assumeMainThread {
                 self?.specialErrorPageUserScript = scripts.specialErrorPageUserScript
                 self?.specialErrorPageUserScript?.delegate = self
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1211113741891098?focus=true

### Description
- Replace `MainActor.assumeIsolated` with custom implmentation
- Add linter rule to highlight `assumeIsolated` usages

### Testing Steps
1. Set a breakpoint into `assumeMainThread` function
2. Launch, switch tabs, close tabs, validate `assumeMainThread` works and doesn‘t crash

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Medium

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
- Random crashes

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)