### PR TITLE
Pinned Tabs SwiftUI: Adds deprecation warnings

### DIFF
--- a/macOS/DuckDuckGo/PinnedTabs/Model/PinnedTabsViewModel.swift
+++ b/macOS/DuckDuckGo/PinnedTabs/Model/PinnedTabsViewModel.swift
@@ -21,6 +21,7 @@ import Combine
 import Common
 import os.log
 
+@available(*, deprecated, message: "PinnedTabsView will soon be replaced by PinnedTabsCollectionView. This ViewModel is soon to be removed!")
 final class PinnedTabsViewModel: ObservableObject {
 
     @Published var items: [Tab] = [] {

--- a/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabsHostingView.swift
+++ b/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabsHostingView.swift
@@ -19,6 +19,7 @@
 import SwiftUI
 import Combine
 
+@available(*, deprecated, message: "Soon to be replaced by PinnedTabsCollectionView!")
 final class PinnedTabsHostingView: NSHostingView<PinnedTabsView> {
 
     let middleClickPublisher: AnyPublisher<CGPoint, Never>

--- a/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabsView.swift
+++ b/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabsView.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+@available(*, deprecated, message: "Soon to be replaced by PinnedTabsCollectionView!")
 struct PinnedTabsView: View {
     @ObservedObject var model: PinnedTabsViewModel
     @State private var draggedTab: Tab?


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211735511642812?focus=true
Tech Design URL:
CC:

### Description
In this PR we're adding a deprecation warning for the SwiftUI implementation of Pinned Tabs.

### Testing Steps
- [ ] Verify the CI is green please!

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing really, this PR adds a deprecation warning. Zero executable code was modified.

### Quality Considerations
Feedback welcomed, I'm not 100% sure about adding an actual warning, but we'll get this removed ASAP.

### Notes to Reviewer
Thanks in advance!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deprecates the SwiftUI pinned tabs components in favor of the upcoming PinnedTabsCollectionView.
> 
> - **Deprecations (SwiftUI Pinned Tabs)**:
>   - Mark `PinnedTabsViewModel` as `@available(*, deprecated, ...)` with note about upcoming `PinnedTabsCollectionView` replacement.
>   - Mark `PinnedTabsHostingView` as deprecated with the same note.
>   - Mark `PinnedTabsView` as deprecated with the same note.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 965520dd6d9e9101fe7dc53557f7c0cca2f28e22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->