### PR TITLE
Do not present New Tab Page tooltip in case the onboarding is in progress

### DIFF
--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
@@ -151,7 +151,7 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
                 return false
             }
 #endif
-            if customizePopoverPresentationCount > Constants.maxNumberOfPopoverPresentations.rawValue {
+            if !shouldShowCustomizePopover {
                 return false
             } else {
                 return (try? keyValueStore.object(forKey: Key.showCustomizePopover.rawValue) as? Bool) ?? true
@@ -170,5 +170,11 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
     var customizePopoverPresentationCount: Int {
         get { (try? keyValueStore.object(forKey: Key.customizePopoverPresentationCount.rawValue) as? Int) ?? 0 }
         set { try? keyValueStore.set(newValue, forKey: Key.customizePopoverPresentationCount.rawValue) }
+    }
+
+    private var shouldShowCustomizePopover: Bool {
+        customizePopoverPresentationCount <= Constants.maxNumberOfPopoverPresentations.rawValue &&
+        OnboardingActionsManager.isOnboardingFinished &&
+        Application.appDelegate.onboardingContextualDialogsManager.state == .onboardingCompleted
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1211448014057434?focus=true

### Description
To make the onboarding less confusing, we decided not present New Tab Page tooltip in case the onboarding is in progress


### Testing Steps
1. Clean the app state using `./macOS/clean-app.sh debug`
2. In `shouldShowOnboarding` `MainWindowController.swift`, comment all code related to DEBUG and REVIEW compilation flags
```
    private var shouldShowOnboarding: Bool {
// #if DEBUG
//        return false
// #elseif REVIEW
//        if AppVersion.runType == .uiTests {
//            Application.appDelegate.onboardingContextualDialogsManager.state = .onboardingCompleted
//            return false
//        } else {
//            if AppVersion.runType == .uiTestsOnboarding {
//                Application.appDelegate.onboardingContextualDialogsManager.state = .onboardingCompleted
//            }
//            let onboardingIsComplete = OnboardingActionsManager.isOnboardingFinished || LocalStatisticsStore().waitlistUnlocked
//            return !onboardingIsComplete
//        }
// #else
        let onboardingIsComplete = OnboardingActionsManager.isOnboardingFinished || LocalStatisticsStore().waitlistUnlocked
        return !onboardingIsComplete
// #endif
    }
```
4. Run the app
5. Go through the onboarding until you see contextual onboarding with duckduckgo.com website
6. Restart the app
7. Verify there is New Tab Page loaded instead of duckduckgo.com
8. Make sure there is no tooltip on New Tab Page
9. Finish the entire onboarding including the contextual dialogs
10. Make sure the tooltip on New Tab Page is visible


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Onboarding and tooltip presentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)