### PR TITLE
Allow write permission for smartling workflow

### DIFF
--- a/.github/workflows/smartling.yml
+++ b/.github/workflows/smartling.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: macos-15
     name: Smartling translation job
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
     env:


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211443495906924?focus=true
Tech Design URL:
CC: 

### Description

Looking at this [workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/18049204426/job/51367323407) I’ve noticed that the permissions were set incorrectly, and the workflow could not push the created commit. This PR allows write permissions for the workflow to change that.

### Testing Steps
N/A

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Smartling GitHub Actions workflow to use contents: write instead of contents: read.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5aac33e7dc5196a1984ef212562c26324679e678. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->