### PR TITLE
Filter out funnel_playstore origins when retrieving macOS DMG variants

### DIFF
--- a/.github/actions/asana-get-build-variants-list/get_build_variants_list.sh
+++ b/.github/actions/asana-get-build-variants-list/get_build_variants_list.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # This scripts fetches Asana tasks from the Origins section defined in the Asana project https://app.asana.com/0/1206716555947156/1206716715679835.
-# 
+#
 
 set -e -o pipefail
 
@@ -14,13 +14,13 @@ _create_origins_and_variants() {
 	local atb_field="ATB"
 
 	# for each element in the data array.
-	# filter out element with null `origin`.
+	# filter out element with null `origin` and those starting with `funnel_playstore` (they will never be used for downloading the macOS browser).
 	# select `origin` and `variant` from the custom_fields response and make a key:value pair structure like {origin: <origin_value>, variant: <variant_value>}.
-	# if variant is not null we need to create two entries. One only with `origin` and one with `origin` and `variant` 
+	# if variant is not null we need to create two entries. One only with `origin` and one with `origin` and `variant`
 	# replace the new line with a comma
 	# remove the trailing comma at the end of the line.
 	jq -c '.data[]
-		| select(.custom_fields[] | select(.name == "'"${origin_field}"'").text_value != null)
+		| select(.custom_fields[] | select(.name == "'"${origin_field}"'") | (.text_value != null and (.text_value | startswith("funnel_playstore") | not)))
 		| {origin: (.custom_fields[] | select(.name == "'"${origin_field}"'") | .text_value), variant: (.custom_fields[] | select(.name == "'"${atb_field}"'") | .text_value)}
 		| if .variant != null then {origin}, {origin, variant} else {origin} end' <<< "$response"
 }
@@ -28,9 +28,9 @@ _create_origins_and_variants() {
 # Fetch all the Asana tasks in the section specified by ORIGIN_ASANA_SECTION_ID for a project.
 # This function fetches only uncompleted tasks.
 # If there are more than 100 items the function takes care of pagination.
-# Returns a JSON string consisting of a list of `origin-variant` pairs concatenated by a comma. Eg. `{"origin":"app","variant":"ab"},{"origin":"app.search","variant":null}`.  
+# Returns a JSON string consisting of a list of `origin-variant` pairs concatenated by a comma. Eg. `{"origin":"app","variant":"ab"},{"origin":"app.search","variant":null}`.
 _fetch_origin_tasks() {
-	# Fetches only tasks that have not been completed yet, includes in the response section name, name of the task and its custom fields. 
+	# Fetches only tasks that have not been completed yet, includes in the response section name, name of the task and its custom fields.
 	local query="completed_since=now&opt_fields=name,custom_fields.id_prefix,custom_fields.name,custom_fields.text_value&opt_expand=custom_fields&opt_fields=memberships.section.name&limit=100"
 
 	local url="${asana_api_url}/sections/${ORIGIN_ASANA_SECTION_ID}/tasks?${query}"
@@ -41,7 +41,7 @@ _fetch_origin_tasks() {
 	# repeat until no more pages (next_page.uri is null)
 	while true; do
 		response="$(curl -fLSs "$url" -H "Authorization: Bearer ${ASANA_ACCESS_TOKEN}")"
-		
+
 		# extract the object in the data array and append to result
 		origin_variants+=("$(_create_origins_and_variants "$response")")
 
@@ -66,13 +66,13 @@ _create_atb_variant_pairs() {
 	# remove the array
 	# replace the new line with a comma
 	# remove the trailing comma at the end of the line.
-	jq -R -c 'split(",") 
-		| map({variant: .}) 
+	jq -R -c 'split(",")
+		| map({variant: .})
 		| .[]' <<< "$response"
 }
 
 # Fetches all the ATB variants defined in the ATB_ASANA_TASK_ID at the Variants list (comma separated) section.
-_fetch_atb_variants() { 
+_fetch_atb_variants() {
 	local url="${asana_api_url}/tasks/${ATB_ASANA_TASK_ID}?opt_fields=notes"
 	local atb_variants
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206716555947156/task/1211666425182635?focus=true

### Description
This change updates `get_build_variants_list.sh` to skip origins starting with `funnel_playstore`
as they’re unlikely to be used for macOS DMG downloads.

### Testing Steps
1. Set up the environment:
```
export ASANA_ACCESS_TOKEN=<your-asana-token>
export ATB_ASANA_TASK_ID=1205370183939342
export ORIGIN_ASANA_SECTION_ID=1206716555947176
export GITHUB_OUTPUT=list.json
```
2. Go to `.github/actions/asana-get-build-variants-list`
3. Call `./get_build_variants_list.sh`
4. Verify that the number of variants is less than or equal to 419 and that the list.json doesn’t contain `funnel_playstore`.


### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exclude Asana origins starting with `funnel_playstore` from the macOS build variants list generated by the GitHub Action.
> 
> - **CI / GitHub Action**:
>   - Update `get_build_variants_list.sh`: in `_create_origins_and_variants`, the `jq` filter now excludes `origin` values starting with `funnel_playstore` when generating `{origin, variant}` pairs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6eadb2286f70170575f27f68321d2b30e3c765cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->