### PR TITLE
Fix and disable sync entry points feature flag

### DIFF
--- a/macOS/DuckDuckGo/Sync/DismissableSyncDeviceButtonModel.swift
+++ b/macOS/DuckDuckGo/Sync/DismissableSyncDeviceButtonModel.swift
@@ -90,6 +90,7 @@ public final class DismissableSyncDeviceButtonModel: ObservableObject {
     private var authState: SyncAuthState = .initializing {
         didSet {
             guard
+                featureFlagger.isNewSyncEntryPointsFeatureOn,
                 case .inactive = authState,
                 !wasDimissed,
                 !wasPresentationCountLimitReached,

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -186,8 +186,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .updateSafariBookmarksImport,
                 .updateFirefoxBookmarksImport,
                 .supportsAlternateStripePaymentFlow,
-                .refactorOfSyncPreferences,
-                .newSyncEntryPoints,
                 .subscriptionPurchaseWidePixelMeasurement:
             true
         default:
@@ -382,9 +380,9 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .subscriptionPurchaseWidePixelMeasurement:
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.subscriptionPurchaseWidePixelMeasurement))
         case .refactorOfSyncPreferences:
-            return .remoteReleasable(.subfeature(SyncSubfeature.refactorOfSyncPreferences))
+            return .disabled
         case .newSyncEntryPoints:
-            return .remoteReleasable(.subfeature(SyncSubfeature.newSyncEntryPoints))
+            return .disabled
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/547792610048271/task/1211221151845325?focus=true
cc @jozsef-vesza 

### Description

There is a flaw in the feature flag logic meaning that one of the new Sync buttons shows in certain cases when the feature flags are off. This fixed that problem and disables the feature flags.

### Testing Steps
1. Launch the app
2. Go to the following screens / popovers and check the Sync button is not showing.

1. Bookmarks Bar
2. More menu
3. Bookmark Added
4. Data import start
5. Data import end
6. Empty Passwords Manager
7. Empty Bookmarks Manager

### Impact and Risks
Low: Disabling a feature flag, reverting back to old state.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)