### PR TITLE
[iOS][PiP] Audio Session crash fix attempt

### DIFF
--- a/iOS/DuckDuckGoTests/VideoPlayer/VideoPlayerCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/VideoPlayer/VideoPlayerCoordinatorTests.swift
@@ -221,19 +221,20 @@ final class VideoPlayerCoordinatorTests {
     }
 
     @Test(
-        "Check Audio Session Is Configured When Picture In Picture Required",
+        "Check Audio Session Is Configured When Video Is Loaded And Picture In Picture Required",
         arguments: [
             VideoPlayerConfiguration(allowsPictureInPicturePlayback: true),
             VideoPlayerConfiguration(allowsPictureInPicturePlayback: false)
         ]
 
     )
-    func whenPictureInPictureRequiredThenConfigureAudioSession(configuration: VideoPlayerConfiguration) {
+    func whenVideoLoadAndPictureInPictureRequiredThenConfigureAudioSession(configuration: VideoPlayerConfiguration) async {
         // GIVEN
+        let sut = makeSUT(configuration: configuration)
         #expect(!mockAudioSessionManager.didCallSetPlaybackSessionActive)
 
         // WHEN
-        makeSUT(configuration: configuration)
+        await sut.loadAsset(url: videoURL, shouldLoopVideo: false).value
 
         // THEN
         #expect(mockAudioSessionManager.didCallSetPlaybackSessionActive == configuration.allowsPictureInPicturePlayback)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1211300957879410?focus=true
Tech Design URL:
CC:

### Description

This PR attempt to fix crashes when the AudioSession is created or set active by delaying its creation until the video gets loaded. This happens when we’re about to show PiP to the user.

### Testing Steps
**Scenario 1 - “Onboarding"**
1. Open Debug Menu.
2. Select ‘Onboarding’.
3. Tap ‘Preview Onboarding Intro’ button.
4. Progress linear onboarding till ‘Protections Activated!’ screen.
5. Tap ‘Choose Your Browser’ button.
6. Ensure that the app deeplinks to the settings and PiP Video is playing.
7. Go back to the App.
8. Ensure that the PiP video is not playing anymore and the onboarding flow has progressed to:
9. ‘Add me to your Dock’ screen for iPhone.
10. 'Choose App Icon color’ screen for iPad.
11. On the 'Add me to your Dock’ screen tap the ’Shoe Me How’ button.
12. Ensure the 'Add to Dock' video plays fine.
13. Send the app to the background and ensure NO pip video plays.

**Scenario 2 - “Settings"**
1. Open Settings Menu.
2. Tap ‘Default Browser’ button from ‘Privacy Protections’ section.
3. Ensure that the app deeplinks to the settings and PiP Video is playing.
4. Go back to the App.
5. Ensure that the PiP video is not playing anymore.

**Scenario 3 - “SAD Active Users”:**
1. In DefaultBrowserModalPresenter.swift comment line 43-46 and 48-50.
2. Launch the app
3. Once the modal show tap ’Set Default Browser’ button.
4. Ensure that the app deeplinks to the settings and PiP Video is playing.
5. Go back to the App.
6. Ensure that the PiP video is not playing anymore.

**Scenario 4 - “SAD Inactive Users”**
1. In DefaultBrowserModalPresenter.swift comment line 43-47 and 49-50.
2. Launch the app
3. Once the modal show tap ’Open Links with DuckDuckGo’ button.
4. Ensure that the app deeplinks to the settings and PiP Video is playing.
5. Go back to the App.
6. Ensure that the PiP video is not playing anymore.

### Impact and Risks
Low: the crash already exists in production.

#### What could go wrong?
PiP won’t appear. We’ll ensure all the scenarios are manually tested. PiP is available only on physical device so we cannot write UI tests as we don’t run them on a device farm.

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)