### PR TITLE
iOS: Fix circle border rendering in Web Tracking Protection settings

### DIFF
--- a/iOS/DuckDuckGo/WebTrackingProtectionView.swift
+++ b/iOS/DuckDuckGo/WebTrackingProtectionView.swift
@@ -160,7 +160,8 @@ struct WebTrackingProtectionFeatureGrid: View {
             FeatureGridView(
                 features: features,
                 layoutStyle: layoutStyle,
-                columns: columnCount
+                columns: columnCount,
+                borderWidth: 1
             )
         }
         .listRowInsets(EdgeInsets())


### PR DESCRIPTION
### Description

Fixed circle border rendering for icons in the Web Tracking Protection settings on iOS. The icons were not showing circular borders around them as intended.

### Testing Steps
1. Navigate to Settings → Web Tracking Protection
2. Scroll down to view the feature grid with icons
3. Verify that each icon now has a visible circular border around it


### Impact and Risks
**Low**: Minor visual improvement to existing feature. No functional changes.