### PR TITLE
Debounce macOS webkit termination pixel to deal with pixel bursts

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Navigation/WKProcessTerminationReason.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Navigation/WKProcessTerminationReason.swift
@@ -22,6 +22,7 @@ public enum WKProcessTerminationReason: Int {
     case exceededCPULimit
     case requestedByClient
     case crash
+    case exceededSharedProcessCrashLimit
 
     public static let userInfoKey: String = "WKProcessTerminationReasonKey"
 }

--- a/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
+++ b/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
@@ -174,6 +174,11 @@ struct PinnedTabView: View, DropDelegate {
             } label: {
                 Text(verbatim: Tab.crashTabMenuOptionTitle)
             }
+            Button { [weak model] in
+                model?.killWebContentProcessMultipleTimes()
+            } label: {
+                Text(verbatim: Tab.crashTabMenuOptionTitleMultipleTimes)
+            }
         }
     }
 

--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -1169,6 +1169,7 @@ protocol NewWindowPolicyDecisionMaker {
 
 extension Tab {
     static let crashTabMenuOptionTitle = "Crash Tab"
+    static let crashTabMenuOptionTitleMultipleTimes = "Crash Tab Multiple Times in a Row"
 
     private enum Selector {
         static let killWebContentProcessAndResetState = NSSelectorFromString("_killWebContentProcessAndResetState")
@@ -1181,6 +1182,18 @@ extension Tab {
     func killWebContentProcess() {
         if webView.responds(to: Selector.killWebContentProcessAndResetState) {
             webView.perform(Selector.killWebContentProcessAndResetState)
+        }
+    }
+
+    func killWebContentProcessMultipleTimes() {
+        if webView.responds(to: Selector.killWebContentProcessAndResetState) {
+            Task { @MainActor [weak self] in
+                for _ in 0..<50 {
+                    guard let self else { return }
+                    self.webView.perform(Selector.killWebContentProcessAndResetState)
+                    try await Task.sleep(nanoseconds: 20 * NSEC_PER_MSEC)
+                }
+            }
         }
     }
 }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabCrashRecoveryExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabCrashRecoveryExtension.swift
@@ -137,7 +137,7 @@ extension TabCrashRecoveryExtension: NavigationResponder {
         let lastFireTime = lastPixelFireTime ?? Date.distantPast
         if now.timeIntervalSince(lastFireTime) >= 0.1 {
             lastPixelFireTime = now
-            
+
             Task.detached(priority: .utility) {
 #if APPSTORE
                 let additionalParameters = [String: String]()

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabCrashRecoveryExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabCrashRecoveryExtension.swift
@@ -133,7 +133,6 @@ extension TabCrashRecoveryExtension: NavigationResponder {
 
         attemptTabCrashRecovery(for: error, in: webView)
 
-        // Debounce pixel firing - only fire if enough time has passed
         let now = Date()
         let lastFireTime = lastPixelFireTime ?? Date.distantPast
         if now.timeIntervalSince(lastFireTime) >= 0.1 {

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabCrashRecoveryExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabCrashRecoveryExtension.swift
@@ -83,6 +83,7 @@ final class TabCrashRecoveryExtension {
     private let firePixel: (PixelKitEvent, [String: String]) -> Void
 
     private var cancellables = Set<AnyCancellable>()
+    private var lastPixelFireTime: Date?
 
     init(
         featureFlagger: FeatureFlagger,
@@ -132,13 +133,20 @@ extension TabCrashRecoveryExtension: NavigationResponder {
 
         attemptTabCrashRecovery(for: error, in: webView)
 
-        Task.detached(priority: .utility) {
+        // Debounce pixel firing - only fire if enough time has passed
+        let now = Date()
+        let lastFireTime = lastPixelFireTime ?? Date.distantPast
+        if now.timeIntervalSince(lastFireTime) >= 0.1 {
+            lastPixelFireTime = now
+            
+            Task.detached(priority: .utility) {
 #if APPSTORE
-            let additionalParameters = [String: String]()
+                let additionalParameters = [String: String]()
 #else
-            let additionalParameters = await SystemInfo.pixelParameters()
+                let additionalParameters = await SystemInfo.pixelParameters()
 #endif
-            self.firePixel(DebugEvent(GeneralPixel.webKitDidTerminate, error: error), additionalParameters)
+                self.firePixel(DebugEvent(GeneralPixel.webKitDidTerminate, error: error), additionalParameters)
+            }
         }
     }
 

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -1417,6 +1417,15 @@ extension TabBarViewController: TabBarViewItemDelegate {
         tabCollectionViewModel.tabViewModel(at: indexPath.item)?.tab.killWebContentProcess()
     }
 
+    func tabBarViewItemCrashMultipleTimesAction(_ tabBarViewItem: TabBarViewItem) {
+        guard let indexPath = collectionView.indexPath(for: tabBarViewItem) else {
+            assertionFailure("TabBarViewController: Failed to get index path of tab bar view item")
+            return
+        }
+
+        tabCollectionViewModel.tabViewModel(at: indexPath.item)?.tab.killWebContentProcessMultipleTimes()
+    }
+
     func tabBarViewItemDidUpdateCrashInfoPopoverVisibility(_ tabBarViewItem: TabBarViewItem, sender: NSButton, shouldShow: Bool) {
         guard shouldShow else {
             crashPopoverViewController?.dismiss()

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -83,6 +83,7 @@ protocol TabBarViewItemDelegate: AnyObject {
     @MainActor func otherTabBarViewItemsState(for tabBarViewItem: TabBarViewItem) -> OtherTabBarViewItemsState
 
     @MainActor func tabBarViewItemCrashAction(_: TabBarViewItem)
+    @MainActor func tabBarViewItemCrashMultipleTimesAction(_: TabBarViewItem)
     @MainActor func tabBarViewItemDidUpdateCrashInfoPopoverVisibility(_: TabBarViewItem, sender: NSButton, shouldShow: Bool)
 }
 
@@ -1044,11 +1045,18 @@ extension TabBarViewItem: NSMenuDelegate {
         if tabViewModel?.canKillWebContentProcess == true {
             menu.addItem(.separator())
             addCrashMenuItem(to: menu)
+            addCrashMultipleTimesMenuItem(to: menu)
         }
     }
 
     private func addCrashMenuItem(to menu: NSMenu) {
         let crashMenuItem = NSMenuItem(title: Tab.crashTabMenuOptionTitle, action: #selector(crashMenuItemAction(_:)), keyEquivalent: "")
+        crashMenuItem.target = self
+        menu.addItem(crashMenuItem)
+    }
+
+    private func addCrashMultipleTimesMenuItem(to menu: NSMenu) {
+        let crashMenuItem = NSMenuItem(title: Tab.crashTabMenuOptionTitleMultipleTimes, action: #selector(crashMultipleTimesMenuItemAction(_:)), keyEquivalent: "")
         crashMenuItem.target = self
         menu.addItem(crashMenuItem)
     }
@@ -1062,6 +1070,10 @@ extension TabBarViewItem: NSMenuDelegate {
 
     @objc private func crashMenuItemAction(_ sender: NSButton) {
         delegate?.tabBarViewItemCrashAction(self)
+    }
+
+    @objc private func crashMultipleTimesMenuItemAction(_ sender: NSButton) {
+        delegate?.tabBarViewItemCrashMultipleTimesAction(self)
     }
 
     private func addPinMenuItem(to menu: NSMenu) {
@@ -1507,6 +1519,7 @@ extension TabBarViewItem {
             .init(hasItemsToTheLeft: false, hasItemsToTheRight: false)
         }
         func tabBarViewItemCrashAction(_: TabBarViewItem) {}
+        func tabBarViewItemCrashMultipleTimesAction(_: TabBarViewItem) {}
         func tabBarViewItemDidUpdateCrashInfoPopoverVisibility(_: TabBarViewItem, sender: NSButton, shouldShow: Bool) {}
     }
 }

--- a/macOS/UnitTests/TabBar/View/MockTabViewItemDelegate.swift
+++ b/macOS/UnitTests/TabBar/View/MockTabViewItemDelegate.swift
@@ -137,6 +137,10 @@ class MockTabViewItemDelegate: TabBarViewItemDelegate {
 
     }
 
+    func tabBarViewItemCrashMultipleTimesAction(_: DuckDuckGo_Privacy_Browser.TabBarViewItem) {
+
+    }
+
     func tabBarViewItemCrashMultiProcessAction(_: DuckDuckGo_Privacy_Browser.TabBarViewItem) {
 
     }

--- a/macOS/UnitTests/TabBar/View/MockTabViewItemDelegate.swift
+++ b/macOS/UnitTests/TabBar/View/MockTabViewItemDelegate.swift
@@ -137,6 +137,10 @@ class MockTabViewItemDelegate: TabBarViewItemDelegate {
 
     }
 
+    func tabBarViewItemCrashMultiProcessAction(_: DuckDuckGo_Privacy_Browser.TabBarViewItem) {
+
+    }
+
     func tabBarViewItemDidUpdateCrashInfoPopoverVisibility(_: TabBarViewItem, sender: NSButton, shouldShow: Bool) {
 
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211198745312534?focus=true

### Description

Debounce macOS webkit termination pixel to deal with pixel bursts.

Also added a new crash-testing option to make the tab crash multiple times in a row.

### Testing Steps

1. Enable Feature Flag > Other > `tabCrashDebugging`
2. Open a tab.
3. Right click on the tab title, select "Crash Tab"

```
👾[Daily and Count-Skipped] m_mac_debug_webkit_did_terminate_daily ["appVersion": "1.158.0", "available_diskspace": "5.03", "available_memory": "53", "d": "WKErrorDomain", "e": "2", "os_version": "15.7.0", "pixelSource": "browser-dmg", "ud": "WKErrorDomain", "ue": "2"]
👾[Daily and Count-Fired] m_mac_debug_webkit_did_terminate ["appVersion": "1.158.0", "available_diskspace": "5.03", "available_memory": "53", "d": "WKErrorDomain", "e": "2", "os_version": "15.7.0", "pixelSource": "browser-dmg", "ud": "WKErrorDomain", "ue": "2"]
```

4. If you trigger that again within 5 seconds, you'll get a different thing:

```
👾[Daily and Count-Fired] m_mac_webkit_termination_loop_daily ["appVersion": "1.158.0", "pixelSource": "browser-dmg"]
👾[Daily and Count-Fired] m_mac_webkit_termination_loop ["appVersion": "1.158.0", "pixelSource": "browser-dmg"]
👾[Daily and Count-Skipped] m_mac_debug_webkit_did_terminate_daily ["appVersion": "1.158.0", "available_diskspace": "5.03", "available_memory": "54", "d": "WKErrorDomain", "e": "2", "os_version": "15.7.0", "pixelSource": "browser-dmg", "ud": "WKErrorDomain", "ue": "2"]
👾[Daily and Count-Fired] m_mac_debug_webkit_did_terminate ["appVersion": "1.158.0", "available_diskspace": "5.03", "available_memory": "54", "d": "WKErrorDomain", "e": "2", "os_version": "15.7.0", "pixelSource": "browser-dmg", "ud": "WKErrorDomain", "ue": "2"]
```

5. At this point you might need to reload the web view if it's empty.
6. Wait 5 seconds.
7. Next thing select from the same menu "Crash multiple times".  You should see this (order might change):

```
👾[Daily and Count-Skipped] m_mac_debug_webkit_did_terminate_daily ["appVersion": "1.158.0", "available_diskspace": "5.03", "available_memory": "49", "d": "WKErrorDomain", "e": "2", "os_version": "15.7.0", "pixelSource": "browser-dmg", "ud": "WKErrorDomain", "ue": "2"]
👾[Daily and Count-Fired] m_mac_webkit_termination_loop_daily ["appVersion": "1.158.0", "pixelSource": "browser-dmg"]
👾[Daily and Count-Fired] m_mac_debug_webkit_did_terminate ["appVersion": "1.158.0", "available_diskspace": "5.03", "available_memory": "49", "d": "WKErrorDomain", "e": "2", "os_version": "15.7.0", "pixelSource": "browser-dmg", "ud": "WKErrorDomain", "ue": "2"]
👾[Daily and Count-Fired] m_mac_webkit_termination_loop ["appVersion": "1.158.0", "pixelSource": "browser-dmg"]

```

### Impact and Risks

Low: just adding rate-limiting / leading-edge debouncing logic for a pixel.

#### What could go wrong?

The rate limiting logic might be wrong.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)