### PR TITLE
Update URLPredictor to use a static library

### DIFF
--- a/SharedPackages/URLPredictor/Package.swift
+++ b/SharedPackages/URLPredictor/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
         .target(name: "URLPredictor", dependencies: ["URLPredictorRust"]),
         .binaryTarget(
             name: "URLPredictorRust",
-            url: "https://github.com/duckduckgo/url_predictor/releases/download/0.2.2/URLPredictorRust.xcframework.zip",
-            checksum: "135dea7943bd40b2ee157dbc3c77aa6b2baf4c28e8cc15170c5067a807c34c79"
+            url: "https://github.com/duckduckgo/url_predictor/releases/download/0.2.4/URLPredictorRust.xcframework.zip",
+            checksum: "3dfaa0c6dbba4d694ef16efb7a089ce00520385a8c8db3cfb3b81a2d265f898f"
         ),
         .testTarget(name: "URLPredictorTests", dependencies: ["URLPredictor"])
     ]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211450429415883?focus=true

### Description
This change updates URLPredictor to use the Rust library compiled as static library. This will slightly
reduce the size of the resulting bundle and speed up app launch, by only compiling required symbols
into the main DuckDuckGo binary.

### Testing Steps
Verify that CI is green
Verify that the DMG produced by [this workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/17984135975) runs fine.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)