### PR TITLE
Fix issue showing the logo on dismiss animation

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -201,7 +201,6 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
             .receive(on: DispatchQueue.main)
             .sink { [weak self] submission in
                 guard let self = self else { return }
-                defer { self.switchBarHandler.clearText() }
 
                 let text = submission.text
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1211202556106913?focus=true

### Description
Fix issue showing the logo on dismiss animation

### Testing Steps
1. Open a website
2. Submit a prompt on the new experimental address bar
3. Check that we don't clean the input text mid animation causing the dax logo to appear

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Clearing input when it shouldn't and showing the dax logo
