### PR TITLE
macOS: Ensure session restore popover closes on older macOS versions

### DIFF
--- a/macOS/DuckDuckGo/StateRestoration/View/SessionRestorePromptPopover.swift
+++ b/macOS/DuckDuckGo/StateRestoration/View/SessionRestorePromptPopover.swift
@@ -45,16 +45,21 @@ final class SessionRestorePromptPopover: NSPopover {
         /// Popover frame used for positioning is 26px wider than `contentSize.width`.
         /// Adjust the width to get the expected positioning.
         contentSize = NSSize(width: SessionRestorePromptView.Const.width - 26, height: 256)
-        contentViewController = SessionRestorePromptViewController(ctaCallback: ctaCallback)
+        contentViewController = SessionRestorePromptViewController(ctaCallback: ctaCallback) { [weak self] in
+            self?.close()
+        }
     }
 }
 
 final class SessionRestorePromptViewController: NSHostingController<SessionRestorePromptView> {
     private let viewModel: SessionRestorePromptViewModel
+    private let dismiss: () -> Void
 
-    init(ctaCallback: @escaping (Bool) -> Void) {
+    init(ctaCallback: @escaping (Bool) -> Void,
+         dismiss: @escaping () -> Void) {
         self.viewModel = SessionRestorePromptViewModel(ctaCallback: ctaCallback)
-        let view = SessionRestorePromptView(model: viewModel)
+        self.dismiss = dismiss
+        let view = SessionRestorePromptView(model: viewModel, dismiss: dismiss)
         super.init(rootView: view)
     }
 

--- a/macOS/DuckDuckGo/StateRestoration/View/SessionRestorePromptView.swift
+++ b/macOS/DuckDuckGo/StateRestoration/View/SessionRestorePromptView.swift
@@ -26,7 +26,7 @@ struct SessionRestorePromptView: View {
     }
 
     @ObservedObject var model: SessionRestorePromptViewModel
-    @Environment(\.dismiss) var dismiss
+    var dismiss: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1211440003639379?focus=true
Tech Design URL:
CC:

### Description

When the app terminates unexpectedly (e.g. a crash) we display a session restore popover the next time the browser is opened. On older macOS versions, the popover appears but clicking either of the buttons doesn't close it. 

This change uses the popover’s `close()` method instead of the Environment dismiss action to ensure the popover is closed on older macOS versions.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Build and run the app on macOS 11 or 12.
2. Force close the app. (You can use the Debug menu > Simulate crash > fatalError.)
3. Reopen the app and confirm the session restore popover opens.
4. Click either button (restore the previous session or not) and confirm the popover closes.

### Impact and Risks
Low: small bug fix

#### What could go wrong?
Tested to confirm this closes the popover on current and older macOS versions.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)