### PR TITLE
Only open file open dialog prompt in the current window

### DIFF
--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -742,7 +742,8 @@ final class BrowserTabViewController: NSViewController {
         // AI Chat sidebar user interaction dialog
         let aiChatSidebarUserDialog = NotificationCenter.default.publisher(for: .aiChatSidebarUserInteractionDialogChanged)
             .map { notification in
-                notification.userInfo?[NSNotification.Name.UserInfoKeys.userInteractionDialog] as? Tab.UserDialog
+                guard let window = self.view.window, window.isKeyWindow == true else { return nil as Tab.UserDialog? }
+                return notification.userInfo?[NSNotification.Name.UserInfoKeys.userInteractionDialog] as? Tab.UserDialog
             }
             .prepend(nil)
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1203936086921904/task/1211199502041471?focus=true
Tech Design URL:
CC:

### Description
Fix for file picker modal appearing on every app window when attempting to upload image to Duck.ai sidebar.

### Testing Steps
1. Open multiple windows with active tab displaying various content (website, website + sidebar, NTP, full Duck.ai etc)
2. Open another window, navigate to a website and open Duck.ai sidebar
3. In the sidebar click a button to upload an image to the conversation
4. Confirm that the modal file selection dialog only appears on the window where the action originated 

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
File selection dialog is not appearing at all

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)