### PR TITLE
Add lastUsed date to credit card fill pixels

### DIFF
--- a/iOS/DuckDuckGo/CreditCardPrompt/CreditCardPromptViewModel.swift
+++ b/iOS/DuckDuckGo/CreditCardPrompt/CreditCardPromptViewModel.swift
@@ -41,15 +41,18 @@ final class CreditCardPromptViewModel {
     }
     
     let cards: [CreditCardRowViewModel]
-    
-    init(creditCards: [SecureVaultModels.CreditCard]) {
+    private let usageProvider: AutofillUsageProvider
+
+    init(creditCards: [SecureVaultModels.CreditCard], usageProvider: AutofillUsageProvider = AutofillUsageStore()) {
         self.cards = creditCards.sorted(by: { $0.created > $1.created }).asCardRowViewModels
+        self.usageProvider = usageProvider
         Pixel.fire(pixel: .autofillCardsFillCardManualInlineDisplayed)
     }
     
     func selected(card: CreditCardRowViewModel) {
         delegate?.creditCardPromptViewModel(self, didSelectCreditCard: card.creditCard)
-        Pixel.fire(pixel: .autofillCardsFillCardManualInlineConfirmed)
+        let parameters = usageProvider.formattedFillDate.flatMap { [PixelParameters.lastUsed: $0] } ?? [:]
+        Pixel.fire(pixel: .autofillCardsFillCardManualInlineConfirmed, withAdditionalParameters: parameters)
     }
     
     func cancelButtonPressed() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208273769335188/task/1211361297086500?focus=true

### Description

Since adding the `lastUsed` parameter to fill pixels, the credit card changes were added to iOS. This just adds the same parameter to credit card fill pixels.

### Testing Steps
1. Add a credit card to the autofill manager (More -> Passwords & Autofill)
2. Go to https://fill.dev/form/credit-card-simple
3. Fill your credit card details.
4. Set your device date forward 1 day
5. Go back to https://fill.dev/form/credit-card-simple
6. Fill your credit card details
7. **You should see the `autofill_cards_fill_card_inline_manual_confirmed` pixel in the debugger with the `lastUsed` parameter set to today's date**
8. **Now reset your device clock back to automatic to avoid device-wide weird bugs and problems** ;)

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)