### PR TITLE
macOS: Fix fire dialog sizing

### DIFF
--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -319,6 +319,7 @@ struct FireDialogView: ModalView {
         )
         .padding(.top, 4)
         .padding(.bottom, 8)
+        .fixedSize(horizontal: false, vertical: true)
     }
 
     private func presentManageFireproof() {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199230911884351/task/1211397736375307?focus=true
Tech Design URL:
CC:

### Description

This is a small change that was lost while resolving merge conflicts and missed before merging https://github.com/duckduckgo/apple-browsers/pull/2195. It ensures the new fire dialog resizes correctly when there are different numbers of visible rows:

Before|After
-|-
<img width="1150" height="803" alt="Screenshot 2025-10-18 at 16 17 21" src="https://github.com/user-attachments/assets/c7bfe7b3-9481-47b7-bc5a-a97a7be7c8c0" />|<img width="1150" height="803" alt="Screenshot 2025-10-18 at 16 18 41" src="https://github.com/user-attachments/assets/ce91d640-3c06-4a56-92f3-3712ad4c278f" />
<img width="1150" height="803" alt="Screenshot 2025-10-18 at 16 17 24" src="https://github.com/user-attachments/assets/3065c150-71cd-44ca-8a31-a1cd40656b10" />|<img width="1150" height="793" alt="Screenshot 2025-10-18 at 16 26 21" src="https://github.com/user-attachments/assets/58745b07-a257-4cf5-a2cb-165f22142dae" />
<img width="1150" height="803" alt="Screenshot 2025-10-18 at 16 17 30" src="https://github.com/user-attachments/assets/0750bd0b-32d3-4434-9a57-f73763592729" />|<img width="1150" height="803" alt="Screenshot 2025-10-18 at 16 18 48" src="https://github.com/user-attachments/assets/1a1e72e1-fdd0-487f-af65-26bc49a2ccc4" />
<img width="1150" height="803" alt="Screenshot 2025-10-18 at 16 17 32" src="https://github.com/user-attachments/assets/878ef4a2-3c85-4a3d-8230-204b2208fe3c" />|<img width="1150" height="793" alt="Screenshot 2025-10-18 at 16 18 50" src="https://github.com/user-attachments/assets/d66a77f9-8e38-4810-8466-02993891d9d2" />
<img width="1150" height="793" alt="Screenshot 2025-10-18 at 16 17 39" src="https://github.com/user-attachments/assets/9a566f00-3ff3-42ea-92e4-90ec0197dedc" />|<img width="1150" height="793" alt="Screenshot 2025-10-18 at 16 18 57" src="https://github.com/user-attachments/assets/a8b041ba-87c8-453b-ace8-55d7478697c8" />
<img width="1150" height="793" alt="Screenshot 2025-10-18 at 16 17 44" src="https://github.com/user-attachments/assets/3b7b7b1e-b96d-4782-8171-766bd8434951" />|<img width="1150" height="793" alt="Screenshot 2025-10-18 at 16 19 01" src="https://github.com/user-attachments/assets/672c284a-8cd1-4318-a214-f3909089f02f" />
<img width="1150" height="793" alt="Screenshot 2025-10-18 at 16 17 49" src="https://github.com/user-attachments/assets/13d46ee9-cb33-462f-bfa9-3b53888755e2" />|<img width="1150" height="793" alt="Screenshot 2025-10-18 at 16 19 05" src="https://github.com/user-attachments/assets/773cc3f9-2880-47d8-a470-604ef12ef747" />


### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
See https://github.com/duckduckgo/apple-browsers/pull/2195

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `FireDialogView` resizes correctly by applying `fixedSize(vertical: true)` to the sections container.
> 
> - **macOS UI**
>   - Apply `fixedSize(horizontal: false, vertical: true)` to the sections container in `FireDialogView.swift` to stabilize height and ensure proper sheet resizing with varying content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75dc76c15a0fbbc593171774021c2fbe8fc373a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->