### PR TITLE
Smartling automation: append date to job name

### DIFF
--- a/scripts/smartling/pr_comment_parser.sh
+++ b/scripts/smartling/pr_comment_parser.sh
@@ -34,15 +34,25 @@ fi
 JOB_ID=""
 PLATFORM=""
 
-# Find job metadata
+# Find job metadata - iterate through all comments to get the latest upload
+LATEST_PLATFORM=""
+LATEST_JOB_ID=""
+
 while IFS= read -r comment; do
 	if [[ "$comment" =~ \<\!--\ smartling-metadata:platform=([^,]+),job_id=([^,]+),action=upload\ --\> ]]; then
-		PLATFORM="${BASH_REMATCH[1]}"
-		JOB_ID="${BASH_REMATCH[2]}"
-		echo "✅ Found job details from metadata: platform=$PLATFORM, job_id=$JOB_ID"
-		break
+		LATEST_PLATFORM="${BASH_REMATCH[1]}"
+		LATEST_JOB_ID="${BASH_REMATCH[2]}"
+		echo "Found upload job: platform=$LATEST_PLATFORM, job_id=$LATEST_JOB_ID"
 	fi
 done <<< "$COMMENTS"
+
+# Use the latest found values
+PLATFORM="$LATEST_PLATFORM"
+JOB_ID="$LATEST_JOB_ID"
+
+if [ -n "$JOB_ID" ] && [ "$JOB_ID" != "N/A" ]; then
+	echo "✅ Using latest job details: platform=$PLATFORM, job_id=$JOB_ID"
+fi
 
 # Validate we found both values
 if [ -z "$JOB_ID" ] || [ "$JOB_ID" == "N/A" ]; then

--- a/scripts/smartling/smartling_upload.sh
+++ b/scripts/smartling/smartling_upload.sh
@@ -20,6 +20,10 @@ if [ -z "$JOB_NAME" ]; then
 	JOB_NAME="$(git rev-parse --abbrev-ref HEAD)"
 fi
 
+# Always append date suffix to prevent naming conflicts
+DATE_SUFFIX="$(date +%Y-%m-%d)"
+JOB_NAME="${JOB_NAME}-${DATE_SUFFIX}"
+
 echo "Uploading translations for platform: $PLATFORM"
 echo "Job name: $JOB_NAME"
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210594645229050/task/1211443495906924
Tech Design URL:
CC: @ayoy 

### Description

This PR adds the following change:
When creating a translation job, it will add the date to the job name as suffix. The change needed to enable creating a new translation job from the same branch (i.e when we encounter [this](https://app.asana.com/0/0/1210223145394340)). I also updated the comment lookup logic to take the latest job id, instead of the first one 

### Testing Steps
1. Add label `start ios translation`
2. Verify that the created job has today’s date as suffix

### Impact and Risks
N/A

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)