### PR TITLE
fix pixel firing for launching favorites

### DIFF
--- a/iOS/DuckDuckGo/FavoritesPreviewDataSource.swift
+++ b/iOS/DuckDuckGo/FavoritesPreviewDataSource.swift
@@ -23,7 +23,7 @@ import Foundation
 
 final class FavoritesPreviewModel: FavoritesViewModel {
     init(favorites: [Favorite] = randomFavorites) {
-        super.init(favoriteDataSource: FavoritesPreviewDataSource(favorites: favorites), faviconLoader: EmptyFaviconLoading())
+        super.init(isFocussedState: false, favoriteDataSource: FavoritesPreviewDataSource(favorites: favorites), faviconLoader: EmptyFaviconLoading())
     }
 
     static var randomFavorites: [Favorite] {

--- a/iOS/DuckDuckGo/FavoritesViewModel.swift
+++ b/iOS/DuckDuckGo/FavoritesViewModel.swift
@@ -54,6 +54,7 @@ class FavoritesViewModel: ObservableObject {
 
     private var cancellables = Set<AnyCancellable>()
 
+    private let isFocussedState: Bool
     private let favoriteDataSource: NewTabPageFavoriteDataSource
     private let faviconsCache: FavoritesFaviconCaching
     private let pixelFiring: PixelFiring.Type
@@ -63,11 +64,13 @@ class FavoritesViewModel: ObservableObject {
         allFavorites.isEmpty
     }
 
-    init(favoriteDataSource: NewTabPageFavoriteDataSource,
+    init(isFocussedState: Bool,
+         favoriteDataSource: NewTabPageFavoriteDataSource,
          faviconLoader: FavoritesFaviconLoading,
          faviconsCache: FavoritesFaviconCaching = Favicons.shared,
          pixelFiring: PixelFiring.Type = Pixel.self,
          dailyPixelFiring: DailyPixelFiring.Type = DailyPixel.self) {
+        self.isFocussedState = isFocussedState
         self.favoriteDataSource = favoriteDataSource
         self.pixelFiring = pixelFiring
         self.dailyPixelFiring = dailyPixelFiring
@@ -100,8 +103,12 @@ class FavoritesViewModel: ObservableObject {
     func favoriteSelected(_ favorite: Favorite) {
         guard let url = favorite.urlObject else { return }
 
-        pixelFiring.fire(.favoriteLaunchedNTP, withAdditionalParameters: [:])
-        dailyPixelFiring.fireDaily(.favoriteLaunchedNTPDaily)
+        if isFocussedState {
+            pixelFiring.fire(.favoriteLaunchedWebsite, withAdditionalParameters: [:])
+        } else {
+            pixelFiring.fire(.favoriteLaunchedNTP, withAdditionalParameters: [:])
+            dailyPixelFiring.fireDaily(.favoriteLaunchedNTPDaily)
+        }
         if let host = url.host {
             faviconsCache.populateFavicon(for: host, intoCache: .fireproof, fromCache: .tabs)
         }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1112,7 +1112,8 @@ class MainViewController: UIViewController {
         let newTabDaxDialogFactory = NewTabDaxDialogFactory(delegate: self, daxDialogsFlowCoordinator: daxDialogsManager, onboardingPixelReporter: contextualOnboardingPixelReporter)
         let narrowLayoutInLandscape = aiChatSettings.isAIChatSearchInputUserSettingsEnabled
 
-        let controller = NewTabPageViewController(tab: tabModel,
+        let controller = NewTabPageViewController(isFocussedState: false,
+                                                  tab: tabModel,
                                                   interactionModel: favoritesViewModel,
                                                   homePageMessagesConfiguration: homePageConfiguration,
                                                   subscriptionDataReporting: subscriptionDataReporter,
@@ -2481,7 +2482,6 @@ extension MainViewController: BrowserChromeDelegate {
             return
         }
 
-        Pixel.fire(pixel: .favoriteLaunchedWebsite)
         newTabPageViewController?.chromeDelegate = nil
         dismissOmniBar()
         Favicons.shared.loadFavicon(forDomain: url.host, intoCache: .fireproof, fromCache: .tabs)
@@ -2976,8 +2976,7 @@ extension MainViewController {
 extension MainViewController: NewTabPageControllerDelegate {
 
     func newTabPageDidSelectFavorite(_ controller: NewTabPageViewController, favorite: BookmarkEntity) {
-        guard let url = favorite.urlObject else { return }
-        handleRequestedURL(url)
+        self.onSelectFavorite(favorite)
     }
 
     func newTabPageDidEditFavorite(_ controller: NewTabPageViewController, favorite: BookmarkEntity) {

--- a/iOS/DuckDuckGo/NewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewController.swift
@@ -48,7 +48,8 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
 
     private let internalUserCommands: URLBasedDebugCommands
 
-    init(tab: Tab,
+    init(isFocussedState: Bool,
+         tab: Tab,
          interactionModel: FavoritesListInteracting,
          homePageMessagesConfiguration: HomePageMessagesConfiguration,
          subscriptionDataReporting: SubscriptionDataReporting? = nil,
@@ -70,7 +71,8 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
         self.internalUserCommands = internalUserCommands
 
         newTabPageViewModel = NewTabPageViewModel()
-        favoritesModel = FavoritesViewModel(favoriteDataSource: FavoritesListInteractingAdapter(favoritesListInteracting: interactionModel),
+        favoritesModel = FavoritesViewModel(isFocussedState: isFocussedState,
+                                            favoriteDataSource: FavoritesListInteractingAdapter(favoritesListInteracting: interactionModel),
                                             faviconLoader: faviconLoader)
         messagesModel = NewTabPageMessagesModel(homePageMessagesConfiguration: homePageMessagesConfiguration,
                                                 subscriptionDataReporter: subscriptionDataReporting,

--- a/iOS/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/iOS/DuckDuckGo/SuggestionTrayViewController.swift
@@ -272,6 +272,7 @@ class SuggestionTrayViewController: UIViewController {
     private func installNewTabPage(animated: Bool, onInstall: @escaping () -> Void = {}) {
         let dependencies = newTabPageDependencies
         let controller = NewTabPageViewController(
+            isFocussedState: true,
             tab: Tab(),
             interactionModel: dependencies.favoritesModel,
             homePageMessagesConfiguration: dependencies.homePageMessagesConfiguration,

--- a/iOS/DuckDuckGoTests/NewTabPageFavoritesModelTests.swift
+++ b/iOS/DuckDuckGoTests/NewTabPageFavoritesModelTests.swift
@@ -26,12 +26,6 @@ import Bookmarks
 final class NewTabPageFavoritesModelTests: XCTestCase {
     private let favoriteDataSource = MockNewTabPageFavoriteDataSource()
 
-    override func setUpWithError() throws {
-        throw XCTSkip("Potentially flaky")
-
-        try super.setUpWithError()
-    }
-
     override func tearDown() {
         PixelFiringMock.tearDown()
     }
@@ -50,6 +44,15 @@ final class NewTabPageFavoritesModelTests: XCTestCase {
 
         XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.favoriteLaunchedNTP.name)
         XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.pixelName, Pixel.Event.favoriteLaunchedNTPDaily.name)
+    }
+
+    func testFiresPixelsOnFavoriteSelectedInFocussedState() {
+        let sut = createSUT(isFocussedState: true)
+
+        sut.favoriteSelected(Favorite(id: "", title: "", domain: "", urlObject: URL(string: "https://foo.bar")))
+
+        XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.favoriteLaunchedWebsite.name)
+        XCTAssertNil(PixelFiringMock.lastDailyPixelInfo?.pixelName)
     }
 
     func testFiresPixelOnFavoriteDeleted() {
@@ -74,8 +77,9 @@ final class NewTabPageFavoritesModelTests: XCTestCase {
         XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.homeScreenEditFavorite.name)
     }
 
-    private func createSUT() -> FavoritesViewModel {
-        FavoritesViewModel(favoriteDataSource: favoriteDataSource,
+    private func createSUT(isFocussedState: Bool = false) -> FavoritesViewModel {
+        FavoritesViewModel(isFocussedState: isFocussedState,
+                           favoriteDataSource: favoriteDataSource,
                            faviconLoader: MockFavoritesFaviconLoading(),
                            faviconsCache: MockFavoritesFaviconCaching(),
                            pixelFiring: PixelFiringMock.self,

--- a/iOS/SharedStateTests/NewTabPageControllerDaxDialogTests.swift
+++ b/iOS/SharedStateTests/NewTabPageControllerDaxDialogTests.swift
@@ -60,6 +60,7 @@ final class NewTabPageControllerDaxDialogTests: XCTestCase {
             winBackOfferService: .mocked)
         let homePageConfiguration = HomePageConfiguration(remoteMessagingClient: remoteMessagingClient, subscriptionDataReporter: MockSubscriptionDataReporter(), isStillOnboarding: { true })
         hvc = NewTabPageViewController(
+            isFocussedState: false,
             tab: Tab(),
             interactionModel: MockFavoritesListInteracting(),
             homePageMessagesConfiguration: homePageConfiguration,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1211822548036195?focus=true
Tech Design URL:
CC:

### Description
Fixes pixel firing logic for launching favorites

### Testing Steps
1. With Duck.ai toggle ON - check that correct pixel is fired when launching favorite from new tab and focussed state
2. With Duck.ai toggle OFF - also check correct pixel is fired when launching favorite from new tab and focussed state

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Break pixel firing for launching favorites even more

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Route favorite-launch pixels by context (NTP vs focussed) using a new isFocussedState flag, update call sites, and add tests.
> 
> - **Analytics/Pixels**:
>   - Route favorite launch pixels based on context via new `isFocussedState` flag in `FavoritesViewModel`:
>     - `true` → fire `favoriteLaunchedWebsite`.
>     - `false` → fire `favoriteLaunchedNTP` and daily `favoriteLaunchedNTPDaily`.
>   - Remove redundant `Pixel.fire(.favoriteLaunchedWebsite)` from `MainViewController.handleFavoriteSelected`.
> - **Architecture**:
>   - Add `isFocussedState` parameter to `FavoritesViewModel` and `NewTabPageViewController` initializers; propagate through `FavoritesPreviewModel`, `MainViewController`, and `SuggestionTrayViewController`.
>   - Update NTP delegate handling: `newTabPageDidSelectFavorite` now routes via `onSelectFavorite`.
> - **Tests**:
>   - Add test for focussed-state pixel firing; update tests to use new initializers (`NewTabPageFavoritesModelTests`, `NewTabPageControllerDaxDialogTests`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7535c7bb4d62f87335cc6f894348abb688d84f8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->