### PR TITLE
Smartling automation: Only add localization-related files to commit when importing.

### DIFF
--- a/scripts/smartling/smartling_download.sh
+++ b/scripts/smartling/smartling_download.sh
@@ -124,7 +124,12 @@ if ! ./scripts/smartling/check_translation_integrity.py; then
 	# Commit the changes to the new branch
 	git config user.name "Dax the Duck"
 	git config user.email "dax@duckduckgo.com"
-	git add -A
+
+	# Reset any non-localization files (e.g., Package.resolved, build artifacts)
+	echo "Cleaning non-localization files from working tree..."
+	git restore --staged --worktree -- . ':(exclude)**/*.strings' ':(exclude)**/*.stringsdict' ':(exclude)**/*.xcstrings'
+
+	git add -A -- ':(glob)**/*.strings' ':(glob)**/*.stringsdict' ':(glob)**/*.xcstrings'
 	git commit -m "Smartling translations with deletions/replacements from job $JOB_ID"
 
 	# Push the new branch
@@ -165,8 +170,12 @@ else
 	git config user.name "Dax the Duck"
 	git config user.email "dax@duckduckgo.com"
 
-	# Add all changes
-	git add -A
+	# Reset any non-localization files (e.g., Package.resolved, build artifacts)
+	echo "Cleaning non-localization files from working tree..."
+	git restore --staged --worktree -- . ':(exclude)**/*.strings' ':(exclude)**/*.stringsdict' ':(exclude)**/*.xcstrings'
+
+	# Add only localization files (including deletions)
+	git add -A -- ':(glob)**/*.strings' ':(glob)**/*.stringsdict' ':(glob)**/*.xcstrings'
 
 	# Create commit message
 	git commit -m "Import translations from Smartling job $JOB_ID"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210594645229050/task/1211592855507294?focus=true
Tech Design URL:
CC: @jleandroperez @bwaresiak 

### Description

Since localization import runs `xcodebuild`, it could happen that the process adds some residual files to the commit (e.g. [here](https://github.com/duckduckgo/apple-browsers/pull/2119/commits/5478095916395875eeb5e5548ddb79e67cf78616)). To avoid that, this PR adds the following changes:
* it will reset the state of non-localization files before committing
* it will add only localization-related files to the commit

Localization files are specified as *.strings, *.stringsdict, and *.xcstrings

### Testing Steps
N/A

### Impact and Risks
N/A

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restricts Smartling download commits to only localization files and cleans non-localization artifacts before committing, in both deletions PR and direct commit paths.
> 
> - **Scripts**:
>   - **`scripts/smartling/smartling_download.sh`**:
>     - Limit staged changes to localization files only: `**/*.strings`, `**/*.stringsdict`, `**/*.xcstrings`.
>     - Clean non-localization files from worktree and index before staging via `git restore --staged --worktree` with excludes.
>     - Apply the same behavior for both the deletions/replacements PR flow and the direct commit flow.
>     - Add concise logging about cleaning and selective staging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7da274c166fe06ea1bba29eaf18db200db81a49b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->