### PR TITLE
Add a workaround for invalid keyboard frame on iOS 26

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -680,6 +680,14 @@ class MainViewController: UIViewController {
     private func keyboardDidHide() {
         keyboardShowing = false
         didSendGestureDismissPixel = false
+
+        if #available(iOS 26, *) {
+            // Make sure the UI adjusts properly.
+            // Fix for a weird behavior on iOS 26, firing `keyboardWillChangeFrame` event
+            // with the same frame when keyboard is shown and hidded rapidly.
+            // https://app.asana.com/1/137249556945/project/414709148257752/task/1211140989378405
+            adjustUI(withKeyboardFrame: .zero)
+        }
     }
 
     private func setUpToolbarButtonsActions() {
@@ -829,6 +837,10 @@ class MainViewController: UIViewController {
         let animationCurveRaw = animationCurveRawNSN?.uintValue ?? UIView.AnimationOptions.curveEaseInOut.rawValue
         let animationCurve = UIView.AnimationOptions(rawValue: animationCurveRaw)
 
+        adjustUI(withKeyboardFrame: keyboardFrame, in: duration, animationCurve: animationCurve)
+    }
+
+    private func adjustUI(withKeyboardFrame keyboardFrame: CGRect, in duration: TimeInterval = 0.2, animationCurve: UIView.AnimationOptions = .curveEaseInOut) {
         var keyboardHeight = keyboardFrame.size.height
 
         let omniBarHeight = viewCoordinator.omniBar.barView.expectedHeight
@@ -879,7 +891,6 @@ class MainViewController: UIViewController {
                 self.currentTab?.borderView.layoutIfNeeded()
             }
         }
-
     }
 
     private func initTabButton() {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -684,7 +684,7 @@ class MainViewController: UIViewController {
         if #available(iOS 26, *) {
             // Make sure the UI adjusts properly.
             // Fix for a weird behavior on iOS 26, firing `keyboardWillChangeFrame` event
-            // with the same frame when keyboard is shown and hidded rapidly.
+            // with the same frame when keyboard is shown and hidden rapidly.
             // https://app.asana.com/1/137249556945/project/414709148257752/task/1211140989378405
             adjustUI(withKeyboardFrame: .zero)
         }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1211140989378405?focus=true
Tech Design URL:
CC:

### Description

Adds a layout reset for iOS 26 and later for invalid/missing keyboard frame updates when keyboard is shown and hidden rapidly.

### Testing Steps
On both iOS 18 and iOS 26 (using simulator is fine)
1. Set address bar position to bottom
2. Open SERP with any query
3. Tap on SERP Region filter and close the dialog.
4. OmniBar and keyboard will attempt to show and hide quickly.
5. Verify OmniBar position updates properly.
6. Verify find in page layout is not broken.
7. Open a few other tabs and browse to any URL and do a keyboard smoke check.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features. Fix targets iOS 26 only.

#### What could go wrong?
Because of additional keyboard frame adjustments there may be some unexpected side effects, but there's nothing concrete coming to my mind. I treat that as very low risk since the adjustment is after the keyboard closes anyway. 

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)