### PR TITLE
[iOS] expand the field if the selection changes for a long URL

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -61,6 +61,10 @@ class SwitchBarTextEntryView: UIView {
     private var heightConstraint: NSLayoutConstraint?
     private var buttonsTrailingConstraint: NSLayoutConstraint?
 
+    /// When true the text entry will expand the text when the selection changes, e.g.  If the user uses the space bar to move the caret then it updates the selection.
+    ///   This gets set to true after selectAll() on the field gets call.
+    var canExpandOnSelectionChange = false
+
     var hasBeenInteractedWith = false
     var isURL: Bool {
         // TODO some kind of text length check?
@@ -374,10 +378,17 @@ class SwitchBarTextEntryView: UIView {
 
     func selectAllText() {
         textView.selectAll(nil)
+        canExpandOnSelectionChange = true
     }
 }
 
 extension SwitchBarTextEntryView: UITextViewDelegate {
+
+    func textViewDidChangeSelection(_ textView: UITextView) {
+        guard canExpandOnSelectionChange else { return }
+        textViewDidChange(textView)
+        canExpandOnSelectionChange = false
+    }
 
     func textViewDidBeginEditing(_ textView: UITextView) {
         fireTextAreaFocusedPixel()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1211612425942975?focus=true
Tech Design URL:
CC:

### Description
Expands the field the first time the selection changes after the field has been setup.

### Testing Steps
1. Test tapping on URLs of various length to open in new input experience.
2. With a long URL selected press and hold the space bar to change the caret position without tapping the field to expand the URL

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Could break text entry

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands the text field when the selection changes after selectAll, enabling long URLs to expand without additional taps.
> 
> - **iOS UI** (`iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift`):
>   - Add `canExpandOnSelectionChange` flag to control expansion on selection updates.
>   - Set flag in `selectAllText()` and handle `textViewDidChangeSelection` to call `textViewDidChange` and reset the flag, triggering height/placeholder/button updates.
>   - No other logic changes to input handling or layout beyond invoking existing update flow on selection change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ec775e4e1d6cfba08d38670c7fdc584ebda0779. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->