### PR TITLE
Update swift-tools-version in SystemFrameworksExtensions to 5.9

### DIFF
--- a/SharedPackages/SystemFrameworksExtensions/Package.swift
+++ b/SharedPackages/SystemFrameworksExtensions/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1211586546256554?focus=true

### Description
This change fixes UI tests runs on macOS 13 and 14.

### Testing Steps
Verify that [this UI tests workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/18351280486) has not failed building on macOS 13 and 14.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change `swift-tools-version` in `SharedPackages/SystemFrameworksExtensions/Package.swift` from `6.1` to `5.9`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd333896d3a266d61ec0b0755a5bc5dabe8be452. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->