### PR TITLE
Enabling Pinned Tabs Rewrite Feature Flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -146,6 +146,10 @@ public enum MacOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// Feature flag for a macOS Tahoe fix only
     /// https://app.asana.com/1/137249556945/project/1204006570077678/task/1211448334620171?focus=true
     case blurryAddressBarTahoeFix
+
+    /// Pinned Tabs AppKit Rewrite Feature Flag
+    /// https://app.asana.com/1/137249556945/project/1201048563534612/task/1209949983074592?focus=true
+    case pinnedTabsViewRewrite
 }
 
 public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -273,7 +273,8 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .dataImportNewSafariFilePicker,
                 .fireDialog,
                 .fireDialogIndividualSitesLink,
-                .blurryAddressBarTahoeFix:
+                .blurryAddressBarTahoeFix,
+                .pinnedTabsViewRewrite:
             true
         default:
             false
@@ -547,7 +548,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .scheduledDefaultBrowserAndDockPromptsInactiveUser:
             return .remoteDevelopment(.subfeature(SetAsDefaultAndAddToDockSubfeature.scheduledDefaultBrowserAndDockPromptsInactiveUser))
         case .pinnedTabsViewRewrite:
-            return .internalOnly()
+            return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.pinnedTabsViewRewrite))
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1211829710605859?focus=true
Tech Design URL: 
CC:

### Description
In this PR we're marking the Pinned Tabs Rewrite Feature Flag as enabled by default, and mapping the Remote Releasable feature.

@ayoy Sending another PR your way, hope that's okay!! 
Thank you!!

### Testing Steps
- [ ] Verify the CI is green
- [ ] Verify the `Pinned Tabs Rewrite` Flag is enabled by default

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Nothing really, this feature has been already tested + reviewed elsewhere!

### Quality Considerations
Nothing in particular!

### Notes to Reviewer
Thanks in advance!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables the macOS Pinned Tabs AppKit rewrite flag by default and maps it to a remote‑releasable subfeature.
> 
> - **Feature Flags (macOS)**:
>   - Enable `FeatureFlag.pinnedTabsViewRewrite` by default.
>   - Map `FeatureFlag.pinnedTabsViewRewrite` to `remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.pinnedTabsViewRewrite))`.
> - **Privacy Config**:
>   - Add `MacOSBrowserConfigSubfeature.pinnedTabsViewRewrite` to `PrivacyFeature.macOSBrowserConfig`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb6bf6c3a58df50fbedbf909fca48b6db29826b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->