### PR TITLE
Fix failing macOS - Sync End-to-End tests

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -12832,7 +12832,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \\\"$CONFIGURATION\\\" != \\\"Debug\\\" ] || [ \\\"$ENABLE_PREVIEWS\\\" = \\\"YES\\\" ]; then exit 0; fi\n\nenv $SOURCE_ROOT/../scripts/xcode-swiftlint.sh\n";
+			shellScript = "env $SOURCE_ROOT/../scripts/xcode-swiftlint.sh\n";
 		};
 		3121F62B2B64266A002F706A /* Copy Swift Package resources */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -12984,7 +12984,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \\\"$CONFIGURATION\\\" != \\\"Debug\\\" ] || [ \\\"$ENABLE_PREVIEWS\\\" = \\\"YES\\\" ]; then exit 0; fi\n\nenv $SOURCE_ROOT/../scripts/xcode-swiftlint.sh\n";
+			shellScript = "env $SOURCE_ROOT/../scripts/xcode-swiftlint.sh\n";
 		};
 		7B2E361D2D6DE89600A08CB7 /* Embed System Network Extension */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/scripts/xcode-swiftlint.sh
+++ b/scripts/xcode-swiftlint.sh
@@ -3,6 +3,8 @@ if [[ -z "$BUILD_ROOT" ]]; then
   exit 1
 fi
 
+if [ "$CONFIGURATION" = "Release" ] || [ "$ENABLE_PREVIEWS" = "YES" ]; then exit 0; fi
+
 LINTER_BASE="$BUILD_ROOT/../.."
 LINTER=`find "$LINTER_BASE" | grep "\-macos/bin/swiftlint$"`
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1211702683378607?focus=true
Tech Design URL:
CC:

### Description
Fixes failing Sync UI test due to fallback favicons (LetterIconView) now set to `.accessibilityHidden(true)`

### Testing Steps
1. Confirm CI is green -> https://github.com/duckduckgo/apple-browsers/actions/runs/18715934759

### Impact and Risks
None: Internal tooling, documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts `checkLogins()` to use updated autofill button labels without the two-letter prefixes.
> 
> - **Tests (macOS Sync E2E)**:
>   - Update `checkLogins()` in `macOS/SyncE2EUITests/CriticalPathsTests.swift` to match new autofill login button labels (remove two-letter prefixes): `"Dax Login, daxthetest"`, `"Github, githubusername"`, `"mywebsite.com, mywebsite"`, `"StackOverflow, stacker"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a182ac619816e60fb50ec06bed4e61c0cc6ef866. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->