### PR TITLE
WatchdogEventMapperTests: Skipping flaky tests temporarily

### DIFF
--- a/macOS/UnitTests/AppHealth/WatchdogEventMapperTests.swift
+++ b/macOS/UnitTests/AppHealth/WatchdogEventMapperTests.swift
@@ -136,7 +136,8 @@ final class WatchdogEventMapperTests: XCTestCase {
         XCTAssert(pixel.name.hasPrefix("m_mac_ui_hang_not-recovered"))
     }
 
-    func testBatteryPowerMappingOnBattery() {
+    func testBatteryPowerMappingOnBattery() throws {
+        throw XCTSkip("Flaky test: https://app.asana.com/1/137249556945/project/1200194497630846/task/1211604496994582?focus=true")
         // Given
         let event = Watchdog.Event.uiHangRecovered(durationSeconds: 1)
         setupMockDiagnostics(isOnBattery: true)
@@ -158,7 +159,8 @@ final class WatchdogEventMapperTests: XCTestCase {
         XCTAssertEqual(pixel.parameters?["battery_power"], "on-battery")
     }
 
-    func testBatteryPowerMappingPluggedIn() {
+    func testBatteryPowerMappingPluggedIn() throws {
+        throw XCTSkip("Flaky test: https://app.asana.com/1/137249556945/project/1200194497630846/task/1211604496994582?focus=true")
         // Given
         let event = Watchdog.Event.uiHangRecovered(durationSeconds: 1)
         setupMockDiagnostics(isOnBattery: false)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1211597294582162?focus=true
Tech Design URL:
CC:

### Description

Two of the new watchdog event mapper tests are still being flaky. I’m going to disable them temporarily until I get chance to investigate further, or remove them entirely.

I’ve added the tests to the flaky / ignored tests task: https://app.asana.com/1/137249556945/project/1200194497630846/task/1211604496994582?focus=true

### Testing Steps

- Check the app builds, CI is happy, and `WatchdogEventMapperTests` passes.

### Impact and Risks

None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Temporarily skips two flaky battery power mapping tests in WatchdogEventMapperTests using XCTSkip.
> 
> - **Tests**:
>   - Temporarily skip flaky battery power mapping tests in `macOS/UnitTests/AppHealth/WatchdogEventMapperTests.swift` by adding `XCTSkip(...)` to:
>     - `testBatteryPowerMappingOnBattery`
>     - `testBatteryPowerMappingPluggedIn`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe133fc54fbfd61bb59cfc6517acbbde9135ed4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->