### PR TITLE
[Release PR] VPN navigation classification fix

### DIFF
--- a/macOS/DuckDuckGo/Application/URLEventHandler.swift
+++ b/macOS/DuckDuckGo/Application/URLEventHandler.swift
@@ -160,7 +160,7 @@ final class URLEventHandler {
     }
 }
 
-private extension String {
+extension String {
     static let dataBrokerProtectionScheme = "databrokerprotection"
     static let networkProtectionScheme = "networkprotection"
 

--- a/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
@@ -127,6 +127,13 @@ extension URL {
         guard featureFlagger.isFeatureOn(.unifiedURLPredictor) else {
             return makeURLUsingNativePredictionLogic(from: addressBarString)
         }
+
+        // Handle VPN URLs first, to avoid them being misclassified. This workaround can be removed when the
+        // URL predictor identifies the networkprotection:// scheme as a navigate action instead of a search.
+        if let vpnURL = URL(string: addressBarString), vpnURL.scheme?.isNetworkProtectionScheme == true {
+            return vpnURL
+        }
+
         let url = makeURLUsingUnifiedPredictionLogic(from: addressBarString)
 
         /// Return early if the metrics feature flag is disabled (only internal users can opt in to metrics collection).


### PR DESCRIPTION
This only runs in the path where the feature flag is enabled, the code without the flag enabled is untouched.

<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1203708860857015/task/1211500631000625?focus=true
Tech Design URL:
CC:

### Description

This PR fixes an issue where VPN URLs were being classified as searches, breaking the VPN agent's ability to open URLs in the app. The fix is to check whether the URL is has a VPN scheme and returning it as-is before passing it to the classifier.

This will need a fix in the URL classifier, which isn't live yet, but this is being worked around now to avoid internal user feedback.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Run the client locally and click the location button in the VPN agent
2. Confirm that the browser opens the location selection panel

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prioritizes `networkprotection://` URLs in unified prediction flow and exposes scheme helpers by removing `private` from the `String` extension.
> 
> - **URL handling**:
>   - In `URL.makeURL(from:enableMetrics:)`, return `networkprotection://` URLs immediately before unified prediction to avoid misclassification; metrics comparison logic retained.
> - **Visibility**:
>   - Change `private extension String` to `extension String` in `Application/URLEventHandler.swift` to make `isNetworkProtectionScheme`/`isDataBrokerProtectionScheme` helpers accessible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea2a3bd10f1b46b4795a7a3d7afbacc264d9c1fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->