### PR TITLE
Update UK and Irish suggested site in contextual onboarding

### DIFF
--- a/SharedPackages/Onboarding/Sources/Onboarding/OnboardingSuggestedSitesProvider.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/OnboardingSuggestedSitesProvider.swift
@@ -85,13 +85,13 @@ public struct OnboardingSuggestedSitesProvider: OnboardingSuggestionsItemsProvid
         let site: String
         switch Countries(rawValue: country) {
         case .indonesia: site = "kompas.com"
-        case .gb: site = "bbc.co.uk"
+        case .gb: site = "uk.yahoo.com"
         case .germany: site = "tagesschau.de"
         case .canada: site = "ctvnews.ca"
         case .netherlands: site = "nu.nl"
         case .australia: site = "yahoo.com"
         case .sweden: site = "dn.se"
-        case .ireland: site = "bbc.co.uk"
+        case .ireland: site = "uk.yahoo.com"
         default: site = "yahoo.com"
         }
         return ContextualOnboardingListItem.site(title: scheme + site)

--- a/SharedPackages/Onboarding/Sources/OnboardingTests/OnboardingSuggestedSitesProviderTests.swift
+++ b/SharedPackages/Onboarding/Sources/OnboardingTests/OnboardingSuggestedSitesProviderTests.swift
@@ -48,7 +48,7 @@ final class OnboardingSuggestedSitesProviderTests: XCTestCase {
 
         // THEN
         XCTAssertEqual(sitesList[0], ContextualOnboardingListItem.site(title: scheme + "skysports.com"))
-        XCTAssertEqual(sitesList[1], ContextualOnboardingListItem.site(title: scheme + "bbc.co.uk"))
+        XCTAssertEqual(sitesList[1], ContextualOnboardingListItem.site(title: scheme + "uk.yahoo.com"))
         XCTAssertEqual(sitesList[2], ContextualOnboardingListItem.site(title: scheme + "eBay.com"))
         XCTAssertEqual(sitesList[3], ContextualOnboardingListItem.surprise(title: scheme + "britannica.com/animal/duck", visibleTitle: surpriseMeTitle))
     }
@@ -138,7 +138,7 @@ final class OnboardingSuggestedSitesProviderTests: XCTestCase {
 
         // THEN
         XCTAssertEqual(sitesList[0], ContextualOnboardingListItem.site(title: scheme + "skysports.com"))
-        XCTAssertEqual(sitesList[1], ContextualOnboardingListItem.site(title: scheme + "bbc.co.uk"))
+        XCTAssertEqual(sitesList[1], ContextualOnboardingListItem.site(title: scheme + "uk.yahoo.com"))
         XCTAssertEqual(sitesList[2], ContextualOnboardingListItem.site(title: scheme + "eBay.com"))
         XCTAssertEqual(sitesList[3], ContextualOnboardingListItem.surprise(title: scheme + "britannica.com/animal/duck", visibleTitle: surpriseMeTitle))
     }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1211642170473306?focus=true

### Description Updates site

### Testing Steps
On both platforms
1. In "edit scheme” -> Options ->  App Region selct UK or Ireland
2. Got through the contextual onboarding and check that in the website suggestion dialog bbc is replaced by yahoo and check it load correctly

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace BBC with uk.yahoo.com as the second suggested site for GB and IE and update tests accordingly.
> 
> - **Onboarding**:
>   - **Suggested sites**: For `GB` and `IE`, change `option2` from `bbc.co.uk` to `uk.yahoo.com` in `OnboardingSuggestedSitesProvider`.
> - **Tests**:
>   - Update expectations in `SharedPackages/Onboarding/Sources/OnboardingTests/OnboardingSuggestedSitesProviderTests.swift` for `GB` and `IE` to assert `uk.yahoo.com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd87bebb3f7292710fd87feb9588d87ed8713187. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->