### PR TITLE
Add fullContentLength to page context payload

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatConsumableDataHandling.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatConsumableDataHandling.swift
@@ -139,6 +139,7 @@ public struct AIChatPageContextData: Codable {
     let url: String
     let content: String
     let truncated: Bool
+    let fullContentLength: Int
 
     public struct PageContextFavicon: Codable {
         let href: String

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatPageContextHandlerTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatPageContextHandlerTests.swift
@@ -39,7 +39,8 @@ final class AIChatPageContextHandlerTests: XCTestCase {
             favicon: [AIChatPageContextData.PageContextFavicon(href: "https://example.com/favicon.ico", rel: "icon")],
             url: "https://example.com",
             content: "hello",
-            truncated: false
+            truncated: false,
+            fullContentLength: 5
         )
         pageContextHandler.setData(testPayload)
 
@@ -56,7 +57,8 @@ final class AIChatPageContextHandlerTests: XCTestCase {
             favicon: [AIChatPageContextData.PageContextFavicon(href: "https://example.com/favicon.ico", rel: "icon")],
             url: "https://example.com",
             content: "hello",
-            truncated: false
+            truncated: false,
+            fullContentLength: 5
         )
         pageContextHandler.setData(testPayload)
 
@@ -73,7 +75,8 @@ final class AIChatPageContextHandlerTests: XCTestCase {
             favicon: [AIChatPageContextData.PageContextFavicon(href: "https://example.com/favicon.ico", rel: "icon")],
             url: "https://example.com",
             content: "hello",
-            truncated: false
+            truncated: false,
+            fullContentLength: 5
         )
         pageContextHandler.setData(testPayload)
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209121419454298/task/1211635910247243?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1211422243640121
CC: @miasma13 

### Description

https://dub.duckduckgo.com/duckduckgo/ddg/pull/41767 made it so that Duck.ai will send better pixels if it is handed `fullContentLength` in the `getAIChatPageContext` and `submitAIChatPageContext` payloads. This value is [already sent to native by C-S-S](https://github.com/duckduckgo/content-scope-scripts/blob/6f249088d0c3f528a572a92fb22f7ebd8eab750a/injected/src/features/page-context.js#L430) so we simply need to add it to the struct to have native pass it along from C-S-S to Duck.ai.

### Testing Steps

1. Navigate to a page 
2. Open the Duck.ai sidebar
4. Right click the sidebar and open the inspector
3. Click _Attach_ (paperclip icon) and select _Current Tab Content_
5. In the inspector’s Network tab, look for the `dc_contextInfoOnAttach` pixel being sent and select it
6. Inspect the headers and notice that `contextLength` is now sent

<img width="1226" height="1019" alt="Screenshot 2025-10-20 at 14 39 06" src="https://github.com/user-attachments/assets/8c6b2332-fa2c-4c9a-83f0-1a483ab48b4e" />

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> Add fullContentLength to page context data model and update related tests.
> 
> - **AIChat Model**:
>   - Add `fullContentLength: Int` to `AIChatPageContextData` for page context payloads.
> - **Tests**:
>   - Update `AIChatPageContextHandlerTests` to construct `AIChatPageContextData` with `fullContentLength` in test payloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 008fbdb2d787735cddb49791536e47587d540409. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY —>