### PR TITLE
Skip CIImage initialization for Favicons on macOS 13

### DIFF
--- a/macOS/DuckDuckGo/Favicons/Model/FaviconManager.swift
+++ b/macOS/DuckDuckGo/Favicons/Model/FaviconManager.swift
@@ -408,6 +408,16 @@ fileprivate extension NSImage {
      * storing `NSImage` initialized with `ico` files in NSKeyedArchiver.
      */
     convenience init?(dataUsingCIImage data: Data) {
+
+        if #available(macOS 13, *) {
+            if #unavailable(macOS 14) {
+                /// On macOS 13.* the `CIImage(data:)` initializer seems to be crashing occasionally.
+                /// Because of that we fall back to regular NSData-based initializer.
+                self.init(data: data)
+                return
+            }
+        }
+
         guard let ciImage = CIImage(data: data) else {
             self.init(data: data)
             return


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1211596969255086?focus=true

### Description
This change restricts the usage of CIImage initializer using NSData to OS versions
other than 13.*, because it seems to be occasionally crashing on Ventura.

### Testing Steps
1. Smoke test favicons – there should be no change on macOS 15/26 since the added code is guarded by OS version checks. Use e.g. https://rpsthecoder.github.io/favicon-canvas-loader/ to verify that the favicon in the tab bar item view looks good.
2. If you can test on Ventura, use a review build generated by [this workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/18376658743) to test the same there.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> On macOS 13 only, skip `CIImage(data:)` in `NSImage(dataUsingCIImage:)` and fall back to `NSImage(data:)` to avoid crashes; unchanged for other versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77ba6701ee4300c1f880a58e80b1974a77ee24e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->