### PR TITLE
Fix failing iOS maestro sync test

### DIFF
--- a/.maestro/sync_tests/05_sync_data_check.yaml
+++ b/.maestro/sync_tests/05_sync_data_check.yaml
@@ -48,6 +48,10 @@ name: 05_sync_data_check
 - runFlow:
     file: ../shared/sync_verify_unified_favorites.yaml
 
+# Ensure the keyboard is dismissed before continuing
+- tapOn:
+    id: "Browser.OmniBar.Button.Dismiss"
+
 # Verify logins
 - tapOn: Browsing menu
 - tapOn: Settings


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201462886803403/task/1211708669670242?focus=true
Tech Design URL:
CC:

### Description
Fixes issue where dictation alert triggered due to keyboard not being explicitly dismissed, causing maestro test to fail

### Testing Steps
1. Confirm CI is happy -> https://github.com/duckduckgo/apple-browsers/actions/runs/18754658326


### Impact and Risks
None: Internal tooling, documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a step in `.maestro/sync_tests/05_sync_data_check.yaml` to tap `Browser.OmniBar.Button.Dismiss` to dismiss the keyboard before proceeding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bc8dbab967a8d61ea057bb925d16e074232a83f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->