### PR TITLE
Enable long-press on Menu to enter debug menu

### DIFF
--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -208,8 +208,6 @@ final class DefaultOmniBarView: UIView, OmniBarView {
     var onBookmarksPressed: (() -> Void)?
     var onAccessoryPressed: (() -> Void)?
     var onDismissPressed: (() -> Void)?
-    var onSettingsLongPress: (() -> Void)?
-    var onAccessoryLongPress: (() -> Void)?
 
     // MARK: - Properties
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2738,14 +2738,6 @@ extension MainViewController: OmniBarDelegate {
         featureDiscovery.setWasUsedBefore(.aiChat)
     }
 
-    func onAccessoryLongPressed(accessoryType: OmniBarAccessoryType) {
-        if featureFlagger.isFeatureOn(.debugMenu) || isDebugBuild {
-            segueToDebugSettings()
-        } else {
-            onAccessoryPressed(accessoryType: accessoryType)
-        }
-    }
-
     func onVoiceSearchPressed() {
         handleVoiceSearchOpenRequest()
     }

--- a/iOS/DuckDuckGo/OmniBarDelegate.swift
+++ b/iOS/DuckDuckGo/OmniBarDelegate.swift
@@ -65,8 +65,6 @@ protocol OmniBarDelegate: AnyObject {
     
     func onAccessoryPressed(accessoryType: OmniBarAccessoryType)
 
-    func onAccessoryLongPressed(accessoryType: OmniBarAccessoryType)
-
     func onTextFieldWillBeginEditing(_ omniBar: OmniBarView, tapped: Bool)
 
     // Returns whether field should select the text or not
@@ -113,10 +111,6 @@ extension OmniBarDelegate {
     
     func onMenuPressed() {
         
-    }
-
-    func onAccessoryLongPressed(accessoryType: OmniBarAccessoryType) {
-
     }
 
     func onBookmarksPressed() {

--- a/iOS/DuckDuckGo/OmniBarView.swift
+++ b/iOS/DuckDuckGo/OmniBarView.swift
@@ -82,9 +82,6 @@ protocol OmniBarView: UIView, OmniBarStatusUpdateable {
     var onAccessoryPressed: (() -> Void)? { get set }
     var onDismissPressed: (() -> Void)? { get set }
 
-    var onSettingsLongPress: (() -> Void)? { get set }
-    var onAccessoryLongPress: (() -> Void)? { get set }
-
     // static function is needed to allow creation of DefaultOmniBarView from xib
     static func create() -> Self
     static var expectedHeight: CGFloat { get }

--- a/iOS/DuckDuckGo/OmniBarViewController.swift
+++ b/iOS/DuckDuckGo/OmniBarViewController.swift
@@ -204,12 +204,6 @@ class OmniBarViewController: UIViewController, OmniBar {
         barView.onDismissPressed = { [weak self] in
             self?.onDismissPressed()
         }
-        barView.onSettingsLongPress = { [weak self] in
-            self?.onSettingsLongPress()
-        }
-        barView.onAccessoryLongPress = { [weak self] in
-            self?.onAccessoryLongPress()
-        }
     }
 
     private func configureEditingMenu() {
@@ -648,14 +642,6 @@ class OmniBarViewController: UIViewController, OmniBar {
         Pixel.fire(pixel: .aiChatLegacyOmnibarBackButtonPressed)
         omniDelegate?.onCancelPressed()
         refreshState(state.onEditingStoppedState)
-    }
-
-    private func onSettingsLongPress() {
-        omniDelegate?.onSettingsLongPressed()
-    }
-
-    private func onAccessoryLongPress() {
-        omniDelegate?.onAccessoryLongPressed(accessoryType: barView.accessoryType)
     }
 }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1211102892900311?focus=true
Tech Design URL:
CC:

### Description

Restore previous capability of quickly opening debug menu from main screen. 

As the accessory button is no longer visible at all times, because of the new search input I decided to add the gesture to Menu button.

### Testing Steps
1. Set `isDebugBuild` in `global.swift` to `false`
2. Run on iPhone and iPad.
3. Menu buttons should allow to highlight the button indefinitely without interrupting the gesture.
4. Reset your changes, run again.
5. Verify long pressing menu button opens Debug menu.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features / None: Internal tooling, documentation

#### What could go wrong?
Gesture recognizer interrupts highlight on menu button for non-debug or non-internal builds.

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)