### PR TITLE
Fix crash at collectionView.layoutAttributesForItemAtIndexPath

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarCollectionView.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarCollectionView.swift
@@ -177,6 +177,6 @@ extension NSCollectionView {
 
 extension NSCollectionView {
     func isIndexPathValid(_ indexPath: IndexPath) -> Bool {
-        return indexPath.section < numberOfSections && indexPath.item < numberOfItems(inSection: indexPath.section)
+        return (0..<numberOfSections).contains(indexPath.section) && (0..<numberOfItems(inSection: indexPath.section)).contains(indexPath.item)
     }
 }

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -844,6 +844,7 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
 
         guard resizeAmount != 0,
               let selectedIndexPath = collectionView.selectionIndexPaths.first,
+              collectionView.isIndexPathValid(selectedIndexPath),
               let layoutAttributes = collectionView.layoutAttributesForItem(at: selectedIndexPath) else { return }
 
         let visibleRect = collectionView.visibleRect


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1211695246857461?focus=true

### Description
- fix crash https://errors.duckduckgo.com/organizations/ddg/issues/88712/?project=6&referrer=asana_plugin

### Testing Steps
1. Validate code sanity (no known steps to reproduce)

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low 
#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Validate selected index path before accessing layout attributes and tighten `NSCollectionView.isIndexPathValid` bounds checks to avoid crashes.
> 
> - **macOS Tab Bar**:
>   - Add index-path validity check in `TabBarViewController.adjustScrollPositionOnResize()` using `collectionView.isIndexPathValid(_:)` before fetching layout attributes.
>   - Refine `NSCollectionView.isIndexPathValid(_:)` to use range-based bounds checks for `section` and `item`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a2856a373b491b3835bec35454eabcbd8fb1061. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->