### PR TITLE
[iOS][Modal Prompt Coordination] Do not present modal prompt if contextual onboarding has not been seen

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1210,6 +1210,10 @@
 		9F254B082CF9FC270063B308 /* SpecialErrorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F254B072CF9FC270063B308 /* SpecialErrorModel.swift */; };
 		9F2D99E42EA9F9EE003950CC /* DefaultBrowserModalPromptProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2D99E32EA9F9EE003950CC /* DefaultBrowserModalPromptProviderTests.swift */; };
 		9F2E797E2E0B9F6500E2BEF3 /* DefaultBrowserPromptService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2E797D2E0B9F6500E2BEF3 /* DefaultBrowserPromptService.swift */; };
+		9F3668752EAF0A7600AA8670 /* MockContextualOnboardingStatusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3668742EAF0A6900AA8670 /* MockContextualOnboardingStatusProvider.swift */; };
+		9F3668762EAF0A7600AA8670 /* MockContextualOnboardingStatusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3668742EAF0A6900AA8670 /* MockContextualOnboardingStatusProvider.swift */; };
+		9F3668772EAF0A7600AA8670 /* MockContextualOnboardingStatusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3668742EAF0A6900AA8670 /* MockContextualOnboardingStatusProvider.swift */; };
+		9F3668782EAF0A7600AA8670 /* MockContextualOnboardingStatusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3668742EAF0A6900AA8670 /* MockContextualOnboardingStatusProvider.swift */; };
 		9F387DD82EA86CE3006861F8 /* PromptCooldownStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DD72EA86CE3006861F8 /* PromptCooldownStoreTests.swift */; };
 		9F387DDA2EA87C0F006861F8 /* PromptCooldownManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DD92EA87C0F006861F8 /* PromptCooldownManagerTests.swift */; };
 		9F387DDD2EA881D1006861F8 /* PromptCooldownMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DDC2EA881C7006861F8 /* PromptCooldownMocks.swift */; };
@@ -3468,6 +3472,7 @@
 		9F254B072CF9FC270063B308 /* SpecialErrorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialErrorModel.swift; sourceTree = "<group>"; };
 		9F2D99E32EA9F9EE003950CC /* DefaultBrowserModalPromptProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserModalPromptProviderTests.swift; sourceTree = "<group>"; };
 		9F2E797D2E0B9F6500E2BEF3 /* DefaultBrowserPromptService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserPromptService.swift; sourceTree = "<group>"; };
+		9F3668742EAF0A6900AA8670 /* MockContextualOnboardingStatusProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockContextualOnboardingStatusProvider.swift; sourceTree = "<group>"; };
 		9F387DD72EA86CE3006861F8 /* PromptCooldownStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownStoreTests.swift; sourceTree = "<group>"; };
 		9F387DD92EA87C0F006861F8 /* PromptCooldownManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownManagerTests.swift; sourceTree = "<group>"; };
 		9F387DDC2EA881C7006861F8 /* PromptCooldownMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownMocks.swift; sourceTree = "<group>"; };
@@ -5261,6 +5266,7 @@
 		362E3EC72E7185A200E4C762 /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
+				9F3668742EAF0A6900AA8670 /* MockContextualOnboardingStatusProvider.swift */,
 				98E563932DE8B32D00E6E75F /* ContextualOnboardingPresenterMock.swift */,
 				98E563B62DE8B32D00E6E75F /* OnboardingFirePixelMock.swift */,
 				98E563B72DE8B32D00E6E75F /* OnboardingHostingControllerMock.swift */,
@@ -11275,6 +11281,7 @@
 				6FF9AD412CE6610F00C5A406 /* TabSwitcherOpenDailyPixelTests.swift in Sources */,
 				569437342BE4E41500C0881B /* SyncErrorHandlerSyncErrorsAlertsTests.swift in Sources */,
 				9F387DF52EA8BED0006861F8 /* ModalPromptCoordinationServiceTests.swift in Sources */,
+				9F3668762EAF0A7600AA8670 /* MockContextualOnboardingStatusProvider.swift in Sources */,
 				CBC88EE32C7F8B1700F0F8C5 /* SSLErrorPageNavigationHandlerTests.swift in Sources */,
 				85C11E4120904BBE00BFFEB4 /* VariantManagerTests.swift in Sources */,
 				563A3D032D37C363001966FD /* AppConfigurationURLProviderTests.swift in Sources */,
@@ -11594,6 +11601,7 @@
 				9876DF2E2DEEE21700E30713 /* MockThemeManager.swift in Sources */,
 				98E5640B2DE8B32D00E6E75F /* MockStatisticsStore.swift in Sources */,
 				98E5640C2DE8B32D00E6E75F /* MockTabPreviewsSource.swift in Sources */,
+				9F3668752EAF0A7600AA8670 /* MockContextualOnboardingStatusProvider.swift in Sources */,
 				98E5640D2DE8B32D00E6E75F /* MockDataExtensions.swift in Sources */,
 				98E5640E2DE8B32D00E6E75F /* MockBundle.swift in Sources */,
 				98E5640F2DE8B32D00E6E75F /* MockTabInteractionStateSource.swift in Sources */,
@@ -11757,6 +11765,7 @@
 				98E563DD2DE8B32D00E6E75F /* MockPersistentPixel.swift in Sources */,
 				98E563DE2DE8B32D00E6E75F /* MockTabDelegate.swift in Sources */,
 				98E563DF2DE8B32D00E6E75F /* MockTutorialSettings.swift in Sources */,
+				9F3668782EAF0A7600AA8670 /* MockContextualOnboardingStatusProvider.swift in Sources */,
 				98E563E02DE8B32D00E6E75F /* OnboardingPixelReporterMock.swift in Sources */,
 				98E563E12DE8B32D00E6E75F /* ContextualOnboardingPresenterMock.swift in Sources */,
 				98E564A52DE8EDE200E6E75F /* CapturingAlertPresenter.swift in Sources */,
@@ -11849,6 +11858,7 @@
 				98E5647F2DE8DDE200E6E75F /* HtmlTestDataLoader.swift in Sources */,
 				F1A83D892E0AB27E00054B03 /* MockFeatureFlagger.swift in Sources */,
 				98E564802DE8DDE200E6E75F /* CoreDataTestUtilities.swift in Sources */,
+				9F3668772EAF0A7600AA8670 /* MockContextualOnboardingStatusProvider.swift in Sources */,
 				98E5646D2DE8DDDC00E6E75F /* ContextualOnboardingPresenterMock.swift in Sources */,
 				98E5646E2DE8DDDC00E6E75F /* OnboardingManagerMock.swift in Sources */,
 				98E564A12DE8EDCE00E6E75F /* CapturingSyncPausedStateManager.swift in Sources */,

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -142,6 +142,7 @@ struct Launching: LaunchingHandling {
         // Initialise modal prompts coordination
         let modalPromptCoordinationService = ModalPromptCoordinationFactory.makeService(
             launchSourceManager: launchSourceManager,
+            daxDialogs: daxDialogs,
             keyValueFileStoreService: appKeyValueFileStoreService.keyValueFilesStore,
             privacyConfigurationManager: privacyConfigurationManager,
             providersDependency: .init(

--- a/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
+++ b/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
@@ -44,12 +44,12 @@ struct ModalPromptProviders {
 final class ModalPromptCoordinationService {
     private let modalPromptCoordinationManager: ModalPromptCoordinationManaging
     private let launchSourceManager: LaunchSourceManaging
-    private let tutorialSettings: TutorialSettings
+    private let contextualOnboardingStatusProvider: ContextualDaxDialogStatusProvider
 
     convenience init(
         launchSourceManager: LaunchSourceManaging,
         keyValueStore: ThrowingKeyValueStoring,
-        tutorialSettings: TutorialSettings,
+        contextualOnboardingStatusProvider: ContextualDaxDialogStatusProvider,
         privacyConfigManager: PrivacyConfigurationManaging,
         providers: ModalPromptProviders
     ) {
@@ -75,16 +75,16 @@ final class ModalPromptCoordinationService {
             cooldownManager: cooldownManager,
         )
 
-        self.init(launchSourceManager: launchSourceManager, tutorialSettings: tutorialSettings, modalPromptCoordinationManager: modalPromptCoordinationManager)
+        self.init(launchSourceManager: launchSourceManager, contextualOnboardingStatusProvider: contextualOnboardingStatusProvider, modalPromptCoordinationManager: modalPromptCoordinationManager)
     }
 
     init(
         launchSourceManager: LaunchSourceManaging,
-        tutorialSettings: TutorialSettings,
+        contextualOnboardingStatusProvider: ContextualDaxDialogStatusProvider,
         modalPromptCoordinationManager: ModalPromptCoordinationManaging
     ) {
         self.launchSourceManager = launchSourceManager
-        self.tutorialSettings = tutorialSettings
+        self.contextualOnboardingStatusProvider = contextualOnboardingStatusProvider
         self.modalPromptCoordinationManager = modalPromptCoordinationManager
     }
 
@@ -94,7 +94,7 @@ final class ModalPromptCoordinationService {
             return
         }
 
-        guard tutorialSettings.hasSeenOnboarding else {
+        guard contextualOnboardingStatusProvider.hasSeenOnboarding else {
             Logger.modalPrompt.info("[Modal Prompt Coordination] - Skipping modal prompt - Onboarding not completed.")
             return
         }

--- a/iOS/DuckDuckGo/DaxDialogs.swift
+++ b/iOS/DuckDuckGo/DaxDialogs.swift
@@ -39,6 +39,10 @@ protocol ContextualDaxDialogDisabling {
     func disableContextualDaxDialogs()
 }
 
+protocol ContextualDaxDialogStatusProvider {
+    var hasSeenOnboarding: Bool { get }
+}
+
 protocol ContextualOnboardingLogic {
     var shouldShowPrivacyButtonPulse: Bool { get }
     var shouldShowFireButtonPulse: Bool { get }
@@ -74,7 +78,7 @@ protocol ContextualOnboardingLogic {
     func overrideShownFlagFor(_ spec: DaxDialogs.BrowsingSpec, flag: Bool)
 }
 
-typealias DaxDialogsManaging = ContextualOnboardingLogic & SubscriptionPromotionCoordinating & NewTabDialogSpecProvider & ContextualDaxDialogDisabling
+typealias DaxDialogsManaging = ContextualOnboardingLogic & SubscriptionPromotionCoordinating & NewTabDialogSpecProvider & ContextualDaxDialogDisabling & ContextualDaxDialogStatusProvider
 
 protocol SubscriptionPromotionCoordinating {
     /// Indicates whether the Subscription promotion dialog is currently being displayed
@@ -92,7 +96,7 @@ extension ContentBlockerRulesManager: EntityProviding {
     
 }
 
-final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
+final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic, ContextualDaxDialogStatusProvider {
     
     struct MajorTrackers {
         
@@ -266,6 +270,10 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic {
     private var shouldDisplayFinalContextualBrowsingDialog: Bool {
         !finalDaxDialogSeen &&
         visitedSiteAndFireButtonSeen
+    }
+
+    var hasSeenOnboarding: Bool {
+        !isEnabled
     }
 
     var isShowingSearchSuggestions: Bool {

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Factory/ModalPromptCoordinationFactory.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Factory/ModalPromptCoordinationFactory.swift
@@ -31,6 +31,7 @@ enum ModalPromptCoordinationFactory {
 
     static func makeService(
         launchSourceManager: LaunchSourceManager,
+        daxDialogs: DaxDialogs,
         keyValueFileStoreService: ThrowingKeyValueStoring,
         privacyConfigurationManager: PrivacyConfigurationManaging,
         providersDependency: ProvidersDependency,
@@ -43,7 +44,7 @@ enum ModalPromptCoordinationFactory {
         return ModalPromptCoordinationService(
             launchSourceManager: launchSourceManager,
             keyValueStore: keyValueFileStoreService,
-            tutorialSettings: DefaultTutorialSettings(),
+            contextualOnboardingStatusProvider: daxDialogs,
             privacyConfigManager: privacyConfigurationManager,
             providers: .init(
                 newAddressBarPicker: newAddressBarPickerModalPromptProvider,

--- a/iOS/DuckDuckGoTests/AppServices/ModalPromptCoordinationServiceTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/ModalPromptCoordinationServiceTests.swift
@@ -27,14 +27,14 @@ import PersistenceTestingUtils
 @Suite("Modal Prompt Coordination - Service")
 final class ModalPromptCoordinationServiceTests {
     private let launchSourceManagerMock: MockLaunchSourceManager
-    private let tutorialSettingsMock: MockTutorialSettings
+    private let contextualOnboardingMock: MockContextualOnboardingStatusProvider
     private let managerMock: MockModalPromptCoordinationManager
     private let presenterMock: MockModalPromptPresenter
     private var sut: ModalPromptCoordinationService!
 
     init() {
         launchSourceManagerMock = MockLaunchSourceManager()
-        tutorialSettingsMock = MockTutorialSettings(hasSeenOnboarding: true)
+        contextualOnboardingMock = MockContextualOnboardingStatusProvider(hasSeenOnboarding: true)
         managerMock = MockModalPromptCoordinationManager()
         presenterMock = MockModalPromptPresenter()
     }
@@ -51,11 +51,11 @@ final class ModalPromptCoordinationServiceTests {
     func whenDifferentNonStandardLaunchSourcesThenModalIsNotPresented(launchSource: LaunchSource) {
         // GIVEN
         launchSourceManagerMock.source = launchSource
-        tutorialSettingsMock.hasSeenOnboarding = true
+        contextualOnboardingMock.hasSeenOnboarding = true
         presenterMock.presentedViewController = nil
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
-            tutorialSettings: tutorialSettingsMock,
+            contextualOnboardingStatusProvider: contextualOnboardingMock,
             modalPromptCoordinationManager: managerMock
         )
 
@@ -70,11 +70,11 @@ final class ModalPromptCoordinationServiceTests {
     func whenLaunchSourceIsStandardThenModalIsPresented() {
         // GIVEN
         launchSourceManagerMock.source = .standard
-        tutorialSettingsMock.hasSeenOnboarding = true
+        contextualOnboardingMock.hasSeenOnboarding = true
         presenterMock.presentedViewController = nil
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
-            tutorialSettings: tutorialSettingsMock,
+            contextualOnboardingStatusProvider: contextualOnboardingMock,
             modalPromptCoordinationManager: managerMock
         )
 
@@ -92,11 +92,11 @@ final class ModalPromptCoordinationServiceTests {
     func whenOnboardingNotCompletedThenModalIsNotPresented() {
         // GIVEN
         launchSourceManagerMock.source = .standard
-        tutorialSettingsMock.hasSeenOnboarding = false
+        contextualOnboardingMock.hasSeenOnboarding = false
         presenterMock.presentedViewController = nil
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
-            tutorialSettings: tutorialSettingsMock,
+            contextualOnboardingStatusProvider: contextualOnboardingMock,
             modalPromptCoordinationManager: managerMock
         )
 
@@ -111,11 +111,11 @@ final class ModalPromptCoordinationServiceTests {
     func whenOnboardingCompletedThenModalIsPresented() {
         // GIVEN
         launchSourceManagerMock.source = .standard
-        tutorialSettingsMock.hasSeenOnboarding = true
+        contextualOnboardingMock.hasSeenOnboarding = true
         presenterMock.presentedViewController = nil
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
-            tutorialSettings: tutorialSettingsMock,
+            contextualOnboardingStatusProvider: contextualOnboardingMock,
             modalPromptCoordinationManager: managerMock
         )
 
@@ -132,12 +132,12 @@ final class ModalPromptCoordinationServiceTests {
     func whenAnotherModalIsPresentedThenModalIsNotPresented() {
         // GIVEN
         launchSourceManagerMock.source = .standard
-        tutorialSettingsMock.hasSeenOnboarding = true
+        contextualOnboardingMock.hasSeenOnboarding = true
         let alreadyPresentedVC = UIViewController()
         presenterMock.presentedViewController = alreadyPresentedVC
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
-            tutorialSettings: tutorialSettingsMock,
+            contextualOnboardingStatusProvider: contextualOnboardingMock,
             modalPromptCoordinationManager: managerMock
         )
 
@@ -152,11 +152,11 @@ final class ModalPromptCoordinationServiceTests {
     func whenNoModalIsPresentedThenModalIsPresented() {
         // GIVEN
         launchSourceManagerMock.source = .standard
-        tutorialSettingsMock.hasSeenOnboarding = true
+        contextualOnboardingMock.hasSeenOnboarding = true
         presenterMock.presentedViewController = nil
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
-            tutorialSettings: tutorialSettingsMock,
+            contextualOnboardingStatusProvider: contextualOnboardingMock,
             modalPromptCoordinationManager: managerMock
         )
 
@@ -171,13 +171,13 @@ final class ModalPromptCoordinationServiceTests {
     func whenPresentedModalIsBeingDismissedThenModalIsPresented() {
         // GIVEN
         launchSourceManagerMock.source = .standard
-        tutorialSettingsMock.hasSeenOnboarding = true
+        contextualOnboardingMock.hasSeenOnboarding = true
         let dismissingVC = MockDismissingViewController()
         dismissingVC.isBeingDismissed = true
         presenterMock.presentedViewController = dismissingVC
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
-            tutorialSettings: tutorialSettingsMock,
+            contextualOnboardingStatusProvider: contextualOnboardingMock,
             modalPromptCoordinationManager: managerMock
         )
 
@@ -192,11 +192,11 @@ final class ModalPromptCoordinationServiceTests {
     func whenMultipleConditionsFailThenModalIsNotPresented() {
         // GIVEN
         launchSourceManagerMock.source = .URL
-        tutorialSettingsMock.hasSeenOnboarding = false
+        contextualOnboardingMock.hasSeenOnboarding = false
         presenterMock.presentedViewController = UIViewController()
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
-            tutorialSettings: tutorialSettingsMock,
+            contextualOnboardingStatusProvider: contextualOnboardingMock,
             modalPromptCoordinationManager: managerMock
         )
 
@@ -221,13 +221,13 @@ final class ModalPromptCoordinationServiceTests {
             winBackOffer: winBackOfferProvider
         )
         launchSourceManagerMock.source = .standard
-        tutorialSettingsMock.hasSeenOnboarding = true
+        contextualOnboardingMock.hasSeenOnboarding = true
         presenterMock.presentedViewController = nil
 
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
             keyValueStore: keyValueStore,
-            tutorialSettings: tutorialSettingsMock,
+            contextualOnboardingStatusProvider: contextualOnboardingMock,
             privacyConfigManager: privacyConfigManager,
             providers: providers
         )
@@ -255,13 +255,13 @@ final class ModalPromptCoordinationServiceTests {
             winBackOffer: winBackOfferProvider
         )
         launchSourceManagerMock.source = .standard
-        tutorialSettingsMock.hasSeenOnboarding = true
+        contextualOnboardingMock.hasSeenOnboarding = true
         presenterMock.presentedViewController = nil
 
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
             keyValueStore: keyValueStore,
-            tutorialSettings: tutorialSettingsMock,
+            contextualOnboardingStatusProvider: contextualOnboardingMock,
             privacyConfigManager: privacyConfigManager,
             providers: providers
         )
@@ -289,13 +289,13 @@ final class ModalPromptCoordinationServiceTests {
             winBackOffer: winBackOfferProvider
         )
         launchSourceManagerMock.source = .standard
-        tutorialSettingsMock.hasSeenOnboarding = true
+        contextualOnboardingMock.hasSeenOnboarding = true
         presenterMock.presentedViewController = nil
 
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
             keyValueStore: keyValueStore,
-            tutorialSettings: tutorialSettingsMock,
+            contextualOnboardingStatusProvider: contextualOnboardingMock,
             privacyConfigManager: privacyConfigManager,
             providers: providers
         )

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/ContextualOnboardingPresenterMock.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/ContextualOnboardingPresenterMock.swift
@@ -134,6 +134,8 @@ final class ContextualOnboardingLogicMock: ContextualOnboardingLogic, Subscripti
 
 // Use to fill parameter list in injection.
 class DummyDaxDialogsManager: DaxDialogsManaging {
+    var hasSeenOnboarding: Bool = false
+
     var isShowingFireDialog: Bool = false
 
     var shouldShowPrivacyButtonPulse: Bool = false

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/MockContextualOnboardingStatusProvider.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/MockContextualOnboardingStatusProvider.swift
@@ -1,0 +1,29 @@
+//
+//  MockContextualOnboardingStatusProvider.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+@testable import DuckDuckGo
+
+final class MockContextualOnboardingStatusProvider: ContextualDaxDialogStatusProvider {
+    var hasSeenOnboarding: Bool = false
+
+    init(hasSeenOnboarding: Bool) {
+        self.hasSeenOnboarding = hasSeenOnboarding
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211765060834465?focus=true
Tech Design URL:
CC:

### Description

### Testing Steps
1. Ensure test pass
2. Ensure first modal prompt is shown only after contextual onboarding is completed.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modal prompts now only show after contextual onboarding is completed, using `DaxDialogs` as a `ContextualDaxDialogStatusProvider` instead of `TutorialSettings`, with factory wiring and tests updated.
> 
> - **App Services**:
>   - `ModalPromptCoordinationService`: replace `TutorialSettings` with `ContextualDaxDialogStatusProvider`; guard on `hasSeenOnboarding` before presenting.
> - **Factory/Wiring**:
>   - `ModalPromptCoordinationFactory.makeService(...)`: inject `daxDialogs` as `contextualOnboardingStatusProvider`.
>   - `Launching`: pass `daxDialogs` into modal prompt coordination service factory.
> - **Onboarding/Dax**:
>   - Add `ContextualDaxDialogStatusProvider` protocol; extend `DaxDialogs` to conform and expose `hasSeenOnboarding`.
> - **Tests**:
>   - Update `ModalPromptCoordinationServiceTests` to use `MockContextualOnboardingStatusProvider`.
>   - Add `MockContextualOnboardingStatusProvider` and wire in project/test targets; add `hasSeenOnboarding` to `DummyDaxDialogsManager`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c84e1b43fe463f78429e40f4b42af0d64b515327. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->