### PR TITLE
macOS: Create release metadata workflow

### DIFF
--- a/.github/workflows/macos_upload_version_metadata.yml
+++ b/.github/workflows/macos_upload_version_metadata.yml
@@ -7,9 +7,6 @@ on:
         description: 'Mark this release as critical (for hotfixes)'
         type: boolean
         default: false
-  pull_request:
-    paths:
-      - '.github/workflows/macos_upload_version_metadata.yml'
   workflow_call:
     inputs:
       is_critical:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1211319503505028?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1209541053254502?focus=true
CC:

### Description
Creates a new workflow that is responsible for uploading or creating a `release_metadata.json` file to our CDN. This file will then be used as a way of checking the latest version available at the App Store.

### Testing Steps
- Check that the workflow ran successfully: https://github.com/duckduckgo/apple-browsers/actions/runs/17649987106
- Check that the file is available at:https://staticcdn.duckduckgo.com/macos-desktop-browser/release_metadata.json

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
I’ve used Cursor to create the workflow and made some modifications.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)