### PR TITLE
PIR: Implement Opt Out Sub Job helper function unit test coverage

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
@@ -611,6 +611,7 @@ public final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecu
     public var lastDeletedEmailConfirmationExtractedProfileId: Int64?
     public var wasIncrementAttemptCountCalled = false
     public var incrementAttemptCountCallCount = 0
+    public var incrementShouldThrow = false
 
     public typealias DatabaseProvider = SecureStorageDatabaseProviderMock
 
@@ -968,6 +969,7 @@ public final class MockDatabase: DataBrokerProtectionRepository {
     public var lastDeletedEmailConfirmationExtractedProfileId: Int64?
     public var wasIncrementAttemptCountCalled = false
     public var incrementAttemptCountCallCount = 0
+    public var incrementAttemptShouldThrow = false
     public var lastAddedHistoryEvent: HistoryEvent?
 
     public var saveResult: Result<Void, Error> = .success(())
@@ -1115,6 +1117,9 @@ public final class MockDatabase: DataBrokerProtectionRepository {
     }
 
     public func incrementAttemptCount(brokerId: Int64, profileQueryId: Int64, extractedProfileId: Int64) throws {
+        if incrementAttemptShouldThrow {
+            throw MockError.saveFailed
+        }
         attemptCount += 1
     }
 

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileOptOutSubJobTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileOptOutSubJobTests.swift
@@ -52,8 +52,6 @@ final class BrokerProfileOptOutSubJobTests: XCTestCase {
         sut = BrokerProfileOptOutSubJob(dependencies: mockDependencies)
     }
 
-    // MARK: - Run opt-out operation tests
-
     private func makeFixtureIdentifiers() -> BrokerProfileOptOutSubJob.OptOutIdentifiers {
         .init(brokerId: 1, profileQueryId: 1, extractedProfileId: 1)
     }
@@ -202,7 +200,6 @@ final class BrokerProfileOptOutSubJobTests: XCTestCase {
 
         XCTAssertTrue(mockDatabase.optOutEvents.contains { $0.type == .optOutStarted })
     }
-
     // MARK: - makeOptOutRunner
 
     func testMakeOptOutRunner_usesFactory() {
@@ -315,6 +312,29 @@ final class BrokerProfileOptOutSubJobTests: XCTestCase {
             XCTAssertEqual(tries, 1)
         } else {
             XCTFail("Expected opt-out submit success pixel")
+        }
+    }
+
+    func testFinalizeOptOut_whenHistoryWriteFails_rethrows() {
+        let calculator = DataBrokerProtectionStageDurationCalculator(dataBroker: "broker",
+                                                                     dataBrokerVersion: "1.0",
+                                                                     handler: mockPixelHandler,
+                                                                     vpnConnectionState: "state",
+                                                                     vpnBypassStatus: "status")
+        let identifiers = makeFixtureIdentifiers()
+        let brokerData = makeFixtureBrokerProfileQueryData()
+        let failingDatabase = MockDatabase()
+        failingDatabase.incrementAttemptShouldThrow = true
+
+        XCTAssertThrowsError(
+            try sut.finalizeOptOut(
+                database: failingDatabase,
+                brokerProfileQueryData: brokerData,
+                identifiers: identifiers,
+                stageDurationCalculator: calculator
+            )
+        ) { error in
+            XCTAssertTrue(error is MockDatabase.MockError)
         }
     }
 
@@ -445,6 +465,41 @@ final class BrokerProfileOptOutSubJobTests: XCTestCase {
         }
     }
 
+    func testRecordOptOutFailure_whenHistoryWriteFails_stillEmitsPixels() {
+        let calculator = DataBrokerProtectionStageDurationCalculator(dataBroker: "broker",
+                                                                     dataBrokerVersion: "1.0",
+                                                                     handler: mockPixelHandler,
+                                                                     vpnConnectionState: "state",
+                                                                     vpnBypassStatus: "status")
+        let identifiers = makeFixtureIdentifiers()
+        let wideEvent = WideEventMock()
+        let recorder = OptOutSubmissionWideEventRecorder.makeIfPossible(wideEvent: wideEvent,
+                                                                        attemptID: calculator.attemptId,
+                                                                        dataBrokerURL: "broker.com",
+                                                                        dataBrokerVersion: "1.0",
+                                                                        recordFoundDate: Date())
+        mockDependencies.wideEvent = wideEvent
+        mockDatabase.saveResult = .failure(MockDatabase.MockError.saveFailed)
+
+        sut.recordOptOutFailure(
+            error: DataBrokerProtectionError.actionFailed(actionID: "action", message: "msg"),
+            brokerProfileQueryData: makeFixtureBrokerProfileQueryData(),
+            database: mockDatabase,
+            wideEvent: wideEvent,
+            wideEventRecorder: recorder,
+            schedulingConfig: .default,
+            identifiers: identifiers,
+            stageDurationCalculator: calculator
+        )
+
+        XCTAssertEqual(wideEvent.completions.first?.1, .failure)
+        if case .optOutFailure = mockPixelHandler.lastFiredEvent {
+            // expected even when history write fails
+        } else {
+            XCTFail("Expected opt-out failure pixel")
+        }
+    }
+
     func testWhenNoBrokerIdIsPresent_thenOptOutOperationThrows() async {
         do {
             _ = try await sut.runOptOut(
@@ -528,12 +583,12 @@ final class BrokerProfileOptOutSubJobTests: XCTestCase {
     func testWhenBrokerHasParentOptOut_thenNothingHappens() async {
         do {
             _ = try await sut.runOptOut(
-                for: .mockWithRemovedDate,
+                for: .mockWithoutRemovedDate,
                 brokerProfileQueryData: .init(
                     dataBroker: .mockWithParentOptOut,
                     profileQuery: .mock,
                     scanJobData: .mock,
-                    optOutJobData: [OptOutJobData.mock(with: .mockWithRemovedDate)]
+                    optOutJobData: [OptOutJobData.mock(with: .mockWithoutRemovedDate)]
                 ),
                 showWebView: false,
                 shouldRunNextStep: { true }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211333680255103
Tech Design URL:
CC: @quanganhdo 

### Description

This PR is a follow up on #2105. It implements direct unit test coverage for the extracted side-effect helper functions and building blocks of Opt Out Sub Jobs

### Testing Steps
Make sure CI stays 🟢 

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
N/A

### Quality Considerations
Make sure you focus on the branch coverage of each side-effect helper function.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds comprehensive unit tests for `BrokerProfileOptOutSubJob` helper flows and updates mocks to simulate attempt-count failures.
> 
> - **Tests**:
>   - Add extensive unit tests in `BrokerProfileOptOutSubJobTests.swift` covering: `validateOptOutPreconditions`, stage duration context creation, marking start, runner factory usage, execution, email-confirmation decoupling, finalize success/error paths, and failure recording (including timeout cases); verifies pixel emissions and attempt counts.
>   - Import `PixelKitTestingUtilities` for wide-event testing.
> - **Test Utils / Mocks**:
>   - `Mocks.swift` (MockDatabase): add `incrementAttemptShouldThrow` flag and make `incrementAttemptCount` throw `MockError.saveFailed` when set; expose `lastAddedHistoryEvent`.
>   - Minor test adjustments to input fixtures (e.g., use `mockWithoutRemovedDate` where needed).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f8e464f71868d1032f50cd7167a64af898957c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->