### PR TITLE
Update .swiftlint.yml to exclude 'doc-bot' directory from linting

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -73,6 +73,7 @@ file_header:
 
 # General Config
 excluded:
+  - doc-bot
   - SharedPackages/*/Package.swift
   - SharedPackages/*/.build
   - SharedPackages/BrowserServicesKit/scripts/


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `doc-bot` to `.swiftlint.yml` excluded paths to skip linting that directory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54b918ad0fe0827db5a3490139378f7f1cd13fa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->