### PR TITLE
Amend timings of watchdog state transition test to avoid failures

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Watchdog/WatchdogTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Watchdog/WatchdogTests.swift
@@ -334,8 +334,12 @@ final class WatchdogTests: XCTestCase {
     // MARK: - State Transitions
 
     func testHangStateTransitions() async throws {
+        let minimumDuration = 0.2
+        let maximumDuration = 0.4
+        let checkInterval   = 0.1
+        
         let mockKill = MockKillAppFunction()
-        let watchdog = Watchdog(minimumHangDuration: 0.2, maximumHangDuration: 0.4, checkInterval: 0.1, killAppFunction: mockKill.killApp)
+        let watchdog = Watchdog(minimumHangDuration: minimumDuration, maximumHangDuration: maximumDuration, checkInterval: checkInterval, killAppFunction: mockKill.killApp)
 
         var receivedStates: [(hangState: Watchdog.HangState, duration: TimeInterval?)] = []
         let cancellable = await watchdog.hangStatePublisher
@@ -380,16 +384,16 @@ final class WatchdogTests: XCTestCase {
         let responsiveState = receivedStates.first { $0.hangState == .responsive }
         XCTAssertNotNil(responsiveState, "Should recover to responsive state")
         XCTAssertNotNil(responsiveState?.duration, "Responsive state includes the previous hang duration")
-        XCTAssertLessThan(responsiveState?.duration ?? 0, 0.5, "Duration should not exceed maximum + check interval")
+        XCTAssertLessThan(responsiveState?.duration ?? 0, maximumDuration + checkInterval, "Duration should not exceed maximum + padding")
 
         // Test 3: Responsive -> Hanging -> Timeout
-        blockMainThread(for: 0.5) // Exceeds maximum
+        blockMainThread(for: maximumDuration + (checkInterval * 2)) // Exceeds maximum
         await waitForState(.timeout)
 
         let timeoutState = receivedStates.first { $0.hangState == .timeout }
         XCTAssertNotNil(timeoutState, "Should transition to timeout state")
         XCTAssertNotNil(timeoutState?.duration, "Should include hang duration")
-        XCTAssertGreaterThan(timeoutState?.duration ?? 0, 0.3, "Duration should exceed maximum")
+        XCTAssertGreaterThan(timeoutState?.duration ?? 0, maximumDuration, "Duration should exceed maximum")
 
         // Test 4: Verify state sequence
         let stateSequence = receivedStates.map { $0.hangState }

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Watchdog/WatchdogTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Watchdog/WatchdogTests.swift
@@ -337,7 +337,7 @@ final class WatchdogTests: XCTestCase {
         let minimumDuration = 0.2
         let maximumDuration = 0.4
         let checkInterval   = 0.1
-        
+
         let mockKill = MockKillAppFunction()
         let watchdog = Watchdog(minimumHangDuration: minimumDuration, maximumHangDuration: maximumDuration, checkInterval: checkInterval, killAppFunction: mockKill.killApp)
 

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Watchdog/WatchdogTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Watchdog/WatchdogTests.swift
@@ -335,7 +335,7 @@ final class WatchdogTests: XCTestCase {
 
     func testHangStateTransitions() async throws {
         let mockKill = MockKillAppFunction()
-        let watchdog = Watchdog(minimumHangDuration: 0.1, maximumHangDuration: 0.3, checkInterval: 0.05, killAppFunction: mockKill.killApp)
+        let watchdog = Watchdog(minimumHangDuration: 0.2, maximumHangDuration: 0.4, checkInterval: 0.1, killAppFunction: mockKill.killApp)
 
         var receivedStates: [(hangState: Watchdog.HangState, duration: TimeInterval?)] = []
         let cancellable = await watchdog.hangStatePublisher
@@ -369,7 +369,7 @@ final class WatchdogTests: XCTestCase {
         }
 
         // Test 1: Responsive -> Hanging
-        blockMainThread(for: 0.2) // Between min and max
+        blockMainThread(for: 0.3) // Between min and max
         await waitForState(.hanging)
 
         let hangingState = receivedStates.first { $0.hangState == .hanging }
@@ -380,7 +380,7 @@ final class WatchdogTests: XCTestCase {
         let responsiveState = receivedStates.first { $0.hangState == .responsive }
         XCTAssertNotNil(responsiveState, "Should recover to responsive state")
         XCTAssertNotNil(responsiveState?.duration, "Responsive state includes the previous hang duration")
-        XCTAssertLessThan(responsiveState?.duration ?? 0, 0.3, "Duration should not exceed maximum")
+        XCTAssertLessThan(responsiveState?.duration ?? 0, 0.5, "Duration should not exceed maximum + check interval")
 
         // Test 3: Responsive -> Hanging -> Timeout
         blockMainThread(for: 0.5) // Exceeds maximum
@@ -393,7 +393,7 @@ final class WatchdogTests: XCTestCase {
 
         // Test 4: Verify state sequence
         let stateSequence = receivedStates.map { $0.hangState }
-        XCTAssertEqual(stateSequence, [.hanging, .responsive, .hanging, .timeout], "Should follow expected state sequence")
+        XCTAssert(stateSequence.prefix(4) == [.hanging, .responsive, .hanging, .timeout], "Should follow expected state sequence")
 
         cancellable.cancel()
         await watchdog.stop()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1211541377992379?focus=true
Tech Design URL:
CC:

### Description

`testHangStateTransitions` in `WatchdogTests` was failing on CI due to a timeout. I’ve amended the timings slightly so that it should have more tolerance – a longer timeout, and shorter heartbeat check interval.

### Testing Steps

1. Check that the amended test passes!

### Impact and Risks

None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts Watchdog hang state transition test timings and expectations to be more tolerant and reduce CI flakiness.
> 
> - **Tests**:
>   - `WatchdogTests.swift` (`testHangStateTransitions`):
>     - Parameterize timings with `minimumDuration`, `maximumDuration`, `checkInterval`; pass to `Watchdog`.
>     - Update hangs: first block to `0.3`; timeout block to `maximumDuration + (checkInterval * 2)`.
>     - Loosen assertions: compare against `maximumDuration + checkInterval` and `maximumDuration`; validate state sequence via `prefix(4)` instead of strict full equality.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1384d8f495f62668cc0e0c654eaaa96ae54f10b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->