### PR TITLE
Show voice modal from new addressbar

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -320,7 +320,30 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
     }
 
     private func handleMicrophoneButtonTapped() {
-        delegate?.onVoiceSearchRequested(from: switchBarHandler.currentToggleState)
+        // Do not dismiss the OmniBar. Just dismiss the keyboard and present Voice Search above.
+        switchBarVC.unfocusTextField()
+        SpeechRecognizer.requestMicAccess { [weak self] permission in
+            guard let self = self else { return }
+            if permission {
+                let preferredTarget: VoiceSearchTarget? = (self.switchBarHandler.currentToggleState == .aiChat) ? .AIChat : .SERP
+                self.showVoiceSearch(preferredTarget: preferredTarget)
+            } else {
+                self.showNoMicrophonePermissionAlert()
+            }
+        }
+    }
+
+    private func showVoiceSearch(preferredTarget: VoiceSearchTarget? = nil) {
+        let voiceSearchController = VoiceSearchViewController(preferredTarget: preferredTarget)
+        voiceSearchController.delegate = self
+        voiceSearchController.modalTransitionStyle = .crossDissolve
+        voiceSearchController.modalPresentationStyle = .overFullScreen
+        present(voiceSearchController, animated: true)
+    }
+
+    private func showNoMicrophonePermissionAlert() {
+        let alertController = NoMicPermissionAlert.buildAlert()
+        present(alertController, animated: true)
     }
 
     private func updateDaxVisibility() {
@@ -390,6 +413,28 @@ extension OmniBarEditingStateViewController: NavigationActionBarManagerDelegate 
         let currentText = switchBarHandler.currentText
         if !currentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             switchBarHandler.submitText(currentText)
+        }
+    }
+}
+
+// MARK: - VoiceSearchViewControllerDelegate
+
+extension OmniBarEditingStateViewController: VoiceSearchViewControllerDelegate {
+
+    func voiceSearchViewController(_ controller: VoiceSearchViewController, didFinishQuery query: String?, target: VoiceSearchTarget) {
+        controller.dismiss(animated: true) { [weak self] in
+            guard let self = self, let query = query else { return }
+            self.handleVoiceSearchCompletion(with: query, for: target)
+        }
+    }
+
+    private func handleVoiceSearchCompletion(with query: String, for target: VoiceSearchTarget) {
+        switch target {
+        case .SERP:
+            delegate?.onQuerySubmitted(query)
+
+        case .AIChat:
+            delegate?.onPromptSubmitted(query, tools: nil)
         }
     }
 }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -422,6 +422,10 @@ extension OmniBarEditingStateViewController: NavigationActionBarManagerDelegate 
 extension OmniBarEditingStateViewController: VoiceSearchViewControllerDelegate {
 
     func voiceSearchViewController(_ controller: VoiceSearchViewController, didFinishQuery query: String?, target: VoiceSearchTarget) {
+        if let text = query {
+            switchBarHandler.updateCurrentText(text)
+        }
+
         controller.dismiss(animated: true) { [weak self] in
             guard let self = self, let query = query else { return }
             self.handleVoiceSearchCompletion(with: query, for: target)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210988181212493?focus=true

### Description
Show voice modal from new addressbar

### Testing Steps
1. Enable voice search under Settings -> Accessibility 
2. Enable the new address bar under Settings -> AI Features
3. Select the address bar, and on both search and duck.ai mode, tap the mic button
4. The voice feedback view should appear, dismissing it should take you back to the focused mode
5. Submitting a query should dismiss the focused mode and go to either search or duck.ai


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
Not performing the voice-search correctly
