### PR TITLE
Fix iOS 26 iPad force-choice screen

### DIFF
--- a/iOS/DuckDuckGo/AIChat/NewAddressBarPicker/NewAddressBarPickerContentView.swift
+++ b/iOS/DuckDuckGo/AIChat/NewAddressBarPicker/NewAddressBarPickerContentView.swift
@@ -61,11 +61,20 @@ private struct ContentView: View {
                 topSpacer
                 headerView
                     .frame(width: 300)
-                    .padding(.top, 64)
+                    .padding(.top, topPadding)
                 Spacer()
                 AnimationView()
             }
             .padding(.horizontal)
+        }
+    }
+
+    /// https://app.asana.com/1/137249556945/project/1204167627774280/task/1211457477666070?focus=true
+    private var topPadding: CGFloat {
+        if #available(iOS 26.0, *), UIDevice.current.userInterfaceIdiom == .pad {
+            return 25
+        } else {
+            return 64
         }
     }
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -630,10 +630,17 @@ class MainViewController: UIViewController {
 
         if presentedViewController == nil || presentedViewController?.isBeingDismissed == true {
             let pickerViewController = NewAddressBarPickerViewController(aiChatSettings: aiChatSettings)
-            pickerViewController.modalPresentationStyle = .pageSheet
+
+            /// https://app.asana.com/1/137249556945/project/1204167627774280/task/1211457477666070?focus=true
+            if #available(iOS 26.0, *), UIDevice.current.userInterfaceIdiom == .pad {
+                pickerViewController.modalPresentationStyle = .formSheet
+            } else {
+                pickerViewController.modalPresentationStyle = .pageSheet
+            }
             pickerViewController.modalTransitionStyle = .coverVertical
             pickerViewController.isModalInPresentation = true
             validator.markPickerDisplayAsSeen()
+
             self.present(pickerViewController, animated: true)
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1211457477666070?focus=true

### Description
Fix iOS 26 iPad force-choice screen

### Testing Steps
1. Open the force choice screen on iPad 26. 
2. Check if no text is cropped and it looks like the screenshot on asana

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
Issues in the UI like cropping text
