### PR TITLE
macOS: Add pixels for monitoring success/failure to read or write the encryption key in the keychain

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -306,13 +306,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         } catch {
             Logger.general.error("App Encryption Key could not be read: \(error.localizedDescription)")
             fileStore = EncryptedFileStore()
-            switch error as? EncryptionKeyStoreError {
-            case .readFailed:
-                PixelKit.fire(DebugEvent(GeneralPixel.encryptionKeystoreReadKeyFailed, error: error), frequency: .dailyAndCount)
-            case .storageFailed:
-                PixelKit.fire(DebugEvent(GeneralPixel.encryptionKeystoreWriteKeyFailed, error: error), frequency: .dailyAndCount)
-            default:
-                break
+            if let pixelEvent = (error as? EncryptionKeyStoreError)?.debugPixel {
+                PixelKit.fire(pixelEvent, frequency: .dailyAndCount)
             }
         }
 

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -285,6 +285,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             didCrashDuringCrashHandlersSetUp.wrappedValue = false
         }
 
+        if AppVersion.runType.requiresEnvironment {
+            Self.configurePixelKit()
+        }
+
         do {
             keyValueStore = try KeyValueFileStore(location: URL.sandboxApplicationSupportURL, name: "AppKeyValueStore")
             // perform a dummy read to ensure that KVS is accessible
@@ -298,9 +302,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         do {
             let encryptionKey = AppVersion.runType.requiresEnvironment ? try keyStore.readKey() : nil
             fileStore = EncryptedFileStore(encryptionKey: encryptionKey)
+            PixelKit.fire(DebugEvent(GeneralPixel.encryptionKeystoreReadKeySucceeded), frequency: .dailyAndCount)
         } catch {
             Logger.general.error("App Encryption Key could not be read: \(error.localizedDescription)")
             fileStore = EncryptedFileStore()
+            switch error as? EncryptionKeyStoreError {
+            case .readFailed:
+                PixelKit.fire(DebugEvent(GeneralPixel.encryptionKeystoreReadKeyFailed, error: error), frequency: .dailyAndCount)
+            case .storageFailed:
+                PixelKit.fire(DebugEvent(GeneralPixel.encryptionKeystoreWriteKeyFailed, error: error), frequency: .dailyAndCount)
+            default:
+                break
+            }
         }
 
         bookmarkDatabase = BookmarkDatabase()
@@ -309,7 +322,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         internalUserDecider = DefaultInternalUserDecider(store: internalUserDeciderStore)
 
         if AppVersion.runType.requiresEnvironment {
-            Self.configurePixelKit()
             let commonDatabase = Database()
             database = commonDatabase
 

--- a/macOS/DuckDuckGo/Common/FileSystem/EncryptionKeys/EncryptionKeyStore.swift
+++ b/macOS/DuckDuckGo/Common/FileSystem/EncryptionKeys/EncryptionKeyStore.swift
@@ -74,6 +74,17 @@ enum EncryptionKeyStoreError: DDGError {
             return "Failed to transform string from keychain to base64 data with error code: \(status)"
         }
     }
+
+    var debugPixel: PixelKitEvent? {
+        switch self {
+        case .storageFailed:
+            return DebugEvent(GeneralPixel.encryptionKeystoreWriteKeyFailed, error: self)
+        case .readFailed:
+            return DebugEvent(GeneralPixel.encryptionKeystoreReadKeyFailed, error: self)
+        default:
+            return nil
+        }
+    }
 }
 
 final class EncryptionKeyStore: EncryptionKeyStoring {

--- a/macOS/DuckDuckGo/Common/FileSystem/EncryptionKeys/EncryptionKeyStore.swift
+++ b/macOS/DuckDuckGo/Common/FileSystem/EncryptionKeys/EncryptionKeyStore.swift
@@ -19,26 +19,59 @@
 import Foundation
 import CryptoKit
 import PixelKit
+import Common
 
-enum EncryptionKeyStoreError: Error, ErrorWithPixelParameters {
+enum EncryptionKeyStoreError: DDGError {
     case storageFailed(OSStatus)
     case readFailed(OSStatus)
     case deletionFailed(OSStatus)
     case cannotTransformDataToString(OSStatus)
-    case cannotTransfrotmStringToBase64Data(OSStatus)
+    case cannotTransformStringToBase64Data(OSStatus)
 
-    var errorParameters: [String: String] {
+    var errorDomain: String { "com.duckduckgo.EncryptionKeyStoreError" }
+
+    var errorCode: Int {
+        switch self {
+        case .storageFailed:
+            return 0
+        case .readFailed:
+            return 1
+        case .deletionFailed:
+            return 2
+        case .cannotTransformDataToString:
+            return 3
+        case .cannotTransformStringToBase64Data:
+            return 4
+        }
+    }
+
+    var underlyingError: Error? {
         switch self {
         case .storageFailed(let status):
-            return [PixelKit.Parameters.keychainErrorCode: "\(status)"]
+            return NSError(domain: NSOSStatusErrorDomain, code: Int(status))
         case .readFailed(let status):
-            return [PixelKit.Parameters.keychainErrorCode: "\(status)"]
+            return NSError(domain: NSOSStatusErrorDomain, code: Int(status))
         case .deletionFailed(let status):
-            return [PixelKit.Parameters.keychainErrorCode: "\(status)"]
+            return NSError(domain: NSOSStatusErrorDomain, code: Int(status))
         case .cannotTransformDataToString(let status):
-            return [PixelKit.Parameters.keychainErrorCode: "\(status)"]
-        case .cannotTransfrotmStringToBase64Data(let status):
-            return [PixelKit.Parameters.keychainErrorCode: "\(status)"]
+            return NSError(domain: NSOSStatusErrorDomain, code: Int(status))
+        case .cannotTransformStringToBase64Data(let status):
+            return NSError(domain: NSOSStatusErrorDomain, code: Int(status))
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .storageFailed(let status):
+            return "Failed to store encryption key in keychain with error code: \(status)"
+        case .readFailed(let status):
+            return "Failed to read encryption key from keychain with error code: \(status)"
+        case .deletionFailed(let status):
+            return "Failed to delete encryption key from keychain with error code: \(status)"
+        case .cannotTransformDataToString(let status):
+            return "Failed to transform data from keychain to string with error code: \(status)"
+        case .cannotTransformStringToBase64Data(let status):
+            return "Failed to transform string from keychain to base64 data with error code: \(status)"
         }
     }
 }
@@ -164,7 +197,7 @@ final class EncryptionKeyStore: EncryptionKeyStoring {
                     throw EncryptionKeyStoreError.cannotTransformDataToString(status)
                 }
                 guard let keyData = Data(base64Encoded: base64String) else {
-                    throw EncryptionKeyStoreError.cannotTransfrotmStringToBase64Data(status)
+                    throw EncryptionKeyStoreError.cannotTransformStringToBase64Data(status)
                 }
                 finalData = keyData
             }

--- a/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -522,6 +522,11 @@ enum GeneralPixel: PixelKitEvent {
     // Enhanced statistics
     case usageSegments
 
+    // Encryption key access
+    case encryptionKeystoreReadKeySucceeded
+    case encryptionKeystoreReadKeyFailed
+    case encryptionKeystoreWriteKeyFailed
+
     var name: String {
         switch self {
         case .crash(let appIdentifier):
@@ -1230,6 +1235,11 @@ enum GeneralPixel: PixelKitEvent {
 
             // Enhanced statistics
         case .usageSegments: return "retention_segments"
+
+            // Encryption key
+        case .encryptionKeystoreReadKeySucceeded: return "m_mac_encryption_keystore_read_key_succeeded"
+        case .encryptionKeystoreReadKeyFailed: return "m_mac_encryption_keystore_read_key_failed"
+        case .encryptionKeystoreWriteKeyFailed: return "m_mac_encryption_keystore_write_key_failed"
 
         }
     }

--- a/macOS/PixelDefinitions/pixels/encryption_keystore_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/encryption_keystore_pixels.json5
@@ -12,10 +12,10 @@
         parameters: [
             'appVersion',
             'pixelSource',
-            {
-                key: 'keychain_error_code',
-                description: 'OSStatus error code describing the failure',
-            },
+            'errorDomain',
+            'errorCode',
+            'underlyingErrorDomain',
+            'underlyingErrorCode',
         ],
     },
     'm_mac_encryption_keystore_write_key_failed': {
@@ -24,11 +24,11 @@
         triggers: ['other'],
         parameters: [
             'appVersion',
-            'pixelSource'
-            {
-                key: 'keychain_error_code',
-                description: 'OSStatus error code describing the failure',
-            },
+            'pixelSource',
+            'errorDomain',
+            'errorCode',
+            'underlyingErrorDomain',
+            'underlyingErrorCode',
         ],
     },
 }

--- a/macOS/PixelDefinitions/pixels/encryption_keystore_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/encryption_keystore_pixels.json5
@@ -1,0 +1,34 @@
+{
+    'm_mac_encryption_keystore_read_key_succeeded': {
+        description: 'Fired when EncryptionKeyStore successfully reads the DuckDuckGo encryption key from the keychain',
+        owners: ['rachelmcr'],
+        triggers: ['other'],
+        parameters: ['appVersion', 'pixelSource'],
+    },
+    'm_mac_encryption_keystore_read_key_failed': {
+        description: 'Fired when EncryptionKeyStore fails to read the DuckDuckGo encryption key from the keychain',
+        owners: ['rachelmcr'],
+        triggers: ['other'],
+        parameters: [
+            'appVersion',
+            'pixelSource',
+            {
+                key: 'keychain_error_code',
+                description: 'OSStatus error code describing the failure',
+            },
+        ],
+    },
+    'm_mac_encryption_keystore_write_key_failed': {
+        description: 'Fired when EncryptionKeyStore fails to write the DuckDuckGo encryption key to the keychain',
+        owners: ['rachelmcr'],
+        triggers: ['other'],
+        parameters: [
+            'appVersion',
+            'pixelSource'
+            {
+                key: 'keychain_error_code',
+                description: 'OSStatus error code describing the failure',
+            },
+        ],
+    },
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211290138405080?focus=true
Tech Design URL:
CC: @diegoreymendez 

### Description

This implements pixels for monitoring when we succeed or fail to read or write the encryption key in the keychain during app startup. The success pixel is used to provide context for failures, and the failures report the underlying OSStatus error. We will use these pixels to monitor for any unexpected failures when we migrate this key to shared storage.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
Success scenario:
1. Build and run the app.
2. Confirm the success pixel fires on app startup.

Failure scenario:
1. Force `EncryptionKeyStore.readKey` to throw an error, e.g. by adding `throw EncryptionKeyStoreError.readFailed(errSecInvalidItemRef)` to the beginning of the method.
2. Build and run the app.
3. Confirm the expected daily and count failure pixels fire with the expected parameters on app startup.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
* Needs privacy triage for the new pixels (will request this before merging)

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

Sample failure pixels:

```
👾[Daily and Count-Fired] m_mac_encryption_keystore_read_key_failed_daily ["appVersion": "1.156.0", "d": "DuckDuckGo_Privacy_Browser.EncryptionKeyStoreError", "e": "1", "pixelSource": "browser-dmg", "ud": "NSOSStatusErrorDomain", "ue": "-25243”]

👾[Daily and Count-Fired] m_mac_encryption_keystore_read_key_failed_count ["appVersion": "1.156.0", "d": "DuckDuckGo_Privacy_Browser.EncryptionKeyStoreError", "e": "1", "pixelSource": "browser-dmg", "ud": "NSOSStatusErrorDomain", "ue": "-25243”]
```

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)