### PR TITLE
Fix macOS release build upload path

### DIFF
--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -492,7 +492,7 @@ jobs:
       if: failure()
       with:
         name: release-xcodebuild.log
-        path: release-xcodebuild.log
+        path: macOS/release-xcodebuild.log
         retention-days: 7
 
   verify-npm-bundles:


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1211655331714287?focus=true
Tech Design URL:
CC:

### Description

This PR fixes an upload path in a macOS workflow.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI is green
2. Check that [this workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/18544876029) has a `release-xcodebuild.log` artifact attached

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes the artifact upload path in the macOS release build workflow to `macOS/release-xcodebuild.log`.
> 
> - **CI (GitHub Actions)**:
>   - In `macOS - PR Checks` workflow, update `Upload failed test log` step to upload `release-xcodebuild.log` from `macOS/release-xcodebuild.log`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0c54a604dce845ed3b79d173a73a23d52b1e4ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->