### PR TITLE
Exclude unused features when injecting Privacy Config to ContentScopeUserScript

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentScopeScript/ContentScopePrivacyConfigurationJSONGenerator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentScopeScript/ContentScopePrivacyConfigurationJSONGenerator.swift
@@ -41,7 +41,12 @@ public struct ContentScopePrivacyConfigurationJSONGenerator: CustomisedPrivacyCo
         guard let config = try? PrivacyConfigurationData(data: privacyConfigurationManager.currentConfig) else { return nil }
 
         let newConfig = PrivacyConfigurationData(features: config.features, unprotectedTemporary: config.unprotectedTemporary, trackerAllowlist: config.trackerAllowlist, version: config.version)
-        return try? newConfig.toJSONData()
+        return try? newConfig.toJSONData(
+            excludeFeatures: [
+                "trackerAllowlist",
+                PrivacyFeature.autoconsent.rawValue
+            ]
+        )
     }
 
 }

--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfigurationData.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/PrivacyConfigurationData.swift
@@ -364,7 +364,12 @@ public struct PrivacyConfigurationData {
 // MARK: Encoding Functions
 extension PrivacyConfigurationData {
     /// Returns a dictionary representation of the configuration.
-    public func toJSONDictionary() -> [String: Any] {
+    ///
+    /// - Parameters:
+    ///   - excludeFeatures: defines a list of keys from the `features` sub-object
+    ///                      that will be skipped and not present in the resulting dictionary.
+    ///
+    public func toJSONDictionary(excludeFeatures: [String] = []) -> [String: Any] {
         var json = [String: Any]()
 
         if let version = self.version {
@@ -374,10 +379,10 @@ extension PrivacyConfigurationData {
         json[CodingKeys.unprotectedTemporary.rawValue] = self.unprotectedTemporary.map { $0.toJSONDictionary() }
 
         var featuresDict = [String: Any]()
-        if let allowlistJSON = trackerAllowlist.toTrackerAllowListJSONDictionary() {
+        if !excludeFeatures.contains(CodingKeys.trackerAllowlist.rawValue), let allowlistJSON = trackerAllowlist.toTrackerAllowListJSONDictionary() {
             featuresDict[CodingKeys.trackerAllowlist.rawValue] = allowlistJSON
         }
-        for (key, feature) in features {
+        for (key, feature) in features where !excludeFeatures.contains(key) {
             if let featureJSON = feature.toJSONDictionary() {
                 featuresDict[key] = featureJSON
             }
@@ -388,8 +393,13 @@ extension PrivacyConfigurationData {
     }
 
     /// Returns the JSON Data representation.
-    public func toJSONData() throws -> Data {
-        let jsonDict = self.toJSONDictionary()
+    ///
+    /// - Parameters:
+    ///   - excludeFeatures: defines a list of keys from the `features` sub-object
+    ///                      that will be skipped and not present in the resulting dictionary.
+    ///
+    public func toJSONData(excludeFeatures: [String] = []) throws -> Data {
+        let jsonDict = self.toJSONDictionary(excludeFeatures: excludeFeatures)
         return try JSONSerialization.data(withJSONObject: jsonDict, options: [])
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1211427805152901?focus=true

### Description
This change updates ContentScopePrivacyConfigurationJSONGenerator so that it generates
a reduced Privacy Config for the ContentScopeUserScript. Such config has features reduced

### Testing Steps
1. Verify that CI is green
2. Smoke test C-S-S dependent features (New Tab Page, History, release notes, favicon loading, etc)

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)