### PR TITLE
Make Navigation dependency explicit for PrivacyDashboard

### DIFF
--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -283,7 +283,8 @@ let package = Package(
                 "Persistence",
                 "BrowserServicesKit",
                 "MaliciousSiteProtection",
-                .product(name: "PrivacyDashboardResources", package: "privacy-dashboard")
+                .product(name: "PrivacyDashboardResources", package: "privacy-dashboard"),
+                "Navigation",
             ],
             path: "Sources/PrivacyDashboard",
             swiftSettings: [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1211582706967749?focus=true
Tech Design URL:
CC:

### Description

“PrivacyDashboard” depends on “Navigation” but this is not explicit in Package.swift.  When opening BSK Package.swift and run tests the compiler complain about undefined symbols

```
Undefined symbols for architecture arm64:
  "direct field offset for Navigation.WKPageLoadTiming.navigationStart : Foundation.Date?", referenced from:
      PrivacyDashboard.BrokenSiteReport.(addPageLoadTimingParameters in _200149F2409D48D262D5B201F3B0D02F)(to: inout [Swift.String : Swift.String], timing: Navigation.WKPageLoadTiming) -> () in PrivacyDashboard.o
  "direct field offset for Navigation.WKPageLoadTiming.firstVisualLayout : Foundation.Date?", referenced from:
      PrivacyDashboard.BrokenSiteReport.(addPageLoadTimingParameters in _200149F2409D48D262D5B201F3B0D02F)(to: inout [Swift.String : Swift.String], timing: Navigation.WKPageLoadTiming) -> () in PrivacyDashboard.o
  "direct field offset for Navigation.WKPageLoadTiming.firstMeaningfulPaint : Foundation.Date?", referenced from:
      PrivacyDashboard.BrokenSiteReport.(addPageLoadTimingParameters in _200149F2409D48D262D5B201F3B0D02F)(to: inout [Swift.String : Swift.String], timing: Navigation.WKPageLoadTiming) -> () in PrivacyDashboard.o
  "direct field offset for Navigation.WKPageLoadTiming.documentFinishedLoading : Foundation.Date?", referenced from:
      PrivacyDashboard.BrokenSiteReport.(addPageLoadTimingParameters in _200149F2409D48D262D5B201F3B0D02F)(to: inout [Swift.String : Swift.String], timing: Navigation.WKPageLoadTiming) -> () in PrivacyDashboard.o
  "direct field offset for Navigation.WKPageLoadTiming.allSubresourcesFinishedLoading : Foundation.Date?", referenced from:
      PrivacyDashboard.BrokenSiteReport.(addPageLoadTimingParameters in _200149F2409D48D262D5B201F3B0D02F)(to: inout [Swift.String : Swift.String], timing: Navigation.WKPageLoadTiming) -> () in PrivacyDashboard.o
  "nominal type descriptor for Navigation.WKPageLoadTiming", referenced from:
      _symbolic _____Sg 10Navigation16WKPageLoadTimingC in PrivacyDashboard.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This PR fixes the issue by make the dependency explicit in Package.swift

### Testing Steps
1. Check out the code
2. Open BSK Package.swift
3. Run tests
4. Ensure code compiles and test pass.

### Impact and Risks
None

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `Navigation` an explicit dependency of `PrivacyDashboard` in `SharedPackages/BrowserServicesKit/Package.swift`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4736ffccd9aed5bb22418c653bdf935f0fc3202. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->