### PR TITLE
exclude .build folders from Xcode SwiftLint

### DIFF
--- a/scripts/xcode-swiftlint.sh
+++ b/scripts/xcode-swiftlint.sh
@@ -13,5 +13,4 @@ if [[ ! -f "$LINTER" ]]; then
   exit 1
 fi
 
-find "$SRCROOT" ! -name 'Package.swift' -prune -o -name "*.swift" | xargs "$LINTER"
-
+find "$SRCROOT" -type d -name ".build" -prune -o -name "Package.swift" -prune -o -name "*.swift" -print | xargs "$LINTER"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1211705194943754?focus=true
Tech Design URL:
CC: @Bunn @jozsef-vesza 

### Description

### Testing Steps
1. Check out code
2. Run build in each project and then in the workspace
3. Should not have extra SwiftLint 
4. From terminal into iOS/LocalPackages/DataBrokerProtection-iOS and run `swift build` (it might fail, that's ok)
5. Build the iOS app - should not have extra SwiftLint

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Minor disruption to team

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943) 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Xcode SwiftLint script to exclude `.build` directories and `Package.swift` when linting Swift files.
> 
> - **Scripts**:
>   - **SwiftLint invocation (`scripts/xcode-swiftlint.sh`)**:
>     - Change `find` command to prune `.build` directories and `Package.swift`, and only pass `.swift` files to SwiftLint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4faf78294fa9c3b67121f4169dfa7e4163605aa3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->