### PR TITLE
Properly handle closeAIChat if comes from sidebar

### DIFF
--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -95,7 +95,13 @@ struct AIChatUserScriptHandler: AIChatUserScriptHandling {
     }
 
     func closeAIChat(params: Any, message: UserScriptMessage) async -> Encodable? {
-        await windowControllersManager.mainWindowController?.mainViewController.closeTab(nil)
+        let isSidebar = await message.messageWebView?.url?.hasAIChatSidebarPlacementParameter == true
+
+        if isSidebar {
+            await windowControllersManager.mainWindowController?.mainViewController.aiChatSidebarPresenter.collapseSidebar(withAnimation: true)
+        } else {
+            await windowControllersManager.mainWindowController?.mainViewController.closeTab(nil)
+        }
         return nil
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/inbox/1200848783436158/item/1211306411026126/story/1211334569980219?focus=true
Tech Design URL:
CC:

### Description
When Duck.ai shows its onboarding and user selects "Not Now" on the policy we should either close the tab or sidebar depending on the context

### Testing Steps
**Note:** _To see Duck.ai onboarding it is best to use Burner window_ 
1. Open new Burner window.
2. Open a new tab and navigate to Duck.ai
3. When privacy policy modal prompt is shown click "Not Yet". As a result the whole tab should be closed.
4. Open a new tab and navigate to a website.
5. Reveal the sidebar (via address bar button or summarize or translation context menu item)
6. When privacy policy modal prompt is shown click "Not Yet". As a result only the sidebar should be closed. 

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Closing Duck.ai is incorrectly handled


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)