### PR TITLE
macOS: Ensure pixel fires when keyValueStore init fails

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -285,6 +285,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             didCrashDuringCrashHandlersSetUp.wrappedValue = false
         }
 
+        if AppVersion.runType.requiresEnvironment {
+            Self.configurePixelKit()
+        }
+
         do {
             keyValueStore = try KeyValueFileStore(location: URL.sandboxApplicationSupportURL, name: "AppKeyValueStore")
             // perform a dummy read to ensure that KVS is accessible
@@ -309,7 +313,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         internalUserDecider = DefaultInternalUserDecider(store: internalUserDeciderStore)
 
         if AppVersion.runType.requiresEnvironment {
-            Self.configurePixelKit()
             let commonDatabase = Database()
             database = commonDatabase
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1211358402273037?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/856498667320406/task/1209798187682774?focus=true
CC: @bwaresiak 

### Description

We attempt to fire a pixel when we fail to init `keyValueStore`, but PixelKit was not configured at that point so this pixel never fired. This PR moves the PixelKit configuration earlier in the `AppDelegate` init to ensure that pixel is fired.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Add an explicit `throw` to the `KeyValueFileStore` init to simulate an error.
2. Build and run the app.
3. Confirm the corresponding pixel fires:

```
👾[Standard-Fired] m_mac_debug_key_value_file_store_init_error ["appVersion": "1.156.0", "d": "test", "e": "1", "pixelSource": "browser-dmg”]
```

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
Confirmed that PixelKit does not have any dependencies preventing it from being configured at this point.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
N/A

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)