### PR TITLE
Stop the VPN expiry notification showing when signing out of the subscription

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/SubscriptionManagerV2.swift
@@ -413,6 +413,8 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
         return (try? oAuthClient.currentTokenContainer())?.decodedAccessToken.email
     }
 
+    var userInitiatedSignOut: Bool = false
+
     var cachedUserEntitlements: [SubscriptionEntitlement] {
         get {
             userDefaults.userEntitlements
@@ -425,7 +427,10 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
             if !SubscriptionEntitlement.areEntitlementsEqual(currentCachedUserEntitlements, newValue) {
                 Logger.subscription.debug("Entitlements changed - New \(String(describing: newValue)) Old \(String(describing: currentCachedUserEntitlements))")
                 let payload = EntitlementsDidChangePayload(entitlements: newValue)
-                NotificationCenter.default.post(name: .entitlementsDidChange, object: self, userInfo: payload.notificationUserInfo)
+
+                var userInfo = payload.notificationUserInfo
+                userInfo[EntitlementsDidChangePayload.userInitiatedEntitlementChangeKey] = userInitiatedSignOut
+                NotificationCenter.default.post(name: .entitlementsDidChange, object: self, userInfo: userInfo)
             }
         }
     }
@@ -551,6 +556,12 @@ public final class DefaultSubscriptionManagerV2: SubscriptionManagerV2 {
 
     public func signOut(notifyUI: Bool) async {
         Logger.subscription.log("SignOut: Removing all traces of the subscription and account. Notify UI: \(notifyUI ? "true" : "false")")
+        userInitiatedSignOut = true
+
+        defer {
+            userInitiatedSignOut = false
+        }
+
         try? await oAuthClient.logout()
         clearSubscriptionCache()
         if notifyUI {

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/NSNotificationName+Subscription.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/NSNotificationName+Subscription.swift
@@ -37,6 +37,8 @@ public extension NSNotification.Name {
 public struct EntitlementsDidChangePayload {
 
     private let entitlementsKey = "entitlements"
+    public static let userInitiatedEntitlementChangeKey = "userInitiatedEntitlementChange"
+
     public let entitlements: [SubscriptionEntitlement]
     public var notificationUserInfo: [AnyHashable: Any] {
         return [entitlementsKey: entitlements]

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2027,6 +2027,8 @@ class MainViewController: UIViewController {
                 Logger.subscription.fault("Missing entitlements payload")
                 return
             }
+
+            let userInitiatedSignOut = (userInfo[EntitlementsDidChangePayload.userInitiatedEntitlementChangeKey] as? Bool) ?? false
             let hasVPNEntitlements = payload.entitlements.contains(.networkProtection)
             let isAuthV2Enabled = AppDependencyProvider.shared.isUsingAuthV2
             let isSubscriptionActive = try? await subscriptionManager.getSubscription(cachePolicy: .cacheFirst).isActive
@@ -2046,7 +2048,7 @@ class MainViewController: UIViewController {
                         sourceObject: notification.object),
                     frequency: .dailyAndCount)
 
-                if await networkProtectionTunnelController.isInstalled {
+                if await networkProtectionTunnelController.isInstalled && !userInitiatedSignOut {
                     tunnelDefaults.enableEntitlementMessaging()
                 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1211187909384612?focus=true
Tech Design URL:
CC:

### Description

This PR fixes a bug where the VPN is reported as expired when you sign out of the subscription.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Sign into the subscription
2. Activate the VPN
3. Sign out of the subscription
4. Check that the VPN is deactivated, and that you don't get an alert saying that your account has expired

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)