### PR TITLE
macOS: Add translations for fire button popover

### DIFF
--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -32903,10 +32903,58 @@
       "comment" : "Title of the dialog where the user can close browser tabs and clear data and Duck.ai chat history.",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tabs schließen und Daten und Chats löschen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close Tabs and Clear Data and Chats"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerrar pestañas y borrar datos y chats"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermer les onglets, effacer les données et les conversations"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chiudi le schede e cancella i dati e le chat"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tabbladen sluiten en gegevens en chats wissen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zamknij karty oraz wyczyść dane i czaty"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fechar separadores e limpar dados e chats"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закрытие вкладок и удаление данных и чатов"
           }
         }
       }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1211370814674975?focus=true
Tech Design URL:
CC:

### Description

This adds translations for the fire button popover title (from https://github.com/duckduckgo/apple-browsers/pull/2195), when clearing Duck.ai history is enabled.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Run the app in a non-English language and disable the `fireDialog` feature flag (currently internal only).
2. Go to Settings > Data Clearing > Auto-Clear and enable the Duck.ai auto-clear setting.
3. Click the fire button and confirm the title is translated.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low: Translated strings only

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds translations for `fire.dialog.fire-window.close-tabs-chats` across major languages in `macOS/DuckDuckGo/Localization/Localizable.xcstrings`.
> 
> - **Localization**:
>   - Adds translations for `fire.dialog.fire-window.close-tabs-chats` in `macOS/DuckDuckGo/Localization/Localizable.xcstrings`.
>     - Languages: `de`, `es`, `fr`, `it`, `nl`, `pl`, `pt`, `ru` (and `en` entry present).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2387bf015f8cd9e8153b7fd7ca54561bb92d4a5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->