### PR TITLE
Check for current version tags when looking for outstanding commits on a branch

### DIFF
--- a/iOS/Gemfile.lock
+++ b/iOS/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: 110eb22218f60726c6977105ba7020694c3a843f
-  branch: dominik/fix-outstanding-commits-check
+  revision: b2cd37327e6bbf027b045e306a4c2b891a5695b7
+  tag: 3.1.3
   specs:
     fastlane-plugin-ddg_apple_automation (3.1.3)
       asana

--- a/iOS/fastlane/Pluginfile
+++ b/iOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', branch: 'dominik/fix-outstanding-commits-check'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '3.1.3'

--- a/macOS/Gemfile.lock
+++ b/macOS/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: 110eb22218f60726c6977105ba7020694c3a843f
-  branch: dominik/fix-outstanding-commits-check
+  revision: b2cd37327e6bbf027b045e306a4c2b891a5695b7
+  tag: 3.1.3
   specs:
     fastlane-plugin-ddg_apple_automation (3.1.3)
       asana

--- a/macOS/fastlane/Pluginfile
+++ b/macOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', branch: 'dominik/fix-outstanding-commits-check'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '3.1.3'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/949243614371883/task/1211637142458565?focus=true
Automation plugin PR: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation/pull/59

### Description
This change updates checking for “is_tagged” in release_branch_state so that the latest tag with a version
matching the release branch name is checked, and not the latest tag overall.

### Testing Steps
Verify that CI is green

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the fastlane Apple automation plugin to 3.1.3 across iOS and macOS, refreshing Gemfile.lock with minor dependency bumps.
> 
> - **Tooling (Fastlane)**:
>   - **Plugin upgrade**: Bump `fastlane-plugin-ddg_apple_automation` from `3.1.2` to `3.1.3` in `iOS/fastlane/Pluginfile` and `macOS/fastlane/Pluginfile`.
>   - **Lockfiles**: Update `iOS/Gemfile.lock` and `macOS/Gemfile.lock` to reference plugin `3.1.3` and refresh transitive gems (e.g., `aws-partitions`, `aws-sdk-kms`, `aws-sdk-s3`, `bigdecimal`, `httparty`, `json`, `rack`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98a9f731bbd7a39248c2736ee76414610da6c910. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->