### PR TITLE
iOS: New Input Metrics - Temp disable prompt length pixels while awaiting privacy triage

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarSubmissionMetrics.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarSubmissionMetrics.swift
@@ -71,16 +71,22 @@ struct SwitchBarSubmissionMetrics: SwitchBarSubmissionMetricsProviding {
     ///   - text: Input text
     ///   - submissionMode: Whether this is a search query or AI chat prompt
     func process(_ text: String, for submissionMode: TextEntryMode) {
-        guard let bucket = SwitchBarTextBucket(text) else { return }
+        // Temp disable until privacy triage done
+//        guard let bucket = SwitchBarTextBucket(text) else { return }
         
-        let additionalParams = [textLengthBucketKey: bucket.rawValue]
+        // Temp disable until privacy triage done
+//        let additionalParams = [textLengthBucketKey: bucket.rawValue]
         
         switch submissionMode {
         case .search:
-            DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarQuerySubmitted, withAdditionalParameters: additionalParams)
+            // Temp disable until privacy triage done
+//            DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarQuerySubmitted, withAdditionalParameters: additionalParams)
+            DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarQuerySubmitted)
         case .aiChat:
-            let mergedParams = additionalParams.merging(featureDiscovery.addToParams([:], forFeature: .aiChat)) { (_, new) in new }
-            DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarPromptSubmitted, withAdditionalParameters: mergedParams)
+            // Temp disable until privacy trige done
+//            let mergedParams = additionalParams.merging(featureDiscovery.addToParams([:], forFeature: .aiChat)) { (_, new) in new }
+//            DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarPromptSubmitted, withAdditionalParameters: mergedParams)
+            DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarPromptSubmitted, withAdditionalParameters: featureDiscovery.addToParams([:], forFeature: .aiChat))
             featureDiscovery.setWasUsedBefore(.aiChat)
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211306690315584

### Description
We added pixels to capture prompt/query text length buckets. However, we missed the privacy triage. Running that now and until it’s complete disabling sending length bucket data.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. N/A Green CI

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)