### PR TITLE
Fix assertion in UserContentController.swift for instantly deallocate…

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentScopeScript/UserContentController.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentScopeScript/UserContentController.swift
@@ -45,7 +45,20 @@ final public class UserContentController: WKUserContentController {
 
     public let privacyConfigurationManager: PrivacyConfigurationManaging
     @MainActor
-    public weak var delegate: UserContentControllerDelegate?
+    public weak var delegate: UserContentControllerDelegate? {
+        didSet {
+#if DEBUG
+            if delegate != nil {
+                self.delegateWasSet = true
+            }
+#endif
+        }
+    }
+
+#if DEBUG
+    /// DEBUG var validating `UserContentController.delegate` is always set shortly after init
+    private var delegateWasSet = false
+#endif
 
     public struct ContentBlockingAssets: CustomDebugStringConvertible {
         public let globalRuleLists: [String: WKContentRuleList]
@@ -144,7 +157,8 @@ final public class UserContentController: WKUserContentController {
 #if DEBUG
         // make sure delegate for UserScripts is set shortly after init
         DispatchQueue.main.async { [weak self] in
-            assert(self == nil || self?.delegate != nil || [.unitTests, .integrationTests].contains(AppVersion.runType), "UserContentController delegate not set")
+            assert(self?.delegateWasSet != false || [.unitTests, .integrationTests].contains(AppVersion.runType),
+                   "UserContentController delegate was not set: delegate must always be set shortly after init.")
         }
 #endif
     }


### PR DESCRIPTION
…d Tab

<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL:
Tech Design URL:
CC:

### Description

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Validate CI is green, no assertion fired on launch (with pinned tabs?)
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Track delegate assignment via a DEBUG-only flag and update the init-time assertion to use it in `UserContentController`.
> 
> - **ContentScopeScript (`UserContentController.swift`)**:
>   - Add DEBUG-only tracking (`delegateWasSet`) set in `delegate`'s `didSet`.
>   - Replace DEBUG init-time assertion to check `delegateWasSet` (with clearer message) instead of direct `delegate != nil`.
>   - Minor refactor of `delegate` to computed property with `didSet`; no non-DEBUG behavior changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit febbef0490084462b0cd3950d45a75629e48d643. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->