### PR TITLE
Add more metrics and diagnostics to better understand bookmarks lost structure issue

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/SyncDataProviders/Bookmarks/internal/BookmarkEntity+Syncable.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SyncDataProviders/Bookmarks/internal/BookmarkEntity+Syncable.swift
@@ -109,8 +109,8 @@ extension BookmarkEntity {
                 decryptedUsing decrypt: (String) throws -> String,
                 metricsEvents: EventMapping<MetricsEvent>? = nil) throws {
         guard !syncable.isDeleted else {
-            if let syncableUUID = syncable.uuid, Constants.favoriteFoldersIDs.union([Constants.rootFolderID]).contains(syncableUUID) {
-                metricsEvents?.fire(.syncAttemptedToDeleteRoot(rootUUID: syncableUUID))
+            if parent == nil {
+                metricsEvents?.fire(.syncAttemptedToDeleteRoot(rootUUID: syncable.uuid ?? ""))
             }
             context.delete(self)
             return

--- a/SharedPackages/BrowserServicesKit/Sources/SyncDataProviders/Bookmarks/internal/BookmarkEntity+Syncable.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SyncDataProviders/Bookmarks/internal/BookmarkEntity+Syncable.swift
@@ -17,6 +17,7 @@
 //
 
 import Bookmarks
+import Common
 import CoreData
 import DDGSync
 import Foundation
@@ -105,8 +106,12 @@ extension BookmarkEntity {
 
     func update(with syncable: SyncableBookmarkAdapter,
                 in context: NSManagedObjectContext,
-                decryptedUsing decrypt: (String) throws -> String) throws {
+                decryptedUsing decrypt: (String) throws -> String,
+                metricsEvents: EventMapping<MetricsEvent>? = nil) throws {
         guard !syncable.isDeleted else {
+            if let syncableUUID = syncable.uuid, Constants.favoriteFoldersIDs.union([Constants.rootFolderID]).contains(syncableUUID) {
+                metricsEvents?.fire(.syncAttemptedToDeleteRoot(rootUUID: syncableUUID))
+            }
             context.delete(self)
             return
         }

--- a/SharedPackages/BrowserServicesKit/Sources/SyncDataProviders/Bookmarks/internal/BookmarksResponseHandler.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SyncDataProviders/Bookmarks/internal/BookmarksResponseHandler.swift
@@ -300,7 +300,7 @@ final class BookmarksResponseHandler {
 
     private func updateEntity(_ entity: BookmarkEntity, with syncable: SyncableBookmarkAdapter) throws {
         let url = entity.url
-        try entity.update(with: syncable, in: context, decryptedUsing: decrypt)
+        try entity.update(with: syncable, in: context, decryptedUsing: decrypt, metricsEvents: metricsEvents)
         if let uuid = entity.uuid {
             if entity.isDeleted {
                 idsOfDeletedBookmarks.insert(uuid)

--- a/SharedPackages/BrowserServicesKit/Sources/SyncDataProviders/Common/MetricsEvent.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SyncDataProviders/Common/MetricsEvent.swift
@@ -22,4 +22,5 @@ import Foundation
 public enum MetricsEvent {
     case overrideEmailProtectionSettings
     case localTimestampResolutionTriggered(feature: Feature)
+    case syncAttemptedToDeleteRoot(rootUUID: String)
 }

--- a/iOS/Core/BookmarksStateValidation.swift
+++ b/iOS/Core/BookmarksStateValidation.swift
@@ -48,11 +48,14 @@ public class BookmarksStateValidator: BookmarksStateValidation {
     }
 
     let keyValueStore: KeyValueStoring
+    let isSyncEnabled: Bool
     let errorHandler: (ValidationError, [String: String]?) -> Void
 
     public init(keyValueStore: KeyValueStoring,
+                isSyncEnabled: Bool = false,
                 errorHandler: @escaping (ValidationError, [String: String]?) -> Void) {
         self.keyValueStore = keyValueStore
+        self.isSyncEnabled = isSyncEnabled
         self.errorHandler = errorHandler
     }
 
@@ -130,12 +133,7 @@ public class BookmarksStateValidator: BookmarksStateValidation {
     }
     
     // MARK: - Diagnostic Helper Methods
-    
-    private var isSyncEnabled: Bool {
-        let syncEnabledKey = "com.duckduckgo.sync.enabled"
-        return UserDefaults.standard.object(forKey: syncEnabledKey) != nil
-    }
-    
+        
     private var hasLaunchedSuccessfullyBefore: Bool {
         guard let marker = BoolFileMarker(name: .hasSuccessfullyLaunchedBefore) else {
             return false

--- a/iOS/Core/BookmarksStateValidation.swift
+++ b/iOS/Core/BookmarksStateValidation.swift
@@ -22,6 +22,10 @@ import CoreData
 import Bookmarks
 import Persistence
 
+private extension BoolFileMarker.Name {
+    static let hasSuccessfullyLaunchedBefore = BoolFileMarker.Name(rawValue: "app-launched-successfully")
+}
+
 public protocol BookmarksStateValidation {
 
     func validateInitialState(context: NSManagedObjectContext,
@@ -119,6 +123,9 @@ public class BookmarksStateValidator: BookmarksStateValidation {
             params["recent-bookmark-error-code"] = "\(recentBookmarkError.code)"
         }
         
+        // Check if launch marker file exists (helps distinguish restore vs corruption)
+        params["launch-marker-present"] = "\(hasLaunchedSuccessfullyBefore)"
+        
         return params
     }
     
@@ -127,6 +134,13 @@ public class BookmarksStateValidator: BookmarksStateValidation {
     private var isSyncEnabled: Bool {
         let syncEnabledKey = "com.duckduckgo.sync.enabled"
         return UserDefaults.standard.object(forKey: syncEnabledKey) != nil
+    }
+    
+    private var hasLaunchedSuccessfullyBefore: Bool {
+        guard let marker = BoolFileMarker(name: .hasSuccessfullyLaunchedBefore) else {
+            return false
+        }
+        return marker.isPresent
     }
 
     private func getRecentBookmarkError() -> (name: String, domain: String, code: Int)? {

--- a/iOS/Core/BookmarksStateValidation.swift
+++ b/iOS/Core/BookmarksStateValidation.swift
@@ -145,7 +145,7 @@ public class BookmarksStateValidator: BookmarksStateValidation {
 
     private func getRecentBookmarkError() -> (name: String, domain: String, code: Int)? {
         let bookmarkErrorKey = "BookmarksValidator.lastBookmarkError"
-        let maxAgeHours: TimeInterval = 24 // 1 day
+        let maxAgeSeconds: TimeInterval = 24 * 60 * 60 // 1 day
 
         // Check UserDefaults for bookmark error
         guard let errorInfo = UserDefaults.app.object(forKey: bookmarkErrorKey) as? [String: Any],
@@ -157,11 +157,11 @@ public class BookmarksStateValidator: BookmarksStateValidation {
         }
 
         // Check if error is recent (within 1 day)
-        let hoursSinceError = Date().timeIntervalSince(timestamp) / 3600
-        guard hoursSinceError <= maxAgeHours else {
+        let secondsSinceError = Date().timeIntervalSince(timestamp)
+        guard secondsSinceError <= maxAgeSeconds else {
             return nil
         }
-        
+
         return (name: name, domain: domain, code: code)
     }
 

--- a/iOS/Core/BookmarksStateValidation.swift
+++ b/iOS/Core/BookmarksStateValidation.swift
@@ -114,6 +114,7 @@ public class BookmarksStateValidator: BookmarksStateValidation {
 
         // Add recent bookmark error information
         if let recentBookmarkError = getRecentBookmarkError() {
+            params["recent-bookmark-error-name"] = recentBookmarkError.name
             params["recent-bookmark-error-domain"] = recentBookmarkError.domain
             params["recent-bookmark-error-code"] = "\(recentBookmarkError.code)"
         }
@@ -128,27 +129,26 @@ public class BookmarksStateValidator: BookmarksStateValidation {
         return UserDefaults.standard.object(forKey: syncEnabledKey) != nil
     }
 
-    private func getRecentBookmarkError() -> (domain: String, code: Int)? {
+    private func getRecentBookmarkError() -> (name: String, domain: String, code: Int)? {
         let bookmarkErrorKey = "BookmarksValidator.lastBookmarkError"
         let maxAgeHours: TimeInterval = 24 // 1 day
 
-        // Check KeyValueFileStore for bookmark error
-        guard let appSupportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first,
-              let keyValueFileStore = try? KeyValueFileStore(location: appSupportDir, name: "AppKeyValueStore"),
-              let errorInfo = (try? keyValueFileStore.object(forKey: bookmarkErrorKey)) as? [String: Any],
+        // Check UserDefaults for bookmark error
+        guard let errorInfo = UserDefaults.app.object(forKey: bookmarkErrorKey) as? [String: Any],
               let timestamp = errorInfo["timestamp"] as? Date,
+              let name = errorInfo["bookmarkError"] as? String,
               let domain = errorInfo["domain"] as? String,
               let code = errorInfo["code"] as? Int else {
             return nil
         }
-        
+
         // Check if error is recent (within 1 day)
         let hoursSinceError = Date().timeIntervalSince(timestamp) / 3600
         guard hoursSinceError <= maxAgeHours else {
             return nil
         }
         
-        return (domain: domain, code: code)
+        return (name: name, domain: domain, code: code)
     }
 
 }

--- a/iOS/Core/BookmarksStateValidation.swift
+++ b/iOS/Core/BookmarksStateValidation.swift
@@ -39,15 +39,15 @@ public class BookmarksStateValidator: BookmarksStateValidation {
     public enum ValidationError {
         case bookmarksStructureLost
         case bookmarksStructureNotRecovered
-        case bookmarksStructureBroken(additionalParams: [String: String])
+        case bookmarksStructureBroken
         case validatorError(Error)
     }
 
     let keyValueStore: KeyValueStoring
-    let errorHandler: (ValidationError) -> Void
+    let errorHandler: (ValidationError, [String: String]?) -> Void
 
     public init(keyValueStore: KeyValueStoring,
-                errorHandler: @escaping (ValidationError) -> Void) {
+                errorHandler: @escaping (ValidationError, [String: String]?) -> Void) {
         self.keyValueStore = keyValueStore
         self.errorHandler = errorHandler
     }
@@ -60,11 +60,16 @@ public class BookmarksStateValidator: BookmarksStateValidation {
         do {
             let count = try context.count(for: fetch)
             if count == 0 {
-                errorHandler(validationError)
+                switch validationError {
+                case .bookmarksStructureLost:
+                    errorHandler(.bookmarksStructureLost, generateDiagnosticParameters())
+                default:
+                    errorHandler(validationError, nil)
+                }
                 return false
             }
         } catch {
-            errorHandler(.validatorError(error))
+            errorHandler(.validatorError(error), nil)
         }
 
         return true
@@ -95,10 +100,55 @@ public class BookmarksStateValidator: BookmarksStateValidation {
 
                 additionalParams["is-marked-as-initialized"] = isMarkedAsInitialized ? "true" : "false"
 
-                errorHandler(.bookmarksStructureBroken(additionalParams: additionalParams))
+                errorHandler(.bookmarksStructureBroken, additionalParams)
             }
         } catch {
-            errorHandler(.validatorError(error))
+            errorHandler(.validatorError(error), nil)
         }
     }
+    
+    private func generateDiagnosticParameters() -> [String: String] {
+        var params = [String: String]()
+        
+        params["sync-enabled"] = "\(isSyncEnabled)"
+
+        // Add recent bookmark error information
+        if let recentBookmarkError = getRecentBookmarkError() {
+            params["recent-bookmark-error-domain"] = recentBookmarkError.domain
+            params["recent-bookmark-error-code"] = "\(recentBookmarkError.code)"
+        }
+        
+        return params
+    }
+    
+    // MARK: - Diagnostic Helper Methods
+    
+    private var isSyncEnabled: Bool {
+        let syncEnabledKey = "com.duckduckgo.sync.enabled"
+        return UserDefaults.standard.object(forKey: syncEnabledKey) != nil
+    }
+
+    private func getRecentBookmarkError() -> (domain: String, code: Int)? {
+        let bookmarkErrorKey = "BookmarksValidator.lastBookmarkError"
+        let maxAgeHours: TimeInterval = 24 // 1 day
+
+        // Check KeyValueFileStore for bookmark error
+        guard let appSupportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first,
+              let keyValueFileStore = try? KeyValueFileStore(location: appSupportDir, name: "AppKeyValueStore"),
+              let errorInfo = (try? keyValueFileStore.object(forKey: bookmarkErrorKey)) as? [String: Any],
+              let timestamp = errorInfo["timestamp"] as? Date,
+              let domain = errorInfo["domain"] as? String,
+              let code = errorInfo["code"] as? Int else {
+            return nil
+        }
+        
+        // Check if error is recent (within 1 day)
+        let hoursSinceError = Date().timeIntervalSince(timestamp) / 3600
+        guard hoursSinceError <= maxAgeHours else {
+            return nil
+        }
+        
+        return (domain: domain, code: code)
+    }
+
 }

--- a/iOS/Core/LegacyBookmarksCoreDataStorage.swift
+++ b/iOS/Core/LegacyBookmarksCoreDataStorage.swift
@@ -21,6 +21,27 @@ import Foundation
 import CoreData
 import Bookmarks
 
+public enum BookmarksDatabaseError: Error {
+    // Legacy storage errors
+    case noDBSchemeFound
+    case unableToLoadPersistentStores(Error)
+    case errorCreatingTopLevelBookmarksFolder
+    case errorCreatingTopLevelFavoritesFolder
+    case couldNotFixBookmarkFolder
+    case couldNotFixFavoriteFolder
+    
+    // Migration errors
+    case couldNotPrepareBookmarksDBStructure(Error)
+    case couldNotWriteToBookmarksDB(Error)
+    
+    // Database setup errors
+    case couldNotGetFavoritesOrder(Error)
+    case couldNotPrepareDatabase(Error)
+    
+    // Generic
+    case other(Error)
+}
+
 public class LegacyBookmarksCoreDataStorage {
 
     private let storeLoadedCondition = RunLoop.ResumeCondition()
@@ -45,10 +66,10 @@ public class LegacyBookmarksCoreDataStorage {
     private var cachedReadOnlyTopLevelBookmarksFolder: BookmarkFolderManagedObject?
     private var cachedReadOnlyTopLevelFavoritesFolder: BookmarkFolderManagedObject?
 
-    internal static var managedObjectModel: NSManagedObjectModel {
+    internal static func getManagedObjectModel() throws -> NSManagedObjectModel {
         let coreBundle = Bundle(identifier: "com.duckduckgo.mobile.ios.Core")!
         guard let managedObjectModel = NSManagedObjectModel.mergedModel(from: [coreBundle]) else {
-            fatalError("No DB scheme found")
+            throw BookmarksDatabaseError.noDBSchemeFound
         }
         return managedObjectModel
     }
@@ -64,7 +85,7 @@ public class LegacyBookmarksCoreDataStorage {
 
     private let storeURL: URL
 
-    public init?(storeURL: URL = defaultStoreURL, createIfNeeded: Bool = false) {
+    public init?(storeURL: URL = defaultStoreURL, createIfNeeded: Bool = false) throws {
         if !FileManager.default.fileExists(atPath: storeURL.path),
            createIfNeeded == false {
             return nil
@@ -72,7 +93,8 @@ public class LegacyBookmarksCoreDataStorage {
 
         self.storeURL = storeURL
 
-        persistentContainer = NSPersistentContainer(name: Constants.databaseName, managedObjectModel: Self.managedObjectModel)
+        let managedObjectModel = try Self.getManagedObjectModel()
+        persistentContainer = NSPersistentContainer(name: Constants.databaseName, managedObjectModel: managedObjectModel)
         persistentContainer.persistentStoreDescriptions = [storeDescription]
     }
 
@@ -103,48 +125,55 @@ public class LegacyBookmarksCoreDataStorage {
         try? FileManager.default.removeItem(atPath: storeURL.path.appending("-shm"))
     }
 
-    public func loadStoreAndCaches(andMigrate handler: @escaping (NSManagedObjectContext) -> Void = { _ in }) {
+    public func loadStoreAndCaches(andMigrate handler: @escaping (NSManagedObjectContext) -> Void = { _ in }) throws {
 
-        loadStore(andMigrate: handler)
+        try loadStore(andMigrate: handler)
 
         RunLoop.current.run(until: storeLoadedCondition)
-        cacheReadOnlyTopLevelBookmarksFolder()
-        cacheReadOnlyTopLevelFavoritesFolder()
+        try cacheReadOnlyTopLevelBookmarksFolder()
+        try cacheReadOnlyTopLevelFavoritesFolder()
     }
 
-    internal func loadStore(andMigrate handler: @escaping (NSManagedObjectContext) -> Void = { _ in }) {
+    internal func loadStore(andMigrate handler: @escaping (NSManagedObjectContext) -> Void = { _ in }) throws {
 
-        persistentContainer = NSPersistentContainer(name: Constants.databaseName, managedObjectModel: Self.managedObjectModel)
+        let managedObjectModel = try Self.getManagedObjectModel()
+        persistentContainer = NSPersistentContainer(name: Constants.databaseName, managedObjectModel: managedObjectModel)
         persistentContainer.persistentStoreDescriptions = [storeDescription]
+        
+        var loadError: Error?
         persistentContainer.loadPersistentStores { _, error in
             if let error = error {
-                fatalError("Unable to load persistent stores: \(error)")
+                loadError = error
+            } else {
+                let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+                context.persistentStoreCoordinator = self.persistentContainer.persistentStoreCoordinator
+                context.name = "Migration"
+                context.performAndWait {
+                    handler(context)
+                    self.storeLoadedCondition.resolve()
+                }
             }
-
-            let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
-            context.persistentStoreCoordinator = self.persistentContainer.persistentStoreCoordinator
-            context.name = "Migration"
-            context.performAndWait {
-                handler(context)
-                self.storeLoadedCondition.resolve()
-            }
+        }
+        
+        if let loadError = loadError {
+            throw BookmarksDatabaseError.unableToLoadPersistentStores(loadError)
         }
     }
 
-    static internal func rootFolderManagedObject(_ context: NSManagedObjectContext) -> BookmarkFolderManagedObject {
+    static internal func rootFolderManagedObject(_ context: NSManagedObjectContext) throws -> BookmarkFolderManagedObject {
         guard let bookmarksFolder = NSEntityDescription.insertNewObject(forEntityName: "BookmarkFolderManagedObject", into: context)
                 as? BookmarkFolderManagedObject else {
-            fatalError("Error creating top level bookmarks folder")
+            throw BookmarksDatabaseError.errorCreatingTopLevelBookmarksFolder
         }
 
         bookmarksFolder.isFavorite = false
         return bookmarksFolder
     }
 
-    static internal func rootFavoritesFolderManagedObject(_ context: NSManagedObjectContext) -> BookmarkFolderManagedObject {
+    static internal func rootFavoritesFolderManagedObject(_ context: NSManagedObjectContext) throws -> BookmarkFolderManagedObject {
         guard let bookmarksFolder = NSEntityDescription.insertNewObject(forEntityName: "BookmarkFolderManagedObject", into: context)
                 as? BookmarkFolderManagedObject else {
-            fatalError("Error creating top level favorites folder")
+            throw BookmarksDatabaseError.errorCreatingTopLevelFavoritesFolder
         }
 
         bookmarksFolder.isFavorite = true
@@ -214,12 +243,12 @@ extension LegacyBookmarksCoreDataStorage {
         return folder
     }
 
-    internal func cacheReadOnlyTopLevelBookmarksFolder() {
+    internal func cacheReadOnlyTopLevelBookmarksFolder() throws {
         guard let folder = fetchReadOnlyTopLevelFolder(withFolderType: .bookmark) else {
-            fixFolderDataStructure(withFolderType: .bookmark)
+            try fixFolderDataStructure(withFolderType: .bookmark)
 
             guard let fixedFolder = fetchReadOnlyTopLevelFolder(withFolderType: .bookmark) else {
-                fatalError("Coudn't fix bookmark folder")
+                throw BookmarksDatabaseError.couldNotFixBookmarkFolder
             }
             self.cachedReadOnlyTopLevelBookmarksFolder = fixedFolder
             return
@@ -227,12 +256,12 @@ extension LegacyBookmarksCoreDataStorage {
         self.cachedReadOnlyTopLevelBookmarksFolder = folder
     }
 
-    internal func cacheReadOnlyTopLevelFavoritesFolder() {
+    internal func cacheReadOnlyTopLevelFavoritesFolder() throws {
         guard let folder = fetchReadOnlyTopLevelFolder(withFolderType: .favorite) else {
-            fixFolderDataStructure(withFolderType: .favorite)
+            try fixFolderDataStructure(withFolderType: .favorite)
 
             guard let fixedFolder = fetchReadOnlyTopLevelFolder(withFolderType: .favorite) else {
-                fatalError("Coudn't fix favorite folder")
+                throw BookmarksDatabaseError.couldNotFixFavoriteFolder
             }
             self.cachedReadOnlyTopLevelFavoritesFolder = fixedFolder
             return
@@ -288,7 +317,7 @@ extension LegacyBookmarksCoreDataStorage {
      i.e: Favorites and Bookmarks each have their own root folder
      */
     private func createMissingTopLevelFolder(onContext context: NSManagedObjectContext,
-                                             withFolderType folderType: TopLevelFolderType) {
+                                             withFolderType folderType: TopLevelFolderType) throws {
 
         // Get all bookmarks
         let bookmarksFetchRequest = NSFetchRequest<BookmarkManagedObject>(entityName: Constants.bookmarkClassName)
@@ -302,9 +331,9 @@ extension LegacyBookmarksCoreDataStorage {
         // Create root folder for the specified folder type
         let bookmarksFolder: BookmarkFolderManagedObject
         if folderType == .favorite {
-            bookmarksFolder = Self.rootFavoritesFolderManagedObject(context)
+            bookmarksFolder = try Self.rootFavoritesFolderManagedObject(context)
         } else {
-            bookmarksFolder = Self.rootFolderManagedObject(context)
+            bookmarksFolder = try Self.rootFolderManagedObject(context)
         }
 
         // Assign all bookmarks to the parent folder
@@ -313,29 +342,34 @@ extension LegacyBookmarksCoreDataStorage {
         }
     }
 
-    internal func fixFolderDataStructure(withFolderType folderType: TopLevelFolderType) {
+    internal func fixFolderDataStructure(withFolderType folderType: TopLevelFolderType) throws {
         let privateContext = getTemporaryPrivateContext()
 
+        var thrownError: Error?
         privateContext.performAndWait {
-            let fetchRequest = NSFetchRequest<BookmarkFolderManagedObject>(entityName: Constants.folderClassName)
-            fetchRequest.predicate = NSPredicate(format: "%K == nil AND %K == %@",
-                                                 #keyPath(BookmarkManagedObject.parent),
-                                                 #keyPath(BookmarkManagedObject.isFavorite),
-                                                 NSNumber(value: folderType == .favorite))
-
-            let results = try? privateContext.fetch(fetchRequest)
-
-            if let orphanedFolders = results, orphanedFolders.count > 1 {
-                deleteExtraOrphanedFolders(orphanedFolders, onContext: privateContext, withFolderType: folderType)
-            } else {
-                createMissingTopLevelFolder(onContext: privateContext, withFolderType: folderType)
-            }
-
             do {
+                let fetchRequest = NSFetchRequest<BookmarkFolderManagedObject>(entityName: Constants.folderClassName)
+                fetchRequest.predicate = NSPredicate(format: "%K == nil AND %K == %@",
+                                                     #keyPath(BookmarkManagedObject.parent),
+                                                     #keyPath(BookmarkManagedObject.isFavorite),
+                                                     NSNumber(value: folderType == .favorite))
+
+                let results = try? privateContext.fetch(fetchRequest)
+
+                if let orphanedFolders = results, orphanedFolders.count > 1 {
+                    deleteExtraOrphanedFolders(orphanedFolders, onContext: privateContext, withFolderType: folderType)
+                } else {
+                    try createMissingTopLevelFolder(onContext: privateContext, withFolderType: folderType)
+                }
+
                 try privateContext.save()
             } catch {
-                assertionFailure("Failure saving bookmark top folder fix")
+                thrownError = error
             }
+        }
+        
+        if let thrownError = thrownError {
+            throw thrownError
         }
     }
 }

--- a/iOS/Core/LegacyBookmarksCoreDataStorage.swift
+++ b/iOS/Core/LegacyBookmarksCoreDataStorage.swift
@@ -40,6 +40,33 @@ public enum BookmarksDatabaseError: Error {
     
     // Generic
     case other(Error)
+
+    public var name: String {
+        switch self {
+        case .noDBSchemeFound:
+            return "noDBSchemeFound"
+        case .unableToLoadPersistentStores:
+            return "unableToLoadPersistentStores"
+        case .errorCreatingTopLevelBookmarksFolder:
+            return "errorCreatingTopLevelBookmarksFolder"
+        case .errorCreatingTopLevelFavoritesFolder:
+            return "errorCreatingTopLevelFavoritesFolder"
+        case .couldNotFixBookmarkFolder:
+            return "couldNotFixBookmarkFolder"
+        case .couldNotFixFavoriteFolder:
+            return "couldNotFixFavoriteFolder"
+        case .couldNotPrepareBookmarksDBStructure:
+            return "couldNotPrepareBookmarksDBStructure"
+        case .couldNotWriteToBookmarksDB:
+            return "couldNotWriteToBookmarksDB"
+        case .couldNotGetFavoritesOrder:
+            return "couldNotGetFavoritesOrder"
+        case .couldNotPrepareDatabase:
+            return "couldNotPrepareDatabase"
+        case .other:
+            return "other"
+        }
+    }
 }
 
 public class LegacyBookmarksCoreDataStorage {

--- a/iOS/Core/LegacyBookmarksCoreDataStorage.swift
+++ b/iOS/Core/LegacyBookmarksCoreDataStorage.swift
@@ -389,7 +389,12 @@ extension LegacyBookmarksCoreDataStorage {
                     try createMissingTopLevelFolder(onContext: privateContext, withFolderType: folderType)
                 }
 
-                try privateContext.save()
+                do {
+                    try privateContext.save()
+                } catch {
+                    DailyPixel.fireDailyAndCount(pixel: .debugBookmarksTopFolderSaveFailed)
+                    assertionFailure("Failure saving bookmark top folder fix")
+                }
             } catch {
                 thrownError = error
             }

--- a/iOS/Core/LegacyBookmarksStoreMigration.swift
+++ b/iOS/Core/LegacyBookmarksStoreMigration.swift
@@ -29,13 +29,21 @@ public class LegacyBookmarksStoreMigration {
     }
 
     public static func migrate(from legacyStorage: LegacyBookmarksCoreDataStorage?,
-                               to context: NSManagedObjectContext) {
+                               to context: NSManagedObjectContext) throws {
         if let legacyStorage = legacyStorage {
             // Perform migration from legacy store.
             let source = legacyStorage.getTemporaryPrivateContext()
+            var thrownError: Error?
             source.performAndWait {
-                LegacyBookmarksStoreMigration.migrate(source: source,
-                                                      destination: context)
+                do {
+                    try LegacyBookmarksStoreMigration.migrate(source: source,
+                                                              destination: context)
+                } catch {
+                    thrownError = error
+                }
+            }
+            if let thrownError = thrownError {
+                throw thrownError
             }
         } else {
             // Initialize structure if needed
@@ -43,16 +51,14 @@ public class LegacyBookmarksStoreMigration {
                 try BookmarkUtils.prepareLegacyFoldersStructure(in: context)
             } catch {
                 Pixel.fire(pixel: .debugBookmarksInitialStructureQueryFailed, error: error)
-                Thread.sleep(forTimeInterval: 1)
-                fatalError("Could not prepare Bookmarks DB structure")
+                throw BookmarksDatabaseError.couldNotPrepareBookmarksDBStructure(error)
             }
 
             if context.hasChanges {
                 do {
                     try context.save(onErrorFire: .bookmarksCouldNotPrepareDatabase)
                 } catch {
-                    Thread.sleep(forTimeInterval: 1)
-                    fatalError("Could not prepare Bookmarks DB structure")
+                    throw BookmarksDatabaseError.couldNotPrepareBookmarksDBStructure(error)
                 }
             }
         }
@@ -77,7 +83,7 @@ public class LegacyBookmarksStoreMigration {
 
     // swiftlint:disable cyclomatic_complexity
 
-    private static func migrate(source: NSManagedObjectContext, destination: NSManagedObjectContext) {
+    private static func migrate(source: NSManagedObjectContext, destination: NSManagedObjectContext) throws {
 
         // Do not migrate more than once
         guard BookmarkUtils.fetchRootFolder(destination) == nil else {
@@ -91,8 +97,8 @@ public class LegacyBookmarksStoreMigration {
               let newFavoritesRoot = BookmarkUtils.fetchFavoritesFolder(withUUID: FavoritesFolderID.unified.rawValue, in: destination),
               let newMobileFavoritesRoot = BookmarkUtils.fetchFavoritesFolder(withUUID: FavoritesFolderID.mobile.rawValue, in: destination) else {
             Pixel.fire(pixel: .bookmarksMigrationCouldNotPrepareDatabase)
-            Thread.sleep(forTimeInterval: 2)
-            fatalError("Could not write to Bookmarks DB")
+            let error = NSError(domain: "BookmarksMigration", code: -1, userInfo: [NSLocalizedDescriptionKey: "Could not prepare database structure for migration"])
+            throw BookmarksDatabaseError.couldNotWriteToBookmarksDB(error)
         }
 
         // Fetch all 'roots' in case we had some kind of inconsistency and duplicated objects
@@ -185,12 +191,16 @@ public class LegacyBookmarksStoreMigration {
         } catch {
             destination.reset()
 
-            try? BookmarkUtils.prepareLegacyFoldersStructure(in: destination)
+            do {
+                try BookmarkUtils.prepareLegacyFoldersStructure(in: destination)
+            } catch {
+                throw BookmarksDatabaseError.couldNotPrepareBookmarksDBStructure(error)
+            }
+            
             do {
                 try destination.save(onErrorFire: .bookmarksMigrationCouldNotPrepareDatabaseOnFailedMigration)
             } catch {
-                Thread.sleep(forTimeInterval: 2)
-                fatalError("Could not write to Bookmarks DB")
+                throw BookmarksDatabaseError.couldNotWriteToBookmarksDB(error)
             }
         }
     }

--- a/iOS/Core/LegacyBookmarksStoreMigration.swift
+++ b/iOS/Core/LegacyBookmarksStoreMigration.swift
@@ -200,7 +200,15 @@ public class LegacyBookmarksStoreMigration {
             do {
                 try destination.save(onErrorFire: .bookmarksMigrationCouldNotPrepareDatabaseOnFailedMigration)
             } catch {
-                throw BookmarksDatabaseError.couldNotWriteToBookmarksDB(error)
+                let nsError = error as NSError
+                let sanitizedError = NSError(domain: nsError.domain,
+                                             code: nsError.code,
+                                             userInfo: [
+                                                NSLocalizedDescriptionKey: nsError.localizedDescription,
+                                                NSLocalizedFailureReasonErrorKey: nsError.localizedFailureReason ?? "Migration save failed"
+                                             ]
+                )
+                throw BookmarksDatabaseError.couldNotWriteToBookmarksDB(sanitizedError)
             }
         }
     }

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -786,6 +786,7 @@ extension Pixel {
         case debugBookmarksValidationFailed
         case debugBookmarksStructureLostAfterCrash
         case debugBookmarksSyncAttemptedToDeleteRoot
+        case debugBookmarksTopFolderSaveFailed
 
         case debugBookmarksPendingDeletionFixed
         case debugBookmarksPendingDeletionRepairError
@@ -2011,6 +2012,7 @@ extension Pixel.Event {
         case .debugBookmarksValidationFailed: return "m_d_bookmarks_validation_failed"
         case .debugBookmarksStructureLostAfterCrash: return "m_debug_bookmarks_structure_lost_after_crash"
         case .debugBookmarksSyncAttemptedToDeleteRoot: return "m_debug_bookmarks_sync_attempted_to_delete_root"
+        case .debugBookmarksTopFolderSaveFailed: return "m_debug_bookmarks_top_folder_save_failed"
 
         case .debugBookmarksPendingDeletionFixed: return "m_debug_bookmarks_pending_deletion_fixed"
         case .debugBookmarksPendingDeletionRepairError: return "m_debug_bookmarks_pending_deletion_repair_error"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -784,9 +784,9 @@ extension Pixel {
         case debugBookmarksStructureNotRecovered
         case debugBookmarksInvalidRoots
         case debugBookmarksValidationFailed
-                case debugBookmarksStructureLostAfterCrash
+        case debugBookmarksStructureLostAfterCrash
         case debugBookmarksSyncAttemptedToDeleteRoot
-        
+
         case debugBookmarksPendingDeletionFixed
         case debugBookmarksPendingDeletionRepairError
 

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -784,8 +784,9 @@ extension Pixel {
         case debugBookmarksStructureNotRecovered
         case debugBookmarksInvalidRoots
         case debugBookmarksValidationFailed
-        case debugBookmarksStructureLostAfterCrash
-
+                case debugBookmarksStructureLostAfterCrash
+        case debugBookmarksSyncAttemptedToDeleteRoot
+        
         case debugBookmarksPendingDeletionFixed
         case debugBookmarksPendingDeletionRepairError
 
@@ -2009,6 +2010,7 @@ extension Pixel.Event {
         case .debugBookmarksInvalidRoots: return "m_d_bookmarks_invalid_roots"
         case .debugBookmarksValidationFailed: return "m_d_bookmarks_validation_failed"
         case .debugBookmarksStructureLostAfterCrash: return "m_debug_bookmarks_structure_lost_after_crash"
+        case .debugBookmarksSyncAttemptedToDeleteRoot: return "m_debug_bookmarks_sync_attempted_to_delete_root"
 
         case .debugBookmarksPendingDeletionFixed: return "m_debug_bookmarks_pending_deletion_fixed"
         case .debugBookmarksPendingDeletionRepairError: return "m_debug_bookmarks_pending_deletion_repair_error"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -784,6 +784,7 @@ extension Pixel {
         case debugBookmarksStructureNotRecovered
         case debugBookmarksInvalidRoots
         case debugBookmarksValidationFailed
+        case debugBookmarksStructureLostAfterCrash
 
         case debugBookmarksPendingDeletionFixed
         case debugBookmarksPendingDeletionRepairError
@@ -2007,6 +2008,7 @@ extension Pixel.Event {
         case .debugBookmarksStructureNotRecovered: return "m_d_bookmarks_structure_not_recovered"
         case .debugBookmarksInvalidRoots: return "m_d_bookmarks_invalid_roots"
         case .debugBookmarksValidationFailed: return "m_d_bookmarks_validation_failed"
+        case .debugBookmarksStructureLostAfterCrash: return "m_debug_bookmarks_structure_lost_after_crash"
 
         case .debugBookmarksPendingDeletionFixed: return "m_debug_bookmarks_pending_deletion_fixed"
         case .debugBookmarksPendingDeletionRepairError: return "m_debug_bookmarks_pending_deletion_repair_error"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -786,6 +786,17 @@ extension Pixel {
         case debugBookmarksValidationFailed
         case debugBookmarksStructureLostAfterCrash
         case debugBookmarksSyncAttemptedToDeleteRoot
+
+        case debugBookmarksNoDBSchemeFound
+        case debugBookmarksUnableToLoadPersistentStores
+        case debugBookmarksErrorCreatingTopLevelBookmarksFolder
+        case debugBookmarksErrorCreatingTopLevelFavoritesFolder
+        case debugBookmarksCouldNotFixBookmarkFolder
+        case debugBookmarksCouldNotFixFavoriteFolder
+        case debugBookmarksCouldNotPrepareDBStructure
+        case debugBookmarksCouldNotWriteToDB
+        case debugBookmarksCouldNotGetFavoritesOrder
+        case debugBookmarksCouldNotPrepareDatabase
         case debugBookmarksTopFolderSaveFailed
 
         case debugBookmarksPendingDeletionFixed
@@ -2012,6 +2023,17 @@ extension Pixel.Event {
         case .debugBookmarksValidationFailed: return "m_d_bookmarks_validation_failed"
         case .debugBookmarksStructureLostAfterCrash: return "m_debug_bookmarks_structure_lost_after_crash"
         case .debugBookmarksSyncAttemptedToDeleteRoot: return "m_debug_bookmarks_sync_attempted_to_delete_root"
+        
+        case .debugBookmarksNoDBSchemeFound: return "m_debug_bookmarks_no_db_scheme_found"
+        case .debugBookmarksUnableToLoadPersistentStores: return "m_debug_bookmarks_unable_to_load_persistent_stores"
+        case .debugBookmarksErrorCreatingTopLevelBookmarksFolder: return "m_debug_bookmarks_error_creating_top_level_bookmarks_folder"
+        case .debugBookmarksErrorCreatingTopLevelFavoritesFolder: return "m_debug_bookmarks_error_creating_top_level_favorites_folder"
+        case .debugBookmarksCouldNotFixBookmarkFolder: return "m_debug_bookmarks_could_not_fix_bookmark_folder"
+        case .debugBookmarksCouldNotFixFavoriteFolder: return "m_debug_bookmarks_could_not_fix_favorite_folder"
+        case .debugBookmarksCouldNotPrepareDBStructure: return "m_debug_bookmarks_could_not_prepare_db_structure"
+        case .debugBookmarksCouldNotWriteToDB: return "m_debug_bookmarks_could_not_write_to_db"
+        case .debugBookmarksCouldNotGetFavoritesOrder: return "m_debug_bookmarks_could_not_get_favorites_order"
+        case .debugBookmarksCouldNotPrepareDatabase: return "m_debug_bookmarks_could_not_prepare_database"
         case .debugBookmarksTopFolderSaveFailed: return "m_debug_bookmarks_top_folder_save_failed"
 
         case .debugBookmarksPendingDeletionFixed: return "m_debug_bookmarks_pending_deletion_fixed"

--- a/iOS/Core/SyncMetricsEventsHandler.swift
+++ b/iOS/Core/SyncMetricsEventsHandler.swift
@@ -30,6 +30,9 @@ public class SyncMetricsEventsHandler: EventMapping<MetricsEvent> {
                 Pixel.fire(pixel: .syncDuckAddressOverride, includedParameters: [.appVersion])
             case .localTimestampResolutionTriggered(let feature):
                 Pixel.fire(pixel: .syncLocalTimestampResolutionTriggered(feature), includedParameters: [.appVersion])
+            case .syncAttemptedToDeleteRoot(let rootUUID):
+                DailyPixel.fire(pixel: .debugBookmarksSyncAttemptedToDeleteRoot,
+                                withAdditionalParameters: ["root-uuid": rootUUID])
             }
         }
     }

--- a/iOS/DuckDuckGo/AppConfiguration/AppConfiguration.swift
+++ b/iOS/DuckDuckGo/AppConfiguration/AppConfiguration.swift
@@ -33,7 +33,7 @@ struct AppConfiguration {
     let atbAndVariantConfiguration = ATBAndVariantConfiguration()
     let contentBlockingConfiguration = ContentBlockingConfiguration()
 
-    func start() throws {
+    func start() throws -> Bool {
         KeyboardConfiguration.disableHardwareKeyboardForUITests()
         PixelConfiguration.configure(with: featureFlagger)
 
@@ -42,11 +42,13 @@ struct AppConfiguration {
 
         onboardingConfiguration.migrateToNewOnboarding()
         clearTemporaryDirectory()
-        try persistentStoresConfiguration.configure()
+        let isBookmarksStructureMissing = try persistentStoresConfiguration.configure()
         migrateAIChatSettings()
 
         WidgetCenter.shared.reloadAllTimelines()
         PrivacyFeatures.httpsUpgrade.loadDataAsync()
+        
+        return isBookmarksStructureMissing
     }
 
     /// Perform AI Chat settings migration, and needs to happen before AIChatSettings is created

--- a/iOS/DuckDuckGo/AppConfiguration/AppConfiguration.swift
+++ b/iOS/DuckDuckGo/AppConfiguration/AppConfiguration.swift
@@ -33,7 +33,7 @@ struct AppConfiguration {
     let atbAndVariantConfiguration = ATBAndVariantConfiguration()
     let contentBlockingConfiguration = ContentBlockingConfiguration()
 
-    func start() throws -> Bool {
+    func start(syncKeyValueStore: ThrowingKeyValueStoring) throws -> Bool {
         KeyboardConfiguration.disableHardwareKeyboardForUITests()
         PixelConfiguration.configure(with: featureFlagger)
 
@@ -42,7 +42,7 @@ struct AppConfiguration {
 
         onboardingConfiguration.migrateToNewOnboarding()
         clearTemporaryDirectory()
-        let isBookmarksStructureMissing = try persistentStoresConfiguration.configure()
+        let isBookmarksStructureMissing = try persistentStoresConfiguration.configure(syncKeyValueStore: syncKeyValueStore)
         migrateAIChatSettings()
 
         WidgetCenter.shared.reloadAllTimelines()

--- a/iOS/DuckDuckGo/AppConfiguration/PersistentStoresConfiguration.swift
+++ b/iOS/DuckDuckGo/AppConfiguration/PersistentStoresConfiguration.swift
@@ -59,15 +59,15 @@ final class PersistentStoresConfiguration {
     }
 
     private func loadAndMigrateBookmarksDatabase() throws -> Bool {
-        var isMissingStructure: Bool = false
+        var didRepairBookmarksStructure: Bool = false
         do {
-            isMissingStructure = try BookmarksDatabaseSetup().loadStoreAndMigrate(bookmarksDatabase: bookmarksDatabase)
+            didRepairBookmarksStructure = try BookmarksDatabaseSetup().loadStoreAndMigrate(bookmarksDatabase: bookmarksDatabase)
         } catch let error as BookmarksDatabaseError {
             throw TerminationError.bookmarksDatabase(error)
         } catch {
             throw TerminationError.bookmarksDatabase(.other(error))
         }
-        return isMissingStructure
+        return didRepairBookmarksStructure
     }
 
 }

--- a/iOS/DuckDuckGo/AppConfiguration/PersistentStoresConfiguration.swift
+++ b/iOS/DuckDuckGo/AppConfiguration/PersistentStoresConfiguration.swift
@@ -59,9 +59,13 @@ final class PersistentStoresConfiguration {
     }
 
     private func loadAndMigrateBookmarksDatabase() throws -> Bool {
-        let (result, isMissingStructure) = BookmarksDatabaseSetup().loadStoreAndMigrate(bookmarksDatabase: bookmarksDatabase)
-        if case .failure(let error) = result {
+        var isMissingStructure: Bool = false
+        do {
+            isMissingStructure = try BookmarksDatabaseSetup().loadStoreAndMigrate(bookmarksDatabase: bookmarksDatabase)
+        } catch let error as BookmarksDatabaseError {
             throw TerminationError.bookmarksDatabase(error)
+        } catch {
+            throw TerminationError.bookmarksDatabase(.other(error))
         }
         return isMissingStructure
     }

--- a/iOS/DuckDuckGo/AppConfiguration/PersistentStoresConfiguration.swift
+++ b/iOS/DuckDuckGo/AppConfiguration/PersistentStoresConfiguration.swift
@@ -38,9 +38,9 @@ final class PersistentStoresConfiguration {
         self.application = application
     }
 
-    func configure() throws -> Bool {
+    func configure(syncKeyValueStore: ThrowingKeyValueStoring) throws -> Bool {
         try loadDatabase()
-        return try loadAndMigrateBookmarksDatabase()
+        return try loadAndMigrateBookmarksDatabase(syncKeyValueStore: syncKeyValueStore)
     }
 
     private func loadDatabase() throws {
@@ -58,10 +58,15 @@ final class PersistentStoresConfiguration {
         }
     }
 
-    private func loadAndMigrateBookmarksDatabase() throws -> Bool {
+    private func loadAndMigrateBookmarksDatabase(syncKeyValueStore: ThrowingKeyValueStoring) throws -> Bool {
+        // Check if sync is enabled from the same keyValueStore that sync uses
+        let syncEnabledKey = "com.duckduckgo.sync.enabled"
+        let isSyncEnabled = (try? syncKeyValueStore.object(forKey: syncEnabledKey)) != nil
+        
         var didRepairBookmarksStructure: Bool = false
         do {
-            didRepairBookmarksStructure = try BookmarksDatabaseSetup().loadStoreAndMigrate(bookmarksDatabase: bookmarksDatabase)
+            let validator = BookmarksDatabaseSetup.makeValidator(isSyncEnabled: isSyncEnabled)
+            didRepairBookmarksStructure = try BookmarksDatabaseSetup().loadStoreAndMigrate(bookmarksDatabase: bookmarksDatabase, validator: validator)
         } catch let error as BookmarksDatabaseError {
             throw TerminationError.bookmarksDatabase(error)
         } catch {

--- a/iOS/DuckDuckGo/AppConfiguration/PersistentStoresConfiguration.swift
+++ b/iOS/DuckDuckGo/AppConfiguration/PersistentStoresConfiguration.swift
@@ -38,9 +38,9 @@ final class PersistentStoresConfiguration {
         self.application = application
     }
 
-    func configure() throws {
+    func configure() throws -> Bool {
         try loadDatabase()
-        try loadAndMigrateBookmarksDatabase()
+        return try loadAndMigrateBookmarksDatabase()
     }
 
     private func loadDatabase() throws {
@@ -58,11 +58,12 @@ final class PersistentStoresConfiguration {
         }
     }
 
-    private func loadAndMigrateBookmarksDatabase() throws {
-        let result = BookmarksDatabaseSetup().loadStoreAndMigrate(bookmarksDatabase: bookmarksDatabase)
+    private func loadAndMigrateBookmarksDatabase() throws -> Bool {
+        let (result, isMissingStructure) = BookmarksDatabaseSetup().loadStoreAndMigrate(bookmarksDatabase: bookmarksDatabase)
         if case .failure(let error) = result {
             throw TerminationError.bookmarksDatabase(error)
         }
+        return isMissingStructure
     }
 
 }

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
@@ -20,6 +20,10 @@
 import UIKit
 import Core
 
+private extension BoolFileMarker.Name {
+    static let hasSuccessfullyLaunchedBefore = BoolFileMarker.Name(rawValue: "app-launched-successfully")
+}
+
 /// Represents the state where the app is in the Foreground and is visible to the user.
 /// - Usage:
 ///   - This state is typically associated with the `applicationDidBecomeActive(_:)` method.
@@ -105,6 +109,10 @@ struct Foreground: ForegroundHandling {
             /// This is called when the **app is ready to handle user interactions** after data clear and authentication are complete.
             onAppReadyForInteractions: {
                 appDependencies.launchTaskManager.start()
+                
+                // Mark that the app has successfully launched at least once
+                // This helps distinguish database corruption from fresh installs/restores
+                BoolFileMarker(name: .hasSuccessfullyLaunchedBefore)?.mark()
             }
         )
 

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -60,18 +60,18 @@ struct Launching: LaunchingHandling {
     init() throws {
         Logger.lifecycle.info("Launching: \(#function)")
 
+        let appKeyValueFileStoreService = try AppKeyValueFileStoreService()
+
         // MARK: - Application Setup
         // Handles one-time application setup during launch
-        let isBookmarksStructureMissing = try configuration.start()
+        let isBookmarksStructureMissing = try configuration.start(syncKeyValueStore: appKeyValueFileStoreService.keyValueFilesStore)
 
-        // MARK: - Service Initialization
-        // Create and initialize core services
+        // MARK: - Service Initialization (continued)
+        // Create and initialize remaining core services
         // These services are instantiated early in the app lifecycle for two main reasons:
         // 1. To begin their essential work immediately, without waiting for UI or other components
         // 2. To potentially complete their tasks before the app becomes visible to the user
         // This approach aims to optimize performance and ensure critical functionalities are ready ASAP
-
-        let appKeyValueFileStoreService = try AppKeyValueFileStoreService()
         let autofillService = AutofillService()
 
         let dbpService = DBPService(appDependencies: AppDependencyProvider.shared)

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -62,8 +62,7 @@ struct Launching: LaunchingHandling {
 
         // MARK: - Application Setup
         // Handles one-time application setup during launch
-
-        try configuration.start()
+        let isBookmarksStructureMissing = try configuration.start()
 
         // MARK: - Service Initialization
         // Create and initialize core services
@@ -77,7 +76,7 @@ struct Launching: LaunchingHandling {
 
         let dbpService = DBPService(appDependencies: AppDependencyProvider.shared)
         let configurationService = RemoteConfigurationService()
-        let crashCollectionService = CrashCollectionService()
+        let crashCollectionService = CrashCollectionService(isBookmarksStructureMissing: isBookmarksStructureMissing)
         let statisticsService = StatisticsService()
         let reportingService = ReportingService(fireproofing: fireproofing, featureFlagging: featureFlagger)
         let syncService = SyncService(bookmarksDatabase: configuration.persistentStoresConfiguration.bookmarksDatabase,

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Simulated.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Simulated.swift
@@ -27,7 +27,7 @@ struct Simulated {
         Pixel.isDryRun = true
         _ = DefaultUserAgentManager.shared
         Database.shared.loadStore { _, _ in }
-        _ = BookmarksDatabaseSetup().loadStoreAndMigrate(bookmarksDatabase: BookmarksDatabase.make())
+        _ = try? BookmarksDatabaseSetup().loadStoreAndMigrate(bookmarksDatabase: BookmarksDatabase.make())
 
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = UIStoryboard.init(name: "LaunchScreen", bundle: nil).instantiateInitialViewController()

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Terminating.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Terminating.swift
@@ -19,6 +19,7 @@
 
 import UIKit.UIApplication
 import Core
+import Persistence
 
 enum TerminationError: Error {
 
@@ -90,6 +91,7 @@ struct Terminating: TerminatingHandling {
                 mode = error.isDiskFull ? .afterAlert(reason: .insufficientDiskSpace) : .immediately(debugMessage: "DB init failed: \(error.localizedDescription)")
             }
         case .bookmarksDatabase(let error):
+            recordBookmarkDatabaseError(error)
             pixel = .bookmarksCouldNotLoadDatabase
             errorToReport = error
             mode = error.isDiskFull ? .afterAlert(reason: .insufficientDiskSpace) : .immediately(debugMessage: "Bookmarks DB init failed: \(error.localizedDescription)")
@@ -152,4 +154,21 @@ private extension Error {
         return false
     }
 
+}
+
+// MARK: - Error Tracking
+
+private func recordBookmarkDatabaseError(_ error: Error) {
+    guard let appSupportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first,
+          let keyValueStore = try? KeyValueFileStore(location: appSupportDir, name: "AppKeyValueStore") else {
+        return
+    }
+    
+    let errorInfo: [String: Any] = [
+        "timestamp": Date(),
+        "domain": (error as NSError).domain,
+        "code": (error as NSError).code
+    ]
+    
+    try? keyValueStore.set(errorInfo, forKey: "BookmarksValidator.lastBookmarkError")
 }

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Terminating.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Terminating.swift
@@ -97,45 +97,45 @@ struct Terminating: TerminatingHandling {
 
             switch bookmarkError {
             // Database setup errors
-            case .couldNotGetFavoritesOrder(let error): // todo pixels
+            case .couldNotGetFavoritesOrder(let error):
                 underlyingError = error
                 debugMessage = "Bookmarks DB init failed: could not get favorites order"
-                pixel = .bookmarksCouldNotLoadDatabase
+                pixel = .debugBookmarksCouldNotGetFavoritesOrder
             case .couldNotPrepareDatabase(let error):
                 underlyingError = error
                 debugMessage = "Bookmarks DB init failed: could not prepare database"
-                pixel = .bookmarksCouldNotLoadDatabase
+                pixel = .debugBookmarksCouldNotPrepareDatabase
                 
             // Legacy storage errors
             case .noDBSchemeFound:
                 debugMessage = "Legacy Bookmarks DB init failed: no DB scheme found"
-                pixel = .bookmarksCouldNotLoadDatabase
+                pixel = .debugBookmarksNoDBSchemeFound
             case .unableToLoadPersistentStores(let error):
                 underlyingError = error
                 debugMessage = "Legacy Bookmarks DB init failed: unable to load persistent stores"
-                pixel = .bookmarksCouldNotLoadDatabase
+                pixel = .debugBookmarksUnableToLoadPersistentStores
             case .errorCreatingTopLevelBookmarksFolder:
                 debugMessage = "Legacy Bookmarks DB init failed: error creating top level bookmarks folder"
-                pixel = .bookmarksCouldNotLoadDatabase
+                pixel = .debugBookmarksErrorCreatingTopLevelBookmarksFolder
             case .errorCreatingTopLevelFavoritesFolder:
                 debugMessage = "Legacy Bookmarks DB init failed: error creating top level favorites folder"
-                pixel = .bookmarksCouldNotLoadDatabase
+                pixel = .debugBookmarksErrorCreatingTopLevelFavoritesFolder
             case .couldNotFixBookmarkFolder:
                 debugMessage = "Legacy Bookmarks DB init failed: could not fix bookmark folder"
-                pixel = .bookmarksCouldNotLoadDatabase
+                pixel = .debugBookmarksCouldNotFixBookmarkFolder
             case .couldNotFixFavoriteFolder:
                 debugMessage = "Legacy Bookmarks DB init failed: could not fix favorite folder"
-                pixel = .bookmarksCouldNotLoadDatabase
+                pixel = .debugBookmarksCouldNotFixFavoriteFolder
                 
             // Migration errors
             case .couldNotPrepareBookmarksDBStructure(let error):
                 underlyingError = error
                 debugMessage = "Bookmarks migration failed: could not prepare DB structure"
-                pixel = .bookmarksMigrationFailed
+                pixel = .debugBookmarksCouldNotPrepareDBStructure
             case .couldNotWriteToBookmarksDB(let error):
                 underlyingError = error
                 debugMessage = "Bookmarks migration failed: could not write to DB"
-                pixel = .bookmarksMigrationFailed
+                pixel = .debugBookmarksCouldNotWriteToDB
                 
             // Generic
             case .other(let error):

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Terminating.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Terminating.swift
@@ -24,12 +24,13 @@ import Persistence
 enum TerminationError: Error {
 
     case database(DatabaseError)
-    case bookmarksDatabase(Error)
+    case bookmarksDatabase(BookmarksDatabaseError)
     case historyDatabase(Error)
     case keyValueFileStore(AppKeyValueFileStoreService.Error)
     case tabsPersistence(TabsPersistenceError)
 
 }
+
 
 private enum TerminationReason {
 
@@ -90,11 +91,67 @@ struct Terminating: TerminatingHandling {
                 errorToReport = error
                 mode = error.isDiskFull ? .afterAlert(reason: .insufficientDiskSpace) : .immediately(debugMessage: "DB init failed: \(error.localizedDescription)")
             }
-        case .bookmarksDatabase(let error):
-            recordBookmarkDatabaseError(error)
-            pixel = .bookmarksCouldNotLoadDatabase
-            errorToReport = error
-            mode = error.isDiskFull ? .afterAlert(reason: .insufficientDiskSpace) : .immediately(debugMessage: "Bookmarks DB init failed: \(error.localizedDescription)")
+        case .bookmarksDatabase(let bookmarkError):
+            let underlyingError: Error
+            let debugMessage: String
+
+            switch bookmarkError {
+            // Database setup errors
+            case .couldNotGetFavoritesOrder(let error): // todo pixels
+                underlyingError = error
+                debugMessage = "Bookmarks DB init failed: could not get favorites order"
+                pixel = .bookmarksCouldNotLoadDatabase
+            case .couldNotPrepareDatabase(let error):
+                underlyingError = error
+                debugMessage = "Bookmarks DB init failed: could not prepare database"
+                pixel = .bookmarksCouldNotLoadDatabase
+                
+            // Legacy storage errors
+            case .noDBSchemeFound:
+                underlyingError = bookmarkError
+                debugMessage = "Legacy Bookmarks DB init failed: no DB scheme found"
+                pixel = .bookmarksCouldNotLoadDatabase
+            case .unableToLoadPersistentStores(let error):
+                underlyingError = error
+                debugMessage = "Legacy Bookmarks DB init failed: unable to load persistent stores"
+                pixel = .bookmarksCouldNotLoadDatabase
+            case .errorCreatingTopLevelBookmarksFolder:
+                underlyingError = bookmarkError
+                debugMessage = "Legacy Bookmarks DB init failed: error creating top level bookmarks folder"
+                pixel = .bookmarksCouldNotLoadDatabase
+            case .errorCreatingTopLevelFavoritesFolder:
+                underlyingError = bookmarkError
+                debugMessage = "Legacy Bookmarks DB init failed: error creating top level favorites folder"
+                pixel = .bookmarksCouldNotLoadDatabase
+            case .couldNotFixBookmarkFolder:
+                underlyingError = bookmarkError
+                debugMessage = "Legacy Bookmarks DB init failed: could not fix bookmark folder"
+                pixel = .bookmarksCouldNotLoadDatabase
+            case .couldNotFixFavoriteFolder:
+                underlyingError = bookmarkError
+                debugMessage = "Legacy Bookmarks DB init failed: could not fix favorite folder"
+                pixel = .bookmarksCouldNotLoadDatabase
+                
+            // Migration errors
+            case .couldNotPrepareBookmarksDBStructure(let error):
+                underlyingError = error
+                debugMessage = "Bookmarks migration failed: could not prepare DB structure"
+                pixel = .bookmarksMigrationFailed
+            case .couldNotWriteToBookmarksDB(let error):
+                underlyingError = error
+                debugMessage = "Bookmarks migration failed: could not write to DB"
+                pixel = .bookmarksMigrationFailed
+                
+            // Generic
+            case .other(let error):
+                underlyingError = error
+                debugMessage = "Bookmarks DB init failed: \(bookmarkError)"
+                pixel = .bookmarksCouldNotLoadDatabase
+            }
+            
+            recordBookmarkDatabaseError(underlyingError)
+            errorToReport = underlyingError
+            mode = underlyingError.isDiskFull ? .afterAlert(reason: .insufficientDiskSpace) : .immediately(debugMessage: debugMessage)
         case .historyDatabase(let error):
             pixel = .historyStoreLoadFailed
             errorToReport = error

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Terminating.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Terminating.swift
@@ -92,7 +92,7 @@ struct Terminating: TerminatingHandling {
                 mode = error.isDiskFull ? .afterAlert(reason: .insufficientDiskSpace) : .immediately(debugMessage: "DB init failed: \(error.localizedDescription)")
             }
         case .bookmarksDatabase(let bookmarkError):
-            let underlyingError: Error
+            var underlyingError: Error = bookmarkError
             let debugMessage: String
 
             switch bookmarkError {
@@ -108,7 +108,6 @@ struct Terminating: TerminatingHandling {
                 
             // Legacy storage errors
             case .noDBSchemeFound:
-                underlyingError = bookmarkError
                 debugMessage = "Legacy Bookmarks DB init failed: no DB scheme found"
                 pixel = .bookmarksCouldNotLoadDatabase
             case .unableToLoadPersistentStores(let error):
@@ -116,19 +115,15 @@ struct Terminating: TerminatingHandling {
                 debugMessage = "Legacy Bookmarks DB init failed: unable to load persistent stores"
                 pixel = .bookmarksCouldNotLoadDatabase
             case .errorCreatingTopLevelBookmarksFolder:
-                underlyingError = bookmarkError
                 debugMessage = "Legacy Bookmarks DB init failed: error creating top level bookmarks folder"
                 pixel = .bookmarksCouldNotLoadDatabase
             case .errorCreatingTopLevelFavoritesFolder:
-                underlyingError = bookmarkError
                 debugMessage = "Legacy Bookmarks DB init failed: error creating top level favorites folder"
                 pixel = .bookmarksCouldNotLoadDatabase
             case .couldNotFixBookmarkFolder:
-                underlyingError = bookmarkError
                 debugMessage = "Legacy Bookmarks DB init failed: could not fix bookmark folder"
                 pixel = .bookmarksCouldNotLoadDatabase
             case .couldNotFixFavoriteFolder:
-                underlyingError = bookmarkError
                 debugMessage = "Legacy Bookmarks DB init failed: could not fix favorite folder"
                 pixel = .bookmarksCouldNotLoadDatabase
                 
@@ -149,7 +144,7 @@ struct Terminating: TerminatingHandling {
                 pixel = .bookmarksCouldNotLoadDatabase
             }
             
-            recordBookmarkDatabaseError(underlyingError)
+            recordBookmarkDatabaseError(error: bookmarkError, underlyingError: underlyingError)
             errorToReport = underlyingError
             mode = underlyingError.isDiskFull ? .afterAlert(reason: .insufficientDiskSpace) : .immediately(debugMessage: debugMessage)
         case .historyDatabase(let error):
@@ -197,6 +192,19 @@ struct Terminating: TerminatingHandling {
         window.rootViewController?.present(alertController, animated: true, completion: nil)
     }
 
+    // MARK: - Error Tracking
+
+    private func recordBookmarkDatabaseError(error: BookmarksDatabaseError, underlyingError: Error) {
+        let errorInfo: [String: Any] = [
+            "timestamp": Date(),
+            "bookmarkError": error.name,
+            "domain": (underlyingError as NSError).domain,
+            "code": (underlyingError as NSError).code
+        ]
+
+        UserDefaults.app.set(errorInfo, forKey: "BookmarksValidator.lastBookmarkError")
+    }
+
 }
 
 private extension Error {
@@ -211,21 +219,4 @@ private extension Error {
         return false
     }
 
-}
-
-// MARK: - Error Tracking
-
-private func recordBookmarkDatabaseError(_ error: Error) {
-    guard let appSupportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first,
-          let keyValueStore = try? KeyValueFileStore(location: appSupportDir, name: "AppKeyValueStore") else {
-        return
-    }
-    
-    let errorInfo: [String: Any] = [
-        "timestamp": Date(),
-        "domain": (error as NSError).domain,
-        "code": (error as NSError).code
-    ]
-    
-    try? keyValueStore.set(errorInfo, forKey: "BookmarksValidator.lastBookmarkError")
 }

--- a/iOS/DuckDuckGo/AppServices/CrashCollectionService.swift
+++ b/iOS/DuckDuckGo/AppServices/CrashCollectionService.swift
@@ -64,7 +64,8 @@ final class CrashCollectionService {
                     DailyPixel.fireDaily(.dbCrashDetectedDaily(appIdentifier: appIdentifier))
                 }
                 
-                if isBookmarksStructureMissing {
+                if isBookmarksStructureMissing && appIdentifier == nil {
+                    // Only fire for main app crashes, not extension crashes
                     DailyPixel.fireDailyAndCount(pixel: .debugBookmarksStructureLostAfterCrash)
                 }
             }

--- a/iOS/DuckDuckGo/AppServices/CrashCollectionService.swift
+++ b/iOS/DuckDuckGo/AppServices/CrashCollectionService.swift
@@ -25,14 +25,17 @@ final class CrashCollectionService {
 
     private let appSettings: AppSettings
     private let application: UIApplication
+    private let isBookmarksStructureMissing: Bool
 
     private lazy var crashCollection = CrashCollection(crashReportSender: CrashReportSender(platform: .iOS,
                                                                                             pixelEvents: CrashReportSender.pixelEvents),
                                                        crashCollectionStorage: UserDefaults())
     private lazy var crashReportUploaderOnboarding = CrashCollectionOnboarding(appSettings: appSettings)
 
-    init(appSettings: AppSettings = AppUserDefaults(),
+    init(isBookmarksStructureMissing: Bool = false,
+         appSettings: AppSettings = AppUserDefaults(),
          application: UIApplication = UIApplication.shared) {
+        self.isBookmarksStructureMissing = isBookmarksStructureMissing
         self.appSettings = appSettings
         self.application = application
 
@@ -59,6 +62,10 @@ final class CrashCollectionService {
                     DailyPixel.fireDaily(.dbCrashDetectedDaily(appIdentifier: appIdentifier), withAdditionalParameters: dailyParameters)
                 } else {
                     DailyPixel.fireDaily(.dbCrashDetectedDaily(appIdentifier: appIdentifier))
+                }
+                
+                if isBookmarksStructureMissing {
+                    DailyPixel.fire(pixel: .debugBookmarksStructureLostAfterCrash)
                 }
             }
 

--- a/iOS/DuckDuckGo/AppServices/CrashCollectionService.swift
+++ b/iOS/DuckDuckGo/AppServices/CrashCollectionService.swift
@@ -65,7 +65,7 @@ final class CrashCollectionService {
                 }
                 
                 if isBookmarksStructureMissing {
-                    DailyPixel.fire(pixel: .debugBookmarksStructureLostAfterCrash)
+                    DailyPixel.fireDailyAndCount(pixel: .debugBookmarksStructureLostAfterCrash)
                 }
             }
 

--- a/iOS/DuckDuckGo/BookmarksDatabaseSetup.swift
+++ b/iOS/DuckDuckGo/BookmarksDatabaseSetup.swift
@@ -59,7 +59,7 @@ struct BookmarksDatabaseSetup {
 
     func loadStoreAndMigrate(bookmarksDatabase: CoreDataStoring,
                              formFactorFavoritesMigrator: BookmarkFormFactorFavoritesMigrating = BookmarkFormFactorFavoritesMigration(),
-                             validator: BookmarksStateValidation = Self.makeValidator()) -> (Result, isMissingStructure: Bool) {
+                             validator: BookmarksStateValidation = Self.makeValidator()) throws -> Bool {
 
         let oldFavoritesOrder: [String]?
         do {
@@ -68,11 +68,12 @@ struct BookmarksDatabaseSetup {
                 dbFileURL: BookmarksDatabase.defaultDBFileURL
             )
         } catch {
-            return (.failure(error), false)
+            throw BookmarksDatabaseError.couldNotGetFavoritesOrder(error)
         }
 
         var migrationHappened = false
         var loadError: Error?
+        var migrationError: Error?
         var isMissingStructure = false
         bookmarksDatabase.loadStore { context, error in
             guard let context = context, error == nil else {
@@ -80,12 +81,17 @@ struct BookmarksDatabaseSetup {
                 return
             }
 
-            // Perform pre-setup/migration validation
-            isMissingStructure = !validator.validateInitialState(context: context,
-                                                                 validationError: .bookmarksStructureLost)
+            do {
+                // Perform pre-setup/migration validation
+                isMissingStructure = !validator.validateInitialState(context: context,
+                                                                     validationError: .bookmarksStructureLost)
 
-            self.migrateFromLegacyCoreDataStorageIfNeeded(context)
-            migrationHappened = self.migrateToFormFactorSpecificFavorites(context, oldFavoritesOrder)
+                try self.migrateFromLegacyCoreDataStorageIfNeeded(context)
+                migrationHappened = try self.migrateToFormFactorSpecificFavorites(context, oldFavoritesOrder)
+            } catch {
+                migrationError = error
+                return
+            }
 
             if isMissingStructure {
                 _ = validator.validateInitialState(context: context,
@@ -97,7 +103,9 @@ struct BookmarksDatabaseSetup {
         }
 
         if let loadError {
-            return (.failure(loadError), isMissingStructure)
+            throw BookmarksDatabaseError.couldNotPrepareDatabase(loadError)
+        } else if let migrationError {
+            throw migrationError
         }
 
         // Perform post-setup validation
@@ -118,7 +126,7 @@ struct BookmarksDatabaseSetup {
             }
         }
 
-        return (.success, isMissingStructure)
+        return isMissingStructure
     }
 
     private func repairDeletedFlag(context: NSManagedObjectContext) {
@@ -139,7 +147,7 @@ struct BookmarksDatabaseSetup {
         }
     }
 
-    private func migrateToFormFactorSpecificFavorites(_ context: NSManagedObjectContext, _ oldFavoritesOrder: [String]?) -> Bool {
+    private func migrateToFormFactorSpecificFavorites(_ context: NSManagedObjectContext, _ oldFavoritesOrder: [String]?) throws -> Bool {
         do {
             BookmarkFormFactorFavoritesMigration.migrateToFormFactorSpecificFavorites(byCopyingExistingTo: .mobile,
                                                                                       preservingOrderOf: oldFavoritesOrder,
@@ -148,17 +156,16 @@ struct BookmarksDatabaseSetup {
                 try context.save(onErrorFire: .bookmarksMigrationCouldNotPrepareMultipleFavoriteFolders)
                 return true
             }
+            return false
         } catch {
-            Thread.sleep(forTimeInterval: 1)
-            fatalError("Could not prepare Bookmarks DB structure")
+            throw BookmarksDatabaseError.couldNotPrepareBookmarksDBStructure(error)
         }
-        return false
     }
-    
-    private func migrateFromLegacyCoreDataStorageIfNeeded(_ context: NSManagedObjectContext) {
-        let legacyStorage = LegacyBookmarksCoreDataStorage()
-        legacyStorage?.loadStoreAndCaches()
-        LegacyBookmarksStoreMigration.migrate(from: legacyStorage, to: context)
+
+    private func migrateFromLegacyCoreDataStorageIfNeeded(_ context: NSManagedObjectContext) throws {
+        let legacyStorage = try LegacyBookmarksCoreDataStorage()
+        try legacyStorage?.loadStoreAndCaches()
+        try LegacyBookmarksStoreMigration.migrate(from: legacyStorage, to: context)
         legacyStorage?.removeStore()
     }
 }

--- a/iOS/DuckDuckGo/BookmarksDatabaseSetup.swift
+++ b/iOS/DuckDuckGo/BookmarksDatabaseSetup.swift
@@ -74,7 +74,7 @@ struct BookmarksDatabaseSetup {
         var migrationHappened = false
         var loadError: Error?
         var migrationError: Error?
-        var isMissingStructure = false
+        var didRepairBookmarksStructure = false
         bookmarksDatabase.loadStore { context, error in
             guard let context = context, error == nil else {
                 loadError = error
@@ -83,8 +83,8 @@ struct BookmarksDatabaseSetup {
 
             do {
                 // Perform pre-setup/migration validation
-                isMissingStructure = !validator.validateInitialState(context: context,
-                                                                     validationError: .bookmarksStructureLost)
+                didRepairBookmarksStructure = !validator.validateInitialState(context: context,
+                                                                              validationError: .bookmarksStructureLost)
 
                 try self.migrateFromLegacyCoreDataStorageIfNeeded(context)
                 migrationHappened = try self.migrateToFormFactorSpecificFavorites(context, oldFavoritesOrder)
@@ -93,7 +93,7 @@ struct BookmarksDatabaseSetup {
                 return
             }
 
-            if isMissingStructure {
+            if didRepairBookmarksStructure {
                 _ = validator.validateInitialState(context: context,
                                                    validationError: .bookmarksStructureNotRecovered)
             }
@@ -126,7 +126,7 @@ struct BookmarksDatabaseSetup {
             }
         }
 
-        return isMissingStructure
+        return didRepairBookmarksStructure
     }
 
     private func repairDeletedFlag(context: NSManagedObjectContext) {

--- a/iOS/DuckDuckGo/BookmarksDatabaseSetup.swift
+++ b/iOS/DuckDuckGo/BookmarksDatabaseSetup.swift
@@ -38,30 +38,28 @@ struct BookmarksDatabaseSetup {
     }
 
     static func makeValidator() -> BookmarksStateValidator {
-        return BookmarksStateValidator(keyValueStore: UserDefaults.app) { validationError in
+        return BookmarksStateValidator(keyValueStore: UserDefaults.app) { validationError, additionalParams in
             switch validationError {
             case .bookmarksStructureLost:
-                DailyPixel.fire(pixel: .debugBookmarksStructureLost, includedParameters: [.appVersion])
+                DailyPixel.fire(pixel: .debugBookmarksStructureLost,
+                                withAdditionalParameters: additionalParams ?? [:])
             case .bookmarksStructureNotRecovered:
-                DailyPixel.fire(pixel: .debugBookmarksStructureNotRecovered, includedParameters: [.appVersion])
-            case .bookmarksStructureBroken(let additionalParams):
+                DailyPixel.fire(pixel: .debugBookmarksStructureNotRecovered)
+            case .bookmarksStructureBroken:
                 DailyPixel.fire(pixel: .debugBookmarksInvalidRoots,
-                                withAdditionalParameters: additionalParams,
-                                includedParameters: [.appVersion])
+                                withAdditionalParameters: additionalParams ?? [:])
             case .validatorError(let underlyingError):
                 let processedErrors = CoreDataErrorsParser.parse(error: underlyingError as NSError)
-
                 DailyPixel.fireDailyAndCount(pixel: .debugBookmarksValidationFailed,
                                              pixelNameSuffixes: DailyPixel.Constant.legacyDailyPixelSuffixes,
-                                             withAdditionalParameters: processedErrors.errorPixelParameters,
-                                             includedParameters: [.appVersion])
+                                             withAdditionalParameters: processedErrors.errorPixelParameters)
             }
         }
     }
 
     func loadStoreAndMigrate(bookmarksDatabase: CoreDataStoring,
                              formFactorFavoritesMigrator: BookmarkFormFactorFavoritesMigrating = BookmarkFormFactorFavoritesMigration(),
-                             validator: BookmarksStateValidation = Self.makeValidator()) -> Result {
+                             validator: BookmarksStateValidation = Self.makeValidator()) -> (Result, isMissingStructure: Bool) {
 
         let oldFavoritesOrder: [String]?
         do {
@@ -70,11 +68,12 @@ struct BookmarksDatabaseSetup {
                 dbFileURL: BookmarksDatabase.defaultDBFileURL
             )
         } catch {
-            return .failure(error)
+            return (.failure(error), false)
         }
 
         var migrationHappened = false
         var loadError: Error?
+        var isMissingStructure = false
         bookmarksDatabase.loadStore { context, error in
             guard let context = context, error == nil else {
                 loadError = error
@@ -82,8 +81,8 @@ struct BookmarksDatabaseSetup {
             }
 
             // Perform pre-setup/migration validation
-            let isMissingStructure = !validator.validateInitialState(context: context,
-                                                                     validationError: .bookmarksStructureLost)
+            isMissingStructure = !validator.validateInitialState(context: context,
+                                                                 validationError: .bookmarksStructureLost)
 
             self.migrateFromLegacyCoreDataStorageIfNeeded(context)
             migrationHappened = self.migrateToFormFactorSpecificFavorites(context, oldFavoritesOrder)
@@ -98,7 +97,7 @@ struct BookmarksDatabaseSetup {
         }
 
         if let loadError {
-            return .failure(loadError)
+            return (.failure(loadError), isMissingStructure)
         }
 
         // Perform post-setup validation
@@ -119,7 +118,7 @@ struct BookmarksDatabaseSetup {
             }
         }
 
-        return .success
+        return (.success, isMissingStructure)
     }
 
     private func repairDeletedFlag(context: NSManagedObjectContext) {

--- a/iOS/DuckDuckGo/BookmarksDatabaseSetup.swift
+++ b/iOS/DuckDuckGo/BookmarksDatabaseSetup.swift
@@ -37,8 +37,8 @@ struct BookmarksDatabaseSetup {
         self.migrationAssertion = migrationAssertion
     }
 
-    static func makeValidator() -> BookmarksStateValidator {
-        return BookmarksStateValidator(keyValueStore: UserDefaults.app) { validationError, additionalParams in
+    static func makeValidator(isSyncEnabled: Bool = false) -> BookmarksStateValidator {
+        return BookmarksStateValidator(keyValueStore: UserDefaults.app, isSyncEnabled: isSyncEnabled) { validationError, additionalParams in
             switch validationError {
             case .bookmarksStructureLost:
                 DailyPixel.fireDailyAndCount(pixel: .debugBookmarksStructureLost,

--- a/iOS/DuckDuckGo/BookmarksDatabaseSetup.swift
+++ b/iOS/DuckDuckGo/BookmarksDatabaseSetup.swift
@@ -41,12 +41,12 @@ struct BookmarksDatabaseSetup {
         return BookmarksStateValidator(keyValueStore: UserDefaults.app) { validationError, additionalParams in
             switch validationError {
             case .bookmarksStructureLost:
-                DailyPixel.fire(pixel: .debugBookmarksStructureLost,
+                DailyPixel.fireDailyAndCount(pixel: .debugBookmarksStructureLost,
                                 withAdditionalParameters: additionalParams ?? [:])
             case .bookmarksStructureNotRecovered:
-                DailyPixel.fire(pixel: .debugBookmarksStructureNotRecovered)
+                DailyPixel.fireDailyAndCount(pixel: .debugBookmarksStructureNotRecovered)
             case .bookmarksStructureBroken:
-                DailyPixel.fire(pixel: .debugBookmarksInvalidRoots,
+                DailyPixel.fireDailyAndCount(pixel: .debugBookmarksInvalidRoots,
                                 withAdditionalParameters: additionalParams ?? [:])
             case .validatorError(let underlyingError):
                 let processedErrors = CoreDataErrorsParser.parse(error: underlyingError as NSError)

--- a/iOS/DuckDuckGoTests/BookmarksDatabaseSetupTests.swift
+++ b/iOS/DuckDuckGoTests/BookmarksDatabaseSetupTests.swift
@@ -157,12 +157,11 @@ class BookmarksDatabaseSetupTests: XCTestCase {
 
         let setup = BookmarksDatabaseSetup(migrationAssertion: BookmarksMigrationAssertion(store: MockKeyValueStore()))
 
-        switch setup.loadStoreAndMigrate(bookmarksDatabase: dbMock,
-                                         formFactorFavoritesMigrator: ffMock,
-                                         validator: validatorMock) {
-        case .success:
-            break
-        case .failure(let error):
+        do {
+            _ = try setup.loadStoreAndMigrate(bookmarksDatabase: dbMock,
+                                              formFactorFavoritesMigrator: ffMock,
+                                              validator: validatorMock)
+        } catch {
             XCTFail("Unexpected error: \(error)")
         }
 
@@ -196,12 +195,12 @@ class BookmarksDatabaseSetupTests: XCTestCase {
 
         let setup = BookmarksDatabaseSetup(migrationAssertion: BookmarksMigrationAssertion(store: MockKeyValueStore()))
 
-        switch setup.loadStoreAndMigrate(bookmarksDatabase: dbMock,
-                                         formFactorFavoritesMigrator: ffMock,
-                                         validator: validatorMock) {
-        case .success:
+        do {
+            _ = try setup.loadStoreAndMigrate(bookmarksDatabase: dbMock,
+                                              formFactorFavoritesMigrator: ffMock,
+                                              validator: validatorMock)
             XCTFail("Unexpected")
-        case .failure(let error):
+        } catch {
             XCTAssertEqual(error as? BookmarksModelError, BookmarksModelError.bookmarkFolderExpected)
         }
 
@@ -238,12 +237,12 @@ class BookmarksDatabaseSetupTests: XCTestCase {
 
         let setup = BookmarksDatabaseSetup(migrationAssertion: BookmarksMigrationAssertion(store: MockKeyValueStore()))
 
-        switch setup.loadStoreAndMigrate(bookmarksDatabase: dbMock,
-                                         formFactorFavoritesMigrator: ffMock,
-                                         validator: validatorMock) {
-        case .success:
+        do {
+            _ = try setup.loadStoreAndMigrate(bookmarksDatabase: dbMock,
+                                              formFactorFavoritesMigrator: ffMock,
+                                              validator: validatorMock)
             XCTFail("Unexpected")
-        case .failure(let error):
+        } catch {
             XCTAssertEqual(error as? BookmarksModelError, BookmarksModelError.bookmarkFolderExpected)
         }
 

--- a/iOS/DuckDuckGoTests/BookmarksDatabaseSetupTests.swift
+++ b/iOS/DuckDuckGoTests/BookmarksDatabaseSetupTests.swift
@@ -201,7 +201,11 @@ class BookmarksDatabaseSetupTests: XCTestCase {
                                               validator: validatorMock)
             XCTFail("Unexpected")
         } catch {
-            XCTAssertEqual(error as? BookmarksModelError, BookmarksModelError.bookmarkFolderExpected)
+            if case BookmarksDatabaseError.couldNotGetFavoritesOrder(let underlyingError) = error {
+                XCTAssertEqual(underlyingError as? BookmarksModelError, BookmarksModelError.bookmarkFolderExpected)
+            } else {
+                XCTFail("Wrong error")
+            }
         }
 
         wait(for: [favsObtained], timeout: 5)
@@ -243,7 +247,11 @@ class BookmarksDatabaseSetupTests: XCTestCase {
                                               validator: validatorMock)
             XCTFail("Unexpected")
         } catch {
-            XCTAssertEqual(error as? BookmarksModelError, BookmarksModelError.bookmarkFolderExpected)
+            if case BookmarksDatabaseError.couldNotPrepareDatabase(let underlyingError) = error {
+                XCTAssertEqual(underlyingError as? BookmarksModelError, BookmarksModelError.bookmarkFolderExpected)
+            } else {
+                XCTFail("Wrong error")
+            }
         }
 
         wait(for: [onLoadStore, favsObtained], timeout: 5)

--- a/iOS/DuckDuckGoTests/BookmarksMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/BookmarksMigrationTests.swift
@@ -34,10 +34,10 @@ class BookmarksMigrationTests: XCTestCase {
         
         let containerLocation = MockBookmarksDatabase.tempDBDir()
         try FileManager.default.createDirectory(at: containerLocation, withIntermediateDirectories: true)
-        
-        sourceStack = LegacyBookmarksCoreDataStorage(storeURL: containerLocation.appendingPathComponent("OldBookmarks.sqlite"),
-                                                    createIfNeeded: true)
-        sourceStack.loadStoreAndCaches()
+
+        sourceStack = try LegacyBookmarksCoreDataStorage(storeURL: containerLocation.appendingPathComponent("OldBookmarks.sqlite"),
+                                                          createIfNeeded: true)
+        try sourceStack.loadStoreAndCaches()
         try await prepareDB(with: sourceStack)
     }
     
@@ -88,7 +88,7 @@ class BookmarksMigrationTests: XCTestCase {
     
     func testWhenThereIsNoDatabaseThenLegacyStackIsNotCreated() {
         let tempURL = MockBookmarksDatabase.tempDBDir().appendingPathComponent("OldBookmarks.sqlite")
-        let legacyStore = LegacyBookmarksCoreDataStorage(storeURL: tempURL)
+        let legacyStore = try? LegacyBookmarksCoreDataStorage(storeURL: tempURL)
         XCTAssertNil(legacyStore)
     }
     

--- a/iOS/DuckDuckGoTests/BookmarksMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/BookmarksMigrationTests.swift
@@ -97,14 +97,14 @@ class BookmarksMigrationTests: XCTestCase {
         let context = destinationStack.makeContext(concurrencyType: .mainQueueConcurrencyType)
         XCTAssertNil(BookmarkUtils.fetchRootFolder(context))
         
-        LegacyBookmarksStoreMigration.migrate(from: nil, to: context)
+        try LegacyBookmarksStoreMigration.migrate(from: nil, to: context)
         
         XCTAssertNotNil(BookmarkUtils.fetchRootFolder(context))
         XCTAssertEqual(BookmarkUtils.fetchFavoritesFolders(withUUIDs: Set(FavoritesFolderID.allCases.map(\.rawValue)), in: context).count, 1)
         
         // Simulate subsequent app instantiations
-        LegacyBookmarksStoreMigration.migrate(from: nil, to: context)
-        LegacyBookmarksStoreMigration.migrate(from: nil, to: context)
+        try LegacyBookmarksStoreMigration.migrate(from: nil, to: context)
+        try LegacyBookmarksStoreMigration.migrate(from: nil, to: context)
         
         let countRequest = BookmarkEntity.fetchRequest()
         countRequest.predicate = NSPredicate(value: true)
@@ -113,10 +113,10 @@ class BookmarksMigrationTests: XCTestCase {
         XCTAssertEqual(count, 2)
     }
     
-    func testWhenRegularMigrationIsNeededThenItIsDoneAndDataIsDeduplicated() {
+    func testWhenRegularMigrationIsNeededThenItIsDoneAndDataIsDeduplicated() throws {
         
         let context = destinationStack.makeContext(concurrencyType: .mainQueueConcurrencyType)
-        LegacyBookmarksStoreMigration.migrate(from: sourceStack, to: context)
+        try LegacyBookmarksStoreMigration.migrate(from: sourceStack, to: context)
         
         XCTAssertNotNil(BookmarkUtils.fetchRootFolder(context))
         XCTAssertEqual(

--- a/iOS/DuckDuckGoTests/BookmarksStateValidationTests.swift
+++ b/iOS/DuckDuckGoTests/BookmarksStateValidationTests.swift
@@ -62,7 +62,7 @@ class BookmarksStateValidationTests: XCTestCase {
             BookmarkUtils.prepareFoldersStructure(in: context)
         }
 
-        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore) { error in
+        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore) { error, _  in
             XCTFail("Did not expect error: \(error)")
         }
 
@@ -77,7 +77,7 @@ class BookmarksStateValidationTests: XCTestCase {
 
     func testWhenDatabaseIsEmptyButItHasNotBeenInitiatedThenThereIsNoError() {
 
-        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore) { error in
+        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore) { error, _ in
             XCTFail("Did not expect error: \(error)")
         }
 
@@ -92,7 +92,7 @@ class BookmarksStateValidationTests: XCTestCase {
         let expectation1 = expectation(description: "Lost structure Error raised")
         let expectation2 = expectation(description: "Broken structure Error raised")
 
-        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore) { error in
+        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore) { error, _ in
             switch error {
             case .bookmarksStructureLost:
                 expectation1.fulfill()
@@ -130,15 +130,15 @@ class BookmarksStateValidationTests: XCTestCase {
 
         let expectation = expectation(description: "Broken structure Error raised")
 
-        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore) { error in
+        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore) { error, params in
             switch error {
-            case .bookmarksStructureBroken(let errorInfo):
+            case .bookmarksStructureBroken:
                 expectation.fulfill()
 
-                XCTAssertEqual(errorInfo[FavoritesFolderID.unified.rawValue], "0")
-                XCTAssertEqual(errorInfo[FavoritesFolderID.mobile.rawValue], "1")
-                XCTAssertEqual(errorInfo[FavoritesFolderID.desktop.rawValue], "1")
-                XCTAssertEqual(errorInfo[BookmarkEntity.Constants.rootFolderID], "0")
+                XCTAssertEqual(params?[FavoritesFolderID.unified.rawValue], "0")
+                XCTAssertEqual(params?[FavoritesFolderID.mobile.rawValue], "1")
+                XCTAssertEqual(params?[FavoritesFolderID.desktop.rawValue], "1")
+                XCTAssertEqual(params?[BookmarkEntity.Constants.rootFolderID], "0")
             default:
                 XCTFail("Did not expect error: \(error)")
             }
@@ -170,15 +170,15 @@ class BookmarksStateValidationTests: XCTestCase {
 
         let expectation = expectation(description: "Broken structure Error raised")
 
-        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore) { error in
+        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore) { error, params in
             switch error {
-            case .bookmarksStructureBroken(let errorInfo):
+            case .bookmarksStructureBroken:
                 expectation.fulfill()
 
-                XCTAssertEqual(errorInfo[FavoritesFolderID.unified.rawValue], "1")
-                XCTAssertEqual(errorInfo[FavoritesFolderID.mobile.rawValue], "1")
-                XCTAssertEqual(errorInfo[FavoritesFolderID.desktop.rawValue], "1")
-                XCTAssertEqual(errorInfo[BookmarkEntity.Constants.rootFolderID], "2")
+                XCTAssertEqual(params?[FavoritesFolderID.unified.rawValue], "1")
+                XCTAssertEqual(params?[FavoritesFolderID.mobile.rawValue], "1")
+                XCTAssertEqual(params?[FavoritesFolderID.desktop.rawValue], "1")
+                XCTAssertEqual(params?[BookmarkEntity.Constants.rootFolderID], "2")
             default:
                 XCTFail("Did not expect error: \(error)")
             }

--- a/iOS/DuckDuckGoTests/BookmarksStateValidationTests.swift
+++ b/iOS/DuckDuckGoTests/BookmarksStateValidationTests.swift
@@ -62,7 +62,7 @@ class BookmarksStateValidationTests: XCTestCase {
             BookmarkUtils.prepareFoldersStructure(in: context)
         }
 
-        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore) { error, _  in
+        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore, isSyncEnabled: false) { error, _  in
             XCTFail("Did not expect error: \(error)")
         }
 
@@ -77,7 +77,7 @@ class BookmarksStateValidationTests: XCTestCase {
 
     func testWhenDatabaseIsEmptyButItHasNotBeenInitiatedThenThereIsNoError() {
 
-        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore) { error, _ in
+        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore, isSyncEnabled: false) { error, _ in
             XCTFail("Did not expect error: \(error)")
         }
 
@@ -92,7 +92,7 @@ class BookmarksStateValidationTests: XCTestCase {
         let expectation1 = expectation(description: "Lost structure Error raised")
         let expectation2 = expectation(description: "Broken structure Error raised")
 
-        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore) { error, _ in
+        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore, isSyncEnabled: false) { error, _ in
             switch error {
             case .bookmarksStructureLost:
                 expectation1.fulfill()
@@ -130,7 +130,7 @@ class BookmarksStateValidationTests: XCTestCase {
 
         let expectation = expectation(description: "Broken structure Error raised")
 
-        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore) { error, params in
+        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore, isSyncEnabled: false) { error, params in
             switch error {
             case .bookmarksStructureBroken:
                 expectation.fulfill()
@@ -170,7 +170,7 @@ class BookmarksStateValidationTests: XCTestCase {
 
         let expectation = expectation(description: "Broken structure Error raised")
 
-        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore) { error, params in
+        let validator = BookmarksStateValidator(keyValueStore: mockKeyValueStore, isSyncEnabled: false) { error, params in
             switch error {
             case .bookmarksStructureBroken:
                 expectation.fulfill()

--- a/iOS/PixelDefinitions/pixels/crash_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/crash_pixels.json5
@@ -173,10 +173,12 @@
             'appVersion',
             {
                 key: 'root-uuid',
-                description: 'UUID of the root folder that sync attempted to delete',
+                description: 'Name of the root folder that sync attempted to delete',
                 type: 'string',
+                enum: ['mobile_favorites_root', 'desktop_favorites_root', 'favorites_root', 'bookmarks_root'],
             },
         ],
+        expires: '2025-10-31',
     },
 
     // Specific database setup error pixels

--- a/iOS/PixelDefinitions/pixels/crash_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/crash_pixels.json5
@@ -123,7 +123,7 @@
         description: 'Fires when bookmarks database loads but structure is missing/empty with detailed diagnostics.',
         owners: ['jaceklyp', 'bwaresiak'],
         triggers: ['exception'],
-        suffixes: ['platform', 'form_factor', 'daily_and_count'],
+        suffixes: ['platform', 'form_factor', 'first_daily_count'],
         parameters: [
             'appVersion',
             {
@@ -159,7 +159,7 @@
         description: 'Fires when structure lost occurs after app crash to identify crash-related corruption.',
         owners: ['jaceklyp', 'bwaresiak'],
         triggers: ['exception'],
-        suffixes: ['platform', 'form_factor', 'daily_and_count'],
+        suffixes: ['platform', 'form_factor', 'first_daily_count'],
         parameters: ['appVersion'],
     },
 
@@ -184,7 +184,7 @@
         description: 'Fires when unable to get favorites order during database setup.',
         owners: ['jaceklyp', 'bwaresiak'],
         triggers: ['exception'],
-        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        suffixes: ['platform', 'form_factor', 'first_daily_count'],
         parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
     },
 
@@ -192,7 +192,7 @@
         description: 'Fires when database preparation fails during setup.',
         owners: ['jaceklyp', 'bwaresiak'],
         triggers: ['exception'],
-        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        suffixes: ['platform', 'form_factor', 'first_daily_count'],
         parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
     },
 
@@ -201,7 +201,7 @@
         description: 'Fires when no database scheme found in legacy bookmarks storage.',
         owners: ['jaceklyp', 'bwaresiak'],
         triggers: ['exception'],
-        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        suffixes: ['platform', 'form_factor', 'first_daily_count'],
         parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
     },
 
@@ -209,7 +209,7 @@
         description: 'Fires when unable to load persistent stores in legacy bookmarks storage.',
         owners: ['jaceklyp', 'bwaresiak'],
         triggers: ['exception'],
-        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        suffixes: ['platform', 'form_factor', 'first_daily_count'],
         parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
     },
 
@@ -217,7 +217,7 @@
         description: 'Fires when unable to create top-level bookmarks folder in legacy storage.',
         owners: ['jaceklyp', 'bwaresiak'],
         triggers: ['exception'],
-        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        suffixes: ['platform', 'form_factor', 'first_daily_count'],
         parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
     },
 
@@ -225,7 +225,7 @@
         description: 'Fires when unable to create top-level favorites folder in legacy storage.',
         owners: ['jaceklyp', 'bwaresiak'],
         triggers: ['exception'],
-        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        suffixes: ['platform', 'form_factor', 'first_daily_count'],
         parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
     },
 
@@ -233,7 +233,7 @@
         description: 'Fires when unable to fix corrupted bookmark folder structure in legacy storage.',
         owners: ['jaceklyp', 'bwaresiak'],
         triggers: ['exception'],
-        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        suffixes: ['platform', 'form_factor', 'first_daily_count'],
         parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
     },
 
@@ -241,7 +241,7 @@
         description: 'Fires when unable to fix corrupted favorite folder structure in legacy storage.',
         owners: ['jaceklyp', 'bwaresiak'],
         triggers: ['exception'],
-        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        suffixes: ['platform', 'form_factor', 'first_daily_count'],
         parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
     },
 
@@ -250,7 +250,7 @@
         description: 'Fires when unable to prepare database structure during migration.',
         owners: ['jaceklyp', 'bwaresiak'],
         triggers: ['exception'],
-        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        suffixes: ['platform', 'form_factor', 'first_daily_count'],
         parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
     },
 
@@ -258,7 +258,7 @@
         description: 'Fires when unable to write to database during migration.',
         owners: ['jaceklyp', 'bwaresiak'],
         triggers: ['exception'],
-        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        suffixes: ['platform', 'form_factor', 'first_daily_count'],
         parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
     },
 }

--- a/iOS/PixelDefinitions/pixels/crash_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/crash_pixels.json5
@@ -117,4 +117,148 @@
         suffixes: ['platform', 'form_factor', 'first_daily_count'],
         parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
     },
+
+    // Enhanced bookmarks structure lost pixel with diagnostic parameters
+    m_d_bookmarks_structure_lost: {
+        description: 'Fires when bookmarks database loads but structure is missing/empty with detailed diagnostics.',
+        owners: ['jaceklyp', 'bwaresiak'],
+        triggers: ['exception'],
+        suffixes: ['platform', 'form_factor', 'daily_and_count'],
+        parameters: [
+            'appVersion',
+            {
+                key: 'sync-enabled',
+                description: 'Whether sync is enabled',
+                type: 'boolean',
+            },
+            {
+                key: 'recent-bookmark-error-name',
+                description: 'Name of recent bookmark error case within 24 hours',
+                type: 'string',
+            },
+            {
+                key: 'recent-bookmark-error-domain',
+                description: 'Domain of recent bookmark error within 24 hours',
+                type: 'string',
+            },
+            {
+                key: 'recent-bookmark-error-code',
+                description: 'Code of recent bookmark error within 24 hours',
+                type: 'number',
+            },
+            {
+                key: 'launch-marker-present',
+                description: 'Whether app has successfully launched before (helps distinguish backup restore from corruption)',
+                type: 'boolean',
+            },
+        ],
+    },
+
+    // Crash correlation pixel
+    m_debug_bookmarks_structure_lost_after_crash: {
+        description: 'Fires when structure lost occurs after app crash to identify crash-related corruption.',
+        owners: ['jaceklyp', 'bwaresiak'],
+        triggers: ['exception'],
+        suffixes: ['platform', 'form_factor', 'daily_and_count'],
+        parameters: ['appVersion'],
+    },
+
+    // Sync vulnerability protection pixel
+    m_debug_bookmarks_sync_attempted_to_delete_root: {
+        description: 'Fires when sync attempts to delete root folders, indicating potential sync vulnerability.',
+        owners: ['jaceklyp', 'bwaresiak'],
+        triggers: ['exception'],
+        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        parameters: [
+            'appVersion',
+            {
+                key: 'root-uuid',
+                description: 'UUID of the root folder that sync attempted to delete',
+                type: 'string',
+            },
+        ],
+    },
+
+    // Specific database setup error pixels
+    m_debug_bookmarks_could_not_get_favorites_order: {
+        description: 'Fires when unable to get favorites order during database setup.',
+        owners: ['jaceklyp', 'bwaresiak'],
+        triggers: ['exception'],
+        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
+    },
+
+    m_debug_bookmarks_could_not_prepare_database: {
+        description: 'Fires when database preparation fails during setup.',
+        owners: ['jaceklyp', 'bwaresiak'],
+        triggers: ['exception'],
+        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
+    },
+
+    // Legacy storage error pixels
+    m_debug_bookmarks_no_db_scheme_found: {
+        description: 'Fires when no database scheme found in legacy bookmarks storage.',
+        owners: ['jaceklyp', 'bwaresiak'],
+        triggers: ['exception'],
+        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
+    },
+
+    m_debug_bookmarks_unable_to_load_persistent_stores: {
+        description: 'Fires when unable to load persistent stores in legacy bookmarks storage.',
+        owners: ['jaceklyp', 'bwaresiak'],
+        triggers: ['exception'],
+        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
+    },
+
+    m_debug_bookmarks_error_creating_top_level_bookmarks_folder: {
+        description: 'Fires when unable to create top-level bookmarks folder in legacy storage.',
+        owners: ['jaceklyp', 'bwaresiak'],
+        triggers: ['exception'],
+        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
+    },
+
+    m_debug_bookmarks_error_creating_top_level_favorites_folder: {
+        description: 'Fires when unable to create top-level favorites folder in legacy storage.',
+        owners: ['jaceklyp', 'bwaresiak'],
+        triggers: ['exception'],
+        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
+    },
+
+    m_debug_bookmarks_could_not_fix_bookmark_folder: {
+        description: 'Fires when unable to fix corrupted bookmark folder structure in legacy storage.',
+        owners: ['jaceklyp', 'bwaresiak'],
+        triggers: ['exception'],
+        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
+    },
+
+    m_debug_bookmarks_could_not_fix_favorite_folder: {
+        description: 'Fires when unable to fix corrupted favorite folder structure in legacy storage.',
+        owners: ['jaceklyp', 'bwaresiak'],
+        triggers: ['exception'],
+        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
+    },
+
+    // Migration error pixels
+    m_debug_bookmarks_could_not_prepare_db_structure: {
+        description: 'Fires when unable to prepare database structure during migration.',
+        owners: ['jaceklyp', 'bwaresiak'],
+        triggers: ['exception'],
+        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
+    },
+
+    m_debug_bookmarks_could_not_write_to_db: {
+        description: 'Fires when unable to write to database during migration.',
+        owners: ['jaceklyp', 'bwaresiak'],
+        triggers: ['exception'],
+        suffixes: ['platform', 'form_factor', 'daily_standard'],
+        parameters: ['appVersion', 'errorCode', 'errorDomain', 'underlyingErrorCode', 'underlyingErrorDomain'],
+    },
 }

--- a/macOS/DuckDuckGo/Sync/SyncMetricsEventsHandler.swift
+++ b/macOS/DuckDuckGo/Sync/SyncMetricsEventsHandler.swift
@@ -30,6 +30,8 @@ public class SyncMetricsEventsHandler: EventMapping<MetricsEvent> {
                 PixelKit.fire(GeneralPixel.syncDuckAddressOverride)
             case .localTimestampResolutionTriggered(let feature):
                 PixelKit.fire(GeneralPixel.syncLocalTimestampResolutionTriggered(feature))
+            case .syncAttemptedToDeleteRoot(let rootID):
+                break
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211050177427683?focus=true
CC: @brindy 

### Description
1. Added 5 diagnostic parameters to identify root causes (sync status, recent errors, file marker presence)
2. Replaced 1 generic database error pixel with 10 specific error pixels for precise failure identification
3. Added pixel to track sync attempts to delete root folders
4. Added pixel to correlate structure loss with app crashes
5. Refactored legacy fatalError calls to structured error throwing with detailed tracking
6. Added file marker system to possibly distinguish backup restores from actual db corruption

### Testing Steps
1. Since there is no straightforward way to confirm that all errors are handled, the recommended approach is to review each error type originating from the Terminating class related to bookmarks. Attempt to reproduce conditions that trigger these errors and verify that they are properly propagated back to the Terminating class.
2. After triggering an error, recompile the app and simulate the structure_lost case. Verify that the recent-bookmark-error-* parameters are populated (non-nil).
3. Enable sync and confirm that the structure_lost pixel includes the parameter sync-enabled with the value true.
4. Use the Crash App option in the Debug menu, then recompile the app and again simulate the structure_lost case. Verify that the debugBookmarksStructureLostAfterCrash pixel is sent.

### Impact and Risks
What's the impact on users if something goes wrong?
High: Could affect user privacy, lose user data, break core functionality

#### What could go wrong?
Some app startup paths may have changed, and we might now be crashing in places we didn’t before.