### PR TITLE
iOS: New Search/Duck.ai Input Metrics - Query/Prompt Length Distribution

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1362,6 +1362,8 @@
 		C13830FE2DCD3FFC00A29B3C /* CreditCardInputAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13830FD2DCD3FFC00A29B3C /* CreditCardInputAccessoryView.swift */; };
 		C13B32D22A0E750700A59236 /* AutofillSettingStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13B32D12A0E750700A59236 /* AutofillSettingStatus.swift */; };
 		C13C076C2D00A6B7006386CF /* VaultCredentialManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13C076B2D00A6B7006386CF /* VaultCredentialManager.swift */; };
+		C13C60DA2E6D7AE100ED2211 /* SwitchBarSubmissionMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13C60D92E6D7AE100ED2211 /* SwitchBarSubmissionMetrics.swift */; };
+		C13C60DC2E6D7B0F00ED2211 /* SwitchBarSubmissionMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13C60DB2E6D7B0F00ED2211 /* SwitchBarSubmissionMetricsTests.swift */; };
 		C13EEA1E2D64CFCA001D5DC3 /* DataImportViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13EEA1D2D64CFCA001D5DC3 /* DataImportViewModelTests.swift */; };
 		C13EEA202D64E59A001D5DC3 /* ZipContentSelectionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13EEA1F2D64E59A001D5DC3 /* ZipContentSelectionViewModelTests.swift */; };
 		C13EEA222D64F6DB001D5DC3 /* DataImportSummaryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13EEA212D64F6DB001D5DC3 /* DataImportSummaryViewModelTests.swift */; };
@@ -3515,6 +3517,8 @@
 		C13830FD2DCD3FFC00A29B3C /* CreditCardInputAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardInputAccessoryView.swift; sourceTree = "<group>"; };
 		C13B32D12A0E750700A59236 /* AutofillSettingStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutofillSettingStatus.swift; sourceTree = "<group>"; };
 		C13C076B2D00A6B7006386CF /* VaultCredentialManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultCredentialManager.swift; sourceTree = "<group>"; };
+		C13C60D92E6D7AE100ED2211 /* SwitchBarSubmissionMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchBarSubmissionMetrics.swift; sourceTree = "<group>"; };
+		C13C60DB2E6D7B0F00ED2211 /* SwitchBarSubmissionMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchBarSubmissionMetricsTests.swift; sourceTree = "<group>"; };
 		C13EEA1D2D64CFCA001D5DC3 /* DataImportViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataImportViewModelTests.swift; sourceTree = "<group>"; };
 		C13EEA1F2D64E59A001D5DC3 /* ZipContentSelectionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipContentSelectionViewModelTests.swift; sourceTree = "<group>"; };
 		C13EEA212D64F6DB001D5DC3 /* DataImportSummaryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataImportSummaryViewModelTests.swift; sourceTree = "<group>"; };
@@ -4720,6 +4724,7 @@
 			children = (
 				317DD5542E0D5DD300CCC28C /* SwitchBarHandlerTests.swift */,
 				C1AAECBE2E69A1CC0016B82E /* SessionStateMetricsTests.swift */,
+				C13C60DB2E6D7B0F00ED2211 /* SwitchBarSubmissionMetricsTests.swift */,
 			);
 			path = SwitchBar;
 			sourceTree = "<group>";
@@ -5275,6 +5280,7 @@
 				315E14A72DF77BCD00419C8A /* SwitchBarHandler.swift */,
 				315E14A82DF77BCD00419C8A /* SwitchBarViewController.swift */,
 				C1AAECBC2E699F740016B82E /* SessionStateMetrics.swift */,
+				C13C60D92E6D7AE100ED2211 /* SwitchBarSubmissionMetrics.swift */,
 			);
 			path = SwitchBar;
 			sourceTree = "<group>";
@@ -10479,6 +10485,7 @@
 				1E8AD1CF27C000A000ABA377 /* CompleteDownloadRow.swift in Sources */,
 				98D98A8F25ED952F00D8E3DF /* BrowsingMenuButton.swift in Sources */,
 				31C3149F2D2EEB44009A412A /* AIChatUserScript.swift in Sources */,
+				C13C60DA2E6D7AE100ED2211 /* SwitchBarSubmissionMetrics.swift in Sources */,
 				31C314A02D2EEB44009A412A /* AIChatUserScriptHandling.swift in Sources */,
 				9865DFF922A8220D00D27829 /* FavoritesOverlay.swift in Sources */,
 				1E4DCF4627B6A33600961E25 /* DownloadsListViewModel.swift in Sources */,
@@ -10619,6 +10626,7 @@
 				F189AEE41F18FDAF001EBAE1 /* LinkTests.swift in Sources */,
 				C1E2C2272D9F1D0F0011C66C /* AutofillCreditCardDetailsViewModelTests.swift in Sources */,
 				C1056A562E253D98003220BA /* AutofillCredentialsImportPresentationManagerTests.swift in Sources */,
+				C13C60DC2E6D7B0F00ED2211 /* SwitchBarSubmissionMetricsTests.swift in Sources */,
 				6F7FB8E12C660B3E00867DA7 /* NewTabPageFavoritesModelTests.swift in Sources */,
 				C1C725B82D63810D00361B81 /* ImportArchiveReaderTests.swift in Sources */,
 				C1C725BA2D63810D00361B81 /* DataImportManagerTests.swift in Sources */,

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -67,11 +67,13 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
     private var suggestionTrayManager: SuggestionTrayManager?
     private let daxLogoManager = DaxLogoManager()
     private var notificationCancellable: AnyCancellable?
+    private let switchBarSubmissionMetrics: SwitchBarSubmissionMetricsProviding
 
     // MARK: - Initialization
 
-    internal init(switchBarHandler: any SwitchBarHandling) {
+    internal init(switchBarHandler: any SwitchBarHandling, switchBarSubmissionMetrics: SwitchBarSubmissionMetricsProviding = SwitchBarSubmissionMetrics()) {
         self.switchBarHandler = switchBarHandler
+        self.switchBarSubmissionMetrics = switchBarSubmissionMetrics
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -211,11 +213,11 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
 
                 switch submission.mode {
                 case .search:
-                    DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarQuerySubmitted)
+                    switchBarSubmissionMetrics.process(text, for: .search)
                     self.delegate?.onQuerySubmitted(text)
 
                 case .aiChat:
-                    DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarPromptSubmitted)
+                    switchBarSubmissionMetrics.process(text, for: .aiChat)
                     // If we (re)add the web rag button, then we need to add it to the array of tools Duck.ai should use
                     //  for this submission.
                     self.delegate?.onPromptSubmitted(text, tools: nil)

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarSubmissionMetrics.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarSubmissionMetrics.swift
@@ -32,7 +32,8 @@ enum SwitchBarTextBucket: String, CaseIterable {
     case veryLong = "very_long"
     
     /// Categorizes text by character count
-    init(_ text: String) {
+    init?(_ text: String) {
+        guard text.count > 0 else { return nil }
         switch text.count {
         case 1...15:
             self = .short
@@ -59,9 +60,7 @@ struct SwitchBarSubmissionMetrics: SwitchBarSubmissionMetricsProviding {
     
     /// Process text submission and fire pixel with length bucket parameter
     func process(_ text: String, for submissionMode: TextEntryMode) {
-        guard !text.isEmpty else { return }
-        
-        let bucket = SwitchBarTextBucket(text)
+        guard let bucket = SwitchBarTextBucket(text) else { return }
         
         let additionalParams = [textLengthBucketKey: bucket.rawValue]
         

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarSubmissionMetrics.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarSubmissionMetrics.swift
@@ -1,0 +1,75 @@
+//
+//  SwitchBarSubmissionMetrics.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Core
+
+/// Privacy-safe text length categorization for input analysis
+enum SwitchBarTextBucket: String, CaseIterable {
+    /// Short: 1-15 characters
+    case short
+    /// Medium: 16-40 characters
+    case medium
+    /// Long: 41-100 characters
+    case long
+    /// Very long: 100+ characters
+    case veryLong = "very_long"
+    
+    /// Categorizes text by character count
+    init(_ text: String) {
+        switch text.count {
+        case 1...15:
+            self = .short
+        case 16...40:
+            self = .medium
+        case 41...100:
+            self = .long
+        default:
+            self = .veryLong
+        }
+    }
+}
+
+/// Protocol for processing submission metrics with text length bucketing
+protocol SwitchBarSubmissionMetricsProviding {
+    /// Process text submission and fire pixel with length bucket parameter
+    func process(_ text: String, for submissionMode: TextEntryMode)
+}
+
+/// Handles text length analysis and pixel firing
+struct SwitchBarSubmissionMetrics: SwitchBarSubmissionMetricsProviding {
+    
+    private let textLengthBucketKey = "text_length_bucket"
+    
+    /// Process text submission and fire pixel with length bucket parameter
+    func process(_ text: String, for submissionMode: TextEntryMode) {
+        guard !text.isEmpty else { return }
+        
+        let bucket = SwitchBarTextBucket(text)
+        
+        let additionalParams = [textLengthBucketKey: bucket.rawValue]
+        
+        switch submissionMode {
+        case .search:
+            DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarQuerySubmitted, withAdditionalParameters: additionalParams)
+        case .aiChat:
+            DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarPromptSubmitted, withAdditionalParameters: additionalParams)
+        }
+    }
+}

--- a/iOS/DuckDuckGoTests/SwitchBar/SwitchBarSubmissionMetricsTests.swift
+++ b/iOS/DuckDuckGoTests/SwitchBar/SwitchBarSubmissionMetricsTests.swift
@@ -1,0 +1,139 @@
+//
+//  SwitchBarSubmissionMetricsTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo
+
+final class SwitchBarSubmissionMetricsTests: XCTestCase {
+    
+    // MARK: - SwitchBarTextBucket Tests
+    
+    func testTextBucketShort() {
+        let bucket = SwitchBarTextBucket("hello")
+        XCTAssertEqual(bucket, .short)
+        XCTAssertEqual(bucket.rawValue, "short")
+    }
+    
+    func testTextBucketShortBoundary() {
+        let bucket15 = SwitchBarTextBucket("123456789012345")
+        XCTAssertEqual(bucket15, .short)
+        XCTAssertEqual(bucket15.rawValue, "short")
+    }
+    
+    func testTextBucketMedium() {
+        let bucket = SwitchBarTextBucket("This is a medium text")
+        XCTAssertEqual(bucket, .medium)
+        XCTAssertEqual(bucket.rawValue, "medium")
+    }
+    
+    func testTextBucketMediumBoundaries() {
+        let bucket16 = SwitchBarTextBucket("1234567890123456")
+        XCTAssertEqual(bucket16, .medium)
+        
+        let bucket40 = SwitchBarTextBucket("1234567890123456789012345678901234567890")
+        XCTAssertEqual(bucket40, .medium)
+    }
+    
+    func testTextBucketLong() {
+        let bucket = SwitchBarTextBucket("This is a longer text that should be categorized as long text for testing purposes")
+        XCTAssertEqual(bucket, .long)
+        XCTAssertEqual(bucket.rawValue, "long")
+    }
+    
+    func testTextBucketLongBoundaries() {
+        let bucket41 = SwitchBarTextBucket("12345678901234567890123456789012345678901")
+        XCTAssertEqual(bucket41, .long)
+        
+        let bucket99 = SwitchBarTextBucket(String(repeating: "a", count: 99))
+        XCTAssertEqual(bucket99, .long)
+        
+        let bucket100 = SwitchBarTextBucket(String(repeating: "a", count: 100))
+        XCTAssertEqual(bucket100, .long)
+    }
+    
+    func testTextBucketVeryLong() {
+        let longText = String(repeating: "a", count: 150)
+        let bucket = SwitchBarTextBucket(longText)
+        XCTAssertEqual(bucket, .veryLong)
+        XCTAssertEqual(bucket.rawValue, "very_long")
+    }
+    
+    func testTextBucketVeryLongBoundary() {
+        let bucket100 = SwitchBarTextBucket(String(repeating: "a", count: 100))
+        XCTAssertEqual(bucket100, .long)
+        
+        let bucket101 = SwitchBarTextBucket(String(repeating: "a", count: 101))
+        XCTAssertEqual(bucket101, .veryLong)
+    }
+    
+    func testTextBucketEmptyString() {
+        let bucket = SwitchBarTextBucket("")
+        XCTAssertEqual(bucket, .veryLong)
+    }
+    
+    func testTextBucketSingleCharacter() {
+        let bucket = SwitchBarTextBucket("a")
+        XCTAssertEqual(bucket, .short)
+    }
+    
+    func testTextBucketUnicodeCharacters() {
+        let unicodeText = "Hello 👋 World 🌍"
+        let bucket = SwitchBarTextBucket(unicodeText)
+        XCTAssertEqual(bucket, .short)
+    }
+    
+    // MARK: - SwitchBarSubmissionMetrics Tests
+    
+    func testSubmissionMetricsProcessSearchShort() {
+        let metrics = SwitchBarSubmissionMetrics()
+        let shortText = "test"
+        
+        metrics.process(shortText, for: .search)
+    }
+    
+    func testSubmissionMetricsProcessAIChatMedium() {
+        let metrics = SwitchBarSubmissionMetrics()
+        let mediumText = "This is a medium length prompt for AI"
+        
+        metrics.process(mediumText, for: .aiChat)
+    }
+    
+    func testSubmissionMetricsProcessSearchLong() {
+        let metrics = SwitchBarSubmissionMetrics()
+        let longText = "This is a very long search query that should be categorized as long text"
+        
+        metrics.process(longText, for: .search)
+    }
+    
+    func testSubmissionMetricsProcessAIChatVeryLong() {
+        let metrics = SwitchBarSubmissionMetrics()
+        let veryLongText = String(repeating: "This is a very long prompt. ", count: 10)
+        
+        metrics.process(veryLongText, for: .aiChat)
+    }
+    
+    func testSubmissionMetricsProcessEmptyTextReturnsEarly() {
+        let metrics = SwitchBarSubmissionMetrics()
+        
+        // Should return early without firing pixels
+        metrics.process("", for: .search)
+        metrics.process("", for: .aiChat)
+    }
+
+}

--- a/iOS/DuckDuckGoTests/SwitchBar/SwitchBarSubmissionMetricsTests.swift
+++ b/iOS/DuckDuckGoTests/SwitchBar/SwitchBarSubmissionMetricsTests.swift
@@ -25,39 +25,39 @@ final class SwitchBarSubmissionMetricsTests: XCTestCase {
     // MARK: - SwitchBarTextBucket Tests
     
     func testTextBucketShort() {
-        let bucket = SwitchBarTextBucket("hello")
+        let bucket = SwitchBarTextBucket("hello")!
         XCTAssertEqual(bucket, .short)
         XCTAssertEqual(bucket.rawValue, "short")
     }
     
     func testTextBucketShortBoundary() {
-        let bucket15 = SwitchBarTextBucket("123456789012345")
+        let bucket15 = SwitchBarTextBucket("123456789012345")!
         XCTAssertEqual(bucket15, .short)
         XCTAssertEqual(bucket15.rawValue, "short")
     }
     
     func testTextBucketMedium() {
-        let bucket = SwitchBarTextBucket("This is a medium text")
+        let bucket = SwitchBarTextBucket("This is a medium text")!
         XCTAssertEqual(bucket, .medium)
         XCTAssertEqual(bucket.rawValue, "medium")
     }
     
     func testTextBucketMediumBoundaries() {
-        let bucket16 = SwitchBarTextBucket("1234567890123456")
+        let bucket16 = SwitchBarTextBucket("1234567890123456")!
         XCTAssertEqual(bucket16, .medium)
         
-        let bucket40 = SwitchBarTextBucket("1234567890123456789012345678901234567890")
+        let bucket40 = SwitchBarTextBucket("1234567890123456789012345678901234567890")!
         XCTAssertEqual(bucket40, .medium)
     }
     
     func testTextBucketLong() {
-        let bucket = SwitchBarTextBucket("This is a longer text that should be categorized as long text for testing purposes")
+        let bucket = SwitchBarTextBucket("This is a longer text that should be categorized as long text for testing purposes")!
         XCTAssertEqual(bucket, .long)
         XCTAssertEqual(bucket.rawValue, "long")
     }
     
     func testTextBucketLongBoundaries() {
-        let bucket41 = SwitchBarTextBucket("12345678901234567890123456789012345678901")
+        let bucket41 = SwitchBarTextBucket("12345678901234567890123456789012345678901")!
         XCTAssertEqual(bucket41, .long)
         
         let bucket99 = SwitchBarTextBucket(String(repeating: "a", count: 99))
@@ -69,32 +69,32 @@ final class SwitchBarSubmissionMetricsTests: XCTestCase {
     
     func testTextBucketVeryLong() {
         let longText = String(repeating: "a", count: 150)
-        let bucket = SwitchBarTextBucket(longText)
+        let bucket = SwitchBarTextBucket(longText)!
         XCTAssertEqual(bucket, .veryLong)
         XCTAssertEqual(bucket.rawValue, "very_long")
     }
     
     func testTextBucketVeryLongBoundary() {
-        let bucket100 = SwitchBarTextBucket(String(repeating: "a", count: 100))
+        let bucket100 = SwitchBarTextBucket(String(repeating: "a", count: 100))!
         XCTAssertEqual(bucket100, .long)
         
-        let bucket101 = SwitchBarTextBucket(String(repeating: "a", count: 101))
+        let bucket101 = SwitchBarTextBucket(String(repeating: "a", count: 101))!
         XCTAssertEqual(bucket101, .veryLong)
     }
     
     func testTextBucketEmptyString() {
         let bucket = SwitchBarTextBucket("")
-        XCTAssertEqual(bucket, .veryLong)
+        XCTAssertNil(bucket)
     }
     
     func testTextBucketSingleCharacter() {
-        let bucket = SwitchBarTextBucket("a")
+        let bucket = SwitchBarTextBucket("a")!
         XCTAssertEqual(bucket, .short)
     }
     
     func testTextBucketUnicodeCharacters() {
         let unicodeText = "Hello 👋 World 🌍"
-        let bucket = SwitchBarTextBucket(unicodeText)
+        let bucket = SwitchBarTextBucket(unicodeText)!
         XCTAssertEqual(bucket, .short)
     }
     

--- a/iOS/PixelDefinitions/pixels/experimental_omnibar_metrics.json5
+++ b/iOS/PixelDefinitions/pixels/experimental_omnibar_metrics.json5
@@ -13,14 +13,30 @@
         owners: ['aataraxiaa'],
         triggers: ['other'],
         suffixes: ['first_daily_count', 'platform', 'form_factor'],
-        parameters: ['appVersion', 'pixelSource'],
+        parameters: [
+            'appVersion',
+            'pixelSource',
+            {
+                key: 'text_length_bucket',
+                description: 'Indicates length of AI prompt text using buckets: short (1-15), medium (16-40), long (41-100), very_long (100+)',
+                type: 'string',
+            },
+        ],
     },
     m_aichat_experimental_omnibar_query_submitted: {
         description: 'Fires when user submits a search query through the experimental omnibar',
         owners: ['aataraxiaa'],
         triggers: ['other'],
         suffixes: ['first_daily_count', 'platform', 'form_factor'],
-        parameters: ['appVersion', 'pixelSource'],
+        parameters: [
+            'appVersion',
+            'pixelSource',
+            {
+                key: 'text_length_bucket',
+                description: 'Indicates length of search query text using buckets: short (1-15), medium (16-40), long (41-100), very_long (100+)',
+                type: 'string',
+            },
+        ],
     },
     m_aichat_experimental_omnibar_mode_switched: {
         description: 'Fires when user toggles between search and AI chat modes in the experimental omnibar',


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211206058788136

### Description
Add metrics to understand text input patterns - query/prompt length distribution for searches vs Duck.ai usage  

#### Changes:
Add `text_length_bucket` parameter to 2 existing pixels:
1. `m_aichat_experimental_omnibar_query_submitted`
2. `m_aichat_experimental_omnibar_prompt_submitted`

### Query & Prompt Length Analysis Testing Steps
#### Search Query - Short Text
* **Prereqs**: Enable experimental omnibar, ensure in search mode
* **Steps**: Type short query (1-15 chars) → Submit
* **Expected**: `m_aichat_experimental_omnibar_query_submitted` pixel fires with `text_length_bucket: "short"`

#### Search Query - Medium Text
* **Prereqs**: Ensure in search mode
* **Steps**: Type medium query (16-40 chars) → Submit
* **Expected**: `m_aichat_experimental_omnibar_query_submitted` pixel fires with `text_length_bucket: "medium"`

#### Search Query - Long Text
* **Prereqs**: Ensure in search mode
* **Steps**: Type long query (41-100 chars) → Submit
* **Expected**: `m_aichat_experimental_omnibar_query_submitted` pixel fires with `text_length_bucket: "long"`

#### Search Query - Very Long Text
* **Prereqs**: Ensure in search mode
* **Steps**: Type very long query (100+ chars) → Submit
* **Expected**: `m_aichat_experimental_omnibar_query_submitted` pixel fires with `text_length_bucket: "very_long"`

#### AI Prompt - Short Text
* **Prereqs**: Toggle to AI chat mode
* **Steps**: Type short prompt (1-15 chars) → Submit
* **Expected**: `m_aichat_experimental_omnibar_prompt_submitted` pixel fires with `text_length_bucket: "short"`

#### AI Prompt - Medium Text
* **Prereqs**: Ensure in AI chat mode
* **Steps**: Type medium prompt (16-40 chars) → Submit
* **Expected**: `m_aichat_experimental_omnibar_prompt_submitted` pixel fires with `text_length_bucket: "medium"`

#### AI Prompt - Long Text
* **Prereqs**: Ensure in AI chat mode
* **Steps**: Type long prompt (41-100 chars) → Submit
* **Expected**: `m_aichat_experimental_omnibar_prompt_submitted` pixel fires with `text_length_bucket: "long"`

#### AI Prompt - Very Long Text
* **Prereqs**: Ensure in AI chat mode
* **Steps**: Type very long prompt (100+ chars) → Submit
* **Expected**: `m_aichat_experimental_omnibar_prompt_submitted` pixel fires with `text_length_bucket: "very_long"`

#### Empty Text Submission Guard
* **Steps**: Leave text empty → Try to submit (both search and AI modes)
* **Expected**: No pixels fire (guard prevents empty submissions)

### Impact and Risks
Low, pixels.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)