### PR TITLE
Update wide event app name value

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Common/AppVersion.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Common/AppVersion.swift
@@ -38,6 +38,10 @@ public struct AppVersion: OSVersionProviding {
         return bundle.object(forInfoDictionaryKey: Bundle.Key.name) as? String ?? ""
     }
 
+    public var productName: String {
+        return bundle.object(forInfoDictionaryKey: Bundle.Key.executableName) as? String ?? ""
+    }
+
     public var identifier: String {
         return bundle.object(forInfoDictionaryKey: Bundle.Key.identifier) as? String ?? ""
     }

--- a/SharedPackages/BrowserServicesKit/Sources/Common/Extensions/BundleExtension.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Common/Extensions/BundleExtension.swift
@@ -27,6 +27,7 @@ extension Bundle {
         static let buildNumber = kCFBundleVersionKey as String
 		static let versionNumber = "CFBundleShortVersionString"
         static let displayName = "CFBundleDisplayName"
+        static let executableName = kCFBundleExecutableKey as String
         /// Custom key that may be added by the adhoc build workflow to append a suffix to the build version
         static let alphaBuildSuffix = "DDG_ALPHA_BUILD_SUFFIX"
         /// Custom key that may be added by the build workflow to indicate a commit of the build

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/WideEvent/WideEventData.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/WideEvent/WideEventData.swift
@@ -156,7 +156,7 @@ public struct WideEventAppData: Codable {
     /// Whether the event was sent by an instance of the app with the internal flag set.
     public var internalUser: Bool?
 
-    public init(name: String = AppVersion.shared.name,
+    public init(name: String = Self.defaultAppName(),
                 version: String = AppVersion.shared.versionNumber,
                 formFactor: String? = nil,
                 internalUser: Bool? = nil) {
@@ -169,6 +169,17 @@ public struct WideEventAppData: Codable {
         self.formFactor = formFactor // Ignore the form factor on macOS, but allow it to be overridden for testing
         #endif
         self.internalUser = internalUser
+    }
+
+    /// Returns the appropriate app name for the current platform.
+    /// - macOS: Uses CFBundleName (the bundle name)
+    /// - iOS: Uses CFBundleExecutable (the product name, which maps to Xcode targets)
+    public static func defaultAppName() -> String {
+        #if os(iOS)
+        return AppVersion.shared.productName
+        #else
+        return AppVersion.shared.name
+        #endif
     }
 }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1211816952427134?focus=true
Tech Design URL:
CC:

### Description

This PR updates wide event app name value to use the product name on iOS.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that the diff looks correct and is using the correct method of pulling the product name from the bundle
2. Sign into the subscription and check that the wide event `app.name` value is populated correctly

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
3. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
4. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> `WideEventAppData.name` now defaults to `CFBundleExecutable` (product name) on iOS and `CFBundleName` on macOS, with supporting bundle key/accessor added.
> 
> - **Telemetry (WideEvent)**:
>   - Default app name now selected via `WideEventAppData.defaultAppName()`:
>     - iOS: uses `AppVersion.shared.productName` (`CFBundleExecutable`).
>     - macOS: uses `AppVersion.shared.name` (`CFBundleName`).
> - **Common**:
>   - `AppVersion`: add `productName` accessor.
>   - `BundleExtension`: add `Key.executableName` for `CFBundleExecutable`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea6c32b62b42c1fd5f5df594efd02c8005edce20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->