### PR TITLE
ContentScopeUserScript needs to be loaded for Duck.ai

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/ContentBlockingTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/ContentBlockingTabExtension.swift
@@ -105,7 +105,9 @@ extension ContentBlockingTabExtension: NavigationResponder {
             // ContentScopeUserScript needs to be loaded for https://duckduckgo.com/subscriptions
             || navigationAction.url.absoluteString.hasPrefix(SubscriptionURL.baseURL.subscriptionURL(environment: .production).absoluteString)
             // ContentScopeUserScript needs to be loaded for https://duckduckgo.com/identity-theft-restoration
-            || navigationAction.url.absoluteString.hasPrefix(SubscriptionURL.identityTheftRestoration.subscriptionURL(environment: .production).absoluteString) {
+            || navigationAction.url.absoluteString.hasPrefix(SubscriptionURL.identityTheftRestoration.subscriptionURL(environment: .production).absoluteString)
+            // ContentScopeUserScript needs to be loaded for Duck.ai
+            || navigationAction.url.isDuckAIURL {
             await prepareForContentBlocking()
         }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1211312976401139?focus=true
Tech Design URL:
CC:

### Description
Ensure CSS load is being triggered on state restoration.

### Testing Steps
1. Enable "Reopen all windows from last session"
2. Navigate to Duck.ai 
3. Start a new or load previous conversation
4. Close the app
5. Reopen the app
**Expected:** On state restoration Duck.ai loads with the previous conversation.


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)