### PR TITLE
Disable flaky watchdog test

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Watchdog/WatchdogTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Watchdog/WatchdogTests.swift
@@ -413,6 +413,8 @@ final class WatchdogTests: XCTestCase {
     // MARK: - State Transitions
 
     func testHangStateTransitions() async throws {
+        throw XCTSkip("Flaky test: https://app.asana.com/1/137249556945/project/1200194497630846/task/1211604496994582?focus=true")
+
         let minimumDuration = 0.2
         let maximumDuration = 0.4
         let checkInterval   = 0.1


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1211678240664873?focus=true
Tech Design URL:
CC:

### Description

Unfortunately the nature of this watchdog test is making it very flaky when run on CI. I’m disabling it until I can investigate further or remove.

### Testing Steps

Just ensure CI is happy.

### Impact and Risks

None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips flaky `testHangStateTransitions` in `WatchdogTests.swift` via `XCTSkip`, referencing tracking URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7549454a899ea160c6d31c2fefa4d8740a9faa06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->