### PR TITLE
PIR: Filter Initial Scan Status for removed brokers

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/UIWeb/DBPUICommunicationModelScanStateExtensions.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/UIWeb/DBPUICommunicationModelScanStateExtensions.swift
@@ -50,9 +50,9 @@ public extension DBPUIInitialScanState {
                                               totalScans: totalScans,
                                               scannedBrokers: partiallyScannedBrokers)
 
-        // resultsFound should continue to have records from removed brokers
-        // https://app.asana.com/1/137249556945/task/1211375571700466/comment/1211467916936711
-        self.resultsFound = DBPUIDataBrokerProfileMatch.profileMatches(from: withoutDeprecated)
+        // resultsFound must have removed brokers filtered out
+        // https://app.asana.com/1/137249556945/project/1203581873609357/task/1211564057688647
+        self.resultsFound = DBPUIDataBrokerProfileMatch.profileMatches(from: withoutRemoved)
     }
 }
 

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DBPUICommunicationViewModelScanStateExtensionsTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DBPUICommunicationViewModelScanStateExtensionsTests.swift
@@ -501,9 +501,7 @@ final class DBPUICommunicationViewModelScanStateExtensionsTests: XCTestCase {
         XCTAssertEqual(result.scanProgress.totalScans, 1)
         XCTAssertEqual(result.scanProgress.currentScans, 1)
         XCTAssertEqual(result.scanProgress.scannedBrokers.map { $0.name }, ["Active Broker"])
-
-        // removed brokers should still be represented in resultsFound
-        XCTAssertEqual(result.resultsFound.count, 2)
+        XCTAssertEqual(result.resultsFound.count, 1)
     }
 
     func testWhenBrokerMarkedAsRemoved_thenMaintenanceNextScanExcludesIt() {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1211564057688647?focus=true
Tech Design URL:
CC: @THISISDINOSAUR 

### Description

This PR is a fix for feature parity with Windows when communicating with PIR Web UI with Initial Scan Status. The results found array must be filtered for removed brokers as stated on https://app.asana.com/1/137249556945/project/1205889582400204/task/1211477959976302?focus=true

### Testing Steps
CI stays 🟢. Further testing will be done during the Ship Review on https://app.asana.com/1/137249556945/project/1142021229838617/task/1211319901173823

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Filters out removed brokers from initial scan results and updates tests accordingly.
> 
> - **Core (DataBrokerProtectionCore/UIWeb)**:
>   - `DBPUIInitialScanState.init(...)`: compute `resultsFound` from `withoutRemoved` to exclude removed brokers.
> - **Tests**:
>   - Update `testWhenBrokerMarkedAsRemoved_thenInitialScanProgressExcludesIt` to expect `resultsFound.count == 1` (removed broker excluded).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab8073314e0091824330b0676e55e51b1c4fbafc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->