### PR TITLE
macOS: Add failure pixels for SERP settings storage

### DIFF
--- a/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -263,6 +263,12 @@ enum GeneralPixel: PixelKitEvent {
     case userAddedToDockFromDefaultBrowserSection
     case serpAddedToDock
 
+    // SERP Settings
+    // See macOS/PixelDefinitions/pixels/serp_settings_pixels.json5
+    case serpSettingsSerializationFailed
+    case serpSettingsKeyValueStoreReadError
+    case serpSettingsKeyValueStoreWriteError
+
     case protectionToggledOffBreakageReport
     case debugBreakageExperiment
 
@@ -931,6 +937,10 @@ enum GeneralPixel: PixelKitEvent {
         case .userAddedToDockFromMoreOptionsMenu: return "m_mac_user_added_to_dock_from_more_options_menu"
         case .userAddedToDockFromDefaultBrowserSection: return "m_mac_user_added_to_dock_from_default_browser_section"
         case .serpAddedToDock: return "m_mac_serp_added_to_dock"
+
+        case .serpSettingsSerializationFailed: return "m_mac_serp_settings_serialization_failed"
+        case .serpSettingsKeyValueStoreReadError: return "m_mac_serp_settings_keyvalue_store_read_error"
+        case .serpSettingsKeyValueStoreWriteError: return "m_mac_serp_settings_keyvalue_store_write_error"
 
         case .protectionToggledOffBreakageReport: return "m_mac_protection-toggled-off-breakage-report"
         case .debugBreakageExperiment: return "m_mac_debug_breakage_experiment_u"

--- a/macOS/DuckDuckGo/Tab/UserScripts/SERPSettingsEventHandler.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/SERPSettingsEventHandler.swift
@@ -51,12 +51,15 @@ final class SERPSettingsEventHandler: EventMapping<SERPSettingsError> {
     init() {
         super.init { event, _, _, _ in
             switch event {
-            case .serializationFailed: ()
-                // Fires when converting settings dictionary to JSON fails. Pixel will be added in an upcoming PR
-            case .keyValueStoreReadError: ()
-                // Fires when reading from persistent storage fails. Pixel will be added in an upcoming PR
-            case .keyValueStoreWriteError: ()
-                // Fires when writing to persistent storage fails. Pixel will be added in an upcoming PR
+            case .serializationFailed:
+                // Fires when converting settings dictionary to JSON fails.
+                PixelKit.fire(GeneralPixel.serpSettingsSerializationFailed, frequency: .dailyAndCount)
+            case .keyValueStoreReadError:
+                // Fires when reading from persistent storage fails.
+                PixelKit.fire(GeneralPixel.serpSettingsKeyValueStoreReadError, frequency: .dailyAndCount)
+            case .keyValueStoreWriteError:
+                // Fires when writing to persistent storage fails.
+                PixelKit.fire(GeneralPixel.serpSettingsKeyValueStoreWriteError, frequency: .dailyAndCount)
             }
         }
     }

--- a/macOS/PixelDefinitions/pixels/serp_settings_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/serp_settings_pixels.json5
@@ -1,0 +1,24 @@
+// SERP settings failure pixels
+{
+    "m_mac_serp_settings_serialization_failed": {
+        "description": "Fired when converting SERP settings dictionary to JSON fails during serialization",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["daily", "count"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_serp_settings_keyvalue_store_read_error": {
+        "description": "Fired when reading SERP settings from persistent storage fails",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["daily", "count"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_serp_settings_keyvalue_store_write_error": {
+        "description": "Fired when writing SERP settings to persistent storage fails",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["daily", "count"],
+        "parameters": ["appVersion", "pixelSource"]
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1211721208107953?focus=true
Tech Design URL:
CC:

### Description
Adds a pixel to track failures when retrieving or storing SERP settings. The pixels will be sent with both daily and count data to understand whether issues are affecting several users.

### Testing Steps
1. You will need to enable the `serpSettings` feature flag
2. Add a `throw SERPSettingsError.keyValueStoreReadError` in line 136 on `SERPSettingsProviding` class inside the `SERPSettings` package
3. Check that the two pixels in the image are in the Xcode console:

<img width="1174" height="98" alt="Screenshot 2025-10-23 at 1 24 35 PM" src="https://github.com/user-attachments/assets/b4bc5563-3f1f-4b65-a8ab-9eae4d6e7f0b" />

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
This needs a privacy review.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds pixels for SERP settings serialization/read/write errors and wires the handler to fire them with daily and count frequency.
> 
> - **macOS**:
>   - `Statistics/GeneralPixel.swift`: Add SERP Settings error cases (`serpSettingsSerializationFailed`, `serpSettingsKeyValueStoreReadError`, `serpSettingsKeyValueStoreWriteError`) with corresponding pixel names.
>   - `Tab/UserScripts/SERPSettingsEventHandler.swift`: Map `SERPSettingsError` events to `PixelKit.fire(...)` for the above pixels using `.dailyAndCount`.
> - **Pixel Definitions**:
>   - `PixelDefinitions/pixels/serp_settings_pixels.json5`: Define three new SERP settings failure pixels with `daily` and `count` suffixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6b9947a35215134c5e2bee26212a8026a1c534a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->