### PR TITLE
[macOS] Fix builds for localization export

### DIFF
--- a/macOS/DuckDuckGo/Bookmarks/Model/MockBookmarkManager.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Model/MockBookmarkManager.swift
@@ -65,37 +65,37 @@ final class MockBookmarkManager: BookmarkManager, URLFavoriteStatusProviding, Re
         return []
     }
 
-    func getBookmark(for url: URL) -> DuckDuckGo_Privacy_Browser.Bookmark? {
+    func getBookmark(for url: URL) -> Bookmark? {
         return nil
     }
 
-    func getBookmark(forUrl url: String) -> DuckDuckGo_Privacy_Browser.Bookmark? {
+    func getBookmark(forUrl url: String) -> Bookmark? {
         return nil
     }
 
-    func getBookmark(forVariantUrl url: URL) -> DuckDuckGo_Privacy_Browser.Bookmark? {
+    func getBookmark(forVariantUrl url: URL) -> Bookmark? {
         return nil
     }
 
-    func getBookmarkFolder(withId id: String) -> DuckDuckGo_Privacy_Browser.BookmarkFolder? {
+    func getBookmarkFolder(withId id: String) -> BookmarkFolder? {
         return nil
     }
 
-    func makeBookmark(for url: URL, title: String, isFavorite: Bool, index: Int?, parent: BookmarkFolder?) -> DuckDuckGo_Privacy_Browser.Bookmark? {
+    func makeBookmark(for url: URL, title: String, isFavorite: Bool, index: Int?, parent: BookmarkFolder?) -> Bookmark? {
         return nil
     }
 
-    func makeBookmarks(for websitesInfo: [DuckDuckGo_Privacy_Browser.WebsiteInfo], inNewFolderNamed folderName: String?, withinParentFolder parent: DuckDuckGo_Privacy_Browser.ParentFolderType) {}
+    func makeBookmarks(for websitesInfo: [WebsiteInfo], inNewFolderNamed folderName: String?, withinParentFolder parent: ParentFolderType) {}
 
     func makeFolder(named title: String, parent: BookmarkFolder?, completion: @escaping (Result<BookmarkFolder, Error>) -> Void) {}
 
     var removeBookmarkCalled = false
-    func remove(bookmark: DuckDuckGo_Privacy_Browser.Bookmark, undoManager: UndoManager?) {
+    func remove(bookmark: Bookmark, undoManager: UndoManager?) {
         removeBookmarkCalled = true
     }
 
     var removeFolderCalled = false
-    func remove(folder: DuckDuckGo_Privacy_Browser.BookmarkFolder, undoManager: UndoManager?) {
+    func remove(folder: BookmarkFolder, undoManager: UndoManager?) {
         removeFolderCalled = true
     }
 
@@ -105,37 +105,37 @@ final class MockBookmarkManager: BookmarkManager, URLFavoriteStatusProviding, Re
     }
 
     var updateBookmarkCalled: Bookmark?
-    func update(bookmark: DuckDuckGo_Privacy_Browser.Bookmark) {
+    func update(bookmark: Bookmark) {
         updateBookmarkCalled = bookmark
     }
 
-    func update(bookmark: DuckDuckGo_Privacy_Browser.Bookmark, withURL url: URL, title: String, isFavorite: Bool) {}
+    func update(bookmark: Bookmark, withURL url: URL, title: String, isFavorite: Bool) {}
 
-    func update(folder: DuckDuckGo_Privacy_Browser.BookmarkFolder) {}
+    func update(folder: BookmarkFolder) {}
 
-    func update(folder: DuckDuckGo_Privacy_Browser.BookmarkFolder, andMoveToParent parent: DuckDuckGo_Privacy_Browser.ParentFolderType) {}
+    func update(folder: BookmarkFolder, andMoveToParent parent: ParentFolderType) {}
 
-    func updateUrl(of bookmark: DuckDuckGo_Privacy_Browser.Bookmark, to newUrl: URL) -> DuckDuckGo_Privacy_Browser.Bookmark? {
+    func updateUrl(of bookmark: Bookmark, to newUrl: URL) -> Bookmark? {
         return nil
     }
 
-    func add(bookmark: DuckDuckGo_Privacy_Browser.Bookmark, to parent: DuckDuckGo_Privacy_Browser.BookmarkFolder?, completion: @escaping (Error?) -> Void) {}
+    func add(bookmark: Bookmark, to parent: BookmarkFolder?, completion: @escaping (Error?) -> Void) {}
 
-    func add(objectsWithUUIDs uuids: [String], to parent: DuckDuckGo_Privacy_Browser.BookmarkFolder?, completion: @escaping (Error?) -> Void) {}
+    func add(objectsWithUUIDs uuids: [String], to parent: BookmarkFolder?, completion: @escaping (Error?) -> Void) {}
 
-    func update(objectsWithUUIDs uuids: [String], update: @escaping (DuckDuckGo_Privacy_Browser.BaseBookmarkEntity) -> Void, completion: @escaping (Error?) -> Void) {}
+    func update(objectsWithUUIDs uuids: [String], update: @escaping (BaseBookmarkEntity) -> Void, completion: @escaping (Error?) -> Void) {}
 
-    func canMoveObjectWithUUID(objectUUID uuid: String, to parent: DuckDuckGo_Privacy_Browser.BookmarkFolder) -> Bool {
+    func canMoveObjectWithUUID(objectUUID uuid: String, to parent: BookmarkFolder) -> Bool {
         return false
     }
 
     struct MoveArgs: Equatable {
         var objectUUIDs: [String] = []
         var toIndex: Int?
-        var withinParentFolder: DuckDuckGo_Privacy_Browser.ParentFolderType
+        var withinParentFolder: ParentFolderType
     }
     var moveObjectsCalled: MoveArgs?
-    func move(objectUUIDs: [String], toIndex: Int?, withinParentFolder: DuckDuckGo_Privacy_Browser.ParentFolderType, completion: @escaping (Error?) -> Void) {
+    func move(objectUUIDs: [String], toIndex: Int?, withinParentFolder: ParentFolderType, completion: @escaping (Error?) -> Void) {
         moveObjectsCalled = .init(objectUUIDs: objectUUIDs, toIndex: toIndex, withinParentFolder: withinParentFolder)
     }
 
@@ -169,7 +169,7 @@ final class MockBookmarkManager: BookmarkManager, URLFavoriteStatusProviding, Re
 }
 
 extension MockBookmarkManager: HistoryViewBookmarksHandling {
-    func addNewBookmarks(for websiteInfos: [DuckDuckGo_Privacy_Browser.WebsiteInfo]) {
+    func addNewBookmarks(for websiteInfos: [WebsiteInfo]) {
         makeBookmarks(for: websiteInfos, inNewFolderNamed: nil, withinParentFolder: .root)
     }
 

--- a/macOS/DuckDuckGo/FileDownload/Model/FileDownloadManagerMock.swift
+++ b/macOS/DuckDuckGo/FileDownload/Model/FileDownloadManagerMock.swift
@@ -35,7 +35,7 @@ final class FileDownloadManagerMock: FileDownloadManagerProtocol, WebKitDownload
     var addDownloadBlock: ((WebKitDownload,
                             DownloadTaskDelegate?,
                             WebKitDownloadTask.DownloadDestination) -> WebKitDownloadTask)?
-    func add(_ download: any WebKitDownload, fireWindowSession: DuckDuckGo_Privacy_Browser.FireWindowSessionRef?, delegate: (any DuckDuckGo_Privacy_Browser.DownloadTaskDelegate)?, destination: DuckDuckGo_Privacy_Browser.WebKitDownloadTask.DownloadDestination) -> DuckDuckGo_Privacy_Browser.WebKitDownloadTask {
+    func add(_ download: any WebKitDownload, fireWindowSession: FireWindowSessionRef?, delegate: (any DownloadTaskDelegate)?, destination: WebKitDownloadTask.DownloadDestination) -> WebKitDownloadTask {
         addDownloadBlock!(download, delegate, destination)
     }
 
@@ -44,7 +44,7 @@ final class FileDownloadManagerMock: FileDownloadManagerProtocol, WebKitDownload
         cancelAllBlock?(waitUntilDone)
     }
 
-    func fileDownloadTaskNeedsDestinationURL(_ task: DuckDuckGo_Privacy_Browser.WebKitDownloadTask, suggestedFilename: String, suggestedFileType: UTType?) async -> (URL?, UTType?) {
+    func fileDownloadTaskNeedsDestinationURL(_ task: WebKitDownloadTask, suggestedFilename: String, suggestedFileType: UTType?) async -> (URL?, UTType?) {
         (nil, nil)
     }
 

--- a/macOS/DuckDuckGo/Permissions/Model/PermissionManagerMock.swift
+++ b/macOS/DuckDuckGo/Permissions/Model/PermissionManagerMock.swift
@@ -38,7 +38,7 @@ final class PermissionManagerMock: PermissionManagerProtocol {
         }
     }
 
-    func hasPermissionPersisted(forDomain domain: String, permissionType: DuckDuckGo_Privacy_Browser.PermissionType) -> Bool {
+    func hasPermissionPersisted(forDomain domain: String, permissionType: PermissionType) -> Bool {
         savedPermissions[domain.droppingWwwPrefix()]?[permissionType] != nil
     }
 

--- a/macOS/DuckDuckGo/Windows/Model/WindowControllersManagerMock.swift
+++ b/macOS/DuckDuckGo/Windows/Model/WindowControllersManagerMock.swift
@@ -27,7 +27,7 @@ final class WindowControllersManagerMock: WindowControllersManagerProtocol, AICh
     var stateChanged: AnyPublisher<Void, Never> = Empty().eraseToAnyPublisher()
     var tabsChanged: AnyPublisher<Void, Never> = Empty().eraseToAnyPublisher()
 
-    var mainWindowControllers: [DuckDuckGo_Privacy_Browser.MainWindowController] = []
+    var mainWindowControllers: [MainWindowController] = []
 
     var pinnedTabsManagerProvider: PinnedTabsManagerProviding
 
@@ -80,7 +80,7 @@ final class WindowControllersManagerMock: WindowControllersManagerProtocol, AICh
     var openWindowCalls: [OpenWindowCall] = []
     var onOpenNewWindow: ((OpenWindowCall) -> Void)?
     @discardableResult
-    func openNewWindow(with tabCollectionViewModel: DuckDuckGo_Privacy_Browser.TabCollectionViewModel?, burnerMode: DuckDuckGo_Privacy_Browser.BurnerMode, droppingPoint: NSPoint?, contentSize: NSSize?, showWindow: Bool, popUp: Bool, lazyLoadTabs: Bool, isMiniaturized: Bool, isMaximized: Bool, isFullscreen: Bool) -> NSWindow? {
+    func openNewWindow(with tabCollectionViewModel: TabCollectionViewModel?, burnerMode: BurnerMode, droppingPoint: NSPoint?, contentSize: NSSize?, showWindow: Bool, popUp: Bool, lazyLoadTabs: Bool, isMiniaturized: Bool, isMaximized: Bool, isFullscreen: Bool) -> NSWindow? {
         let call = OpenWindowCall(
             contents: tabCollectionViewModel?.tabs.map(\.content),
             burnerMode: burnerMode,
@@ -98,14 +98,14 @@ final class WindowControllersManagerMock: WindowControllersManagerProtocol, AICh
         return nil
     }
 
-    func open(_ url: URL, source: DuckDuckGo_Privacy_Browser.Tab.TabContent.URLSource, target window: NSWindow?, event: NSEvent?) {
+    func open(_ url: URL, source: Tab.TabContent.URLSource, target window: NSWindow?, event: NSEvent?) {
         openCalls.append(.init(url, source, window, event))
     }
-    func showTab(with content: DuckDuckGo_Privacy_Browser.Tab.TabContent) {
+    func showTab(with content: Tab.TabContent) {
         showTabCalls.append(content)
     }
 
-    func openTab(_ tab: DuckDuckGo_Privacy_Browser.Tab, afterParentTab parentTab: DuckDuckGo_Privacy_Browser.Tab, selected: Bool) {
+    func openTab(_ tab: Tab, afterParentTab parentTab: Tab, selected: Bool) {
         openTabCalls.append(OpenTabCall(tab: tab, parentTab: parentTab, selected: selected))
     }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1211877184665325?focus=true
Tech Design URL:
CC:

### Description

This resolves a build failure when exporting strings for localization. Previously, the export build failed with errors `Error: cannot find type 'DuckDuckGo_Privacy_Browser' in scope`.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Confirm PR checks pass.
2. Confirm localization exports (i.e. `macOS/scripts/loc_export.sh`) build and export the .xliff file.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->


### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace module-qualified type references with local types across macOS test mocks to resolve localization export build errors.
> 
> - **Mocks updated to use local types (remove `DuckDuckGo_Privacy_Browser` qualifiers):**
>   - **Bookmarks (`MockBookmarkManager`)**:
>     - Update method signatures to `Bookmark`, `BookmarkFolder`, `WebsiteInfo`, `ParentFolderType`, `BaseBookmarkEntity`.
>   - **File Download (`FileDownloadManagerMock`)**:
>     - Update `add`, `fileDownloadTaskNeedsDestinationURL`, and delegate types to `WebKitDownloadTask`, `DownloadTaskDelegate`, `FireWindowSessionRef`.
>   - **Permissions (`PermissionManagerMock`)**:
>     - Use `PermissionType` directly in persistence checks and storage.
>   - **Windows (`WindowControllersManagerMock`)**:
>     - Use unqualified `MainWindowController`, `Tab`, `TabContent`, `TabCollectionViewModel`, `BurnerMode` in properties and methods.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2179d369f62ad7e43b78a1bfcd764ab66462f0ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->