### PR TITLE
Update autofill to 18.4.0

### DIFF
--- a/SharedPackages/BrowserServicesKit/Package.resolved
+++ b/SharedPackages/BrowserServicesKit/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "123b64c7c78f492a1a3e6f60a8f891557a23a2eb",
-        "version" : "18.3.1"
+        "revision" : "0b91be6b29805466d101b556f775763f7c0c5c18",
+        "version" : "18.4.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         .library(name: "WKAbstractions", targets: ["WKAbstractions"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "18.3.1"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "18.4.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit.git", exact: "3.0.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.7.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "3.0.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211543808525887
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.4.0
Apple PR: 

## Description
Updates Autofill to version [18.4.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.4.0).

### Autofill 18.4.0 release notes
## What's Changed
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/900
* [SiteSpecificFixes] Allow forcing unknown input type by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/903
* [InterfacePrototype] Get rid of `GetIdentity(id)` call on Windows by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/904
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/902
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/908


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/18.3.1...18.4.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Autofill dependency to 18.4.0 across BrowserServicesKit.
> 
> - **Dependencies**:
>   - Upgrade `duckduckgo-autofill` from `18.3.1` to `18.4.0` in `SharedPackages/BrowserServicesKit/Package.swift` and update `Package.resolved` pin/revision accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c54d8aaef15d297f49c3c567d59fdf20cb0c4141. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->