### PR TITLE
Optimize doc-bot rules structure

### DIFF
--- a/doc-bot/rules/anti-patterns-original.md
+++ b/doc-bot/rules/anti-patterns-original.md
@@ -1,0 +1,529 @@
+---
+alwaysApply: true
+title: "Anti-patterns and Common Mistakes"
+description: "Anti-patterns to avoid and common mistakes to prevent in DuckDuckGo browser development including singleton misuse, memory leaks, and performance issues"
+keywords: ["anti-patterns", "common mistakes", "singletons", "memory leaks", "async/await", "error handling", "performance", "testing"]
+---
+
+# Anti-patterns and Common Mistakes to Avoid
+
+## Singleton Anti-patterns
+
+### ❌ NEVER: Static Shared Instances Without Dependency Injection (.shared instance pattern)
+```swift
+// ❌ AVOID - Static shared instance without DI
+final class FeatureManager {
+    static let shared = FeatureManager()
+    private init() {}
+    
+    func performAction() {
+        // Implementation
+    }
+}
+
+// Usage:
+FeatureManager.shared.performAction() // Hard to test and tightly coupled
+
+// ✅ CORRECT - Dependency injection pattern
+protocol FeatureManagerProtocol {
+    func performAction()
+}
+
+final class FeatureManager: FeatureManagerProtocol {
+    func performAction() {
+        // Implementation
+    }
+}
+
+// Register in AppDependencyProvider
+extension AppDependencyProvider {
+    var featureManager: FeatureManagerProtocol {
+        return FeatureManager()
+    }
+}
+
+// Usage:
+final class ViewModel {
+    private let featureManager: FeatureManagerProtocol
+    
+    init(dependencies: DependencyProvider = AppDependencyProvider.shared) {
+        self.featureManager = dependencies.featureManager
+    }
+}
+```
+
+### ❌ NEVER: Global State Access
+```swift
+// ❌ AVOID - Global state access
+var globalSettings: [String: Any] = [:]
+
+func someFunction() {
+    globalSettings["key"] = "value" // Global state is hard to test and debug
+}
+
+// ✅ CORRECT - Injected dependencies
+final class SomeService {
+    private let settings: AppSettings
+    
+    init(settings: AppSettings) {
+        self.settings = settings
+    }
+    
+    func someFunction() {
+        settings.setValue("value", for: "key")
+    }
+}
+```
+
+## Async/Await Anti-patterns
+
+### ❌ NEVER: UI Updates Without @MainActor
+```swift
+// ❌ AVOID - UI updates without main thread guarantee
+class ViewModel: ObservableObject {
+    @Published var isLoading = false
+    
+    func loadData() async {
+        isLoading = true // May crash if not on main thread
+        let data = try? await service.fetchData()
+        isLoading = false // May crash if not on main thread
+    }
+}
+
+// ✅ CORRECT - @MainActor for UI updates
+@MainActor
+class ViewModel: ObservableObject {
+    @Published var isLoading = false
+    
+    func loadData() async {
+        isLoading = true
+        let data = try? await service.fetchData()
+        isLoading = false
+    }
+}
+```
+
+### ❌ NEVER: Unhandled Async Errors
+```swift
+// ❌ AVOID - Swallowing async errors
+func fetchData() async {
+    let data = try? await networkService.getData() // Silently ignoring errors
+    // Process data...
+}
+
+// ✅ CORRECT - Proper error handling
+func fetchData() async throws {
+    let data = try await networkService.getData()
+    // Process data...
+}
+
+// Or handle errors appropriately:
+func fetchData() async {
+    do {
+        let data = try await networkService.getData()
+        // Process data...
+    } catch {
+        // Log error and show user-friendly message
+        logger.error("Failed to fetch data: \(error)")
+        await showError(error)
+    }
+}
+```
+
+### ❌ NEVER: Blocking Main Thread with Sync Operations
+```swift
+// ❌ AVOID - Blocking main thread
+@MainActor
+func loadData() {
+    let data = NetworkService.fetchDataSynchronously() // Blocks UI
+    updateUI(with: data)
+}
+
+// ✅ CORRECT - Use async operations
+@MainActor
+func loadData() async {
+    let data = try await NetworkService.fetchData() // Non-blocking
+    updateUI(with: data)
+}
+```
+
+## Memory Management Anti-patterns
+
+### ❌ NEVER: Strong Reference Cycles in Closures
+```swift
+// ❌ AVOID - Strong reference cycle
+class ViewController: UIViewController {
+    private var timer: Timer?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+            self.updateUI() // Strong reference cycle - ViewController won't be deallocated
+        }
+    }
+}
+
+// ✅ CORRECT - Weak self to break cycle
+class ViewController: UIViewController {
+    private var timer: Timer?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.updateUI()
+        }
+    }
+    
+    deinit {
+        timer?.invalidate()
+    }
+}
+```
+
+### ❌ NEVER: Retaining View Controllers in Cache
+```swift
+// ❌ AVOID - Caching view controllers without cleanup
+class NavigationManager {
+    private var cachedViewControllers: [String: UIViewController] = [:]
+    
+    func getViewController(for identifier: String) -> UIViewController {
+        if let cached = cachedViewControllers[identifier] {
+            return cached // May contain stale data and strong references
+        }
+        let vc = createViewController(for: identifier)
+        cachedViewControllers[identifier] = vc
+        return vc
+    }
+}
+
+// ✅ CORRECT - Cache view models, not view controllers
+class NavigationManager {
+    private var cachedViewModels: [String: ViewModel] = [:]
+    
+    func getViewController(for identifier: String) -> UIViewController {
+        let viewModel = getOrCreateViewModel(for: identifier)
+        return createViewController(with: viewModel)
+    }
+    
+    private func getOrCreateViewModel(for identifier: String) -> ViewModel {
+        if let cached = cachedViewModels[identifier] {
+            return cached
+        }
+        let viewModel = createViewModel(for: identifier)
+        cachedViewModels[identifier] = viewModel
+        return viewModel
+    }
+}
+```
+
+## Error Handling Anti-patterns
+
+### ❌ NEVER: Force Unwrapping Without Justification
+```swift
+// ❌ AVOID - Force unwrapping
+func processUser() {
+    let user = getCurrentUser()!  // Will crash if no user
+    let name = user.name!         // Will crash if no name
+    displayName(name)
+}
+
+// ✅ CORRECT - Safe unwrapping
+func processUser() {
+    guard let user = getCurrentUser(),
+          let name = user.name else {
+        showErrorMessage("User information unavailable")
+        return
+    }
+    displayName(name)
+}
+```
+
+### ❌ NEVER: Generic Error Messages
+```swift
+// ❌ AVOID - Generic error handling
+func handleError(_ error: Error) {
+    print("Something went wrong") // Not helpful for debugging
+    showAlert("Error occurred")   // Not helpful for users
+}
+
+// ✅ CORRECT - Specific error handling
+enum NetworkError: LocalizedError {
+    case noConnection
+    case timeout
+    case unauthorized
+    case serverError(Int)
+    
+    var errorDescription: String? {
+        switch self {
+        case .noConnection:
+            return "No internet connection. Please check your network settings."
+        case .timeout:
+            return "Request timed out. Please try again."
+        case .unauthorized:
+            return "You are not authorized to access this resource."
+        case .serverError(let code):
+            return "Server error (\(code)). Please try again later."
+        }
+    }
+}
+
+func handleNetworkError(_ error: NetworkError) {
+    logger.error("Network error: \(error)")
+    showAlert(error.localizedDescription)
+}
+```
+
+## SwiftUI Anti-patterns
+
+### ❌ NEVER: Heavy Computation in View Body
+```swift
+// ❌ AVOID - Expensive operations in body
+struct ContentView: View {
+    let items: [Item]
+    
+    var body: some View {
+        List {
+            ForEach(items) { item in
+                Text(expensiveProcessing(item)) // Computed every view update
+            }
+        }
+    }
+    
+    private func expensiveProcessing(_ item: Item) -> String {
+        // Heavy computation
+        return item.data.complexProcessing()
+    }
+}
+
+// ✅ CORRECT - Pre-compute or use lazy loading
+struct ContentView: View {
+    @StateObject private var viewModel: ContentViewModel
+    
+    var body: some View {
+        List {
+            ForEach(viewModel.processedItems) { item in
+                Text(item.displayText)
+            }
+        }
+        .onAppear {
+            viewModel.processItems()
+        }
+    }
+}
+```
+
+### ❌ NEVER: Direct State Mutation from View
+```swift
+// ❌ AVOID - Direct state mutation in view
+struct ContentView: View {
+    @State private var items: [Item] = []
+    
+    var body: some View {
+        List {
+            ForEach(items) { item in
+                ItemRow(item: item) { updatedItem in
+                    // Don't mutate state directly in view
+                    if let index = items.firstIndex(where: { $0.id == updatedItem.id }) {
+                        items[index] = updatedItem
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ✅ CORRECT - Use ViewModel for state management
+struct ContentView: View {
+    @StateObject private var viewModel: ContentViewModel
+    
+    var body: some View {
+        List {
+            ForEach(viewModel.items) { item in
+                ItemRow(item: item) { updatedItem in
+                    viewModel.updateItem(updatedItem)
+                }
+            }
+        }
+    }
+}
+```
+
+## Design System Anti-patterns
+
+### ❌ NEVER: Hardcoded Colors or Icons
+```swift
+// ❌ AVOID - Hardcoded colors and system icons
+struct FeatureView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "star.fill") // Use DesignResourcesKit icons
+                .foregroundColor(.blue)   // Use semantic colors
+            
+            Text("Title")
+                .foregroundColor(.black)  // Doesn't adapt to dark mode
+        }
+        .background(.gray)               // Use semantic colors
+    }
+}
+
+// ✅ CORRECT - Design system integration
+struct FeatureView: View {
+    var body: some View {
+        VStack {
+            Image(uiImage: DesignSystemImages.Color.Size16.star)
+                .foregroundColor(Color(designSystemColor: .accent))
+            
+            Text("Title")
+                .foregroundColor(Color(designSystemColor: .textPrimary))
+        }
+        .background(Color(designSystemColor: .surface))
+    }
+}
+```
+
+## Network and API Anti-patterns
+
+### ❌ NEVER: Hardcoded URLs or API Keys
+```swift
+// ❌ AVOID - Hardcoded values
+func fetchData() async throws -> Data {
+    let url = URL(string: "https://api.example.com/data")! // Hardcoded URL
+    let apiKey = "abc123xyz"                               // Hardcoded API key
+    
+    var request = URLRequest(url: url)
+    request.addValue(apiKey, forHTTPHeaderField: "Authorization")
+    
+    let (data, _) = try await URLSession.shared.data(for: request)
+    return data
+}
+
+// ✅ CORRECT - Configuration-based approach
+struct APIConfiguration {
+    let baseURL: URL
+    let apiKey: String
+    
+    static let production = APIConfiguration(
+        baseURL: URL(string: "https://api.duckduckgo.com")!,
+        apiKey: Bundle.main.object(forInfoDictionaryKey: "API_KEY") as! String
+    )
+}
+
+func fetchData() async throws -> Data {
+    let config = APIConfiguration.production
+    let url = config.baseURL.appendingPathComponent("data")
+    
+    var request = URLRequest(url: url)
+    request.addValue(config.apiKey, forHTTPHeaderField: "Authorization")
+    
+    let (data, _) = try await URLSession.shared.data(for: request)
+    return data
+}
+```
+
+## Testing Anti-patterns
+
+### ❌ NEVER: Testing Implementation Details
+```swift
+// ❌ AVOID - Testing private implementation
+class ViewModelTests: XCTestCase {
+    func testPrivateMethod() {
+        let viewModel = ViewModel()
+        
+        // Don't test private methods directly
+        let result = viewModel.privateHelperMethod()
+        XCTAssertEqual(result, expected)
+    }
+}
+
+// ✅ CORRECT - Test public behavior
+class ViewModelTests: XCTestCase {
+    func testLoadDataUpdatesState() async {
+        let mockService = MockDataService()
+        let viewModel = ViewModel(service: mockService)
+        
+        await viewModel.loadData()
+        
+        // Test the observable behavior, not implementation
+        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertNotNil(viewModel.data)
+        XCTAssertNil(viewModel.error)
+    }
+}
+```
+
+### ❌ NEVER: Tests That Don't Test Anything
+```swift
+// ❌ AVOID - Tests without assertions
+func testInitialization() {
+    let viewModel = ViewModel()
+    // Test does nothing
+}
+
+// ❌ AVOID - Tests that can't fail
+func testAlwaysTrue() {
+    XCTAssertTrue(true) // This test is meaningless
+}
+
+// ✅ CORRECT - Meaningful tests with specific assertions
+func testInitializationSetsDefaultState() {
+    let viewModel = ViewModel()
+    
+    XCTAssertEqual(viewModel.state, .idle)
+    XCTAssertTrue(viewModel.items.isEmpty)
+    XCTAssertFalse(viewModel.isLoading)
+}
+```
+
+## Performance Anti-patterns
+
+### ❌ NEVER: Synchronous Operations on Main Thread
+```swift
+// ❌ AVOID - Blocking main thread
+@MainActor
+func processLargeDataSet() {
+    let result = heavyComputation() // Blocks UI
+    updateUI(with: result)
+}
+
+// ✅ CORRECT - Background processing
+@MainActor
+func processLargeDataSet() async {
+    let result = await Task.detached(priority: .userInitiated) {
+        return heavyComputation()
+    }.value
+    
+    updateUI(with: result)
+}
+```
+
+## Communication Anti-patterns
+
+### ❌ NEVER: Celebrate Partial Results or Progress
+```
+// ❌ AVOID - Celebrating when work is incomplete
+"✅ MISSION ACCOMPLISHED!" (when tests still failing)
+"🎯 Outstanding Achievement:" (when task isn't finished)
+"📊 FINAL RESULTS:" (when results aren't final)
+"✅ Successfully achieved X" (when Y tests still failing)
+
+// ✅ CORRECT - Focus on what's left to do
+"7 tests still failing. Continuing to fix remaining issues."
+"Progress made but task incomplete. Working on remaining failures."
+"X tests now passing, Y still need work."
+```
+
+**Never celebrate or summarize achievements when:**
+- Tests are still failing
+- Tasks are incomplete
+- User's request hasn't been fully satisfied
+- Work is in progress
+
+**Only summarize results when:**
+- ALL tests pass (100% success rate)
+- Task is completely finished
+- User's request is fully satisfied
+- No work remaining
+
+These anti-patterns should be actively avoided to maintain code quality, testability, and performance in the DuckDuckGo browser codebase.

--- a/doc-bot/rules/anti-patterns.examples.md
+++ b/doc-bot/rules/anti-patterns.examples.md
@@ -1,0 +1,446 @@
+---
+alwaysApply: false
+title: "Anti-patterns Examples"
+description: "Detailed examples of anti-patterns to avoid in DuckDuckGo browser development"
+keywords: ["anti-patterns", "examples", "memory leaks", "retain cycles", "singletons", "threading", "performance"]
+---
+
+# Anti-patterns Examples
+
+## Singleton Anti-patterns Examples
+
+```swift
+// ❌ BAD - Singleton abuse
+class NetworkManager {
+    static let shared = NetworkManager()
+    private init() {}
+    
+    func fetchData() { }
+}
+
+class UserManager {
+    static let shared = UserManager()
+    private init() {}
+}
+
+// Everything depends on global state
+class ViewModel {
+    func loadData() {
+        NetworkManager.shared.fetchData()
+        UserManager.shared.getCurrentUser()
+    }
+}
+
+// ✅ GOOD - Dependency injection
+protocol NetworkManaging {
+    func fetchData() async throws -> Data
+}
+
+class NetworkManager: NetworkManaging {
+    func fetchData() async throws -> Data { /* implementation */ }
+}
+
+class ViewModel {
+    private let networkManager: NetworkManaging
+    
+    init(networkManager: NetworkManaging = AppDependencyProvider.shared.networkManager) {
+        self.networkManager = networkManager
+    }
+    
+    func loadData() async {
+        do {
+            let data = try await networkManager.fetchData()
+            // Process data
+        } catch {
+            // Handle error
+        }
+    }
+}
+```
+
+## Memory Leak Examples
+
+### Retain Cycle Examples
+
+```swift
+// ❌ BAD - Closure retain cycle
+class DataService {
+    var onDataReceived: ((Data) -> Void)?
+    
+    func fetchData() {
+        onDataReceived = { data in
+            self.processData(data)  // Strong reference to self
+        }
+    }
+}
+
+// ✅ GOOD - Weak self
+class DataService {
+    var onDataReceived: ((Data) -> Void)?
+    
+    func fetchData() {
+        onDataReceived = { [weak self] data in
+            self?.processData(data)
+        }
+    }
+}
+
+// ❌ BAD - Delegate retain cycle
+class ViewController: UIViewController {
+    let service = NetworkService()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        service.delegate = self  // Strong reference if delegate isn't weak
+    }
+}
+
+// ✅ GOOD - Weak delegate
+protocol NetworkServiceDelegate: AnyObject {
+    func networkService(_ service: NetworkService, didReceive data: Data)
+}
+
+class NetworkService {
+    weak var delegate: NetworkServiceDelegate?  // Weak reference
+}
+```
+
+### Timer Retain Cycles
+
+```swift
+// ❌ BAD - Timer retains self
+class PollingManager {
+    var timer: Timer?
+    
+    func startPolling() {
+        timer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { _ in
+            self.poll()  // Timer retains closure, closure retains self
+        }
+    }
+}
+
+// ✅ GOOD - Weak self in timer
+class PollingManager {
+    var timer: Timer?
+    
+    func startPolling() {
+        timer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
+            self?.poll()
+        }
+    }
+    
+    deinit {
+        timer?.invalidate()
+        timer = nil
+    }
+}
+```
+
+## Async/Await Anti-patterns
+
+```swift
+// ❌ BAD - Blocking main thread
+func loadData() {
+    let semaphore = DispatchSemaphore(value: 0)
+    var result: Data?
+    
+    URLSession.shared.dataTask(with: url) { data, _, _ in
+        result = data
+        semaphore.signal()
+    }.resume()
+    
+    semaphore.wait()  // Blocks current thread
+    return result
+}
+
+// ✅ GOOD - Proper async/await
+func loadData() async throws -> Data {
+    let (data, _) = try await URLSession.shared.data(from: url)
+    return data
+}
+
+// ❌ BAD - Mixing completion handlers with async/await
+func fetchUserData() async throws -> User {
+    return try await withCheckedThrowingContinuation { continuation in
+        NetworkManager.shared.fetchUser { result in  // Unnecessary wrapper
+            switch result {
+            case .success(let user):
+                continuation.resume(returning: user)
+            case .failure(let error):
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+}
+
+// ✅ GOOD - Native async/await
+func fetchUserData() async throws -> User {
+    let userData = try await networkManager.fetchUserData()
+    return try JSONDecoder().decode(User.self, from: userData)
+}
+```
+
+## Force Unwrapping Anti-patterns
+
+```swift
+// ❌ BAD - Force unwrapping without safety
+func openURL(_ urlString: String) {
+    let url = URL(string: urlString)!  // Crash if invalid
+    UIApplication.shared.open(url)
+}
+
+func processResponse(_ response: HTTPURLResponse) {
+    let data = response.data!  // Properties don't exist
+    let json = try! JSONSerialization.jsonObject(with: data)  // Can throw
+}
+
+// ✅ GOOD - Safe unwrapping
+func openURL(_ urlString: String) {
+    guard let url = URL(string: urlString) else {
+        Logger.general.error("Invalid URL: \(urlString)")
+        return
+    }
+    UIApplication.shared.open(url)
+}
+
+func processResponse(data: Data) {
+    do {
+        let json = try JSONSerialization.jsonObject(with: data)
+        // Process JSON
+    } catch {
+        Logger.general.error("Failed to parse JSON: \(error)")
+    }
+}
+```
+
+## Threading Anti-patterns
+
+```swift
+// ❌ BAD - UI updates on background thread
+func updateUI() {
+    DispatchQueue.global().async {
+        self.label.text = "Updated"  // Crash or undefined behavior
+        self.imageView.image = processedImage
+    }
+}
+
+// ✅ GOOD - UI updates on main thread
+func updateUI() {
+    DispatchQueue.global().async {
+        let processedImage = self.processImage()
+        
+        DispatchQueue.main.async {
+            self.label.text = "Updated"
+            self.imageView.image = processedImage
+        }
+    }
+}
+
+// ✅ BETTER - Using MainActor
+@MainActor
+func updateUI() async {
+    let processedImage = await processImageInBackground()
+    label.text = "Updated"
+    imageView.image = processedImage
+}
+
+func processImageInBackground() async -> UIImage {
+    // Heavy processing on background thread
+    await Task.detached {
+        // Image processing
+        return processedImage
+    }.value
+}
+```
+
+## Error Handling Anti-patterns
+
+```swift
+// ❌ BAD - Silently ignoring errors
+func saveData() {
+    do {
+        try coreDataContext.save()
+    } catch {
+        // Silent failure - data loss!
+    }
+}
+
+// ❌ BAD - Generic error messages
+func authenticateUser() throws {
+    guard isValidCredentials else {
+        throw NSError(domain: "Error", code: 1, userInfo: nil)  // Useless error
+    }
+}
+
+// ✅ GOOD - Proper error handling
+func saveData() {
+    do {
+        try coreDataContext.save()
+    } catch {
+        Logger.general.error("Failed to save Core Data context: \(error)")
+        // Show user-appropriate error message
+        showErrorAlert("Unable to save your changes. Please try again.")
+    }
+}
+
+// ✅ GOOD - Meaningful errors
+enum AuthenticationError: LocalizedError {
+    case invalidUsername
+    case invalidPassword
+    case accountLocked
+    
+    var errorDescription: String? {
+        switch self {
+        case .invalidUsername:
+            return "Username not found"
+        case .invalidPassword:
+            return "Incorrect password"
+        case .accountLocked:
+            return "Account has been temporarily locked"
+        }
+    }
+}
+```
+
+## Testing Anti-patterns
+
+```swift
+// ❌ BAD - Testing implementation details
+func testViewControllerInternals() {
+    let vc = ViewController()
+    vc.loadView()
+    
+    // Testing private methods
+    XCTAssertTrue(vc.validateInternalState())
+    XCTAssertEqual(vc.privateCounter, 5)
+}
+
+// ❌ BAD - Flaky time-dependent tests
+func testAsyncOperation() {
+    service.performAsyncOperation()
+    
+    // Race condition - test might fail randomly
+    Thread.sleep(forTimeInterval: 0.1)
+    XCTAssertTrue(service.isComplete)
+}
+
+// ✅ GOOD - Testing behavior, not implementation
+func testViewControllerDisplaysData() {
+    let viewModel = MockViewModel()
+    let vc = ViewController(viewModel: viewModel)
+    
+    viewModel.data = [testData]
+    vc.loadView()
+    
+    // Test visible behavior
+    XCTAssertEqual(vc.tableView.numberOfRows(inSection: 0), 1)
+}
+
+// ✅ GOOD - Deterministic async testing
+func testAsyncOperation() async {
+    let expectation = XCTestExpectation(description: "Operation completes")
+    
+    service.performAsyncOperation { result in
+        XCTAssertNotNil(result)
+        expectation.fulfill()
+    }
+    
+    await fulfillment(of: [expectation], timeout: 5.0)
+}
+```
+
+## Performance Anti-patterns
+
+```swift
+// ❌ BAD - Expensive operations on main thread
+func processLargeDataSet() {
+    let processedData = largeDataSet.map { expensiveOperation($0) }  // Blocks UI
+    updateUI(with: processedData)
+}
+
+// ❌ BAD - Creating expensive objects repeatedly
+func formatDates(_ dates: [Date]) -> [String] {
+    return dates.map { date in
+        let formatter = DateFormatter()  // Expensive creation in loop
+        formatter.dateStyle = .medium
+        return formatter.string(from: date)
+    }
+}
+
+// ✅ GOOD - Background processing
+func processLargeDataSet() async {
+    let processedData = await Task.detached {
+        largeDataSet.map { expensiveOperation($0) }
+    }.value
+    
+    await MainActor.run {
+        updateUI(with: processedData)
+    }
+}
+
+// ✅ GOOD - Reuse expensive objects
+private static let dateFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .medium
+    return formatter
+}()
+
+func formatDates(_ dates: [Date]) -> [String] {
+    return dates.map { Self.dateFormatter.string(from: $0) }
+}
+```
+
+## SwiftUI Anti-patterns
+
+```swift
+// ❌ BAD - Heavy computation in body
+struct ExpensiveView: View {
+    let items: [Item]
+    
+    var body: some View {
+        let processedItems = items
+            .filter { $0.isValid }
+            .sorted { $0.priority > $1.priority }  // Runs on every render
+        
+        List(processedItems) { item in
+            ItemRow(item: item)
+        }
+    }
+}
+
+// ❌ BAD - Wrong property wrapper usage
+struct BadStateView: View {
+    @State var viewModel: ViewModel  // Wrong - @State is for simple values
+    
+    var body: some View {
+        Text(viewModel.title)
+    }
+}
+
+// ✅ GOOD - Computed property for expensive operations
+struct EfficientView: View {
+    let items: [Item]
+    
+    private var processedItems: [ProcessedItem] {
+        items
+            .filter { $0.isValid }
+            .sorted { $0.priority > $1.priority }
+    }
+    
+    var body: some View {
+        List(processedItems) { item in
+            ItemRow(item: item)
+        }
+    }
+}
+
+// ✅ GOOD - Correct property wrapper
+struct GoodStateView: View {
+    @StateObject private var viewModel = ViewModel()  // For owned objects
+    // OR @ObservedObject var viewModel: ViewModel    // For injected objects
+    
+    var body: some View {
+        Text(viewModel.title)
+    }
+}
+```

--- a/doc-bot/rules/anti-patterns.md
+++ b/doc-bot/rules/anti-patterns.md
@@ -1,0 +1,220 @@
+---
+alwaysApply: true
+title: "Anti-patterns and Common Mistakes"
+description: "Anti-patterns to avoid and common mistakes to prevent in DuckDuckGo browser development including singleton misuse, memory leaks, and performance issues"
+keywords: ["anti-patterns", "common mistakes", "singletons", "memory leaks", "async/await", "error handling", "performance", "testing"]
+---
+
+# Anti-patterns and Common Mistakes to Avoid
+
+## Singleton Anti-patterns
+
+**❌ NEVER use singletons** - they create global state, make testing difficult, and violate dependency injection principles.
+
+**✅ ALWAYS use dependency injection** through AppDependencyProvider.
+
+📖 **[See singleton examples →](anti-patterns.examples.md#singleton-anti-patterns-examples)**
+
+## Memory Management Anti-patterns
+
+### Retain Cycles (Critical)
+**❌ Common causes:**
+- Closures capturing `self` strongly
+- Delegate properties not marked `weak`
+- Timer callbacks retaining objects
+- Combine subscriptions without proper cleanup
+
+**✅ Solutions:**
+- Use `[weak self]` in closures
+- Mark delegates as `weak`
+- Invalidate timers in `deinit`
+- Store cancellables properly
+
+📖 **[See memory leak examples →](anti-patterns.examples.md#memory-leak-examples)**
+
+### Strong Reference Cycles
+**❌ NEVER create circular references** between objects.
+
+**✅ ALWAYS use `weak` or `unowned` references** to break cycles.
+
+## Async/Await Anti-patterns
+
+### Blocking Operations
+**❌ NEVER block threads** with semaphores or synchronous waits in async contexts.
+
+**✅ ALWAYS use proper async/await** patterns for asynchronous operations.
+
+### Mixing Paradigms
+**❌ AVOID mixing** completion handlers with async/await unnecessarily.
+
+**✅ PREFER native async/await** over wrapped completion handlers.
+
+📖 **[See async/await anti-patterns →](anti-patterns.examples.md#asyncawait-anti-patterns)**
+
+## Force Unwrapping Anti-patterns
+
+**❌ NEVER force unwrap** without absolute certainty the value exists.
+
+**✅ ALWAYS use safe unwrapping:**
+- `guard let` for early returns
+- `if let` for conditional execution  
+- Nil coalescing (`??`) for defaults
+
+📖 **[See force unwrapping examples →](anti-patterns.examples.md#force-unwrapping-anti-patterns)**
+
+## Threading Anti-patterns
+
+### UI Updates Off Main Thread
+**❌ NEVER update UI** from background threads - causes crashes.
+
+**✅ ALWAYS update UI on main thread** using:
+- `DispatchQueue.main.async`
+- `@MainActor` functions
+- `MainActor.run`
+
+### Race Conditions
+**❌ AVOID unsynchronized** access to shared mutable state.
+
+**✅ USE proper synchronization:**
+- Serial queues for shared resources
+- Actors for Swift concurrency
+- Locks when necessary
+
+📖 **[See threading anti-patterns →](anti-patterns.examples.md#threading-anti-patterns)**
+
+## Error Handling Anti-patterns
+
+### Silent Failures
+**❌ NEVER ignore errors** silently - leads to data loss and bugs.
+
+**✅ ALWAYS handle errors:**
+- Log errors appropriately
+- Show user-appropriate messages
+- Implement recovery strategies
+
+### Generic Error Messages  
+**❌ AVOID vague errors** like "Error occurred".
+
+**✅ PROVIDE specific, actionable** error messages.
+
+📖 **[See error handling examples →](anti-patterns.examples.md#error-handling-anti-patterns)**
+
+## Testing Anti-patterns
+
+### Testing Implementation Details
+**❌ DON'T test private methods** or internal implementation.
+
+**✅ TEST public behavior** and observable outcomes.
+
+### Flaky Tests
+**❌ AVOID time-dependent** or order-dependent tests.
+
+**✅ USE deterministic** test patterns with proper expectations.
+
+### Real Network/Database
+**❌ NEVER use real services** in unit tests.
+
+**✅ ALWAYS use mocks** and dependency injection.
+
+📖 **[See testing anti-patterns →](anti-patterns.examples.md#testing-anti-patterns)**
+
+## Performance Anti-patterns
+
+### Main Thread Blocking
+**❌ NEVER perform expensive operations** on the main thread.
+
+**✅ USE background queues** for heavy computation.
+
+### Inefficient Object Creation
+**❌ AVOID creating expensive objects** repeatedly in loops.
+
+**✅ REUSE expensive objects** like formatters and regex patterns.
+
+### Inefficient Collections
+**❌ AVOID multiple passes** through collections unnecessarily.
+
+**✅ USE lazy evaluation** and efficient algorithms.
+
+📖 **[See performance anti-patterns →](anti-patterns.examples.md#performance-anti-patterns)**
+
+## SwiftUI Anti-patterns
+
+### Heavy Body Computation
+**❌ NEVER perform expensive operations** in view body.
+
+**✅ USE computed properties** or state management.
+
+### Wrong Property Wrappers
+**❌ DON'T misuse** `@State`, `@StateObject`, `@ObservedObject`.
+
+**✅ UNDERSTAND the lifecycle** of each property wrapper.
+
+📖 **[See SwiftUI anti-patterns →](anti-patterns.examples.md#swiftui-anti-patterns)**
+
+## Git & Testing Anti-patterns
+
+### Auto-Committing/Pushing
+**❌ NEVER automatically commit** or push without explicit permission.
+
+**✅ ALWAYS ask user first** before git operations.
+
+### Auto-Running Tests  
+**❌ NEVER run tests automatically** without user request.
+
+**✅ ASK permission first** before executing test suites.
+
+## Logging Anti-patterns
+
+### Print Statements
+**❌ NEVER use `print()`** for logging in production code.
+
+**✅ ALWAYS use Logger extensions:**
+- `Logger.general` for app functionality
+- `Logger.network` for network operations  
+- `Logger.ui` for UI updates
+
+## Design System Anti-patterns
+
+### Hardcoded Values
+**❌ NEVER hardcode colors, fonts, or spacing.**
+
+**✅ ALWAYS use DesignResourcesKit** tokens and design system.
+
+### Manual Dark Mode
+**❌ NEVER manually check** `colorScheme` or `userInterfaceStyle`.
+
+**✅ USE semantic colors** that adapt automatically.
+
+## Code Organization Anti-patterns
+
+### Massive View Controllers
+**❌ AVOID putting all logic** in view controllers.
+
+**✅ USE MVVM pattern** with proper separation of concerns.
+
+### Deep Nesting
+**❌ AVOID deeply nested** conditional statements.
+
+**✅ USE guard statements** for early returns (Golden Path pattern).
+
+### Magic Numbers/Strings
+**❌ NEVER use unexplained** magic numbers or string literals.
+
+**✅ CREATE named constants** with clear purposes.
+
+## Quick Anti-pattern Checklist
+
+Before committing code, verify:
+- [ ] No singletons used (use dependency injection)
+- [ ] No retain cycles (use `[weak self]`)  
+- [ ] No force unwrapping without safety
+- [ ] No UI updates off main thread
+- [ ] No `print()` statements (use Logger)
+- [ ] No hardcoded colors/fonts (use DesignResourcesKit)
+- [ ] No silent error handling
+- [ ] No expensive operations in view bodies
+- [ ] No auto git/test operations
+
+---
+
+📖 **For detailed examples of all these anti-patterns and their solutions, see [anti-patterns.examples.md](anti-patterns.examples.md)**

--- a/doc-bot/rules/code-style-original.md
+++ b/doc-bot/rules/code-style-original.md
@@ -1,0 +1,1027 @@
+---
+alwaysApply: true
+title: "Swift Code Style Guide"
+description: "Swift code style and conventions for DuckDuckGo browser development including naming, formatting, and best practices"
+keywords: ["Swift", "code style", "naming conventions", "formatting", "best practices", "async/await", "property wrappers", "SwiftLint"]
+---
+
+# Swift Code Style Guide
+
+*This style guide is based on the [official iOS style guide](iOS/styleguide/STYLEGUIDE.md) and incorporates DuckDuckGo-specific patterns and requirements.*
+
+## Correctness
+
+**Strive to make your code compile without warnings.** This rule informs many style decisions such as using `#selector` types instead of string literals.
+
+## SwiftLint
+
+We use [SwiftLint](https://github.com/realm/SwiftLint) for enforcing Swift style and conventions. See the [SwiftLint configuration](.swiftlint.yml) for specific rules.
+
+**Key SwiftLint settings**:
+- Line length: 150 characters (not the default 100)
+- Force cast/try: warnings (not errors for pragmatic development)
+- Identifier naming: flexible for single-letter variables in closures
+
+## Naming Conventions
+
+Follow the [Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/) with these key principles:
+
+### Core Principles
+- **Clarity at the call site** over brevity
+- **Use camelCase** (not snake_case)
+- **UpperCamelCase** for types and protocols
+- **lowerCamelCase** for everything else
+- **Include all needed words** while omitting needless words
+- **Use names based on roles**, not types
+
+### Type Names
+Use **UpperCamelCase** for classes, structs, enums, and protocols. Names should be descriptive and avoid generic terms.
+
+📖 **[See detailed examples →](code-style.examples.md#type-names-examples)**
+
+### Variable and Function Names
+Use **lowerCamelCase** for variables, functions, and methods. Names should be descriptive and boolean properties should read like assertions.
+
+📖 **[See detailed examples →](code-style.examples.md#variable-and-function-names-examples)**
+
+### Protocol Naming
+- **Capability protocols**: end in `-able`, `-ible`, `-ing`
+- **Type protocols**: use nouns
+
+📖 **[See detailed examples →](code-style.examples.md#protocol-naming-examples)**
+
+### Method Naming Patterns
+- **Factory methods**: begin with "make"
+- **Non-mutating methods**: use `-ed`, `-ing` forms
+- **Boolean methods**: read like assertions
+
+📖 **[See detailed examples →](code-style.examples.md#method-naming-examples)**
+
+### Delegate Methods
+When creating custom delegate methods, the **unnamed first parameter should be the delegate source**:
+
+```swift
+// ✅ CORRECT: Delegate pattern
+func namePickerView(_ namePickerView: NamePickerView, didSelectName name: String)
+func namePickerViewShouldReload(_ namePickerView: NamePickerView) -> Bool
+
+// ❌ INCORRECT: Missing source parameter
+func didSelectName(namePicker: NamePickerViewController, name: String)
+func namePickerShouldReload() -> Bool
+```
+
+### Use Type Inferred Context
+Use compiler inferred context to write shorter, clear code:
+
+```swift
+// ✅ CORRECT: Type inferred context
+let selector = #selector(viewDidLoad)
+view.backgroundColor = .red
+let toView = context.view(forKey: .to)
+let view = UIView(frame: .zero)
+
+// ❌ INCORRECT: Redundant type information
+let selector = #selector(ViewController.viewDidLoad)
+view.backgroundColor = UIColor.red
+let toView = context.view(forKey: UITransitionContextViewKey.to)
+let view = UIView(frame: CGRect.zero)
+```
+
+### Generics
+Generic type parameters should be **descriptive, UpperCamelCase names**:
+
+```swift
+// ✅ CORRECT: Descriptive generic names
+struct Stack<Element> { ... }
+func write<Target: OutputStream>(to target: inout Target)
+func swap<T>(_ a: inout T, _ b: inout T)  // T is acceptable when no meaningful relationship
+
+// ❌ INCORRECT: Non-descriptive or wrong case
+struct Stack<T> { ... }
+func write<target: OutputStream>(to target: inout target)
+```
+
+### Language
+Use **US English spelling** to match Apple's API:
+
+```swift
+// ✅ CORRECT: US English
+let color = "red"
+
+// ❌ INCORRECT: British English
+let colour = "red"
+```
+
+## Code Organization
+
+### File Structure
+```swift
+// 1. Import statements (minimal - only what's needed)
+import UIKit
+import Combine
+
+// 2. Protocol definitions
+protocol FeatureDelegate: AnyObject {
+    func featureDidUpdate()
+}
+
+// 3. Main type declaration
+class FeatureViewController: UIViewController {
+    // Properties first
+    private let viewModel: FeatureViewModel
+    
+    // Lifecycle methods
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+    }
+    
+    // Private methods
+    private func setupUI() { }
+}
+
+// 4. Extensions for protocol conformance
+// MARK: - UITableViewDataSource
+extension FeatureViewController: UITableViewDataSource {
+    // Protocol methods
+}
+```
+
+### Protocol Conformance
+**Prefer separate extensions** for protocol conformance to keep related methods grouped:
+
+```swift
+// ✅ CORRECT: Separate extensions
+class MyViewController: UIViewController {
+    // class implementation
+}
+
+// MARK: - UITableViewDataSource
+extension MyViewController: UITableViewDataSource {
+    // table view data source methods
+}
+
+// MARK: - UIScrollViewDelegate
+extension MyViewController: UIScrollViewDelegate {
+    // scroll view delegate methods
+}
+
+// ❌ INCORRECT: All in main class declaration
+class MyViewController: UIViewController, UITableViewDataSource, UIScrollViewDelegate {
+    // all methods mixed together
+}
+```
+
+### Minimal Imports
+**Import only the modules a source file requires**:
+
+```swift
+// ✅ CORRECT: Minimal imports
+import UIKit
+var view: UIView
+var deviceModels: [String]
+
+// ✅ CORRECT: Foundation when UIKit not needed
+import Foundation
+var deviceModels: [String]
+
+// ❌ INCORRECT: Unnecessary imports
+import UIKit
+import Foundation  // UIKit already includes Foundation
+var view: UIView
+var deviceModels: [String]
+```
+
+### Remove Unused Code
+**Remove unused (dead) code**, including Xcode template code:
+
+```swift
+// ✅ CORRECT: Keep only implemented methods
+override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    return Database.contacts.count
+}
+
+// ❌ INCORRECT: Template code and unused methods
+override func didReceiveMemoryWarning() {
+    super.didReceiveMemoryWarning()
+    // Dispose of any resources that can be recreated.
+}
+
+override func numberOfSections(in tableView: UITableView) -> Int {
+    // #warning Incomplete implementation, return the number of sections
+    return 1
+}
+```
+
+## Formatting and Style
+
+### Line Breaks and Length
+- **Line margin: 150 characters** (not the default 100)
+- **Long lines should be wrapped** at around 150 characters
+- **Avoid trailing whitespace** at ends of lines
+- **Add single newline** at end of each file
+
+### Spacing
+- **Indent using 4 spaces** rather than tabs
+- **Method braces open on same line**, close on new line
+- **One blank line between methods**
+- **No blank lines after opening brace or before closing brace**
+
+```swift
+// ✅ CORRECT: Spacing and braces
+if user.isHappy {
+    // Do something
+} else {
+    // Do something else
+}
+
+// ❌ INCORRECT: Wrong brace placement
+if user.isHappy
+{
+    // Do something
+}
+else {
+    // Do something else
+}
+```
+
+### Colons
+**Colons have no space on left, one space on right**. Exceptions: ternary operator `? :`, empty dictionary `[:]`, `#selector` syntax:
+
+```swift
+// ✅ CORRECT: Colon spacing
+class TestDatabase: Database {
+    var data: [String: CGFloat] = ["A": 1.2, "B": 3.2]
+}
+
+// ❌ INCORRECT: Wrong colon spacing
+class TestDatabase : Database {
+    var data :[String:CGFloat] = ["A" : 1.2, "B":3.2]
+}
+```
+
+### Function Parameters
+**Closing parentheses should not appear on line by themselves**:
+
+```swift
+// ✅ CORRECT: Closing parenthesis placement
+let user = try await getUser(
+    for: userID,
+    on: connection)
+
+// ❌ INCORRECT: Closing parenthesis on own line
+let user = try await getUser(
+    for: userID,
+    on: connection
+)
+```
+
+## Function Declarations
+
+### Short Functions
+**Keep short function declarations on one line**:
+
+```swift
+// ✅ CORRECT: Short function on one line
+func reticulateSplines(spline: [Double]) -> Bool {
+    // implementation
+}
+```
+
+### Long Function Signatures
+**For functions with long signatures, put each parameter on new line**:
+
+```swift
+// ✅ CORRECT: Long signature formatting
+func reticulateSplines(spline: [Double],
+                      adjustmentFactor: Double,
+                      translateConstant: Int,
+                      comment: String) -> Bool {
+    // implementation
+}
+```
+
+### Return Types
+**Use `Void` for closure/function outputs, `()` for inputs**:
+
+```swift
+// ✅ CORRECT: Return type formatting
+func updateConstraints() -> Void {
+    // implementation
+}
+
+typealias CompletionHandler = (result) -> Void
+
+// ❌ INCORRECT: Wrong return type syntax
+func updateConstraints() -> () {
+    // implementation
+}
+
+typealias CompletionHandler = (result) -> ()
+```
+
+## Function Calls
+
+**Mirror function declaration style at call sites**:
+
+```swift
+// ✅ CORRECT: Single line when it fits
+let success = reticulateSplines(splines)
+
+// ✅ CORRECT: Multi-line when wrapped
+let success = reticulateSplines(
+    spline: splines,
+    adjustmentFactor: 1.3,
+    translateConstant: 2,
+    comment: "normalize the display")
+```
+
+## Closure Expressions
+
+### Trailing Closure Syntax
+**Use trailing closure syntax only for single closure at end**:
+
+```swift
+// ✅ CORRECT: Trailing closure usage
+UIView.animate(withDuration: 1.0) {
+    self.myView.alpha = 0
+}
+
+UIView.animate(withDuration: 1.0, animations: {
+    self.myView.alpha = 0
+}, completion: { finished in
+    self.myView.removeFromSuperview()
+})
+
+// ❌ INCORRECT: Trailing closure with multiple closures
+UIView.animate(withDuration: 1.0, animations: {
+    self.myView.alpha = 0
+}) { f in
+    self.myView.removeFromSuperview()
+}
+```
+
+### Single-Expression Closures
+**Use implicit returns for single-expression closures**:
+
+```swift
+// ✅ CORRECT: Implicit return
+attendeeList.sort { a, b in
+    a > b
+}
+```
+
+### Chained Methods
+**Format chained methods for clarity**:
+
+```swift
+// ✅ CORRECT: Chained methods - compact when clear
+let value = numbers.map { $0 * 2 }.filter { $0 % 3 == 0 }.index(of: 90)
+
+// ✅ CORRECT: Chained methods - multi-line when complex
+let value = numbers
+    .map { $0 * 2 }
+    .filter { $0 > 50 }
+    .map { $0 + 10 }
+```
+
+## Types and Constants
+
+### Native Types
+**Always use Swift's native types** when available:
+
+```swift
+// ✅ CORRECT: Native Swift types
+let width = 120.0                    // Double
+let widthString = "\(width)"         // String
+
+// ❌ INCORRECT: Objective-C types
+let width: NSNumber = 120.0          // NSNumber
+let widthString: NSString = width.stringValue  // NSString
+```
+
+### Constants vs Variables
+**Use `let` by default, change to `var` only when compiler complains**:
+
+```swift
+// ✅ CORRECT: Type properties for constants
+enum Math {
+    static let e = 2.718281828459045235360287
+    static let root2 = 1.41421356237309504880168872
+}
+
+let hypotenuse = side * Math.root2
+
+// ❌ INCORRECT: Global constants
+let e = 2.718281828459045235360287  // pollutes global namespace
+let root2 = 1.41421356237309504880168872
+```
+
+### Type Inference
+**Prefer compact code and let compiler infer types**:
+
+```swift
+// ✅ CORRECT: Type inference
+let message = "Click the button"
+let currentBounds = computeViewBounds()
+var names = ["Mic", "Sam", "Christine"]
+let maximumWidth: CGFloat = 106.5  // Specify when needed
+
+// ❌ INCORRECT: Unnecessary type annotations
+let message: String = "Click the button"
+let currentBounds: CGRect = computeViewBounds()
+```
+
+### Empty Collections
+**Use type annotation for empty arrays and dictionaries**:
+
+```swift
+// ✅ CORRECT: Type annotation for empty collections
+var names: [String] = []
+var lookup: [String: Int] = [:]
+
+// ❌ INCORRECT: Constructor syntax
+var names = [String]()
+var lookup = [String: Int]()
+```
+
+### Syntactic Sugar
+**Prefer shortcut type declarations**:
+
+```swift
+// ✅ CORRECT: Syntactic sugar
+var deviceModels: [String]
+var employees: [Int: String]
+var faxNumber: Int?
+
+// ❌ INCORRECT: Full generics syntax
+var deviceModels: Array<String>
+var employees: Dictionary<Int, String>
+var faxNumber: Optional<Int>
+```
+
+## Optionals
+
+### Optional Declarations
+**Use `?` for optional types, `!` only when you know initialization timing**:
+
+```swift
+// ✅ CORRECT: Optional usage
+var subview: UIView?
+var volume: Double?
+
+// Use ! only for outlets that initialize in viewDidLoad
+@IBOutlet weak var tableView: UITableView!
+```
+
+### Optional Binding
+**Shadow original names in optional binding**:
+
+```swift
+// ✅ CORRECT: Shadow original name
+if let subview = subview, let volume = volume {
+    // do something with unwrapped subview and volume
+}
+
+// ❌ INCORRECT: Different names for unwrapped values
+if let unwrappedSubview = optionalSubview {
+    if let realVolume = volume {
+        // do something with unwrappedSubview and realVolume
+    }
+}
+```
+
+### Optional Chaining vs Binding
+**Use optional chaining for single access, binding for multiple operations**:
+
+```swift
+// ✅ CORRECT: Optional chaining for single access
+textContainer?.textLabel?.setNeedsDisplay()
+
+// ✅ CORRECT: Optional binding for multiple operations
+if let textContainer = textContainer {
+    // do many things with textContainer
+}
+```
+
+## Memory Management
+
+### Reference Cycles
+**Prevent reference cycles with `weak` and `unowned` references**:
+
+```swift
+// ✅ CORRECT: Weak self pattern
+resource.request().onComplete { [weak self] response in
+    guard let self = self else { return }
+    let model = self.updateModel(response)
+    self.updateUI(model)
+}
+
+// ❌ INCORRECT: Potential crash with unowned
+resource.request().onComplete { [unowned self] response in
+    let model = self.updateModel(response)  // Might crash
+    self.updateUI(model)
+}
+
+// ❌ INCORRECT: Optional chaining can cause issues
+resource.request().onComplete { [weak self] response in
+    let model = self?.updateModel(response)  // Self might be nil here
+    self?.updateUI(model)                    // And here, causing inconsistency
+}
+```
+
+### Lazy Initialization
+**Use lazy initialization for fine-grained control**:
+
+```swift
+// ✅ CORRECT: Lazy initialization
+lazy var locationManager = makeLocationManager()
+
+private func makeLocationManager() -> CLLocationManager {
+    let manager = CLLocationManager()
+    manager.desiredAccuracy = kCLLocationAccuracyBest
+    manager.delegate = self
+    manager.requestAlwaysAuthorization()
+    return manager
+}
+```
+
+## Access Control
+
+### Access Control Order
+**Access control comes first, except for `static` and attributes**:
+
+```swift
+// ✅ CORRECT: Access control ordering
+private let message = "Great Scott!"
+
+class TimeMachine {
+    private dynamic lazy var fluxCapacitor = FluxCapacitor()
+    @IBAction private func activate() { }
+    static private let timeConstant = 88.0
+}
+
+// ❌ INCORRECT: Wrong ordering
+fileprivate let message = "Great Scott!"
+
+class TimeMachine {
+    lazy dynamic private var fluxCapacitor = FluxCapacitor()
+}
+```
+
+### Private vs Fileprivate
+**Prefer `private` to `fileprivate`**; use `fileprivate` only when compiler requires it.
+
+## Control Flow
+
+### Loop Style
+**Prefer `for-in` style over `while-condition-increment`**:
+
+```swift
+// ✅ CORRECT: for-in style
+for _ in 0..<3 {
+    print("Hello three times")
+}
+
+for (index, person) in attendeeList.enumerated() {
+    print("\(person) is at position #\(index)")
+}
+
+// ❌ INCORRECT: while style
+var i = 0
+while i < 3 {
+    print("Hello three times")
+    i += 1
+}
+```
+
+### Ternary Operator
+**Use ternary operator only when it increases clarity**:
+
+```swift
+// ✅ CORRECT: Simple ternary usage
+let value = 5
+result = value != 0 ? x : y
+
+let isHorizontal = true
+result = isHorizontal ? x : y
+
+// ❌ INCORRECT: Complex nested ternary
+result = a > b ? x = c > d ? c : d : y
+```
+
+### Golden Path
+**Use the "golden path" pattern - don't nest `if` statements**:
+
+```swift
+// ✅ CORRECT: Golden path with guard
+func computeFFT(context: Context?, inputData: InputData?) throws -> Frequencies {
+    guard let context = context else {
+        throw FFTError.noContext
+    }
+    guard let inputData = inputData else {
+        throw FFTError.noInputData
+    }
+    
+    // use context and input to compute the frequencies
+    return frequencies
+}
+
+// ❌ INCORRECT: Nested if statements
+func computeFFT(context: Context?, inputData: InputData?) throws -> Frequencies {
+    if let context = context {
+        if let inputData = inputData {
+            // use context and input to compute the frequencies
+            return frequencies
+        } else {
+            throw FFTError.noInputData
+        }
+    } else {
+        throw FFTError.noContext
+    }
+}
+```
+
+### Compound Guard Statements
+**Use compound guard for multiple optionals**:
+
+```swift
+// ✅ CORRECT: Compound guard
+guard 
+    let number1 = number1,
+    let number2 = number2,
+    let number3 = number3 
+else {
+    fatalError("impossible")
+}
+
+// ❌ INCORRECT: Nested optional binding
+if let number1 = number1 {
+    if let number2 = number2 {
+        if let number3 = number3 {
+            // do something with numbers
+        }
+    }
+}
+```
+
+## Class and Struct Definitions
+
+### Example Well-Styled Class
+```swift
+final class Circle: Shape {
+    var x: Int, y: Int
+    var radius: Double
+    var diameter: Double {
+        get {
+            radius * 2
+        }
+        set {
+            radius = newValue / 2
+        }
+    }
+    
+    init(x: Int, y: Int, radius: Double) {
+        self.x = x
+        self.y = y
+        self.radius = radius
+    }
+    
+    convenience init(x: Int, y: Int, diameter: Double) {
+        self.init(x: x, y: y, radius: diameter / 2)
+    }
+    
+    override func area() -> Double {
+        Double.pi * radius * radius
+    }
+}
+
+extension Circle: CustomStringConvertible {
+    var description: String {
+        "center = \(centerString) area = \(area())"
+    }
+    
+    private var centerString: String {
+        "(\(x),\(y))"
+    }
+}
+```
+
+### Use of Self
+**Avoid using `self` unless required by compiler**:
+
+```swift
+// ✅ CORRECT: Self only when required
+class PhotoViewController: UIViewController {
+    var image: UIImage
+    
+    init(image: UIImage) {
+        self.image = image  // Required to disambiguate
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    func setupImageView() {
+        imageView.image = image  // self not needed
+    }
+}
+```
+
+### Computed Properties
+**Omit get clause for read-only computed properties**:
+
+```swift
+// ✅ CORRECT: Implicit get for read-only
+var diameter: Double {
+    radius * 2
+}
+
+// ❌ INCORRECT: Unnecessary get clause
+var diameter: Double {
+    get {
+        return radius * 2
+    }
+}
+```
+
+### Final
+**Use `final` when inheritance is not intended**:
+
+```swift
+// ✅ CORRECT: Final for utility classes
+final class Box<T> {
+    let value: T
+    init(_ value: T) {
+        self.value = value
+    }
+}
+```
+
+## DuckDuckGo-Specific Patterns
+
+### Design System Integration (MANDATORY)
+
+**ALWAYS use DesignResourcesKit** for colors, typography, and icons:
+
+```swift
+// ✅ REQUIRED: Use DesignResourcesKit colors
+label.textColor = UIColor(designSystemColor: .textPrimary)
+view.backgroundColor = UIColor(designSystemColor: .background)
+
+// ✅ REQUIRED: Use DesignResourcesKit typography
+titleLabel.font = UIFont.daxTitle1()
+bodyLabel.font = UIFont.daxBody()
+
+// ✅ REQUIRED: Use DesignResourcesKit icons
+let image = DesignSystemImages.Color.Size24.bookmark
+
+// ❌ FORBIDDEN: Hardcoded colors/fonts/icons
+label.textColor = UIColor.black
+titleLabel.font = UIFont.systemFont(ofSize: 24)
+let image = UIImage(systemName: "bookmark")
+```
+
+### Dependency Injection Pattern
+**Use AppDependencyProvider for dependency injection**:
+
+```swift
+// ✅ CORRECT: Dependency injection pattern
+final class FeatureViewModel: ObservableObject {
+    private let service: FeatureServiceProtocol
+    
+    init(dependencies: DependencyProvider = AppDependencyProvider.shared) {
+        self.service = dependencies.featureService
+    }
+}
+```
+
+### Async/Await Patterns
+```swift
+// ✅ CORRECT: Modern async/await with proper error handling
+@MainActor
+class FeatureViewModel: ObservableObject {
+    @Published var state: FeatureState = .idle
+    
+    func loadData() async {
+        state = .loading
+        
+        do {
+            let data = try await service.fetchData()
+            state = .loaded(data)
+        } catch {
+            state = .error(error)
+        }
+    }
+}
+```
+
+### Property Wrappers
+```swift
+// ✅ CORRECT: Use custom property wrappers
+final class SettingsManager {
+    @UserDefaultsWrapper(key: .showBookmarksBar, defaultValue: true)
+    var showBookmarksBar: Bool
+    
+    @UserDefaultsWrapper(key: .homePageURL, defaultValue: "https://duckduckgo.com")
+    var homePageURL: String
+}
+```
+
+## Comments and Documentation
+
+### When to Comment
+**Use comments to explain WHY, not WHAT**:
+
+```swift
+// ✅ CORRECT: Explains why
+// We delay the animation to avoid conflicting with the previous transition
+DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+    self.animateTransition()
+}
+
+// ❌ INCORRECT: Explains what (obvious from code)
+// Set the background color to red
+view.backgroundColor = .red
+```
+
+### Comment Style
+**Prefer double/triple-slash over C-style comments**:
+
+```swift
+// ✅ CORRECT: Swift-style comments
+// This is a comment
+/// This is a documentation comment
+
+// ❌ INCORRECT: C-style comments
+/* This is a comment */
+```
+
+## String Literals
+
+### Multi-line Strings
+**Use multi-line string syntax for long strings**:
+
+```swift
+// ✅ CORRECT: Multi-line string formatting
+let message = """
+    You cannot charge the flux \
+    capacitor with a 9V battery.
+    You must use a super-charger \
+    which costs 10 credits. You currently \
+    have \(credits) credits available.
+    """
+
+// ❌ INCORRECT: Concatenation or inline text
+let message = """You cannot charge the flux \
+    capacitor with a 9V battery.
+    You must use a super-charger \
+    which costs 10 credits. You currently \
+    have \(credits) credits available.
+    """
+```
+
+## Prohibited Patterns
+
+### No Emoji
+**Do not use emoji in code** - it creates unnecessary friction:
+
+```swift
+// ❌ FORBIDDEN: Emoji in code
+let isHappy = true 😀
+func celebrate() 🎉 { }
+
+// ✅ CORRECT: Clear, text-based names
+let isHappy = true
+func celebrate() { }
+```
+
+### No Color/Image Literals
+**Do not use `#colorLiteral` or `#imageLiteral`** - they're hard to read and maintain:
+
+```swift
+// ❌ FORBIDDEN: Literals
+let color = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1)
+let image = #imageLiteral(resourceName: "icon")
+
+// ✅ CORRECT: Explicit constructors (but prefer DesignResourcesKit)
+let color = UIColor(red: 1, green: 0, blue: 0, alpha: 1)
+let image = UIImage(named: "icon")
+
+// ✅ BEST: DesignResourcesKit
+let color = UIColor(designSystemColor: .accent)
+let image = DesignSystemImages.Color.Size24.bookmark
+```
+
+### No Parentheses Around Conditionals
+**Don't use unnecessary parentheses**:
+
+```swift
+// ✅ CORRECT: No parentheses needed
+if name == "Hello" {
+    print("World")
+}
+
+// ❌ INCORRECT: Unnecessary parentheses
+if (name == "Hello") {
+    print("World")
+}
+```
+
+### No Semicolons
+**Swift doesn't require semicolons** - don't use them:
+
+```swift
+// ✅ CORRECT: No semicolons
+let swift = "not a scripting language"
+
+// ❌ INCORRECT: Unnecessary semicolons
+let swift = "not a scripting language";
+```
+
+## Error Handling and Assertions
+
+### Fatal Errors
+**Use `fatalError()` when app reaches unrecoverable state**:
+
+```swift
+// ✅ CORRECT: Fatal error for impossible states
+guard let viewController = storyboard.instantiateViewController(withIdentifier: "Main") as? MainViewController else {
+    fatalError("Failed to instantiate MainViewController from storyboard")
+}
+```
+
+### Assertions
+**Use `assert()` and `assertionFailure()` for recoverable but unexpected states**:
+
+```swift
+// ✅ CORRECT: Assert for development debugging
+func processItems(_ items: [Item]) {
+    assert(!items.isEmpty, "Items array should not be empty")
+    
+    // Handle empty array gracefully in release builds
+    guard !items.isEmpty else { return }
+    
+    // Process items...
+}
+```
+
+## Logging
+
+**Use unified logging system** for all logging:
+
+```swift
+import os
+
+// ✅ CORRECT: Unified logging
+private let logger = Logger(subsystem: "com.duckduckgo.browser", category: "FeatureManager")
+
+func performAction() {
+    logger.debug("Starting action with parameter: \(parameter, privacy: .public)")
+    
+    // Perform action...
+    
+    if success {
+        logger.info("Action completed successfully")
+    } else {
+        logger.error("Action failed: \(error.localizedDescription, privacy: .public)")
+    }
+}
+```
+
+**See [Logging Guidelines](logging-guidelines.md) for comprehensive logging patterns.**
+
+## Unit Test Naming
+
+**Use "when/then" convention for test names**:
+
+```swift
+// ✅ CORRECT: When/then test naming
+func testWhenUrlIsNotATrackerThenMatchesIsFalse() { }
+func testWhenUserTapsBookmarkButtonThenBookmarkIsAdded() { }
+func testWhenNetworkFailsThenErrorIsDisplayed() { }
+
+// ❌ INCORRECT: Unclear test names
+func testBookmarks() { }
+func testNetworking() { }
+```
+
+## Functions vs Methods
+
+**Prefer methods over free functions** for discoverability:
+
+```swift
+// ✅ CORRECT: Methods are easily discoverable
+let sorted = items.mergeSorted()
+rocket.launch()
+
+// ❌ INCORRECT: Free functions are hard to discover
+let sorted = mergeSort(items)
+launch(&rocket)
+
+// ✅ ACCEPTABLE: Free functions that feel natural
+let tuples = zip(a, b)
+let value = max(x, y, z)
+```
+
+---
+
+**Remember**: This style guide ensures consistency across the DuckDuckGo browser codebase. When in doubt, prioritize clarity and follow the patterns established in existing code.

--- a/doc-bot/rules/code-style.examples.md
+++ b/doc-bot/rules/code-style.examples.md
@@ -1,0 +1,516 @@
+---
+alwaysApply: false
+title: "Swift Code Style Examples"
+description: "Detailed code examples demonstrating Swift style conventions for DuckDuckGo browser development"
+keywords: ["Swift", "code examples", "style", "formatting", "patterns", "naming conventions"]
+---
+
+# Swift Code Style Examples
+
+## Type Names Examples
+
+```swift
+// ✅ CORRECT: Descriptive, UpperCamelCase
+class UserAuthenticationManager { }
+struct BookmarkItem { }
+enum NavigationState { }
+protocol DataSourceProtocol { }
+
+// ❌ INCORRECT: Too generic
+class Manager { }
+struct Data { }
+```
+
+## Variable and Function Names Examples
+
+```swift
+// ✅ CORRECT: Descriptive, clear intent
+let maximumNumberOfLoginAttempts = 3
+func fetchUserProfile(for userId: String) -> UserProfile
+func updateBookmark(with url: URL, title: String)
+
+// ❌ INCORRECT: Too brief or unclear
+let max = 3
+func fetch(_ id: String)
+func update(_ url: URL)
+```
+
+## Protocol Naming Examples
+
+```swift
+// ✅ CORRECT: Nouns for capabilities
+protocol DataSource { }
+protocol NavigationDelegate { }
+
+// ✅ CORRECT: -ing/-able for behaviors
+protocol Downloading {
+    func download(from url: URL)
+}
+
+protocol Cacheable {
+    func cache()
+}
+
+// ❌ INCORRECT: Generic or unclear
+protocol Helper { }
+protocol Thing { }
+```
+
+## Method Naming Examples
+
+```swift
+// ✅ CORRECT: Clear action and parameters
+func convert(_ temperature: Temperature, to unit: TemperatureUnit) -> Temperature
+func move(from start: Point, to end: Point)
+func addBookmark(for url: URL, in folder: BookmarkFolder?)
+
+// ❌ INCORRECT: Unclear parameters
+func convert(_ temp: Temperature, _ unit: TemperatureUnit) -> Temperature
+func move(_ start: Point, _ end: Point)
+```
+
+## Delegate Method Naming
+
+```swift
+// ✅ CORRECT: Start with delegate name
+protocol BookmarkManagerDelegate {
+    func bookmarkManager(_ manager: BookmarkManager, didAdd bookmark: Bookmark)
+    func bookmarkManager(_ manager: BookmarkManager, willRemove bookmark: Bookmark)
+    func bookmarkManagerDidFinishImport(_ manager: BookmarkManager)
+}
+
+// ❌ INCORRECT: Unclear source
+protocol BookmarkManagerDelegate {
+    func didAddBookmark(_ bookmark: Bookmark)  // From where?
+    func willRemove(_ bookmark: Bookmark)      // What will remove?
+}
+```
+
+## Type Inferred Context Examples
+
+```swift
+// ✅ CORRECT: Use type inference when clear
+let selector: Selector = #selector(buttonTapped)
+let view = UIView(frame: .zero)
+let bookmarks: [Bookmark] = []
+
+// ❌ INCORRECT: Unnecessary type repetition
+let selector: Selector = Selector(#selector(buttonTapped))
+let view = UIView(frame: CGRect.zero)
+```
+
+## Generics Examples
+
+```swift
+// ✅ CORRECT: Descriptive generic names
+struct NetworkResponse<ResponseData> {
+    let data: ResponseData
+}
+
+func fetchData<DataType: Decodable>() -> DataType {
+    // Implementation
+}
+
+// ❌ INCORRECT: Single letters for unclear generics
+struct NetworkResponse<T> {  // What is T?
+    let data: T
+}
+```
+
+## File Organization Example
+
+```swift
+//
+//  BookmarkViewModel.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+// MARK: - Protocol Definitions
+
+protocol BookmarkViewModelDelegate: AnyObject {
+    func bookmarkViewModelDidUpdate(_ viewModel: BookmarkViewModel)
+}
+
+// MARK: - Main Implementation
+
+final class BookmarkViewModel: ObservableObject {
+    
+    // MARK: - Properties
+    
+    // Public stored properties
+    @Published var bookmarks: [Bookmark] = []
+    @Published var isLoading = false
+    
+    // Private stored properties
+    private let bookmarkManager: BookmarkManagerProtocol
+    private var cancellables = Set<AnyCancellable>()
+    
+    // Computed properties
+    var hasBookmarks: Bool {
+        !bookmarks.isEmpty
+    }
+    
+    // MARK: - Initialization
+    
+    init(dependencies: DependencyProvider = AppDependencyProvider.shared) {
+        self.bookmarkManager = dependencies.bookmarkManager
+    }
+    
+    // MARK: - Public Methods
+    
+    func loadBookmarks() {
+        // Implementation
+    }
+    
+    // MARK: - Private Methods
+    
+    private func setupBindings() {
+        // Implementation
+    }
+}
+
+// MARK: - Extensions
+
+extension BookmarkViewModel {
+    func bookmarkURL(at index: Int) -> URL? {
+        guard bookmarks.indices.contains(index) else { return nil }
+        return bookmarks[index].url
+    }
+}
+```
+
+## Function Declaration Examples
+
+```swift
+// ✅ CORRECT: Short function
+func isValid() -> Bool {
+    return !isEmpty && count > 0
+}
+
+// ✅ CORRECT: Multi-line parameter list
+func authenticateUser(
+    username: String,
+    password: String,
+    completion: @escaping (Result<User, AuthError>) -> Void
+) {
+    // Implementation
+}
+
+// ✅ CORRECT: Generic function with constraints
+func sorted<T: Comparable>(
+    _ elements: [T],
+    by keyPath: KeyPath<T, String>
+) -> [T] {
+    // Implementation
+}
+```
+
+## Closure Expression Examples
+
+```swift
+// ✅ CORRECT: Trailing closure
+bookmarks.forEach { bookmark in
+    process(bookmark)
+}
+
+// ✅ CORRECT: Single expression closure
+let doubled = numbers.map { $0 * 2 }
+
+// ✅ CORRECT: Multi-line closure with capture list
+let networkTask = Task { [weak self] in
+    guard let self = self else { return }
+    
+    do {
+        let result = try await self.networkService.fetch()
+        await MainActor.run {
+            self.handleResult(result)
+        }
+    } catch {
+        Logger.network.error("Network request failed: \(error)")
+    }
+}
+
+// ✅ CORRECT: Chained methods with closures
+let processedBookmarks = bookmarks
+    .filter { $0.isValid }
+    .sorted { $0.title < $1.title }
+    .map { BookmarkViewModel(bookmark: $0) }
+```
+
+## Memory Management Examples
+
+```swift
+// ✅ CORRECT: Weak self in closure
+class NetworkManager {
+    func fetchData() {
+        urlSession.dataTask(with: url) { [weak self] data, _, error in
+            guard let self = self else { return }
+            self.handleResponse(data, error)
+        }
+    }
+}
+
+// ✅ CORRECT: Lazy initialization
+class ExpensiveService {
+    lazy var processor: DataProcessor = {
+        DataProcessor(configuration: self.configuration)
+    }()
+}
+```
+
+## Control Flow Examples
+
+```swift
+// ✅ CORRECT: Guard for early returns
+func processBookmark(_ bookmark: Bookmark?) {
+    guard 
+        let bookmark = bookmark,
+        bookmark.isValid,
+        !bookmark.isDeleted
+    else {
+        Logger.general.debug("Invalid bookmark")
+        return
+    }
+    
+    // Process valid bookmark
+    updateUI(with: bookmark)
+}
+
+// ✅ CORRECT: Ternary for simple assignments
+let statusText = isConnected ? "Online" : "Offline"
+
+// ❌ INCORRECT: Ternary for complex operations
+let result = isValid ? performComplexValidation() : showErrorAndReturnDefault()
+```
+
+## Class Definition Examples
+
+```swift
+// ✅ CORRECT: Well-organized class
+final class BookmarkService {
+    
+    // MARK: - Properties
+    
+    private let networkClient: NetworkClient
+    private let cacheStore: CacheStore
+    
+    // MARK: - Initialization
+    
+    init(networkClient: NetworkClient, cacheStore: CacheStore) {
+        self.networkClient = networkClient
+        self.cacheStore = cacheStore
+    }
+    
+    // MARK: - Public Interface
+    
+    func fetchBookmarks() async throws -> [Bookmark] {
+        if let cached = cacheStore.bookmarks, !cached.isEmpty {
+            return cached
+        }
+        
+        let bookmarks = try await networkClient.fetchBookmarks()
+        cacheStore.store(bookmarks)
+        return bookmarks
+    }
+    
+    // MARK: - Private Helpers
+    
+    private func validateBookmark(_ bookmark: Bookmark) -> Bool {
+        return !bookmark.title.isEmpty && bookmark.url.isValid
+    }
+}
+```
+
+## Async/Await Examples
+
+```swift
+// ✅ CORRECT: Async function
+func fetchUserData(for userID: String) async throws -> User {
+    let response = try await networkClient.get("/users/\(userID)")
+    return try decoder.decode(User.self, from: response.data)
+}
+
+// ✅ CORRECT: Task with error handling
+func updateBookmarks() {
+    Task { @MainActor in
+        do {
+            isLoading = true
+            bookmarks = try await bookmarkService.fetchAll()
+        } catch {
+            showError(error)
+        }
+        isLoading = false
+    }
+}
+
+// ✅ CORRECT: TaskGroup for concurrent operations
+func fetchAllData() async throws -> (bookmarks: [Bookmark], history: [HistoryItem]) {
+    try await withThrowingTaskGroup(of: Any.self) { group in
+        group.addTask { try await self.fetchBookmarks() }
+        group.addTask { try await self.fetchHistory() }
+        
+        var bookmarks: [Bookmark] = []
+        var history: [HistoryItem] = []
+        
+        for try await result in group {
+            switch result {
+            case let fetchedBookmarks as [Bookmark]:
+                bookmarks = fetchedBookmarks
+            case let fetchedHistory as [HistoryItem]:
+                history = fetchedHistory
+            default:
+                break
+            }
+        }
+        
+        return (bookmarks, history)
+    }
+}
+```
+
+## Property Wrapper Examples
+
+```swift
+// ✅ CORRECT: AppStorage usage
+struct SettingsView: View {
+    @AppStorage("showFavicons") private var showFavicons = true
+    @AppStorage("defaultSearchEngine") private var searchEngine = SearchEngine.duckDuckGo
+    
+    var body: some View {
+        Form {
+            Toggle("Show Favicons", isOn: $showFavicons)
+            Picker("Search Engine", selection: $searchEngine) {
+                ForEach(SearchEngine.allCases) { engine in
+                    Text(engine.displayName).tag(engine)
+                }
+            }
+        }
+    }
+}
+
+// ✅ CORRECT: Custom property wrapper
+@propertyWrapper
+struct Clamped<Value: Comparable> {
+    private var value: Value
+    private let range: ClosedRange<Value>
+    
+    var wrappedValue: Value {
+        get { value }
+        set { value = max(range.lowerBound, min(range.upperBound, newValue)) }
+    }
+    
+    init(wrappedValue: Value, _ range: ClosedRange<Value>) {
+        self.range = range
+        self.value = max(range.lowerBound, min(range.upperBound, wrappedValue))
+    }
+}
+
+// Usage
+struct VolumeControl {
+    @Clamped(0...100) var volume: Int = 50
+}
+```
+
+## Design System Integration Examples
+
+```swift
+// ✅ CORRECT: Use DesignResourcesKit
+struct BookmarkCell: View {
+    let bookmark: Bookmark
+    
+    var body: some View {
+        HStack {
+            Image(uiImage: DesignSystemImages.Glyphs.Size20.bookmark)
+                .renderingMode(.template)
+                .foregroundColor(Color(designSystemColor: .iconPrimary))
+            
+            Text(bookmark.title)
+                .font(Font(designSystemFont: .body))
+                .foregroundColor(Color(designSystemColor: .textPrimary))
+        }
+        .padding()
+        .background(Color(designSystemColor: .backgroundSecondary))
+    }
+}
+
+// ❌ INCORRECT: Hardcoded values
+struct BookmarkCell: View {
+    let bookmark: Bookmark
+    
+    var body: some View {
+        HStack {
+            Image(systemName: "bookmark")
+                .foregroundColor(.blue)
+            
+            Text(bookmark.title)
+                .font(.system(size: 17, weight: .medium))
+                .foregroundColor(.black)
+        }
+        .padding()
+        .background(Color.gray.opacity(0.1))
+    }
+}
+```
+
+## Dependency Injection Examples
+
+```swift
+// ✅ CORRECT: Dependency injection pattern
+final class BookmarkViewModel: ObservableObject {
+    private let bookmarkService: BookmarkServiceProtocol
+    private let analytics: AnalyticsTracking
+    
+    init(dependencies: DependencyProvider = AppDependencyProvider.shared) {
+        self.bookmarkService = dependencies.bookmarkService
+        self.analytics = dependencies.analytics
+    }
+}
+
+// ❌ INCORRECT: Direct singleton usage
+final class BookmarkViewModel: ObservableObject {
+    private let bookmarkService = BookmarkService.shared  // Hard dependency
+    private let analytics = Analytics.shared              // Hard dependency
+}
+```
+
+## Testing Examples
+
+```swift
+// ✅ CORRECT: Testable code with dependency injection
+class BookmarkManagerTests: XCTestCase {
+    private var sut: BookmarkManager!
+    private var mockNetworkClient: MockNetworkClient!
+    private var mockCacheStore: MockCacheStore!
+    
+    override func setUp() {
+        super.setUp()
+        mockNetworkClient = MockNetworkClient()
+        mockCacheStore = MockCacheStore()
+        sut = BookmarkManager(
+            networkClient: mockNetworkClient,
+            cacheStore: mockCacheStore
+        )
+    }
+    
+    func testFetchBookmarks_WhenCacheEmpty_FetchesFromNetwork() async throws {
+        // Given
+        mockCacheStore.bookmarks = []
+        mockNetworkClient.bookmarksToReturn = [
+            Bookmark(title: "Test", url: URL(string: "https://example.com")!)
+        ]
+        
+        // When
+        let bookmarks = try await sut.fetchBookmarks()
+        
+        // Then
+        XCTAssertEqual(bookmarks.count, 1)
+        XCTAssertEqual(bookmarks.first?.title, "Test")
+        XCTAssertTrue(mockNetworkClient.fetchBookmarksWasCalled)
+    }
+}
+```

--- a/doc-bot/rules/code-style.md
+++ b/doc-bot/rules/code-style.md
@@ -1,0 +1,286 @@
+---
+alwaysApply: true
+title: "Swift Code Style Guide"
+description: "Swift code style and conventions for DuckDuckGo browser development including naming, formatting, and best practices"
+keywords: ["Swift", "code style", "naming conventions", "formatting", "best practices", "async/await", "property wrappers", "SwiftLint"]
+---
+
+# Swift Code Style Guide
+
+*This style guide is based on the [official iOS style guide](iOS/styleguide/STYLEGUIDE.md) and incorporates DuckDuckGo-specific patterns and requirements.*
+
+## Correctness
+
+**Strive to make your code compile without warnings.** This rule informs many style decisions such as using `#selector` types instead of string literals.
+
+## SwiftLint
+
+We use [SwiftLint](https://github.com/realm/SwiftLint) for enforcing Swift style and conventions. See the [SwiftLint configuration](.swiftlint.yml) for specific rules.
+
+**Key SwiftLint settings**:
+- Line length: 150 characters (not the default 100)
+- Force cast/try: warnings (not errors for pragmatic development)
+- Identifier naming: flexible for single-letter variables in closures
+
+## Naming Conventions
+
+Follow the [Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/) with these key principles:
+
+### Core Principles
+- **Clarity at the call site** over brevity
+- **Use camelCase** (not snake_case)
+- **UpperCamelCase** for types and protocols
+- **lowerCamelCase** for everything else
+- **Include all needed words** while omitting needless words
+- **Use names based on roles**, not types
+
+### Type Names
+Use **UpperCamelCase** for classes, structs, enums, and protocols. Names should be descriptive and avoid generic terms.
+
+📖 **[See detailed examples →](code-style.examples.md#type-names-examples)**
+
+### Variable and Function Names
+Use **lowerCamelCase** for variables, functions, and methods. Names should be descriptive and boolean properties should read like assertions.
+
+📖 **[See detailed examples →](code-style.examples.md#variable-and-function-names-examples)**
+
+### Protocol Naming
+- **Capability protocols**: end in `-able`, `-ible`, `-ing`
+- **Type protocols**: use nouns
+
+📖 **[See detailed examples →](code-style.examples.md#protocol-naming-examples)**
+
+### Method Naming Patterns
+- **Factory methods**: begin with "make"
+- **Non-mutating methods**: use `-ed`, `-ing` forms
+- **Boolean methods**: read like assertions
+
+📖 **[See detailed examples →](code-style.examples.md#method-naming-examples)**
+
+### Delegate Methods
+The **unnamed first parameter should be the delegate source**.
+
+📖 **[See detailed examples →](code-style.examples.md#delegate-method-naming)**
+
+### Use Type Inferred Context
+Use compiler inferred context to write shorter, clear code.
+
+📖 **[See detailed examples →](code-style.examples.md#type-inferred-context-examples)**
+
+### Generics
+When using generics, use descriptive names when the purpose isn't clear from context.
+
+📖 **[See detailed examples →](code-style.examples.md#generics-examples)**
+
+### Language
+Use US English spelling to match Swift API guidelines.
+
+## Code Organization
+
+### File Structure
+**Order within files**:
+1. Imports
+2. Protocols 
+3. Class/Struct definition
+4. Properties (IBOutlets → stored → computed)
+5. Lifecycle methods
+6. Public methods
+7. Private methods 
+8. Extensions
+
+📖 **[See detailed examples →](code-style.examples.md#file-organization-example)**
+
+### Protocol Conformance
+When adding protocol conformance to a model, prefer adding a separate extension for the protocol methods.
+
+### Minimal Imports
+Import only the modules a source file requires. For example, don't import `UIKit` when importing `Foundation` will suffice.
+
+### Remove Unused Code
+Unused (dead) code should be removed. Don't comment out code - use version control.
+
+## Formatting and Style
+
+### Line Breaks and Length
+- **Maximum line length**: 150 characters
+- **Break after operators**: Place operators at the beginning of continuation lines
+
+### Spacing
+- **Method braces**: Opening brace on same line as definition
+- **Control flow braces**: Opening brace on same line as statement
+- **Indent with 4 spaces** (not tabs)
+
+### Colons
+Colons always have no space on the left and one space on the right (except in ternary operator).
+
+### Function Parameters
+When parameter lists are too long, break after each parameter with proper indentation.
+
+📖 **[See detailed examples →](code-style.examples.md#function-declaration-examples)**
+
+## Function Declarations
+
+### Short Functions
+Keep functions short and focused on a single task.
+
+### Long Function Signatures
+Break long signatures across multiple lines with proper indentation.
+
+### Return Types
+Be explicit about return types for public functions.
+
+## Function Calls
+
+Use trailing closure syntax when appropriate and the closure is the last parameter.
+
+📖 **[See detailed examples →](code-style.examples.md#closure-expression-examples)**
+
+## Types and Constants
+
+### Native Types
+Always use Swift's native types when available (prefer `String` over `NSString`).
+
+### Constants vs Variables
+Prefer `let` over `var` whenever possible.
+
+### Type Inference
+Rely on Swift's type inference when the type is obvious from context.
+
+### Empty Collections
+Use empty collection literals over explicit constructors.
+
+### Syntactic Sugar
+Use syntactic sugar for Array, Dictionary, and Optional types.
+
+## Optionals
+
+### Optional Declarations
+Prefer optional binding over comparing to `nil`.
+
+### Optional Binding
+Use `if let` and `guard let` for optional binding.
+
+### Optional Chaining vs Binding
+Use optional chaining for simple property access, optional binding for complex operations.
+
+📖 **[See detailed examples →](code-style.examples.md#control-flow-examples)**
+
+## Memory Management
+
+### Reference Cycles
+Use `[weak self]` and `[unowned self]` to prevent retain cycles in closures.
+
+### Lazy Initialization
+Use lazy initialization for expensive properties.
+
+📖 **[See detailed examples →](code-style.examples.md#memory-management-examples)**
+
+## Access Control
+
+### Access Control Order
+Order access modifiers consistently: `private` → `fileprivate` → `internal` → `public` → `open`.
+
+### Private vs Fileprivate
+Prefer `private` over `fileprivate` when possible.
+
+## Control Flow
+
+### Loop Style
+Prefer `for-in` loops over `while` loops.
+
+### Ternary Operator
+Use ternary operator for simple value assignments only.
+
+### Golden Path
+Use guard statements to exit early and avoid nesting.
+
+### Compound Guard Statements
+Combine multiple conditions in guard statements when appropriate.
+
+## Class and Struct Definitions
+
+📖 **[See complete well-organized class example →](code-style.examples.md#class-definition-examples)**
+
+### Use of Self
+Avoid using `self` unless required by the compiler.
+
+### Computed Properties
+Use computed properties when appropriate instead of methods.
+
+### Final
+Mark classes as `final` when they're not designed for inheritance.
+
+## DuckDuckGo-Specific Patterns
+
+### Design System Integration (MANDATORY)
+**ALWAYS use DesignResourcesKit** - never hardcode colors, fonts, or icons.
+
+📖 **[See design system examples →](code-style.examples.md#design-system-integration-examples)**
+
+### Dependency Injection Pattern
+**ALWAYS use dependency injection** - avoid singletons.
+
+📖 **[See dependency injection examples →](code-style.examples.md#dependency-injection-examples)**
+
+### Async/Await Patterns
+Use modern Swift concurrency patterns appropriately.
+
+📖 **[See async/await examples →](code-style.examples.md#asyncawait-examples)**
+
+### Property Wrappers
+Use property wrappers for common patterns like UserDefaults.
+
+📖 **[See property wrapper examples →](code-style.examples.md#property-wrapper-examples)**
+
+## Comments and Documentation
+
+### When to Comment
+Write comments for complex algorithms, business logic, and non-obvious decisions.
+
+### Comment Style
+Use `// MARK:` for organizing code sections.
+
+## String Literals
+
+### Multi-line Strings
+Use multi-line string literals for long strings.
+
+## Prohibited Patterns
+
+### No Emoji
+Never use emoji in code or comments.
+
+### No Color/Image Literals
+Never use Xcode color or image literals - use DesignResourcesKit.
+
+### No Parentheses Around Conditionals
+Don't use unnecessary parentheses around conditionals.
+
+### No Semicolons
+Don't use semicolons except when required for multiple statements on one line.
+
+## Error Handling and Assertions
+
+### Fatal Errors
+Use `fatalError()` for truly unrecoverable conditions only.
+
+### Assertions
+Use assertions for debugging and development validation.
+
+## Logging
+
+**NEVER use `print()` in production code.** Always use appropriate Logger extensions.
+
+📖 **[See logging examples →](code-style.examples.md#logging-examples)**
+
+## Unit Test Naming
+
+Test method names should describe what they test and the expected outcome.
+
+## Functions vs Methods
+
+Prefer methods over free functions when operating on instances.
+
+---
+
+📖 **For comprehensive code examples demonstrating all these patterns, see [code-style.examples.md](code-style.examples.md)**

--- a/doc-bot/rules/design-system-designresourceskit-original.md
+++ b/doc-bot/rules/design-system-designresourceskit-original.md
@@ -1,0 +1,600 @@
+---
+alwaysApply: true
+title: "DuckDuckGo iOS Design System & DesignResourcesKit (DRK)"
+description: "DuckDuckGo iOS design system implementation through DesignResourcesKit including typography, colors, component strategy, enforcement mechanisms, and modularization guidelines"
+keywords: ["design system", "DesignResourcesKit", "DRK", "typography", "colors", "icons", "UIKit", "SwiftUI", "Figma", "semantic colors", "Danger", "modularization"]
+---
+
+# DuckDuckGo iOS Design System & DesignResourcesKit (DRK)
+
+## Overview
+
+The DuckDuckGo iOS design system is implemented through **DesignResourcesKit (DRK)**, a shared Swift package that contains our design tokens, type styles, colors, and design system elements.
+
+**Repository**: [https://github.com/duckduckgo/DesignResourcesKit](https://github.com/duckduckgo/DesignResourcesKit)
+
+**Figma Designs**: [🖱️ iOS & iPadOS Components](https://www.figma.com/file/GzGKD6gR24AHoUqVykX1ah/%F0%9F%93%B1-iOS-%26-iPadOS-Components?type=design&node-id=3938%3A23329&mode=design&t=0fuiNF84nnV5zExC-1)
+
+### What DRK Contains
+
+✅ **Currently Included**:
+- **Type styles and typography** (based on system styles)
+- **Semantic color system** (with light/dark mode support)
+- **Design tokens and foundations**
+
+🔄 **Future Expansion**:
+- **Reusable components** (when patterns emerge)
+- **Advanced interaction patterns**
+
+❌ **Not Included**:
+- **Icons** (remain in iOS app directly for now)
+
+## ⚠️ Critical Rule: Don't Break the Design System
+
+> **If you take only one thing away from this documentation**: 
+> **Don't add new colors or type styles outside of the design system without reading the guidelines below.**
+
+Breaking the design system:
+- **Undermines consistency** across the app
+- **Creates maintenance debt** with scattered styles
+- **Breaks accessibility** features like dynamic type
+- **Fragments the user experience**
+
+## Typography System
+
+### Philosophy
+
+Our typography system is **based on system styles** rather than hardcoded sizes. This ensures:
+- **Automatic dynamic type support** for accessibility
+- **Consistent scaling** across different user preferences
+- **Platform-appropriate styling** that feels native
+
+### UIKit Usage
+
+DRK defines **static functions on UIFont** for all typography:
+
+```swift
+// ✅ CORRECT: Use DRK typography functions directly
+let titleLabel = UILabel()
+titleLabel.font = UIFont.daxTitle1()
+titleLabel.text = "Main Title"
+
+let bodyLabel = UILabel()
+bodyLabel.font = UIFont.daxBody()
+bodyLabel.text = "Body content that scales with dynamic type"
+
+let captionLabel = UILabel()
+captionLabel.font = UIFont.daxCaption()
+titleLabel.text = "Small caption text"
+```
+
+#### Available Typography Styles
+
+```swift
+// Large titles and headers
+UIFont.daxTitle1()      // Largest title
+UIFont.daxTitle2()      // Secondary title
+UIFont.daxTitle3()      // Tertiary title
+
+// Body text
+UIFont.daxBody()        // Standard body text
+UIFont.daxBodySemibold() // Emphasized body text
+
+// Small text
+UIFont.daxCaption()     // Caption text
+UIFont.daxFootnote()    // Footnote text
+
+// Special cases
+UIFont.daxCallout()     // Callout text
+UIFont.daxSubheadline() // Subheading text
+```
+
+#### Best Practices for UIKit
+
+```swift
+// ✅ CORRECT: Use typography directly without modification
+class FeatureViewController: UIViewController {
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var bodyLabel: UILabel!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // Typography is automatically configured for dynamic type
+        titleLabel.font = UIFont.daxTitle2()
+        bodyLabel.font = UIFont.daxBody()
+        
+        // Colors should also come from design system
+        titleLabel.textColor = UIColor(designSystemColor: .textPrimary)
+        bodyLabel.textColor = UIColor(designSystemColor: .textSecondary)
+    }
+}
+
+// ❌ INCORRECT: Don't modify or override DRK fonts
+titleLabel.font = UIFont.daxBody().withSize(18) // Don't override size
+bodyLabel.font = UIFont.systemFont(ofSize: 16)  // Don't use system fonts
+```
+
+### SwiftUI Usage
+
+DRK provides **view modifiers and extensions** for SwiftUI that should be used instead of direct font access:
+
+```swift
+// ✅ CORRECT: Use DRK view modifiers
+struct ContentView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Main Title")
+                .daxTitle1()
+                .foregroundColor(Color(designSystemColor: .textPrimary))
+            
+            Text("Secondary heading")
+                .daxTitle3()
+                .foregroundColor(Color(designSystemColor: .textPrimary))
+            
+            Text("Body content that automatically supports dynamic type and accessibility features.")
+                .daxBody()
+                .foregroundColor(Color(designSystemColor: .textSecondary))
+            
+            Text("Small caption text")
+                .daxCaption()
+                .foregroundColor(Color(designSystemColor: .textSecondary))
+        }
+        .padding()
+    }
+}
+
+// ❌ INCORRECT: Don't use .font() modifier
+Text("Title")
+    .font(.title2) // This makes it harder to spot design system violations
+
+Text("Body")
+    .font(Font(UIFont.daxBody())) // Don't access UIFont directly
+```
+
+#### Available SwiftUI Typography Modifiers
+
+```swift
+// View modifiers for typography
+.daxTitle1()        // Largest title
+.daxTitle2()        // Secondary title  
+.daxTitle3()        // Tertiary title
+.daxBody()          // Standard body text
+.daxBodySemibold()  // Emphasized body text
+.daxCaption()       // Caption text
+.daxFootnote()      // Footnote text
+.daxCallout()       // Callout text
+.daxSubheadline()   // Subheading text
+```
+
+#### SwiftUI Code Review Guidelines
+
+**When reviewing PRs**: Look for `.font()` usage as a red flag:
+
+```swift
+// 🚨 RED FLAG: Using .font() likely indicates design system violation
+Text("Title")
+    .font(.title) // Should be .daxTitle2() or similar
+
+Text("Body")  
+    .font(.system(size: 16)) // Should be .daxBody()
+
+// ✅ CORRECT: Using DRK modifiers
+Text("Title")
+    .daxTitle2()
+
+Text("Body")
+    .daxBody()
+```
+
+### Emergency Escape Hatch (Avoid!)
+
+**For legacy layout fixes only**: If you absolutely must disable dynamic type, there's a deliberately obtusely named function:
+
+```swift
+// ❌ LAST RESORT: Only for fixing legacy layouts
+let fixedFont = UIFont.daxFontOutsideOfTheDesignSystemToFixLegacyLayoutBreakage()
+```
+
+**Important Notes**:
+- This function **may not exist** in current DRK versions
+- If you need it, you must **revert the commit** that removed it: [Commit 971979d](https://github.com/duckduckgo/DesignResourcesKit/pull/1/commits/971979d3dcd95567b9812b800eb22ab1611ce3a5)
+- This is **deliberately annoying** to discourage usage
+- **Always prefer** fixing the layout to support dynamic type instead
+
+## Color System
+
+### Semantic Color Approach
+
+Our color system uses **semantic naming** rather than literal colors (e.g., "primary text" instead of "black"). This enables:
+- **Automatic dark mode support**
+- **Future theme flexibility**
+- **Accessibility compliance**
+- **Consistent visual hierarchy**
+
+### Color Categories
+
+#### Text Colors
+```swift
+// UIKit
+label.textColor = UIColor(designSystemColor: .textPrimary)    // Main text
+label.textColor = UIColor(designSystemColor: .textSecondary)  // Supporting text
+label.textColor = UIColor(designSystemColor: .textLink)       // Interactive text
+
+// SwiftUI
+Text("Primary text")
+    .foregroundColor(Color(designSystemColor: .textPrimary))
+
+Text("Secondary text")
+    .foregroundColor(Color(designSystemColor: .textSecondary))
+
+Text("Link text")
+    .foregroundColor(Color(designSystemColor: .textLink))
+```
+
+#### Background Colors
+```swift
+// UIKit
+view.backgroundColor = UIColor(designSystemColor: .background)  // Main app background
+view.backgroundColor = UIColor(designSystemColor: .surface)     // Card/panel background
+view.backgroundColor = UIColor(designSystemColor: .panel)       // Secondary panel
+
+// SwiftUI
+VStack {
+    // Content
+}
+.background(Color(designSystemColor: .background))
+
+Rectangle()
+    .fill(Color(designSystemColor: .surface))
+```
+
+#### Control Colors
+```swift
+// UIKit
+button.backgroundColor = UIColor(designSystemColor: .controlsFillPrimary)
+button.backgroundColor = UIColor(designSystemColor: .controlsFillSecondary)
+
+// SwiftUI
+Button("Action") { }
+    .foregroundColor(Color(designSystemColor: .controlsFillPrimary))
+    .background(Color(designSystemColor: .controlsFillSecondary))
+```
+
+#### Button-Specific Colors
+```swift
+// UIKit
+primaryButton.backgroundColor = UIColor(designSystemColor: .buttonPrimaryBackground)
+primaryButton.setTitleColor(UIColor(designSystemColor: .buttonPrimaryText), for: .normal)
+
+secondaryButton.backgroundColor = UIColor(designSystemColor: .buttonSecondaryBackground)
+secondaryButton.setTitleColor(UIColor(designSystemColor: .buttonSecondaryText), for: .normal)
+
+// SwiftUI
+Button("Primary Action") { }
+    .foregroundColor(Color(designSystemColor: .buttonPrimaryText))
+    .background(Color(designSystemColor: .buttonPrimaryBackground))
+
+Button("Secondary Action") { }
+    .foregroundColor(Color(designSystemColor: .buttonSecondaryText))
+    .background(Color(designSystemColor: .buttonSecondaryBackground))
+```
+
+#### Accent Colors
+```swift
+// UIKit
+view.tintColor = UIColor(designSystemColor: .accent)
+
+// SwiftUI
+Image(systemName: "heart.fill")
+    .foregroundColor(Color(designSystemColor: .accent))
+```
+
+### Anti-patterns: What NOT to Do
+
+```swift
+// ❌ NEVER: Hardcoded colors
+view.backgroundColor = UIColor.black
+text.foregroundColor = Color.blue
+button.setTitleColor(UIColor(red: 0.2, green: 0.4, blue: 0.8, alpha: 1.0), for: .normal)
+
+// ❌ NEVER: System colors for app content
+view.backgroundColor = UIColor.systemBackground  // Use .background instead
+label.textColor = UIColor.label                 // Use .textPrimary instead
+
+// ❌ NEVER: Manual dark mode handling
+@Environment(\.colorScheme) var colorScheme
+let textColor = colorScheme == .dark ? Color.white : Color.black // Use semantic colors!
+
+// ✅ CORRECT: Always use semantic design system colors
+view.backgroundColor = UIColor(designSystemColor: .background)
+label.textColor = UIColor(designSystemColor: .textPrimary)
+```
+
+## Enforcement and Code Review
+
+### Automated Enforcement
+
+#### Danger Integration
+**Asset catalog enforcement**: We use [Danger](https://danger.systems/) to prevent new colors being added directly to iOS app asset catalogs:
+
+```ruby
+# Dangerfile example
+if git.added_files.any? { |file| file.include?("Assets.xcassets") && file.include?("colorset") }
+  fail("🚨 New colors detected in asset catalog. Use DesignResourcesKit instead!")
+end
+```
+
+This ensures all colors go through the design system rather than being added ad-hoc.
+
+### Manual Code Review Checklist
+
+#### ✅ Look for in PRs:
+- **DRK typography usage**: `UIFont.daxTitle1()`, `.daxBody()` modifiers
+- **DRK color usage**: `UIColor(designSystemColor: .textPrimary)`
+- **No hardcoded colors**: No hex values, RGB tuples, or named colors
+- **No `.font()` modifiers** in SwiftUI (red flag for design system violations)
+- **Semantic naming**: Colors described by purpose, not appearance
+
+#### 🚨 Red flags in PRs:
+```swift
+// RED FLAGS - should be caught in review
+.font(.title)                           // Should use .daxTitle2()
+UIColor.black                          // Should use design system color
+Color(red: 0.1, green: 0.2, blue: 0.3) // Should use semantic color
+UIColor.systemBlue                     // Should use .accent or appropriate semantic color
+```
+
+#### ✅ Good patterns to approve:
+```swift
+// GOOD PATTERNS - approve these
+Text("Title").daxTitle2()
+UIFont.daxBody()
+UIColor(designSystemColor: .textPrimary)
+Color(designSystemColor: .background)
+```
+
+### Opportunistic Improvements
+
+**Most of the iOS app currently does not use the design system**, so you're encouraged to:
+
+1. **Opportunistically refactor** old code to use DRK when you encounter it
+2. **Update hardcoded colors** to semantic colors when working in an area
+3. **Replace system fonts** with DRK typography when touching text styling
+4. **File follow-up tickets** for systematic cleanup when you notice patterns
+
+#### Example: Opportunistic Refactoring
+
+```swift
+// BEFORE: Legacy hardcoded styling
+class OldViewController: UIViewController {
+    @IBOutlet weak var titleLabel: UILabel!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        titleLabel.font = UIFont.systemFont(ofSize: 24, weight: .bold)
+        titleLabel.textColor = UIColor.black
+    }
+}
+
+// AFTER: Updated to use design system
+class OldViewController: UIViewController {
+    @IBOutlet weak var titleLabel: UILabel!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        titleLabel.font = UIFont.daxTitle2()
+        titleLabel.textColor = UIColor(designSystemColor: .textPrimary)
+    }
+}
+```
+
+## Components
+
+### Current State: Minimal Component Library
+
+We primarily use **system components** rather than custom ones, following iOS design guidelines. This is different from our Android app which has more custom components.
+
+**Philosophy**: 
+- **System components first** - leverages platform conventions
+- **Custom components only when needed** - avoid overengineering
+- **Reusable when patterns emerge** - extract when used in multiple places
+
+### Existing Custom Components
+
+#### Blue Button (Reusable)
+Our primary custom component used across multiple screens:
+
+```swift
+// Current usage (likely not yet in DRK)
+class DuckBlueButton: UIButton {
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        backgroundColor = UIColor(designSystemColor: .buttonPrimaryBackground)
+        setTitleColor(UIColor(designSystemColor: .buttonPrimaryText), for: .normal)
+        titleLabel?.font = UIFont.daxBody()
+        layer.cornerRadius = 8
+    }
+}
+
+// Future: Should be moved to DRK as reusable component
+```
+
+**Candidate for DRK**: This button is used in multiple places and should be extracted into DesignResourcesKit as a reusable component.
+
+### Future Component Strategy
+
+#### When to Create Components
+
+**✅ Create a component when**:
+- Pattern is used in **3+ different contexts**
+- Styling is **complex or specialized**
+- Behavior needs to be **consistent across usage**
+- Component **encapsulates design system tokens**
+
+**❌ Don't create a component when**:
+- Used in only **one place** (keep it local)
+- **System component exists** that meets needs
+- Component would be **overly generic** or complex
+
+#### Emerging Patterns to Watch
+
+Look for these patterns that might become components:
+
+```swift
+// Bottom sheets - if format becomes consistent
+struct BottomSheetView: View {
+    // Consistent styling, behavior, animation
+    // Could become reusable component
+}
+
+// Info cards/panels - if layout patterns emerge  
+struct InfoCardView: View {
+    // Standard card styling with DRK colors
+    // Could be extracted if reused
+}
+
+// Form elements - if custom styling is needed
+struct FormFieldView: View {
+    // Consistent form field styling
+    // Could become component library
+}
+```
+
+#### Component Creation Process
+
+1. **Identify the pattern** in your current work
+2. **Check if existing implementations** could be generalized
+3. **Design the API** to be flexible but opinionated
+4. **Implement using DRK tokens** for colors, typography, spacing
+5. **Add to DesignResourcesKit** package
+6. **Update existing usages** to use the new component
+7. **Document the component** with usage examples
+
+```swift
+// Example: Converting blue button to DRK component
+public struct DRKPrimaryButton: View {
+    let title: String
+    let action: () -> Void
+    
+    public init(title: String, action: @escaping () -> Void) {
+        self.title = title
+        self.action = action
+    }
+    
+    public var body: some View {
+        Button(action: action) {
+            Text(title)
+                .daxBody()
+                .foregroundColor(Color(designSystemColor: .buttonPrimaryText))
+                .padding(.horizontal, 24)
+                .padding(.vertical, 12)
+        }
+        .background(Color(designSystemColor: .buttonPrimaryBackground))
+        .cornerRadius(8)
+    }
+}
+```
+
+## Modularization Strategy
+
+### Why DRK is a Separate Package
+
+**High friction is a feature**: Making DRK a separate module provides beneficial constraints:
+
+1. **Immutability encouragement**: Changes require more thought and process
+2. **API stability**: Forces consideration of breaking changes
+3. **Reusability**: Can be shared across iOS/macOS if needed
+4. **Clear boundaries**: Separates design tokens from app logic
+5. **Version control**: Can be tagged and versioned independently
+
+### Design System Evolution
+
+**Original Discussion**: [Tech Design: How to modularise iOS/macOS design system elements](✓ Tech Design: How to modularise iOS/macOS design system elements)
+
+**Guiding Principles**:
+- **Start minimal**: Don't over-engineer early
+- **Evolve based on usage**: Add components when patterns emerge
+- **Maintain consistency**: All additions should follow established patterns
+- **Document decisions**: Keep rationale for future developers
+
+## Working with DesignResourcesKit
+
+### Adding New Design Tokens
+
+**Process for adding colors/typography**:
+
+1. **Design system first**: Ensure token is defined in Figma
+2. **Semantic naming**: Use purpose-based names (`textPrimary` not `black`)
+3. **Light/dark variants**: Define both light and dark mode values
+4. **PR to DRK**: Add to DesignResourcesKit repository
+5. **Update app**: Use new tokens in consuming apps
+6. **Documentation**: Update usage examples and guidelines
+
+### Updating DRK Version
+
+**In consuming app (iOS/macOS)**:
+
+```swift
+// Package.swift or Xcode package manager
+.package(url: "https://github.com/duckduckgo/DesignResourcesKit", from: "1.2.0")
+```
+
+**Testing DRK changes**:
+- Test in both **light and dark modes**
+- Verify **dynamic type scaling** works correctly  
+- Check **accessibility** with larger text sizes
+- Test on **different device sizes**
+
+### Local Development
+
+**For iterating on DRK**:
+
+```bash
+# Clone both repositories
+git clone https://github.com/duckduckgo/DesignResourcesKit
+git clone https://github.com/duckduckgo/apple-browsers
+
+# Use local package for development
+# In Xcode: File > Add Package Dependencies > Add Local...
+# Point to local DesignResourcesKit directory
+```
+
+## Resources and References
+
+### Official Resources
+
+- **GitHub Repository**: [duckduckgo/DesignResourcesKit](https://github.com/duckduckgo/DesignResourcesKit)
+- **Figma Designs**: [iOS & iPadOS Components](https://www.figma.com/file/GzGKD6gR24AHoUqVykX1ah/%F0%9F%93%B1-iOS-%26-iPadOS-Components?type=design&node-id=3938%3A23329&mode=design&t=0fuiNF84nnV5zExC-1)
+
+### Related Documentation
+
+- **Colors**: [Tech Design: How to organise colors and icons in iOS and macOS wrt the design system](✓ Tech Design: How to organise colors and icons in iOS and macOS wrt the design system)
+- **Colors Update**: [Tech Design: Redefine design system colors in DesignResourcesKit](✓ Tech Design: Redefine design system colors in DesignResourcesKit)
+- **Typography**: [Tech Design: How to organise typography/label styles in iOS and macOS wrt the design system](✓ Tech Design: How to organise typography/label styles in iOS and macOS wrt the design system)
+- **Enforcement**: [Use danger to stop new colors being added to the iOS app](✓ Use danger to stop new colors being added to the iOS app)
+
+### Quick Reference
+
+#### UIKit Checklist
+- [ ] Use `UIFont.daxTitle1()`, `UIFont.daxBody()`, etc.
+- [ ] Use `UIColor(designSystemColor: .textPrimary)` etc.
+- [ ] No hardcoded colors or fonts
+- [ ] No system colors for app content
+
+#### SwiftUI Checklist  
+- [ ] Use `.daxTitle1()`, `.daxBody()` modifiers
+- [ ] Use `Color(designSystemColor: .textPrimary)` etc.
+- [ ] Avoid `.font()` modifier (red flag in reviews)
+- [ ] No hardcoded colors
+
+#### Code Review Checklist
+- [ ] No new colors in asset catalogs
+- [ ] DRK typography used consistently
+- [ ] Semantic color naming
+- [ ] No hardcoded styling
+- [ ] Opportunistic improvements to legacy code
+
+---
+
+**Remember**: The design system is only as strong as our commitment to using it. Every PR is an opportunity to improve consistency and user experience. 

--- a/doc-bot/rules/design-system-designresourceskit.examples.md
+++ b/doc-bot/rules/design-system-designresourceskit.examples.md
@@ -1,0 +1,278 @@
+---
+alwaysApply: false
+title: "Design System Implementation Examples"
+description: "Detailed examples for DesignResourcesKit implementation in DuckDuckGo browser"
+keywords: ["design system", "DesignResourcesKit", "DRK", "examples", "SwiftUI", "colors", "typography", "icons"]
+---
+
+# Design System Implementation Examples
+
+## Color Usage Examples
+
+```swift
+// ✅ CORRECT - Use design system colors
+Text("Welcome")
+    .foregroundColor(Color(designSystemColor: .textPrimary))
+    .background(Color(designSystemColor: .backgroundSecondary))
+
+Button("Action") { }
+    .foregroundColor(Color(designSystemColor: .textInverted))
+    .background(Color(designSystemColor: .interactivePrimary))
+
+// ❌ INCORRECT - Hardcoded colors
+Text("Welcome")
+    .foregroundColor(.black)
+    .background(.gray)
+```
+
+## Typography Examples
+
+```swift
+// ✅ CORRECT - Use design system fonts
+VStack(alignment: .leading, spacing: 8) {
+    Text("Title")
+        .font(Font(designSystemFont: .title1))
+    
+    Text("Body content here")
+        .font(Font(designSystemFont: .body))
+    
+    Text("Caption text")
+        .font(Font(designSystemFont: .caption1))
+}
+
+// ❌ INCORRECT - System fonts
+Text("Title")
+    .font(.system(size: 28, weight: .bold))
+```
+
+## Icon Usage Examples
+
+```swift
+// ✅ CORRECT - Use DesignResourcesKit icons
+HStack {
+    Image(uiImage: DesignSystemImages.Glyphs.Size16.add)
+        .renderingMode(.template)
+        .foregroundColor(Color(designSystemColor: .iconPrimary))
+    
+    Text("Add Bookmark")
+}
+
+// Different sizes available
+Image(uiImage: DesignSystemImages.Glyphs.Size24.bookmark)
+Image(uiImage: DesignSystemImages.Glyphs.Size20.share)
+Image(uiImage: DesignSystemImages.Glyphs.Size32.shield)
+
+// ❌ INCORRECT - System images
+Image(systemName: "plus")
+    .foregroundColor(.blue)
+```
+
+## Component Pattern Examples
+
+```swift
+// ✅ CORRECT - Design system button
+struct PrimaryButton: View {
+    let title: String
+    let action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(Font(designSystemFont: .button))
+                .foregroundColor(Color(designSystemColor: .textInverted))
+                .padding(.horizontal, 20)
+                .padding(.vertical, 12)
+        }
+        .background(Color(designSystemColor: .interactivePrimary))
+        .cornerRadius(8)
+    }
+}
+
+// ✅ CORRECT - Settings row component  
+struct SettingsRow: View {
+    let icon: UIImage
+    let title: String
+    let value: String?
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(uiImage: icon)
+                .renderingMode(.template)
+                .foregroundColor(Color(designSystemColor: .iconSecondary))
+                .frame(width: 24, height: 24)
+            
+            Text(title)
+                .font(Font(designSystemFont: .body))
+                .foregroundColor(Color(designSystemColor: .textPrimary))
+            
+            Spacer()
+            
+            if let value = value {
+                Text(value)
+                    .font(Font(designSystemFont: .caption1))
+                    .foregroundColor(Color(designSystemColor: .textSecondary))
+            }
+        }
+        .padding(.vertical, 12)
+        .padding(.horizontal, 16)
+    }
+}
+```
+
+## Layout and Spacing Examples
+
+```swift
+// ✅ CORRECT - Use design system spacing
+VStack(spacing: 16) {  // Standard spacing
+    HeaderView()
+    
+    VStack(spacing: 8) {  // Tight spacing
+        TitleView()
+        SubtitleView()
+    }
+    .padding(20)  // Standard padding
+    
+    FooterView()
+}
+```
+
+## Form Component Examples  
+
+```swift
+// ✅ CORRECT - Design system text field
+struct DRKTextField: View {
+    let placeholder: String
+    @Binding var text: String
+    
+    var body: some View {
+        TextField(placeholder, text: $text)
+            .font(Font(designSystemFont: .body))
+            .foregroundColor(Color(designSystemColor: .textPrimary))
+            .padding(12)
+            .background(Color(designSystemColor: .backgroundSecondary))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color(designSystemColor: .borderPrimary), lineWidth: 1)
+            )
+    }
+}
+
+// ✅ CORRECT - Design system toggle
+struct DRKToggle: View {
+    let title: String
+    @Binding var isOn: Bool
+    
+    var body: some View {
+        Toggle(title, isOn: $isOn)
+            .font(Font(designSystemFont: .body))
+            .foregroundColor(Color(designSystemColor: .textPrimary))
+            .tint(Color(designSystemColor: .interactivePrimary))
+    }
+}
+```
+
+## Complete View Examples
+
+```swift
+// ✅ CORRECT - Fully compliant settings view
+struct BookmarkSettingsView: View {
+    @State private var showFavicons = true
+    @State private var sortOrder = BookmarkSortOrder.title
+    
+    var body: some View {
+        NavigationView {
+            Form {
+                Section {
+                    DRKToggle(
+                        title: "Show Favicons",
+                        isOn: $showFavicons
+                    )
+                    
+                    Picker("Sort Order", selection: $sortOrder) {
+                        ForEach(BookmarkSortOrder.allCases) { order in
+                            Text(order.displayName)
+                                .font(Font(designSystemFont: .body))
+                                .tag(order)
+                        }
+                    }
+                    .pickerStyle(MenuPickerStyle())
+                }
+            }
+            .navigationTitle("Bookmark Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .background(Color(designSystemColor: .backgroundPrimary))
+        }
+    }
+}
+
+// ✅ CORRECT - Bookmark list item
+struct BookmarkRowView: View {
+    let bookmark: Bookmark
+    let onTap: () -> Void
+    let onDelete: () -> Void
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            // Favicon or default icon
+            AsyncImage(url: bookmark.faviconURL) { image in
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            } placeholder: {
+                Image(uiImage: DesignSystemImages.Glyphs.Size16.bookmark)
+                    .renderingMode(.template)
+                    .foregroundColor(Color(designSystemColor: .iconSecondary))
+            }
+            .frame(width: 16, height: 16)
+            
+            VStack(alignment: .leading, spacing: 4) {
+                Text(bookmark.title)
+                    .font(Font(designSystemFont: .body))
+                    .foregroundColor(Color(designSystemColor: .textPrimary))
+                    .lineLimit(1)
+                
+                Text(bookmark.url.host ?? bookmark.url.absoluteString)
+                    .font(Font(designSystemFont: .caption1))
+                    .foregroundColor(Color(designSystemColor: .textSecondary))
+                    .lineLimit(1)
+            }
+            
+            Spacer()
+        }
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onTap)
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button("Delete", role: .destructive, action: onDelete)
+        }
+        .listRowBackground(Color(designSystemColor: .backgroundPrimary))
+    }
+}
+```
+
+## Dark Mode Adaptation Examples
+
+```swift
+// ✅ Design system colors automatically adapt to dark mode
+struct AdaptiveView: View {
+    var body: some View {
+        VStack {
+            Text("This text adapts automatically")
+                .foregroundColor(Color(designSystemColor: .textPrimary))
+                .background(Color(designSystemColor: .backgroundPrimary))
+            
+            // No manual dark mode checking needed!
+        }
+    }
+}
+
+// ❌ INCORRECT - Manual dark mode handling
+struct ManualDarkModeView: View {
+    @Environment(\.colorScheme) var colorScheme
+    
+    var body: some View {
+        Text("Manual handling")
+            .foregroundColor(colorScheme == .dark ? .white : .black)
+            .background(colorScheme == .dark ? .black : .white)
+    }
+}
+```

--- a/doc-bot/rules/design-system-designresourceskit.md
+++ b/doc-bot/rules/design-system-designresourceskit.md
@@ -1,0 +1,231 @@
+---
+alwaysApply: true
+title: "DuckDuckGo iOS Design System & DesignResourcesKit (DRK)"
+description: "DuckDuckGo iOS design system implementation through DesignResourcesKit including typography, colors, component strategy, enforcement mechanisms, and modularization guidelines"
+keywords: ["design system", "DesignResourcesKit", "DRK", "typography", "colors", "icons", "UIKit", "SwiftUI", "Figma", "semantic colors", "Danger", "modularization"]
+---
+
+# DuckDuckGo iOS Design System & DesignResourcesKit (DRK)
+
+## Overview
+
+The DuckDuckGo iOS design system is implemented through **DesignResourcesKit (DRK)**, a shared Swift package that contains our design tokens, type styles, colors, and design system elements.
+
+**Repository**: [https://github.com/duckduckgo/DesignResourcesKit](https://github.com/duckduckgo/DesignResourcesKit)
+
+**Figma Designs**: [🖱️ iOS & iPadOS Components](https://www.figma.com/file/GzGKD6gR24AHoUqVykX1ah/%F0%9F%93%B1-iOS-%26-iPadOS-Components?type=design&node-id=3938%3A23329&mode=design&t=0fuiNF84nnV5zExC-1)
+
+### What DRK Contains
+
+✅ **Currently Included**:
+- **Type styles and typography** (based on system styles)
+- **Semantic color system** (with light/dark mode support)
+- **Design tokens and foundations**
+
+🔄 **Future Expansion**:
+- **Reusable components** (when patterns emerge)
+- **Advanced interaction patterns**
+
+❌ **Not Included**:
+- **Icons** (remain in iOS app directly for now)
+
+## ⚠️ Critical Rule: Don't Break the Design System
+
+> **If you take only one thing away from this documentation**: 
+> **Don't add new colors or type styles outside of the design system without reading the guidelines below.**
+
+Breaking the design system:
+- **Undermines consistency** across the app
+- **Creates maintenance debt** with scattered styles
+- **Breaks accessibility** features like dynamic type
+- **Fragments the user experience**
+
+## Typography System
+
+### Philosophy
+Our typography system is **based on system styles** rather than hardcoded sizes. This ensures:
+- **Automatic dynamic type support** for accessibility
+- **Consistent scaling** across different user preferences
+- **Platform-appropriate styling** that feels native
+
+### Usage
+**MANDATORY**: Use `Font(designSystemFont: .styleName)` for all text.
+
+📖 **[See typography examples →](design-system-designresourceskit.examples.md#typography-examples)**
+
+### Available Type Styles
+- `.largeTitle` - Page titles and major headings
+- `.title1`, `.title2`, `.title3` - Section headings
+- `.body` - Primary body text (default)
+- `.bodyLarge` - Emphasized body text
+- `.bodySmall` - De-emphasized body text
+- `.caption1`, `.caption2` - Supporting text
+- `.footnote` - Fine print
+- `.button` - Button text
+
+## Color System
+
+### Philosophy
+**Semantic colors over literal colors**: Use `.textPrimary` instead of `.black`, use `.backgroundSecondary` instead of `.lightGray`.
+
+### Mandatory Usage
+**ALWAYS use `Color(designSystemColor: .tokenName)`** - NEVER hardcode colors.
+
+📖 **[See color usage examples →](design-system-designresourceskit.examples.md#color-usage-examples)**
+
+### Color Token Categories
+
+**Text Colors**:
+- `.textPrimary` - Primary text content
+- `.textSecondary` - Supporting text
+- `.textTertiary` - Disabled/placeholder text
+- `.textInverted` - Text on dark backgrounds
+- `.textLink` - Interactive links
+- `.textError`, `.textSuccess`, `.textWarning` - Status messages
+
+**Background Colors**:
+- `.backgroundPrimary` - Main background
+- `.backgroundSecondary` - Cards and sections  
+- `.backgroundTertiary` - Subtle areas
+- `.backgroundElevated` - Elevated surfaces
+
+**Interactive Colors**:
+- `.interactivePrimary` - Primary buttons/actions
+- `.interactiveSecondary` - Secondary actions
+- `.interactiveDisabled` - Disabled states
+
+**Brand Colors**:
+- `.brandPrimary` - DuckDuckGo orange
+- `.brandSecondary` - Secondary brand color
+
+## Icons & Glyphs
+
+### Current State
+Icons are **NOT yet in DesignResourcesKit**. They remain in the main iOS app.
+
+### Usage Pattern
+```swift
+// Current pattern (will be updated when icons move to DRK)
+Image(uiImage: DesignSystemImages.Glyphs.Size24.bookmark)
+    .renderingMode(.template)
+    .foregroundColor(Color(designSystemColor: .iconPrimary))
+```
+
+📖 **[See icon usage examples →](design-system-designresourceskit.examples.md#icon-usage-examples)**
+
+## Component Patterns
+
+### Philosophy
+- **Consistency over customization**
+- **Reuse common patterns**
+- **Compose complex UIs from simple components**
+
+### Available Components
+📖 **[See component examples →](design-system-designresourceskit.examples.md#component-pattern-examples)**
+
+## Implementation Guidelines
+
+### SwiftUI Integration
+
+**MANDATORY**: Always use design system tokens in SwiftUI views.
+
+```swift
+// ✅ CORRECT
+Text("Title")
+    .font(Font(designSystemFont: .title1))
+    .foregroundColor(Color(designSystemColor: .textPrimary))
+
+// ❌ INCORRECT  
+Text("Title")
+    .font(.system(size: 28, weight: .bold))
+    .foregroundColor(.black)
+```
+
+### UIKit Integration
+
+```swift
+// ✅ CORRECT
+label.font = UIFont(designSystemFont: .body)
+label.textColor = UIColor(designSystemColor: .textPrimary)
+
+// ❌ INCORRECT
+label.font = UIFont.systemFont(ofSize: 17)
+label.textColor = .black
+```
+
+## Dark Mode Support
+
+**Automatic**: All design system colors automatically adapt to light/dark mode. **NEVER** manually check `colorScheme` or `traitCollection.userInterfaceStyle`.
+
+📖 **[See dark mode examples →](design-system-designresourceskit.examples.md#dark-mode-adaptation-examples)**
+
+## Adding New Design Elements
+
+### When You Need New Colors
+1. **First**: Check if existing semantic colors can work
+2. **Then**: Discuss with design team
+3. **Finally**: Add to DesignResourcesKit with proper semantic naming
+
+### When You Need New Typography
+1. **First**: Check if existing type styles can work  
+2. **Then**: Consider if it's truly a new pattern vs. one-off styling
+3. **Finally**: Add to DesignResourcesKit if it's a repeating pattern
+
+### Process for Additions
+1. Create issue in DesignResourcesKit repository
+2. Get design team approval
+3. Add with semantic naming
+4. Update documentation
+5. Use in implementation
+
+## Enforcement
+
+### Code Review Checklist
+- [ ] No hardcoded colors (`.red`, `UIColor.blue`, `Color(red: 0.5...)`)
+- [ ] No hardcoded fonts (`UIFont.systemFont`, `.system(size: 17)`)
+- [ ] All text uses `Font(designSystemFont:)` or `UIFont(designSystemFont:)`
+- [ ] All colors use `Color(designSystemColor:)` or `UIColor(designSystemColor:)`
+- [ ] No manual dark mode handling
+
+### SwiftLint Rules
+We have custom SwiftLint rules that detect:
+- Hardcoded color usage
+- Direct system font usage
+- Manual dark mode checks
+
+### Danger Checks
+Our Danger setup automatically checks for design system violations in pull requests.
+
+## Migration Guide
+
+### From Hardcoded Colors
+```swift
+// Before
+.foregroundColor(.black)
+.backgroundColor = UIColor.systemGray
+
+// After  
+.foregroundColor(Color(designSystemColor: .textPrimary))
+.backgroundColor = UIColor(designSystemColor: .backgroundSecondary)
+```
+
+### From System Fonts
+```swift
+// Before
+.font(.system(size: 17, weight: .medium))
+.font = UIFont.systemFont(ofSize: 17)
+
+// After
+.font(Font(designSystemFont: .body))
+.font = UIFont(designSystemFont: .body)
+```
+
+## Resources
+
+- **Repository**: [DesignResourcesKit on GitHub](https://github.com/duckduckgo/DesignResourcesKit)
+- **Figma**: [iOS Components](https://www.figma.com/file/GzGKD6gR24AHoUqVykX1ah/%F0%9F%93%B1-iOS-%26-iPadOS-Components)
+- **Documentation**: This file + examples
+
+---
+
+📖 **For detailed implementation examples, see [design-system-designresourceskit.examples.md](design-system-designresourceskit.examples.md)**

--- a/doc-bot/rules/development-commands.md
+++ b/doc-bot/rules/development-commands.md
@@ -1,0 +1,359 @@
+---
+title: "Development Commands & Build Instructions"
+description: "Essential commands for building, testing, and developing the DuckDuckGo browser applications"
+keywords: ["build", "development", "commands", "Xcode", "simulator", "testing", "debugging"]
+alwaysApply: true
+---
+
+# Development Commands & Build Instructions
+
+## 📋 When to Use This Document
+
+Use these instructions when you need to:
+- Build the iOS Browser app for testing or development
+- Build the macOS Browser app for testing or development
+- Verify that code changes compile successfully
+- Prepare the app for testing or debugging
+- Understand build failures and how to fix them
+
+## 🚦 Golden Rules for Building
+
+### ✅ ALWAYS DO THESE
+1. **Use the full shell wrapper**: `/bin/sh -c 'set -e -o pipefail && xcodebuild ... | xcbeautify'`
+2. **Detect environment first**: Never hardcode paths or simulator IDs
+3. **Check exit codes**: Ensure the build succeeded before proceeding
+4. **Use absolute paths**: Always use full paths for workspace files
+5. **Include xcbeautify**: Output is unreadable without it
+
+### ❌ NEVER DO THESE
+1. **Never use `-jobs` flag**: It's been removed from all commands
+2. **Never skip xcbeautify**: Raw xcodebuild output is nearly impossible to parse
+3. **Never use .xcodeproj files**: Always use .xcworkspace
+4. **Never hardcode simulator IDs**: They change between systems
+5. **Never ignore build failures**: Always check and handle errors
+
+## 🔍 Phase 1: Environment Detection
+
+### Pre-Flight Checks
+Before building, validate your environment:
+
+```bash
+# 1. Verify you're in the project directory
+ls -la | grep DuckDuckGo.xcworkspace
+# Expected: DuckDuckGo.xcworkspace directory exists
+
+# 2. Check Xcode command line tools
+xcodebuild -version
+# Expected: Xcode version output (e.g., "Xcode 15.0")
+
+# 3. Verify xcbeautify is installed
+which xcbeautify
+# Expected: Path to xcbeautify (e.g., "/opt/homebrew/bin/xcbeautify")
+# If missing: brew install xcbeautify
+```
+
+### Required Variables to Detect
+
+| Variable | Purpose | Detection Command | Expected Format |
+|----------|---------|-------------------|-----------------|
+| `WORKSPACE_PATH` | Full path to .xcworkspace | `pwd` + `find . -name "DuckDuckGo.xcworkspace"` | `/Users/.../DuckDuckGo.xcworkspace` |
+| `SIMULATOR_ID` | iOS Simulator UUID | `xcrun simctl list devices \| grep iPhone` | `XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX` |
+| `ARCHITECTURE` | Mac CPU type | `uname -m` | `arm64` or `x86_64` |
+
+### Detection Commands
+
+```bash
+# Step 1: Get workspace path
+WORKSPACE_DIR=$(pwd)
+WORKSPACE_FILE=$(find . -name "DuckDuckGo.xcworkspace" | head -1)
+WORKSPACE_PATH="${WORKSPACE_DIR}/${WORKSPACE_FILE#./}"
+echo "Workspace: ${WORKSPACE_PATH}"
+
+# Step 2: Get architecture (for macOS builds)
+ARCHITECTURE=$(uname -m)
+echo "Architecture: ${ARCHITECTURE}"
+
+# Step 3: Find iOS simulator (for iOS builds)
+SIMULATOR_ID=$(xcrun simctl list devices | grep -E "iPhone.*\([A-F0-9-]{36}\)" | head -1 | grep -oE "[A-F0-9-]{36}")
+echo "Simulator ID: ${SIMULATOR_ID}"
+```
+
+## 🏗️ Phase 2: Build Execution
+
+### iOS Build Command Template
+
+Replace the placeholders with your detected values:
+
+```bash
+/bin/sh -c 'set -e -o pipefail && xcodebuild \
+  ONLY_ACTIVE_ARCH=YES \
+  DEBUG_INFORMATION_FORMAT=dwarf \
+  COMPILER_INDEX_STORE_ENABLE=NO \
+  -scheme "iOS Browser" \
+  -configuration Debug \
+  -workspace <REPLACE_WITH_WORKSPACE_PATH> \
+  -destination "platform=iOS Simulator,id=<REPLACE_WITH_SIMULATOR_ID>" \
+  -allowProvisioningUpdates \
+  -parallelizeTargets \
+  build | xcbeautify'
+```
+
+### macOS Build Command Template
+
+Replace the placeholders with your detected values:
+
+```bash
+/bin/sh -c 'set -e -o pipefail && xcodebuild \
+  ONLY_ACTIVE_ARCH=YES \
+  DEBUG_INFORMATION_FORMAT=dwarf \
+  COMPILER_INDEX_STORE_ENABLE=NO \
+  -scheme "macOS Browser" \
+  -configuration Debug \
+  -workspace <REPLACE_WITH_WORKSPACE_PATH> \
+  -destination "platform=macOS,arch=<REPLACE_WITH_ARCHITECTURE>" \
+  -skipPackagePluginValidation \
+  -skipMacroValidation \
+  -disableAutomaticPackageResolution \
+  -parallelizeTargets \
+  build | xcbeautify'
+```
+
+### Complete Working Examples
+
+#### iOS Build (Real Values)
+```bash
+/bin/sh -c 'set -e -o pipefail && xcodebuild \
+  ONLY_ACTIVE_ARCH=YES \
+  DEBUG_INFORMATION_FORMAT=dwarf \
+  COMPILER_INDEX_STORE_ENABLE=NO \
+  -scheme "iOS Browser" \
+  -configuration Debug \
+  -workspace /Users/daniel/Developer/browser/apple-browsers/DuckDuckGo.xcworkspace \
+  -destination "platform=iOS Simulator,id=6E6A828D-8C2C-4409-8E56-753DB02090F7" \
+  -allowProvisioningUpdates \
+  -parallelizeTargets \
+  build | xcbeautify'
+```
+
+#### macOS Build (Real Values)
+```bash
+/bin/sh -c 'set -e -o pipefail && xcodebuild \
+  ONLY_ACTIVE_ARCH=YES \
+  DEBUG_INFORMATION_FORMAT=dwarf \
+  COMPILER_INDEX_STORE_ENABLE=NO \
+  -scheme "macOS Browser" \
+  -configuration Debug \
+  -workspace /Users/daniel/Developer/browser/apple-browsers/DuckDuckGo.xcworkspace \
+  -destination "platform=macOS,arch=arm64" \
+  -allowProvisioningUpdates \
+  -disableAutomaticPackageResolution \
+  -parallelizeTargets \
+  build | xcbeautify'
+```
+
+## ✅ Phase 3: Build Verification
+
+### Signs of Success
+- Command exits with code 0
+- Last line contains "BUILD SUCCEEDED"
+- No error messages in red
+- Build time is within expected range (see performance table below)
+
+### Signs of Failure
+- Command exits with non-zero code
+- Output contains "BUILD FAILED"
+- Red error messages appear
+- Build hangs for more than 15 minutes
+
+### Performance Expectations
+
+| Build Type | Expected Duration | Action if Exceeded |
+|------------|------------------|-------------------|
+| First build | 5-10 minutes | Normal - downloading dependencies |
+| Subsequent build | 1-3 minutes | Check for errors in output |
+| Clean build | 3-5 minutes | Normal - rebuilding everything |
+| Incremental | 10-30 seconds | Normal for small changes |
+| Hanging >15 min | Abnormal | Cancel and check for issues |
+
+## 🔧 Error Recovery
+
+### If Build Fails - Immediate Actions
+
+1. **Check the error message** - Last few red lines usually indicate the issue
+2. **Clean and retry**:
+   ```bash
+   xcodebuild clean -workspace <WORKSPACE_PATH> -scheme "iOS Browser"
+   # Then retry the build command
+   ```
+3. **If "No such module" errors**:
+   ```bash
+   rm -rf ~/Library/Developer/Xcode/DerivedData/
+   # Then retry the build command
+   ```
+4. **If simulator issues**:
+   ```bash
+   # List available simulators and pick a different one
+   xcrun simctl list devices
+   ```
+
+### Common Problems and Solutions
+
+| Problem | Diagnosis Command | Solution |
+|---------|------------------|----------|
+| No workspace found | `ls *.xcworkspace` | Ensure you're in project root directory |
+| Simulator not found | `xcrun simctl list devices` | Pick a different simulator ID from the list |
+| "Command not found: xcbeautify" | `which xcbeautify` | Install: `brew install xcbeautify` |
+| Build hangs | Check Activity Monitor | Kill xcodebuild process and retry |
+| "No such module" | Check package resolution | Clean DerivedData and rebuild |
+| Provisioning errors | Check Xcode account | May need manual Xcode intervention |
+
+## 🤖 Complete Automation Script
+
+Use this script for reliable, automated builds:
+
+```bash
+#!/bin/bash
+set -e  # Exit on any error
+
+echo "🔍 Phase 1: Environment Detection"
+echo "================================="
+
+# Detect workspace
+WORKSPACE_DIR=$(pwd)
+WORKSPACE_FILE=$(find . -name "DuckDuckGo.xcworkspace" | head -1)
+if [ -z "$WORKSPACE_FILE" ]; then
+    echo "❌ Error: No DuckDuckGo.xcworkspace found"
+    echo "Make sure you're in the project root directory"
+    exit 1
+fi
+WORKSPACE="${WORKSPACE_DIR}/${WORKSPACE_FILE#./}"
+echo "✅ Workspace: ${WORKSPACE}"
+
+# Detect architecture
+ARCH=$(uname -m)
+echo "✅ Architecture: ${ARCH}"
+
+# Find iOS simulator
+SIMULATOR_ID=$(xcrun simctl list devices | grep -E "iPhone.*\([A-F0-9-]{36}\)" | head -1 | grep -oE "[A-F0-9-]{36}")
+if [ -z "$SIMULATOR_ID" ]; then
+    echo "⚠️  Warning: No iOS simulator found"
+    echo "iOS build will be skipped"
+else
+    echo "✅ Simulator ID: ${SIMULATOR_ID}"
+fi
+
+# Check xcbeautify
+if ! command -v xcbeautify &> /dev/null; then
+    echo "❌ Error: xcbeautify not found"
+    echo "Install with: brew install xcbeautify"
+    exit 1
+fi
+echo "✅ xcbeautify: installed"
+
+echo ""
+echo "🏗️  Phase 2: Building Apps"
+echo "========================"
+
+# Build iOS if simulator available
+if [ -n "$SIMULATOR_ID" ]; then
+    echo ""
+    echo "📱 Building iOS Browser..."
+    /bin/sh -c "set -e -o pipefail && xcodebuild \
+      ONLY_ACTIVE_ARCH=YES \
+      DEBUG_INFORMATION_FORMAT=dwarf \
+      COMPILER_INDEX_STORE_ENABLE=NO \
+      -scheme 'iOS Browser' \
+      -configuration Debug \
+      -workspace ${WORKSPACE} \
+      -destination 'platform=iOS Simulator,id=${SIMULATOR_ID}' \
+      -allowProvisioningUpdates \
+      -parallelizeTargets \
+      build | xcbeautify"
+    echo "✅ iOS Browser built successfully"
+fi
+
+# Build macOS
+echo ""
+echo "💻 Building macOS Browser..."
+/bin/sh -c "set -e -o pipefail && xcodebuild \
+  ONLY_ACTIVE_ARCH=YES \
+  DEBUG_INFORMATION_FORMAT=dwarf \
+  COMPILER_INDEX_STORE_ENABLE=NO \
+  -scheme 'macOS Browser' \
+  -configuration Debug \
+  -workspace ${WORKSPACE} \
+  -destination 'platform=macOS,arch=${ARCH}' \
+  -allowProvisioningUpdates \
+  -disableAutomaticPackageResolution \
+  -parallelizeTargets \
+  build | xcbeautify"
+echo "✅ macOS Browser built successfully"
+
+echo ""
+echo "🎉 All builds completed successfully!"
+```
+
+## 📊 Build Flag Reference
+
+Understanding what each flag does:
+
+| Flag | Purpose | Impact |
+|------|---------|--------|
+| `ONLY_ACTIVE_ARCH=YES` | Build only for current architecture | 50% faster builds |
+| `DEBUG_INFORMATION_FORMAT=dwarf` | Use DWARF debug symbols | Smaller build size |
+| `COMPILER_INDEX_STORE_ENABLE=NO` | Skip code indexing | Faster builds |
+| `-allowProvisioningUpdates` | Auto-update certificates | Prevents signing failures |
+| `-disableAutomaticPackageResolution` | Skip package updates | Faster, more stable |
+| `-parallelizeTargets` | Build targets in parallel | Uses all CPU cores |
+| `-scheme` | Which app to build | Selects iOS or macOS |
+| `-configuration` | Debug or Release | Debug = faster, Release = optimized |
+| `-destination` | Where to run | Simulator/device/Mac |
+
+## 📚 Additional Resources
+
+### Available Schemes
+- `iOS Browser` - Main iOS app
+- `macOS Browser` - Main macOS app (sometimes called "DuckDuckGo")
+
+### Useful Commands
+```bash
+# List all schemes
+xcodebuild -list -workspace DuckDuckGo.xcworkspace
+
+# List all simulators
+xcrun simctl list devices
+
+# Clean everything
+rm -rf ~/Library/Developer/Xcode/DerivedData/
+
+# Open workspace in Xcode
+open DuckDuckGo.xcworkspace
+```
+
+## ✅ Task Completion Checklist
+
+Before considering the build task complete, verify:
+
+- [ ] Build command executed without errors
+- [ ] "BUILD SUCCEEDED" message appeared
+- [ ] Exit code was 0
+- [ ] Build time was within expected range
+- [ ] No unresolved errors in output
+- [ ] If requested, both iOS and macOS builds completed
+
+## 🚨 Critical Warnings
+
+### For Release Builds
+If building for release/production, change `-configuration Debug` to `-configuration Release`
+
+### For Device Builds
+If building for a physical iOS device (not simulator), you'll need:
+- Device UUID instead of simulator ID
+- Valid provisioning profiles
+- Device connected and trusted
+
+### For CI/Automation
+- Always check exit codes
+- Implement timeouts (15 minutes max)
+- Log full output for debugging
+- Clean build environment between runs

--- a/doc-bot/rules/general.md
+++ b/doc-bot/rules/general.md
@@ -1,0 +1,255 @@
+---
+alwaysApply: true
+title: "DuckDuckGo Browser Development Overview"
+description: "General project overview and development guidelines for DuckDuckGo browser development across iOS and macOS platforms"
+keywords: ["Swift", "iOS", "macOS", "MVVM", "SwiftUI", "privacy", "architecture", "dependency injection", "design system"]
+---
+
+# DuckDuckGo Browser Development Rules Overview
+
+## 🛑 CRITICAL: STOP IMMEDIATELY WHEN TOLD
+
+**MANDATORY BEHAVIOR**: When user says ANY of:
+- "stop"
+- "wtf" 
+- "u doing wrong"
+- "what u doing now"
+- "why [doing something]"
+- Any variation indicating to stop or questioning current action
+
+**IMMEDIATELY STOP** the current action:
+1. Do NOT continue with tool calls
+2. Do NOT continue explanations  
+3. Do NOT try to "fix" things
+4. Just acknowledge briefly and wait for new instructions
+
+## 📝 DOCUMENTATION EDITING RULE
+
+**CRITICAL: When updating coding rules and documentation:**
+- **ALWAYS edit markdown files directly using file editing tools**
+- **NEVER use MCP tools to create or update documentation**
+- **This ensures proper version control and maintains documentation integrity**
+
+## 🔍 DOCUMENTATION LOOKUP PROTOCOL
+
+**MANDATORY: Always follow this exact sequence when looking for documentation:**
+
+1. **FIRST**: Call `doc_bot()` for any task - this is non-negotiable
+2. **SECOND**: Call `get_document_index()` to see ALL available documents with exact filenames
+3. **THIRD**: Use `read_specific_document("exact-filename.md")` with the EXACT filename from the index
+4. **NEVER**: Make claims about "documentation says" without actually reading the full document
+5. **NEVER**: Use search snippets alone - always read the complete relevant documentation
+
+**Common Mistake Pattern to Avoid:**
+```
+❌ WRONG: search_documentation() → assume content → make statements
+✅ CORRECT: doc_bot() → get_document_index() → read_specific_document() → accurate information
+```
+
+**Why This Protocol Exists:**
+- Search results show document **titles**, not **filenames**
+- Document titles like "Development Commands & Build Instructions" have filenames like `development-commands.md`
+- Reading incomplete search snippets leads to wrong conclusions
+- The document index shows the exact filenames needed for `read_specific_document()`
+
+## Project Context
+This is the DuckDuckGo browser for iOS and macOS, built with privacy-first principles, modern Swift patterns, and cross-platform architecture.
+
+**Key Directories:**
+- `iOS/` - iOS browser app (UIKit + SwiftUI hybrid)
+- `macOS/` - macOS browser app (AppKit + SwiftUI hybrid) 
+- `SharedPackages/` - Cross-platform Swift packages
+- `doc-bot/` - Development rules and guidelines
+
+## Architecture Summary
+- **Pattern**: MVVM + Coordinators + Dependency Injection
+- **UI**: SwiftUI preferred, UIKit/AppKit for legacy
+- **Storage**: Core Data + GRDB + Keychain for sensitive data
+- **Design**: DesignResourcesKit for colors/icons (MANDATORY)
+- **Testing**: >80% coverage required
+
+## Rule Files Reference
+
+### Core Development Rules (Apply to All Code)
+- `anti-patterns.md` - What NOT to do (memory leaks, force unwrapping, etc.)
+- `code-style.md` - Swift style guide and conventions
+- `privacy-security.md` - Privacy requirements (ALWAYS applies)
+
+### Architecture & Patterns
+- `architecture.md` - MVVM, DI, and structural patterns
+- `property-wrappers.md` - @UserDefaultsWrapper and custom property wrappers
+- `feature-flags.md` - Type-safe feature flags and A/B testing
+
+### UI Development
+- `swiftui-style.md` - SwiftUI + DesignResourcesKit integration
+- `swiftui-advanced.md` - Advanced SwiftUI patterns and techniques
+- `webkit-browser.md` - WebView and browser-specific patterns
+
+### Platform-Specific Rules
+- `ios-architecture.md` - iOS AppDependencyProvider, MainCoordinator, UIKit patterns
+- `macos-window-management.md` - macOS window management and AppKit patterns
+- `macos-system-integration.md` - macOS system services and extensions
+
+### Specialized Development
+- `testing.md` - Testing patterns and requirements and xcodebuild commands
+- `ui-testing.md` - UI testing guidelines and best practices for macOS browser
+- `performance-optimization.md` - Performance best practices
+- `shared-packages.md` - Cross-platform package development
+- `analytics-patterns.md` - Pixel analytics and event tracking
+
+## Quick Start Checklist
+
+### Before Writing Any Code:
+1. ✅ Read `privacy-security.md` - Privacy is non-negotiable
+2. ✅ Check platform rules (`ios-architecture.md` or `macos-architecture.md`)
+3. ✅ Review `anti-patterns.md` - Avoid common mistakes
+4. ✅ REMEMBER: NEVER commit, push, or run tests without explicit user permission or unless explicitly asked to
+
+### For UI Development:
+1. ✅ Use `swiftui-style.md` for SwiftUI components
+2. ✅ MUST use DesignResourcesKit colors: `Color(designSystemColor: .textPrimary)`
+3. ✅ MUST use DesignResourcesKit icons: `DesignSystemImages.Glyphs.Size16.add`
+
+### For New Features:
+1. ✅ Follow `architecture.md` for MVVM + DI patterns
+2. ✅ Use AppDependencyProvider (iOS) or equivalent (macOS)
+3. ✅ Write tests per `testing.md` requirements
+
+## Critical Don'ts (from anti-patterns.md)
+- ❌ NEVER commit, push changes, create or delete branches on git or trigger github actions without EXPLICIT user permission
+- ❌ NEVER run tests without EXPLICIT user permission or if user explicitly asked to in their prompt
+- ❌ NEVER use `.shared` singletons - use dependency injection instead
+- ❌ NEVER hardcode colors/icons (use DesignResourcesKit)
+- ❌ NEVER update UI without @MainActor
+- ❌ NEVER ignore privacy implications
+- ❌ NEVER force unwrap without justification
+- ❌ NEVER use `print()` statements - use appropriate Logger extensions instead
+
+## Logging Guidelines
+
+**NEVER use `print()` in production code. ALWAYS use appropriate Logger extensions:**
+
+```swift
+import os.log
+
+✅ // GOOD: Use Logger extensions for different contexts
+Logger.general.debug("Service state changed: \(newState)")
+Logger.network.info("HTTP request completed: \(response.statusCode)")
+Logger.ui.debug("View layout updated with \(items.count) items")
+
+❌ // BAD: Using print() statements
+print("Service state changed")  // Never use print()
+print("DEBUG: \(someValue)")    // Use Logger.debug() instead
+```
+
+**Available Logger categories:**
+- `Logger.general` - General app functionality
+- `Logger.network` - Network requests and responses  
+- `Logger.ui` - UI updates and user interactions
+- `Logger.tests` - Test-specific logging (import `os.log` in tests)
+
+**Benefits of Logger extensions:**
+- Structured logging with categories and levels
+- Better performance than print() statements
+- Automatic log collection and filtering
+- Integration with system logging infrastructure
+
+## Dependency Injection Pattern (iOS)
+```swift
+// ✅ CORRECT pattern used throughout codebase
+final class FeatureViewModel: ObservableObject {
+    private let service: FeatureServiceProtocol
+    
+    init(dependencies: DependencyProvider = AppDependencyProvider.shared) {
+        self.service = dependencies.featureService
+    }
+}
+```
+
+## Design System Usage (MANDATORY)
+```swift
+// ✅ REQUIRED - Use DesignResourcesKit
+Text("Title")
+    .foregroundColor(Color(designSystemColor: .textPrimary))
+
+Image(uiImage: DesignSystemImages.Color.Size24.bookmark)
+
+// ❌ FORBIDDEN - Hardcoded colors/icons
+Text("Title").foregroundColor(.black)
+Image(systemName: "bookmark")
+```
+
+## When to Consult Specific Rules
+- **New ViewModels**: `architecture.md` + `swiftui-style.md` + `anti-patterns.md`
+- **Network calls**: `performance-optimization.md` + `privacy-security.md`
+- **Settings/Preferences**: Platform-specific rules + `property-wrappers.md`
+- **Feature flags**: `feature-flags.md`
+- **Analytics/Tracking**: `analytics-patterns.md` + `privacy-security.md`
+- **Advanced SwiftUI**: `swiftui-advanced.md`
+- **Testing**: `testing.md` + `anti-patterns.md`
+- **UI Testing**: `ui-testing.md` + `testing.md`
+- **Cross-platform code**: `shared-packages.md`
+- **WebView integration**: `webkit-browser.md` + `anti-patterns.md`
+- **macOS windows**: `macos-window-management.md` + `anti-patterns.md`
+- **macOS system features**: `macos-system-integration.md`
+
+## Code Review Checklist
+1. Privacy implications assessed (`privacy-security.md`)
+2. Design system properly used (`swiftui-style.md`)
+3. Architecture patterns followed (platform-specific rules)
+4. Anti-patterns avoided (`anti-patterns.md`)
+5. Tests written and passing (`testing.md`)
+6. Performance considered (`performance-optimization.md`)
+
+## Git & Testing Workflow Rules
+
+### 🚨 MANDATORY: Never Auto-Execute Commands
+**NEVER commit, push, or run tests without EXPLICIT user permission.**
+
+#### Git Workflow:
+1. Make file changes as requested
+2. **STOP** before any `git add`, `git commit`, or `git push` commands  
+3. **ASK** the user: "Should I commit/push these changes?"
+4. **WAIT** for explicit permission (e.g., "yes", "commit it", "push it", "go ahead")
+5. Only then execute git commands
+
+#### Testing Workflow:
+1. Write or modify code as requested
+2. **STOP** before running any tests (`swift test`, `npm test`, `xcodebuild test`, etc.)
+3. **ASK** the user: "Should I run the tests?"
+4. **WAIT** for explicit permission (e.g., "yes", "run tests", "test it")
+5. Only then execute test commands
+
+#### What NOT to Do:
+```bash
+# ❌ WRONG - Never do these automatically
+git add .
+git commit -m "Updated files"
+git push origin main
+swift test
+npm test
+xcodebuild test
+```
+
+#### What TO Do:
+```bash
+# ✅ CORRECT - Ask first
+echo "I've made the requested changes. Would you like me to:"
+echo "1. Commit these changes?"
+echo "2. Run the tests?" 
+echo "3. Push to remote?"
+# Wait for user response before any commands
+```
+
+**These rules have NO exceptions. Always ask before executing git or test commands.**
+
+## Communication Style
+
+- Keep responses concise and focused on the task
+- Avoid enthusiastic language like "Perfect!", "You are absolutely right!", "Excellent!"
+- Keep work summaries brief - focus on what was changed, not how great it is
+- Let the code quality speak for itself rather than using excessive praise
+
+---
+
+This overview ensures you understand the project context and know which specific rules to consult for your development task.

--- a/doc-bot/rules/privacy-security.md
+++ b/doc-bot/rules/privacy-security.md
@@ -1,0 +1,187 @@
+---
+alwaysApply: true
+title: "Privacy & Security Guidelines"
+description: "Privacy and security guidelines for DuckDuckGo browser development with privacy-by-design principles"
+keywords: ["privacy", "security", "keychain", "data protection", "HTTPS", "authentication", "content blocking", "cookies"]
+---
+
+# Privacy & Security Guidelines
+
+## Core Principles
+
+### Privacy by Design
+- Never collect or transmit user data without explicit consent
+- All features must have privacy implications documented
+- Default to the most private option
+- Implement data minimization - only collect what's absolutely necessary
+
+### Secure Storage
+```swift
+// Use Keychain for sensitive data
+let keychainService = KeychainService()
+try keychainService.store(password, for: account)
+
+// Use encrypted Core Data for sensitive persistent data
+let container = NSPersistentContainer(name: "SecureData")
+container.persistentStoreDescriptions.forEach { storeDescription in
+    storeDescription.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+    storeDescription.setOption(FileProtectionType.complete as NSObject, forKey: NSPersistentStoreFileProtectionKey)
+}
+```
+
+## Data Handling
+
+### User Data Classification
+1. **Sensitive Data**: Passwords, credentials, personal information
+   - Must use Keychain or encrypted storage
+   - Never log or transmit in plain text
+   - Clear on app logout/uninstall
+
+2. **Private Data**: Browsing history, bookmarks, settings
+   - Store locally only
+   - Implement proper data clearing
+   - Respect fireproofing settings
+
+3. **Anonymous Data**: Crash reports, usage statistics
+   - Only collect with user consent
+   - Strip all identifying information
+   - Use differential privacy where applicable
+
+### Network Security
+```swift
+// Always use HTTPS
+guard url.scheme == "https" else {
+    throw NetworkError.insecureConnection
+}
+
+// Implement certificate pinning for critical endpoints
+let pinnedCertificates = [
+    "duckduckgo.com": "SHA256:XXXXXXXXXX"
+]
+
+// Validate all external inputs
+func validateInput(_ input: String) -> Bool {
+    // Implement proper validation
+    return input.matches(allowedPattern)
+}
+```
+
+## Content Blocking
+
+### Tracker Protection
+```swift
+// Use TrackerRadarKit for blocking
+let trackerDataSet = TrackerDataSet(data: trackerData)
+let contentBlocker = ContentBlocker(trackerDataSet: trackerDataSet)
+
+// Apply blocking rules
+webView.configuration.userContentController.add(contentBlocker.makeBlockingRules())
+```
+
+### Cookie Management
+```swift
+// Clear cookies on demand
+HTTPCookieStorage.shared.removeCookies(since: Date.distantPast)
+WKWebsiteDataStore.default().removeData(ofTypes: [WKWebsiteDataTypeCookies], 
+                                       modifiedSince: Date.distantPast)
+
+// Implement fireproofing
+let fireproofedDomains = FireproofingManager.shared.fireproofedDomains
+// Preserve cookies only for fireproofed domains
+```
+
+## Authentication & Authorization
+
+### Biometric Authentication
+```swift
+// Use LocalAuthentication for sensitive operations
+let context = LAContext()
+context.evaluatePolicy(.deviceOwnerAuthentication, 
+                      localizedReason: "Authenticate to access your passwords") { success, error in
+    if success {
+        // Grant access
+    } else {
+        // Handle authentication failure
+    }
+}
+```
+
+### Credential Management
+```swift
+// Never store passwords in plain text
+// Use AutofillCredentialProvider for password management
+let credential = ASPasswordCredential(user: username, password: password)
+ASCredentialIdentityStore.shared.saveCredentialIdentities([credential])
+```
+
+## Error Handling
+
+### Secure Error Messages
+```swift
+// Don't expose sensitive information in errors
+// Bad
+throw NetworkError.authenticationFailed(username: user.email)
+
+// Good
+throw NetworkError.authenticationFailed
+
+// Log securely
+Logger.log(.error, "Authentication failed for user", 
+          parameters: ["userId": user.anonymizedId])
+```
+
+## Code Security
+
+### Input Validation
+```swift
+extension String {
+    var sanitizedForWeb: String {
+        // Remove potentially dangerous characters
+        return self.replacingOccurrences(of: "<", with: "&lt;")
+                   .replacingOccurrences(of: ">", with: "&gt;")
+                   .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+}
+```
+
+### Secure Defaults
+```swift
+struct PrivacySettings {
+    var blockTrackers = true  // Default to blocking
+    var httpsEverywhere = true  // Default to HTTPS
+    var sendDiagnostics = false  // Default to no data collection
+    var saveHistory = false  // Default to no history
+}
+```
+
+## Testing Security
+
+### Security Test Cases
+```swift
+func testSensitiveDataNotLogged() {
+    let password = "secret123"
+    authenticator.login(password: password)
+    
+    XCTAssertFalse(logOutput.contains(password))
+}
+
+func testDataEncryption() {
+    let sensitiveData = "user information"
+    let encrypted = encryptor.encrypt(sensitiveData)
+    
+    XCTAssertNotEqual(encrypted, sensitiveData)
+    XCTAssertEqual(encryptor.decrypt(encrypted), sensitiveData)
+}
+```
+
+## Review Checklist
+
+Before committing code, ensure:
+- [ ] No hardcoded secrets or API keys
+- [ ] All user data is properly classified and protected
+- [ ] Network requests use HTTPS
+- [ ] Input validation is implemented
+- [ ] Error messages don't leak sensitive information
+- [ ] Logging doesn't include PII
+- [ ] Data clearing mechanisms are tested
+- [ ] Privacy impact has been assessed


### PR DESCRIPTION
Reduce always-loaded tokens from 25K to 2K by moving detailed examples to reference files.

**Changes:**
- New lean `core-rules.md` with essential rules only (alwaysApply: true)
- Detailed examples moved to reference files (alwaysApply: false)
- 92% reduction in token overhead