### PR TITLE
Global AI Switch 7. Clean up settings

### DIFF
--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -1461,6 +1461,7 @@ struct UserText {
     // Favorites
     static let newTabFavoriteSectionTitle = NSLocalizedString("newTab.favorites.section.title", value: "Favorites", comment: "Title of the Favorites section in the home page")
     static let newTabOmnibarSectionTitle = NSLocalizedString("newTab.favorites.section.omnibar", value: "Search", comment: "Title of the Search section in the home page")
+    static let newTabAIChatSectionTitle = NSLocalizedString("newTab.aichat.section.title", value: "Duck.ai", comment: "Title of the Duck.ai section in the home page")
 
     // Set Up
     static let newTabSetUpDefaultBrowserCardTitle = NSLocalizedString("newTab.setup.default.browser.title", value: "Default to Privacy", comment: "Title of the Default Browser card of the Set Up section in the home page")

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -477,6 +477,7 @@ struct UserText {
     // Misc
 
     static let aiChatShowOnNewTabPageBarToggle = NSLocalizedString("duckai.show-on-new-tab-page.toggle", value: "Show on New Tab Page", comment: "A checkbox to control AI Chat shortcut visibility on the New Tab Page")
+    static let aiChatShowInSearchBoxOnNewTabPageBarToggle = NSLocalizedString("duckai.show-in-search-box-on-new-tab-page.toggle", value: "Show in Search box on New Tab Page", comment: "A checkbox to control AI Chat shortcut visibility in a search box on the New Tab Page")
     static let aiChatShowInAddressBarToggle = NSLocalizedString("duckai.show-in-address-bar.toggle", value: "Show Duck.ai shortcut in the address bar", comment: "Show AI Chat in the address bar")
     static let aiChatShowInApplicationMenuToggle = NSLocalizedString("duckai.show-in-application-menu.toggle-setting", value: "Show Duck.ai shortcuts in menus", comment: "Show Duck.ai in application menus")
     static let aiChatOpenInSidebarToggle = NSLocalizedString("duckai.open-in-sidebar.toggle-setting", value: "Open Duck.ai in the sidebar", comment: "Settings option to open Duck.ai in the sidebar")

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -47186,6 +47186,18 @@
         }
       }
     },
+    "newTab.aichat.section.title" : {
+      "comment" : "Title of the Duck.ai section in the home page",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Duck.ai"
+          }
+        }
+      }
+    },
     "newTab.bottom.popover.title" : {
       "comment" : "Title of the popover that appears when pressing the bottom right button",
       "extractionState" : "extracted_with_value",

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -23765,6 +23765,18 @@
         }
       }
     },
+    "duckai.show-in-search-box-on-new-tab-page.toggle" : {
+      "comment" : "A checkbox to control AI Chat shortcut visibility in a search box on the New Tab Page",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show in Search box on New Tab Page"
+          }
+        }
+      }
+    },
     "duckai.show-on-new-tab-page.toggle" : {
       "comment" : "A checkbox to control AI Chat shortcut visibility on the New Tab Page",
       "extractionState" : "extracted_with_value",

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
@@ -70,7 +70,7 @@ extension Preferences {
 
                     PreferencePaneSection(UserText.aiChatShortcutsSectionTitle,
                                           spacing: 6) {
-                        ToggleMenuItem(UserText.aiChatShowOnNewTabPageBarToggle,
+                        ToggleMenuItem(UserText.aiChatShowInSearchBoxOnNewTabPageBarToggle,
                                        isOn: $model.showShortcutOnNewTabPage)
                         .accessibilityIdentifier("Preferences.AIChat.showOnNewTabPageToggle")
                         .onChange(of: model.showShortcutOnNewTabPage) { newValue in

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAppearanceView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAppearanceView.swift
@@ -111,7 +111,7 @@ extension Preferences {
                             ToggleMenuItem(UserText.newTabAIChatSectionTitle, isOn: $aiChatModel.showShortcutOnNewTabPage)
                                 .accessibilityIdentifier("Preferences.AppearanceView.showAIChatToggle")
                                 .padding(.leading, 19)
-                                .visibility(model.isOmnibarVisible ? .visible : .gone)
+                                .disabled(!model.isOmnibarVisible)
                         }
                         ToggleMenuItem(UserText.newTabFavoriteSectionTitle, isOn: $model.isFavoriteVisible).accessibilityIdentifier("Preferences.AppearanceView.showFavoritesToggle")
                         ToggleMenuItem(UserText.newTabProtectionsReportSectionTitle, isOn: $model.isProtectionsReportVisible)

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAppearanceView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAppearanceView.swift
@@ -112,6 +112,7 @@ extension Preferences {
                                 .accessibilityIdentifier("Preferences.AppearanceView.showAIChatToggle")
                                 .padding(.leading, 19)
                                 .disabled(!model.isOmnibarVisible)
+                                .visibility(aiChatModel.isAIFeaturesEnabled ? .visible : .gone)
                         }
                         ToggleMenuItem(UserText.newTabFavoriteSectionTitle, isOn: $model.isFavoriteVisible).accessibilityIdentifier("Preferences.AppearanceView.showFavoritesToggle")
                         ToggleMenuItem(UserText.newTabProtectionsReportSectionTitle, isOn: $model.isProtectionsReportVisible)

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAppearanceView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAppearanceView.swift
@@ -84,6 +84,7 @@ extension Preferences {
 
     struct AppearanceView: View {
         @ObservedObject var model: AppearancePreferences
+        @ObservedObject var aiChatModel: AIChatPreferences
 
         var body: some View {
             PreferencePane(UserText.appearance) {
@@ -105,7 +106,12 @@ extension Preferences {
 
                     PreferencePaneSubSection {
                         if model.isOmnibarAvailable {
-                            ToggleMenuItem(UserText.newTabOmnibarSectionTitle, isOn: $model.isOmnibarVisible).accessibilityIdentifier("Preferences.AppearanceView.showOmnibarToggle")
+                            ToggleMenuItem(UserText.newTabOmnibarSectionTitle, isOn: $model.isOmnibarVisible)
+                                .accessibilityIdentifier("Preferences.AppearanceView.showOmnibarToggle")
+                            ToggleMenuItem(UserText.newTabAIChatSectionTitle, isOn: $aiChatModel.showShortcutOnNewTabPage)
+                                .accessibilityIdentifier("Preferences.AppearanceView.showAIChatToggle")
+                                .padding(.leading, 19)
+                                .visibility(model.isOmnibarVisible ? .visible : .gone)
                         }
                         ToggleMenuItem(UserText.newTabFavoriteSectionTitle, isOn: $model.isFavoriteVisible).accessibilityIdentifier("Preferences.AppearanceView.showFavoritesToggle")
                         ToggleMenuItem(UserText.newTabProtectionsReportSectionTitle, isOn: $model.isProtectionsReportVisible)

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesRootView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesRootView.swift
@@ -118,7 +118,7 @@ enum Preferences {
                 case .sync:
                     SyncView()
                 case .appearance:
-                    AppearanceView(model: NSApp.delegateTyped.appearancePreferences)
+                    AppearanceView(model: NSApp.delegateTyped.appearancePreferences, aiChatModel: AIChatPreferences.shared)
                 case .dataClearing:
                     DataClearingView(model: NSApp.delegateTyped.dataClearingPreferences)
                 case .privacyPro:
@@ -360,7 +360,7 @@ enum Preferences {
                 case .sync:
                     SyncView()
                 case .appearance:
-                    AppearanceView(model: NSApp.delegateTyped.appearancePreferences)
+                    AppearanceView(model: NSApp.delegateTyped.appearancePreferences, aiChatModel: AIChatPreferences.shared)
                 case .dataClearing:
                     DataClearingView(model: NSApp.delegateTyped.dataClearingPreferences)
                 case .privacyPro:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203936086921904/task/1211145082826761?focus=true
Tech Design URL:
CC:

### Description
- update to the Settings -> AI Features option label to "Show in Search box on New Tab Page"
- add in Settings -> Appearance "Duck.ai" as a sub-option under Search toggle

### Testing Steps
1. Open Settings -> AI Features and confirm copy is updated to "Show in Search box on New Tab Page"
2. Open Settings -> Appearance and confirm that "Duck.ai" is a sub-option under Search option
3. Disable "Duck.ai" on Settings -> Appearance
4. Check that:
- NTP is not showing Duck.ai
- NTP settings has the Duck.ai toggle disabled
- Settings -> AI Features has the "Show in Search box on New Tab Page" option unchecked
5. Open Settings -> Appearance
6. Uncheck the "Search" option
7. Confirm that the "Duck.ai" sub-option is greyed out and inactive

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Incorrect behaviour of modified settings options


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)