### PR TITLE
fix privacy dashboard toggle

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarPopovers.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarPopovers.swift
@@ -414,19 +414,20 @@ final class NavigationBarPopovers: NSObject, PopoverPresenter {
         let privacyDashboardViewController = privacyDashboardPopover.viewController
 
         privacyDashboadPendingUpdatesCancellable = privacyDashboardViewController.rulesUpdateObserver
-            .$pendingUpdates.dropFirst().receive(on: DispatchQueue.main).sink { [weak privacyDashboardPopover] _ in
+            .$pendingUpdates.dropFirst().receive(on: DispatchQueue.main).sink { [weak self] _ in
                 let isPendingUpdate = privacyDashboardViewController.isPendingUpdates()
-
+                guard let self else { return }
             // Prevent popover from being closed when clicking away, while pending updates
             if isPendingUpdate {
-                privacyDashboardPopover?.behavior = .applicationDefined
+                self.privacyDashboardPopover?.behavior = .applicationDefined
             } else {
-                privacyDashboardPopover?.close()
+                self.privacyDashboardPopover?.close()
 #if DEBUG
-                privacyDashboardPopover?.behavior = .semitransient
+                self.privacyDashboardPopover?.behavior = .semitransient
 #else
-                privacyDashboardPopover?.behavior = .transient
+                self.privacyDashboardPopover?.behavior = .transient
 #endif
+                self.resetPrivacyDashboardPopover()
             }
         }
     }
@@ -604,9 +605,7 @@ extension NavigationBarPopovers: NSPopoverDelegate {
         case privacyDashboardPopover:
             // Prevent popover from being deallocated while pending updates
             if let popover = privacyDashboardPopover, !popover.viewController.isPendingUpdates() {
-                privacyDashboardPopover = nil
-                privacyInfoCancellable = nil
-                privacyDashboadPendingUpdatesCancellable = nil
+                resetPrivacyDashboardPopover()
             }
 
         case zoomPopover:
@@ -615,6 +614,12 @@ extension NavigationBarPopovers: NSPopoverDelegate {
 
         default: break
         }
+    }
+
+    private func resetPrivacyDashboardPopover() {
+        privacyDashboardPopover = nil
+        privacyInfoCancellable = nil
+        privacyDashboadPendingUpdatesCancellable = nil
     }
 
 }

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarPopovers.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarPopovers.swift
@@ -228,6 +228,7 @@ final class NavigationBarPopovers: NSObject, PopoverPresenter {
 
     func togglePrivacyDashboardPopover(for tabViewModel: TabViewModel?, from button: MouseOverButton, entryPoint: PrivacyDashboardEntryPoint) {
         if privacyDashboardPopover?.isShown == true {
+            print("Sabrina: togglePrivacyDashboardPopover")
             closePrivacyDashboard()
         } else if let tabViewModel {
             openPrivacyDashboard(for: tabViewModel, from: button, entryPoint: entryPoint)
@@ -437,6 +438,7 @@ final class NavigationBarPopovers: NSObject, PopoverPresenter {
               !popover.viewController.isPendingUpdates() else { return }
 
         popover.close()
+        print("Sabrina: popover.close() from closePrivacyDashboard")
     }
 
     func showPasswordManagementPopover(selectedCategory: SecureVaultSorting.Category?, from button: MouseOverButton, withDelegate delegate: NSPopoverDelegate, source: PasswordManagementSource?) {
@@ -602,7 +604,10 @@ extension NavigationBarPopovers: NSPopoverDelegate {
             bookmarkPopover = nil
 
         case privacyDashboardPopover:
-            closePrivacyDashboard()
+            // Prevent popover from being deallocated while pending updates
+            if let popover = privacyDashboardPopover, !popover.viewController.isPendingUpdates() {
+                privacyDashboardPopover = nil
+            }
             privacyInfoCancellable = nil
             privacyDashboadPendingUpdatesCancellable = nil
 

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarPopovers.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarPopovers.swift
@@ -228,7 +228,6 @@ final class NavigationBarPopovers: NSObject, PopoverPresenter {
 
     func togglePrivacyDashboardPopover(for tabViewModel: TabViewModel?, from button: MouseOverButton, entryPoint: PrivacyDashboardEntryPoint) {
         if privacyDashboardPopover?.isShown == true {
-            print("Sabrina: togglePrivacyDashboardPopover")
             closePrivacyDashboard()
         } else if let tabViewModel {
             openPrivacyDashboard(for: tabViewModel, from: button, entryPoint: entryPoint)
@@ -438,7 +437,6 @@ final class NavigationBarPopovers: NSObject, PopoverPresenter {
               !popover.viewController.isPendingUpdates() else { return }
 
         popover.close()
-        print("Sabrina: popover.close() from closePrivacyDashboard")
     }
 
     func showPasswordManagementPopover(selectedCategory: SecureVaultSorting.Category?, from button: MouseOverButton, withDelegate delegate: NSPopoverDelegate, source: PasswordManagementSource?) {
@@ -607,9 +605,9 @@ extension NavigationBarPopovers: NSPopoverDelegate {
             // Prevent popover from being deallocated while pending updates
             if let popover = privacyDashboardPopover, !popover.viewController.isPendingUpdates() {
                 privacyDashboardPopover = nil
+                privacyInfoCancellable = nil
+                privacyDashboadPendingUpdatesCancellable = nil
             }
-            privacyInfoCancellable = nil
-            privacyDashboadPendingUpdatesCancellable = nil
 
         case zoomPopover:
             zoomPopoverDelegate?.popoverDidClose?(notification)

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarPopovers.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarPopovers.swift
@@ -414,20 +414,20 @@ final class NavigationBarPopovers: NSObject, PopoverPresenter {
         let privacyDashboardViewController = privacyDashboardPopover.viewController
 
         privacyDashboadPendingUpdatesCancellable = privacyDashboardViewController.rulesUpdateObserver
-            .$pendingUpdates.dropFirst().receive(on: DispatchQueue.main).sink { [weak self] _ in
+            .$pendingUpdates.dropFirst().receive(on: DispatchQueue.main).sink { [weak privacyDashboardPopover, weak self] _ in
                 let isPendingUpdate = privacyDashboardViewController.isPendingUpdates()
-                guard let self else { return }
+
             // Prevent popover from being closed when clicking away, while pending updates
             if isPendingUpdate {
-                self.privacyDashboardPopover?.behavior = .applicationDefined
+                privacyDashboardPopover?.behavior = .applicationDefined
             } else {
-                self.privacyDashboardPopover?.close()
+                privacyDashboardPopover?.close()
 #if DEBUG
-                self.privacyDashboardPopover?.behavior = .semitransient
+                privacyDashboardPopover?.behavior = .semitransient
 #else
-                self.privacyDashboardPopover?.behavior = .transient
+                privacyDashboardPopover?.behavior = .transient
 #endif
-                self.resetPrivacyDashboardPopover()
+                self?.resetPrivacyDashboardPopover()
             }
         }
     }

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarPopovers.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarPopovers.swift
@@ -602,7 +602,7 @@ extension NavigationBarPopovers: NSPopoverDelegate {
             bookmarkPopover = nil
 
         case privacyDashboardPopover:
-            privacyDashboardPopover = nil
+            closePrivacyDashboard()
             privacyInfoCancellable = nil
             privacyDashboadPendingUpdatesCancellable = nil
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1211533077233322?focus=true

### Description Fix a bug where on rules compilation the page is not reloaded and therefore protection are not abled or disabled as the user asks.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. ./clean-app.sh debug
2. Launch the browser
3. Navigate a site 
4. go to the privacy dashboard and deactivate protection
5. Check the page is reloaded, hover on the shield and check shield and dashboard status match
6. Check that re-enable protections works as expected
7. Try a couple of other sites

### Impact and Risks
<!— 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
—>

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents the Privacy Dashboard popover from being deallocated while updates are pending and resets related state once updates complete.
> 
> - **Privacy Dashboard Popover**:
>   - **Pending Updates Handling**: Update sink to capture `self` weakly and call `resetPrivacyDashboardPopover()` after updates finish; keep behavior transient/semitransient accordingly.
>   - **Close Lifecycle**: On `popoverDidClose`, only reset when there are no pending updates to avoid premature deallocation.
>   - **Refactor**: Add `resetPrivacyDashboardPopover()` to clear `privacyDashboardPopover` and related cancellables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 560dc1bd44d5cf397f4a011da2d4368267e15eb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->