### PR TITLE
macOS: Make app store updates flag macOS only

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -84,7 +84,6 @@ public enum PrivacyFeature: String {
     case daxEasterEggLogos
     case openFireWindowByDefault
     case behaviorMetrics
-    case appStoreUpdateFlow
 }
 
 /// An abstraction to be implemented by any "subfeature" of a given `PrivacyConfiguration` feature.
@@ -135,6 +134,10 @@ public enum MacOSBrowserConfigSubfeature: String, PrivacySubfeature {
     case fireDialog
     // Controls visibility of the "Manage individual sites" link in the Fire dialog
     case fireDialogIndividualSitesLink
+
+    /// New App Store Update flow feature flag
+    /// https://app.asana.com/1/137249556945/project/1199230911884351/task/1211563301906360?focus=true
+    case appStoreUpdateFlow
 }
 
 public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -450,7 +450,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .themes:
             return .disabled
         case .appStoreUpdateFlow:
-            return .remoteReleasable(.feature(.appStoreUpdateFlow))
+            return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.appStoreUpdateFlow))
         case .unifiedURLPredictor:
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.unifiedURLPredictor))
         case .unifiedURLPredictorMetrics:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1199230911884351/task/1211563301906360?focus=true
Tech Design URL:
CC:

### Description
Changes the `appStoreUpdateFlow` to be a macOS subfeature instead of a global feature.

### Testing Steps
Nothing specific.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scopes `appStoreUpdateFlow` to macOS by moving it from a global feature to a `MacOSBrowserConfig` subfeature and updating the feature flag source.
> 
> - **Privacy Config**:
>   - Move `appStoreUpdateFlow` from global `PrivacyFeature` to `MacOSBrowserConfigSubfeature.appStoreUpdateFlow`.
> - **macOS Feature Flags**:
>   - Update `FeatureFlag.source` for `appStoreUpdateFlow` to reference `.subfeature(MacOSBrowserConfigSubfeature.appStoreUpdateFlow)` instead of a global feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d855d98dcb9ce7e96bfb4bb1f98fdb8cc09d0f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->