### PR TITLE
Revert "iOS: New Input Metrics - Temp disable prompt length pixels while awaiting privacy triage (#1897)"

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarSubmissionMetrics.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarSubmissionMetrics.swift
@@ -71,22 +71,16 @@ struct SwitchBarSubmissionMetrics: SwitchBarSubmissionMetricsProviding {
     ///   - text: Input text
     ///   - submissionMode: Whether this is a search query or AI chat prompt
     func process(_ text: String, for submissionMode: TextEntryMode) {
-        // Temp disable until privacy triage done
-//        guard let bucket = SwitchBarTextBucket(text) else { return }
+        guard let bucket = SwitchBarTextBucket(text) else { return }
         
-        // Temp disable until privacy triage done
-//        let additionalParams = [textLengthBucketKey: bucket.rawValue]
+        let additionalParams = [textLengthBucketKey: bucket.rawValue]
         
         switch submissionMode {
         case .search:
-            // Temp disable until privacy triage done
-//            DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarQuerySubmitted, withAdditionalParameters: additionalParams)
-            DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarQuerySubmitted)
+            DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarQuerySubmitted, withAdditionalParameters: additionalParams)
         case .aiChat:
-            // Temp disable until privacy trige done
-//            let mergedParams = additionalParams.merging(featureDiscovery.addToParams([:], forFeature: .aiChat)) { (_, new) in new }
-//            DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarPromptSubmitted, withAdditionalParameters: mergedParams)
-            DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarPromptSubmitted, withAdditionalParameters: featureDiscovery.addToParams([:], forFeature: .aiChat))
+            let mergedParams = additionalParams.merging(featureDiscovery.addToParams([:], forFeature: .aiChat)) { (_, new) in new }
+            DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarPromptSubmitted, withAdditionalParameters: mergedParams)
             featureDiscovery.setWasUsedBefore(.aiChat)
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211306690315585

### Description
Revert temp change which removed some pixels firing. This reverts commit a4215a2f6ed11b426fb2d58bf5eb32e2b4f7fc95.

### Testing Steps
N/A, previously tested

### Impact and Risks
Low

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)