### PR TITLE
Fix internal user check not working for PIR background agent when evaluating feature flag overrides

### DIFF
--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/PrivacyConfiguration/DBPPrivacyConfigurationManager.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/PrivacyConfiguration/DBPPrivacyConfigurationManager.swift
@@ -82,7 +82,7 @@ public final class DBPPrivacyConfigurationManager: PrivacyConfigurationManaging 
         return privacyConfig
     }
 
-    public var internalUserDecider: InternalUserDecider = DefaultInternalUserDecider(store: UserDefaults.config)
+    public let internalUserDecider: InternalUserDecider
 
     @discardableResult
     public func reload(etag: String?, data: Data?) -> PrivacyConfigurationManager.ReloadResult {
@@ -108,7 +108,9 @@ public final class DBPPrivacyConfigurationManager: PrivacyConfigurationManaging 
         return result
     }
 
-    public init() {}
+    public init(internalUserDecider: InternalUserDecider = DefaultInternalUserDecider(store: UserDefaults.config)) {
+        self.internalUserDecider = internalUserDecider
+    }
 }
 
 func privacyConfiguration(withData data: PrivacyConfigurationData,

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/DataBrokerProtectionAgentManagerTests.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/DataBrokerProtectionAgentManagerTests.swift
@@ -22,6 +22,7 @@ import Persistence
 @testable import DataBrokerProtection_macOS
 import DataBrokerProtectionCore
 import DataBrokerProtectionCoreTestsUtils
+import BrowserServicesKit
 
 final class DataBrokerProtectionAgentManagerTests: XCTestCase {
 
@@ -43,6 +44,7 @@ final class DataBrokerProtectionAgentManagerTests: XCTestCase {
     private var mockAuthenticationManager: MockAuthenticationManager!
     private var mockFreemiumDBPUserStateManager: MockFreemiumDBPUserStateManager!
     private var mockBrokerUpdater: MockBrokerJSONService!
+    private var mockInternalUserDecider: InternalUserDecider!
 
     override func setUpWithError() throws {
 
@@ -54,7 +56,9 @@ final class DataBrokerProtectionAgentManagerTests: XCTestCase {
         mockAuthenticationManager = MockAuthenticationManager()
         mockAgentStopper = MockAgentStopper()
         mockConfigurationManager = MockConfigurationManager()
-        mockPrivacyConfigurationManager = DBPPrivacyConfigurationManager()
+        let mockInternalUserStore = InternalUserDeciderStoreMock(isInternalUser: false)
+        mockInternalUserDecider = DefaultInternalUserDecider(store: mockInternalUserStore)
+        mockPrivacyConfigurationManager = DBPPrivacyConfigurationManager(internalUserDecider: mockInternalUserDecider)
         mockBrokerUpdater = MockBrokerJSONService()
 
         let mockDatabase = MockDatabase()


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1211209997963413
Tech Design URL:
CC:

### Description

Uses proper storage for `InternalUserDecider` in PIR background agent

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Enable Feature Flag Overrides > Others > dbpEmailConfirmationDecoupling
2. Update PIR profile and run a scan
3. The flag should stick. In `main`, it’s being reverted back to default (`false`).

### Impact and Risks

Low

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)