### PR TITLE
Removes a call that's causing trouble when checking for Sparkle updates

### DIFF
--- a/macOS/DuckDuckGo/Updates/Sparkle/SparkleUpdateController.swift
+++ b/macOS/DuckDuckGo/Updates/Sparkle/SparkleUpdateController.swift
@@ -427,9 +427,6 @@ final class SparkleUpdateController: NSObject, SparkleUpdateControllerProtocol {
         }
 
         let updater = SPUUpdater(hostBundle: Bundle.main, applicationBundle: Bundle.main, userDriver: userDriver, delegate: self)
-        Task { @MainActor in
-            updater.checkForUpdateInformation()
-        }
 
 #if DEBUG
         if NSApp.delegateTyped.featureFlagger.isFeatureOn(.autoUpdateInDEBUG) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1211635838672297?focus=true

### Description

Check for updates keep spinning forever

### Testing Steps

1. Change build number in configuration
2. Run the app
3. Go to Settings > About
4. Check for updates should be available / enabled - not forever spinning

### Impact and Risks

High.  Updates logic is risky by nature.

#### What could go wrong?

Unclear, please test widely.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the immediate `updater.checkForUpdateInformation()` call after creating `SPUUpdater` to prevent the update check from spinning indefinitely.
> 
> - **Updater (Sparkle)**:
>   - Remove immediate `checkForUpdateInformation()` call right after initializing `SPUUpdater` in `macOS/DuckDuckGo/Updates/Sparkle/SparkleUpdateController.swift` to avoid indefinite "checking for updates" state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f45632161e6e0e11f6ebbf4c2aed1d9c427bbcb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->