### PR TITLE
Improve transition from autocomplete to empty state

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
@@ -150,10 +150,10 @@ final class SuggestionTrayManager: NSObject {
     }
     
     /// Handles query updates and shows appropriate suggestions
-    func handleQueryUpdate(_ query: String) {
+    func handleQueryUpdate(_ query: String, animated: Bool) {
         guard switchBarHandler.currentToggleState == .search else { return }
 
-        updateSuggestionTrayForCurrentState()
+        updateSuggestionTrayForCurrentState(animated: animated)
     }
     
     /// Shows the suggestion tray for the initial selected state
@@ -189,28 +189,28 @@ final class SuggestionTrayManager: NSObject {
             .store(in: &cancellables)
     }
     
-    private func updateSuggestionTrayForCurrentState() {
+    private func updateSuggestionTrayForCurrentState(animated: Bool = false) {
         if shouldDisplaySuggestionTray {
             let query = switchBarHandler.currentText
-            showSuggestionTray(.autocomplete(query: query))
+            showSuggestionTray(.autocomplete(query: query), animated: animated)
         } else {
-            showSuggestionTray(.favorites)
+            showSuggestionTray(.favorites, animated: animated)
         }
     }
     
-    private func showSuggestionTray(_ type: SuggestionTrayViewController.SuggestionType) {
+    private func showSuggestionTray(_ type: SuggestionTrayViewController.SuggestionType, animated: Bool) {
         guard let suggestionTray = suggestionTrayViewController else { return }
         
         let canShowSuggestion =
-            suggestionTray.canShow(for: type) ||
+            suggestionTray.canShow(for: type, animated: animated) ||
             (type == .favorites && suggestionTray.hasRemoteMessages)
 
         if canShowSuggestion {
-            suggestionTray.fill()
-            suggestionTray.show(for: type, animated: false)
             suggestionTray.view.isHidden = false
+            suggestionTray.fill()
+            suggestionTray.show(for: type, animated: animated)
         } else {
-            suggestionTray.view.isHidden = true
+            suggestionTray.didHide(animated: animated)
         }
     }
     

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -300,13 +300,19 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
         switchBarHandler.currentTextPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] currentText in
-                self?.delegate?.onQueryUpdated(currentText)
-                self?.suggestionTrayManager?.handleQueryUpdate(currentText)
-                self?.updateDaxVisibility()
-                DispatchQueue.main.async {
-                    // Delay to next runloop so the text field size is updated.
-                    self?.updateSwipeContainerSafeArea()
+
+                guard let self else { return }
+
+                self.delegate?.onQueryUpdated(currentText)
+
+                let animator = UIViewPropertyAnimator(duration: Constants.animationDuration, curve: .easeInOut) {
+                    self.updateDaxVisibility()
+                    self.updateSwipeContainerSafeArea()
                 }
+
+                self.suggestionTrayManager?.handleQueryUpdate(currentText, animated: true)
+
+                animator.startAnimation()
             }
             .store(in: &cancellables)
 
@@ -528,5 +534,6 @@ private extension OmniBarEditingStateViewController {
         // Adjusts for two buttons in the action bar
         static let horizontalMarginForCompactLayout: CGFloat = 108
         static let backgroundColor = UIColor(designSystemColor: .background)
+        static let animationDuration: TimeInterval = 0.15
     }
 }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1608,7 +1608,7 @@ class MainViewController: UIViewController {
         viewCoordinator.omniBar.showSeparator()
         viewCoordinator.suggestionTrayContainer.isHidden = true
         currentTab?.webView.accessibilityElementsHidden = false
-        suggestionTrayController?.didHide()
+        suggestionTrayController?.didHide(animated: false)
     }
     
     func launchAutofillLogins(with currentTabUrl: URL? = nil, currentTabUid: String? = nil, openSearch: Bool = false, source: AutofillSettingsSource, selectedAccount: SecureVaultModels.WebsiteAccount? = nil) {

--- a/iOS/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/iOS/DuckDuckGo/SuggestionTrayViewController.swift
@@ -156,11 +156,11 @@ class SuggestionTrayViewController: UIViewController {
     
     override var canBecomeFirstResponder: Bool { return true }
     
-    func canShow(for type: SuggestionType) -> Bool {
+    func canShow(for type: SuggestionType, animated: Bool = true) -> Bool {
         var canShow = false
         switch type {
         case .autocomplete(let query):
-            canShow = canDisplayAutocompleteSuggestions(forQuery: query)
+            canShow = canDisplayAutocompleteSuggestions(forQuery: query, animated: animated)
         case.favorites:
             canShow = canDisplayFavorites
         }
@@ -175,12 +175,12 @@ class SuggestionTrayViewController: UIViewController {
             displayAutocompleteSuggestions(forQuery: query, animated: animated)
         case .favorites:
             if isPad {
-                removeAutocomplete()
+                removeAutocomplete(animated: animated)
                 displayFavoritesIfNeeded(animated: animated)
             } else {
                 willRemoveAutocomplete = true
                 displayFavoritesIfNeeded(animated: animated) { [weak self] in
-                    self?.removeAutocomplete()
+                    self?.removeAutocomplete(animated: animated)
                     self?.willRemoveAutocomplete = false
                 }
             }
@@ -191,10 +191,10 @@ class SuggestionTrayViewController: UIViewController {
         return containerView.frame
     }
     
-    func didHide() {
-        removeAutocomplete()
-        removeFavorites()
-        removeNewTabPage()
+    func didHide(animated: Bool) {
+        removeAutocomplete(animated: animated)
+        removeFavorites(animated: animated)
+        removeNewTabPage(animated: animated)
     }
     
     @objc func keyboardMoveSelectionDown() {
@@ -317,10 +317,10 @@ class SuggestionTrayViewController: UIViewController {
         favoritesOverlay = controller
     }
     
-    private func canDisplayAutocompleteSuggestions(forQuery query: String) -> Bool {
+    private func canDisplayAutocompleteSuggestions(forQuery query: String, animated: Bool) -> Bool {
         let canDisplay = appSettings.autocomplete && !query.isEmpty
         if !canDisplay {
-            removeAutocomplete()
+            removeAutocomplete(animated: animated)
         }
         return canDisplay
     }
@@ -346,28 +346,41 @@ class SuggestionTrayViewController: UIViewController {
         autocompleteController = controller
     }
 
-    private func removeAutocomplete() {
+    private func removeAutocomplete(animated: Bool) {
         guard let controller = autocompleteController else { return }
-        removeController(controller)
+        removeController(controller, animated: animated)
         autocompleteController = nil
     }
     
-    private func removeFavorites() {
+    private func removeFavorites(animated: Bool) {
         guard let controller = favoritesOverlay else { return }
-        removeController(controller)
+        removeController(controller, animated: animated)
         favoritesOverlay = nil
     }
 
-    private func removeNewTabPage() {
+    private func removeNewTabPage(animated: Bool) {
         guard let controller = newTabPage else { return }
-        removeController(controller)
+        removeController(controller, animated: animated)
         newTabPage = nil
     }
 
-    private func removeController(_ controller: UIViewController) {
+    private func removeController(_ controller: UIViewController, animated: Bool) {
         controller.willMove(toParent: nil)
-        controller.view.removeFromSuperview()
-        controller.removeFromParent()
+
+        let finalize = {
+            controller.view.removeFromSuperview()
+            controller.removeFromParent()
+        }
+
+        if animated {
+            UIView.animate(withDuration: 0.2) {
+                controller.view.alpha = 0.0
+            } completion: { _ in
+                finalize()
+            }
+        } else {
+            finalize()
+        }
     }
 
     private func install(controller: UIViewController,
@@ -407,7 +420,7 @@ extension SuggestionTrayViewController: AutocompleteViewControllerPresentationDe
     
     func autocompleteDidChangeContentHeight(height: CGFloat) {
         if autocompleteController != nil && !willRemoveAutocomplete {
-            removeFavorites()
+            removeFavorites(animated: false)
         }
         
         guard !fullHeightConstraint.isActive else { return }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1211523340102294?focus=true
Tech Design URL:
CC:

### Description

Adds fade in/out to autocomplete results and Dax logo.

### Testing Steps
1. Enable New Search Input
2. Type something into search field, verify fade in animation for autocomplete results and fade out for dax (if there are no favorites)
3. Change modes, verify there's no animation glitches
4. Clear input field, verify fade out for autocomplete 

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds fade-in/out animations and animated state updates for the suggestion tray (autocomplete/favorites) and Dax visibility during query changes.
> 
> - **Suggestion Tray UX**:
>   - Add `animated` propagation across `SuggestionTrayManager` and `SuggestionTrayViewController` (`handleQueryUpdate`, `updateSuggestionTrayForCurrentState`, `showSuggestionTray`, `canShow`, `didHide`).
>   - Implement fade-out on removal of child controllers via `removeController(_:animated:)`; fade-in preserved on install.
>   - Ensure visibility handling uses `didHide(animated:)` and passes animation flags when showing/hiding autocomplete and favorites/New Tab Page.
> - **OmniBar updates**:
>   - Animate Dax visibility and safe-area updates with `UIViewPropertyAnimator` on text changes; introduce `Constants.animationDuration` (0.15s).
>   - Pass `animated: true` to `SuggestionTrayManager.handleQueryUpdate`.
> - **MainView integration**:
>   - Update `hideSuggestionTray` to call `suggestionTrayController?.didHide(animated: false)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 999d3863512c9bca68a0663a1515a605a51e74a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->