### PR TITLE
AuthV2 refresh optimization

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Networking/Auth/OAuthClient.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Networking/Auth/OAuthClient.swift
@@ -165,6 +165,7 @@ final public actor DefaultOAuthClient: @preconcurrency OAuthClient {
     private var tokenStorage: any AuthTokenStoring
     private var legacyTokenStorage: (any LegacyAuthTokenStoring)?
     private var migrationOngoingTask: Task<Void, Error>?
+    private var refreshOngoingTask: Task<TokenContainer, Error>?
 
     public init(tokensStorage: any AuthTokenStoring,
                 legacyTokenStorage: (any LegacyAuthTokenStoring)?,
@@ -273,22 +274,36 @@ final public actor DefaultOAuthClient: @preconcurrency OAuthClient {
                 Logger.OAuthClient.log("Tokens not found")
                 throw OAuthClientError.missingTokenContainer
             }
-            do {
-                let refreshTokenResponse = try await authService.refreshAccessToken(clientID: Constants.clientID, refreshToken: localTokenContainer.refreshToken)
-                let refreshedTokens = try await decode(accessToken: refreshTokenResponse.accessToken, refreshToken: refreshTokenResponse.refreshToken)
-                Logger.OAuthClient.log("Tokens refreshed, expiry: \(refreshedTokens.decodedAccessToken.exp.value.description, privacy: .public)")
-                try tokenStorage.saveTokenContainer(refreshedTokens)
-                return refreshedTokens
-            } catch OAuthServiceError.authAPIError(let code) where code == .invalidTokenRequest {
-                Logger.OAuthClient.error("Failed to refresh token: invalidTokenRequest")
-                throw OAuthClientError.invalidTokenRequest
-            } catch OAuthServiceError.authAPIError(let code) where code == .unknownAccount {
-                Logger.OAuthClient.error("Failed to refresh token: unknownAccount")
-                throw OAuthClientError.unknownAccount
-            } catch {
-                Logger.OAuthClient.error("Failed to refresh token: \(String(describing: error), privacy: .public)")
-                throw error
+
+            if let task = refreshOngoingTask {
+                return try await task.value
             }
+
+            let task = Task {
+                defer {
+                    self.refreshOngoingTask = nil
+                }
+
+                do {
+                    let refreshTokenResponse = try await authService.refreshAccessToken(clientID: Constants.clientID, refreshToken: localTokenContainer.refreshToken)
+                    let refreshedTokens = try await decode(accessToken: refreshTokenResponse.accessToken, refreshToken: refreshTokenResponse.refreshToken)
+                    Logger.OAuthClient.log("Tokens refreshed, expiry: \(refreshedTokens.decodedAccessToken.exp.value.description, privacy: .public)")
+                    try tokenStorage.saveTokenContainer(refreshedTokens)
+                    return refreshedTokens
+                } catch OAuthServiceError.authAPIError(let code) where code == .invalidTokenRequest {
+                    Logger.OAuthClient.error("Failed to refresh token: invalidTokenRequest")
+                    throw OAuthClientError.invalidTokenRequest
+                } catch OAuthServiceError.authAPIError(let code) where code == .unknownAccount {
+                    Logger.OAuthClient.error("Failed to refresh token: unknownAccount")
+                    throw OAuthClientError.unknownAccount
+                } catch {
+                    Logger.OAuthClient.error("Failed to refresh token: \(String(describing: error), privacy: .public)")
+                    throw error
+                }
+            }
+
+            refreshOngoingTask = task
+            return try await task.value
 
         case .createIfNeeded:
             do {

--- a/SharedPackages/BrowserServicesKit/Sources/NetworkingTestingUtils/MockOAuthService.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/NetworkingTestingUtils/MockOAuthService.swift
@@ -24,6 +24,13 @@ public final class MockOAuthService: OAuthService {
 
     public init() {}
 
+    public private(set) var refreshAccessTokenCallCount = 0
+    private var refreshAccessTokenDelay: UInt64 = 0
+
+    public func setRefreshAccessTokenDelay(_ delay: UInt64) {
+        refreshAccessTokenDelay = delay
+    }
+
     public var authorizeResponse: Result<Networking.OAuthSessionID, Error>?
     public func authorize(codeChallenge: String) async throws -> Networking.OAuthSessionID {
         switch authorizeResponse! {
@@ -66,6 +73,10 @@ public final class MockOAuthService: OAuthService {
 
     public var refreshAccessTokenResponse: Result<Networking.OAuthTokenResponse, Error>?
     public func refreshAccessToken(clientID: String, refreshToken: String) async throws -> Networking.OAuthTokenResponse {
+        refreshAccessTokenCallCount += 1
+        if refreshAccessTokenDelay > 0 {
+            try await Task.sleep(nanoseconds: refreshAccessTokenDelay)
+        }
         switch refreshAccessTokenResponse! {
         case .success(let result):
             return result

--- a/SharedPackages/BrowserServicesKit/Tests/NetworkingTests/Auth/OAuthClientTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/NetworkingTests/Auth/OAuthClientTests.swift
@@ -200,6 +200,31 @@ final class OAuthClientTests: XCTestCase {
         }
     }
 
+    func testGetToken_localForceRefresh_concurrentCallsOnlyRefreshOnce() async throws {
+        mockOAuthService.getJWTSignersResponse = .success(JWTSigners())
+        mockOAuthService.refreshAccessTokenResponse = .success(OAuthTokensFactory.makeValidOAuthTokenResponse())
+        mockOAuthService.setRefreshAccessTokenDelay(100_000_000) // 0.1 seconds
+
+        try tokenStorage.saveTokenContainer(OAuthTokensFactory.makeExpiredTokenContainer())
+        await oAuthClient.setTestingDecodedTokenContainer(OAuthTokensFactory.makeValidTokenContainer())
+
+        async let result1 = oAuthClient.getTokens(policy: .localForceRefresh)
+        async let result2 = oAuthClient.getTokens(policy: .localForceRefresh)
+        async let result3 = oAuthClient.getTokens(policy: .localForceRefresh)
+        async let result4 = oAuthClient.getTokens(policy: .localForceRefresh)
+        async let result5 = oAuthClient.getTokens(policy: .localForceRefresh)
+
+        let results = try await [result1, result2, result3, result4, result5]
+
+        for result in results {
+            XCTAssertNotNil(result.accessToken)
+            XCTAssertNotNil(result.refreshToken)
+            XCTAssertFalse(result.decodedAccessToken.isExpired())
+        }
+
+        XCTAssertEqual(mockOAuthService.refreshAccessTokenCallCount, 1, "Expected only one refresh call for concurrent requests")
+    }
+
     // MARK: Create if needed
 
     func testGetToken_createIfNeeded_foundLocal() async throws {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211548969099201?focus=true
Tech Design URL:
CC:

### Description

This PR makes the AuthV2 refresh operation only run once at a time.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Sign into a staging Privacy Pro account
2. Close the app and wait a few minutes
3. Relaunch the app and check that only one refresh operation actually happens

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

High risk as it modifies the AuthV2 refresh flow.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)