### PR TITLE
Moves calls to checkForUpdateInformation to the main thread

### DIFF
--- a/macOS/DuckDuckGo/Updates/Sparkle/SparkleUpdateController.swift
+++ b/macOS/DuckDuckGo/Updates/Sparkle/SparkleUpdateController.swift
@@ -281,7 +281,7 @@ final class SparkleUpdateController: NSObject, SparkleUpdateControllerProtocol {
     private func performUpdateCheck() async {
         // Check if we can start a new check (Sparkle availability + rate limiting)
         let updaterAvailability = SparkleUpdaterAvailabilityChecker(updater: updater)
-        guard false else { // await updateCheckState.canStartNewCheck(updater: updaterAvailability) else {
+        guard await updateCheckState.canStartNewCheck(updater: updaterAvailability) else {
             Logger.updates.debug("Update check skipped - not allowed by Sparkle or rate limited")
             Task { @MainActor in
                 updater?.checkForUpdateInformation()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211617344839434?focus=true

### Description

Moves calls to `checkForUpdateInformation` to the main thread

This is just matching [a requirement](https://sparkle-project.github.io/documentation/api-reference/Classes/SPUUpdater.html) from the Sparkle documentation that I had missed.

### Testing Steps

Disconnect from internet, launch our app, go to release notes, make sure it looks right.

### Impact and Risks

Medium - just because we're merging against .160.

#### What could go wrong?

Not sure, please be critical.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Run `SPUUpdater.checkForUpdateInformation()` on the main thread across key code paths by wrapping calls in `@MainActor` tasks.
> 
> - **macOS Updates (Sparkle)**:
>   - Ensure `SPUUpdater.checkForUpdateInformation()` is invoked on the main thread by wrapping calls in `Task { @MainActor in ... }` within:
>     - `checkForUpdateRespectingRollout()` (DEBUG fallback)
>     - `performUpdateCheck()` (rate-limited/skip path)
>     - `configureUpdater()` (post-initialization)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7af24a75ae6f599da54b2d08707f3bcdfdae31d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->