### PR TITLE
macOS: Fix config url overriding bug

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Configuration/CustomConfigurationURLProvider.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Configuration/CustomConfigurationURLProvider.swift
@@ -29,10 +29,10 @@ public protocol CustomConfigurationURLSetting {
     func isURLOverridden(for configuration: Configuration) -> Bool
 }
 
-public enum URLSettingError: Error {
+public enum URLSettingError: LocalizedError {
     case notInternalUser
 
-    public var description: String {
+    public var errorDescription: String? {
         switch self {
         case .notInternalUser:
             return "Not an internal user"

--- a/SharedPackages/BrowserServicesKit/Sources/Configuration/CustomConfigurationURLProvider.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Configuration/CustomConfigurationURLProvider.swift
@@ -24,9 +24,20 @@ public protocol ConfigurationURLProviding {
 }
 
 public protocol CustomConfigurationURLSetting {
-    func setCustomURL(_ url: URL?, for configuration: Configuration)
+    func setCustomURL(_ url: URL?, for configuration: Configuration) throws
     var isCustomURLEnabled: Bool { get }
     func isURLOverridden(for configuration: Configuration) -> Bool
+}
+
+public enum URLSettingError: Error {
+    case notInternalUser
+
+    public var description: String {
+        switch self {
+        case .notInternalUser:
+            return "Not an internal user"
+        }
+    }
 }
 
 public typealias CustomConfigurationURLProviding = ConfigurationURLProviding & CustomConfigurationURLSetting
@@ -64,8 +75,8 @@ public class ConfigurationURLProvider: CustomConfigurationURLProviding {
         return customURL ?? defaultURL
     }
 
-    public func setCustomURL(_ url: URL?, for configuration: Configuration) {
-        guard isCustomURLEnabled else { return }
+    public func setCustomURL(_ url: URL?, for configuration: Configuration) throws {
+        guard isCustomURLEnabled else { throw  URLSettingError.notInternalUser }
         switch configuration {
         case .bloomFilterSpec:
             store.customBloomFilterSpecURL = url

--- a/SharedPackages/BrowserServicesKit/Tests/ConfigurationTests/ConfigurationURLProviderTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/ConfigurationTests/ConfigurationURLProviderTests.swift
@@ -94,7 +94,7 @@ final class ConfigurationURLProviderTests {
 
         // When
         let customURL = URL(string: urlString)!
-        sut.setCustomURL(customURL, for: config)
+        try? sut.setCustomURL(customURL, for: config)
 
         // Then
         var value: URL?
@@ -117,7 +117,7 @@ final class ConfigurationURLProviderTests {
         let customURL = URL(string: urlString)!
 
         // When
-        sut.setCustomURL(customURL, for: config)
+        try? sut.setCustomURL(customURL, for: config)
 
         // Then
         var value: URL?
@@ -141,7 +141,7 @@ final class ConfigurationURLProviderTests {
         setCustomURL(mockStore, customURL)
 
         // When
-        sut.setCustomURL(nil, for: config)
+        try? sut.setCustomURL(nil, for: config)
 
         // Then
         var value: URL?

--- a/iOS/DuckDuckGo/DebugScreensViewModel.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewModel.swift
@@ -154,8 +154,7 @@ class DebugScreensViewModel: ObservableObject {
         do {
             try dependencies.customConfigurationURLProvider.setCustomURL(url, for: configuration)
         } catch {
-            let message = (error as? URLSettingError)?.description ?? error.localizedDescription
-            ActionMessageView.present(message: "Failed to set custom URL: \(message)")
+            ActionMessageView.present(message: "Failed to set custom URL: \(error.localizedDescription)")
         }
     }
 

--- a/iOS/DuckDuckGo/DebugScreensViewModel.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewModel.swift
@@ -151,7 +151,12 @@ class DebugScreensViewModel: ObservableObject {
     }
 
     func setCustomURL(_ url: URL?, for configuration: Configuration) {
-        dependencies.customConfigurationURLProvider.setCustomURL(url, for: configuration)
+        do {
+            try dependencies.customConfigurationURLProvider.setCustomURL(url, for: configuration)
+        } catch {
+            let message = (error as? URLSettingError)?.description ?? error.localizedDescription
+            ActionMessageView.present(message: "Failed to set custom URL: \(message)")
+        }
     }
 
     func urlString(for configuration: Configuration) -> String {

--- a/iOS/IntegrationTests/Configuration/ConfigurationManagerIntegrationTests.swift
+++ b/iOS/IntegrationTests/Configuration/ConfigurationManagerIntegrationTests.swift
@@ -46,7 +46,7 @@ final class ConfigurationManagerIntegrationTests: XCTestCase {
         await configManager.fetchAndUpdateTrackerBlockingDependencies()
         let etag = ContentBlocking.shared.trackerDataManager.fetchedData?.etag
         // use test privacyConfiguration link with tds experiments
-        customURLProvider.setCustomURL(URL(string: "https://staticcdn.duckduckgo.com/trackerblocking/config/test/macos-config.json"), for: .privacyConfiguration)
+        try? customURLProvider.setCustomURL(URL(string: "https://staticcdn.duckduckgo.com/trackerblocking/config/test/macos-config.json"), for: .privacyConfiguration)
 
         // WHEN
         await configManager.fetchAndUpdateTrackerBlockingDependencies()
@@ -57,7 +57,7 @@ final class ConfigurationManagerIntegrationTests: XCTestCase {
         XCTAssertEqual(newEtag, "\"5c0f8d8cdcd80e3f26889323dae1dff9\"")
 
         // RESET
-        customURLProvider.setCustomURL(nil, for: .privacyConfiguration)
+        try? customURLProvider.setCustomURL(nil, for: .privacyConfiguration)
         await configManager.fetchAndUpdateTrackerBlockingDependencies()
         let resetEtag = ContentBlocking.shared.trackerDataManager.fetchedData?.etag
         XCTAssertNotEqual(newEtag, resetEtag)

--- a/macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift
+++ b/macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift
@@ -23,35 +23,6 @@ import os.log
 
 struct AppConfigurationURLProvider: ConfigurationURLProviding {
 
-    // MARK: - Debug
-    internal init(privacyConfigurationManager: PrivacyConfigurationManaging,
-                  featureFlagger: FeatureFlagger,
-                  customPrivacyConfiguration: URL? = nil) {
-        let trackerDataUrlProvider = TrackerDataURLOverrider(privacyConfigurationManager: privacyConfigurationManager, featureFlagger: featureFlagger)
-        self.init(trackerDataUrlProvider: trackerDataUrlProvider)
-        if let customPrivacyConfiguration {
-            // Overwrite custom privacy configuration if provided
-            self.customPrivacyConfiguration = customPrivacyConfiguration.absoluteString
-        }
-        // Otherwise use the default or already stored custom configuration
-    }
-
-    @UserDefaultsWrapper(key: .customConfigurationUrl, defaultValue: nil)
-    private var customPrivacyConfiguration: String?
-
-    private var customPrivacyConfigurationUrl: URL? {
-        if let customPrivacyConfiguration {
-            return URL(string: customPrivacyConfiguration)
-        }
-        return nil
-    }
-
-    mutating func resetToDefaultConfigurationUrl() {
-        self.customPrivacyConfiguration = nil
-    }
-
-    // MARK: - Main
-
     private var trackerDataUrlProvider: TrackerDataURLProviding
 
     public enum Constants {
@@ -69,13 +40,13 @@ struct AppConfigurationURLProvider: ConfigurationURLProviding {
     }
 
     func url(for configuration: Configuration) -> URL {
-        // URLs for privacyConfiguration and trackerDataSet shall match the ones in update_embedded.sh. 
+        // URLs for privacyConfiguration and trackerDataSet shall match the ones in update_embedded.sh.
         // Danger checks that the URLs match on every PR. If the code changes, the regex that Danger uses may need an update.
         switch configuration {
         case .bloomFilterBinary: return URL(string: "https://staticcdn.duckduckgo.com/https/https-mobile-v2-bloom.bin")!
         case .bloomFilterSpec: return URL(string: "https://staticcdn.duckduckgo.com/https/https-mobile-v2-bloom-spec.json")!
         case .bloomFilterExcludedDomains: return URL(string: "https://staticcdn.duckduckgo.com/https/https-mobile-v2-false-positives.json")!
-        case .privacyConfiguration: return customPrivacyConfigurationUrl ?? Constants.defaultPrivacyConfigurationURL
+        case .privacyConfiguration: return Constants.defaultPrivacyConfigurationURL
         case .surrogates: return URL(string: "https://staticcdn.duckduckgo.com/surrogates.txt")!
         case .trackerDataSet:
             return trackerDataUrlProvider.trackerDataURL ?? Constants.defaultTrackerDataURL

--- a/macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift
+++ b/macOS/DuckDuckGo/Application/AppConfigurationURLProvider.swift
@@ -23,7 +23,7 @@ import os.log
 
 struct AppConfigurationURLProvider: ConfigurationURLProviding {
 
-    private var trackerDataUrlProvider: TrackerDataURLProviding
+    private let trackerDataUrlProvider: TrackerDataURLProviding
 
     public enum Constants {
         public static let baseTdsURLString = "https://staticcdn.duckduckgo.com/trackerblocking/"
@@ -40,7 +40,7 @@ struct AppConfigurationURLProvider: ConfigurationURLProviding {
     }
 
     func url(for configuration: Configuration) -> URL {
-        // URLs for privacyConfiguration and trackerDataSet shall match the ones in update_embedded.sh.
+        // URLs for privacyConfiguration and trackerDataSet shall match the ones in update_embedded.sh. 
         // Danger checks that the URLs match on every PR. If the code changes, the regex that Danger uses may need an update.
         switch configuration {
         case .bloomFilterBinary: return URL(string: "https://staticcdn.duckduckgo.com/https/https-mobile-v2-bloom.bin")!

--- a/macOS/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
+++ b/macOS/DuckDuckGo/Common/Utilities/UserDefaultsWrapper.swift
@@ -174,7 +174,6 @@ public struct UserDefaultsWrapper<T> {
         case loggingCategories = "logging.categories"
 
         case firstLaunchDate = "first.app.launch.date"
-        case customConfigurationUrl = "custom.configuration.url"
 
         case lastRemoteMessagingRefreshDate = "last.remote.messaging.refresh.date"
 

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -800,8 +800,7 @@ extension AppDelegate {
             do {
                 try setPrivacyConfigurationUrl(newConfigurationUrl)
             } catch let error {
-                let message = (error as? URLSettingError)?.description ?? "It was not possible the set the configuration"
-                showErrorAlert(message: message)
+                showErrorAlert(message: error.localizedDescription)
             }
         }
     }
@@ -810,8 +809,7 @@ extension AppDelegate {
         do {
             try setPrivacyConfigurationUrl(nil)
         } catch let error {
-            let message = (error as? URLSettingError)?.description ?? "It was not possible the set the configuration"
-            showErrorAlert(message: message)
+            showErrorAlert(message: error.localizedDescription)
         }
     }
 

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -770,14 +770,22 @@ extension AppDelegate {
         Application.appDelegate.configurationManager.forceRefresh(isDebug: true)
     }
 
-    private func setPrivacyConfigurationUrl(_ configurationUrl: URL?) {
-        configurationURLProvider.setCustomURL(configurationUrl, for: .privacyConfiguration)
+    private func setPrivacyConfigurationUrl(_ configurationUrl: URL?) throws {
+        try configurationURLProvider.setCustomURL(configurationUrl, for: .privacyConfiguration)
         Application.appDelegate.configurationManager.forceRefresh(isDebug: true)
         if let configurationUrl {
             Logger.config.debug("New configuration URL set to \(configurationUrl.absoluteString)")
         } else {
             Logger.config.log("New configuration URL reset to default")
         }
+    }
+
+    private func showErrorAlert(message: String) {
+        let alert = NSAlert()
+        alert.messageText = "Error"
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.runModal()
     }
 
     @objc func setCustomPrivacyConfigurationURL(_ sender: Any?) {
@@ -789,13 +797,22 @@ extension AppDelegate {
                 Logger.config.error("Failed to set custom configuration URL")
                 return
             }
-
-            setPrivacyConfigurationUrl(newConfigurationUrl)
+            do {
+                try setPrivacyConfigurationUrl(newConfigurationUrl)
+            } catch let error {
+                let message = (error as? URLSettingError)?.description ?? "It was not possible the set the configuration"
+                showErrorAlert(message: message)
+            }
         }
     }
 
     @objc func resetPrivacyConfigurationToDefault(_ sender: Any?) {
-        setPrivacyConfigurationUrl(nil)
+        do {
+            try setPrivacyConfigurationUrl(nil)
+        } catch let error {
+            let message = (error as? URLSettingError)?.description ?? "It was not possible the set the configuration"
+            showErrorAlert(message: message)
+        }
     }
 
     @objc func resetInstallStatistics() {

--- a/macOS/IntegrationTests/Configurations/ConfigurationManagerIntegrationTests.swift
+++ b/macOS/IntegrationTests/Configurations/ConfigurationManagerIntegrationTests.swift
@@ -54,7 +54,7 @@ final class ConfigurationManagerIntegrationTests: XCTestCase {
         await configManager.refreshNow()
         let etag = await Application.appDelegate.privacyFeatures.contentBlocking.trackerDataManager.fetchedData?.etag
         // use test privacyConfiguration link with tds experiments
-        customURLProvider.setCustomURL(URL(string: "https://staticcdn.duckduckgo.com/trackerblocking/config/test/macos-config.json"), for: .privacyConfiguration)
+        try? customURLProvider.setCustomURL(URL(string: "https://staticcdn.duckduckgo.com/trackerblocking/config/test/macos-config.json"), for: .privacyConfiguration)
 
         // WHEN
         await configManager.refreshNow()
@@ -65,7 +65,7 @@ final class ConfigurationManagerIntegrationTests: XCTestCase {
         XCTAssertEqual(newEtag, "\"2ce60c57c3d384f986ccbe2c422aac44\"")
 
         // RESET
-        customURLProvider.setCustomURL(nil, for: .privacyConfiguration)
+        try? customURLProvider.setCustomURL(nil, for: .privacyConfiguration)
         await configManager.refreshNow()
         let resetEtag = await Application.appDelegate.privacyFeatures.contentBlocking.trackerDataManager.fetchedData?.etag
         XCTAssertNotEqual(newEtag, resetEtag)

--- a/macOS/UnitTests/AppDelegate/AppConfigurationURLProviderTests.swift
+++ b/macOS/UnitTests/AppDelegate/AppConfigurationURLProviderTests.swift
@@ -25,8 +25,7 @@ fileprivate extension AppConfigurationURLProvider {
     init() {
         self.init(
             privacyConfigurationManager: MockPrivacyConfigurationManager(),
-            featureFlagger: MockFeatureFlagger(),
-            customPrivacyConfiguration: nil
+            featureFlagger: MockFeatureFlagger()
         )
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1211185941851033

### Description Remove code that reads old url override in the url provider

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Run defaults write com.duckduckgo.macos.browser.debug custom.configuration.url https://jsonblob.com/api/1404775931268227072
2. open the app foo to the debug menu and check the privacy config url is not overriden
3. override it from the debug menu and check the value is updated
4. Reset the configuration url from the debug menu and check it is updated

### Impact and Risks
Low: Internal tooling but touching prod code


#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!--
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)