### PR TITLE
macOS: Add translations for Open Fire Windowy by Default

### DIFF
--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -18917,8 +18917,8 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Deine Sitzung wird nicht wiederhergestellt, wenn die Daten beim Beenden gelöscht werden."
+            "state" : "translated",
+            "value" : "Deine Sitzung wird nicht wiederhergestellt, wenn die automatische Löschung aktiviert ist. Auch Fire Windows werden nicht wiederhergestellt."
           }
         },
         "en" : {
@@ -18929,44 +18929,44 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Tu sesión no se restaurará si se eliminan los datos al salir."
+            "state" : "translated",
+            "value" : "Tu sesión no se restaurará si el borrado automático está activado. Las Fire windows tampoco se restaurarán."
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Votre session ne sera pas rétablie si les données sont supprimées à la fermeture."
+            "state" : "translated",
+            "value" : "Votre session ne sera pas rétablie si l'effacement automatique est activé. Les fenêtres Fire ne seront pas non plus restaurées."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "La sessione non sarà ripristinata se i dati vengono eliminati all'uscita."
+            "state" : "translated",
+            "value" : "La sessione non sarà ripristinata se è attivata la cancellazione automatica. Anche le finestre Fire non saranno ripristinate."
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Je sessie wordt niet hersteld als de gegevens bij het afsluiten worden verwijderd."
+            "state" : "translated",
+            "value" : "Je sessie wordt niet hersteld als Automatisch wissen is ingeschakeld. Fire Windows worden ook niet hersteld."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Sesja nie zostanie przywrócona, jeśli dane zostaną usunięte przy wychodzeniu."
+            "state" : "translated",
+            "value" : "Sesja nie zostanie przywrócona, jeśli jest włączona funkcja automatycznego czyszczenia. Również okna Fire Window nie zostaną przywrócone."
           }
         },
         "pt" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "A tua sessão não será restaurada se os dados forem eliminados ao sair."
+            "state" : "translated",
+            "value" : "A tua sessão não será restaurada se a Limpeza automática estiver ativada. As Fire Windows também não serão restauradas."
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Если данные удаляются при выходе, восстановление сеанса невозможно."
+            "state" : "translated",
+            "value" : "Если функция «Автоочистка» включена, восстановление сеанса невозможно. Окна Fire Window также не будут восстанавливаться."
           }
         }
       }
@@ -32475,10 +32475,58 @@
       "comment" : "Warning message explaining that session restoration is not available when using Fire Window",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bei Verwendung von Fire Windows wird deine Sitzung nicht wiederhergestellt."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fire Windows won’t be restored with your session."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las Fire Windows no se restaurarán con tu sesión."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les fenêtres Fire ne seront pas restaurées avec votre session."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le finestre Fire non saranno ripristinate con la sessione."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fire Windows worden niet hersteld met je sessie."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Okna Fire Window nie zostaną przywrócone wraz z sesją."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As Fire Windows não serão restauradas com a tua sessão."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Окна Fire Window не восстанавливаются вместе с сеансом."
           }
         }
       }
@@ -68564,10 +68612,58 @@
       "comment" : "Explanation for the option to make all new windows Fire Windows. The %@ will be replaced with a keyboard shortcut for opening new Fire Windows and regular Windows (e.g. '⌘N' and '⇧⌘N').",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Standardmäßig Fire Windows öffnen, wenn neue Fenster geöffnet werden (%1$@). Du kannst weiterhin ein normales Browserfenster öffnen, wenn diese Einstellung aktiviert ist (%2$@)."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Open Fire Windows by default when opening new windows (%1$@). You can still open a regular browser window when this setting is on (%2$@)."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abre Fire Windows de forma predeterminada al abrir nuevas ventanas (%1$@). Puedes seguir abriendo una ventana normal del navegador con esta configuración usando (%2$@)."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrez les Fire Windows par défaut lorsque vous ouvrez de nouvelles fenêtres (%1$@). Lorsque ce paramètre est activé, vous pouvez tout de même ouvrir une fenêtre de navigateur classique (%2$@)."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apri Fire Windows per impostazione predefinita quando apri nuove finestre (%1$@). Puoi comunque aprire una normale finestra del browser quando questa impostazione è attiva (%2$@)."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fire Windows worden standaard geopend wanneer je nieuwe vensters opent (%1$@). Je kunt nog steeds een gewoon browservenster openen als deze instelling is ingeschakeld (%2$@)."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Domyślnie otwieraj okna Fire Window przy otwieraniu nowych okien (%1$@). Po włączeniu tego ustawienia nadal możesz otworzyć zwykłe okno przeglądarki (%2$@)."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir Fire Windows por predefinição ao abrir novas janelas (%1$@). Continua a ser possível abrir uma janela normal do navegador com esta definição ativada (%2$@)."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открывать Fire Windows по умолчанию (%1$@). Вы по-прежнему сможете открывать обычные окна (%2$@)."
           }
         }
       }
@@ -69356,10 +69452,58 @@
       "comment" : "Label for startup window type selection",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Öffnen eines neuen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Open a new"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abre una nueva"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir une nouvelle"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apri una nuova"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open een nieuwe"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otwórz nowy"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir um novo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открыть новое"
           }
         }
       }
@@ -69368,10 +69512,58 @@
       "comment" : "Option for regular window type",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fenster"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Window"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ventana"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fenêtre"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finestra"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Venster"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Okno"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Janela"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Окно"
           }
         }
       }
@@ -75328,8 +75520,8 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Einstellungen zum Löschen von Daten öffnen"
+            "state" : "translated",
+            "value" : "Zu den Einstellungen zum Löschen von Daten"
           }
         },
         "en" : {
@@ -75340,43 +75532,43 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Abrir configuración de borrado de datos"
+            "state" : "translated",
+            "value" : "Ve a la configuración de borrado de datos"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Ouvrir les paramètres d'effacement des données"
+            "state" : "translated",
+            "value" : "Accéder aux paramètres d'effacement des données"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Apri Impostazioni cancellazione dati"
+            "state" : "translated",
+            "value" : "Vai a Impostazioni cancellazione dati"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Instellingen voor het wissen van open gegevens"
+            "state" : "translated",
+            "value" : "Ga naar Instellingen voor het wissen van gegevens"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Otwórz ustawienia czyszczenia danych"
+            "state" : "translated",
+            "value" : "Przejdź do ustawień czyszczenia danych"
           }
         },
         "pt" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Abrir Definições de limpeza de dados"
+            "state" : "translated",
+            "value" : "Aceder a Definições de limpeza de dados"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Открыть настройки очистки данных"
           }
         }
@@ -75446,10 +75638,58 @@
       "comment" : "Button in Data Clearing Settings. It navigates user to Startup Settings.",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gehe zu den Starteinstellungen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Go to Startup Settings"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ve a la configuración de inicio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accéder aux paramètres de démarrage"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vai a Impostazioni di avvio"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ga naar Opstartinstellingen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przejdź do ustawień uruchamiania"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aceder a Definições de arranque"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открыть настройки запуска"
           }
         }
       }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/45878998844068/task/1211198556132457?focus=true
Tech Design URL:
CC:

### Description
Merge translations for the new Open Fire Window by Default feature.

### Testing Steps
1. Open the application
2. Go to Data Clearing, and verify the Open Fire Window by Default option is present
3. Change the language to one of the supported languages
4. Verify the text is translated

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific

### Notes to Reviewer
Nothing specific

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)