### PR TITLE
Add fireproof domains from Fireproof manager dialog

### DIFF
--- a/macOS/DuckDuckGo/Common/Extensions/NSAlertExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/NSAlertExtension.swift
@@ -279,6 +279,26 @@ extension NSAlert {
         return alert
     }
 
+    /// Creates a prompt for adding a new Fireproof domain, returning the configured alert and the bound text field.
+    /// Caller can run it as a sheet or modally and read the domain from the returned text field.
+    static func fireproofAddDomainPrompt() -> (alert: NSAlert, textField: NSTextField) {
+        let alert = NSAlert()
+        alert.messageText = UserText.fireproofAddTitle
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: UserText.fireproofAddButton)
+        alert.addButton(withTitle: UserText.cancel)
+
+        let textField = NSTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 24))
+        textField.maximumNumberOfLines = 1
+        textField.lineBreakMode = .byTruncatingTail
+        textField.placeholderString = "example.com"
+        alert.accessoryView = textField
+        alert.window.initialFirstResponder = textField
+        return (alert, textField)
+    }
+
+    // Intentionally no presenting helper: callers own sheet presentation and validation
+
     @discardableResult
     func runModal() async -> NSApplication.ModalResponse {
         await withCheckedContinuation { continuation in

--- a/macOS/DuckDuckGo/Fireproofing/Model/FireproofDomains.swift
+++ b/macOS/DuckDuckGo/Fireproofing/Model/FireproofDomains.swift
@@ -151,6 +151,17 @@ internal class FireproofDomains: DomainFireproofStatusProviding {
         }
     }
 
+    /// Validates and normalizes arbitrary user input (URL or host) into an eTLD+1 host.
+    /// Returns nil if the input is empty, invalid, or already fireproofed.
+    func normalizedHost(fromUserInput input: String) -> String? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let url = URL(trimmedAddressBarString: trimmed),
+              url.navigationalScheme?.isHypertextScheme == true,
+              let eTLDPlus1Domain = tld.eTLDplus1(url.host) else { return nil }
+        return eTLDPlus1Domain
+    }
+
     func remove(domain: String, changeToETLDPlus1: Bool = true) {
         dispatchPrecondition(condition: .onQueue(.main))
 

--- a/macOS/DuckDuckGo/Preferences/View/FireproofDomainsViewController.swift
+++ b/macOS/DuckDuckGo/Preferences/View/FireproofDomainsViewController.swift
@@ -39,6 +39,8 @@ final class FireproofDomainsViewController: NSViewController {
 
     // MARK: - UI
     private let buttonsStackView = NSStackView()
+    private lazy var addDomainButton = NSButton(title: UserText.fireproofAddButton, target: self, action: #selector(addDomain(_:)))
+    private lazy var addCurrentDomainButton = NSButton(title: UserText.fireproofAddCurrentButton, target: self, action: #selector(addCurrentDomain(_:)))
     private lazy var removeDomainButton = NSButton(title: UserText.remove, target: self, action: #selector(removeSelectedDomain(_:)))
     private lazy var removeAllDomainsButton = NSButton(title: UserText.fireproofRemoveAllButton, target: self, action: #selector(removeAllDomains(_:)))
     private lazy var doneButton = NSButton(title: UserText.done, target: self, action: #selector(doneButtonClicked(_:)))
@@ -116,10 +118,14 @@ final class FireproofDomainsViewController: NSViewController {
         tableView.dataSource = self
 
         // Buttons
+        addDomainButton.setAccessibilityIdentifier("FireproofDomainsViewController.addButton")
+        addCurrentDomainButton.setAccessibilityIdentifier("FireproofDomainsViewController.addCurrentButton")
         removeDomainButton.setAccessibilityIdentifier("FireproofDomainsViewController.removeButton")
         removeAllDomainsButton.setAccessibilityIdentifier("FireproofDomainsViewController.removeAllButton")
         doneButton.setAccessibilityIdentifier("FireproofDomainsViewController.doneButton")
 
+        configureToolbarButton(addDomainButton)
+        configureToolbarButton(addCurrentDomainButton)
         configureToolbarButton(removeDomainButton)
         configureToolbarButton(removeAllDomainsButton)
         configureToolbarButton(doneButton)
@@ -127,6 +133,8 @@ final class FireproofDomainsViewController: NSViewController {
         buttonsStackView.orientation = .horizontal
         buttonsStackView.spacing = 12
         buttonsStackView.translatesAutoresizingMaskIntoConstraints = false
+        buttonsStackView.addArrangedSubview(addDomainButton)
+        buttonsStackView.addArrangedSubview(addCurrentDomainButton)
         buttonsStackView.addArrangedSubview(removeDomainButton)
         buttonsStackView.addArrangedSubview(removeAllDomainsButton)
         view.addSubview(buttonsStackView)
@@ -206,6 +214,7 @@ final class FireproofDomainsViewController: NSViewController {
         let hasAnyDomains = !allFireproofDomains.isEmpty
         removeAllDomainsButton.isEnabled = hasAnyDomains
         searchBar.isEnabled = hasAnyDomains
+        updateAddCurrentButtonState()
     }
 
     private func updateFilteredFireproofDomains() {
@@ -223,6 +232,70 @@ final class FireproofDomainsViewController: NSViewController {
         dismiss()
     }
 
+    @objc private func addDomain(_ sender: NSButton) {
+        guard let window = view.window else {
+            assertionFailure("Expected to have a valid window to present from")
+            return
+        }
+        let (alert, textField) = NSAlert.fireproofAddDomainPrompt()
+        guard let firstButton = alert.buttons.first else {
+            assertionFailure("Expected to have a 'Add' button in the alert")
+            return
+        }
+
+        // Pre-fill with current tab domain if available
+        if let mainWindowController = Application.appDelegate.windowControllersManager.mainWindowController(for: view.window),
+           let url = mainWindowController.mainViewController.tabCollectionViewModel.selectedTab?.url,
+           url.navigationalScheme?.isHypertextScheme ?? false,
+           let host = url.host {
+            textField.stringValue = host
+        }
+        // Live validation: enable Add only when input resolves to a hypertext URL host (canFireproof)
+        let changeObserver = NotificationCenter.default.addObserver(forName: NSControl.textDidChangeNotification, object: textField, queue: .main) { [weak self] _ in
+            guard let self else { return }
+            firstButton.isEnabled = self.isInputFireproofable(textField.stringValue)
+        }
+        // Initial state based on the (possibly prefilled) text
+        firstButton.isEnabled = isInputFireproofable(textField.stringValue)
+
+        alert.beginSheetModal(for: window) { [weak self] response in
+            NotificationCenter.default.removeObserver(changeObserver)
+            guard let self,
+                  response == .alertFirstButtonReturn,
+                  self.isInputFireproofable(textField.stringValue),
+                  let host = self.fireproofDomains.normalizedHost(fromUserInput: textField.stringValue) else { return }
+            self.addDomainSilently(host)
+        }
+    }
+
+    private func isInputFireproofable(_ input: String) -> Bool {
+        guard let host = fireproofDomains.normalizedHost(fromUserInput: input) else { return false }
+        // Apply same rule as toolbar/menu enablement: only hypertext schemes and not DDG domain
+        let candidate = URL(string: URL.NavigationalScheme.https.separated() + host)
+        return (candidate?.canFireproof ?? false) && !fireproofDomains.isFireproof(fireproofDomain: host)
+    }
+
+    @objc private func addCurrentDomain(_ sender: NSButton) {
+        guard let mainWindowController = Application.appDelegate.windowControllersManager.mainWindowController(for: view.window),
+              let url = mainWindowController.mainViewController.tabCollectionViewModel.selectedTab?.url,
+              url.canFireproof,
+              let host = url.host else {
+            assertionFailure("Expected to have a valid main window, a tab with a valid, fireproofable URL, and a valid host")
+            return
+        }
+
+        let before = Set(allFireproofDomains)
+        fireproofDomains.add(domain: host)
+        reloadData()
+        let after = Set(allFireproofDomains)
+        if let actuallyAdded = after.subtracting(before).first {
+            undoManager?.registerUndo(withTarget: self) { vc in
+                vc.removeDomainSilently(actuallyAdded, setActionName: false)
+            }
+            if undoManager?.isUndoing == false { undoManager?.setActionName(UserText.fireproofAddCurrentButton) }
+        }
+    }
+
     @objc private func removeSelectedDomain(_ sender: NSButton) {
         deleteSelectedItems()
     }
@@ -232,10 +305,9 @@ final class FireproofDomainsViewController: NSViewController {
 
         undoManager?.beginUndoGrouping()
         undoManager?.registerUndo(withTarget: self) { vc in
-            domainsBeforeClear.forEach { vc.fireproofDomains.add(domain: $0) }
-            vc.reloadData()
+            domainsBeforeClear.forEach { vc.addDomainSilently($0, setActionName: false) }
         }
-        undoManager?.setActionName(UserText.fireproofRemoveAllButton)
+        if undoManager?.isUndoing == false { undoManager?.setActionName(UserText.fireproofRemoveAllButton) }
         undoManager?.endUndoGrouping()
 
         fireproofDomains.clearAll()
@@ -260,11 +332,10 @@ final class FireproofDomainsViewController: NSViewController {
         undoManager?.beginUndoGrouping()
         for domain in domains {
             undoManager?.registerUndo(withTarget: self) { vc in
-                vc.fireproofDomains.add(domain: domain)
-                vc.reloadData()
+                vc.addDomainSilently(domain, setActionName: false)
             }
         }
-        undoManager?.setActionName(UserText.remove)
+        if undoManager?.isUndoing == false { undoManager?.setActionName(UserText.remove) }
         undoManager?.endUndoGrouping()
 
         domains.forEach { fireproofDomains.remove(domain: $0) }
@@ -282,6 +353,18 @@ final class FireproofDomainsViewController: NSViewController {
         return true
     }
 
+    private func updateAddCurrentButtonState() {
+        guard let sourceWindow = view.window else { return }
+
+        let mainWindowController = Application.appDelegate.windowControllersManager.mainWindowController(for: sourceWindow)
+        let url = mainWindowController?.mainViewController.tabCollectionViewModel.selectedTab?.url
+        if let url, url.canFireproof, let host = url.host {
+            addCurrentDomainButton.isEnabled = !fireproofDomains.isFireproof(fireproofDomain: host)
+        } else {
+            addCurrentDomainButton.isEnabled = false
+        }
+    }
+
     override func keyDown(with event: NSEvent) {
         switch Int(event.keyCode) {
         case kVK_Delete, kVK_ForwardDelete:
@@ -296,6 +379,30 @@ final class FireproofDomainsViewController: NSViewController {
     override func cancelOperation(_ sender: Any?) {
         dismiss()
     }
+
+    // MARK: - Undo/Redo helpers
+    private func addDomainSilently(_ domain: String, setActionName: Bool = true) {
+        fireproofDomains.add(domain: domain)
+        reloadData()
+        undoManager?.registerUndo(withTarget: self) { vc in
+            vc.removeDomainSilently(domain, setActionName: setActionName)
+        }
+        if setActionName, undoManager?.isUndoing == false {
+            undoManager?.setActionName(UserText.fireproofAddButton)
+        }
+    }
+
+    private func removeDomainSilently(_ domain: String, setActionName: Bool = true) {
+        fireproofDomains.remove(domain: domain)
+        reloadData()
+        undoManager?.registerUndo(withTarget: self) { vc in
+            vc.addDomainSilently(domain, setActionName: setActionName)
+        }
+        if setActionName, undoManager?.isUndoing == false {
+            undoManager?.setActionName(UserText.remove)
+        }
+    }
+
 }
 // MARK: - NSTableViewDataSource
 extension FireproofDomainsViewController: NSTableViewDataSource, NSTableViewDelegate {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1211586281230235?focus=true

### Description
- add Add, Add Current site buttons to the Manage Fireproof Sites dialog

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. open the Manage Fireproof domains dialog from Settings -> Data Clearing: validate no blinking and favicons are shown with letters for missing favicons, Add button should display an alert and domain should be added, Add button should be disabled when invalid domain name is entered
2. Activate "fireDialog" feature flag; open fire dialog from the Fire Dialog using the "Manage" buttons
3. Validate Add Current button only enabled when there's a correct websites loaded
4. Validate cmd+z removes added site, cmd+shift+z re-adds it

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
Incorrect "Add" sites buttons behavior

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)