### PR TITLE
Implements Theme Switcher UI: Mark 2

### DIFF
--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAppearanceView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAppearanceView.swift
@@ -158,7 +158,7 @@ extension Preferences {
                 RoundedRectangle(cornerRadius: innerCornerRadius)
                     .fill(Color(themeColors.surfacePrimary))
                     .frame(width: innerSize.width, height: innerSize.height)
-                    .mask (
+                    .mask(
                         VStack {
                             Rectangle()
                                 .frame(height: 10)
@@ -171,7 +171,7 @@ extension Preferences {
                 RoundedRectangle(cornerRadius: innerCornerRadius)
                     .fill(Color(themeColors.surfaceTertiary))
                     .frame(width: innerSize.width, height: innerSize.height)
-                    .mask (
+                    .mask(
                         VStack {
                             Color.clear
                             Rectangle()

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAppearanceView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAppearanceView.swift
@@ -121,6 +121,93 @@ extension Preferences {
         }
     }
 
+    // MARK: - Theme View
+    //
+    struct ThemeView: View {
+
+        // MARK: - Constants
+        private let outerSize: CGFloat = 42
+        private let outerCornerRadius: CGFloat = 8
+
+        private let innerSize = CGSize(width: 40, height: 31)
+        private let innerCornerRadius: CGFloat = 7
+
+        private let knobSize = CGSize(width: 28, height: 8)
+        private let knobRadius: CGFloat = 7
+
+        /// MARK: - Properties
+        private let themeColors: ThemeColors
+
+        /// Designated Initializer
+        ///
+        init(themeName: ThemeName) {
+            themeColors = ThemeColors(themeName: themeName)
+        }
+
+        var body: some View {
+            ZStack(alignment: .bottom) {
+                // Background
+                RoundedRectangle(cornerRadius: outerCornerRadius)
+                    .fill(Color(themeColors.surfaceBackdrop))
+                    .frame(width: outerSize, height: outerSize)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: outerCornerRadius)
+                        .stroke(Color(themeColors.decorationPrimary), lineWidth: 1)
+                        .frame(width: outerSize, height: outerSize)
+                    )
+
+                // Inner Top
+                RoundedRectangle(cornerRadius: innerCornerRadius)
+                    .fill(Color(themeColors.surfacePrimary))
+                    .frame(width: innerSize.width, height: innerSize.height)
+                    .mask (
+                        VStack {
+                            Rectangle()
+                                .frame(height: 10)
+                            Color.clear
+                        }
+                    )
+                    .padding(.bottom, 1)
+
+                // Inner Bottom
+                RoundedRectangle(cornerRadius: innerCornerRadius)
+                    .fill(Color(themeColors.surfaceTertiary))
+                    .frame(width: innerSize.width, height: innerSize.height)
+                    .mask (
+                        VStack {
+                            Color.clear
+                            Rectangle()
+                                .frame(height: 21)
+                        }
+                    )
+                    .padding(.bottom, 1)
+
+                // Knob
+                RoundedRectangle(cornerRadius: knobRadius)
+                    .fill(Color(themeColors.accentPrimary))
+                    .frame(width: knobSize.width, height: knobSize.height)
+                    .padding(.bottom, 6)
+            }
+        }
+    }
+
+    // MARK: - Picker: Themes
+    //
+    struct ThemesPickerView: View {
+        @EnvironmentObject var model: AppearancePreferences
+
+        var body: some View {
+            SlidingPickerView(settings: .themesPickerSettings, allValues: ThemeName.allCases, selectedValue: $model.themeName) { themeName in
+                AnyView(
+                    ThemeView(themeName: themeName)
+                )
+            }
+            .frame(height: 32)
+        }
+    }
+
+    // MARK: - Appearance Container View
+    //
     struct AppearanceView: View {
         @ObservedObject var model: AppearancePreferences
         @ObservedObject var aiChatModel: AIChatPreferences
@@ -135,7 +222,10 @@ extension Preferences {
                     if isThemeSwitcherEnabled {
                         ThemeAppearancePickerV2()
                             .environmentObject(model)
+                            .padding(.bottom, 16)
 
+                        ThemesPickerView()
+                            .environmentObject(model)
                     } else {
                         ThemeAppearancePicker()
                             .environmentObject(model)
@@ -243,6 +333,15 @@ private extension ThemeAppearance {
 // MARK: - SlidingPickerSettings Helpers
 //
 private extension SlidingPickerSettings {
+
+    static var themesPickerSettings: SlidingPickerSettings {
+        SlidingPickerSettings(
+            selectionBorderColor: Color(designSystemColor: .accentPrimary),
+            cornerRadius: 8,
+            elementsPadding: 12,
+            sliderInset: 1,
+            sliderLineWidth: 2)
+    }
 
     static var appearancePickerSettings: SlidingPickerSettings {
         SlidingPickerSettings(

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAppearanceView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAppearanceView.swift
@@ -128,10 +128,8 @@ extension Preferences {
         // MARK: - Constants
         private let outerSize: CGFloat = 42
         private let outerCornerRadius: CGFloat = 8
-
         private let innerSize = CGSize(width: 40, height: 31)
         private let innerCornerRadius: CGFloat = 7
-
         private let knobSize = CGSize(width: 28, height: 8)
         private let knobRadius: CGFloat = 7
 

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAppearanceView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAppearanceView.swift
@@ -224,6 +224,10 @@ extension Preferences {
 
                         ThemesPickerView()
                             .environmentObject(model)
+<<<<<<< HEAD
+=======
+
+>>>>>>> ba106427e (Preferences: Disables Appearance's Slider Animations)
                     } else {
                         ThemeAppearancePicker()
                             .environmentObject(model)
@@ -347,6 +351,7 @@ private extension SlidingPickerSettings {
             borderColor: Color(designSystemColor: .containerDecorationSecondary),
             selectionBackgroundColor: Color(designSystemColor: .surfaceTertiary),
             selectionBorderColor: Color(designSystemColor: .containerDecorationSecondary),
+            animationsEnabled: false,
             dividerSize: CGSize(width: 1, height: 16))
     }
 }

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAppearanceView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAppearanceView.swift
@@ -224,10 +224,7 @@ extension Preferences {
 
                         ThemesPickerView()
                             .environmentObject(model)
-<<<<<<< HEAD
-=======
 
->>>>>>> ba106427e (Preferences: Disables Appearance's Slider Animations)
                     } else {
                         ThemeAppearancePicker()
                             .environmentObject(model)

--- a/macOS/LocalPackages/SwiftUIExtensions/Sources/SwiftUIExtensions/SlidingPickerView.swift
+++ b/macOS/LocalPackages/SwiftUIExtensions/Sources/SwiftUIExtensions/SlidingPickerView.swift
@@ -24,6 +24,7 @@ public struct SlidingPickerSettings {
     let borderColor: Color
     let selectionBackgroundColor: Color
     let selectionBorderColor: Color
+    let animationsEnabled: Bool
     let cornerRadius: CGFloat
     let dividerSize: CGSize?
     let elementsPadding: CGFloat
@@ -35,6 +36,7 @@ public struct SlidingPickerSettings {
         borderColor: Color = .clear,
         selectionBackgroundColor: Color = .clear,
         selectionBorderColor: Color = .clear,
+        animationsEnabled: Bool = true,
         cornerRadius: CGFloat = 4,
         dividerSize: CGSize? = nil,
         elementsPadding: CGFloat = .zero,
@@ -45,6 +47,7 @@ public struct SlidingPickerSettings {
         self.borderColor = borderColor
         self.selectionBackgroundColor = selectionBackgroundColor
         self.selectionBorderColor = selectionBorderColor
+        self.animationsEnabled = animationsEnabled
         self.cornerRadius = cornerRadius
         self.dividerSize = dividerSize
         self.elementsPadding = elementsPadding
@@ -160,7 +163,7 @@ private extension SlidingPickerView {
         }
 
         // Note: Avoid animating from Zero Size -> Actual Size
-        animationsEnabled = highlightSize != .zero
+        animationsEnabled = highlightSize != .zero && settings.animationsEnabled
 
         // Note: Our Highlight with Zero Offset appears at the center of the ZStack
         highlightOffset = buttonFrame.minX - (contentSize.width - buttonFrame.width) * 0.5


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1211373040955472?focus=true
Tech Design URL:
CC: [Figma](https://www.figma.com/design/lowzSNK3XysASQ1urGCZFp/Browser-Color-Themes--2025-09-12-?node-id=504-17677&m=dev)

### Description
In this PR we're wiring the new Theme Switcher mechanism.

### Testing Steps
1. Flip the Internal User flag
2. Open `Settings > Appearance`

- [ ] Verify you now see the Theme Picker
- [ ] Verify you can click anywhere, and the highlight slides with an animation
- [ ] Verify that if you relaunch, the last selected Theme is preserved
- [ ] Verify that if you remove the `Internal User` state, you no longer see this new picker

⚠️ Please note that the actual themes aren't wired, just the UX. Wiring comes in a follow-up!

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The new Themes Picker component could be presented to users, and it's not currently switching themes.

### Quality Considerations
No edge cases, this is a UI Picker placeholder, the actual mechanism will be built in a follow-up.

### Notes to Reviewer
Please ensure the UX is as smooth as possible!

Thank you!!

### Screenshots

Light | Dark
-|-
<img width="400" height="1129" alt="Screenshot 2025-09-30 at 12 26 36 PM" src="https://github.com/user-attachments/assets/cddb30e9-658c-4177-aa4e-2dfb24cc841a" /> | <img width="400" height="1129" alt="Screenshot 2025-09-30 at 12 26 34 PM" src="https://github.com/user-attachments/assets/9f30549f-1f45-405d-be5c-441df1edde16" />


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new Themes picker with visual previews in Appearance settings and introduces an animationsEnabled flag to SlidingPickerView, updating settings accordingly.
> 
> - **Preferences UI (macOS)**:
>   - **New `ThemesPickerView`** using `SlidingPickerView` to select `ThemeName` with visual `ThemeView` previews.
>   - Integrates into `Preferences.AppearanceView` (behind `isThemeSwitcherEnabled`), with spacing tweaks (`.padding(.bottom, 16)`).
>   - **Settings**: adds `SlidingPickerSettings.themesPickerSettings`; updates `appearancePickerSettings` to set `animationsEnabled: false`.
> - **SwiftUIExtensions**:
>   - `SlidingPickerSettings`: adds `animationsEnabled` (default `true`).
>   - `SlidingPickerView`: slider animation now respects `settings.animationsEnabled` when refreshing highlight.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d59b52277b4a0f8d96e871e8425e3220484c56e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->