### PR TITLE
prevent over firing the enabling experimental duck.ai pixel on iOS

### DIFF
--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -1314,6 +1314,7 @@ extension SettingsViewModel {
         Binding<Bool>(
             get: { self.aiChatSettings.isAIChatSearchInputUserSettingsEnabled },
             set: { newValue in
+                guard newValue != self.aiChatSettings.isAIChatSearchInputUserSettingsEnabled else { return }
                 self.objectWillChange.send()
                 self.aiChatSettings.enableAIChatSearchInputUserSettings(enable: newValue)
             }
@@ -1336,15 +1337,6 @@ extension SettingsViewModel {
                 self.aiChatSettings.enableAIChatTabSwitcherUserSettings(enable: newValue)
             }
         )
-    }
-
-    var aiChatExperimentalBinding: Binding<Bool> {
-        Binding<Bool>(
-            get: { self.state.isExperimentalAIChatEnabled },
-            set: { _ in
-                self.experimentalAIChatManager.toggleExperimentalTheming()
-                self.state.isExperimentalAIChatEnabled = self.experimentalAIChatManager.isExperimentalAIChatSettingsEnabled
-            })
     }
 
     func launchAIFeaturesLearnMore() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211221733324862?focus=true
Tech Design URL:
CC:

### Description
Prevents over-firing the enable experimental duck.ai pixel by only triggering the call if the value really has changed.

Also removed some dead code.

### Testing Steps
1. Go to Settings > AI Features and toggle between the input states
2. Ensure pixel is fired and state change is applied
3. Go to Settings > AI Features and tap the currently selected state several times
4. Ensure no pixel is fired and the state is not changed 

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Changing the state of the experimental input might break.

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)