### PR TITLE
[iOS] Option to hide refresh in address bar - unit tests

### DIFF
--- a/iOS/DuckDuckGoTests/AppUserDefaultsTests.swift
+++ b/iOS/DuckDuckGoTests/AppUserDefaultsTests.swift
@@ -219,6 +219,29 @@ class AppUserDefaultsTests: XCTestCase {
         XCTAssertTrue(appUserDefaults.autoconsentEnabled)
     }
 
+    func testWhenRefreshButtonPositionIsSetThenItIsPersisted() {
+        let appUserDefaults = AppUserDefaults(groupName: testGroupName)
+        appUserDefaults.featureFlagger = createFeatureFlagger(withFeatureFlagEnabled: .refreshButtonPosition)
+        
+        appUserDefaults.currentRefreshButtonPosition = .menu
+        XCTAssertEqual(appUserDefaults.currentRefreshButtonPosition, .menu)
+    }
+
+    func testWhenReadingRefreshButtonPositionDefaultThenAddressBarIsReturned() {
+        let appUserDefaults = AppUserDefaults(groupName: testGroupName)
+        appUserDefaults.featureFlagger = createFeatureFlagger(withFeatureFlagEnabled: .refreshButtonPosition)
+        
+        XCTAssertEqual(appUserDefaults.currentRefreshButtonPosition, .addressBar)
+    }
+
+    func testWhenRefreshButtonPositionFeatureFlagIsDisabledThenDefaultAddressBarIsReturned() {
+        let appUserDefaults = AppUserDefaults(groupName: testGroupName)
+        appUserDefaults.featureFlagger = MockFeatureFlagger()
+        
+        appUserDefaults.currentRefreshButtonPosition = .menu
+        XCTAssertEqual(appUserDefaults.currentRefreshButtonPosition, .addressBar)
+    }
+
     // MARK: - Mock Creation
 
     private func mockConfiguration(subfeatureEnabled: Bool) -> PrivacyConfiguration {

--- a/iOS/DuckDuckGoTests/LargeOmniBarStateTests.swift
+++ b/iOS/DuckDuckGoTests/LargeOmniBarStateTests.swift
@@ -519,6 +519,17 @@ class LargeOmniBarStateTests: XCTestCase {
         XCTAssertTrue(testee.showBookmarksButton)
         XCTAssertFalse(testee.showAccessoryButton)
     }
+    
+    func testWhenInBrowsingNonEditingStateThenRefreshButtonIsHiddenIfNotEnabled() {
+        mockFeatureFlagger.enabledFeatureFlags = [.refreshButtonPosition]
+        let mockAppSettings = AppSettingsMock()
+        mockAppSettings.currentRefreshButtonPosition = .menu
+        let dependencies = MockOmnibarDependency(voiceSearchHelper: enabledVoiceSearchHelper,
+                                                 featureFlagger: mockFeatureFlagger,
+                                                 appSettings: mockAppSettings)
+        let testee = LargeOmniBarState.BrowsingNonEditingState(dependencies: dependencies, isLoading: false)
+        XCTAssertFalse(testee.showRefresh)
+    }
 
     func testWhenEnteringBrowsingNonEditingStateThenTextIsMaintained() {
         let testee = LargeOmniBarState.BrowsingTextEditingState(dependencies: MockOmnibarDependency(voiceSearchHelper: enabledVoiceSearchHelper, featureFlagger: mockFeatureFlagger), isLoading: false)

--- a/iOS/DuckDuckGoTests/SmallOmniBarStateTests.swift
+++ b/iOS/DuckDuckGoTests/SmallOmniBarStateTests.swift
@@ -456,6 +456,17 @@ class SmallOmniBarStateTests: XCTestCase {
         XCTAssertFalse(testee.showBookmarksButton)
         XCTAssertFalse(testee.showAccessoryButton)
     }
+    
+    func testWhenInBrowsingNonEditingStateThenRefreshButtonIsHiddenIfNotEnabled() {
+        mockFeatureFlagger.enabledFeatureFlags = [.refreshButtonPosition]
+        let mockAppSettings = AppSettingsMock()
+        mockAppSettings.currentRefreshButtonPosition = .menu
+        let dependencies = MockOmnibarDependency(voiceSearchHelper: enabledVoiceSearchHelper,
+                                                 featureFlagger: mockFeatureFlagger,
+                                                 appSettings: mockAppSettings)
+        let testee = SmallOmniBarState.BrowsingNonEditingState(dependencies: dependencies, isLoading: false)
+        XCTAssertFalse(testee.showRefresh)
+    }
 
     func testWhenEnteringBrowsingNonEditingStateThenTextIsMaintained() {
         let testee = SmallOmniBarState.BrowsingTextEditingState(dependencies: MockOmnibarDependency(voiceSearchHelper: enabledVoiceSearchHelper, featureFlagger: mockFeatureFlagger), isLoading: false)
@@ -495,5 +506,41 @@ class SmallOmniBarStateTests: XCTestCase {
     func testWhenInBrowsingNonEditingStateThenBrowsingStoppedTransitionsToHomeNonEditingState() {
         let testee = SmallOmniBarState.BrowsingNonEditingState(dependencies: MockOmnibarDependency(voiceSearchHelper: enabledVoiceSearchHelper, featureFlagger: mockFeatureFlagger), isLoading: false)
         XCTAssertEqual(testee.onBrowsingStoppedState.name, SmallOmniBarState.HomeNonEditingState(dependencies: MockOmnibarDependency(voiceSearchHelper: enabledVoiceSearchHelper, featureFlagger: mockFeatureFlagger), isLoading: false).name)
+    }
+    
+    func testWhenRefreshButtonFeatureFlagIsOffThenIsRefreshButtonEnabledReturnsTrue() {
+        // Given
+        let dependencies = MockOmnibarDependency(voiceSearchHelper: disabledVoiceSearchHelper, featureFlagger: mockFeatureFlagger)
+        
+        // When
+        let isEnabled = dependencies.isRefreshButtonEnabled
+        
+        // Then
+        XCTAssertTrue(isEnabled)
+    }
+    
+    func testWhenRefreshButtonFeatureFlagIsOnThenIsRefreshButtonEnabledReturnsAppSettingsValue() {
+        // Given
+        mockFeatureFlagger.enabledFeatureFlags = [.refreshButtonPosition]
+        let mockAppSettings = AppSettingsMock()
+        mockAppSettings.currentRefreshButtonPosition = .addressBar
+        let dependencies = MockOmnibarDependency(voiceSearchHelper: disabledVoiceSearchHelper,
+                                                 featureFlagger: mockFeatureFlagger,
+                                                 appSettings: mockAppSettings)
+        
+        // When
+        let isEnabled = dependencies.isRefreshButtonEnabled
+        
+        // Then
+        XCTAssertTrue(isEnabled)
+        
+        // Given
+        mockAppSettings.currentRefreshButtonPosition = .menu
+        
+        // When
+        let isEnabledWithMenuSetting = dependencies.isRefreshButtonEnabled
+        
+        // Then
+        XCTAssertFalse(isEnabledWithMenuSetting)
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210947754188321/task/1211181054046850

### Description

This PR is an addition to the main PR https://github.com/duckduckgo/apple-browsers/pull/1790 that adds unit tests to it.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

None: unit tests

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)