### PR TITLE
Remove focus from NTP search box on the new tab page

### DIFF
--- a/macOS/DuckDuckGo/Common/Extensions/WKWebViewExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/WKWebViewExtension.swift
@@ -465,4 +465,8 @@ extension WKWebView {
         return nil
     }
 
+    @MainActor
+    func blurActiveElement() {
+        evaluateJavaScript("document.activeElement?.blur()")
+    }
 }

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -689,6 +689,10 @@ final class MainViewController: NSViewController {
         let tabContent = tabContent ?? selectedTabViewModel.tab.content
 
         if case .newtab = tabContent {
+            // Blur NTP search box to remove focus from it
+            browserTabViewController.blurActiveElement()
+
+            // Focus the address bar
             navigationBarViewController.addressBarViewController?.addressBarTextField.makeMeFirstResponder()
         } else {
             // ignore published tab switch: BrowserTabViewController

--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -884,6 +884,10 @@ final class BrowserTabViewController: NSViewController {
         window.makeFirstResponder(contentView)
     }
 
+    func blurActiveElement() {
+        webView?.blurActiveElement()
+    }
+
     private var viewToMakeFirstResponderAfterAdding: (() -> NSView?)?
     private func adjustFirstResponderAfterAddingContentViewIfNeeded() {
         guard let window = view.window,


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1211511420745374
Tech Design URL:
CC: @ayoy 

### Description
This PR fixes a problem where both search boxes would appear focused in the following scenario:
1. Focus NTP search box in tab 1
2. Open tab 2 (NTP)
3. Close tab 2
4. Now both the URL bar search box and the NTP search box (which is HTML) have focus rings

I blurred the active element as recommended by @noisysocks and it seems to work.

### Testing Steps
* Follow repro steps above
* When closing tab 2, only the URL bar should have focus

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
If JS evaluation fails for some reason, the NTP search box might remain focused.

### Quality Considerations
N/A

### Notes to Reviewer
N/A

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Blurs the New Tab Page search box via WebView JS before focusing the address bar to prevent dual focus rings.
> 
> - **Focus handling (NTP)**:
>   - In `MainViewController.adjustFirstResponder(...)`, blur the NTP active element, then focus the address bar when `tab.content == .newtab`.
>   - `BrowserTabViewController`: add `blurActiveElement()` to forward blur to the current `webView`.
>   - `WKWebViewExtension`: add `@MainActor func blurActiveElement()` that runs `document.activeElement?.blur()` via `evaluateJavaScript`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63d1d6f19d767e711ca1c2092235bb6ec450b787. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->