### PR TITLE
Enables Pinned Tabs Rewrite Feature Flag

### DIFF
--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -541,7 +541,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .dataImportNewExperience:
             return .disabled
         case .pinnedTabsViewRewrite:
-            return .disabled
+            return .internalOnly()
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1211626392446032?focus=true
Tech Design URL:
CC:

### Description
In this PR we're enabling the `pinnedTabsViewRewrite` Feature Flag for Internal Users.

@jotaemepereira Sending you a really small PR, hope that's okay!
Thanks in advance, sir!!

### Testing Steps
1. Install the Browser
2. Enable the Internal User state

- [ ] Verify the `pinnedTabsViewRewrite` Feature Flag is enabled, by default

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing really, we're only enabling the Pinned Tabs AppKit Rewrite to Internal Users.

### Quality Considerations
Nothing in particular.

### Notes to Reviewer
Thanks in advance!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `pinnedTabsViewRewrite` feature flag source from `disabled` to `internalOnly()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6db35dfb279421ef9910f7b0afe0bb9913fbd4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->