### PR TITLE
Default to automatic page context sending

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/macOS/PublicAPI/AIChatPreferencesStorage.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/macOS/PublicAPI/AIChatPreferencesStorage.swift
@@ -137,7 +137,9 @@ private extension UserDefaults {
         static let showAIChatShortcutInAddressBar = "aichat.showAIChatShortcutInAddressBar"
         static let showAIChatShortcutInAddressBarWhenTyping = "aichat.showAIChatShortcutInAddressBarWhenTyping"
         static let openAIChatInSidebar = "aichat.openAIChatInSidebar"
-        static let shouldAutomaticallySendPageContext = "aichat.automaticallySendPageContext"
+        /// The key here is set to a temporary value to allow defaulting to `true`.
+        /// Update to `aichat.automaticallySendPageContext` before releasing it publicly.
+        static let shouldAutomaticallySendPageContext = "aichat.automaticallySendPageContext.temporary.internal"
     }
 
     static let isAIFeaturesEnabledDefaultValue = true
@@ -146,7 +148,8 @@ private extension UserDefaults {
     static let showAIChatShortcutInAddressBarDefaultValue = true
     static let showAIChatShortcutInAddressBarWhenTypingDefaultValue = true
     static let openAIChatInSidebarDefaultValue = true
-    static let shouldAutomaticallySendPageContextDefaultValue = false
+    /// Update to `false` before releasing publicly.
+    static let shouldAutomaticallySendPageContextDefaultValue = true
 
     @objc dynamic var isAIFeaturesEnabled: Bool {
         get {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201621708115095/task/1211375156305527?focus=true

### Description
This change updates the storage for automatic page context sending to a new temporary key in User Defaults
and sets the default value to true. This will override existing setting for internal users to true and set true
for all new users.

### Testing Steps
1. Launch the app and make sure that `aiChatPageContext` feature flag is enabled.
2. Go to AI Features settings and verify that "Automatically send page context” is set to true.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `shouldAutomaticallySendPageContext` to a temporary UserDefaults key and defaults it to true.
> 
> - **Preferences (macOS)** in `AIChatPreferencesStorage.swift`:
>   - Change `UserDefaults` key for `shouldAutomaticallySendPageContext` to temporary internal key `"aichat.automaticallySendPageContext.temporary.internal"`.
>   - Set `shouldAutomaticallySendPageContextDefaultValue` to `true` (was `false`).
>   - Add inline notes to revert key and default before public release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98aa399fbe7fe91ad778c424b400f3e8d4649a0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->