### PR TITLE
[iOS][Malicious Site Protection] Disable Flaky Test

### DIFF
--- a/iOS/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionDatasetsFetcherTests.swift
+++ b/iOS/DuckDuckGoTests/MaliciousSiteProtection/MaliciousSiteProtectionDatasetsFetcherTests.swift
@@ -629,6 +629,7 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
     @MainActor
     @Test(
         "Test Background Task Is Not Executed If Fetch is In Progress",
+        .disabled("Flaky Test"),
         arguments: [
             DataManager.StoredDataType.Kind.hashPrefixSet,
             .filterSet,
@@ -650,7 +651,7 @@ final class MaliciousSiteProtectionDatasetsFetcherTests {
         let firstCallTask = sut.startFetching()
 
         // THEN
-         #expect(sut.isDatasetsFetchInProgress)
+        #expect(sut.isDatasetsFetchInProgress)
 
         // WHEN
         launchHandler?(backgroundTask)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200194497630846/task/1211688144594507?focus=true
Tech Design URL:
CC:

### Description

Disable datasets flaky test in CI. Locally, the test works fine. Will need investigation. Disabling it do avoid disrupting other team members workflows.

### Testing Steps
1. Ensure CI Pass.

### Impact and Risks
None.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables a flaky background-task test in `MaliciousSiteProtectionDatasetsFetcherTests` to stabilize CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c71f6640211e67c4bb8174d8ad87e59d71499d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->