### PR TITLE
Fix: Last Pinned Tab Separator Logic

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarCollectionView.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarCollectionView.swift
@@ -129,6 +129,10 @@ open class TabBarCollectionView: NSCollectionView {
         collectionViewLayout?.invalidateLayout()
     }
 
+    func isLastItemInSection(indexPath: IndexPath) -> Bool {
+        numberOfSections > .zero && indexPath.item == numberOfItems(inSection: indexPath.section) - 1
+    }
+
     func setLastItemSeparatorHidden(_ isHidden: Bool) {
         let numberOfItems = numberOfItems(inSection: 0)
         guard numberOfItems > 0, let item = item(at: numberOfItems-1) as? TabBarViewItem else {

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -652,9 +652,12 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
             return
         }
 
+        defer {
+            refreshPinnedTabsLastSeparator()
+        }
+
         guard collectionView.selectionIndexPaths.first?.item != tabCollectionViewModel.selectionIndex?.item else {
             collectionView.updateItemsLeftToSelectedItems()
-            pinnedTabsCollectionView?.setLastItemSeparatorHidden(tabMode == .divided && tabCollectionViewModel.selectionIndex == .unpinned(0))
             return
         }
 
@@ -668,12 +671,25 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
         let newSelectionIndexPath = IndexPath(item: selectionIndex.item)
         if tabMode == .divided {
             collectionView.animator().selectItems(at: [newSelectionIndexPath], scrollPosition: .centeredHorizontally)
-            pinnedTabsCollectionView?.setLastItemSeparatorHidden(selectionIndex == .unpinned(0))
         } else {
             collectionView.selectItems(at: [newSelectionIndexPath], scrollPosition: .centeredHorizontally)
             collectionView.scrollToSelected()
-            pinnedTabsCollectionView?.setLastItemSeparatorHidden(false)
         }
+    }
+
+    private func refreshPinnedTabsLastSeparator() {
+        guard featureFlagger.isFeatureOn(.pinnedTabsViewRewrite), let pinnedTabsCollectionView else {
+            return
+        }
+
+        pinnedTabsCollectionView.setLastItemSeparatorHidden(shouldHideLastPinnedSeparator)
+    }
+
+    private var shouldHideLastPinnedSeparator: Bool {
+        let isTabModeDivided = tabMode == .divided
+        let isFirstUnpinnedTabSelected = tabCollectionViewModel.selectionIndex == .unpinned(.zero)
+
+        return isTabModeDivided && isFirstUnpinnedTabSelected
     }
 
     private func bringSelectedTabCollectionToFront() {
@@ -1428,6 +1444,10 @@ extension TabBarViewController: NSCollectionViewDataSource {
         tabBarViewItem.delegate = self
         tabBarViewItem.isBurner = tabCollectionViewModel.isBurner
         tabBarViewItem.subscribe(to: tabViewModel)
+
+        if let pinnedTabsCollectionView, pinnedTabsCollectionView == collectionView {
+            tabBarViewItem.isLeftToSelected = pinnedTabsCollectionView.isLastItemInSection(indexPath: indexPath) && shouldHideLastPinnedSeparator
+        }
 
         return tabBarViewItem
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1211720412766081?focus=true
Tech Design URL:
CC:

### Description
This PR fixes a glitch that caused the **Last Pinned Tab Separator** to remain visible after relaunch, when the first Unpinned Tab was selected. 

### Details:
The root cause of this bug is the asynchronous nature of the `tabCollectionViewModel.pinnedTabs` collection, on top of the `NSCollectionView.reloadData` async behavior.

In order to circumvent this, in this PR we're:

1. Extracting the logic to determine if the Last Pinned Tab Separator should be hidden
2. Making the `collectionView(..., itemForRepresentedObjectAt:)` API responsible for hiding the Separator (when applicable)

This allows us to set the correct state of the last Pinned Tab Separator at a deferred time, while we preserve the explicit refresh chain, triggered from the `reloadSelection` API.


### Testing Steps
1. Enable the `pinnedTabsViewRewrite` Feature Flag
2. Pin at least 3 tabs (weird but seems to be working great with 1 or 2 pinned tabs)
3. Quit the app and relaunch

- [ ] Verify the last Pinned Tab doesn't render the separator on its right hand side

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing should go wrong, this code affects a UI element that's behind a feature flag.

### Quality Considerations
Please LMK if you notice any other weirdness!

### Notes to Reviewer
Thanks in advance!!

### Screenshots

Before | Now
-|-
<img width="400" height="119" alt="Before" src="https://github.com/user-attachments/assets/e04962e1-3fb8-4d4c-90a1-3fd364fb8e8d" /> | <img width="400" height="117" alt="Now" src="https://github.com/user-attachments/assets/f291bde7-21f6-476e-8e78-7e8a1c9947b8" />


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes last pinned tab separator handling, updating selection flow and item rendering to hide the separator on the last pinned tab when appropriate.
> 
> - **Tab Bar (macOS)**:
>   - **Separator logic**:
>     - Add `TabBarCollectionView.isLastItemInSection(_:)` to identify last items.
>     - Introduce `TabBarViewController.shouldHideLastPinnedSeparator` and `refreshPinnedTabsLastSeparator()`; invoke via `defer` in `reloadSelection()`.
>     - Remove scattered `setLastItemSeparatorHidden` calls; compute once and refresh.
>   - **Rendering**:
>     - In `collectionView(_:itemForRepresentedObjectAt:)`, set `TabBarViewItem.isLeftToSelected` for pinned tabs when item is last and separator should be hidden.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 133110e75b87cf79251c7159d07cd6285b85401c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->