### PR TITLE
macOS: Fix upload metadata workflow to get the correct version and build numbers

### DIFF
--- a/.github/workflows/macos_upload_version_metadata.yml
+++ b/.github/workflows/macos_upload_version_metadata.yml
@@ -18,6 +18,12 @@ on:
         required: true
       AWS_SECRET_ACCESS_KEY_RELEASE_S3:
         required: true
+      APPLE_API_KEY_ID:
+        required: true
+      APPLE_API_KEY_ISSUER:
+        required: true
+      APPLE_API_KEY_BASE64:
+        required: true
 
 defaults:
   run:
@@ -43,99 +49,27 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Extract version and build number
-        id: version-info
-        run: |
-          # Extract version and build number from configuration files
-          VERSION=$(cut -d ' ' -f 3 < Configuration/Version.xcconfig)
-          BUILD=$(cut -d ' ' -f 3 < Configuration/BuildNumber.xcconfig)
-          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          
-          # Validate that we got the version info
-          if [[ -z "$VERSION" ]]; then
-            echo "Error: Failed to extract version from Configuration/Version.xcconfig"
-            exit 1
-          fi
-          
-          if [[ -z "$BUILD" ]]; then
-            echo "Error: Failed to extract build number from Configuration/BuildNumber.xcconfig"
-            exit 1
-          fi
-          
-          echo "Extracted version: $VERSION"
-          echo "Extracted build: $BUILD"
-          echo "Generated timestamp: $TIMESTAMP"
-          
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "build=${BUILD}" >> $GITHUB_OUTPUT
-          echo "timestamp=${TIMESTAMP}" >> $GITHUB_OUTPUT
+      - name: Set up Ruby and Bundler
+        uses: ./.github/actions/setup-ruby
+        with:
+          working-directory: macOS
+          cache-key-prefix: macos-ruby
 
-      - name: Download existing metadata (if exists)
-        continue-on-error: true
-        run: |
-          echo "Checking for existing metadata at ${CDN_PATH}release_metadata.json"
-          if curl -fLSs "${CDN_PATH}release_metadata.json" --output existing_metadata.json; then
-            echo "✅ Found existing metadata file"
-            echo "Current content:"
-            cat existing_metadata.json | jq .
-          else
-            echo "❌ No existing metadata found, will create new file"
-            echo "{}" > existing_metadata.json
-          fi
-
-      - name: Generate updated metadata JSON
-        run: |
-          echo "Generating updated metadata JSON..."
-          jq --arg version "${{ steps.version-info.outputs.version }}" \
-             --arg build "${{ steps.version-info.outputs.build }}" \
-             --arg timestamp "${{ steps.version-info.outputs.timestamp }}" \
-             --argjson critical "${{ inputs.is_critical || false }}" \
-             '.latest_appstore_version = {
-               "latest_version": $version,
-               "build_number": $build,
-               "release_date": $timestamp,
-               "is_critical": $critical
-             }' existing_metadata.json > release_metadata.json
-          
-          echo "Generated metadata:"
-          cat release_metadata.json | jq .
-          
-          # Validate JSON structure
-          if ! jq -e '.latest_appstore_version.latest_version' release_metadata.json > /dev/null; then
-            echo "Error: Generated JSON is missing required latest_version field"
-            exit 1
-          fi
-
-      - name: Upload metadata to S3
+      - name: Upload App Store version metadata to CDN
         env:
+          # Apple API keys
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          # AWS S3 configuration
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_RELEASE_S3 }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_RELEASE_S3 }}
           AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
+          # S3 and CDN paths
+          RELEASE_BUCKET_NAME: ${{ vars.RELEASE_BUCKET_NAME }}
+          RELEASE_BUCKET_PREFIX: ${{ vars.RELEASE_BUCKET_PREFIX }}
+          CDN_PATH: ${{ vars.DMG_URL_ROOT }}
         run: |
-          echo "Uploading release_metadata.json to S3..."
-          aws s3 cp release_metadata.json "${S3_PATH}release_metadata.json" --acl public-read
-          
-          echo "✅ Upload completed successfully"
-      - name: Summary
-        run: |
-          echo "🎉 Successfully updated macOS release metadata"
-          echo "Version: ${{ steps.version-info.outputs.version }}"
-          echo "Build: ${{ steps.version-info.outputs.build }}"
-          echo "Release Date: ${{ steps.version-info.outputs.timestamp }}"
-          echo "Is Critical: ${{ inputs.is_critical || false }}"
-          echo "📍 Available at: ${CDN_PATH}release_metadata.json"
-          
-          # Add to GitHub Step Summary
-          {
-            echo "## 📱 macOS Version Metadata Updated"
-            echo ""
-            echo "| Field | Value |"
-            echo "|-------|-------|"
-            echo "| **Version** | \`${{ steps.version-info.outputs.version }}\` |"
-            echo "| **Build Number** | \`${{ steps.version-info.outputs.build }}\` |"
-            echo "| **Release Date** | \`${{ steps.version-info.outputs.timestamp }}\` |"
-            echo "| **Is Critical** | \`${{ inputs.is_critical || false }}\` |"
-            echo "| **CDN URL** | [release_metadata.json](${CDN_PATH}release_metadata.json) |"
-            echo ""
-            echo "✅ Metadata successfully uploaded to CDN"
-          } >> $GITHUB_STEP_SUMMARY
+          echo "Uploading App Store version metadata using fastlane..."
+          bundle exec fastlane upload_appstore_version_metadata \
+            is_critical:${{ inputs.is_critical || false }}

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -191,6 +191,14 @@ Fetches and updates certificates and provisioning profiles for DMG Review builds
 
 Fetches and updates certificates and provisioning profiles for CI builds
 
+### mac release_appstore
+
+```sh
+[bundle exec] fastlane mac release_appstore
+```
+
+Makes App Store release build and uploads it to App Store Connect
+
 ### mac release_testflight
 
 ```sh
@@ -215,6 +223,70 @@ Makes App Store Review build and uploads it to TestFlight
 
 Makes App Store Alpha build and uploads it to TestFlight
 
+### mac build_appstore
+
+```sh
+[bundle exec] fastlane mac build_appstore
+```
+
+Makes App Store release build
+
+### mac upload_appstore
+
+```sh
+[bundle exec] fastlane mac upload_appstore
+```
+
+Uploads App Store release build to App Store Connect
+
+### mac build_testflight
+
+```sh
+[bundle exec] fastlane mac build_testflight
+```
+
+Makes App Store release build
+
+### mac upload_testflight
+
+```sh
+[bundle exec] fastlane mac upload_testflight
+```
+
+Uploads App Store release build to TestFlight
+
+### mac build_testflight_review
+
+```sh
+[bundle exec] fastlane mac build_testflight_review
+```
+
+Makes App Store Review build
+
+### mac upload_testflight_review
+
+```sh
+[bundle exec] fastlane mac upload_testflight_review
+```
+
+Uploads App Store Review build to TestFlight
+
+### mac build_testflight_alpha
+
+```sh
+[bundle exec] fastlane mac build_testflight_alpha
+```
+
+Makes App Store Alpha build
+
+### mac upload_testflight_alpha
+
+```sh
+[bundle exec] fastlane mac upload_testflight_alpha
+```
+
+Uploads App Store Alpha build to TestFlight
+
 ### mac promote_latest_testflight_to_appstore
 
 ```sh
@@ -223,13 +295,13 @@ Makes App Store Alpha build and uploads it to TestFlight
 
 Promotes the latest TestFlight build to App Store without submitting for review
 
-### mac release_appstore
+### mac upload_appstore_version_metadata
 
 ```sh
-[bundle exec] fastlane mac release_appstore
+[bundle exec] fastlane mac upload_appstore_version_metadata
 ```
 
-Makes App Store release build and uploads it to App Store Connect
+Fetches latest App Store version and uploads metadata to CDN
 
 ### mac create_keychain_ui_tests
 

--- a/macOS/fastlane/Fastfile
+++ b/macOS/fastlane/Fastfile
@@ -333,15 +333,6 @@ platform :mac do
     UI.message("Release Date: #{timestamp}")
     UI.message("Is Critical: #{is_critical}")
     UI.message("📍 Available at: #{cdn_url}")
-    
-    # Return summary for workflow
-    {
-      version: version,
-      build_number: build_number,
-      release_date: timestamp,
-      is_critical: is_critical,
-      cdn_url: cdn_url
-    }
   end
 
   desc 'Creates a new Kechain to use on UI tests'
@@ -479,15 +470,6 @@ platform :mac do
       platform: 'osx',
       live: options[:live] || true
     )
-    
-    # The action sets these lane context variables:
-    # lane_context[SharedValues::LATEST_BUILD_NUMBER] - The build number
-    # lane_context[SharedValues::LATEST_VERSION] - The version number
-    
-    {
-      version: lane_context[SharedValues::LATEST_VERSION],
-      build_number: lane_context[SharedValues::LATEST_BUILD_NUMBER]
-    }
   end
 
 

--- a/macOS/fastlane/Fastfile
+++ b/macOS/fastlane/Fastfile
@@ -264,6 +264,86 @@ platform :mac do
 
   end
 
+  desc 'Fetches latest App Store version and uploads metadata to CDN'
+  lane :upload_appstore_version_metadata do |options|
+    # Get latest App Store version using existing lane
+    version_info = fetch_appstore_version_info(options)
+    
+    # Extract values from lane context
+    version = lane_context[SharedValues::LATEST_VERSION]
+    build_number = lane_context[SharedValues::LATEST_BUILD_NUMBER]
+    timestamp = Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+    is_critical = options[:is_critical] || false
+    
+    UI.message("App Store version: #{version}")
+    UI.message("App Store build: #{build_number}")
+    UI.message("Is critical: #{is_critical}")
+    
+    # Generate metadata JSON
+    metadata = {
+      latest_appstore_version: {
+        latest_version: version,
+        build_number: build_number,
+        release_date: timestamp,
+        is_critical: is_critical
+      }
+    }
+    
+    # Get S3 configuration from environment
+    s3_bucket = ENV['RELEASE_BUCKET_NAME']
+    s3_prefix = ENV['RELEASE_BUCKET_PREFIX']
+    cdn_path = ENV['CDN_PATH']
+    
+    unless s3_bucket && s3_prefix
+      UI.user_error!("Missing required S3 configuration: RELEASE_BUCKET_NAME and RELEASE_BUCKET_PREFIX")
+    end
+    
+    s3_path = "s3://#{s3_bucket}/#{s3_prefix}/"
+    
+    # Download existing metadata (if exists)
+    existing_metadata = {}
+    cdn_url = "#{cdn_path}release_metadata.json"
+    
+    begin
+      UI.message("Checking for existing metadata at #{cdn_url}")
+      existing_content = sh("curl -fLSs '#{cdn_url}'", log: false)
+      existing_metadata = JSON.parse(existing_content)
+      UI.message("Found existing metadata with keys: #{existing_metadata.keys}")
+    rescue => e
+      UI.message("No existing metadata found, will create new file")
+      existing_metadata = {}
+    end
+    
+    # Replace the latest_appstore_version entry (this should overwrite any existing entry)
+    updated_metadata = existing_metadata.dup
+    updated_metadata['latest_appstore_version'] = metadata[:latest_appstore_version]
+    
+    # Write metadata to file
+    File.write('release_metadata.json', JSON.pretty_generate(updated_metadata))
+    UI.message("Generated metadata:")
+    UI.message(JSON.pretty_generate(updated_metadata))
+    
+    # Upload to S3
+    UI.message("Uploading release_metadata.json to S3...")
+    sh("aws s3 cp release_metadata.json '#{s3_path}release_metadata.json' --acl public-read")
+    
+    UI.success("✅ Successfully updated macOS release metadata")
+    UI.message("Version: #{version}")
+    UI.message("Build: #{build_number}")
+    UI.message("Release Date: #{timestamp}")
+    UI.message("Is Critical: #{is_critical}")
+    UI.message("📍 Available at: #{cdn_url}")
+    
+    # Return summary for workflow
+    {
+      version: version,
+      build_number: build_number,
+      release_date: timestamp,
+      is_critical: is_critical,
+      cdn_url: cdn_url
+    }
+  end
+
   desc 'Creates a new Kechain to use on UI tests'
   lane :create_keychain_ui_tests do |options|
     create_keychain(
@@ -386,6 +466,30 @@ platform :mac do
     )
     build_number
   end
+
+  # Gets the latest App Store version and build number for macOS
+  #
+  # @option [String] username (default: nil) Your DDG Apple ID
+  # @option [Boolean] live (default: true) Whether to get live version or TestFlight version
+  #
+  private_lane :fetch_appstore_version_info do |options|
+    app_store_build_number(
+      api_key: get_api_key,
+      username: get_username(options),
+      platform: 'osx',
+      live: options[:live] || true
+    )
+    
+    # The action sets these lane context variables:
+    # lane_context[SharedValues::LATEST_BUILD_NUMBER] - The build number
+    # lane_context[SharedValues::LATEST_VERSION] - The version number
+    
+    {
+      version: lane_context[SharedValues::LATEST_VERSION],
+      build_number: lane_context[SharedValues::LATEST_BUILD_NUMBER]
+    }
+  end
+
 
   # Updates version and build number in respective config files
   #


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1211383429781102?focus=true
Tech Design URL:
CC:

### Description
The previous workflow was fetching the version and build numbers from the xcconfig files; the problem is that those numbers pointed to the current internal release. These new changes uses the https://docs.fastlane.tools/actions/app_store_build_number/ fastlane action to get the latest version from the App Store.

### Testing Steps
- Check that https://github.com/duckduckgo/apple-browsers/actions/runs/17799694385/job/50595871839 works as expected in this branch.
- https://staticcdn.duckduckgo.com/macos-desktop-browser/release_metadata.json should have the correct version.

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)