### PR TITLE
macOS: Delete new feedback form feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -80,7 +80,6 @@ public enum PrivacyFeature: String {
     case tabCrashRecovery
     case delayedWebviewPresentation
     case disableFireAnimation
-    case feedbackForm
     case htmlNewTabPage
     case daxEasterEggLogos
     case openFireWindowByDefault

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -275,11 +275,7 @@ extension AppDelegate {
             if self.internalUserDecider.isInternalUser {
                 Application.appDelegate.windowControllersManager.showTab(with: .url(.internalFeedbackForm, source: .ui))
             } else {
-                if self.featureFlagger.isFeatureOn(.newFeedbackForm) {
-                    Application.appDelegate.openRequestANewFeature(nil)
-                } else {
-                    FeedbackPresenter.presentFeedbackForm()
-                }
+                Application.appDelegate.openRequestANewFeature(nil)
             }
         }
     }

--- a/macOS/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
@@ -894,12 +894,7 @@ final class FeedbackSubMenu: NSMenu {
                                  featureFlagger: FeatureFlagger,
                                  moreOptionsMenuIconsProvider: MoreOptionsMenuIconsProviding) {
         removeAllItems()
-
-        if featureFlagger.isFeatureOn(.newFeedbackForm) {
-            newFlow(moreOptionsMenuIconsProvider: moreOptionsMenuIconsProvider)
-        } else {
-            legacyFlow(moreOptionsMenuIconsProvider: moreOptionsMenuIconsProvider)
-        }
+        feedbackFlow(moreOptionsMenuIconsProvider: moreOptionsMenuIconsProvider)
 
         if authenticationStateProvider.isUserAuthenticated {
             addItem(.separator())
@@ -918,7 +913,7 @@ final class FeedbackSubMenu: NSMenu {
         }
     }
 
-    private func newFlow(moreOptionsMenuIconsProvider: MoreOptionsMenuIconsProviding) {
+    private func feedbackFlow(moreOptionsMenuIconsProvider: MoreOptionsMenuIconsProviding) {
         let reportBrokenSiteItem = NSMenuItem(title: UserText.reportBrokenSite,
                                               action: #selector(AppDelegate.openReportBrokenSite(_:)),
                                               keyEquivalent: "")
@@ -938,21 +933,6 @@ final class FeedbackSubMenu: NSMenu {
                                                 keyEquivalent: "")
             .withImage(DesignSystemImages.Glyphs.Size16.windowNew)
         addItem(requestANewFeatureItem)
-    }
-
-    private func legacyFlow(moreOptionsMenuIconsProvider: MoreOptionsMenuIconsProviding) {
-        let browserFeedbackItem = NSMenuItem(title: UserText.browserFeedback,
-                                             action: #selector(sendFeedback(_:)),
-                                             keyEquivalent: "")
-            .targetting(self)
-            .withImage(moreOptionsMenuIconsProvider.browserFeedbackIcon)
-        addItem(browserFeedbackItem)
-
-        let reportBrokenSiteItem = NSMenuItem(title: UserText.reportBrokenSite,
-                                              action: #selector(AppDelegate.openReportBrokenSite(_:)),
-                                              keyEquivalent: "")
-            .withImage(moreOptionsMenuIconsProvider.reportBrokenSiteIcon)
-        addItem(reportBrokenSiteItem)
     }
 
     @MainActor

--- a/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
+++ b/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
@@ -43,7 +43,6 @@ final class PrivacyDashboardViewController: NSViewController {
     private let privacyDashboardController: PrivacyDashboardController
     private var privacyDashboardDidTriggerDismiss: Bool = false
     private let contentBlocking: ContentBlockingProtocol
-    private let featureFlagger: FeatureFlagger
 
     public let rulesUpdateObserver: ContentBlockingRulesUpdateObserver
 
@@ -83,8 +82,7 @@ final class PrivacyDashboardViewController: NSViewController {
     init(privacyInfo: PrivacyInfo? = nil,
          entryPoint: PrivacyDashboardEntryPoint = .dashboard,
          contentBlocking: ContentBlockingProtocol,
-         permissionManager: PermissionManagerProtocol,
-         featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger) {
+         permissionManager: PermissionManagerProtocol) {
         let toggleReportingConfiguration = ToggleReportingConfiguration(privacyConfigurationManager: contentBlocking.privacyConfigurationManager)
         let toggleReportingFeature = ToggleReportingFeature(toggleReportingConfiguration: toggleReportingConfiguration)
         let toggleReportingManager = ToggleReportingManager(feature: toggleReportingFeature)
@@ -96,7 +94,6 @@ final class PrivacyDashboardViewController: NSViewController {
         self.contentBlocking = contentBlocking
         // swiftlint:disable:next force_cast
         self.rulesUpdateObserver = ContentBlockingRulesUpdateObserver(userContentUpdating: (contentBlocking as! AppContentBlocking).userContentUpdating)
-        self.featureFlagger = featureFlagger
 
         brokenSiteReporter = {
             BrokenSiteReporter(pixelHandler: { parameters in
@@ -282,13 +279,7 @@ extension PrivacyDashboardViewController: PrivacyDashboardControllerDelegate {
 
     func privacyDashboardControllerDidRequestShowGeneralFeedback(_ privacyDashboardController: PrivacyDashboardController) {
         dismiss()
-
-        if featureFlagger.isFeatureOn(.newFeedbackForm) {
-            NSApp.delegateTyped.openReportABrowserProblem(nil)
-        } else {
-            NSApp.delegateTyped.openFeedback(nil)
-        }
-
+        NSApp.delegateTyped.openReportABrowserProblem(nil)
     }
 
     func privacyDashboardController(_ privacyDashboardController: PrivacyDashboardController,

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -160,9 +160,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1148564399326804/task/1210625630564796?focus=true
     case newTabPageOmnibar
 
-    /// https://app.asana.com/1/137249556945/project/1204006570077678/task/1210733970843912?focus=true
-    case newFeedbackForm
-
     /// https://app.asana.com/1/137249556945/project/72649045549333/task/1210561963620632?focus=true
     case vpnToolbarUpsell
 
@@ -330,7 +327,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .newTabPageOmnibar,
                 .newTabPagePerTab,
                 .newTabPageTabIDs,
-                .newFeedbackForm,
                 .vpnToolbarUpsell,
                 .supportsAlternateStripePaymentFlow,
                 .restoreSessionPrompt,
@@ -484,8 +480,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.feature(.disableFireAnimation))
         case .newTabPageOmnibar:
             return .remoteReleasable(.subfeature(HtmlNewTabPageSubfeature.omnibar))
-        case .newFeedbackForm:
-            return .remoteReleasable(.feature(.feedbackForm))
         case .vpnToolbarUpsell:
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.vpnToolbarUpsell))
         case .newTabPagePerTab:

--- a/macOS/UnitTests/Menus/MoreOptionsMenuTests.swift
+++ b/macOS/UnitTests/Menus/MoreOptionsMenuTests.swift
@@ -733,9 +733,11 @@ final class MoreOptionsMenuTests: XCTestCase {
                                   moreOptionsMenuIconsProvider: CurrentMoreOptionsMenuIcons(),
                                   featureFlagger: MockFeatureFlagger())
 
-        XCTAssertTrue(sut.items.count == 2)
-        XCTAssertEqual(sut.item(at: 0)?.title, UserText.browserFeedback)
-        XCTAssertEqual(sut.item(at: 1)?.title, UserText.reportBrokenSite)
+        XCTAssertTrue(sut.items.count == 4)
+        XCTAssertEqual(sut.item(at: 0)?.title, UserText.reportBrokenSite)
+        XCTAssertEqual(sut.item(at: 1)?.isSeparatorItem, true)
+        XCTAssertEqual(sut.item(at: 2)?.title, UserText.reportBrowserProblem)
+        XCTAssertEqual(sut.item(at: 3)?.title, UserText.requestNewFeature)
     }
 
     func testCorrectItemsAreShown_whenNotInternalUserAndSubscriptionUser() {
@@ -745,11 +747,13 @@ final class MoreOptionsMenuTests: XCTestCase {
                                   moreOptionsMenuIconsProvider: CurrentMoreOptionsMenuIcons(),
                                   featureFlagger: MockFeatureFlagger())
 
-        XCTAssertTrue(sut.items.count == 4)
-        XCTAssertEqual(sut.item(at: 0)?.title, UserText.browserFeedback)
-        XCTAssertEqual(sut.item(at: 1)?.title, UserText.reportBrokenSite)
-        XCTAssertEqual(sut.item(at: 2)?.isSeparatorItem, true)
-        XCTAssertEqual(sut.item(at: 3)?.title, UserText.sendSubscriptionFeedback)
+        XCTAssertTrue(sut.items.count == 6)
+        XCTAssertEqual(sut.item(at: 0)?.title, UserText.reportBrokenSite)
+        XCTAssertEqual(sut.item(at: 1)?.isSeparatorItem, true)
+        XCTAssertEqual(sut.item(at: 2)?.title, UserText.reportBrowserProblem)
+        XCTAssertEqual(sut.item(at: 3)?.title, UserText.requestNewFeature)
+        XCTAssertEqual(sut.item(at: 4)?.isSeparatorItem, true)
+        XCTAssertEqual(sut.item(at: 5)?.title, UserText.sendSubscriptionFeedback)
     }
 
     func testCorrectItemsAreShown_whenInternalUserAndNotSubscriptionUser() {
@@ -759,11 +763,13 @@ final class MoreOptionsMenuTests: XCTestCase {
                                   moreOptionsMenuIconsProvider: CurrentMoreOptionsMenuIcons(),
                                   featureFlagger: MockFeatureFlagger())
 
-        XCTAssertTrue(sut.items.count == 4)
-        XCTAssertEqual(sut.item(at: 0)?.title, UserText.browserFeedback)
-        XCTAssertEqual(sut.item(at: 1)?.title, UserText.reportBrokenSite)
-        XCTAssertEqual(sut.item(at: 2)?.isSeparatorItem, true)
-        XCTAssertEqual(sut.item(at: 3)?.title, "Copy Version")
+        XCTAssertTrue(sut.items.count == 6)
+        XCTAssertEqual(sut.item(at: 0)?.title, UserText.reportBrokenSite)
+        XCTAssertEqual(sut.item(at: 1)?.isSeparatorItem, true)
+        XCTAssertEqual(sut.item(at: 2)?.title, UserText.reportBrowserProblem)
+        XCTAssertEqual(sut.item(at: 3)?.title, UserText.requestNewFeature)
+        XCTAssertEqual(sut.item(at: 4)?.isSeparatorItem, true)
+        XCTAssertEqual(sut.item(at: 5)?.title, "Copy Version")
     }
 
     func testCorrectItemsAreShown_whenInternalUserAndSubscriptionUser() {
@@ -773,18 +779,19 @@ final class MoreOptionsMenuTests: XCTestCase {
                                   moreOptionsMenuIconsProvider: CurrentMoreOptionsMenuIcons(),
                                   featureFlagger: MockFeatureFlagger())
 
-        XCTAssertTrue(sut.items.count == 6)
-        XCTAssertEqual(sut.item(at: 0)?.title, UserText.browserFeedback)
-        XCTAssertEqual(sut.item(at: 1)?.title, UserText.reportBrokenSite)
-        XCTAssertEqual(sut.item(at: 2)?.isSeparatorItem, true)
-        XCTAssertEqual(sut.item(at: 3)?.title, UserText.sendSubscriptionFeedback)
+        XCTAssertTrue(sut.items.count == 8)
+        XCTAssertEqual(sut.item(at: 0)?.title, UserText.reportBrokenSite)
+        XCTAssertEqual(sut.item(at: 1)?.isSeparatorItem, true)
+        XCTAssertEqual(sut.item(at: 2)?.title, UserText.reportBrowserProblem)
+        XCTAssertEqual(sut.item(at: 3)?.title, UserText.requestNewFeature)
         XCTAssertEqual(sut.item(at: 4)?.isSeparatorItem, true)
-        XCTAssertEqual(sut.item(at: 5)?.title, "Copy Version")
+        XCTAssertEqual(sut.item(at: 5)?.title, UserText.sendSubscriptionFeedback)
+        XCTAssertEqual(sut.item(at: 6)?.isSeparatorItem, true)
+        XCTAssertEqual(sut.item(at: 7)?.title, "Copy Version")
     }
 
     func testCorrectItemsAreShown_whenNewFeedbackFeatureFlagIsOn() {
         let featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags = [.newFeedbackForm]
         let sut = FeedbackSubMenu(targetting: self,
                                   authenticationStateProvider: MockSubscriptionAuthenticationStateProvider(isUserAuthenticated: true),
                                   internalUserDecider: MockInternalUserDecider(isInternalUser: true),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1211007394846495?focus=true
Tech Design URL:
CC:

### Description
Deletes the `newFeedbackForm` feature flag. Now that we have had this for more than a couple of months, we are confident about the new form.

### Testing Steps
When logged in as a internal user with a subscription, you should see the following menu items in the more options menu, Send Feedback.

<img width="231" height="163" alt="Screenshot 2025-11-03 at 9 26 38 AM" src="https://github.com/user-attachments/assets/af40c070-556e-455b-8032-55f63a464d8c" />

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the newFeedbackForm feature flag and legacy code paths, standardizing macOS feedback menus and routing to the new problem/feature request forms.
> 
> - **macOS UI**:
>   - **Feedback menus**: Replace legacy/new split with a single `feedbackFlow` showing `Report Broken Site`, `Report a Browser Problem`, and `Request a New Feature`.
>   - **Main menu**: Non‑internal users now always open `openRequestANewFeature`.
>   - **Privacy Dashboard**: General feedback now always opens `openReportABrowserProblem`; `PrivacyDashboardViewController` init no longer takes `FeatureFlagger`.
> - **Feature Flags & Config**:
>   - Remove `FeatureFlag.newFeedbackForm` and its mappings.
>   - Remove `PrivacyFeature.feedbackForm`.
> - **Tests**:
>   - Update `FeedbackSubMenu` expectations (item counts/titles) to reflect the unified feedback flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5092d2e514204f9cf96f28d8598ec94584339b30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->