### PR TITLE
Fixes a bug where the progress bar will hide without a connection

### DIFF
--- a/macOS/DuckDuckGo/Common/View/AppKit/LoadingProgressView.swift
+++ b/macOS/DuckDuckGo/Common/View/AppKit/LoadingProgressView.swift
@@ -282,7 +282,7 @@ extension LoadingProgressView {
             ProgressEvent(progress: 0.65, interval: 15.0),
             ProgressEvent(progress: 0.80, interval: 5.0),
             ProgressEvent(progress: 0.85, interval: 3.0),
-            ProgressEvent(progress: 1.00, interval: 2.5)
+            ProgressEvent(progress: 0.90, interval: 2.5)
         ]
 
         static let initialValue = milestones[0].progress
@@ -301,14 +301,14 @@ extension LoadingProgressView {
             var estimatedElapsedTime: CFTimeInterval = 0.0
             var nextStepIdx: Int!
 
+            if let lastProgressEvent,
+               lastProgressEvent.progress >= Constants.max {
+                return nil
+            }
+
             for (idx, step) in milestones.enumerated() {
                 if let event = lastProgressEvent {
-                    if event.progress == Constants.max {
-                        // 100%: finish fast
-                        nextStepIdx = milestones.indices.last!
-                        estimatedElapsedTime = TimeInterval.greatestFiniteMagnitude
-                        break
-                    } else if event.progress >= step.progress {
+                    if event.progress >= step.progress {
                         estimatedElapsedTime += step.interval
                     } else {
                         // take percentage of estimated time for the current step based of (actual / estimated) progress difference


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1211406158148089?focus=true

### Description

This is a 2nd attempt to merge https://github.com/duckduckgo/apple-browsers/pull/1979 which was rolled back in https://github.com/duckduckgo/apple-browsers/pull/2007

The site loading progress bar sometimes goes away while a request is still ongoing, creating the wrong impression the site has fully loaded, and leaving the UI in a weird state.

There's a video in [this task](https://app.asana.com/1/137249556945/project/1203108348835387/task/1211406158148089?focus=true) showcasing the issue.

### Testing Steps

You can use the same steps to reproduce the original issue in `main`.  The progress bar sometimes goes away before an error is shown making it look like the site has finished loading.

1. Load any site.
2. Set Network Link Conditioner to 100% loss
3. Try loading another site, make sure the progress bar is always visible at least until an error page is shown

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)