### PR TITLE
[Release PR] Set Duck.ai usage when visiting via URL

### DIFF
--- a/iOS/DuckDuckGo/AIChat/AIChatViewControllerManager.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatViewControllerManager.swift
@@ -52,6 +52,7 @@ final class AIChatViewControllerManager {
     private let downloadsDirectoryHandler: DownloadsDirectoryHandling
     private let userAgentManager: AIChatUserAgentProviding
     private let featureFlagger: FeatureFlagger
+    private let featureDiscovery: FeatureDiscovery
     private let experimentalAIChatManager: ExperimentalAIChatManager
     private let aiChatSettings: AIChatSettingsProvider
     private var cancellables = Set<AnyCancellable>()
@@ -65,6 +66,7 @@ final class AIChatViewControllerManager {
          userAgentManager: UserAgentManaging = DefaultUserAgentManager.shared,
          experimentalAIChatManager: ExperimentalAIChatManager,
          featureFlagger: FeatureFlagger,
+         featureDiscovery: FeatureDiscovery,
          aiChatSettings: AIChatSettingsProvider,
          subscriptionAIChatStateHandler: SubscriptionAIChatStateHandling = SubscriptionAIChatStateHandler()) {
 
@@ -73,6 +75,7 @@ final class AIChatViewControllerManager {
         self.userAgentManager = AIChatUserAgentHandler(userAgentManager: userAgentManager)
         self.experimentalAIChatManager = experimentalAIChatManager
         self.featureFlagger = featureFlagger
+        self.featureDiscovery = featureDiscovery
         self.aiChatSettings = aiChatSettings
         self.subscriptionAIChatStateHandler = subscriptionAIChatStateHandler
     }
@@ -94,6 +97,7 @@ final class AIChatViewControllerManager {
 
         pixelMetricHandler = AIChatPixelMetricHandler(timeElapsedInMinutes: sessionTimer?.timeElapsedInMinutes())
         pixelMetricHandler?.fireOpenAIChat()
+        featureDiscovery.setWasUsedBefore(.aiChat)
 
         /// If we have a query or payload, let's clean the previous session and start fresh
         if query != nil || payload != nil || subscriptionAIChatStateHandler.shouldForceAIChatRefresh {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -214,6 +214,7 @@ class MainViewController: UIViewController {
     private lazy var aiChatViewControllerManager: AIChatViewControllerManager = {
         let manager = AIChatViewControllerManager(experimentalAIChatManager: .init(featureFlagger: featureFlagger),
                                                   featureFlagger: featureFlagger,
+                                                  featureDiscovery: featureDiscovery,
                                                   aiChatSettings: aiChatSettings)
         manager.delegate = self
         return manager

--- a/iOS/IntegrationTests/AiChat/AIChatViewControllerManagerTests.swift
+++ b/iOS/IntegrationTests/AiChat/AIChatViewControllerManagerTests.swift
@@ -21,6 +21,7 @@ import Testing
 import Foundation
 import Combine
 import BrowserServicesKit
+import BrowserServicesKitTestsUtils
 import Subscription
 @testable import DuckDuckGo
 import UIKit
@@ -36,6 +37,7 @@ struct AIChatViewControllerManagerTests {
             userAgentManager: MockUserAgentManager(privacyConfig: MockPrivacyConfiguration()),
             experimentalAIChatManager: ExperimentalAIChatManager(),
             featureFlagger: MockFeatureFlagger(),
+            featureDiscovery: MockFeatureDiscovery(),
             aiChatSettings: MockAIChatSettingsProvider()
         )
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1211790375925306?focus=true
Tech Design URL:
CC:

### Description

This PR fixes an issue where `FeatureDiscovery` wasn't correctly setting that Duck.ai has been used.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Set a breakpoint in `DefaultFeatureDiscovery`'s `setWasUsedBefore` function
2. Visit `duck.ai` via the address bar
3. Confirm that the breakpoint gets hit
4. Open Duck.ai via other entry points and confirm the breakpoint gets hit each time

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
5. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

The main risk is whether it's deliberate that we aren't setting this here, but we set it through every entry point (including when visiting via URL) on macOS, so the iOS behavior appears to be a bug.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates FeatureDiscovery into AI Chat flow to record usage on open, wiring it through MainViewController and tests.
> 
> - **AI Chat**:
>   - Injects `FeatureDiscovery` into `AIChatViewControllerManager` and calls `featureDiscovery.setWasUsedBefore(.aiChat)` in `openAIChat`.
>   - Updates `MainViewController` to pass `featureDiscovery` when creating `AIChatViewControllerManager`.
> - **Tests**:
>   - Add `BrowserServicesKitTestsUtils` import and use `MockFeatureDiscovery` in `AIChatViewControllerManagerTests`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 056b9b57c1accd2cac1febfb20daedb8fed0c80d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->