### PR TITLE
macOS AI Chat improvements 5 - Keep sidebar session - subscribe to chat restoration data

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -254,6 +254,8 @@
 		1E5921C52CF47A0F00E15CCA /* FeatureFlags in Frameworks */ = {isa = PBXBuildFile; productRef = 1E5921C42CF47A0F00E15CCA /* FeatureFlags */; };
 		1E5FA8A62DD394EB0082FA72 /* DuckDuckGoUserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF0E5112AD25A2600FFEC9E /* DuckDuckGoUserAgent.swift */; };
 		1E5FA8A72DD394EB0082FA72 /* DuckDuckGoUserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF0E5112AD25A2600FFEC9E /* DuckDuckGoUserAgent.swift */; };
+		1E66454B2E93F3FB000C8E35 /* AIChatSidebarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E66454A2E93F3FB000C8E35 /* AIChatSidebarTests.swift */; };
+		1E66454C2E93F3FB000C8E35 /* AIChatSidebarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E66454A2E93F3FB000C8E35 /* AIChatSidebarTests.swift */; };
 		1E6783F02E156DA200AE465A /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 1E6783EF2E156DA200AE465A /* Localizable.xcstrings */; };
 		1E6783F12E156DA200AE465A /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 1E6783EF2E156DA200AE465A /* Localizable.xcstrings */; };
 		1E6783F32E156DA200AE465A /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 1E6783EF2E156DA200AE465A /* Localizable.xcstrings */; };
@@ -4254,6 +4256,7 @@
 		1E4EDA272DE9ED2D0019B6E8 /* AIChatSidebarProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSidebarProvider.swift; sourceTree = "<group>"; };
 		1E4EDA2D2DE9ED710019B6E8 /* AIChatSidebarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSidebarViewController.swift; sourceTree = "<group>"; };
 		1E559BB02BBCA9F1002B4AF6 /* RedirectNavigationResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedirectNavigationResponder.swift; sourceTree = "<group>"; };
+		1E66454A2E93F3FB000C8E35 /* AIChatSidebarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSidebarTests.swift; sourceTree = "<group>"; };
 		1E6783EF2E156DA200AE465A /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; name = Localizable.xcstrings; path = DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionAndNotificationTargets/Localizable.xcstrings; sourceTree = SOURCE_ROOT; };
 		1E6783F42E156DA200AE465A /* AppStoreInfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; name = AppStoreInfoPlist.xcstrings; path = NetworkProtectionSystemExtension/AppStoreInfoPlist.xcstrings; sourceTree = SOURCE_ROOT; };
 		1E6783F62E156DA200AE465A /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; name = InfoPlist.xcstrings; path = NetworkProtectionSystemExtension/InfoPlist.xcstrings; sourceTree = SOURCE_ROOT; };
@@ -6801,6 +6804,7 @@
 				31031EB62CC94C6C00684340 /* AIChatRemoteSettingsTests.swift */,
 				31F25EFE2CC3CA00002F9084 /* AIChatMenuConfigurationTests.swift */,
 				1E2A88792E2E477A00C29AC0 /* AIChatSidebarProviderTests.swift */,
+				1E66454A2E93F3FB000C8E35 /* AIChatSidebarTests.swift */,
 				1E2A887F2E2E532600C29AC0 /* AIChatSidebarPresenterTests.swift */,
 			);
 			path = AIChat;
@@ -14292,6 +14296,7 @@
 				84D0B9822E0BD7EA00E3256A /* MockFeatureFlagger.swift in Sources */,
 				3706FE39293F661700E42796 /* TabTests.swift in Sources */,
 				9FAD623E2BD09DE5007F3A65 /* WebsiteInfoTests.swift in Sources */,
+				1E66454C2E93F3FB000C8E35 /* AIChatSidebarTests.swift in Sources */,
 				3767319A2C7F36B300EB097B /* UserBackgroundImageTests.swift in Sources */,
 				3706FE3A293F661700E42796 /* MockVariantManager.swift in Sources */,
 				BB349A4F2E3B8B0E0028AFE1 /* MockDefaultBrowserProvider.swift in Sources */,
@@ -16071,6 +16076,7 @@
 				84A37DF02DAFB68A009E0A68 /* URLDragPreviewProviderTests.swift in Sources */,
 				9F6434702BECBA2800D2D8A0 /* SubscriptionRedirectManagerTests.swift in Sources */,
 				142879DA24CE1179005419BB /* SuggestionViewModelTests.swift in Sources */,
+				1E66454B2E93F3FB000C8E35 /* AIChatSidebarTests.swift in Sources */,
 				4B9292BC2667103100AD2C21 /* BookmarkSidebarTreeControllerTests.swift in Sources */,
 				37697D802D4A0D12004C0CBB /* NewTabPageShownPixelSenderTests.swift in Sources */,
 				9F97B31F2DE8311000653C0D /* DefaultBrowserAndDockPromptFeatureFlaggerTests.swift in Sources */,

--- a/macOS/DuckDuckGo/AIChat/Sidebar/AIChatSidebar.swift
+++ b/macOS/DuckDuckGo/AIChat/Sidebar/AIChatSidebar.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import AIChat
+import Combine
 
 /// A wrapper class that represents the AI Chat sidebar contents and its displayed view controller.
 
@@ -44,7 +45,14 @@ final class AIChatSidebar: NSObject {
 
     /// The view controller that displays the sidebar contents.
     /// This property is set by the AIChatSidebarProvider when the view controller is created.
-    var sidebarViewController: AIChatSidebarViewController?
+    var sidebarViewController: AIChatSidebarViewController? {
+        didSet {
+            subscribeToRestorationDataUpdates()
+        }
+    }
+
+    /// Cancellables for Combine subscriptions
+    private var cancellables = Set<AnyCancellable>()
 
     /// The current AI chat URL being displayed.
     public var currentAIChatURL: URL {
@@ -80,6 +88,20 @@ final class AIChatSidebar: NSObject {
         hiddenAt = date
     }
 
+    /// Subscribes to restoration data updates from the sidebar view controller.
+    /// This method is called automatically when the sidebarViewController is set.
+    private func subscribeToRestorationDataUpdates() {
+        // Cancel existing subscriptions
+        cancellables.removeAll()
+
+        // Subscribe to restoration data updates if the publisher is available
+        sidebarViewController?.chatRestorationDataPublisher?
+            .sink { [weak self] restorationData in
+                self?.restorationData = restorationData
+            }
+            .store(in: &cancellables)
+    }
+
     /// Unloads the sidebar view controller after reading and updating the current AI chat URL and restoration data.
     /// This method ensures the current URL state and restoration data are captured before the view controller is unloaded.
     /// Also marks the sidebar as hidden since the view controller is being unloaded.
@@ -95,6 +117,9 @@ final class AIChatSidebar: NSObject {
             sidebarViewController.removeCompletely()
             self.sidebarViewController = nil
         }
+
+        // Cancel all subscriptions when unloading
+        cancellables.removeAll()
 
         setHidden()
     }

--- a/macOS/DuckDuckGo/AIChat/Sidebar/AIChatSidebarViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/Sidebar/AIChatSidebarViewController.swift
@@ -101,6 +101,10 @@ final class AIChatSidebarViewController: NSViewController {
         aiTab.aiChat?.pageContextRequestedPublisher
     }
 
+    public var chatRestorationDataPublisher: AnyPublisher<AIChatRestorationData?, Never>? {
+        aiTab.aiChat?.chatRestorationDataPublisher
+    }
+
     override func loadView() {
         let container = ColorView(frame: .zero, backgroundColor: visualStyle.colorsProvider.navigationBackgroundColor)
 

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -46,7 +46,7 @@ protocol AIChatUserScriptHandling {
     func getPageContext(params: Any, message: UserScriptMessage) -> Encodable?
     var pageContextPublisher: AnyPublisher<AIChatPageContextData?, Never> { get }
     var pageContextRequestedPublisher: AnyPublisher<Void, Never> { get }
-    var chatRestorationDataPublisher: AnyPublisher<String?, Never> { get }
+    var chatRestorationDataPublisher: AnyPublisher<AIChatRestorationData?, Never> { get }
 
     var messageHandling: AIChatMessageHandling { get }
     func submitAIChatNativePrompt(_ prompt: AIChatNativePrompt)
@@ -66,7 +66,7 @@ struct AIChatUserScriptHandler: AIChatUserScriptHandling {
     private let aiChatNativePromptSubject = PassthroughSubject<AIChatNativePrompt, Never>()
     private let pageContextSubject = PassthroughSubject<AIChatPageContextData?, Never>()
     private let pageContextRequestedSubject = PassthroughSubject<Void, Never>()
-    private let chatRestorationDataSubject = PassthroughSubject<String?, Never>()
+    private let chatRestorationDataSubject = PassthroughSubject<AIChatRestorationData?, Never>()
     private let storage: AIChatPreferencesStorage
     private let windowControllersManager: WindowControllersManagerProtocol
     private let notificationCenter: NotificationCenter

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -46,6 +46,7 @@ protocol AIChatUserScriptHandling {
     func getPageContext(params: Any, message: UserScriptMessage) -> Encodable?
     var pageContextPublisher: AnyPublisher<AIChatPageContextData?, Never> { get }
     var pageContextRequestedPublisher: AnyPublisher<Void, Never> { get }
+    var chatRestorationDataPublisher: AnyPublisher<String?, Never> { get }
 
     var messageHandling: AIChatMessageHandling { get }
     func submitAIChatNativePrompt(_ prompt: AIChatNativePrompt)
@@ -60,10 +61,12 @@ struct AIChatUserScriptHandler: AIChatUserScriptHandling {
     public let aiChatNativePromptPublisher: AnyPublisher<AIChatNativePrompt, Never>
     public let pageContextPublisher: AnyPublisher<AIChatPageContextData?, Never>
     public let pageContextRequestedPublisher: AnyPublisher<Void, Never>
+    public let chatRestorationDataPublisher: AnyPublisher<AIChatRestorationData?, Never>
 
     private let aiChatNativePromptSubject = PassthroughSubject<AIChatNativePrompt, Never>()
     private let pageContextSubject = PassthroughSubject<AIChatPageContextData?, Never>()
     private let pageContextRequestedSubject = PassthroughSubject<Void, Never>()
+    private let chatRestorationDataSubject = PassthroughSubject<String?, Never>()
     private let storage: AIChatPreferencesStorage
     private let windowControllersManager: WindowControllersManagerProtocol
     private let notificationCenter: NotificationCenter
@@ -87,6 +90,7 @@ struct AIChatUserScriptHandler: AIChatUserScriptHandling {
         self.aiChatNativePromptPublisher = aiChatNativePromptSubject.eraseToAnyPublisher()
         self.pageContextPublisher = pageContextSubject.eraseToAnyPublisher()
         self.pageContextRequestedPublisher = pageContextRequestedSubject.eraseToAnyPublisher()
+        self.chatRestorationDataPublisher = chatRestorationDataSubject.eraseToAnyPublisher()
     }
 
     enum AIChatKeys {
@@ -151,6 +155,7 @@ struct AIChatUserScriptHandler: AIChatUserScriptHandling {
         else { return nil }
 
         messageHandling.setData(data, forMessageType: .chatRestorationData)
+        chatRestorationDataSubject.send(data)
         return nil
     }
 
@@ -163,6 +168,7 @@ struct AIChatUserScriptHandler: AIChatUserScriptHandling {
 
     public func removeChat(params: Any, message: any UserScriptMessage) -> (any Encodable)? {
         messageHandling.setData(nil, forMessageType: .chatRestorationData)
+        chatRestorationDataSubject.send(nil)
         return nil
     }
 

--- a/macOS/DuckDuckGo/Tab/TabExtensions/AIChatTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/AIChatTabExtension.swift
@@ -45,6 +45,7 @@ final class AIChatTabExtension {
          isLoadedInSidebar: Bool) {
         self.isLoadedInSidebar = isLoadedInSidebar
         pageContextRequestedPublisher = pageContextRequestedSubject.eraseToAnyPublisher()
+        chatRestorationDataPublisher = chatRestorationDataSubject.eraseToAnyPublisher()
 
         webViewPublisher.sink { [weak self] webView in
             self?.webView = webView
@@ -93,10 +94,19 @@ final class AIChatTabExtension {
                 self?.pageContextRequestedSubject.send()
             }
             .store(in: &userScriptCancellables)
+
+        aiChatUserScript.handler.chatRestorationDataPublisher
+            .sink { [weak self] data in
+                self?.chatRestorationDataSubject.send(data)
+            }
+            .store(in: &userScriptCancellables)
     }
 
     private let pageContextRequestedSubject = PassthroughSubject<Void, Never>()
     let pageContextRequestedPublisher: AnyPublisher<Void, Never>
+
+    private let chatRestorationDataSubject = PassthroughSubject<AIChatRestorationData?, Never>()
+    let chatRestorationDataPublisher: AnyPublisher<AIChatRestorationData?, Never>
 
     private var temporaryAIChatNativeHandoffData: AIChatPayload?
     func setAIChatNativeHandoffData(payload: AIChatPayload) {
@@ -183,6 +193,7 @@ protocol AIChatProtocol: AnyObject, NavigationResponder {
     func submitPageContext(_ pageContext: AIChatPageContextData?)
 
     var pageContextRequestedPublisher: AnyPublisher<Void, Never> { get }
+    var chatRestorationDataPublisher: AnyPublisher<AIChatRestorationData?, Never> { get }
 }
 
 extension AIChatTabExtension: AIChatProtocol, TabExtension {

--- a/macOS/UnitTests/AIChat/AIChatSidebarTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatSidebarTests.swift
@@ -1,0 +1,133 @@
+//
+//  AIChatSidebarTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Combine
+import AIChat
+@testable import DuckDuckGo_Privacy_Browser
+
+final class AIChatSidebarTests: XCTestCase {
+
+    var sidebar: AIChatSidebar!
+
+    override func setUp() {
+        super.setUp()
+        sidebar = AIChatSidebar(burnerMode: .regular)
+    }
+
+    override func tearDown() {
+        sidebar = nil
+        super.tearDown()
+    }
+
+    // MARK: - Initialization Tests
+
+    func testInit_setsDefaultProperties() {
+        // Given & When
+        let sidebar = AIChatSidebar(burnerMode: .regular)
+
+        // Then
+        XCTAssertNil(sidebar.restorationData)
+        XCTAssertFalse(sidebar.isPresented)
+        XCTAssertNil(sidebar.hiddenAt)
+        XCTAssertNil(sidebar.sidebarViewController)
+    }
+
+    // MARK: - Unload View Controller Tests
+
+    func testUnloadViewController_withPersistingState_clearsViewController() {
+        // Given
+        let aiChatRemoteSettings = AIChatRemoteSettings()
+        let initialAIChatURL = aiChatRemoteSettings.aiChatURL.forAIChatSidebar()
+        let viewController = AIChatSidebarViewController(currentAIChatURL: initialAIChatURL, burnerMode: .regular)
+        sidebar.sidebarViewController = viewController
+        XCTAssertNotNil(sidebar.sidebarViewController)
+
+        // When
+        sidebar.unloadViewController(persistingState: true)
+
+        // Then
+        XCTAssertNil(sidebar.sidebarViewController)
+        XCTAssertFalse(sidebar.isPresented)
+        XCTAssertNotNil(sidebar.hiddenAt)
+    }
+
+    func testUnloadViewController_withoutPersistingState_clearsViewController() {
+        // Given
+        let aiChatRemoteSettings = AIChatRemoteSettings()
+        let initialAIChatURL = aiChatRemoteSettings.aiChatURL.forAIChatSidebar()
+        let viewController = AIChatSidebarViewController(currentAIChatURL: initialAIChatURL, burnerMode: .regular)
+        sidebar.sidebarViewController = viewController
+        XCTAssertNotNil(sidebar.sidebarViewController)
+
+        // When
+        sidebar.unloadViewController(persistingState: false)
+
+        // Then
+        XCTAssertNil(sidebar.sidebarViewController)
+        XCTAssertFalse(sidebar.isPresented)
+        XCTAssertNotNil(sidebar.hiddenAt)
+    }
+
+    func testUnloadViewController_setsHiddenState() {
+        // Given
+        let aiChatRemoteSettings = AIChatRemoteSettings()
+        let initialAIChatURL = aiChatRemoteSettings.aiChatURL.forAIChatSidebar()
+        let viewController = AIChatSidebarViewController(currentAIChatURL: initialAIChatURL, burnerMode: .regular)
+        sidebar.sidebarViewController = viewController
+        sidebar.setRevealed()
+        XCTAssertTrue(sidebar.isPresented)
+        XCTAssertNil(sidebar.hiddenAt)
+
+        // When
+        sidebar.unloadViewController(persistingState: true)
+
+        // Then
+        XCTAssertFalse(sidebar.isPresented)
+        XCTAssertNotNil(sidebar.hiddenAt)
+    }
+
+    // MARK: - State Management Tests
+
+    func testSetRevealed_clearsHiddenAt() {
+        // Given
+        sidebar.setHidden()
+        XCTAssertNotNil(sidebar.hiddenAt)
+
+        // When
+        sidebar.setRevealed()
+
+        // Then
+        XCTAssertTrue(sidebar.isPresented)
+        XCTAssertNil(sidebar.hiddenAt)
+    }
+
+    func testSetHidden_setsHiddenAt() {
+        // Given
+        sidebar.setRevealed()
+        XCTAssertTrue(sidebar.isPresented)
+        XCTAssertNil(sidebar.hiddenAt)
+
+        // When
+        sidebar.setHidden()
+
+        // Then
+        XCTAssertFalse(sidebar.isPresented)
+        XCTAssertNotNil(sidebar.hiddenAt)
+    }
+}

--- a/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
@@ -118,6 +118,7 @@ final class MockAIChatUserScriptHandler: AIChatUserScriptHandling {
     var didTogglePageContextTelemetry = false
     var pageContextSubject = PassthroughSubject<AIChatPageContextData?, Never>()
     var pageContextRequestedSubject = PassthroughSubject<Void, Never>()
+    var chatRestorationDataSubject = PassthroughSubject<AIChatRestorationData?, Never>()
 
     var didReportMetric = false
 
@@ -201,6 +202,10 @@ final class MockAIChatUserScriptHandler: AIChatUserScriptHandling {
 
     var pageContextRequestedPublisher: AnyPublisher<Void, Never> {
         pageContextRequestedSubject.eraseToAnyPublisher()
+    }
+
+    var chatRestorationDataPublisher: AnyPublisher<AIChatRestorationData?, Never> {
+        chatRestorationDataSubject.eraseToAnyPublisher()
     }
 
     func submitPageContext(_ pageContext: AIChatPageContextData?) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1211026820773885?focus=true
Tech Design URL:
CC:

### Description
This expands logic for persisting sidebar state _when recent chats are OFF_ and fixes a bug described in https://app.asana.com/1/137249556945/project/1203936086921904/task/1211520488267800. The core implementation was in https://github.com/duckduckgo/apple-browsers/pull/2035

### Testing Steps
1. In Duck.ai disable recent chats
2. Navigate to a website
3. Open a sidebar and have a conversation there
4. Close the sidebar and reopen it to confirm that the state is persisted
5. Click "+ New" to start a new conversation - but don't type anything
6. Close the sidebar and reopen it
7. Verify that an empty conversation is loaded not the previous one

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)