### PR TITLE
update task copy to include Flaky test guide

### DIFF
--- a/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
@@ -154,7 +154,7 @@ class OnboardingManagerTests: XCTestCase {
         navigationDelegate.fireNavigationDidEnd()
 
         // Then
-        XCTAssertTrue(navigationDelegate.focusOnAddressBarCalled)
+        XCTAssertFalse(navigationDelegate.focusOnAddressBarCalled)
     }
 
     func testGoToAddressBar_NavigatesToSettings() {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1211575981609589

### Description Update Template of the "PR Check is failing on” task

### Testing Steps
N/A

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds flaky test guidance to the Asana PR-check task copy and updates a macOS onboarding test to expect address bar focus after a second navigation end.
> 
> - **CI/GitHub Actions**:
>   - Update `/.github/actions/asana-failed-pr-checks/action.yml` to expand the created task description with a flaky test resolution guide link and sharing note.
> - **macOS Unit Tests**:
>   - In `macOS/UnitTests/Onboarding/OnboardingManagerTests.swift`, change the second `fireNavigationDidEnd()` assertion to expect `focusOnAddressBarCalled` to be `true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd5e2f83f2cbbd1ad6c0ff277febb73dc609ad68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->