### PR TITLE
[iOS][Modal Prompt Coordination] Refactor Providers to return an already configured view controller  

### DIFF
--- a/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
@@ -91,10 +91,6 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
 private extension ModalPromptCoordinationManager {
 
     func presentModalPrompt(modalPromptConfiguration: ModalPromptConfiguration, from presenter: ModalPromptPresenter, completion: @escaping (() -> Void)) {
-        let viewControllerToPresent = modalPromptConfiguration.viewController
-        viewControllerToPresent.modalPresentationStyle = modalPromptConfiguration.presentationStyle
-        viewControllerToPresent.modalTransitionStyle = modalPromptConfiguration.transitionStyle
-        viewControllerToPresent.isModalInPresentation = modalPromptConfiguration.shouldDisablePullDownToDismiss
         scheduler.schedule(after: 0.1) {
             presenter.present(modalPromptConfiguration.viewController, animated: modalPromptConfiguration.animated, completion: completion)
         }

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Providers/DefaultBrowserModalPromptProvider.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Providers/DefaultBrowserModalPromptProvider.swift
@@ -32,9 +32,6 @@ final class DefaultBrowserModalPromptProvider: ModalPromptProvider {
 
         return ModalPromptConfiguration(
             viewController: defaultBrowserPromptVC,
-            presentationStyle: defaultBrowserPromptVC.modalPresentationStyle,
-            transitionStyle: defaultBrowserPromptVC.modalTransitionStyle,
-            shouldDisablePullDownToDismiss: false,
             animated: true
         )
     }

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Providers/ModalPromptProvider.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Providers/ModalPromptProvider.swift
@@ -22,28 +22,17 @@ import UIKit
 /// Represent the Configuration for presenting a modal prompt.
 struct ModalPromptConfiguration {
     /// The view controller to present.
+    /// The provider is responsible for configuring the view controller's presentation properties
+    /// (modalPresentationStyle, modalTransitionStyle, isModalInPresentation) before returning it.
     let viewController: UIViewController
-    /// Modal presentation styles available when presenting view controllers.
-    let presentationStyle: UIModalPresentationStyle
-    /// Transition styles available when presenting view controllers. The default value of this property is `.coverVertical`.
-    let transitionStyle: UIModalTransitionStyle
-    /// A Boolean value indicating whether the view controller enforces a modal behavior.
-    /// The default value of this property is `false`. When you set it to true, UIKit ignores events outside the view controller’s bounds and prevents the interactive dismissal of the view controller while it is onscreen.
-    let shouldDisablePullDownToDismiss: Bool
     /// Whether the presentation should be animated or not. The default value of this property is `true`.
     let animated: Bool
 
     init(
         viewController: UIViewController,
-        presentationStyle: UIModalPresentationStyle,
-        transitionStyle: UIModalTransitionStyle = .coverVertical,
-        shouldDisablePullDownToDismiss: Bool = false,
         animated: Bool = true
     ) {
         self.viewController = viewController
-        self.presentationStyle = presentationStyle
-        self.transitionStyle = transitionStyle
-        self.shouldDisablePullDownToDismiss = shouldDisablePullDownToDismiss
         self.animated = animated
     }
 }

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Providers/NewAddressBarPickerModalPromptProvider.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Providers/NewAddressBarPickerModalPromptProvider.swift
@@ -46,19 +46,18 @@ final class NewAddressBarPickerModalPromptProvider: ModalPromptProvider {
         }
 
         let pickerViewController = NewAddressBarPickerViewController(aiChatSettings: aiChatSettings)
-        let modalPresentationStyle: UIModalPresentationStyle
 
+        // Configure presentation properties on the view controller
         if #available(iOS 26.0, *), isIPad {
-            modalPresentationStyle = .formSheet
+            pickerViewController.modalPresentationStyle = .formSheet
         } else {
-            modalPresentationStyle = .pageSheet
+            pickerViewController.modalPresentationStyle = .pageSheet
         }
+        pickerViewController.modalTransitionStyle = .coverVertical
+        pickerViewController.isModalInPresentation = true
 
         return ModalPromptConfiguration(
             viewController: pickerViewController,
-            presentationStyle: modalPresentationStyle,
-            transitionStyle: .coverVertical,
-            shouldDisablePullDownToDismiss: true,
             animated: true
         )
     }

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
@@ -205,16 +205,17 @@ final class ModalPromptCoordinationManagerTests {
 
     // MARK: - Presentation Tests
 
-    @Test("Check Modal Configuration Is Applied To View Controller")
-    func whenPresentingModalThenConfigurationIsApplied() {
+    @Test("Check View Controller From Provider Is Presented")
+    func whenPresentingModalThenViewControllerFromProviderIsPresented() {
         // GIVEN
         cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
         let provider = MockModalPromptProvider()
+        let viewController = UIViewController()
+        viewController.modalPresentationStyle = .pageSheet
+        viewController.modalTransitionStyle = .coverVertical
+        viewController.isModalInPresentation = true
         provider.modalConfigurationToReturn = ModalPromptConfiguration(
-            viewController: UIViewController(),
-            presentationStyle: .pageSheet,
-            transitionStyle: .coverVertical,
-            shouldDisablePullDownToDismiss: true,
+            viewController: viewController,
             animated: true
         )
         sut = ModalPromptCoordinationManager(
@@ -229,106 +230,11 @@ final class ModalPromptCoordinationManagerTests {
 
         // THEN
         let presentedVC = presenterMock.capturedViewController
+        #expect(presenterMock.capturedViewController === presentedVC)
         #expect(presentedVC?.modalPresentationStyle == .pageSheet)
         #expect(presentedVC?.modalTransitionStyle == .coverVertical)
         #expect(presentedVC?.isModalInPresentation == true)
         #expect(presenterMock.capturedAnimated == true)
-    }
-
-    @Test(
-        "Check Different Presentation Styles Are Applied Correctly",
-        arguments: [
-            UIModalPresentationStyle.pageSheet,
-            .formSheet,
-            .overFullScreen,
-            .fullScreen
-        ]
-    )
-    func whenDifferentPresentationStylesThenStyleIsAppliedCorrectly(presentationStyle: UIModalPresentationStyle) {
-        // GIVEN
-        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
-        let provider = MockModalPromptProvider()
-        provider.modalConfigurationToReturn = ModalPromptConfiguration(
-            viewController: UIViewController(),
-            presentationStyle: presentationStyle,
-            transitionStyle: .coverVertical,
-            shouldDisablePullDownToDismiss: false,
-            animated: true
-        )
-        sut = ModalPromptCoordinationManager(
-            providers: [provider],
-            cooldownManager: cooldownManagerMock,
-            modalPromptScheduling: schedulerMock
-        )
-
-        // WHEN
-        sut.presentModalPromptIfNeeded(from: presenterMock)
-        schedulerMock.executeScheduledBlock()
-
-        // THEN
-        #expect(presenterMock.capturedViewController?.modalPresentationStyle == presentationStyle)
-    }
-
-    @Test(
-        "Check Different Transition Styles Are Applied Correctly",
-        arguments: [
-            UIModalTransitionStyle.coverVertical,
-            .crossDissolve,
-            .flipHorizontal
-        ]
-    )
-    func whenDifferentTransitionStylesThenStyleIsAppliedCorrectly(transitionStyle: UIModalTransitionStyle) {
-        // GIVEN
-        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
-        let provider = MockModalPromptProvider()
-        provider.modalConfigurationToReturn = ModalPromptConfiguration(
-            viewController: UIViewController(),
-            presentationStyle: .pageSheet,
-            transitionStyle: transitionStyle,
-            shouldDisablePullDownToDismiss: false,
-            animated: true
-        )
-        sut = ModalPromptCoordinationManager(
-            providers: [provider],
-            cooldownManager: cooldownManagerMock,
-            modalPromptScheduling: schedulerMock
-        )
-
-        // WHEN
-        sut.presentModalPromptIfNeeded(from: presenterMock)
-        schedulerMock.executeScheduledBlock()
-
-        // THEN
-        #expect(presenterMock.capturedViewController?.modalTransitionStyle == transitionStyle)
-    }
-
-    @Test(
-        "Check shouldDisablePullDownToDismiss Flag Is Applied Correctly",
-        arguments: [true, false]
-    )
-    func whenDifferentPullDownSettingsThenIsModalInPresentationIsSetCorrectly(shouldDisable: Bool) {
-        // GIVEN
-        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
-        let provider = MockModalPromptProvider()
-        provider.modalConfigurationToReturn = ModalPromptConfiguration(
-            viewController: UIViewController(),
-            presentationStyle: .pageSheet,
-            transitionStyle: .coverVertical,
-            shouldDisablePullDownToDismiss: shouldDisable,
-            animated: true
-        )
-        sut = ModalPromptCoordinationManager(
-            providers: [provider],
-            cooldownManager: cooldownManagerMock,
-            modalPromptScheduling: schedulerMock
-        )
-
-        // WHEN
-        sut.presentModalPromptIfNeeded(from: presenterMock)
-        schedulerMock.executeScheduledBlock()
-
-        // THEN
-        #expect(presenterMock.capturedViewController?.isModalInPresentation == shouldDisable)
     }
 
     @Test(
@@ -341,9 +247,6 @@ final class ModalPromptCoordinationManagerTests {
         let provider = MockModalPromptProvider()
         provider.modalConfigurationToReturn = ModalPromptConfiguration(
             viewController: UIViewController(),
-            presentationStyle: .pageSheet,
-            transitionStyle: .coverVertical,
-            shouldDisablePullDownToDismiss: false,
             animated: animated
         )
         sut = ModalPromptCoordinationManager(

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/Providers/DefaultBrowserModalPromptProviderTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/Providers/DefaultBrowserModalPromptProviderTests.swift
@@ -56,8 +56,8 @@ final class DefaultBrowserModalPromptProviderTests {
         #expect(presenter.didCallMakePresentDefaultModalPrompt)
     }
 
-    @Test("Check Configuration Uses View Controller's Modal Presentation Style")
-    func whenPresenterReturnsViewControllerThenConfigurationUsesItsModalPresentationStyle() {
+    @Test("Check View Controller Preserves Modal Presentation Style")
+    func whenPresenterReturnsViewControllerThenModalPresentationStyleIsPreserved() {
         // GIVEN
         let mockViewController = UIViewController()
         mockViewController.modalPresentationStyle = .fullScreen
@@ -68,11 +68,11 @@ final class DefaultBrowserModalPromptProviderTests {
         let configuration = sut.provideModalPrompt()
 
         // THEN
-        #expect(configuration?.presentationStyle == .fullScreen)
+        #expect(configuration?.viewController.modalPresentationStyle == .fullScreen)
     }
 
     @Test(
-        "Check Configuration Respects Different Presentation Styles",
+        "Check View Controller Preserves Different Presentation Styles",
         arguments: [
             UIModalPresentationStyle.fullScreen,
             .pageSheet,
@@ -81,7 +81,7 @@ final class DefaultBrowserModalPromptProviderTests {
             .popover
         ]
     )
-    func whenViewControllerHasDifferentPresentationStylesThenConfigurationRespectsIt(style: UIModalPresentationStyle) {
+    func whenViewControllerHasDifferentPresentationStylesThenTheyArePreserved(style: UIModalPresentationStyle) {
         // GIVEN
         let mockViewController = UIViewController()
         mockViewController.modalPresentationStyle = style
@@ -92,11 +92,11 @@ final class DefaultBrowserModalPromptProviderTests {
         let configuration = sut.provideModalPrompt()
 
         // THEN
-        #expect(configuration?.presentationStyle == style)
+        #expect(configuration?.viewController.modalPresentationStyle == style)
     }
 
     @Test(
-        "Check Configuration Respects Different Transition Styles",
+        "Check View Controller Preserves Different Transition Styles",
         arguments: [
             UIModalTransitionStyle.coverVertical,
             .flipHorizontal,
@@ -104,7 +104,7 @@ final class DefaultBrowserModalPromptProviderTests {
             .partialCurl
         ]
     )
-    func whenViewControllerHasDifferentTransitionStylesThenConfigurationRespectsIt(style: UIModalTransitionStyle) {
+    func whenViewControllerHasDifferentTransitionStylesThenTheyArePreserved(style: UIModalTransitionStyle) {
         // GIVEN
         let mockViewController = UIViewController()
         mockViewController.modalTransitionStyle = style
@@ -115,13 +115,14 @@ final class DefaultBrowserModalPromptProviderTests {
         let configuration = sut.provideModalPrompt()
 
         // THEN
-        #expect(configuration?.transitionStyle == style)
+        #expect(configuration?.viewController.modalTransitionStyle == style)
     }
 
-    @Test("Check Configuration Sets Should Disable Pull Down To Dismiss To False")
-    func whenProvideModalPromptCalledThenConfigurationSetsShouldDisablePullDownToDismissToFalse() {
+    @Test("Check View Controller Preserves isModalInPresentation Property")
+    func whenViewControllerHasIsModalInPresentationSetThenItIsPreserved() {
         // GIVEN
         let mockViewController = UIViewController()
+        mockViewController.isModalInPresentation = false
         let presenter = MockDefaultBrowserPromptPresenter(viewControllerToReturn: mockViewController)
         let sut = DefaultBrowserModalPromptProvider(presenter: presenter)
 
@@ -129,7 +130,7 @@ final class DefaultBrowserModalPromptProviderTests {
         let configuration = sut.provideModalPrompt()
 
         // THEN
-        #expect(configuration?.shouldDisablePullDownToDismiss == false)
+        #expect(configuration?.viewController.isModalInPresentation == false)
     }
 
     @Test("Check Configuration Sets Animated To True")

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/Providers/NewAddressBarPickerModalPromptProviderTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/Providers/NewAddressBarPickerModalPromptProviderTests.swift
@@ -98,7 +98,7 @@ final class NewAddressBarPickerModalPromptProviderTests {
     }
 
 
-    @Test("Check Configuration Sets Cover Vertical Transition Style")
+    @Test("Check View Controller Sets Cover Vertical Transition Style")
     func whenProvideModalPromptCalledThenSetsCoverVerticalTransitionStyle() {
         // GIVEN
         let validator = MockNewAddressBarPickerDisplayValidator(shouldDisplayPicker: true)
@@ -115,11 +115,11 @@ final class NewAddressBarPickerModalPromptProviderTests {
         let configuration = sut.provideModalPrompt()
 
         // THEN
-        #expect(configuration?.transitionStyle == .coverVertical)
+        #expect(configuration?.viewController.modalTransitionStyle == .coverVertical)
     }
 
-    @Test("Check Configuration Sets Should Disable Pull Down To Dismiss True")
-    func whenProvideModalPromptCalledThenSetsShouldDisablePullDownToDismissToTrue() {
+    @Test("Check View Controller Sets Is Modal In Presentation To True")
+    func whenProvideModalPromptCalledThenSetsIsModalInPresentationToTrue() {
         // GIVEN
         let validator = MockNewAddressBarPickerDisplayValidator(shouldDisplayPicker: true)
         let store = MockNewAddressBarPickerStorage()
@@ -135,7 +135,7 @@ final class NewAddressBarPickerModalPromptProviderTests {
         let configuration = sut.provideModalPrompt()
 
         // THEN
-        #expect(configuration?.shouldDisablePullDownToDismiss == true)
+        #expect(configuration?.viewController.isModalInPresentation == true)
     }
 
     @Test("Check Configuration Sets Animated To True")
@@ -158,7 +158,7 @@ final class NewAddressBarPickerModalPromptProviderTests {
         #expect(configuration?.animated == true)
     }
 
-    @Test("Check Configuration Sets Page Sheet Presentation Style On iPhone")
+    @Test("Check View Controller Sets Page Sheet Presentation Style On iPhone")
     func whenIsIPadFalseThenUsesPageSheetPresentationStyle() {
         // GIVEN
         let validator = MockNewAddressBarPickerDisplayValidator(shouldDisplayPicker: true)
@@ -175,10 +175,10 @@ final class NewAddressBarPickerModalPromptProviderTests {
         let configuration = sut.provideModalPrompt()
 
         // THEN
-        #expect(configuration?.presentationStyle == .pageSheet)
+        #expect(configuration?.viewController.modalPresentationStyle == .pageSheet)
     }
 
-    @Test("Check Configuration Sets Page Sheet Presentation Style on iPad iOS < 26", .disabled(if: Self.isOS26))
+    @Test("Check View Controller Sets Page Sheet Presentation Style on iPad iOS < 26", .disabled(if: Self.isOS26))
     func whenIsIPadTrueAndIOSBelow26ThenUsesPageSheetPresentationStyle() {
         // GIVEN
         let validator = MockNewAddressBarPickerDisplayValidator(shouldDisplayPicker: true)
@@ -195,11 +195,11 @@ final class NewAddressBarPickerModalPromptProviderTests {
         let configuration = sut.provideModalPrompt()
 
         // THEN
-        #expect(configuration?.presentationStyle == .pageSheet)
+        #expect(configuration?.viewController.modalPresentationStyle == .pageSheet)
     }
 
     @available(iOS 26.0, *)
-    @Test("Check Configuration Sets Form Sheet Presentation Style on iPad iOS 26+")
+    @Test("Check View Controller Sets Form Sheet Presentation Style on iPad iOS 26+")
     func whenIsIPadTrueAndIOS26OrAboveThenUsesFormSheetPresentationStyle() {
         // GIVEN
         let validator = MockNewAddressBarPickerDisplayValidator(shouldDisplayPicker: true)
@@ -216,7 +216,7 @@ final class NewAddressBarPickerModalPromptProviderTests {
         let configuration = sut.provideModalPrompt()
 
         // THEN
-        #expect(configuration?.presentationStyle == .formSheet)
+        #expect(configuration?.viewController.modalPresentationStyle == .formSheet)
     }
 
     @Test("Check Did Present Modal Calls Mark As Shown On The Store When Modal Is Presented")

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptProvider.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptProvider.swift
@@ -31,9 +31,6 @@ final class MockModalPromptProvider: ModalPromptProvider {
         if shouldReturnPrompt {
             modalConfigurationToReturn = ModalPromptConfiguration(
                 viewController: UIViewController(),
-                presentationStyle: .pageSheet,
-                transitionStyle: .coverVertical,
-                shouldDisablePullDownToDismiss: false,
                 animated: true
             )
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1211780488875023?focus=true
Tech Design URL:
CC:

### Description

During What’s New presentation I found an issue where if we access the `presentationController` before setting the presentation style, this has no effect unless the view controller is dismissed and presented again.

From Apple doc:
_"If you’ve not yet presented the current view controller, accessing this property creates a presentation controller based on the current value in the [modalPresentationStyle](doc://com.apple.documentation/documentation/uikit/uiviewcontroller/modalpresentationstyle?language=swift) property. Always set the value of that property before accessing any presentation controllers."_ 

This PR fixes the issue by letting the providers configure the ViewController presentation parameters.

### Testing Steps
1. Smoke Test showing NewAddressBarPicker prompt and DefaultBrowserPrompt

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Providers now return fully configured view controllers; presentation config fields removed from ModalPromptConfiguration, manager no longer applies them, and tests/mocks updated accordingly.
> 
> - **Core API**:
>   - Simplify `ModalPromptConfiguration` to only contain `viewController` and `animated`; remove `presentationStyle`, `transitionStyle`, `shouldDisablePullDownToDismiss`.
>   - `ModalPromptCoordinationManager` no longer configures VC presentation; it just schedules and presents.
> - **Providers**:
>   - `DefaultBrowserModalPromptProvider`: returns provided VC as-is (preserves its modal properties).
>   - `NewAddressBarPickerModalPromptProvider`: explicitly sets VC `modalPresentationStyle` (iPad iOS 26+ = `.formSheet`, else `.pageSheet`), `modalTransitionStyle = .coverVertical`, and `isModalInPresentation = true` before returning.
> - **Tests & Mocks**:
>   - Update tests to assert modal properties on the returned VC rather than on `ModalPromptConfiguration` fields.
>   - Enhance coordination manager tests for presenting the provider’s VC, scheduling delay, cooldown recording.
>   - Update `MockModalPromptProvider` to match new configuration shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08823152fc662015f4eeb9dedfdbb086d9bdb070. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->