### PR TITLE
macOS: Add code to check for latest AppStore version

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -3334,6 +3334,8 @@
 		BB4339DB2C7F9606005D7ED7 /* PinnedTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4339DA2C7F9606005D7ED7 /* PinnedTabsTests.swift */; };
 		BB470EBB2C5A66D6002EE91D /* BookmarkManagementDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB470EBA2C5A66D6002EE91D /* BookmarkManagementDetailViewModel.swift */; };
 		BB470EBC2C5A66D6002EE91D /* BookmarkManagementDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB470EBA2C5A66D6002EE91D /* BookmarkManagementDetailViewModel.swift */; };
+		BB486B512E74770D0026B972 /* LatestReleaseCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB486B502E74770D0026B972 /* LatestReleaseCheckerTests.swift */; };
+		BB486B522E74770D0026B972 /* LatestReleaseCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB486B502E74770D0026B972 /* LatestReleaseCheckerTests.swift */; };
 		BB4EC6952D9B5C8000660600 /* VisualStyleProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4EC6942D9B5C7800660600 /* VisualStyleProviding.swift */; };
 		BB4EC6962D9B5C8000660600 /* VisualStyleProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4EC6942D9B5C7800660600 /* VisualStyleProviding.swift */; };
 		BB53CF3E2E26CEED007F0B42 /* RequestNewFeatureFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB53CF3D2E26CEE5007F0B42 /* RequestNewFeatureFormView.swift */; };
@@ -3408,6 +3410,8 @@
 		BBC256A32E66209200D3A9F6 /* FireWindowByDefaultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC256A22E66209200D3A9F6 /* FireWindowByDefaultTests.swift */; };
 		BBC386832DE5E6EA0004583A /* SuggestionsIconsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC386822DE5E6E70004583A /* SuggestionsIconsProviding.swift */; };
 		BBC386842DE5E6EA0004583A /* SuggestionsIconsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC386822DE5E6E70004583A /* SuggestionsIconsProviding.swift */; };
+		BBC6E3D92E736A54005C08EB /* LatestReleaseChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC6E3D82E736A52005C08EB /* LatestReleaseChecker.swift */; };
+		BBC6E3DA2E736A54005C08EB /* LatestReleaseChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC6E3D82E736A52005C08EB /* LatestReleaseChecker.swift */; };
 		BBC7BDA92D5B82BD0037A4AE /* DefaultBrowserAndDockPromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC7BDA82D5B82A20037A4AE /* DefaultBrowserAndDockPromptCoordinator.swift */; };
 		BBC7BDAA2D5B82BD0037A4AE /* DefaultBrowserAndDockPromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC7BDA82D5B82A20037A4AE /* DefaultBrowserAndDockPromptCoordinator.swift */; };
 		BBC7BDAC2D5BB0890037A4AE /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC7BDAB2D5BB0720037A4AE /* BannerView.swift */; };
@@ -3587,8 +3591,6 @@
 		CC0942FE2E16AF9C00E67336 /* FavoritesImportProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0942FC2E16AF6000E67336 /* FavoritesImportProcessor.swift */; };
 		CC0943002E16B6F000E67336 /* FavoritesImportProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0942FF2E16B6F000E67336 /* FavoritesImportProcessorTests.swift */; };
 		CC0943012E16B6F000E67336 /* FavoritesImportProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0942FF2E16B6F000E67336 /* FavoritesImportProcessorTests.swift */; };
-		CC34456F2E674E7700019518 /* UserScriptErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC34456E2E674E7700019518 /* UserScriptErrorTests.swift */; };
-		CC3445702E674E7700019518 /* UserScriptErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC34456E2E674E7700019518 /* UserScriptErrorTests.swift */; };
 		CC0DD90F2E5DD74600277E46 /* AppStateRestorationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD90E2E5DD74600277E46 /* AppStateRestorationManagerTests.swift */; };
 		CC0DD9102E5DD74600277E46 /* AppStateRestorationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD90E2E5DD74600277E46 /* AppStateRestorationManagerTests.swift */; };
 		CC0DD9132E5DF47E00277E46 /* SessionRestorePromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9122E5DF47E00277E46 /* SessionRestorePromptView.swift */; };
@@ -3599,6 +3601,8 @@
 		CC0DD91A2E5DFA5800277E46 /* SessionRestorePromptPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD9182E5DFA4D00277E46 /* SessionRestorePromptPopover.swift */; };
 		CC0DD91C2E5EF7CE00277E46 /* SessionRestorePromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD91B2E5EF7C100277E46 /* SessionRestorePromptCoordinator.swift */; };
 		CC0DD91D2E5EF7CE00277E46 /* SessionRestorePromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0DD91B2E5EF7C100277E46 /* SessionRestorePromptCoordinator.swift */; };
+		CC34456F2E674E7700019518 /* UserScriptErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC34456E2E674E7700019518 /* UserScriptErrorTests.swift */; };
+		CC3445702E674E7700019518 /* UserScriptErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC34456E2E674E7700019518 /* UserScriptErrorTests.swift */; };
 		CC5B3D012E158B9F00115521 /* ChromiumDataImporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5B3D002E158B9F00115521 /* ChromiumDataImporterTests.swift */; };
 		CC5B3D022E158B9F00115521 /* ChromiumDataImporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5B3D002E158B9F00115521 /* ChromiumDataImporterTests.swift */; };
 		CC6E897C2E5F08EA00F6BED0 /* SessionRestorePromptCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6E897B2E5F08EA00F6BED0 /* SessionRestorePromptCoordinatorTests.swift */; };
@@ -3609,10 +3613,10 @@
 		CC87770A2E1FF39B00113863 /* FirefoxHistoryReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC8777082E1FF39B00113863 /* FirefoxHistoryReader.swift */; };
 		CC87770C2E1FF5CA00113863 /* FirefoxHistoryReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC87770B2E1FF5CA00113863 /* FirefoxHistoryReaderTests.swift */; };
 		CC87770D2E1FF5CA00113863 /* FirefoxHistoryReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC87770B2E1FF5CA00113863 /* FirefoxHistoryReaderTests.swift */; };
-		CCB36B132E56383500DBFE3A /* UserScriptError+Pixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB36B122E56382E00DBFE3A /* UserScriptError+Pixel.swift */; };
-		CCB36B142E56383500DBFE3A /* UserScriptError+Pixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB36B122E56382E00DBFE3A /* UserScriptError+Pixel.swift */; };
 		CC9B678C2E607AD9003353C3 /* SessionRestorePromptPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9B678B2E607AD1003353C3 /* SessionRestorePromptPixel.swift */; };
 		CC9B678D2E607AD9003353C3 /* SessionRestorePromptPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9B678B2E607AD1003353C3 /* SessionRestorePromptPixel.swift */; };
+		CCB36B132E56383500DBFE3A /* UserScriptError+Pixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB36B122E56382E00DBFE3A /* UserScriptError+Pixel.swift */; };
+		CCB36B142E56383500DBFE3A /* UserScriptError+Pixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB36B122E56382E00DBFE3A /* UserScriptError+Pixel.swift */; };
 		CCC87D6D2E1412D70091344D /* ChromiumTopSitesReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC87D6C2E1412D00091344D /* ChromiumTopSitesReader.swift */; };
 		CCC87D6E2E1412D70091344D /* ChromiumTopSitesReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC87D6C2E1412D00091344D /* ChromiumTopSitesReader.swift */; };
 		CCC87D732E1429570091344D /* ChromiumTopSitesReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC87D722E1429570091344D /* ChromiumTopSitesReaderTests.swift */; };
@@ -5670,6 +5674,7 @@
 		BB349A4D2E3B8B0E0028AFE1 /* MockDefaultBrowserProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDefaultBrowserProvider.swift; sourceTree = "<group>"; };
 		BB4339DA2C7F9606005D7ED7 /* PinnedTabsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedTabsTests.swift; sourceTree = "<group>"; };
 		BB470EBA2C5A66D6002EE91D /* BookmarkManagementDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkManagementDetailViewModel.swift; sourceTree = "<group>"; };
+		BB486B502E74770D0026B972 /* LatestReleaseCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatestReleaseCheckerTests.swift; sourceTree = "<group>"; };
 		BB4EC6942D9B5C7800660600 /* VisualStyleProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualStyleProviding.swift; sourceTree = "<group>"; };
 		BB53CF3D2E26CEE5007F0B42 /* RequestNewFeatureFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestNewFeatureFormView.swift; sourceTree = "<group>"; };
 		BB5789712B2CA70F0009DFE2 /* DataBrokerProtectionSubscriptionEventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBrokerProtectionSubscriptionEventHandler.swift; sourceTree = "<group>"; };
@@ -5709,6 +5714,7 @@
 		BBC114642D89E859007A82D8 /* TabCollectionViewModelCloseTabLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabCollectionViewModelCloseTabLogicTests.swift; sourceTree = "<group>"; };
 		BBC256A22E66209200D3A9F6 /* FireWindowByDefaultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireWindowByDefaultTests.swift; sourceTree = "<group>"; };
 		BBC386822DE5E6E70004583A /* SuggestionsIconsProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionsIconsProviding.swift; sourceTree = "<group>"; };
+		BBC6E3D82E736A52005C08EB /* LatestReleaseChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatestReleaseChecker.swift; sourceTree = "<group>"; };
 		BBC7BDA82D5B82A20037A4AE /* DefaultBrowserAndDockPromptCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserAndDockPromptCoordinator.swift; sourceTree = "<group>"; };
 		BBC7BDAB2D5BB0720037A4AE /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
 		BBC90A2A2E3265D50013E52C /* ReportProblemFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportProblemFormViewModel.swift; sourceTree = "<group>"; };
@@ -5792,19 +5798,19 @@
 		CC00A08F2E1D52A700750ED3 /* FirefoxPreferencesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirefoxPreferencesTests.swift; sourceTree = "<group>"; };
 		CC0942FC2E16AF6000E67336 /* FavoritesImportProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesImportProcessor.swift; sourceTree = "<group>"; };
 		CC0942FF2E16B6F000E67336 /* FavoritesImportProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesImportProcessorTests.swift; sourceTree = "<group>"; };
-		CC34456E2E674E7700019518 /* UserScriptErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserScriptErrorTests.swift; sourceTree = "<group>"; };
 		CC0DD90E2E5DD74600277E46 /* AppStateRestorationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateRestorationManagerTests.swift; sourceTree = "<group>"; };
 		CC0DD9122E5DF47E00277E46 /* SessionRestorePromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorePromptView.swift; sourceTree = "<group>"; };
 		CC0DD9152E5DF4B000277E46 /* SessionRestorePromptViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorePromptViewModel.swift; sourceTree = "<group>"; };
 		CC0DD9182E5DFA4D00277E46 /* SessionRestorePromptPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorePromptPopover.swift; sourceTree = "<group>"; };
 		CC0DD91B2E5EF7C100277E46 /* SessionRestorePromptCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorePromptCoordinator.swift; sourceTree = "<group>"; };
+		CC34456E2E674E7700019518 /* UserScriptErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserScriptErrorTests.swift; sourceTree = "<group>"; };
 		CC5B3D002E158B9F00115521 /* ChromiumDataImporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromiumDataImporterTests.swift; sourceTree = "<group>"; };
 		CC6E897B2E5F08EA00F6BED0 /* SessionRestorePromptCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorePromptCoordinatorTests.swift; sourceTree = "<group>"; };
 		CC6E897F2E5F0DD600F6BED0 /* SessionRestorePromptCoordinatorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorePromptCoordinatorMock.swift; sourceTree = "<group>"; };
 		CC8777082E1FF39B00113863 /* FirefoxHistoryReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirefoxHistoryReader.swift; sourceTree = "<group>"; };
 		CC87770B2E1FF5CA00113863 /* FirefoxHistoryReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirefoxHistoryReaderTests.swift; sourceTree = "<group>"; };
-		CCB36B122E56382E00DBFE3A /* UserScriptError+Pixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserScriptError+Pixel.swift"; sourceTree = "<group>"; };
 		CC9B678B2E607AD1003353C3 /* SessionRestorePromptPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorePromptPixel.swift; sourceTree = "<group>"; };
+		CCB36B122E56382E00DBFE3A /* UserScriptError+Pixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserScriptError+Pixel.swift"; sourceTree = "<group>"; };
 		CCC87D6C2E1412D00091344D /* ChromiumTopSitesReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromiumTopSitesReader.swift; sourceTree = "<group>"; };
 		CCC87D722E1429570091344D /* ChromiumTopSitesReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromiumTopSitesReaderTests.swift; sourceTree = "<group>"; };
 		CCEB617F2E05710A00AEBED4 /* FirefoxPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirefoxPreferences.swift; sourceTree = "<group>"; };
@@ -6445,6 +6451,7 @@
 		1D72D5902BFF361700AEDE36 /* Updates */ = {
 			isa = PBXGroup;
 			children = (
+				BBC6E3D82E736A52005C08EB /* LatestReleaseChecker.swift */,
 				BB01275B2E6F409E00263AD8 /* CheckForUpdatesAppStorePixels.swift */,
 				7BC641142DD1FBD600272A9D /* UpdatesDebugMenu.swift */,
 				1DA84D2E2C11989D0011C80F /* Update.swift */,
@@ -6494,6 +6501,7 @@
 		1D838A302C44EFF20078373F /* Updates */ = {
 			isa = PBXGroup;
 			children = (
+				BB486B502E74770D0026B972 /* LatestReleaseCheckerTests.swift */,
 				4BCBFDCA2E4BDD4800E41763 /* UpdateControllerTests.swift */,
 				1D838A312C44F0180078373F /* ReleaseNotesParserTests.swift */,
 				1D638D602C44F2BA00530DD5 /* ApplicationUpdateDetectorTests.swift */,
@@ -12889,6 +12897,7 @@
 				3706FAA2293F65D500E42796 /* MainWindow.swift in Sources */,
 				4B44FEF42B1FEF5A000619D8 /* FocusableTextEditor.swift in Sources */,
 				7BFF35742C10D75000F89673 /* IPCServiceLauncher.swift in Sources */,
+				BBC6E3DA2E736A54005C08EB /* LatestReleaseChecker.swift in Sources */,
 				CCB36B132E56383500DBFE3A /* UserScriptError+Pixel.swift in Sources */,
 				1EB01D922E61DF2B006CB411 /* AIChatTranslator.swift in Sources */,
 				F1D042A22BFBB4DD00A31506 /* DataBrokerProtectionSettings+Environment.swift in Sources */,
@@ -14254,6 +14263,7 @@
 				3706FE75293F661700E42796 /* WebsiteBreakageReportTests.swift in Sources */,
 				C18194682C7F60E500381092 /* FreemiumDBPPresenterTests.swift in Sources */,
 				56D145EF29E6DAD900E3488A /* DataImportProviderTests.swift in Sources */,
+				BB486B522E74770D0026B972 /* LatestReleaseCheckerTests.swift in Sources */,
 				56504F0F2E0D9A8C00333A1E /* MockSubscriptionTabsShowing.swift in Sources */,
 				569277C529DEE09D00B633EF /* ContinueSetUpModelTests.swift in Sources */,
 				9F15567F2DDC3FA200A35DBA /* MockDefaultBrowserAndDockPromptFeatureFlagger.swift in Sources */,
@@ -14883,6 +14893,7 @@
 				7BD504B72E5FC740008A0646 /* NativeMessagingConnection.swift in Sources */,
 				7BD504B92E5FC740008A0646 /* BitwardenNativeMessagingHandler.swift in Sources */,
 				7BD504BA2E5FC740008A0646 /* NativeMessagingHandlerFactory.swift in Sources */,
+				BBC6E3D92E736A54005C08EB /* LatestReleaseChecker.swift in Sources */,
 				B65E5DAF2B74DE6D00480415 /* TrackerNetwork.swift in Sources */,
 				37657FC82DB95140003D749E /* TabCrashIndicatorModel.swift in Sources */,
 				37F09AD62DDE483500643A1B /* AppearancePreferencesMock.swift in Sources */,
@@ -16107,6 +16118,7 @@
 				4B98D27C28D960DD003C2B6F /* FirefoxFaviconsReaderTests.swift in Sources */,
 				9F0FFFBE2BCCAF1F007C87DD /* BookmarkAllTabsDialogViewModelMock.swift in Sources */,
 				9FFBEE842DE016E70058B11A /* MockDefaultBrowserAndDockPromptStatusUpdateNotifier.swift in Sources */,
+				BB486B512E74770D0026B972 /* LatestReleaseCheckerTests.swift in Sources */,
 				C1CE846C2C88868D0068913B /* FreemiumDBPScanResultPollingTests.swift in Sources */,
 				37479F152891BC8300302FE2 /* TabCollectionViewModelTests+WithoutPinnedTabsManager.swift in Sources */,
 				AA63745424C9BF9A00AB2AC4 /* SuggestionContainerTests.swift in Sources */,

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -861,6 +861,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         Task {
+            try? await LatestReleaseChecker().getLatestReleaseAvailable(for: .macOSAppStore)
+        }
+
+        Task {
             await subscriptionManagerV1?.loadInitialData()
             await subscriptionManagerV2?.loadInitialData()
 

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -861,10 +861,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         Task {
-            try? await LatestReleaseChecker().getLatestReleaseAvailable(for: .macOSAppStore)
-        }
-
-        Task {
             await subscriptionManagerV1?.loadInitialData()
             await subscriptionManagerV2?.loadInitialData()
 

--- a/macOS/DuckDuckGo/Updates/LatestReleaseChecker.swift
+++ b/macOS/DuckDuckGo/Updates/LatestReleaseChecker.swift
@@ -1,0 +1,118 @@
+//
+//  LatestReleaseChecker.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+import Foundation
+
+public enum LatestReleaseMetadataType {
+    case macOSAppStore
+}
+
+public enum LatestReleaseError: Error, LocalizedError {
+    case invalidURL
+    case networkError(Error)
+    case decodingError(Error)
+    case metadataNotFound
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "Invalid release metadata URL"
+        case .networkError(let error):
+            return "Network error: \(error.localizedDescription)"
+        case .decodingError(let error):
+            return "Failed to decode metadata: \(error.localizedDescription)"
+        case .metadataNotFound:
+            return "Release metadata not found"
+        }
+    }
+}
+
+public struct ReleaseMetadata: Codable {
+    public let latestVersion: String
+    public let buildNumber: String
+    public let releaseDate: String
+    public let isCritical: Bool
+
+    public init(latestVersion: String, buildNumber: String, releaseDate: String, isCritical: Bool) {
+        self.latestVersion = latestVersion
+        self.buildNumber = buildNumber
+        self.releaseDate = releaseDate
+        self.isCritical = isCritical
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case latestVersion = "latest_version"
+        case buildNumber = "build_number"
+        case releaseDate = "release_date"
+        case isCritical = "is_critical"
+    }
+}
+
+private struct ReleaseMetadataCollector: Codable {
+    let latestAppStoreVersion: ReleaseMetadata
+
+    enum CodingKeys: String, CodingKey {
+        case latestAppStoreVersion = "latest_appstore_version"
+    }
+}
+
+public final class LatestReleaseChecker {
+    private let baseURL: String
+    private let urlSession: URLSession
+
+    public init(baseURL: String = "https://staticcdn.duckduckgo.com/macos-desktop-browser/",
+                urlSession: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.urlSession = urlSession
+    }
+
+    private var releaseMetadataURL: String {
+        return baseURL + "release_metadata.json"
+    }
+
+    public func getLatestReleaseAvailable(
+        for metadataType: LatestReleaseMetadataType
+    ) async throws -> ReleaseMetadata {
+        guard let url = URL(string: releaseMetadataURL) else {
+            throw LatestReleaseError.invalidURL
+        }
+
+        do {
+            let (data, response) = try await urlSession.data(from: url)
+
+            // Validate HTTP response
+            if let httpResponse = response as? HTTPURLResponse,
+               httpResponse.statusCode != 200 {
+                throw LatestReleaseError.networkError(URLError(.badServerResponse))
+            }
+
+            let decoder = JSONDecoder()
+            let metadata = try decoder.decode(ReleaseMetadataCollector.self, from: data)
+
+            switch metadataType {
+            case .macOSAppStore:
+                return metadata.latestAppStoreVersion
+            }
+        } catch let error as DecodingError {
+            throw LatestReleaseError.decodingError(error)
+        } catch let error as LatestReleaseError {
+            throw error
+        } catch {
+            throw LatestReleaseError.networkError(error)
+        }
+    }
+}

--- a/macOS/UnitTests/Updates/LatestReleaseCheckerTests.swift
+++ b/macOS/UnitTests/Updates/LatestReleaseCheckerTests.swift
@@ -1,0 +1,547 @@
+//
+//  LatestReleaseCheckerTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Foundation
+import NetworkingTestingUtils
+@testable import DuckDuckGo_Privacy_Browser
+
+final class LatestReleaseCheckerTests: XCTestCase {
+
+    private var mockURLSession: URLSession!
+    private var checker: LatestReleaseChecker!
+
+    override func setUp() {
+        super.setUp()
+        // Configure MockURLProtocol
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        mockURLSession = URLSession(configuration: config)
+
+        checker = LatestReleaseChecker(
+            baseURL: "https://test.example.com/",
+            urlSession: mockURLSession
+        )
+    }
+
+    override func tearDown() {
+        MockURLProtocol.requestHandler = nil
+        mockURLSession = nil
+        checker = nil
+        super.tearDown()
+    }
+
+    // MARK: - Success Cases
+
+    func testGetLatestReleaseAvailable_whenValidResponse_returnsCorrectMetadata() async throws {
+        // Given
+        let expectedMetadata = ReleaseMetadata(
+            latestVersion: "1.156.0",
+            buildNumber: "540",
+            releaseDate: "2025-09-11T10:30:00Z",
+            isCritical: false
+        )
+
+        let jsonResponse = """
+        {
+            "latest_appstore_version": {
+                "latest_version": "1.156.0",
+                "build_number": "540",
+                "release_date": "2025-09-11T10:30:00Z",
+                "is_critical": false
+            }
+        }
+        """
+
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, jsonResponse.data(using: .utf8)!)
+        }
+
+        // When
+        let result = try await checker.getLatestReleaseAvailable(for: .macOSAppStore)
+
+        // Then
+        XCTAssertEqual(result.latestVersion, expectedMetadata.latestVersion)
+        XCTAssertEqual(result.buildNumber, expectedMetadata.buildNumber)
+        XCTAssertEqual(result.releaseDate, expectedMetadata.releaseDate)
+        XCTAssertEqual(result.isCritical, expectedMetadata.isCritical)
+    }
+
+    func testGetLatestReleaseAvailable_whenCriticalRelease_returnsCorrectMetadata() async throws {
+        // Given
+        let jsonResponse = """
+        {
+            "latest_appstore_version": {
+                "latest_version": "1.157.0",
+                "build_number": "541",
+                "release_date": "2025-09-12T14:15:00Z",
+                "is_critical": true
+            }
+        }
+        """
+
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, jsonResponse.data(using: .utf8)!)
+        }
+
+        // When
+        let result = try await checker.getLatestReleaseAvailable(for: .macOSAppStore)
+
+        // Then
+        XCTAssertEqual(result.latestVersion, "1.157.0")
+        XCTAssertEqual(result.buildNumber, "541")
+        XCTAssertEqual(result.releaseDate, "2025-09-12T14:15:00Z")
+        XCTAssertTrue(result.isCritical)
+    }
+
+    // MARK: - Network Error Cases
+
+    func testGetLatestReleaseAvailable_whenNetworkError_throwsNetworkError() async {
+        // Given
+        MockURLProtocol.requestHandler = { request in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        // When & Then
+        do {
+            _ = try await checker.getLatestReleaseAvailable(for: .macOSAppStore)
+            XCTFail("Expected network error to be thrown")
+        } catch let error as LatestReleaseError {
+            switch error {
+            case .networkError(let underlyingError):
+                XCTAssertTrue(underlyingError is URLError)
+                let urlError = underlyingError as! URLError
+                XCTAssertEqual(urlError.code, .notConnectedToInternet)
+            default:
+                XCTFail("Expected network error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected LatestReleaseError, got \(error)")
+        }
+    }
+
+    func testGetLatestReleaseAvailable_whenTimeoutError_throwsNetworkError() async {
+        // Given
+        MockURLProtocol.requestHandler = { request in
+            throw URLError(.timedOut)
+        }
+
+        // When & Then
+        do {
+            _ = try await checker.getLatestReleaseAvailable(for: .macOSAppStore)
+            XCTFail("Expected timeout error to be thrown")
+        } catch let error as LatestReleaseError {
+            switch error {
+            case .networkError(let underlyingError):
+                XCTAssertTrue(underlyingError is URLError)
+                let urlError = underlyingError as! URLError
+                XCTAssertEqual(urlError.code, .timedOut)
+            default:
+                XCTFail("Expected network error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected LatestReleaseError, got \(error)")
+        }
+    }
+
+    // MARK: - HTTP Error Cases
+
+    func testGetLatestReleaseAvailable_when404Response_throwsHTTPError() async {
+        // Given
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 404,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data())
+        }
+
+        // When & Then
+        do {
+            _ = try await checker.getLatestReleaseAvailable(for: .macOSAppStore)
+            XCTFail("Expected HTTP error to be thrown")
+        } catch let error as LatestReleaseError {
+            switch error {
+            case .networkError(let error):
+                XCTAssertEqual(error as! URLError, URLError(.badServerResponse))
+            default:
+                XCTFail("Expected HTTP error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected LatestReleaseError, got \(error)")
+        }
+    }
+
+    func testGetLatestReleaseAvailable_when500Response_throwsHTTPError() async {
+        // Given
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data())
+        }
+
+        // When & Then
+        do {
+            _ = try await checker.getLatestReleaseAvailable(for: .macOSAppStore)
+            XCTFail("Expected HTTP error to be thrown")
+        } catch let error as LatestReleaseError {
+            switch error {
+            case .networkError(let error):
+                XCTAssertEqual(error as! URLError, URLError(.badServerResponse))
+            default:
+                XCTFail("Expected HTTP error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected LatestReleaseError, got \(error)")
+        }
+    }
+
+    func testGetLatestReleaseAvailable_when403Response_throwsHTTPError() async {
+        // Given
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 403,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data())
+        }
+
+        // When & Then
+        do {
+            _ = try await checker.getLatestReleaseAvailable(for: .macOSAppStore)
+            XCTFail("Expected HTTP error to be thrown")
+        } catch let error as LatestReleaseError {
+            switch error {
+            case .networkError(let error):
+                XCTAssertEqual(error as! URLError, URLError(.badServerResponse))
+            default:
+                XCTFail("Expected HTTP error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected LatestReleaseError, got \(error)")
+        }
+    }
+
+    // MARK: - JSON Parsing Error Cases
+
+    func testGetLatestReleaseAvailable_whenInvalidJSON_throwsParsingError() async {
+        // Given
+        let invalidJSON = "{ invalid json }"
+
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, invalidJSON.data(using: .utf8)!)
+        }
+
+        // When & Then
+        do {
+            _ = try await checker.getLatestReleaseAvailable(for: .macOSAppStore)
+            XCTFail("Expected parsing error to be thrown")
+        } catch let error as LatestReleaseError {
+            switch error {
+            case .decodingError(let underlyingError):
+                XCTAssertTrue(underlyingError is DecodingError)
+            default:
+                XCTFail("Expected parsing error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected LatestReleaseError, got \(error)")
+        }
+    }
+
+    func testGetLatestReleaseAvailable_whenMissingRequiredFields_throwsParsingError() async {
+        // Given
+        let incompleteJSON = """
+        {
+            "latest_appstore_version": {
+                "latest_version": "1.156.0"
+            }
+        }
+        """
+
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, incompleteJSON.data(using: .utf8)!)
+        }
+
+        // When & Then
+        do {
+            _ = try await checker.getLatestReleaseAvailable(for: .macOSAppStore)
+            XCTFail("Expected parsing error to be thrown")
+        } catch let error as LatestReleaseError {
+            switch error {
+            case .decodingError(let underlyingError):
+                XCTAssertTrue(underlyingError is DecodingError)
+            default:
+                XCTFail("Expected parsing error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected LatestReleaseError, got \(error)")
+        }
+    }
+
+    func testGetLatestReleaseAvailable_whenWrongJSONStructure_throwsParsingError() async {
+        // Given
+        let wrongStructureJSON = """
+        {
+            "wrong_key": {
+                "latest_version": "1.156.0",
+                "build_number": "540",
+                "release_date": "2025-09-11T10:30:00Z",
+                "is_critical": false
+            }
+        }
+        """
+
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, wrongStructureJSON.data(using: .utf8)!)
+        }
+
+        // When & Then
+        do {
+            _ = try await checker.getLatestReleaseAvailable(for: .macOSAppStore)
+            XCTFail("Expected parsing error to be thrown")
+        } catch let error as LatestReleaseError {
+            switch error {
+            case .decodingError(let underlyingError):
+                XCTAssertTrue(underlyingError is DecodingError)
+            default:
+                XCTFail("Expected parsing error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected LatestReleaseError, got \(error)")
+        }
+    }
+
+    func testGetLatestReleaseAvailable_whenEmptyResponse_throwsParsingError() async {
+        // Given
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, Data())
+        }
+
+        // When & Then
+        do {
+            _ = try await checker.getLatestReleaseAvailable(for: .macOSAppStore)
+            XCTFail("Expected parsing error to be thrown")
+        } catch let error as LatestReleaseError {
+            switch error {
+            case .decodingError(let underlyingError):
+                XCTAssertTrue(underlyingError is DecodingError)
+            default:
+                XCTFail("Expected parsing error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected LatestReleaseError, got \(error)")
+        }
+    }
+
+    // MARK: - Data Types Tests
+
+    func testGetLatestReleaseAvailable_whenWrongDataTypes_throwsParsingError() async {
+        // Given
+        let wrongTypesJSON = """
+        {
+            "latest_appstore_version": {
+                "latest_version": 123,
+                "build_number": true,
+                "release_date": "2025-09-11T10:30:00Z",
+                "is_critical": "false"
+            }
+        }
+        """
+
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, wrongTypesJSON.data(using: .utf8)!)
+        }
+
+        // When & Then
+        do {
+            _ = try await checker.getLatestReleaseAvailable(for: .macOSAppStore)
+            XCTFail("Expected parsing error to be thrown")
+        } catch let error as LatestReleaseError {
+            switch error {
+            case .decodingError(let underlyingError):
+                XCTAssertTrue(underlyingError is DecodingError)
+            default:
+                XCTFail("Expected parsing error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected LatestReleaseError, got \(error)")
+        }
+    }
+
+    // MARK: - Edge Cases
+
+    func testGetLatestReleaseAvailable_whenNullValues_throwsParsingError() async {
+        // Given
+        let nullValuesJSON = """
+        {
+            "latest_appstore_version": {
+                "latest_version": null,
+                "build_number": "540",
+                "release_date": "2025-09-11T10:30:00Z",
+                "is_critical": false
+            }
+        }
+        """
+
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, nullValuesJSON.data(using: .utf8)!)
+        }
+
+        // When & Then
+        do {
+            _ = try await checker.getLatestReleaseAvailable(for: .macOSAppStore)
+            XCTFail("Expected parsing error to be thrown")
+        } catch let error as LatestReleaseError {
+            switch error {
+            case .decodingError(let underlyingError):
+                XCTAssertTrue(underlyingError is DecodingError)
+            default:
+                XCTFail("Expected parsing error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected LatestReleaseError, got \(error)")
+        }
+    }
+
+    func testGetLatestReleaseAvailable_whenVeryLongVersionString_returnsCorrectMetadata() async throws {
+        // Given
+        let longVersionString = String(repeating: "1.2.3.4.5.6.7.8.9.0.", count: 50) + "1"
+        let jsonResponse = """
+        {
+            "latest_appstore_version": {
+                "latest_version": "\(longVersionString)",
+                "build_number": "540",
+                "release_date": "2025-09-11T10:30:00Z",
+                "is_critical": false
+            }
+        }
+        """
+
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, jsonResponse.data(using: .utf8)!)
+        }
+
+        // When
+        let result = try await checker.getLatestReleaseAvailable(for: .macOSAppStore)
+
+        // Then
+        XCTAssertEqual(result.latestVersion, longVersionString)
+        XCTAssertEqual(result.buildNumber, "540")
+        XCTAssertEqual(result.releaseDate, "2025-09-11T10:30:00Z")
+        XCTAssertFalse(result.isCritical)
+    }
+
+    // MARK: - URL Construction Tests
+
+    func testGetLatestReleaseAvailable_constructsCorrectURL() async {
+        // Given
+        var capturedRequest: URLRequest?
+        MockURLProtocol.requestHandler = { request in
+            capturedRequest = request
+
+            let jsonResponse = """
+            {
+                "latest_appstore_version": {
+                    "latest_version": "1.156.0",
+                    "build_number": "540",
+                    "release_date": "2025-09-11T10:30:00Z",
+                    "is_critical": false
+                }
+            }
+            """
+
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, jsonResponse.data(using: .utf8)!)
+        }
+
+        // When
+        _ = try? await checker.getLatestReleaseAvailable(for: .macOSAppStore)
+
+        // Then
+        XCTAssertNotNil(capturedRequest)
+        XCTAssertEqual(capturedRequest?.url?.absoluteString, "https://test.example.com/release_metadata.json")
+        XCTAssertEqual(capturedRequest?.httpMethod, "GET")
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1211319503505031?focus=true
Tech Design URL:
CC:

### Description
This PR adds the class responsible for getting the latest version available of the App Store build from our CDN. This PR only adds the code; it doesn’t connect it yet. That will come in follow-up PRs.

### Testing Steps
Add this piece of code to the `applicationDidFinishLaunching`:

```swift
Task {
  try? await LatestReleaseChecker().getLatestReleaseAvailable(for: .macOSAppStore)
}
```

1. Run the application and add a breakpoint inside the `getLatestReleaseAvailable` function
2. Check the `metadata` object is correctly parsed
3. The metadata should be the same as the JSON here: https://staticcdn.duckduckgo.com/macos-desktop-browser/release_metadata.json

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
This code is not running yet; so I do not see any issues.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)