### PR TITLE
macOS: Fix flaky crash restore UI test

### DIFF
--- a/macOS/UITests/StateRestorationPromptTests.swift
+++ b/macOS/UITests/StateRestorationPromptTests.swift
@@ -139,15 +139,10 @@ private extension StateRestorationPromptTests {
     }
 
     func waitForSessionFileToExist() {
-        let fileSavedExpectation = expectation(description: "Session persistence file should be saved")
-        let checkTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { timer in
-            if FileManager.default.fileExists(atPath: Self.persistenceFileLocation.path) {
-                fileSavedExpectation.fulfill()
-                timer.invalidate()
-            }
-        }
-        wait(for: [fileSavedExpectation], timeout: UITests.Timeouts.elementExistence)
-        checkTimer.invalidate()
+        let expectation = expectation(for: NSPredicate(description: "Session persistence file should be saved", block: { _, _ in
+            FileManager.default.fileExists(atPath: Self.persistenceFileLocation.path)
+        }), evaluatedWith: nil)
+        wait(for: [expectation], timeout: UITests.Timeouts.elementExistence)
     }
 
     func waitForSessionFileToBeUpdated(since previouslySavedState: Date?) {
@@ -155,18 +150,13 @@ private extension StateRestorationPromptTests {
             XCTFail("Date for previously saved state was unexpectedly nil.")
             return
         }
-        let fileUpdatedExpectation = expectation(description: "Session persistence file should be updated")
-        let checkTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] timer in
-            guard let self, let lastSavedState = dateOfLastSavedState() else {
-                return
+        let expectation = expectation(for: NSPredicate(description: "Session persistence file should be updated since \(previouslySavedState ??? "<nil>")") { _, _ in
+            guard let dateOfLastSavedState = self.dateOfLastSavedState() else {
+                return false
             }
-            if lastSavedState > previouslySavedState {
-                fileUpdatedExpectation.fulfill()
-                timer.invalidate()
-            }
-        }
-        wait(for: [fileUpdatedExpectation], timeout: UITests.Timeouts.elementExistence)
-        checkTimer.invalidate()
+            return dateOfLastSavedState > previouslySavedState
+        }, evaluatedWith: nil)
+        wait(for: [expectation], timeout: UITests.Timeouts.elementExistence)
     }
 }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1211725959381802?focus=true
Tech Design URL:
CC:

### Description

This should fix the flakiness in the UI test `StateRestorationPromptTests.test_sessionCanBeRestored_whenSessionRestoreDisabled_andAppRelaunchesAfterCrash`.

This test could sometimes fail because the session persistence file existed but hadn’t finished updating with the latest session state before the app was terminated. This caused the wrong session state to be restored (a new tab page, instead of the expected URL).

This change adds a deterministic check to ensure the persistence file exists and has updated before terminating the app.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Run the UI tests in `StateRestorationPromptTests` and confirm they pass.
2. Confirm the tests pass in CI: https://github.com/duckduckgo/apple-browsers/actions/runs/18787410924

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make crash-restore UI tests wait for the session persistence file to exist and have a newer modification date before app relaunch.
> 
> - **macOS UI Tests**:
>   - Replace `waitForSessionFileToBeSaved` with deterministic checks in `StateRestorationPromptTests`:
>     - `waitForSessionFileToExist`
>     - `dateOfLastSavedState`
>     - `waitForSessionFileToBeUpdated(since:)`
>   - Update tests to wait for session file existence and modification time before terminating/relaunching the app to ensure correct state restoration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd9ca64612412c1cafb311c95ef460faac5b06bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->