### PR TITLE
[iOS] Fix main actor crash

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -91,15 +91,6 @@
       }
     },
     {
-      "identity" : "openssl-xcframework",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/duckduckgo/OpenSSL-XCFramework",
-      "state" : {
-        "revision" : "263f0422b0b516838bc4f8cf5f4b5aac4df144c1",
-        "version" : "3.3.2000"
-      }
-    },
-    {
       "identity" : "privacy-dashboard",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/privacy-dashboard",
@@ -115,15 +106,6 @@
       "state" : {
         "revision" : "30a462bdb4398ea835a3585472229e0d74b36ba5",
         "version" : "3.0.0"
-      }
-    },
-    {
-      "identity" : "sparkle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sparkle-project/Sparkle.git",
-      "state" : {
-        "revision" : "b456fd404954a9e13f55aa0c88cd5a40b8399638",
-        "version" : "2.6.3"
       }
     },
     {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/547792610048271/task/1211323364448459?focus=true

### Description
Mark async UNUserNotificationCenterDelegate methods (willPresent, didReceive) with @MainActor to ensure they are always executed on the main thread.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Build and run the app. Force notification to show up. 
2. Click and not seeing crashes.
3. Repeat multiple times

Note: The original crash happens occasionally so this is hard to test

### Impact and Risks
Fix a known crash

#### What could go wrong?
Very low risk fix. No risk with the fix itself. But there could always be bugs we did not find out 

### Notes to Reviewer
Originally included in https://github.com/duckduckgo/apple-browsers/pull/1912

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)