### PR TITLE
PIR: queue manager resetting logic changes

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/QueueManaging/BrokerProfileJobQueueManager.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/QueueManaging/BrokerProfileJobQueueManager.swift
@@ -247,19 +247,16 @@ private extension BrokerProfileJobQueueManager {
             jobQueue.cancelAllOperations()
             let errorCollection = DataBrokerProtectionJobsErrorCollection(oneTimeError: BrokerProfileJobQueueError.interrupted, operationErrors: operationErrorsForCurrentOperations())
             errorHandler?(errorCollection)
-            resetMode(clearErrors: true)
-            completion?()
             resetMode()
+            completion?()
         default:
             break
         }
     }
 
-    func resetMode(clearErrors: Bool = false) {
+    func resetMode() {
         mode = .idle
-        if clearErrors {
-            operationErrors = []
-        }
+        operationErrors = []
     }
 
     func addJobs(for jobType: JobType,
@@ -293,9 +290,8 @@ private extension BrokerProfileJobQueueManager {
         jobQueue.addBarrierBlock1 { [weak self] in
             let errorCollection = DataBrokerProtectionJobsErrorCollection(oneTimeError: nil, operationErrors: self?.operationErrorsForCurrentOperations())
             errorHandler?(errorCollection)
-            self?.resetMode(clearErrors: true)
-            completion?()
             self?.resetMode()
+            completion?()
         }
     }
 

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/QueueManaging/BrokerProfileJobQueueManager.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/QueueManaging/BrokerProfileJobQueueManager.swift
@@ -285,6 +285,7 @@ private extension BrokerProfileJobQueueManager {
         } catch {
             Logger.dataBrokerProtection.error("DataBrokerProtectionProcessor error: addOperations, error: \(error.localizedDescription, privacy: .public)")
             errorHandler?(DataBrokerProtectionJobsErrorCollection(oneTimeError: error))
+            resetMode()
             completion?()
             return
         }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1211198697406015?focus=true
Tech Design URL:
CC:

### Description
In a certain error case resetMode()  isn't called, which could potentially cause the queue to block scheduled operations from running
Make it so the completion handler is always called after resetting mode

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Smoke test PIR on macOS
2.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)