### PR TITLE
Decrease watchdog max hang duration to 5 seconds, to match Windows

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/Watchdog/Watchdog.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/Watchdog/Watchdog.swift
@@ -94,7 +94,7 @@ public final actor Watchdog {
     ///   - crashOnTimeout: Whether the watchdog should kill the app once the maximum hang duration has been reached (used for debugging purposes)
     ///   - killAppFunction: A closure to be executed when the maximum hang duration has been reached (used for testing purposes)
     ///
-    public init(minimumHangDuration: TimeInterval = 1.0, maximumHangDuration: TimeInterval = 10.0, checkInterval: TimeInterval = 0.5, eventMapper: EventMapping<Watchdog.Event>? = nil, crashOnTimeout: Bool = false, killAppFunction: ((TimeInterval) -> Void)? = nil) {
+    public init(minimumHangDuration: TimeInterval = 1.0, maximumHangDuration: TimeInterval = 5.0, checkInterval: TimeInterval = 0.5, eventMapper: EventMapping<Watchdog.Event>? = nil, crashOnTimeout: Bool = false, killAppFunction: ((TimeInterval) -> Void)? = nil) {
 
         assert(checkInterval > 0, "checkInterval must be greater than 0")
         assert(minimumHangDuration >= 0, "minimumHangDuration must be greater than or equal to 0")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211264967278501/task/1211588624651650?focus=true
Tech Design URL:
CC:

### Description

This PR is simply changing the maximum hang duration timeout for the hang detection watchdog from 10 seconds to 5 seconds, to match the Windows browser implementation.

### Testing Steps

1. Build and run a debug build
2. From the Debug menu, choose Hang Debugging > Toggle Hang Watchdog
3. From the Debug menu, choose Hang Debugging > Simulate hang, and test a 2 second hang - ensure you see a `m_mac_ui_hang_recovered_*` pixel in your console
4. From the Debug menu, choose Hang Debugging > Simulate hang, and test a 10 second hang - ensure you see a `m_mac_ui_hang_not-recovered_*` pixel in your console

### Impact and Risks

None: Internal tooling, documentation

Should be no risks, just changing an internal timeout for our reporting.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduce `Watchdog` default `maximumHangDuration` from 10s to 5s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c403145e09fc9b94db051979af3091b936d7c7fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->