### PR TITLE
Allow custom navigation type to NTP and history

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/HistoryTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/HistoryTabExtension.swift
@@ -204,7 +204,15 @@ extension HistoryTabExtension: NavigationResponder {
     func decidePolicy(for navigationAction: NavigationAction, preferences: inout NavigationPreferences) async -> NavigationActionPolicy? {
         let unknownSource = !navigationAction.sourceFrame.url.isDuckURLScheme && !navigationAction.sourceFrame.url.isEmpty
         let isSpecialURL = navigationAction.url.isHistory || navigationAction.url.isNTP
-        let shouldBeCancelled = !navigationAction.navigationType.isBackForward && isSpecialURL && unknownSource
+        let isAllowedNavigationType: Bool = {
+            switch navigationAction.navigationType {
+            case .backForward, .custom:
+                return true
+            default:
+                return false
+            }
+        }()
+        let shouldBeCancelled = !isAllowedNavigationType && isSpecialURL && unknownSource
 
         if shouldBeCancelled {
             return .cancel


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/949243614371883/task/1211795782476274?focus=true

### Description
This change allows custom navigation type (apart from backForward) to New Tab Page from other websites.
Custom navigation type is used by the Home Button (and possibly other developer-defined scenarios).

### Testing Steps
1. Launch the app
2. Visit a website
3. Enable home button
4. Click home button
5. Verify that you’re redirected to the New Tab Page

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Permits `.custom` navigation (in addition to back/forward) to History and New Tab Page; other unknown-source navigations are canceled.
> 
> - **Navigation policy** (`macOS/DuckDuckGo/Tab/TabExtensions/HistoryTabExtension.swift`):
>   - Allow `.custom` and `.backForward` navigation types when targeting `isHistory` or `isNTP` URLs.
>   - Cancel other navigation types to these special URLs when originating from unknown sources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1edb45010662f761db1adf756d4cfd19ac472a65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->