### PR TITLE
Fix issue with the toggle view stuck during rotation

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -166,7 +166,8 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-
+        super.viewWillTransition(to: size, with: coordinator)
+        
         coordinator.animate { _ in
             self.adjustLayoutForViewSize(size)
             self.view.layoutIfNeeded()

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwipeContainerViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwipeContainerViewController.swift
@@ -55,7 +55,7 @@ final class SwipeContainerViewController: UIViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -65,11 +65,13 @@ final class SwipeContainerViewController: UIViewController {
         configureInitialPosition()
     }
 
-    override func viewWillTransition(to size: CGSize, with coordinator: any UIViewControllerTransitionCoordinator) {
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator)  {
         super.viewWillTransition(to: size, with: coordinator)
 
         coordinator.animate { _ in
             self.updateLayout(viewBounds: CGRect(origin: .zero, size: size))
+        } completion: { _ in
+            self.syncScrollProgress()
         }
     }
 
@@ -169,6 +171,13 @@ final class SwipeContainerViewController: UIViewController {
     private func updateScrollProgress(_ progress: CGFloat) {
         scrollProgress = progress
         delegate?.swipeContainerViewController(self, didUpdateScrollProgress: progress)
+    }
+
+    private func syncScrollProgress() {
+        let pageWidth = swipeScrollView.frame.width
+        guard pageWidth > 0 else { return }
+        let progress = max(0, min(1, swipeScrollView.contentOffset.x / pageWidth))
+        updateScrollProgress(progress)
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1211393477988791?focus=true

### Description
Fix issue with the toggle view stuck during rotation

### Testing Steps
1. Enable the new AI Feature address bar
2. Select search, rotate the device, check if you're still on search
3. Rotate back to portrait, select duck.ai, rotate the device, check if you're still on duck.ai

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
Incorrectly set the toggle state on rotation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure the switch bar/toggle stays correctly synced after device rotation by syncing scroll progress and invoking super on transition.
> 
> - **iOS (AI Chat Switch Bar)**
>   - **Rotation handling**:
>     - `OmniBarEditingStateViewController`: call `super.viewWillTransition` and continue adjusting layout during transition.
>     - `SwipeContainerViewController`: refine `viewWillTransition` signature and, after animated layout updates, call new `syncScrollProgress()` to recalculate and propagate scroll progress based on `contentOffset`/page width.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a1b74788ead779389035c0ebda7e8c9adc27fc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->