### PR TITLE
Enables Themes Feature Flag for Internal Users

### DIFF
--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -457,7 +457,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .syncFeatureLevel3:
             return .remoteReleasable(.subfeature(SyncSubfeature.level3AllowCreateAccount))
         case .themes:
-            return .disabled
+            return .internalOnly()
         case .appStoreUpdateFlow:
             return .remoteReleasable(.feature(.appStoreUpdateFlow))
         case .unifiedURLPredictor:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1211580177841212?focus=true
Tech Design URL:
CC:

### Description
In this PR we're enabling the `themes` Feature Flag for Internal Users.

### Testing Steps
1. Launch the Browser
2. Verify that if you open `Settings -> Appearance` you do **NOT** see the Theme Colors picker
3. Set the Internal User State
4. Remove all feature flag overrides
5. Open Settings -> Appearance

- [ ] Verify you now see the Theme Colors Picker

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing really!

### Quality Considerations
-

### Notes to Reviewer
Thanks a lot, in advance!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)