### PR TITLE
Filter PIR scan progress status and opt-out schedule by non-removed brokers

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
@@ -42,20 +42,23 @@ public extension BrokerProfileQueryData {
                      scanHistoryEvents: [HistoryEvent] = [HistoryEvent](),
                      mirrorSites: [MirrorSite] = [MirrorSite](),
                      deprecated: Bool = false,
-                     optOutJobData: [OptOutJobData]? = nil) -> BrokerProfileQueryData {
-        BrokerProfileQueryData(
-            dataBroker: DataBroker(
-                name: dataBrokerName,
-                url: url,
-                steps: steps,
-                version: "1.0.0",
-                schedulingConfig: DataBrokerScheduleConfig.mock,
-                parent: parentURL,
-                mirrorSites: mirrorSites,
-                optOutUrl: optOutUrl ?? "",
-                eTag: "",
-                removedAt: nil
-            ),
+                     optOutJobData: [OptOutJobData]? = nil,
+                     dataBrokerRemovedAt: Date? = nil) -> BrokerProfileQueryData {
+        let dataBroker = DataBroker(
+            name: dataBrokerName,
+            url: url,
+            steps: steps,
+            version: "1.0.0",
+            schedulingConfig: DataBrokerScheduleConfig.mock,
+            parent: parentURL,
+            mirrorSites: mirrorSites,
+            optOutUrl: optOutUrl ?? "",
+            eTag: "",
+            removedAt: dataBrokerRemovedAt
+        )
+
+        return BrokerProfileQueryData(
+            dataBroker: dataBroker,
             profileQuery: ProfileQuery(firstName: "John", lastName: "Doe", city: "Miami", state: "FL", birthYear: 50, deprecated: deprecated),
             scanJobData: ScanJobData(brokerId: 1,
                                      profileQueryId: 1,
@@ -2628,7 +2631,8 @@ public extension DataBroker {
                                  parent: String? = nil,
                                  mirrorSites: [MirrorSite] = [MirrorSite](),
                                  optOutUrl: String = "testbroker.com/optout",
-                                 eTag: String = "") -> DataBroker {
+                                 eTag: String = "",
+                                 removedAt: Date? = nil) -> DataBroker {
         return DataBroker(
             id: id,
             name: name,
@@ -2640,7 +2644,7 @@ public extension DataBroker {
             mirrorSites: mirrorSites,
             optOutUrl: optOutUrl,
             eTag: eTag,
-            removedAt: nil)
+            removedAt: removedAt)
     }
 
     static func mock(withId id: Int64) -> DataBroker {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1211377372075564?focus=true
Tech Design URL:
CC: @THISISDINOSAUR 

### Description
This PR fixes a bug where a second manually triggered initial scan never finishes due to communication between the native app and the Web UI not being filtered for removed brokers on the `getInitialScanStatus` response.

### Testing Steps
Instructions on how to test removed brokers are available both on #1796 and on https://app.asana.com/1/137249556945/project/1203581873609357/task/1211319901173827?focus=true. Make sure to build the app from this branch instead of using an Alpha build.
The expected result is that the second, manually triggered, scan should also complete successfully like the first.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
Feedback on general filtering strategy is appreciated 👍 

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exclude removed brokers from initial scan progress and maintenance next-scan data sent to the Web UI, while keeping resultsFound computation unchanged.
> 
> - **Core/UI Web**:
>   - **Initial Scan State (`DBPUIInitialScanState`)**:
>     - Filter out `dataBroker.isRemoved` before grouping and calculating `scanProgress` (current/total/scannedBrokers).
>     - Keep `resultsFound` based on non-deprecated queries, including removed brokers.
>   - **Maintenance State (`DBPUIScanAndOptOutMaintenanceState`)**:
>     - Compute `nextScan` (brokers and earliest date) from non-removed brokers only.
> - **Tests**:
>   - Add tests ensuring removed brokers are excluded from initial scan progress and maintenance next scans, but still present in `resultsFound`.
>   - Extend mocks to support `removedAt` on `DataBroker` and `BrokerProfileQueryData`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1d4f2a07de4ac17349eba60e86588fa420c12a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->