### PR TITLE
Update autofill to 18.3.1

### DIFF
--- a/SharedPackages/BrowserServicesKit/Package.resolved
+++ b/SharedPackages/BrowserServicesKit/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "252082be808ece0ab91d60a27e18bfcf10dcec1b",
-        "version" : "18.3.0"
+        "revision" : "123b64c7c78f492a1a3e6f60a8f891557a23a2eb",
+        "version" : "18.3.1"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         .library(name: "WKAbstractions", targets: ["WKAbstractions"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "18.3.0"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "18.3.1"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit.git", exact: "3.0.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.7.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "3.0.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211327838125218
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.3.1
Apple PR: 

## Description
Updates Autofill to version [18.3.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.3.1).

### Autofill 18.3.1 release notes
## What's Changed
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/899
* [Autosubmit/Autoprompt] Force autoprompt and submit on accounts.google.com by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/901


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/18.3.0...18.3.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).