### PR TITLE
macOS: Prevent post-crash restore prompt from interfering with UI tests

### DIFF
--- a/macOS/DuckDuckGo/StateRestoration/AppStateRestorationManager.swift
+++ b/macOS/DuckDuckGo/StateRestoration/AppStateRestorationManager.swift
@@ -212,6 +212,12 @@ final class AppStateRestorationManager: NSObject {
     }
 
     private func detectUnexpectedAppTermination() {
+#if DEBUG || REVIEW
+        guard AppVersion.runType != .uiTests else {
+            return
+        }
+#endif
+
         let didCloseUnexpectedly = !appDidTerminateAsExpected
         appDidTerminateAsExpected = false // Set to false so it will be false if the app closes without terminating properly
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1211255127092280?focus=true
Tech Design URL:
CC: @tomasstrba 

### Description

There is a new post-crash restore prompt that is triggered when the app does not terminate as expected. This can be triggered by sudden app terminations in test runs, causing the prompt to appear and interfere with unrelated UI tests.

This PR disables the prompt during UI tests by skipping the check for unexpected app terminations. This is a bit risky because it alters the app behavior during UI tests, but as of now we aren’t doing any explicit UI testing of this prompt and it causes spurious failures. This allows the prompt to continue working normally outside of UI tests, e.g. in normal runs of debug/review builds. (I’ll raise this in the project postmortem for further discussion about potential risks/followups.)

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Confirm UI tests pass and the prompt does not appear during UI test runs.
2. Build the app normally and ensure automatic session restore is disabled in Settings → General.
3. Open one or more websites (so there is something to restore).
4. Go to Debug > Simulate crash > select any crash type.
5. Reopen the app and confirm the popover appears.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
This is a UI test fix. If it goes wrong it could disable the post-crash restore prompt, so for extra safety the guard statement is limited to debug and review builds.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)