### PR TITLE
Fix tap areas for sync and autofill maestro tests

### DIFF
--- a/.maestro/shared/add_login_from_settings.yaml
+++ b/.maestro/shared/add_login_from_settings.yaml
@@ -6,11 +6,14 @@ appId: com.duckduckgo.mobile.ios
 - tapOn: Passwords & Autofill
 - tapOn: Passwords
 - tapOn: Add 24
-- tapOn: Title
-- inputText: mypersonalwebsite.com
-- tapOn: username@example.com
+- tapOn:
+    id: Field_PasswordName
+- inputText: My Personal Website
+- tapOn:
+    id: Field_Username
 - inputText: me@mypersonalwebsite.com
-- tapOn: example.com
+- tapOn:
+    id: Field_Address
 - inputText: mypersonalwebsite.com
 - tapOn: Save
 - tapOn: Passwords

--- a/.maestro/shared/add_login_from_settings.yaml
+++ b/.maestro/shared/add_login_from_settings.yaml
@@ -7,7 +7,7 @@ appId: com.duckduckgo.mobile.ios
 - tapOn: Passwords
 - tapOn: Add 24
 - tapOn: Title
-- inputText: My Personal Website
+- inputText: mypersonalwebsite.com
 - tapOn: username@example.com
 - inputText: me@mypersonalwebsite.com
 - tapOn: example.com

--- a/.maestro/shared/remove_local_logins.yaml
+++ b/.maestro/shared/remove_local_logins.yaml
@@ -13,7 +13,7 @@ appId: com.duckduckgo.mobile.ios
 - tapOn:
     id: Button_DismissImportPromo
     optional: true
-- tapOn: My Personal Website 
+- tapOn: mypersonalwebsite.com
 - tapOn: Delete Password
 - tapOn: Delete Password
 - tapOn: Passwords & Autofill

--- a/.maestro/shared/remove_local_logins.yaml
+++ b/.maestro/shared/remove_local_logins.yaml
@@ -13,7 +13,7 @@ appId: com.duckduckgo.mobile.ios
 - tapOn:
     id: Button_DismissImportPromo
     optional: true
-- tapOn: mypersonalwebsite.com
+- tapOn: My Personal Website
 - tapOn: Delete Password
 - tapOn: Delete Password
 - tapOn: Passwords & Autofill

--- a/.maestro/shared/sync_verify_logins.yaml
+++ b/.maestro/shared/sync_verify_logins.yaml
@@ -38,9 +38,9 @@ appId: com.duckduckgo.mobile.ios
 
 - tapOn: Passwords
 - scrollUntilVisible:
-    element: My Personal Website
-- assertVisible: My Personal Website
-- tapOn: My Personal Website
+    element: mypersonalwebsite.com
+- assertVisible: mypersonalwebsite.com
+- tapOn: mypersonalwebsite.com
 - assertVisible: me@mypersonalwebsite.com
 - assertVisible: mypersonalwebsite.com
 

--- a/.maestro/shared/sync_verify_logins.yaml
+++ b/.maestro/shared/sync_verify_logins.yaml
@@ -38,9 +38,9 @@ appId: com.duckduckgo.mobile.ios
 
 - tapOn: Passwords
 - scrollUntilVisible:
-    element: mypersonalwebsite.com
-- assertVisible: mypersonalwebsite.com
-- tapOn: mypersonalwebsite.com
+    element: My Personal Website
+- assertVisible: My Personal Website
+- tapOn: My Personal Website
 - assertVisible: me@mypersonalwebsite.com
 - assertVisible: mypersonalwebsite.com
 

--- a/.maestro/shared/sync_verify_unified_favorites.yaml
+++ b/.maestro/shared/sync_verify_unified_favorites.yaml
@@ -13,8 +13,8 @@ appId: com.duckduckgo.mobile.ios
         index: 1 
     commands:
         - tapOn:
-            rightOf: 
-              id: "UnifiedFavoritesToggle"
+            text: "0"
+            index: 1
 - tapOn: Settings
 - tapOn: Done
 - tapOn: Bookmarks

--- a/iOS/DuckDuckGo/AutofillEditableCell.swift
+++ b/iOS/DuckDuckGo/AutofillEditableCell.swift
@@ -32,7 +32,8 @@ struct AutofillEditableCell: View {
     let inEditMode: Bool
     var characterLimit: Int?
     @Binding var selectedCell: UUID?
-    
+    let textFieldAccessibilityIdentifier: String
+
     @FocusState private var isFieldFocused: Bool
     
     var body: some View {
@@ -61,6 +62,7 @@ struct AutofillEditableCell: View {
                                    characterLimit: characterLimit)
                 }
             }
+            .accessibilityIdentifier(textFieldAccessibilityIdentifier)
         }
         .frame(minHeight: 60)
         .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))

--- a/iOS/DuckDuckGo/AutofillEditableMaskedCell.swift
+++ b/iOS/DuckDuckGo/AutofillEditableMaskedCell.swift
@@ -86,7 +86,8 @@ struct AutofillEditableMaskedCell: View {
                             unmaskedString = String(unmaskedString.prefix(limit))
                         }
                     }
-                
+                    .accessibilityIdentifier(textFieldAccessibilityIdentifier)
+
                 Spacer()
                 
                 if unmaskedString.count > 0 {

--- a/iOS/DuckDuckGo/AutofillEditableMaskedCell.swift
+++ b/iOS/DuckDuckGo/AutofillEditableMaskedCell.swift
@@ -33,6 +33,7 @@ struct AutofillEditableMaskedCell: View {
     var keyboardType: UIKeyboardType = .default
     var characterLimit: Int?
     @Binding var selectedCell: UUID?
+    let textFieldAccessibilityIdentifier: String
 
     @FocusState private var isFieldFocused: Bool
     @State private var shouldBeMonospaced: Bool
@@ -47,7 +48,8 @@ struct AutofillEditableMaskedCell: View {
          disableAutoCorrection: Bool = true,
          keyboardType: UIKeyboardType = .default,
          characterLimit: Int? = nil,
-         selectedCell: Binding<UUID?>) {
+         selectedCell: Binding<UUID?>,
+         textFieldAccessibilityIdentifier: String) {
 
         self.title = title
         self.placeholderText = placeholderText
@@ -59,6 +61,7 @@ struct AutofillEditableMaskedCell: View {
         self.keyboardType = keyboardType
         self.characterLimit = characterLimit
         self._selectedCell = selectedCell
+        self.textFieldAccessibilityIdentifier = textFieldAccessibilityIdentifier
 
         // Initialize shouldBeMonospaced based on the initial unmaskedString value
         self._shouldBeMonospaced = State(initialValue: unmaskedString.wrappedValue.count > 0)

--- a/iOS/DuckDuckGo/AutofillLoginDetailsView.swift
+++ b/iOS/DuckDuckGo/AutofillLoginDetailsView.swift
@@ -74,8 +74,8 @@ struct AutofillLoginDetailsView: View {
                                      autoCapitalizationType: .words,
                                      disableAutoCorrection: false,
                                      inEditMode: viewModel.viewMode == .edit,
-                                     selectedCell: $viewModel.selectedCell)
-                .accessibilityIdentifier("Field_PasswordName")
+                                     selectedCell: $viewModel.selectedCell,
+                                     textFieldAccessibilityIdentifier: "Field_PasswordName")
             }
             
             Section {
@@ -84,8 +84,8 @@ struct AutofillLoginDetailsView: View {
                                      placeholderText: UserText.autofillLoginDetailsEditUsernamePlaceholder,
                                      keyboardType: .emailAddress,
                                      inEditMode: viewModel.viewMode == .edit,
-                                     selectedCell: $viewModel.selectedCell)
-                .accessibilityIdentifier("Field_Username")
+                                     selectedCell: $viewModel.selectedCell,
+                                     textFieldAccessibilityIdentifier: "Field_Username")
                 
                 if viewModel.viewMode == .new {
                     AutofillEditableCell(title: UserText.autofillLoginDetailsPassword,
@@ -93,16 +93,16 @@ struct AutofillLoginDetailsView: View {
                                          placeholderText: UserText.autofillLoginDetailsEditPasswordPlaceholder,
                                          secure: true,
                                          inEditMode: viewModel.viewMode == .edit,
-                                         selectedCell: $viewModel.selectedCell)
-                    .accessibilityIdentifier("Field_Password")
+                                         selectedCell: $viewModel.selectedCell,
+                                         textFieldAccessibilityIdentifier: "Field_Password")
                 } else {
                     AutofillEditableMaskedCell(title: UserText.autofillLoginDetailsPassword,
                                                placeholderText: UserText.autofillLoginDetailsEditPasswordPlaceholder,
                                                unmaskedString: $viewModel.password,
                                                maskedString: .constant(viewModel.userVisiblePassword),
                                                isMasked: $viewModel.isPasswordHidden,
-                                               selectedCell: $viewModel.selectedCell)
-                    .accessibilityIdentifier("Field_Password")
+                                               selectedCell: $viewModel.selectedCell,
+                                               textFieldAccessibilityIdentifier: "Field_Password")
                 }
             }
             
@@ -112,14 +112,14 @@ struct AutofillLoginDetailsView: View {
                                      placeholderText: UserText.autofillLoginDetailsEditURLPlaceholder,
                                      keyboardType: .URL,
                                      inEditMode: viewModel.viewMode == .edit,
-                                     selectedCell: $viewModel.selectedCell)
-                .accessibilityIdentifier("Field_Address")
+                                     selectedCell: $viewModel.selectedCell,
+                                     textFieldAccessibilityIdentifier: "Field_Address")
             }
             
             Section {
                 editableMultilineCell(UserText.autofillLoginDetailsNotes,
-                                      subtitle: $viewModel.notes)
-                .accessibilityIdentifier("Field_Notes")
+                                      subtitle: $viewModel.notes,
+                                      textFieldAccessibilityIdentifier: "Field_Notes")
             }
             
             if viewModel.viewMode == .edit {
@@ -234,13 +234,14 @@ struct AutofillLoginDetailsView: View {
                                        subtitle: Binding<String>,
                                        autoCapitalizationType: UITextAutocapitalizationType = .none,
                                        disableAutoCorrection: Bool = true,
-                                       keyboardType: UIKeyboardType = .default) -> some View {
-        
+                                       keyboardType: UIKeyboardType = .default,
+                                       textFieldAccessibilityIdentifier: String) -> some View {
+
         VStack(alignment: .leading, spacing: Constants.verticalPadding) {
             Text(title)
                 .label4Style()
             
-            MultilineTextEditor(text: subtitle)
+            MultilineTextEditor(text: subtitle).accessibilityIdentifier(textFieldAccessibilityIdentifier)
         }
         .frame(minHeight: Constants.minRowHeight)
         .padding(EdgeInsets(top: 6, leading: 0, bottom: 0, trailing: 0))

--- a/iOS/DuckDuckGo/CreditCardManagement/CreditCardDetails/AutofillCreditCardDetailsView.swift
+++ b/iOS/DuckDuckGo/CreditCardManagement/CreditCardDetails/AutofillCreditCardDetailsView.swift
@@ -142,8 +142,8 @@ struct AutofillCreditCardDetailsView: View {
                                          keyboardType: .numberPad,
                                          inEditMode: viewModel.viewMode == .edit,
                                          characterLimit: 4,
-                                         selectedCell: $viewModel.selectedCell)
-                    .accessibilityIdentifier("Field_SecurityCode")
+                                         selectedCell: $viewModel.selectedCell,
+                                         textFieldAccessibilityIdentifier: "Field_SecurityCode")
                 } else {
                     AutofillEditableMaskedCell(title: UserText.autofillCreditCardDetailsCVV,
                                                placeholderText: UserText.autofillCreditCardDetailsEditCVVPlaceholder,
@@ -152,8 +152,8 @@ struct AutofillCreditCardDetailsView: View {
                                                isMasked: $viewModel.isSecurityCodeHidden,
                                                keyboardType: .numberPad,
                                                characterLimit: 4,
-                                               selectedCell: $viewModel.selectedCell)
-                    .accessibilityIdentifier("Field_SecurityCode")
+                                               selectedCell: $viewModel.selectedCell,
+                                               textFieldAccessibilityIdentifier: "Field_SecurityCode")
                 }
                 
                 AutofillEditableCell(title: UserText.autofillCreditCardDetailsCardName,
@@ -162,8 +162,8 @@ struct AutofillCreditCardDetailsView: View {
                                      autoCapitalizationType: .words,
                                      disableAutoCorrection: true,
                                      inEditMode: viewModel.viewMode == .edit,
-                                     selectedCell: $viewModel.selectedCell)
-                .accessibilityIdentifier("Field_CardName")
+                                     selectedCell: $viewModel.selectedCell,
+                                     textFieldAccessibilityIdentifier: "Field_CardName")
             }
             
             Section {
@@ -172,8 +172,8 @@ struct AutofillCreditCardDetailsView: View {
                                      placeholderText: UserText.autofillCreditCardDetailsEditCardNicknamePlaceholder,
                                      autoCapitalizationType: .words,
                                      inEditMode: viewModel.viewMode == .edit,
-                                     selectedCell: $viewModel.selectedCell)
-                .accessibilityIdentifier("Field_CardNickname")
+                                     selectedCell: $viewModel.selectedCell,
+                                     textFieldAccessibilityIdentifier: "Field_CardNickname")
             }
             
             if viewModel.viewMode == .edit {

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncSettingsViewExtension.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncSettingsViewExtension.swift
@@ -252,9 +252,9 @@ extension SyncSettingsView {
                     Text(UserText.unifiedFavoritesInstruction)
                         .daxFootnoteRegular()
                         .foregroundColor(.secondary)
-                        .accessibility(identifier: "UnifiedFavoritesToggle")
                 }
             }
+            .accessibility(identifier: "UnifiedFavoritesToggle")
         } header: {
             Text(UserText.optionsSectionHeader)
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1211379898690459?focus=true

### Description

UI tests randomly started failing due to tap areas not working / changing. I've updated the UI tests to tap the right places. This involved moving some accessibility IDs to more precise view.

### Testing Steps
https://github.com/duckduckgo/apple-browsers/actions/runs/17858612529

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)