### PR TITLE
Allow newlines in failed unit test task body

### DIFF
--- a/scripts/report-failed-unit-test.sh
+++ b/scripts/report-failed-unit-test.sh
@@ -103,7 +103,11 @@ create_task() {
 	local message
 	local occurrences=1
 	local task_id
-	message=$(sed -E -e 's/\\/\\\\/g' -e 's/"/\\"/g' <<< "$3")
+	# replace newlines with %0A to have them survive backslash escaping
+	message="${3//$'\n'/'%0A'}"
+	message=$(sed -E -e 's/\\/\\\\/g' -e 's/"/\\"/g' <<< "$message")
+	# restore newlines
+	message="${message//'%0A'/$'\n'}"
 
 	task_id=$(curl -X POST -s "${asana_api_url}/tasks?opt_fields=gid" \
 		-H "Authorization: Bearer ${asana_personal_access_token}" \


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1211730956719104?focus=true

### Description Changes the script so that newlines survive backslash escaping

### Testing Steps
N/A

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preserves newlines in failure messages when creating Asana tasks by adjusting message escaping in `report-failed-unit-test.sh`.
> 
> - **Scripts**:
>   - `scripts/report-failed-unit-test.sh`:
>     - In `create_task()`, preprocess `message` to preserve newlines in Asana task `notes` by temporarily replacing newlines with `%0A`, escaping backslashes/quotes, then restoring newlines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb23230296f8e99441b70bf747a9935f4f02dc38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->