### PR TITLE
Do not translate debug menu items

### DIFF
--- a/iOS/DuckDuckGo/WinBackOffer/WinBackOfferDebugMenu.swift
+++ b/iOS/DuckDuckGo/WinBackOffer/WinBackOfferDebugMenu.swift
@@ -167,31 +167,41 @@ struct WinBackOfferDebugView: View {
 
     var body: some View {
         List {
-            Section(header: Text("Debug Controls")) {
-                Button("Simulate Churn") {
+            Section(header: Text(verbatim: "Debug Controls")) {
+                Button(action: {
                     viewModel.simulateChurn()
+                }) {
+                    Text(verbatim: "Simulate Churn")
                 }
 
-                Button("Override Today's Date") {
+                Button(action: {
                     showingDatePicker = true
+                }) {
+                    Text(verbatim: "Override Today's Date")
                 }
 
-                Button("Reset Win-back Offer") {
+                Button(action: {
                     viewModel.resetWinBackOffer()
+                }) {
+                    Text(verbatim: "Reset Win-back Offer")
                 }
             }
 
-            Section(header: Text("Quick Test Scenarios")) {
-                Button("Jump to First Day (3 days after churn)") {
+            Section(header: Text(verbatim: "Quick Test Scenarios")) {
+                Button(action: {
                     viewModel.jumpToFirstDay()
+                }) {
+                    Text(verbatim: "Jump to First Day (3 days after churn)")
                 }
 
-                Button("Jump to Last Day (offer ending)") {
+                Button(action: {
                     viewModel.jumpToLastDay()
+                }) {
+                    Text(verbatim: "Jump to Last Day (offer ending)")
                 }
             }
 
-            Section(header: Text("Current State")) {
+            Section(header: Text(verbatim: "Current State")) {
                 LabeledRow(label: "Today's Date", value: Self.dateFormatter.string(from: viewModel.simulatedToday))
 
                 if let churnDate = viewModel.churnDate {
@@ -212,12 +222,12 @@ struct WinBackOfferDebugView: View {
                     LabeledRow(label: "Redeemed", value: viewModel.hasRedeemed ? "Yes" : "No")
                     LabeledRow(label: "Modal Shown", value: viewModel.modalShown ? "Yes" : "No")
                 } else {
-                    Text("No churn simulated")
+                    Text(verbatim: "No churn simulated")
                         .foregroundColor(.secondary)
                 }
             }
         }
-        .navigationTitle("Win-back Offer")
+        .navigationTitle(Text(verbatim: "Win-back Offer"))
         .sheet(isPresented: $showingDatePicker) {
             DatePickerView(date: $viewModel.simulatedToday) {
                 viewModel.overrideTodaysDate(viewModel.simulatedToday)
@@ -234,9 +244,9 @@ private struct LabeledRow: View {
 
     var body: some View {
         HStack {
-            Text(label)
+            Text(verbatim: label)
             Spacer()
-            Text(value)
+            Text(verbatim: value)
                 .foregroundColor(.secondary)
         }
     }
@@ -251,24 +261,29 @@ private struct DatePickerView: View {
         NavigationView {
             Form {
                 DatePicker(
-                    "Select Date",
                     selection: $date,
                     displayedComponents: [.date]
-                )
+                ) {
+                    Text(verbatim: "Select Date")
+                }
                 .datePickerStyle(.graphical)
             }
-            .navigationTitle("Simulate Today's Date")
+            .navigationTitle(Text(verbatim: "Simulate Today's Date"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") {
+                    Button(action: {
                         dismiss()
+                    }) {
+                        Text(verbatim: "Cancel")
                     }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Save") {
+                    Button(action: {
                         onSave()
                         dismiss()
+                    }) {
+                        Text(verbatim: "Save")
                     }
                 }
             }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210594645229050/task/1211729509636946
Tech Design URL:
CC:

### Description

This PR applies `verbatim` to strings used on the debug view to avoid flagging them for translations.

### Testing Steps
N/A, green CI should be enough

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps debug UI strings in Text(verbatim:) and updates Button/DatePicker initializers to avoid localization in WinBackOfferDebugMenu.
> 
> - **WinBackOfferDebugMenu (`iOS/DuckDuckGo/WinBackOffer/WinBackOfferDebugMenu.swift`)**:
>   - Wrap all user-visible debug strings with `Text(verbatim:)` (section headers, labels, navigation titles, helper rows, and messages).
>   - Update `Button` usages to `Button(action:) { Text(verbatim: ...) }`.
>   - Convert `DatePicker` title to trailing label closure with `Text(verbatim: ...)`.
>   - Ensure all titles/toolbars use non-localized `Text(verbatim:)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 307e7043c37eb785ae448624629da155a817f05e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->