### PR TITLE
Support Bottom Address Bar in New Input Screen - Part 3

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -178,9 +178,6 @@ public enum FeatureFlag: String {
 
     /// https://app.asana.com/1/137249556945/project/1142021229838617/task/1211394727337421?focus=true
     case newDeviceSyncPrompt
-
-    /// https://app.asana.com/1/137249556945/project/1206226850447395/task/1211302776234329?focus=true
-    case aiSearchBottomBarSupport
     
     /// https://app.asana.com/1/137249556945/project/1142021229838617/task/1211245201777978?focus=true
     case serpSettingsFollowUpQuestions
@@ -298,8 +295,7 @@ extension FeatureFlag: FeatureFlagDescribing {
                .failsafeExamplePlatformSpecificSubfeature,
                .experimentalAddressBar,
                .aiChatKeepSession,
-               .aiFeaturesSettingsUpdate,
-               .aiSearchBottomBarSupport:
+               .aiFeaturesSettingsUpdate:
             return false
         }
     }
@@ -448,8 +444,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(AIChatSubfeature.showAIChatAddressBarChoiceScreen))
         case .newDeviceSyncPrompt:
             return .remoteReleasable(.subfeature(SyncSubfeature.newDeviceSyncPrompt))
-        case .aiSearchBottomBarSupport:
-            return .internalOnly()
         case .serpSettingsFollowUpQuestions:
             return .remoteReleasable(.subfeature(AIChatSubfeature.serpSettingsFollowUpQuestions))
         }

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -518,7 +518,6 @@
 		6FF4943F2DDDDC4000BCF5F0 /* NSLayoutConstraintExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF4943E2DDDDC4000BCF5F0 /* NSLayoutConstraintExtension.swift */; };
 		6FF9AD3F2CE63DD800C5A406 /* TabSwitcherOpenDailyPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9AD3E2CE63DC200C5A406 /* TabSwitcherOpenDailyPixel.swift */; };
 		6FF9AD412CE6610F00C5A406 /* TabSwitcherOpenDailyPixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9AD402CE6610600C5A406 /* TabSwitcherOpenDailyPixelTests.swift */; };
-		6FFBA0D42E30FCC300873286 /* OmniBarEditingStateTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFBA0D32E30FCC300873286 /* OmniBarEditingStateTransition.swift */; };
 		7B020B9A2D11F99D00876178 /* FavoritesDisplayMode+UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373608912ABB430D00629E7F /* FavoritesDisplayMode+UserDefaults.swift */; };
 		7B059F0F2D0387E900371ED0 /* NumberedParagraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B059F0A2D0387E900371ED0 /* NumberedParagraphView.swift */; };
 		7B059F112D0387E900371ED0 /* WidgetEducationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B059F0D2D0387E900371ED0 /* WidgetEducationViewController.swift */; };
@@ -2460,7 +2459,6 @@
 		6FF4943E2DDDDC4000BCF5F0 /* NSLayoutConstraintExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLayoutConstraintExtension.swift; sourceTree = "<group>"; };
 		6FF9AD3E2CE63DC200C5A406 /* TabSwitcherOpenDailyPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSwitcherOpenDailyPixel.swift; sourceTree = "<group>"; };
 		6FF9AD402CE6610600C5A406 /* TabSwitcherOpenDailyPixelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSwitcherOpenDailyPixelTests.swift; sourceTree = "<group>"; };
-		6FFBA0D32E30FCC300873286 /* OmniBarEditingStateTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmniBarEditingStateTransition.swift; sourceTree = "<group>"; };
 		7B059F0A2D0387E900371ED0 /* NumberedParagraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberedParagraphView.swift; sourceTree = "<group>"; };
 		7B059F0C2D0387E900371ED0 /* WidgetEducationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetEducationView.swift; sourceTree = "<group>"; };
 		7B059F0D2D0387E900371ED0 /* WidgetEducationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetEducationViewController.swift; sourceTree = "<group>"; };
@@ -5631,7 +5629,6 @@
 			isa = PBXGroup;
 			children = (
 				6FE1F33E2E3130F700C88A09 /* MainViewEditingStateTransitioning.swift */,
-				6FFBA0D32E30FCC300873286 /* OmniBarEditingStateTransition.swift */,
 				6F5DCFCD2E854C2000758C8A /* UniversalOmniBarEditingStateTransition.swift */,
 				6FE1F3402E33A1E200C88A09 /* OmniBarEditingStateTransitioning.swift */,
 			);
@@ -10134,7 +10131,6 @@
 				CBF259C52D4ED37700AC63E4 /* ATBAndVariantConfiguration.swift in Sources */,
 				B609D5522862EAFF0088CAC2 /* InlineWKDownloadDelegate.swift in Sources */,
 				BDFF03222BA3D8E200F324C9 /* NetworkProtectionFeatureVisibility.swift in Sources */,
-				6FFBA0D42E30FCC300873286 /* OmniBarEditingStateTransition.swift in Sources */,
 				B652DEFD287BE67400C12A9C /* UserScripts.swift in Sources */,
 				3768D8472C2CC98C004120AE /* RemoteMessagingConfigMatcherProvider.swift in Sources */,
 				1D200C992BA3176D00108701 /* SettingsOthersView.swift in Sources */,

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -80,7 +80,6 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
     private weak var contentContainerViewLeadingConstraint: NSLayoutConstraint?
     private weak var contentContainerViewTrailingConstraint: NSLayoutConstraint?
 
-    let featureFlagger: FeatureFlagger
     let appSettings: AppSettings
 
     // MARK: - Manager Components
@@ -96,14 +95,12 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
 
     internal init(switchBarHandler: any SwitchBarHandling,
                   switchBarSubmissionMetrics: SwitchBarSubmissionMetricsProviding = SwitchBarSubmissionMetrics(),
-                  appSettings: AppSettings = AppDependencyProvider.shared.appSettings,
-                  featureFlagger: FeatureFlagger) {
+                  appSettings: AppSettings = AppDependencyProvider.shared.appSettings) {
         self.switchBarHandler = switchBarHandler
         self.switchBarSubmissionMetrics = switchBarSubmissionMetrics
         self.daxLogoManager = DaxLogoManager()
         self.appSettings = appSettings
-        self.featureFlagger = featureFlagger
-        self.isUsingTopBarPosition = appSettings.currentAddressBarPosition == .top || !featureFlagger.isFeatureOn(.aiSearchBottomBarSupport) || isLandscapeOrientation
+        self.isUsingTopBarPosition = appSettings.currentAddressBarPosition == .top || isLandscapeOrientation
         self.isAdjustedForTopBar = self.isUsingTopBarPosition
 
         super.init(nibName: nil, bundle: nil)

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -68,7 +68,7 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
     private var isUsingTopBarPosition: Bool
     private var isLandscapeOrientation: Bool = false {
         didSet {
-            isUsingTopBarPosition = appSettings.currentAddressBarPosition == .top || !featureFlagger.isFeatureOn(.aiSearchBottomBarSupport) || isLandscapeOrientation
+            isUsingTopBarPosition = appSettings.currentAddressBarPosition == .top || isLandscapeOrientation
         }
     }
     private var isAdjustedForTopBar: Bool

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -65,7 +65,14 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
     private let switchBarHandler: SwitchBarHandling
     private var cancellables = Set<AnyCancellable>()
 
-    private let isUsingTopBarPosition: Bool
+    private var isUsingTopBarPosition: Bool
+    private var isLandscapeOrientation: Bool = false {
+        didSet {
+            isUsingTopBarPosition = appSettings.currentAddressBarPosition == .top || !featureFlagger.isFeatureOn(.aiSearchBottomBarSupport) || isLandscapeOrientation
+        }
+    }
+    private var isAdjustedForTopBar: Bool
+
     lazy var switchBarVC = SwitchBarViewController(switchBarHandler: switchBarHandler,
                                                    showsSeparator: !isUsingTopBarPosition,
                                                    reduceTopPaddings: !isUsingTopBarPosition)
@@ -96,7 +103,8 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
         self.daxLogoManager = DaxLogoManager()
         self.appSettings = appSettings
         self.featureFlagger = featureFlagger
-        self.isUsingTopBarPosition = appSettings.currentAddressBarPosition == .top || !featureFlagger.isFeatureOn(.aiSearchBottomBarSupport)
+        self.isUsingTopBarPosition = appSettings.currentAddressBarPosition == .top || !featureFlagger.isFeatureOn(.aiSearchBottomBarSupport) || isLandscapeOrientation
+        self.isAdjustedForTopBar = self.isUsingTopBarPosition
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -165,11 +173,13 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
     private func adjustLayoutForViewSize(_ size: CGSize) {
 
         let isHorizontallyCompactLayoutEnabled = requiresHorizontallyCompactLayout(for: size)
+        self.isLandscapeOrientation = isHorizontallyCompactLayoutEnabled
 
         let horizontalMargin: CGFloat = isHorizontallyCompactLayoutEnabled ? Constants.horizontalMarginForCompactLayout : 0
         self.contentContainerViewLeadingConstraint?.constant = horizontalMargin
         self.contentContainerViewTrailingConstraint?.constant = -horizontalMargin
         self.updateDaxVisibility()
+        self.updateLayoutForCurrentOrientation()
 
         self.navigationActionBarManager?.navigationActionBarViewController?.isShowingGradient = !isHorizontallyCompactLayoutEnabled && isUsingTopBarPosition
     }
@@ -341,9 +351,36 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
         if isUsingTopBarPosition {
             swipeContainerManager?.swipeContainerViewController.additionalSafeAreaInsets.bottom = 0
         } else {
+            switchBarVC.view.layoutIfNeeded()
             let barHeigthAboveSafeArea = switchBarVC.view.bounds.height - switchBarVC.view.safeAreaInsets.bottom
             swipeContainerManager?.swipeContainerViewController.additionalSafeAreaInsets.bottom = barHeigthAboveSafeArea
         }
+    }
+
+    private func updateLayoutForCurrentOrientation() {
+
+        guard isUsingTopBarPosition != isAdjustedForTopBar else { return }
+
+        var currentSelection: UITextRange?
+        if switchBarVC.textEntryViewController.isFocused {
+            currentSelection = switchBarVC.textEntryViewController.currentTextSelection
+        }
+
+        contentContainerView.subviews.forEach { $0.removeFromSuperview() }
+        navigationActionBarManager?.navigationActionBarViewController?.willMove(toParent: nil)
+        navigationActionBarManager?.navigationActionBarViewController?.view.removeFromSuperview()
+        navigationActionBarManager?.navigationActionBarViewController?.removeFromParent()
+
+        switchBarVC.showsSeparator = !isUsingTopBarPosition
+
+        installComponents()
+
+        if let currentSelection {
+            switchBarVC.textEntryViewController.focusTextField()
+            switchBarVC.textEntryViewController.currentTextSelection = currentSelection
+        }
+
+        isAdjustedForTopBar = isUsingTopBarPosition
     }
 
     private func observeRemoteMessagesChanges() {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -296,7 +296,10 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
                 self?.delegate?.onQueryUpdated(currentText)
                 self?.suggestionTrayManager?.handleQueryUpdate(currentText)
                 self?.updateDaxVisibility()
-                self?.updateSwipeContainerSafeArea()
+                DispatchQueue.main.async {
+                    // Delay to next runloop so the text field size is updated.
+                    self?.updateSwipeContainerSafeArea()
+                }
             }
             .store(in: &cancellables)
 

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarViewController.swift
@@ -46,7 +46,15 @@ class SwitchBarViewController: UIViewController {
         return view
     }()
 
-    private let showsSeparator: Bool
+    var isFocused: Bool {
+        textEntryViewController.isFocused
+    }
+
+    var showsSeparator: Bool {
+        didSet {
+            updateSeparatorVisibility()
+        }
+    }
     private let usesReducedTopPadding: Bool
 
     private let switchBarHandler: SwitchBarHandling
@@ -202,6 +210,39 @@ class SwitchBarViewController: UIViewController {
             backButton.heightAnchor.constraint(equalToConstant: Constants.backButtonSize),
             backButton.widthAnchor.constraint(equalToConstant: Constants.backButtonSize)
         ])
+    }
+
+    private func updateSeparatorVisibility() {
+        guard let segmentedPickerView = segmentedPickerHostingController?.view else { return }
+
+        var selection: UITextRange?
+        if textEntryViewController.isFirstResponder {
+            selection = textEntryViewController.currentTextSelection
+        }
+
+        // For simplicity, just remove from superviews and recreate constraints.
+        // It should animate to new position automatically, preserving state
+        segmentedPickerView.removeFromSuperview()
+        view.addSubview(segmentedPickerView)
+
+        backButton.removeFromSuperview()
+        view.addSubview(backButton)
+
+        textEntryViewController.view.removeFromSuperview()
+        view.addSubview(textEntryViewController.view)
+
+        topSeparatorView.removeFromSuperview()
+        if showsSeparator {
+            view.addSubview(topSeparatorView)
+        }
+
+        setupConstraints()
+
+        if let selection {
+            textEntryViewController.focusTextField()
+            textEntryViewController.currentTextSelection = selection
+        }
+
     }
 
     // MARK: - Actions

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -79,6 +79,15 @@ class SwitchBarTextEntryView: UIView {
         }
     }
 
+    var currentTextSelection: UITextRange? {
+        get { textView.selectedTextRange }
+        set { textView.selectedTextRange = newValue }
+    }
+
+    override var isFirstResponder: Bool {
+        textView.isFirstResponder
+    }
+
     // MARK: - Initialization
     init(handler: SwitchBarHandling) {
         self.handler = handler

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryViewController.swift
@@ -42,6 +42,15 @@ class SwitchBarTextEntryViewController: UIViewController {
         set { textEntryView.isUsingIncreasedButtonPadding = newValue }
     }
 
+    var currentTextSelection: UITextRange? {
+        get { textEntryView.currentTextSelection }
+        set { textEntryView.currentTextSelection = newValue }
+    }
+
+    var isFocused: Bool {
+        textEntryView.isFirstResponder
+    }
+
     // MARK: - Initialization
     init(handler: SwitchBarHandling) {
         self.handler = handler

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Transition/MainViewEditingStateTransitioning.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Transition/MainViewEditingStateTransitioning.swift
@@ -20,7 +20,7 @@
 import UIKit
 
 protocol MainViewEditingStateTransitioning {
-    var newTabView: UIView? { get }
+    var logoView: UIView? { get }
     
     func hide(with barYOffset: CGFloat, contentYOffset: CGFloat)
     func show()

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Transition/OmniBarEditingStateTransition.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Transition/OmniBarEditingStateTransition.swift
@@ -120,7 +120,7 @@ final class OmniBarEditingStateTransition: NSObject, UIViewControllerAnimatedTra
 
         let logoAnimator = UIViewPropertyAnimator(duration: 0.13, curve: .easeIn) {
             if !self.isTopBarPosition {
-                fromVC.newTabView?.alpha = 0
+                fromVC.logoView?.alpha = 0
             }
         }
 
@@ -174,7 +174,7 @@ final class OmniBarEditingStateTransition: NSObject, UIViewControllerAnimatedTra
         }
 
         animator.addAnimations({
-            toVC.newTabView?.alpha = 1.0
+            toVC.logoView?.alpha = 1.0
         }, delayFactor: 0.07)
 
         animator.addCompletion { position in

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Transition/UniversalOmniBarEditingStateTransition.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Transition/UniversalOmniBarEditingStateTransition.swift
@@ -37,12 +37,13 @@ final class UniversalOmniBarEditingStateTransition: NSObject, UIViewControllerAn
         let switcherYOffset = switchBarTextViewHeight * switcherMultiplier
         let contentYOffset: CGFloat = switchBarTextViewHeight * switcherMultiplier
         let barYOffset: CGFloat = isTopBarPosition ? switchBarTextViewHeight : 0
+        let logoYOffset: CGFloat = isTopBarPosition ? switcherYOffset : DefaultOmniBarView.expectedHeight * -0.5
 
         return TransitionOffsets(
             switcherYOffset: switcherYOffset,
             contentYOffset: contentYOffset,
             barYOffset: barYOffset,
-            logoYOffset: 0
+            logoYOffset: logoYOffset
         )
     }
 
@@ -121,6 +122,10 @@ final class UniversalOmniBarEditingStateTransition: NSObject, UIViewControllerAn
         }
 
         animator.addAnimations {
+            if !self.isTopBarPosition {
+                fromVC.newTabView?.alpha = 0
+            }
+
             toVC.view.alpha = 1.0
             toVC.view.layer.sublayerTransform = CATransform3DIdentity
             toVC.switchBarVC.textEntryViewController.isExpandable = true

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Transition/UniversalOmniBarEditingStateTransition.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Transition/UniversalOmniBarEditingStateTransition.swift
@@ -123,7 +123,7 @@ final class UniversalOmniBarEditingStateTransition: NSObject, UIViewControllerAn
 
         animator.addAnimations {
             if !self.isTopBarPosition {
-                fromVC.newTabView?.alpha = 0
+                fromVC.logoView?.alpha = 0
             }
 
             toVC.view.alpha = 1.0
@@ -179,7 +179,7 @@ final class UniversalOmniBarEditingStateTransition: NSObject, UIViewControllerAn
         }
 
         animator.addAnimations({
-            toVC.newTabView?.alpha = 1.0
+            toVC.logoView?.alpha = 1.0
         }, delayFactor: 0.07)
 
         animator.addCompletion { position in

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -190,7 +190,7 @@ final class DefaultOmniBarViewController: OmniBarViewController {
         let switchBarHandler = createSwitchBarHandler(for: textField)
         let shouldAutoSelectText = shouldAutoSelectTextForUrl(textField)
 
-        let editingStateViewController = OmniBarEditingStateViewController(switchBarHandler: switchBarHandler, featureFlagger: dependencies.featureFlagger)
+        let editingStateViewController = OmniBarEditingStateViewController(switchBarHandler: switchBarHandler)
         editingStateViewController.delegate = self
 
         editingStateViewController.modalPresentationStyle = .custom
@@ -286,22 +286,12 @@ extension DefaultOmniBarViewController: UIViewControllerTransitioningDelegate {
     func animationController(forPresented presented: UIViewController,
                              presenting: UIViewController,
                              source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        if dependencies.featureFlagger.isFeatureOn(.aiSearchBottomBarSupport) {
-            return UniversalOmniBarEditingStateTransition(isPresenting: true,
-                                                    addressBarPosition: dependencies.appSettings.currentAddressBarPosition)
-        } else {
-            return OmniBarEditingStateTransition(isPresenting: true,
-                                                 addressBarPosition: dependencies.appSettings.currentAddressBarPosition)
-        }
+        UniversalOmniBarEditingStateTransition(isPresenting: true,
+                                               addressBarPosition: dependencies.appSettings.currentAddressBarPosition)
     }
 
     func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        if dependencies.featureFlagger.isFeatureOn(.aiSearchBottomBarSupport) {
-            return UniversalOmniBarEditingStateTransition(isPresenting: false,
-                                                    addressBarPosition: dependencies.appSettings.currentAddressBarPosition)
-        } else {
-            return OmniBarEditingStateTransition(isPresenting: false,
-                                                 addressBarPosition: dependencies.appSettings.currentAddressBarPosition)
-        }
+        UniversalOmniBarEditingStateTransition(isPresenting: false,
+                                               addressBarPosition: dependencies.appSettings.currentAddressBarPosition)
     }
 }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3770,7 +3770,8 @@ extension MainViewController: MainViewEditingStateTransitioning {
 
     var logoView: UIView? {
         if newTabPageViewController?.isShowingLogo == true {
-            // Treat w NTP view as logo view, but only if it's visible
+            // Treat NTP view as logo view, but only if it's visible.
+            // This prevents favorites from flickering during transition.
             return newTabPageViewController?.view
         } else {
             return nil

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3768,8 +3768,13 @@ extension MainViewController: MainViewEditingStateTransitioning {
         newTabPageViewController?.isShowingLogo == true
     }
 
-    var newTabView: UIView? {
-        newTabPageViewController?.view
+    var logoView: UIView? {
+        if newTabPageViewController?.isShowingLogo == true {
+            // Treat w NTP view as logo view, but only if it's visible
+            return newTabPageViewController?.view
+        } else {
+            return nil
+        }
     }
 
     func hide(with barYOffset: CGFloat, contentYOffset: CGFloat) {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1211532998319427?focus=true
Tech Design URL:
CC:

### Description

* Prevent flickering when transitioning to focus mode when location is set to bottom.
* Improve Dax logo alignment during transition from bottom bar position.
* Always keep top bar location when rotating to landscape.
* Remove internal flag and make available for all users.

### Testing Steps
1. Set address bar location to bottom.
2. Enable New Input Screen.
3. For both with and without favorites do the following steps:
4. Rotate to landscape, focus on address bar make sure functionality work as expected and address bar is on top
5. Rotate back to portrait, focus on address bar, rotate back to landscape, verify the bar moved back to top and keyboard is still visible with text selection preserved.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Items after rotation are misaligned or invisible.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies to the universal editing-state transition, improves bottom address bar behavior (landscape forces top, less flicker, preserved selection), and removes the legacy transition/flag usage.
> 
> - **OmniBar editing state**:
>   - Always use `UniversalOmniBarEditingStateTransition`; remove legacy `OmniBarEditingStateTransition` from project and selection paths.
>   - `DefaultOmniBarViewController`: drop `aiSearchBottomBarSupport` checks; stop passing `featureFlagger` into `OmniBarEditingStateViewController`.
>   - `OmniBarEditingStateViewController`: orientation-aware layout (landscape forces top), rebuilds components on orientation change, preserves text selection/focus, and delays safe-area updates to avoid glitches.
>   - `SwitchBarViewController`: separator visibility becomes dynamic; exposes focus state.
>   - Text entry (`SwitchBarTextEntryView`, `SwitchBarTextEntryViewController`): expose `currentTextSelection` and focus helpers.
> - **Transitions/animations**:
>   - Use `logoView` instead of entire NTP view to avoid favorites flicker; adjust logo Y-offsets for bottom position; fade logo appropriately during transitions.
> - **MainViewController**:
>   - Conform to `logoView` API for transitions and only expose logo when visible to prevent flicker.
> - **Feature flags**:
>   - Remove usage of `aiSearchBottomBarSupport` gating from code paths (unconditional behavior).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77da4df3146836a910a135f91a22e8a4a63cdf29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->