### PR TITLE
Fixes edge case where Restart to Update button does nothing

### DIFF
--- a/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -429,6 +429,7 @@ enum GeneralPixel: PixelKitEvent {
     case updaterDidFindUpdate
     case updaterDidDownloadUpdate
     case updaterDidRunUpdate
+    case updaterAttemptToRestartWithoutResumeBlock
     case releaseNotesEmpty
 
     case faviconDecryptionFailedUnique
@@ -1143,6 +1144,8 @@ enum GeneralPixel: PixelKitEvent {
             return "updater_did_download_update"
         case .updaterDidRunUpdate:
             return "updater_did_run_update"
+        case .updaterAttemptToRestartWithoutResumeBlock:
+            return "updater_attempt_to_restart_without_resume_block"
         case .releaseNotesEmpty:
             return "m_mac_release_notes_empty"
 

--- a/macOS/DuckDuckGo/Updates/Sparkle/ReleaseNotesTabExtension.swift
+++ b/macOS/DuckDuckGo/Updates/Sparkle/ReleaseNotesTabExtension.swift
@@ -167,8 +167,6 @@ extension ReleaseNotesValues {
                 let status = {
                     if currentVersion == cachedVersion {
                         return ReleaseNotesValues.Status.loaded
-                    } else if updateController.hasPendingUpdate {
-                        return .updateReady
                     } else if case .updateCycleNotStarted = updateController.updateProgress {
                         return .loading
                     } else {

--- a/macOS/DuckDuckGo/Updates/Sparkle/ReleaseNotesTabExtension.swift
+++ b/macOS/DuckDuckGo/Updates/Sparkle/ReleaseNotesTabExtension.swift
@@ -169,6 +169,8 @@ extension ReleaseNotesValues {
                         return ReleaseNotesValues.Status.loaded
                     } else if updateController.hasPendingUpdate {
                         return updateController.latestUpdate?.type == .critical ? .criticalUpdateReady : .updateReady
+                    } else if case .updateCycleNotStarted = updateController.updateProgress {
+                        return .loading
                     } else {
                         return updateController.updateProgress.toStatus
                     }

--- a/macOS/DuckDuckGo/Updates/Sparkle/ReleaseNotesTabExtension.swift
+++ b/macOS/DuckDuckGo/Updates/Sparkle/ReleaseNotesTabExtension.swift
@@ -164,7 +164,15 @@ extension ReleaseNotesValues {
                 let releaseTitle = formatter.string(from: cached.date)
 
                 let cachedVersion = "\(cached.version) (\(cached.build))"
-                let status = currentVersion == cachedVersion ? ReleaseNotesValues.Status.loaded : ReleaseNotesValues.Status.updateReady
+                let status = {
+                    if currentVersion == cachedVersion {
+                        return ReleaseNotesValues.Status.loaded
+                    } else if updateController.hasPendingUpdate {
+                        return .updateReady
+                    } else {
+                        return .loading
+                    }
+                }()
 
                 self.init(status: status,
                           currentVersion: currentVersion,

--- a/macOS/DuckDuckGo/Updates/Sparkle/ReleaseNotesTabExtension.swift
+++ b/macOS/DuckDuckGo/Updates/Sparkle/ReleaseNotesTabExtension.swift
@@ -168,7 +168,7 @@ extension ReleaseNotesValues {
                     if currentVersion == cachedVersion {
                         return ReleaseNotesValues.Status.loaded
                     } else if updateController.hasPendingUpdate {
-                        return updateController.latestUpdate?.type == .critical ? .criticalUpdateReady : .updateReady
+                        return .updateReady
                     } else if case .updateCycleNotStarted = updateController.updateProgress {
                         return .loading
                     } else {

--- a/macOS/DuckDuckGo/Updates/Sparkle/ReleaseNotesTabExtension.swift
+++ b/macOS/DuckDuckGo/Updates/Sparkle/ReleaseNotesTabExtension.swift
@@ -168,9 +168,9 @@ extension ReleaseNotesValues {
                     if currentVersion == cachedVersion {
                         return ReleaseNotesValues.Status.loaded
                     } else if updateController.hasPendingUpdate {
-                        return .updateReady
+                        return updateController.latestUpdate?.type == .critical ? .criticalUpdateReady : .updateReady
                     } else {
-                        return .loading
+                        return updateController.updateProgress.toStatus
                     }
                 }()
 

--- a/macOS/DuckDuckGo/Updates/Sparkle/SparkleUpdateController.swift
+++ b/macOS/DuckDuckGo/Updates/Sparkle/SparkleUpdateController.swift
@@ -475,12 +475,12 @@ final class SparkleUpdateController: NSObject, SparkleUpdateControllerProtocol {
         PixelKit.fire(DebugEvent(GeneralPixel.updaterDidRunUpdate))
 
         guard useLegacyAutoRestartLogic else {
-            userDriver.resume()
+            resumeUpdater()
             return
         }
 
         guard shouldForceUpdateCheck else {
-            userDriver.resume()
+            resumeUpdater()
             return
         }
 
@@ -497,6 +497,12 @@ final class SparkleUpdateController: NSObject, SparkleUpdateControllerProtocol {
         }
     }
 
+    private func resumeUpdater() {
+        if userDriver?.isResumable == false {
+            PixelKit.fire(DebugEvent(GeneralPixel.updaterAttemptToRestartWithoutResumeBlock))
+        }
+        userDriver?.resume()
+    }
 }
 
 extension SparkleUpdateController: SPUUpdaterDelegate {

--- a/macOS/DuckDuckGo/Updates/Sparkle/SparkleUpdateController.swift
+++ b/macOS/DuckDuckGo/Updates/Sparkle/SparkleUpdateController.swift
@@ -627,6 +627,7 @@ extension SparkleUpdateController: SPUUpdaterDelegate {
             Task { @UpdateCheckActor in await updateCheckState.recordCheckTime() }
         } else if let error {
             Logger.updates.log("Updater did finish update cycle with error: \(error.localizedDescription, privacy: .public) (\(error.pixelParameters, privacy: .public))")
+            updateProgress = .updaterError(error)
         }
     }
 

--- a/macOS/DuckDuckGo/Updates/Sparkle/SparkleUpdateController.swift
+++ b/macOS/DuckDuckGo/Updates/Sparkle/SparkleUpdateController.swift
@@ -61,7 +61,23 @@ final class SparkleUpdateController: NSObject, SparkleUpdateControllerProtocol {
             self.needsLatestReleaseNote = needsLatestReleaseNote
         }
     }
-    private var cachedUpdateResult: UpdateCheckResult?
+
+    private var cachedUpdateResult: UpdateCheckResult? {
+        didSet {
+            if let cachedUpdateResult {
+                refreshUpdateFromCache(cachedUpdateResult)
+            } else {
+                latestUpdate = nil
+                hasPendingUpdate = false
+                needsNotificationDot = false
+            }
+        }
+    }
+
+    private func refreshUpdateFromCache(_ cachedUpdateResult: UpdateCheckResult) {
+        latestUpdate = Update(appcastItem: cachedUpdateResult.item, isInstalled: cachedUpdateResult.isInstalled, needsLatestReleaseNote: cachedUpdateResult.needsLatestReleaseNote)
+        hasPendingUpdate = latestUpdate?.isInstalled == false && updateProgress.isDone && userDriver?.isResumable == true
+    }
 
     // Struct used to persist pending update info across app restarts
     struct PendingUpdateInfo: Codable {
@@ -86,8 +102,7 @@ final class SparkleUpdateController: NSObject, SparkleUpdateControllerProtocol {
     @Published private(set) var updateProgress = UpdateCycleProgress.default {
         didSet {
             if let cachedUpdateResult {
-                latestUpdate = Update(appcastItem: cachedUpdateResult.item, isInstalled: cachedUpdateResult.isInstalled, needsLatestReleaseNote: cachedUpdateResult.needsLatestReleaseNote)
-                hasPendingUpdate = latestUpdate?.isInstalled == false && updateProgress.isDone && userDriver?.isResumable == true
+                refreshUpdateFromCache(cachedUpdateResult)
                 needsNotificationDot = hasPendingUpdate
             }
             showUpdateNotificationIfNeeded()
@@ -392,7 +407,6 @@ final class SparkleUpdateController: NSObject, SparkleUpdateControllerProtocol {
     private func configureUpdater() throws -> SPUUpdater? {
         // Workaround to reset the updater state
         cachedUpdateResult = nil
-        latestUpdate = nil
 
         if !useLegacyAutoRestartLogic, let userDriver {
             userDriver.areAutomaticUpdatesEnabled = areAutomaticUpdatesEnabled

--- a/macOS/PixelDefinitions/pixels/update_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/update_pixels.json5
@@ -7,7 +7,7 @@
         suffixes: ['first_daily_count'],
         parameters: ['appVersion', 'pixelSource'],
     },
-    m_mac_updater_attempt_to_restart_without_resume_block: {
+    updater_attempt_to_restart_without_resume_block: {
         description: 'Fires when the Restart to Update when clicked does nothing. Used to measure how often users encounter this anomaly case.',
         owners: ['quanganhdo'],
         triggers: ['other'],

--- a/macOS/PixelDefinitions/pixels/update_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/update_pixels.json5
@@ -7,4 +7,11 @@
         suffixes: ['first_daily_count'],
         parameters: ['appVersion', 'pixelSource'],
     },
+    m_mac_updater_attempt_to_restart_without_resume_block: {
+        description: 'Fires when the Restart to Update when clicked does nothing. Used to measure how often users encounter this anomaly case.',
+        owners: ['quanganhdo'],
+        triggers: ['other'],
+        suffixes: ['first_daily_count'],
+        parameters: ['appVersion', 'pixelSource'],
+    },
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1211540600152635?focus=true
Tech Design URL:
CC:

### Description

Displays a more appropriate status in Release Notes screen.

### Testing Steps

Taken from https://github.com/duckduckgo/apple-browsers/pull/1741:

The steps described below can be used to both reproduce the original issue in the release branch and test it's fixed in this branch.

1. Make sure we get an update while testing:
   1. Edit `macOS/Configuration/BuildNumber.xcconfig` and set the build number to 400.
   2. Edit `macOS/Configuration/Version.xcconfig` and set the marketing version to 1.151.0
   3. Run the app once in debug mode, and enable  the `autoUpdateInDebug` feature flag.
2. Make sure we set-up the exact conditions that make the bug show up.  Add the following two lines of code [here](https://github.com/duckduckgo/apple-browsers/blob/main/macOS/DuckDuckGo/Updates/Sparkle/SparkleUpdateController.swift#L450):

```swift
updateValidityStartDate = Date.distantPast
latestUpdate = nil
```

Now to test:

1. Run the app
2. When you see the notification dot prompting an app update, kill the Internet connection
3. Use the overflow menu > Update app / Install now button to open Release Notes screen
4. Expect to not see a Restart to update button that does nothing until you reconnect to the Internet (you might instead see an Update failed button or a Checking for updating spinner)

### Impact and Risks

Wrong state display causes confusion to the users.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> Adjusts status resolution in `ReleaseNotesTabExtension` to consider `hasPendingUpdate` and `updateProgress` when falling back to cached update info.
> 
> - **macOS / Updates**:
>   - `macOS/DuckDuckGo/Updates/Sparkle/ReleaseNotesTabExtension.swift`:
>     - Refines cached-mode status computation when `latestUpdate` is nil:
>       - If versions match → `loaded`.
>       - Else if `updateController.hasPendingUpdate` → `updateReady`.
>       - Else if `updateProgress` is `updateCycleNotStarted` → `loading`.
>       - Else → use `updateProgress.toStatus`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b06b6c3c33d8df6e83bc7a9800deee9afd0cb59e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY —>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines Release Notes status fallback, improves Sparkle update caching/resume flow (with error propagation), and adds a pixel for restart attempts without a resume block.
> 
> - **Updates (macOS)**:
>   - `Updates/Sparkle/ReleaseNotesTabExtension.swift`:
>     - Refines fallback status when `latestUpdate` is nil: if versions match → `loaded`; else if `updateProgress` is `updateCycleNotStarted` → `loading`; else → `updateProgress.toStatus`.
>   - `Updates/Sparkle/SparkleUpdateController.swift`:
>     - Adds `cachedUpdateResult` observer and `refreshUpdateFromCache` to keep `latestUpdate`/`hasPendingUpdate` in sync.
>     - Replaces direct `userDriver.resume()` with `resumeUpdater()` that guards `isResumable` and logs a debug pixel.
>     - On update cycle error, sets `updateProgress = .updaterError(error)`.
>     - Simplifies state reset during `configureUpdater`.
> - **Telemetry**:
>   - `Statistics/GeneralPixel.swift`: adds `updaterAttemptToRestartWithoutResumeBlock` event and mapping.
>   - `PixelDefinitions/pixels/update_pixels.json5`: defines `updater_attempt_to_restart_without_resume_block` pixel.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55195127f6df5c615966b1b9fddda5ca77437fc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->