### PR TITLE
Set hang reporting feature flag to remoteReleasable

### DIFF
--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -413,7 +413,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .willSoonDropBigSurSupport:
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.willSoonDropBigSurSupport))
         case .hangReporting:
-            return .internalOnly()
+            return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.hangReporting))
         case .shortHistoryMenu:
             return .remoteReleasable(.feature(.shortHistoryMenu))
         case .importChromeShortcuts:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211264967278501/task/1211598303236902?focus=true
Tech Design URL:
CC:

### Description

This PR simply changes the hang reporting feature flag from `internalOnly` to `remoteReleasable`, as the project’s core changes are now complete.

### Testing Steps

1. Check the code, and that CI is happy!
2. The remote config is currently set to internal, so if you check Feature Flag Overrides in the debug menu, you should see a checkmark next to hang reporting if you’re using an internal user.

### Impact and Risks

None: Internal tooling, documentation


—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch `FeatureFlag.hangReporting` source from `internalOnly()` to `remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.hangReporting))`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6f823c3219efbc64535e73923528562161ab991. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->