### PR TITLE
Move autoconsent dependency to workspace package.json

### DIFF
--- a/iOS/package.json
+++ b/iOS/package.json
@@ -11,14 +11,9 @@
   },
   "devDependencies": {
     "@duckduckgo/pixel-schema": "github:duckduckgo/pixel-schema#v1.0.8",
-    "@rollup/plugin-json": "^4.1.0",
-    "@rollup/plugin-node-resolve": "^13.0.6",
-    "prettier": "^3.6.2",
-    "rollup": "^2.61.0",
-    "rollup-plugin-terser": "^7.0.2"
+    "prettier": "^3.6.2"
   },
   "dependencies": {
-    "@duckduckgo/autoconsent": "^14.19.0"
   },
   "prettier": {
     "singleQuote": true,

--- a/macOS/package.json
+++ b/macOS/package.json
@@ -11,14 +11,9 @@
   },
   "devDependencies": {
     "@duckduckgo/pixel-schema": "github:duckduckgo/pixel-schema#v1.0.8",
-    "@rollup/plugin-json": "^4.1.0",
-    "@rollup/plugin-node-resolve": "^13.0.6",
-    "prettier": "^3.6.2",
-    "rollup": "^2.61.0",
-    "rollup-plugin-terser": "^7.0.2"
+    "prettier": "^3.6.2"
   },
   "dependencies": {
-    "@duckduckgo/autoconsent": "^14.19.0"
   },
   "prettier": {
     "singleQuote": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,37 +14,30 @@
         "SharedPackages/BrowserServicesKit"
       ],
       "dependencies": {
+        "@duckduckgo/autoconsent": "^14.19.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.26.0"
+      },
+      "devDependencies": {
+        "@rollup/plugin-json": "^4.1.0",
+        "@rollup/plugin-node-resolve": "^13.0.6",
+        "rollup": "^2.61.0",
+        "rollup-plugin-terser": "^7.0.2"
       }
     },
     "iOS": {
       "name": "ios",
       "version": "1.0.0",
-      "dependencies": {
-        "@duckduckgo/autoconsent": "^14.19.0"
-      },
       "devDependencies": {
         "@duckduckgo/pixel-schema": "github:duckduckgo/pixel-schema#v1.0.8",
-        "@rollup/plugin-json": "^4.1.0",
-        "@rollup/plugin-node-resolve": "^13.0.6",
-        "prettier": "^3.6.2",
-        "rollup": "^2.61.0",
-        "rollup-plugin-terser": "^7.0.2"
+        "prettier": "^3.6.2"
       }
     },
     "macOS": {
       "name": "macos-browser",
       "version": "1.0.0",
-      "dependencies": {
-        "@duckduckgo/autoconsent": "^14.19.0"
-      },
       "devDependencies": {
         "@duckduckgo/pixel-schema": "github:duckduckgo/pixel-schema#v1.0.8",
-        "@rollup/plugin-json": "^4.1.0",
-        "@rollup/plugin-node-resolve": "^13.0.6",
-        "prettier": "^3.6.2",
-        "rollup": "^2.61.0",
-        "rollup-plugin-terser": "^7.0.2"
+        "prettier": "^3.6.2"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,14 @@
     "build-content-scope-scripts": "npm run build-content-scope-scripts --workspace=SharedPackages/BrowserServicesKit",
     "postinstall": "npm run build-content-scope-scripts"
   },
+  "devDependencies": {
+    "@rollup/plugin-json": "^4.1.0",
+    "@rollup/plugin-node-resolve": "^13.0.6",
+    "rollup": "^2.61.0",
+    "rollup-plugin-terser": "^7.0.2"
+  },
   "dependencies": {
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.26.0"
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.26.0",
+    "@duckduckgo/autoconsent": "^14.19.0"
   }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201844467387842/task/1210587615333327
Tech Design URL:
CC:

### Description
Leverage the new workspace setup for dependencies to put make autoconsent dependencies shared between iOS and macOS. This will make it easier for our release script to bump this dependency in both projects simultaneously.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1.
2.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)