### PR TITLE
Rename shouldAutomaticallySendPageContext storage key

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/macOS/PublicAPI/AIChatPreferencesStorage.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/macOS/PublicAPI/AIChatPreferencesStorage.swift
@@ -137,9 +137,7 @@ private extension UserDefaults {
         static let showAIChatShortcutInAddressBar = "aichat.showAIChatShortcutInAddressBar"
         static let showAIChatShortcutInAddressBarWhenTyping = "aichat.showAIChatShortcutInAddressBarWhenTyping"
         static let openAIChatInSidebar = "aichat.openAIChatInSidebar"
-        /// The key here is set to a temporary value to allow defaulting to `true`.
-        /// Update to `aichat.automaticallySendPageContext` before releasing it publicly.
-        static let shouldAutomaticallySendPageContext = "aichat.automaticallySendPageContext.temporary.internal"
+        static let shouldAutomaticallySendPageContext = "aichat.sendPageContextAutomatically"
     }
 
     static let isAIFeaturesEnabledDefaultValue = true
@@ -148,7 +146,6 @@ private extension UserDefaults {
     static let showAIChatShortcutInAddressBarDefaultValue = true
     static let showAIChatShortcutInAddressBarWhenTypingDefaultValue = true
     static let openAIChatInSidebarDefaultValue = true
-    /// Update to `false` before releasing publicly.
     static let shouldAutomaticallySendPageContextDefaultValue = true
 
     @objc dynamic var isAIFeaturesEnabled: Bool {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1211691913520551?focus=true

### Description
Remove the “temporary.internal” mention from the user defaults key.

### Testing Steps
1. Verify that CI is green.
2. Launch the app, go to Settings -> AI Features and verify that “Automatically send page context to the sidebar” is on.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the `UserDefaults` key for automatically sending page context and removes temporary/internal comments.
> 
> - **AI Chat (macOS) Preferences**:
>   - Rename `UserDefaults` key: `aichat.automaticallySendPageContext.temporary.internal` -> `aichat.sendPageContextAutomatically` in `AIChatPreferencesStorage.swift`.
>   - Remove temporary/internal comments and note about updating default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98968db1717971f7835aaeb829ec3266806d2669. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->