### PR TITLE
Avoid `loadView` for creating popover view

### DIFF
--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNPopoverPresenter.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNPopoverPresenter.swift
@@ -80,8 +80,8 @@ final class DefaultVPNUpsellPopoverPresenter: VPNUpsellPopoverPresenter, Popover
         let swiftUIView = VPNUpsellPopoverView(viewModel: viewModel).fixedSize()
         let hostingController = NSHostingController(rootView: swiftUIView)
 
-        // Force layout and set frame explicitly to ensure proper positioning
-        hostingController.loadView()
+        // Access view to trigger loading, then force layout for proper sizing
+        _ = hostingController.view
         hostingController.view.layoutSubtreeIfNeeded()
         hostingController.view.frame = CGRect(origin: .zero, size: hostingController.view.intrinsicContentSize)
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1207340338530322/task/1211437903660692?focus=true
Tech Design URL:
CC:

### Description

Although I was unable to repro the exact crash, I found that the code was calling `NSViewController.loadView()` directly, which caused the crash. From the [docs](https://developer.apple.com/documentation/appkit/nsviewcontroller/loadview()):

> Do not call this method. If you require this method to be called, access the [view](https://developer.apple.com/documentation/appkit/nsviewcontroller/view) property.

So I did just that.

### Testing Steps
1. Open macOS app
2. Reset upsell state via Debug > VPN > Upsell > Reset Upsell State and relaunch
3. Show toolbar upsell button via Debug > VPN > Show Upsell Button, and verify that the layout is still correct.

### Impact and Risks
Low: removes a low frequency crash

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)