### PR TITLE
Disable flaky watchdog test

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Watchdog/WatchdogTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Watchdog/WatchdogTests.swift
@@ -414,7 +414,7 @@ final class WatchdogTests: XCTestCase {
 
     func testHangStateTransitions() async throws {
         throw XCTSkip("Flaky test: https://app.asana.com/1/137249556945/project/1200194497630846/task/1211604496994582?focus=true")
-        
+
         let minimumDuration = 0.2
         let maximumDuration = 1.0
         let checkInterval   = 0.1


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211264967278501/task/1211854991288087?focus=true
Tech Design URL:
CC:

### Description

### Testing Steps

Manually run the WatchdogTests, and also check that CI is happy!

### Impact and Risks

None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skip flaky `testHangStateTransitions` in `WatchdogTests` by throwing `XCTSkip`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd4a89a5047d4d61dd84c1436b33658f66c4ce21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->