### PR TITLE
fix opening new tab from burner window

### DIFF
--- a/macOS/DuckDuckGo/History/View/WindowControllersManager+URLOpening.swift
+++ b/macOS/DuckDuckGo/History/View/WindowControllersManager+URLOpening.swift
@@ -24,7 +24,11 @@ extension WindowControllersManager: URLOpening {
     func openInNewTab(_ urls: [URL], sourceWindow: NSWindow?) {
         guard let mainWindowController = mainWindowController(for: sourceWindow), !urls.isEmpty else { return }
 
-        let tabs = urls.map { Tab(content: .url($0, source: .historyEntry), shouldLoadInBackground: true) }
+        let tabs = urls.map {
+            Tab(content: .url($0, source: .historyEntry),
+                shouldLoadInBackground: true,
+                burnerMode: mainWindowController.mainViewController.tabCollectionViewModel.burnerMode)
+        }
 
         let tabCollectionViewModel = mainWindowController.mainViewController.tabCollectionViewModel
         tabCollectionViewModel.append(tabs: tabs, andSelect: TabsPreferences.shared.switchToNewTabWhenOpened)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1211729130903639?focus=true

### Description
- fix opening in new tab in Fire Window

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Open New Fire Window
2. Open duck://history
3. Right click a record, Open in New Tab, validate there's no crash and the tab is opened

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `openInNewTab` creates new tabs with the current window's `burnerMode` when opening history URLs.
> 
> - **macOS – History** (`WindowControllersManager+URLOpening.swift`):
>   - `openInNewTab`: pass `burnerMode` from the current window's `tabCollectionViewModel` to newly created `Tab`s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69b056ae630bc63306f3782cd8d9f68019024ae4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->