### PR TITLE
Address Bar: Hiding Loading Indicator when needed

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -335,7 +335,7 @@ final class AddressBarViewController: NSViewController {
 
                 subscribeToTabContent()
                 subscribeToPassiveAddressBarString()
-                subscribeToProgressEvents()
+                subscribeToProgressEventsIfNeeded()
 
                 // don't resign first responder on tab switching
                 clickPoint = nil
@@ -374,8 +374,12 @@ final class AddressBarViewController: NSViewController {
             .store(in: &tabViewModelCancellables)
     }
 
-    private func subscribeToProgressEvents() {
-        guard let tabViewModel else {
+    private var displaysLoadingProgressIndicator: Bool {
+        featureFlagger.isFeatureOn(.tabProgressIndicator) == false
+    }
+
+    private func subscribeToProgressEventsIfNeeded() {
+        guard let tabViewModel, displaysLoadingProgressIndicator else {
             progressIndicator.hide(animated: false)
             return
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211711035105393?focus=true
Tech Design URL:
CC:

### Description
In this PR we're concealing the **Address Bar Loading Indicator** whenever the `tabProgressIndicator` flag is enabled.

Context: We'll be implementing a loading indicator in the Tab itself.

@jotaemepereira hope you don't mind!! sending this one over to make really sure I'm not missing anything too obvious.
Thanks in advance!!


### Testing Steps
1. Launch the browser
2. Open any website
3. Verify the Address Bar displays the loading indicator
4. Enable the `tabProgressIndicator` flag
5. Create a new Browser Window

- [ ] Verify the Loading Indicator is no longer displayed

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
In the very worst case scenario, the Loading Indicator would be (incorrectly) hidden.
This of course should never happen!

### Quality Considerations
Nothing in particular

### Notes to Reviewer
Thanks in advance!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Address bar loading indicator now shows only when `tabProgressIndicator` is off; otherwise it’s hidden and subscriptions are skipped.
> 
> - **Address Bar**:
>   - Gate loading progress indicator with `featureFlagger.isFeatureOn(.tabProgressIndicator)`.
>     - Added `displaysLoadingProgressIndicator` and `subscribeToProgressEventsIfNeeded()`.
>     - Replaced calls to `subscribeToProgressEvents()` with the conditional version.
>     - Hides `progressIndicator` when the flag is enabled; otherwise maintains existing progress updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 145b657f1fcbaf239f368746d256ba55d47655d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->