### PR TITLE
fix failing fire tests

### DIFF
--- a/macOS/IntegrationTests/Fire/FireTests.swift
+++ b/macOS/IntegrationTests/Fire/FireTests.swift
@@ -71,7 +71,7 @@ final class FireTests: XCTestCase {
                         faviconManagement: faviconManager,
                         tld: Application.appDelegate.tld,
                         visualizeFireAnimationDecider: visualizeFire,
-                        isAppActiveProvider: { true })  // App is active - should manage windows
+                        isAppActiveProvider: { true }) // App is active - should manage windows
 
         let tabCollectionViewModel = TabCollectionViewModel.makeTabCollectionViewModel(with: pinnedTabsManagerProvider)
         var window: NSWindow! = WindowsManager.openNewWindow(with: tabCollectionViewModel, lazyLoadTabs: true)
@@ -127,7 +127,7 @@ final class FireTests: XCTestCase {
                         faviconManagement: faviconManager,
                         pinnedTabsManagerProvider: pinnedTabsManagerProvider,
                         tld: Application.appDelegate.tld,
-                        isAppActiveProvider: { true })  // App is active - should open new window
+                        isAppActiveProvider: { true }) // App is active - should open new window
 
         // Ensure no windows exist
         XCTAssertEqual(Application.appDelegate.windowControllersManager.mainWindowControllers.count, 0,
@@ -203,7 +203,8 @@ final class FireTests: XCTestCase {
                         windowControllersManager: Application.appDelegate.windowControllersManager,
                         faviconManagement: faviconManager,
                         pinnedTabsManagerProvider: pinnedTabsManagerProvider,
-                        tld: Application.appDelegate.tld)
+                        tld: Application.appDelegate.tld,
+                        isAppActiveProvider: { true }) // App is active - should manage windows
         let tabCollectionViewModel = TabCollectionViewModel.makeTabCollectionViewModel(with: pinnedTabsManagerProvider)
         var window: NSWindow! = WindowsManager.openNewWindow(with: tabCollectionViewModel, lazyLoadTabs: true)
         Logger.tests.info("\(self.name) opened \(window.windowController ??? "<nil>")")
@@ -243,7 +244,8 @@ final class FireTests: XCTestCase {
                         recentlyClosedCoordinator: recentlyClosedCoordinator,
                         pinnedTabsManagerProvider: pinnedTabsManagerProvider,
                         tld: Application.appDelegate.tld,
-                        getVisitedLinkStore: { WKVisitedLinkStoreWrapper(visitedLinkStore: visitedLinkStore) })
+                        getVisitedLinkStore: { WKVisitedLinkStoreWrapper(visitedLinkStore: visitedLinkStore) },
+                        isAppActiveProvider: { false })
         let tabCollectionViewModel = TabCollectionViewModel.makeTabCollectionViewModel(with: pinnedTabsManagerProvider)
         var window: NSWindow! = WindowsManager.openNewWindow(with: tabCollectionViewModel, lazyLoadTabs: true)
         Logger.tests.info("\(self.name) opened \(window.windowController ??? "<nil>")")
@@ -278,7 +280,8 @@ final class FireTests: XCTestCase {
                         permissionManager: permissionManager,
                         faviconManagement: faviconManager,
                         pinnedTabsManagerProvider: pinnedTabsManagerProvider,
-                        tld: Application.appDelegate.tld)
+                        tld: Application.appDelegate.tld,
+                        isAppActiveProvider: { false })
 
         _ = TabCollectionViewModel.makeTabCollectionViewModel(with: pinnedTabsManagerProvider)
 
@@ -379,7 +382,8 @@ final class FireTests: XCTestCase {
                         recentlyClosedCoordinator: recentlyClosedCoordinator,
                         pinnedTabsManagerProvider: pinnedTabsManagerProvider,
                         tld: Application.appDelegate.tld,
-                        getVisitedLinkStore: { WKVisitedLinkStoreWrapper(visitedLinkStore: visitedLinkStore) })
+                        getVisitedLinkStore: { WKVisitedLinkStoreWrapper(visitedLinkStore: visitedLinkStore) },
+                        isAppActiveProvider: { true }) // App is active - should open new window
         let tabCollectionViewModel = TabCollectionViewModel.makeTabCollectionViewModel(with: pinnedTabsManagerProvider)
         var window: NSWindow! = WindowsManager.openNewWindow(with: tabCollectionViewModel, lazyLoadTabs: true)
         Logger.tests.info("\(self.name) opened \(window.windowController ??? "<nil>")")
@@ -429,7 +433,8 @@ final class FireTests: XCTestCase {
                         recentlyClosedCoordinator: recentlyClosedCoordinator,
                         pinnedTabsManagerProvider: pinnedTabsManagerProvider,
                         tld: Application.appDelegate.tld,
-                        getVisitedLinkStore: { WKVisitedLinkStoreWrapper(visitedLinkStore: visitedLinkStore) })
+                        getVisitedLinkStore: { WKVisitedLinkStoreWrapper(visitedLinkStore: visitedLinkStore) },
+                        isAppActiveProvider: { true }) // App is active - should open new window
         let tabCollectionViewModel = TabCollectionViewModel.makeTabCollectionViewModel(with: pinnedTabsManagerProvider)
         var window: NSWindow! = WindowsManager.openNewWindow(with: tabCollectionViewModel, lazyLoadTabs: true)
         Logger.tests.info("\(self.name) opened \(window.windowController ??? "<nil>")")


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1211725584561048?focus=true

### Description
- fix failing fire tests (by providing is app active mock value)

### Testing Steps
Ensure CI is green

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
No

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
Nothing

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Injects isAppActiveProvider into Fire test initializers to control app activity state and align window-management expectations.
> 
> - **Tests**:
>   - Update `macOS/IntegrationTests/Fire/FireTests.swift` to pass `isAppActiveProvider` to `Fire` in relevant tests:
>     - Use `{ true }` where tests expect windows to be managed/opened during burn operations.
>     - Use `{ false }` where tests require no window to open when the app is inactive.
>   - Adjust constructor calls accordingly (including cases with `getVisitedLinkStore`) to ensure consistent behavior across burn scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6422ffbafdbea74f55566f1520cb19baa183147. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->