### PR TITLE
Remove URL prediction mismatch pixel

### DIFF
--- a/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
@@ -122,35 +122,12 @@ extension URL {
         return url
     }
 
-    static func makeURL(from addressBarString: String, enableMetrics: Bool = true) -> URL? {
-        let featureFlagger = Application.appDelegate.featureFlagger
-        guard featureFlagger.isFeatureOn(.unifiedURLPredictor) else {
+    static func makeURL(from addressBarString: String) -> URL? {
+        guard Application.appDelegate.featureFlagger.isFeatureOn(.unifiedURLPredictor) else {
             return makeURLUsingNativePredictionLogic(from: addressBarString)
         }
 
-        let url = makeURLUsingUnifiedPredictionLogic(from: addressBarString)
-
-        /// Return early if the metrics feature flag is disabled (only internal users can opt in to metrics collection).
-        guard enableMetrics, featureFlagger.isFeatureOn(.unifiedURLPredictorMetrics) else {
-            return url
-        }
-
-        /// Verify unified prediction logic against native one and fire a pixel when the output (wrt search/navigate/error) differs.
-        let expectedURL = makeURLUsingNativePredictionLogic(from: addressBarString)
-        switch (url?.isDuckDuckGoSearch, expectedURL?.isDuckDuckGoSearch) {
-        case (true, false):
-            PixelKit.fire(DebugEvent(GeneralPixel.unifiedURLPredictionMismatch(prediction: "search", input: addressBarString)))
-        case (false, true):
-            PixelKit.fire(DebugEvent(GeneralPixel.unifiedURLPredictionMismatch(prediction: "navigate", input: addressBarString)))
-        case (nil, nil):
-            break
-        case (nil, _):
-            PixelKit.fire(DebugEvent(GeneralPixel.unifiedURLPredictionMismatch(prediction: "error", input: addressBarString)))
-        default:
-            break
-        }
-
-        return url
+        return makeURLUsingUnifiedPredictionLogic(from: addressBarString)
     }
 
     static func makeURLUsingUnifiedPredictionLogic(from addressBarString: String) -> URL? {

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -333,7 +333,7 @@ final class AddressBarTextField: NSTextField {
             PixelKit.fire(NavigationEngagementPixel.navigateToURL(source: .suggestion))
         case .none:
             // Fire engagement pixel for direct URL entry (not search phrases)
-            if URL.makeURL(from: stringValueWithoutSuffix, enableMetrics: false) != nil {
+            if URL.makeURL(from: stringValueWithoutSuffix) != nil {
                 PixelKit.fire(NavigationEngagementPixel.navigateToURL(source: .addressBar))
             }
         default:

--- a/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
+++ b/macOS/DuckDuckGo/PinnedTabs/View/PinnedTabView.swift
@@ -103,7 +103,7 @@ struct PinnedTabView: View, DropDelegate {
               ].first(where: { item.registeredTypeIdentifiers.contains($0) }) else { return false }
 
         item.loadItem(forTypeIdentifier: typeIdentifier) { (result, _) in
-            guard let url = result as? URL ?? ((result as? Data)?.utf8String() ?? result as? String).flatMap({ URL.makeURL(from: $0, enableMetrics: false) }) else { return }
+            guard let url = result as? URL ?? ((result as? Data)?.utf8String() ?? result as? String).flatMap(URL.makeURL(from:)) else { return }
             DispatchQueue.main.async {
                 model.setUrl(url, source: .userEntered(url.absoluteString, downloadRequested: false))
             }

--- a/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -551,8 +551,6 @@ enum GeneralPixel: PixelKitEvent {
      */
     case userScriptLoadJSFailed(jsFile: String, error: Error)
 
-    case unifiedURLPredictionMismatch(prediction: String, input: String)
-
     var name: String {
         switch self {
         case .crash(let appIdentifier):
@@ -1283,9 +1281,6 @@ enum GeneralPixel: PixelKitEvent {
 
             // UserScript
         case .userScriptLoadJSFailed: return "m_mac_debug_user_script_load_js_failed"
-
-        case .unifiedURLPredictionMismatch:
-            return "unified_url_prediction_mismatch"
         }
     }
 
@@ -1463,9 +1458,6 @@ enum GeneralPixel: PixelKitEvent {
             var params = error.pixelParameters
             params[PixelKit.Parameters.jsFile] = jsFile
             return params
-
-        case .unifiedURLPredictionMismatch(let prediction, let input):
-            return ["prediction": prediction, "input": input]
 
         default: return nil
         }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -203,9 +203,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1201048563534612/task/1211260578559159?focus=true
     case unifiedURLPredictor
 
-    /// https://app.asana.com/1/137249556945/project/72649045549333/task/1211396583578252?focus=true
-    case unifiedURLPredictorMetrics
-
     /// https://app.asana.com/1/137249556945/task/1211354430557015?focus=true
     case subscriptionRestoreWidePixelMeasurement
 
@@ -356,7 +353,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .themes,
                 .appStoreUpdateFlow,
                 .unifiedURLPredictor,
-                .unifiedURLPredictorMetrics,
                 .authV2WideEventEnabled,
                 .webKitPerformanceReporting,
                 .fireDialog,
@@ -530,8 +526,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.appStoreUpdateFlow))
         case .unifiedURLPredictor:
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.unifiedURLPredictor))
-        case .unifiedURLPredictorMetrics:
-            return .disabled
         case .authV2WideEventEnabled:
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.authV2WideEventEnabled))
         case .webKitPerformanceReporting:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1211436196567315?focus=true

### Description
This change removes a temporary URL prediction mismatch pixel and simplifies URL prediction logic.

### Testing Steps
1. Verify that CI is green.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the unified URL prediction mismatch pixel and feature flag, simplifies URL creation by dropping the metrics path/parameter, and updates call sites.
> 
> - **URL prediction**:
>   - Simplify `URL.makeURL(from:)`: remove metrics verification/pixel firing and the `enableMetrics` parameter; always use unified logic when feature `unifiedURLPredictor` is on.
>   - Update callers to new signature in `AddressBarTextField.navigate` and `PinnedTabView.performDrop`.
> - **Telemetry & Feature Flags**:
>   - Remove `GeneralPixel.unifiedURLPredictionMismatch` and its name/parameter handling.
>   - Remove `FeatureFlag.unifiedURLPredictorMetrics` and all references (defaults, supportsLocalOverriding, source).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f1fabaa2cfa4bf4688372cc2f27d3c35e3a22ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->