### PR TITLE
Fix for flaky tests

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/SyncDataProvidersTests/CreditCards/CreditCardsProviderTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SyncDataProvidersTests/CreditCards/CreditCardsProviderTests.swift
@@ -267,7 +267,7 @@ final class CreditCardsProviderTests: CreditCardsProviderTestsBase {
         let sent = try await provider.fetchChangedObjects(encryptedUsing: crypter)
         let received: [Syncable] = [.creditCard(uuid: "1", cardholderName: "Updated", cardNumber: "4111111111111111")]
 
-        try await provider.handleSyncResponse(sent: sent, received: received, clientTimestamp: Date(), serverTimestamp: "1234", crypter: crypter)
+        try await provider.handleSyncResponse(sent: sent, received: received, clientTimestamp: Date().advanced(by: 1).withMillisecondPrecision, serverTimestamp: "1234", crypter: crypter)
 
         let syncableCreditCards = try fetchAllSyncableCreditCards()
         XCTAssertEqual(syncableCreditCards.count, 1)

--- a/SharedPackages/BrowserServicesKit/Tests/SyncDataProvidersTests/Identities/IdentitiesProviderTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SyncDataProvidersTests/Identities/IdentitiesProviderTests.swift
@@ -282,7 +282,7 @@ final class IdentitiesProviderTests: IdentitiesProviderTestsBase {
             .identity("Updated", uuid: "1", firstName: "Updated", lastName: "Person")
         ]
 
-        try await provider.handleSyncResponse(sent: sent, received: received, clientTimestamp: Date(), serverTimestamp: "1234", crypter: crypter)
+        try await provider.handleSyncResponse(sent: sent, received: received, clientTimestamp: Date().advanced(by: 1).withMillisecondPrecision, serverTimestamp: "1234", crypter: crypter)
 
         let syncableIdentities = try fetchAllSyncableIdentities()
         XCTAssertEqual(syncableIdentities.count, 1)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1211688275097672?focus=true
Tech Design URL:
CC:

### Description
Updates test for credit card & identities sync to follow credentials equivalent test, adding 1 second to make test deterministic

### Testing Steps
1. Confirm CI is green

### Impact and Risks
None: Update to unit test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make two sync tests deterministic by advancing clientTimestamp by 1s with millisecond precision.
> 
> - **Tests**:
>   - `CreditCardsProviderTests.swift` and `IdentitiesProviderTests.swift`:
>     - In `testWhenObjectDeleteIsSentAndTheSameObjectUpdateIsReceivedThenObjectIsNotDeleted`, change `clientTimestamp` to `Date().advanced(by: 1).withMillisecondPrecision` when calling `handleSyncResponse` to eliminate flakiness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4eeef91c16abe8f05578556b7da2d6284f6f180f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->