### PR TITLE
Fix TabBarRemoteMessage model memory leak

### DIFF
--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabBarRemoteMessageViewModel.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabBarRemoteMessageViewModel.swift
@@ -31,8 +31,8 @@ final class TabBarRemoteMessageViewModel: ObservableObject {
         self.tabBarRemoteActiveMessage = activeRemoteMessageModel
 
         cancellable = tabBarRemoteActiveMessage.remoteMessagePublisher
-            .sink(receiveValue: { model in
-                guard !isFireWindow else { return }
+            .sink(receiveValue: { [weak self] model in
+                guard let self, !isFireWindow else { return }
 
                 guard let model = model else {
                     self.remoteMessage = nil


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1211643425602606?focus=true
Tech Design URL:
CC:

### Description

This PR fixes a memory leak with the TabBarRemoteMessage model.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Open and close a bunch of windows
2. Open the Memory Graph Debugger
3. Search for `TabBar`
4. Check that nothing shows up - compare this to main where you will see an instance of `TabBarRemoteMessageViewModel` left over for every window you open

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

Low, small bug fix

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

Could affect our ability to see remote messages in the tab bar, but these instances are created and retained correctly while the window is active.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Capture self weakly in remoteMessagePublisher sink and guard self to prevent a memory leak while keeping existing message handling logic.
> 
> - **macOS • Tab Bar**:
>   - `TabBarRemoteMessageViewModel`: Capture `self` weakly in `remoteMessagePublisher.sink` and add `guard let self` to avoid a retain cycle/memory leak.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 600d6ff065e8b4b51284cd328d3550f739eb8d78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->