### PR TITLE
Add keyboard shortcut for reloading privacy config from debug menu

### DIFF
--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -741,7 +741,7 @@ final class MainMenu: NSMenu {
                 customConfigurationUrlMenuItem
                 configurationDateAndTimeMenuItem
                 NSMenuItem.separator()
-                NSMenuItem(title: "Reload Configuration Now", action: #selector(AppDelegate.reloadConfigurationNow))
+                NSMenuItem(title: "Reload Configuration Now", action: #selector(AppDelegate.reloadConfigurationNow), keyEquivalent: [.command, .shift, .option, "r"])
                 NSMenuItem(title: "Set custom configuration URL…", action: #selector(AppDelegate.setCustomPrivacyConfigurationURL))
                 NSMenuItem(title: "Reset configuration to default", action: #selector(AppDelegate.resetPrivacyConfigurationToDefault))
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1211211393637911

### Description
This change adds a keyboard shortcut to the debug menu option that reloads privacy configuration:
<img width="809" height="367" alt="Screenshot 2025-09-03 at 17 21 09 (2)" src="https://github.com/user-attachments/assets/7c0109b2-24fc-40ee-8f67-c5c36161e778" />

### Testing Steps
1. Launch the app
2. Press cmd+shift+option+R and verify that privacy configuration is reloaded (you should see `didInstallContentRuleLists` in the log)
3. Comment out lines 442-443 in MainMenu.swift to hide Debug menu.
4. Launch the app and verify that cmd+shift+option+R has no effect.

### Impact and Risks
None

#### What could go wrong?
The shortcut is made available for all users – that shouldn’t happen because regular users don’t see the Debug menu and the shortcut is tied to the Debug menu.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)