### PR TITLE
Fix dax title color on dark mode

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/DaxLogo/AnimatedDaxLogoView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/DaxLogo/AnimatedDaxLogoView.swift
@@ -21,7 +21,15 @@ import UIKit
 import Lottie
 
 final class AnimatedDaxLogoView: UIView, DaxLogoViewSwitching {
-    private(set) lazy var logoAnimation = LottieAnimationView(name: Constant.daxLogoAnimationName)
+    private(set) lazy var logoAnimation = LottieAnimationView(name: daxAnimationName)
+
+    private var daxAnimationName: String {
+        if traitCollection.userInterfaceStyle == .dark {
+            return Constant.daxLogoAnimationDarkName
+        } else {
+            return Constant.daxLogoAnimationName
+        }
+    }
 
     init() {
         super.init(frame: .zero)
@@ -56,11 +64,7 @@ final class AnimatedDaxLogoView: UIView, DaxLogoViewSwitching {
 
     private func updateAnimationForCurrentTraitCollection() {
         let progress = logoAnimation.currentProgress
-        if traitCollection.userInterfaceStyle == .dark {
-            logoAnimation.animation = LottieAnimation.named(Constant.daxLogoAnimationDarkName)
-        } else {
-            logoAnimation.animation = LottieAnimation.named(Constant.daxLogoAnimationName)
-        }
+        logoAnimation.animation = LottieAnimation.named(daxAnimationName)
         logoAnimation.currentProgress = progress
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1211550795622086?focus=true

### Description
Fix dax title color on dark mode

### Testing Steps
1. Enable the new duck.ai address bar in AI Features
2. Test in light mode the dax logo color in both search and duck.ai. Make sure to open the NTP from the tab switcher menu
3. Change the app to dark mode, do the same steps as step 2
4. Change dark/light mode with the NTP opened and check the title color

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
Wrong color in the title
