### PR TITLE
fix bug where previous tab data would show in new tab omnibar

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -998,15 +998,16 @@ class MainViewController: UIViewController {
         viewCoordinator.logoContainer.isHidden = true
         adjustNewTabPageSafeAreaInsets(for: appSettings.currentAddressBarPosition)
 
+        // This has to happen after the new tab controller is created so that it knows to set the buttons correctly
+        // ie remove back/forward and show bookmarks/passwords
+        // but also before any other UI updates so that data from the old tab doesn't find its way into the new one
+        refreshControls()
+
         if isNewTab && allowingKeyboard && KeyboardSettings().onNewTab {
             omniBar.beginEditing(animated: true)
         }
 
         syncService.scheduler.requestSyncImmediately()
-
-        // This has to happen after the new tab controller is created so that it knows to set the buttons correctly
-        // ie remove back/forward and show bookmarks/passwords
-        refreshControls()
 
         // It's possible for this to be called when in the background of the
         //  switcher, and we only want to show the pixel when it's actually


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1211196986755529?focus=true
Tech Design URL:
CC: @aataraxiaa @miasma13 

### Description

### Testing Steps
1. Enable experimental search 
2. Search for batman
3. Long press tab button to open a new tab (or use new tab from tabswitcher)
4. Ensure omnibar is in new state

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Break new tab page

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)