### PR TITLE
Don't send navigation pixel on developer redirects

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/NavigationPixelNavigationResponder.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/NavigationPixelNavigationResponder.swift
@@ -53,8 +53,8 @@ extension NavigationPixelNavigationResponder: NavigationResponder {
         }
 
         let shouldFireNavigationPixel: Bool = {
-            /// Fire navigation pixel on all navigations except for developer redirects and loading error pages
-            if [.redirect(.developer), .alternateHtmlLoad].contains(navigation.navigationAction.navigationType) {
+            /// Fire navigation pixel on all navigations except for JS redirects and loading error pages
+            if [.redirect(.developer), .redirect(.client), .alternateHtmlLoad].contains(navigation.navigationAction.navigationType) {
                 return false
             }
             /// Sometimes navigation type for an error page is reported as `.other`, so checking also target frame URL


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1211181718360957

### Description
This change updates criteria for sending navigation pixel to filter out some redirects.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Open https://privacy-test-pages.site/privacy-protections/https-loop-protection/
2. Filter console logs for `m_mac_navigation [`
3. Start the test on the website.
4. Verify that after the test, only a single navigation pixel is fired.

### Impact and Risks
None: Internal tooling, documentation

--
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)