### PR TITLE
Disable flaky test

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Autofill/AutofillVaultUserScriptTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Autofill/AutofillVaultUserScriptTests.swift
@@ -658,7 +658,8 @@ class AutofillVaultUserScriptTests: XCTestCase {
         XCTAssertEqual(delegate.capturedMainType, .creditCards)
     }
 
-    func testWhenGetAutofillDataFocusCalledWithNilCard_ThenNoneActionReturned() {
+    func testWhenGetAutofillDataFocusCalledWithNilCard_ThenNoneActionReturned() throws {
+        throw XCTSkip("Flaky test")
         class FocusDelegate: MockSecureVaultDelegate {
             override func autofillUserScriptDidFocus(_: AutofillUserScript,
                                                      mainType: AutofillUserScript.GetAutofillDataMainType,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1211168405505980?focus=true
Tech Design URL:
CC:

### Description
Disables flaky test `testWhenGetAutofillDataFocusCalledWithNilCard_ThenNoneActionReturned`

### Testing Steps
1. Confirm CI is green

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)