### PR TITLE
Test danger check for Xcode project's objectVersion

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -14,4 +14,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: "--dangerfile duckduckgo/danger-settings/org/allPRs.ts@main"
+          args: "--dangerfile duckduckgo/danger-settings/org/allPRs.ts@dominik/xcode-object-version"

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1211833448510890?focus=true

### Description
This is a test PR to verify the new danger check for the objectVersion field in the Xcode project file.
**NOTE:** This PR is only for testing, it shouldn't be merged.

### Testing Steps
Review danger-settings PR here: https://github.com/duckduckgo/danger-settings/pull/19
1. Verify that Danger check fails here because objectVersion is bumped over 60.
2. Revert the change to the project file, push to this branch and verify that the Danger check passes.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
