### PR TITLE
Hide free trial promotion from overflow menu after 4 views

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -3350,6 +3350,10 @@
 		BB80DDD32D75EEAC00ED1FFF /* ApplicationBuildType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB80DDD12D75EEA100ED1FFF /* ApplicationBuildType.swift */; };
 		BB80DDDB2D761EC700ED1FFF /* DefaultBrowserAndDockPromptPresentingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB80DDDA2D761EC400ED1FFF /* DefaultBrowserAndDockPromptPresentingTests.swift */; };
 		BB80DDDC2D761EC700ED1FFF /* DefaultBrowserAndDockPromptPresentingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB80DDDA2D761EC400ED1FFF /* DefaultBrowserAndDockPromptPresentingTests.swift */; };
+		BB91BEEA2E842771006CC502 /* FreeTrialBadgePersistor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB91BEE92E842771006CC502 /* FreeTrialBadgePersistor.swift */; };
+		BB91BEEB2E842771006CC502 /* FreeTrialBadgePersistor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB91BEE92E842771006CC502 /* FreeTrialBadgePersistor.swift */; };
+		BB91BEED2E8427A0006CC502 /* FreeTrialBadgePersistorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB91BEEC2E8427A0006CC502 /* FreeTrialBadgePersistorTests.swift */; };
+		BB91BEEE2E8427A0006CC502 /* FreeTrialBadgePersistorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB91BEEC2E8427A0006CC502 /* FreeTrialBadgePersistorTests.swift */; };
 		BB960BCD2DD77A0B002C46DD /* SettingsIconsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB960BCC2DD77A02002C46DD /* SettingsIconsProviding.swift */; };
 		BB960BCE2DD77A0B002C46DD /* SettingsIconsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB960BCC2DD77A02002C46DD /* SettingsIconsProviding.swift */; };
 		BB960BD32DD7890B002C46DD /* BookmarksIconsProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB960BD22DD788FD002C46DD /* BookmarksIconsProviding.swift */; };
@@ -5672,6 +5676,8 @@
 		BB80DDCE2D75E94A00ED1FFF /* DefaultBrowserAndDockPromptCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserAndDockPromptCoordinatorTests.swift; sourceTree = "<group>"; };
 		BB80DDD12D75EEA100ED1FFF /* ApplicationBuildType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBuildType.swift; sourceTree = "<group>"; };
 		BB80DDDA2D761EC400ED1FFF /* DefaultBrowserAndDockPromptPresentingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserAndDockPromptPresentingTests.swift; sourceTree = "<group>"; };
+		BB91BEE92E842771006CC502 /* FreeTrialBadgePersistor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBadgePersistor.swift; sourceTree = "<group>"; };
+		BB91BEEC2E8427A0006CC502 /* FreeTrialBadgePersistorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBadgePersistorTests.swift; sourceTree = "<group>"; };
 		BB960BCC2DD77A02002C46DD /* SettingsIconsProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsIconsProviding.swift; sourceTree = "<group>"; };
 		BB960BD22DD788FD002C46DD /* BookmarksIconsProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksIconsProviding.swift; sourceTree = "<group>"; };
 		BB9851912E3102ED00FED56A /* NetworkProtectionNavBarButtonModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionNavBarButtonModelTests.swift; sourceTree = "<group>"; };
@@ -6877,6 +6883,7 @@
 		378205F9283C275E00D1D4AA /* Menus */ = {
 			isa = PBXGroup;
 			children = (
+				BB91BEEC2E8427A0006CC502 /* FreeTrialBadgePersistorTests.swift */,
 				566B195F29CDB7A9007E38F4 /* Mocks */,
 				378205FA283C277800D1D4AA /* MainMenuTests.swift */,
 				566B195C29CDB692007E38F4 /* MoreOptionsMenuTests.swift */,
@@ -7233,6 +7240,7 @@
 		37EE55D72D5F197300D53C7C /* View */ = {
 			isa = PBXGroup;
 			children = (
+				BB91BEE92E842771006CC502 /* FreeTrialBadgePersistor.swift */,
 				BBFE94EA2E391421000D4920 /* NetworkProtectionButton.swift */,
 				BBFE94EB2E391421000D4920 /* NotificationDotProviding.swift */,
 				37EE55C42D5F197300D53C7C /* Animations */,
@@ -13262,6 +13270,7 @@
 				37FD78122A29EBD100B36DB1 /* SyncErrorHandler.swift in Sources */,
 				1D4B03D62CA4432000224E99 /* BookmarkUrlExtension.swift in Sources */,
 				987799F42999993C005D8EB6 /* LegacyBookmarksStoreMigration.swift in Sources */,
+				BB91BEEA2E842771006CC502 /* FreeTrialBadgePersistor.swift in Sources */,
 				3706FB7A293F65D500E42796 /* FileDownloadManager.swift in Sources */,
 				3706FB7B293F65D500E42796 /* BookmarkImport.swift in Sources */,
 				3706FB7C293F65D500E42796 /* KeySetDictionary.swift in Sources */,
@@ -14272,6 +14281,7 @@
 				3706FE7F293F661700E42796 /* FileDownloadManagerMock.swift in Sources */,
 				7B1522B12DE9CCA900887371 /* MockFeatureGatekeeper.swift in Sources */,
 				3706FE81293F661700E42796 /* PermissionModelTests.swift in Sources */,
+				BB91BEED2E8427A0006CC502 /* FreeTrialBadgePersistorTests.swift in Sources */,
 				5681ED442BDBA5F900F59729 /* SyncBookmarksAdapterTests.swift in Sources */,
 				BB0036652E426EDD0016DDEF /* ReportProblemFormViewModelTests.swift in Sources */,
 				BB0036662E426EDD0016DDEF /* FeedbackTests.swift in Sources */,
@@ -15153,6 +15163,7 @@
 				B6B1E88B26D774090062C350 /* LinkButton.swift in Sources */,
 				4BBF0915282DD40100EE1418 /* TemporaryFileHandler.swift in Sources */,
 				B602E8162A1E2570006D261F /* URL+NetworkProtection.swift in Sources */,
+				BB91BEEB2E842771006CC502 /* FreeTrialBadgePersistor.swift in Sources */,
 				C1935A142C88F958001AD72D /* SyncPromoView.swift in Sources */,
 				CB6BCDF927C6BEFF00CC76DC /* PrivacyFeatures.swift in Sources */,
 				378F44EB29B4C73E00899924 /* ViewExtension.swift in Sources */,
@@ -15939,6 +15950,7 @@
 				84DC715B2C1C1E9000033B8C /* UserDefaultsWrapperTests.swift in Sources */,
 				561D29CA2BDA752F007B91D0 /* MockAppearancePreferencesPersistor.swift in Sources */,
 				56A0540D2C1C375D007D8FAB /* MockWindow.swift in Sources */,
+				BB91BEEE2E8427A0006CC502 /* FreeTrialBadgePersistorTests.swift in Sources */,
 				567DA93F29E8045D008AC5EE /* MockEmailStorage.swift in Sources */,
 				37CD54B727F1B28A00F1F7B9 /* DefaultBrowserPreferencesTests.swift in Sources */,
 				028904202A7B25380028369C /* AppConfigurationURLProviderTests.swift in Sources */,

--- a/macOS/DuckDuckGo/NavigationBar/View/FreeTrialBadgePersistor.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/FreeTrialBadgePersistor.swift
@@ -1,0 +1,56 @@
+//
+//  FreeTrialBadgePersistor.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Persistence
+
+protocol FreeTrialBadgePersisting {
+    var viewCount: Int { get }
+    var hasReachedViewLimit: Bool { get }
+    func incrementViewCount()
+}
+
+struct FreeTrialBadgePersistor: FreeTrialBadgePersisting {
+
+    private enum Key: String {
+        case freeTrialBadgeViewCount = "free-trial-badge.view-count"
+    }
+
+    private static let maxViewCount = 4
+
+    private let keyValueStore: KeyValueStoring
+
+    init(keyValueStore: KeyValueStoring) {
+        self.keyValueStore = keyValueStore
+    }
+
+    var viewCount: Int {
+        keyValueStore.object(forKey: Key.freeTrialBadgeViewCount.rawValue) as? Int ?? 0
+    }
+
+    var hasReachedViewLimit: Bool {
+        viewCount >= Self.maxViewCount
+    }
+
+    func incrementViewCount() {
+        let currentCount = viewCount
+        if currentCount < Self.maxViewCount {
+            keyValueStore.set(currentCount + 1, forKey: Key.freeTrialBadgeViewCount.rawValue)
+        }
+    }
+}

--- a/macOS/UnitTests/Menus/FreeTrialBadgePersistorTests.swift
+++ b/macOS/UnitTests/Menus/FreeTrialBadgePersistorTests.swift
@@ -1,0 +1,121 @@
+//
+//  FreeTrialBadgePersistorTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Persistence
+@testable import DuckDuckGo_Privacy_Browser
+
+final class FreeTrialBadgePersistorTests: XCTestCase {
+
+    private var mockKeyValueStore: MockKeyValueStore!
+    private var persistor: FreeTrialBadgePersistor!
+
+    override func setUp() {
+        super.setUp()
+        mockKeyValueStore = MockKeyValueStore()
+        persistor = FreeTrialBadgePersistor(keyValueStore: mockKeyValueStore)
+    }
+
+    override func tearDown() {
+        mockKeyValueStore = nil
+        persistor = nil
+        super.tearDown()
+    }
+
+    func testInitialViewCountIsZero() {
+        XCTAssertEqual(persistor.viewCount, 0)
+        XCTAssertFalse(persistor.hasReachedViewLimit)
+    }
+
+    func testIncrementViewCount() {
+        persistor.incrementViewCount()
+        XCTAssertEqual(persistor.viewCount, 1)
+        XCTAssertFalse(persistor.hasReachedViewLimit)
+
+        persistor.incrementViewCount()
+        XCTAssertEqual(persistor.viewCount, 2)
+        XCTAssertFalse(persistor.hasReachedViewLimit)
+
+        persistor.incrementViewCount()
+        XCTAssertEqual(persistor.viewCount, 3)
+        XCTAssertFalse(persistor.hasReachedViewLimit)
+    }
+
+    func testViewLimitIsReachedAfterFourViews() {
+        // Increment to 4 views
+        for _ in 1...4 {
+            persistor.incrementViewCount()
+        }
+
+        XCTAssertEqual(persistor.viewCount, 4)
+        XCTAssertTrue(persistor.hasReachedViewLimit)
+    }
+
+    func testIncrementDoesNotExceedLimit() {
+        // Increment to 4 views
+        for _ in 1...4 {
+            persistor.incrementViewCount()
+        }
+
+        // Try to increment beyond the limit
+        persistor.incrementViewCount()
+        persistor.incrementViewCount()
+
+        // Should still be at the limit
+        XCTAssertEqual(persistor.viewCount, 4)
+        XCTAssertTrue(persistor.hasReachedViewLimit)
+    }
+
+    func testPersistenceAcrossInstances() {
+        // Set a count with first instance
+        persistor.incrementViewCount()
+        persistor.incrementViewCount()
+
+        // Create new instance with same store
+        let newPersistor = FreeTrialBadgePersistor(keyValueStore: mockKeyValueStore)
+
+        // Should have the same count
+        XCTAssertEqual(newPersistor.viewCount, 2)
+        XCTAssertFalse(newPersistor.hasReachedViewLimit)
+    }
+}
+
+// Mock for testing
+private final class MockKeyValueStore: KeyValueStoring {
+    private var storage: [String: Any] = [:]
+
+    func object(forKey key: String) -> Any? {
+        return storage[key]
+    }
+
+    func set(_ value: Any?, forKey key: String) {
+        if let value = value {
+            storage[key] = value
+        } else {
+            storage.removeValue(forKey: key)
+        }
+    }
+
+    func removeObject(forKey key: String) {
+        storage.removeValue(forKey: key)
+    }
+
+    func synchronize() -> Bool {
+        return true
+    }
+}

--- a/macOS/UnitTests/Menus/MoreOptionsMenuTests.swift
+++ b/macOS/UnitTests/Menus/MoreOptionsMenuTests.swift
@@ -25,6 +25,7 @@ import SubscriptionTestingUtilities
 import BrowserServicesKit
 import DataBrokerProtection_macOS
 import DataBrokerProtectionCore
+import Persistence
 
 @testable import DuckDuckGo_Privacy_Browser
 
@@ -107,7 +108,7 @@ final class MoreOptionsMenuTests: XCTestCase {
     }
 
     @MainActor
-    private func setupMoreOptionsMenu(isFireWindowDefault: Bool = false) {
+    private func setupMoreOptionsMenu(isFireWindowDefault: Bool = false, freeTrialBadgePersistor: FreeTrialBadgePersisting = FreeTrialBadgePersistor(keyValueStore: UserDefaults.standard)) {
         let aiChatPreferencesStorage = MockAIChatPreferencesStorage()
         aiChatPreferencesStorage.showShortcutInApplicationMenu = true
 
@@ -135,7 +136,8 @@ final class MoreOptionsMenuTests: XCTestCase {
                                             featureFlagger: mockFeatureFlagger
                                           ),
                                           isFireWindowDefault: isFireWindowDefault,
-                                          isUsingAuthV2: true)
+                                          isUsingAuthV2: true,
+                                          freeTrialBadgePersistor: freeTrialBadgePersistor)
 
         moreOptionsMenu.actionDelegate = capturingActionDelegate
     }
@@ -793,6 +795,68 @@ final class MoreOptionsMenuTests: XCTestCase {
 
         XCTAssertEqual(moreOptionsMenu.items[3].title, UserText.newBurnerWindowMenuItem)
         XCTAssertEqual(moreOptionsMenu.items[4].title, UserText.newWindowMenuItem)
+    }
+
+    // MARK: - Free Trial Badge Visibility
+
+    @MainActor
+    func testSubscriptionBadge_ShowsWhenEligibleAndUnderCap() {
+        // Given
+        let persistor = MockFreeTrialBadgePersistor(initialCount: 3, cap: 4)
+
+        subscriptionManager.canPurchase = true
+        subscriptionManager.isEligibleForFreeTrialResult = true
+        mockFeatureFlagger.enabledFeatureFlags = [.privacyProFreeTrial]
+
+        setupMoreOptionsMenu(freeTrialBadgePersistor: persistor)
+
+        // When
+        let subscriptionItem = moreOptionsMenu.items.first {
+            $0.action == #selector(MoreOptionsMenu.openSubscriptionPurchasePage(_:))
+        }
+
+        // Then
+        XCTAssertNotNil(subscriptionItem, "Subscription item should be present")
+        XCTAssertNotNil(subscriptionItem?.view, "Free trial badge should be shown when under view limit and eligible")
+    }
+
+    @MainActor
+    func testSubscriptionBadge_HidesWhenEligibleAndAtOrAboveCap() {
+        // Given
+        let persistor = MockFreeTrialBadgePersistor(initialCount: 4, cap: 4)
+
+        subscriptionManager.canPurchase = true
+        subscriptionManager.isEligibleForFreeTrialResult = true
+        mockFeatureFlagger.enabledFeatureFlags = [.privacyProFreeTrial]
+
+        setupMoreOptionsMenu(freeTrialBadgePersistor: persistor)
+
+        // When
+        let subscriptionItem = moreOptionsMenu.items.first {
+            $0.action == #selector(MoreOptionsMenu.openSubscriptionPurchasePage(_:))
+        }
+
+        // Then
+        XCTAssertNotNil(subscriptionItem, "Subscription item should be present")
+        XCTAssertNil(subscriptionItem?.view, "Free trial badge should be hidden when view limit has been reached")
+    }
+}
+
+// MARK: - Test Doubles
+
+private final class MockFreeTrialBadgePersistor: FreeTrialBadgePersisting {
+    private(set) var viewCount: Int
+    private let cap: Int
+
+    init(initialCount: Int, cap: Int) {
+        self.viewCount = initialCount
+        self.cap = cap
+    }
+
+    var hasReachedViewLimit: Bool { viewCount >= cap }
+
+    func incrementViewCount() {
+        if viewCount < cap { viewCount += 1 }
     }
 }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210594645229050/task/1211380911418738
Tech Design URL:
CC: @vkraucunas 

### Description
This PR makes sure that the “Try for Free” label is hidden after the user has opened the overflow menu 4 times.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Enable `privacyProFreeTrial` (Debug > Feature Flag Overrides)
2. Remove subscription (Debug > Subscription > Remove Subscription From This Device)
3. Switch to Stripe platform to force free trial eligibility (Debug > Subscription > Purchase platform > Stripe, then restart the app)
4. Upon next app launch, you should see the free trial badge next to the subscription item in the overflow menu
5. Open/close the menu 4 times -> confirm that the badge disappears on the 5th open.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
If the code is incorrect, the badge may never appear to eligible users. I added tests to lower the risk.

### Quality Considerations
I’ve added unit tests for the new persistor and the badge menu option logic.

### Notes to Reviewer
N/A

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)