### PR TITLE
Pinned Tabs: Disabling Drag + Drop

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabDragAndDropManager.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabDragAndDropManager.swift
@@ -51,6 +51,7 @@ final class TabDragAndDropManager {
     @discardableResult
     func performDragAndDropIfNeeded() -> Bool {
         if let sourceUnit = sourceUnit,
+           sourceUnit.index.isPinnedTab == false,
            let destinationUnit = destinationUnit,
            sourceUnit.tabCollectionViewModel !== destinationUnit.tabCollectionViewModel,
            sourceUnit.tabCollectionViewModel?.isBurner == destinationUnit.tabCollectionViewModel?.isBurner {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1211822379324829?focus=true
Tech Design URL:
CC:

### Description
In this PR we're fixing a regression that caused Drag + Drop to actually work for Pinned Tabs (which is currently not supported).

@ayoy It was exactly as you mentioned, a one liner fix. TY!!

### Testing Steps
1. Set pinned tabs mode to “separate per window"
2. Have a few pinned and unpinned tabs.
3. Open a new window.
4. Drag a pinned tab onto the new window.

As a result, the dragged Tab should remain in its source Window

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing really, we currently don't support Drag + Drop for Pinned Tabs.
Plus only users with the `pinnedTabsViewtRewrite` Feature Flag should be affected by this new conditional.

### Quality Considerations
Nothing in special

### Notes to Reviewer
Thanks in advance!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
