### PR TITLE
iOS New Search/Duck.ai Input - Update Impression Pixels to Daily and Count

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -112,7 +112,7 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
         super.viewDidAppear(animated)
 
         DailyPixel.fireDailyAndCount(pixel: .aiChatInternalSwitchBarDisplayed)
-        DailyPixel.fire(pixel: .aiChatExperimentalOmnibarShown)
+        DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarShown)
     }
 
     // MARK: - Public Methods

--- a/iOS/DuckDuckGo/OmniBarViewController.swift
+++ b/iOS/DuckDuckGo/OmniBarViewController.swift
@@ -659,7 +659,7 @@ extension OmniBarViewController: UITextFieldDelegate {
     }
 
     @objc func textFieldDidBeginEditing(_ textField: UITextField) {
-        DailyPixel.fire(pixel: .aiChatLegacyOmnibarShown)
+        DailyPixel.fireDailyAndCount(pixel: .aiChatLegacyOmnibarShown)
         
         DispatchQueue.main.async {
             let highlightText = self.omniDelegate?.onTextFieldDidBeginEditing(self.barView) ?? true

--- a/iOS/PixelDefinitions/pixels/experimental_omnibar_metrics.json5
+++ b/iOS/PixelDefinitions/pixels/experimental_omnibar_metrics.json5
@@ -5,7 +5,7 @@
         description: 'Fires when the experimental omnibar with Duck.ai toggle is displayed to the user',
         owners: ['aataraxiaa'],
         triggers: ['other'],
-        suffixes: ['daily', 'platform', 'form_factor'],
+        suffixes: ['first_daily_count', 'platform', 'form_factor'],
         parameters: ['appVersion', 'pixelSource'],
     },
     m_aichat_experimental_omnibar_prompt_submitted: {
@@ -88,7 +88,7 @@
         description: 'Fires when the legacy omnibar is displayed to the user (baseline comparison for experimental omnibar)',
         owners: ['aataraxiaa'],
         triggers: ['other'],
-        suffixes: ['daily', 'platform', 'form_factor'],
+        suffixes: ['first_daily_count', 'platform', 'form_factor'],
         parameters: ['appVersion', 'pixelSource'],
     },
     m_aichat_legacy_omnibar_query_submitted: {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211327117482763

### Description
To correctly measure task completion we need to utilize count pixels. This updates existing pixels from daily only to daily and count.

### Testing Steps
1. Delete app from sim
2. Launch app
3. When legacy omnibar becomes focused first time we should see the following in the console (filter by “m.aichat”):
```
Pixel fired m.aichat.legacy.omnibar.shown.daily
Pixel fired m.aichat.legacy.omnibar.shown.count
```
4. On subsequent focus we should see more count pixels
5. Enable new input
6. On first focus on new input we should see:
```
Pixel fired m.aichat.experimental.omnibar.shown.daily
Pixel fired m.aichat.experimental.omnibar.shown.count
```
7. On subsequent focus we should see more count pixels

### Impact and Risks
Low, pixel update

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)