### PR TITLE
macOS: Allow pinning special pages

### DIFF
--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -1472,7 +1472,7 @@ extension MainViewController: NSMenuItemValidation {
 
         // Pin Tab
         case #selector(MainViewController.pinOrUnpinTab(_:)):
-            guard getActiveTabAndIndex()?.tab.isUrl == true,
+            guard getActiveTabAndIndex()?.tab.content.canBePinned == true,
                   tabCollectionViewModel.pinnedTabsManager != nil,
                   !isBurner
             else {

--- a/macOS/DuckDuckGo/Tab/Model/TabContent.swift
+++ b/macOS/DuckDuckGo/Tab/Model/TabContent.swift
@@ -338,7 +338,9 @@ extension TabContent {
 
     var canBePinned: Bool {
         switch self {
-        case .subscription, .identityTheftRestoration, .dataBrokerProtection, .releaseNotes, .history:
+        case .subscription, .identityTheftRestoration, .dataBrokerProtection, .history, .settings, .newtab, .bookmarks:
+            return true
+        case .releaseNotes:
             return false
         default:
             return isUrl

--- a/macOS/UITests/Common/XCUIApplicationExtension.swift
+++ b/macOS/UITests/Common/XCUIApplicationExtension.swift
@@ -163,6 +163,14 @@ extension XCUIApplication {
         typeKey("j", modifierFlags: .command)
     }
 
+    /// Opens settings
+    func openSettings() {
+        typeKey(",", modifierFlags: .command)
+        XCTAssertTrue(
+            preferencesWindow.scrollViews[AccessibilityIdentifiers.settingsScrollView].waitForExistence(timeout: UITests.Timeouts.elementExistence)
+        )
+    }
+
     func openSite(pageTitle: String) {
         let url = UITests.simpleServedPage(titled: pageTitle)
         let addressBar = addressBar

--- a/macOS/UITests/PinnedTabsTests.swift
+++ b/macOS/UITests/PinnedTabsTests.swift
@@ -46,6 +46,12 @@ class PinnedTabsTests: UITestCase {
         assertPinnedTabsRestoredState()
     }
 
+    func testSettingsCanBePinned() {
+        app.openSettings()
+        pinCurrentPage()
+        assertCurrentPageCanBeUnpinned()
+    }
+
     // MARK: - Utilities
 
     private func openThreeSitesOnSameWindow() {
@@ -74,11 +80,15 @@ class PinnedTabsTests: UITestCase {
     private func pinsPageOne() {
         app.typeKey("[", modifierFlags: [.command, .shift])
         app.typeKey("[", modifierFlags: [.command, .shift])
-        app.menuItems["Pin Tab"].tap()
+        pinCurrentPage()
     }
 
     private func pinsPageTwo() {
         app.typeKey("]", modifierFlags: [.command, .shift])
+        pinCurrentPage()
+    }
+    
+    private func pinCurrentPage() {
         app.menuItems["Pin Tab"].tap()
     }
 
@@ -153,6 +163,12 @@ class PinnedTabsTests: UITestCase {
         XCTAssertTrue(newApp.staticTexts["Sample text for Page #1"].waitForExistence(timeout: UITests.Timeouts.elementExistence))
     }
 
+    private func assertCurrentPageCanBeUnpinned() {
+        XCTAssertTrue(
+            app.menuItems["Unpin Tab"].waitForExistence(timeout: UITests.Timeouts.elementExistence)
+        )
+    }
+    
     private func waitForSite(pageTitle: String) {
         XCTAssertTrue(app.windows.webViews[pageTitle].waitForExistence(timeout: UITests.Timeouts.elementExistence))
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1211211712495247?focus=true
Tech Design URL:
CC:

### Description
In this PR we’re allowing users to pin special pages, to bring the mac browser in line with its windows counterpart.

### Testing Steps
1. Open Settings (`cmd ,`)

- [ ] Verify `Window > Pin Tab` is enabled
- [ ] Verify you can **Pin / Unpin** the Settings UI via `Window > Pin Tab`
- [ ] Verify right-clicking the **Settings Tab** shows the Pin/Unpin Item, and it works as expected

2. Open Bookmarks (`option cmd B`)

- [ ] Verify `Window > Pin Tab` is enabled
- [ ] Verify you can **Pin / Unpin** the Bookmarks UI via `Window > Pin Tab`
- [ ] Verify right-clicking the **Bookmarks Tab** shows the Pin/Unpin Item, and it works as expected

3. Open History (`cmd Y`)

- [ ] Verify `Window > Pin Tab` is enabled
- [ ] Verify you can **Pin / Unpin** the History UI via `Window > Pin Tab`
- [ ] Verify right-clicking the **History Tab** shows the Pin/Unpin Item, and it works as expected

4. Open a New Tab (`cmd T`

- [ ] Verify `Window > Pin Tab` is enabled
- [ ] Verify you can **Pin / Unpin** the New Tab UI via `Window > Pin Tab`
- [ ] Verify right-clicking your **New Tab** shows the Pin/Unpin Item, and it works as expected



### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Users could be incorrectly allowed to pin Tabs that shouldn’t be.

### Quality Considerations
Test that it’s now allowed to bookmark special pages (Settings, History, Bookmarks, new Tab)

### Notes to Reviewer
Thanks in advance!

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)