### PR TITLE
[macOS] Fix assertion failure pixel call

### DIFF
--- a/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -324,8 +324,6 @@ enum GeneralPixel: PixelKitEvent {
 
     // MARK: - Debug
 
-    case assertionFailure(message: String, file: StaticString, line: UInt)
-
     case keyValueFileStoreInitError
     case dbContainerInitializationError(error: Error)
     case dbInitializationError(error: Error)
@@ -937,9 +935,6 @@ enum GeneralPixel: PixelKitEvent {
         case .developerToolsOpened: return "m_mac_dev_tools_opened"
 
             // DEBUG
-        case .assertionFailure:
-            return "assertion_failure"
-
         case .keyValueFileStoreInitError:
             return "key_value_file_store_init_error"
         case .dbContainerInitializationError:

--- a/macOS/DuckDuckGo/Statistics/PixelKit+Assertion.swift
+++ b/macOS/DuckDuckGo/Statistics/PixelKit+Assertion.swift
@@ -20,6 +20,6 @@ import Foundation
 import PixelKit
 
 public func pixelAssertionFailure(_ message: @autoclosure () -> String = String(), file: StaticString = #fileID, line: UInt = #line) {
-    PixelKit.fire(DebugEvent(eventType: .assertionFailure(message: message(), file: file, line: line)))
+    PixelKit.fire(DebugEvent(eventType: .assertionFailure(message: message(), file: file, line: line)), frequency: .dailyAndStandard)
     Swift.assertionFailure(message(), file: file, line: line)
 }

--- a/macOS/DuckDuckGo/Statistics/PixelKit+Assertion.swift
+++ b/macOS/DuckDuckGo/Statistics/PixelKit+Assertion.swift
@@ -20,6 +20,6 @@ import Foundation
 import PixelKit
 
 public func pixelAssertionFailure(_ message: @autoclosure () -> String = String(), file: StaticString = #fileID, line: UInt = #line) {
-    PixelKit.fire(DebugEvent(GeneralPixel.assertionFailure(message: message(), file: file, line: line)))
+    PixelKit.fire(DebugEvent(eventType: .assertionFailure(message: message(), file: file, line: line)))
     Swift.assertionFailure(message(), file: file, line: line)
 }

--- a/macOS/PixelDefinitions/pixels/debug_assertion_failure.json5
+++ b/macOS/PixelDefinitions/pixels/debug_assertion_failure.json5
@@ -1,0 +1,27 @@
+{
+    m_mac_debug_assertion_failure: {
+        description: 'Fired when an unexpected condition triggers',
+        owners: ['alessandroboron'],
+        triggers: ['other'],
+        suffixes: ['daily_standard'],
+        parameters: [
+            'appVersion',
+            'pixelSource',
+            {
+                key: 'message',
+                description: 'The custom message describing the unexpected condition, e.g "Failed to access Downloads folder"',
+                type: 'string',
+            },
+            {
+                key: 'file',
+                description: 'The name of the file where the unexpected condition happened, e.g. "DuckDuckGo_Privacy_Browser/AppDelegate.swift"',
+                type: 'string',
+            },
+            {
+                key: 'line',
+                description: 'The line number of the file where the unexpected condition happened, e.g. "1017"',
+                type: 'string',
+            },
+        ],
+    },
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1211368892557106?focus=true
Tech Design URL:
CC:

### Description

We use the `pixelAssertionFailure(_:file:line:)` global function to send an assertion_failure pixel. The issue arises when firing the pixel with `PixelKit.fire(DebugEvent(GeneralPixel.assertionFailure(message: message(), file: file, line: line)))`. In this case, the convenient initializer for DebugEvent sets the event type to custom, which prevents the assertion failure parameters from being sent.

This has been fixed by using the designated initializer for DebugEvent and explicitly passing the event type

### Testing Steps
1. In AppDelegate -> `applicationDidFinishLaunching` line 1013. add call `pixelAssertionFailure(“Test Fix”)`
2. Ensure parameters are printed in the console log.

### Impact and Risks
Low: Fixes assertion failure pixel missing parameters

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)