### PR TITLE
macOS: Disable themes feature flag for internal users

### DIFF
--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -438,7 +438,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .syncFeatureLevel3:
             return .remoteReleasable(.subfeature(SyncSubfeature.level3AllowCreateAccount))
         case .themes:
-            return .internalOnly()
+            return .disabled
         case .appStoreUpdateFlow:
             return .remoteReleasable(.feature(.appStoreUpdateFlow))
         case .unifiedURLPredictor:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211569720561406?focus=true
Tech Design URL:
CC:

### Description
Disable the `themes` feature flag for internal users.

### Testing Steps
1. Run the app, set internal user state
2. Remove all feature flag overrides
3. Go to Settings -> Appearance, check that the Light, Dark, and System picker is visible.
4. Turn on the `themes` feature flag.
5. Go to Settings -> Appearance, check that the theme picker is shown.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables the `themes` feature flag by changing its source from `internalOnly()` to `disabled`.
> 
> - **Feature Flags**:
>   - `FeatureFlag.themes`: change `source` from `internalOnly()` to `disabled` in `macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a4b30c541dead8c98bedb78041c5565e8b9fe97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->