### PR TITLE
Adjust NTP layout in landscape when new ai search is enabled

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1043,6 +1043,8 @@ class MainViewController: UIViewController {
         tabModel.viewed = true
 
         let newTabDaxDialogFactory = NewTabDaxDialogFactory(delegate: self, daxDialogsFlowCoordinator: daxDialogsManager, onboardingPixelReporter: contextualOnboardingPixelReporter)
+        let narrowLayoutInLandscape = aiChatSettings.isAIChatSearchInputUserSettingsEnabled && featureFlagger.isFeatureOn(.adjustNewSearchForLandscape)
+
         let controller = NewTabPageViewController(tab: tabModel,
                                                   interactionModel: favoritesViewModel,
                                                   homePageMessagesConfiguration: homePageConfiguration,
@@ -1052,7 +1054,9 @@ class MainViewController: UIViewController {
                                                   faviconLoader: faviconLoader,
                                                   messageNavigationDelegate: self,
                                                   appSettings: appSettings,
-                                                  internalUserCommands: internalUserCommands)
+                                                  internalUserCommands: internalUserCommands,
+                                                  narrowLayoutInLandscape: narrowLayoutInLandscape
+        )
 
         controller.delegate = self
         controller.chromeDelegate = self

--- a/iOS/DuckDuckGo/NewTabPageView.swift
+++ b/iOS/DuckDuckGo/NewTabPageView.swift
@@ -23,17 +23,22 @@ import RemoteMessaging
 
 struct NewTabPageView: View {
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @Environment(\.isLandscapeOrientation) var isLandscapeOrientation
 
     @ObservedObject private var viewModel: NewTabPageViewModel
     @ObservedObject private var messagesModel: NewTabPageMessagesModel
     @ObservedObject private var favoritesViewModel: FavoritesViewModel
 
-    init(viewModel: NewTabPageViewModel,
+    let narrowLayoutInLandscape: Bool
+
+    init(narrowLayoutInLandscape: Bool = false,
+         viewModel: NewTabPageViewModel,
          messagesModel: NewTabPageMessagesModel,
          favoritesViewModel: FavoritesViewModel) {
         self.viewModel = viewModel
         self.messagesModel = messagesModel
         self.favoritesViewModel = favoritesViewModel
+        self.narrowLayoutInLandscape = narrowLayoutInLandscape
 
         self.messagesModel.load()
     }
@@ -83,7 +88,8 @@ private extension NewTabPageView {
                     FavoritesView(model: favoritesViewModel)
                         .fixedSize(horizontal: false, vertical: true)
                 }
-                .padding(sectionsViewPadding(in: proxy))
+                .padding(.vertical, sectionsViewPadding(in: proxy))
+                .padding(.horizontal, sectionsViewHorizontalPadding(in: proxy))
                 .background(Color(designSystemColor: .background))
             }
             .withScrollKeyboardDismiss()
@@ -118,6 +124,14 @@ private extension NewTabPageView {
         }
     }
 
+    private func sectionsViewHorizontalPadding(in geometry: GeometryProxy) -> CGFloat {
+        if UIDevice.current.userInterfaceIdiom == .phone, isLandscapeOrientation, narrowLayoutInLandscape {
+            return Metrics.increasedHorizontalPadding + Metrics.regularPadding
+        } else {
+            return geometry.frame(in: .local).width > Metrics.verySmallScreenWidth ? Metrics.regularPadding : Metrics.smallPadding
+        }
+    }
+
     private func sectionsViewPadding(in geometry: GeometryProxy) -> CGFloat {
         geometry.frame(in: .local).width > Metrics.verySmallScreenWidth ? Metrics.regularPadding : Metrics.smallPadding
     }
@@ -138,6 +152,7 @@ private struct Metrics {
 
     static let smallPadding = 12.0
     static let regularPadding = 24.0
+    static let increasedHorizontalPadding = 108.0
     static let sectionSpacing = 32.0
     static let nonGridSectionTopPadding = -8.0
     static let updatedNonGridSectionHorizontalPadding = -8.0

--- a/iOS/DuckDuckGo/NewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewController.swift
@@ -58,6 +58,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
          messageNavigationDelegate: MessageNavigationDelegate,
          appSettings: AppSettings,
          internalUserCommands: URLBasedDebugCommands,
+         narrowLayoutInLandscape: Bool = false,
          appWidthObserver: AppWidthObserver = .shared) {
 
         self.associatedTab = tab
@@ -75,7 +76,8 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
                                                 privacyProDataReporter: privacyProDataReporting,
                                                 navigator: DefaultMessageNavigator(delegate: messageNavigationDelegate))
 
-        super.init(rootView: NewTabPageView(viewModel: self.newTabPageViewModel,
+        super.init(rootView: NewTabPageView(narrowLayoutInLandscape: narrowLayoutInLandscape,
+                                            viewModel: self.newTabPageViewModel,
                                             messagesModel: self.messagesModel,
                                             favoritesViewModel: self.favoritesModel))
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1210716480546568?focus=true
Tech Design URL:
CC:

### Description

Adjust NTP padding for new AI Search mode in landscape so favorites are aligned during transition.

### Testing Steps
1. Enable internal user flag and AI Search mode
2. Add favorites (4 is best to verify the alignment)
3. Rotate to landscape and focus on search field while on NTP. Verify favorites are horizontally aligned during transition.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Layout is off when AI Search is disabled, however this is guarded by a feature flag and should not happen.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)