### PR TITLE
Fix restoring Duck.ai sidebars in proper state

### DIFF
--- a/macOS/DuckDuckGo/Common/Extensions/NSCoderExtensions.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/NSCoderExtensions.swift
@@ -45,6 +45,11 @@ extension NSCoder {
         return decodeInteger(forKey: key)
     }
 
+    func decodeIfPresent(at key: String) -> Bool? {
+        guard containsValue(forKey: key) else { return nil }
+        return decodeBool(forKey: key)
+    }
+
     func decodeIfPresent<T: NSObject>(at key: String) -> T? where T: NSSecureCoding {
         guard containsValue(forKey: key) else { return nil }
         return decodeObject(of: T.self, forKey: key)

--- a/macOS/DuckDuckGo/StateRestoration/WindowManager+StateRestoration.swift
+++ b/macOS/DuckDuckGo/StateRestoration/WindowManager+StateRestoration.swift
@@ -34,7 +34,8 @@ extension WindowsManager {
         }
 
         if let aiChatSidebarsByTab = state.aiChatSidebarsByTab {
-            Application.appDelegate.aiChatSidebarProvider.restoreState(aiChatSidebarsByTab)
+            let presentedSidebars = aiChatSidebarsByTab.filter { (_, value) in value.isPresented }
+            Application.appDelegate.aiChatSidebarProvider.restoreState(presentedSidebars)
         }
 
         if includeWindows {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1211577344115122?focus=true

### Description
Fix for issue when restarting the app sidebars from previous session were being opened even if they were previously collapsed.

### Testing Steps
1. Make sure that in Settings → General → Reopen all windows from last session is selected
2. Make sure that within the Duck.ai settings recent chats are ON
3. Open multiple tabs and navigate to some websites
4. On each tab open a sidebar and have some conversation
5., Go through the tabs and on some of them close the sidebar
6. Restart the browser

**Expected result:** State is consistent with how the browser was closed on restart.  Sidebars are open only on these tabs where user left them open.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
Incorrect sidebar state restoration

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)