### PR TITLE
Remove AIChatPreferences singleton

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -180,6 +180,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     )
     let aiChatMenuConfiguration: AIChatMenuVisibilityConfigurable
     let aiChatSidebarProvider: AIChatSidebarProviding
+    let aiChatPreferences: AIChatPreferences
 
     let privacyStats: PrivacyStatsCollecting
     let activeRemoteMessageModel: ActiveRemoteMessageModel
@@ -678,6 +679,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         contentScopePreferences = ContentScopePreferences(windowControllersManager: windowControllersManager)
         webTrackingProtectionPreferences = WebTrackingProtectionPreferences(persistor: WebTrackingProtectionPreferencesUserDefaultsPersistor(), windowControllersManager: windowControllersManager)
         cookiePopupProtectionPreferences = CookiePopupProtectionPreferences(persistor: CookiePopupProtectionPreferencesUserDefaultsPersistor(), windowControllersManager: windowControllersManager)
+        aiChatPreferences = AIChatPreferences(
+            storage: DefaultAIChatPreferencesStorage(),
+            aiChatMenuConfiguration: aiChatMenuConfiguration,
+            windowControllersManager: windowControllersManager,
+            featureFlagger: featureFlagger
+        )
 
         let subscriptionNavigationCoordinator = SubscriptionNavigationCoordinator(
             tabShower: windowControllersManager,

--- a/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
@@ -113,7 +113,7 @@ extension URL {
 
         if NSApp.delegateTyped.featureFlagger.isFeatureOn(.duckAISearchParameter) {
             /// Append the kbg disable parameter only when Duck AI features are not shown
-            if !AIChatPreferences.shared.shouldShowAIFeatures {
+            if !NSApp.delegateTyped.aiChatPreferences.shouldShowAIFeatures {
                 url = url.appendingParameter(name: URL.DuckDuckGoParameters.KBG.kbg,
                                              value: URL.DuckDuckGoParameters.KBG.kbgDisabledValue)
             }

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -117,6 +117,7 @@ final class MainViewController: NSViewController {
          tabsPreferences: TabsPreferences = NSApp.delegateTyped.tabsPreferences,
          webTrackingProtectionPreferences: WebTrackingProtectionPreferences = NSApp.delegateTyped.webTrackingProtectionPreferences,
          cookiePopupProtectionPreferences: CookiePopupProtectionPreferences = NSApp.delegateTyped.cookiePopupProtectionPreferences,
+         aiChatPreferences: AIChatPreferences = NSApp.delegateTyped.aiChatPreferences,
          themeManager: ThemeManager = NSApp.delegateTyped.themeManager,
          fireCoordinator: FireCoordinator = NSApp.delegateTyped.fireCoordinator,
          pixelFiring: PixelFiring? = PixelKit.shared,
@@ -198,7 +199,8 @@ final class MainViewController: NSViewController {
             searchPreferences: searchPreferences,
             tabsPreferences: tabsPreferences,
             webTrackingProtectionPreferences: webTrackingProtectionPreferences,
-            cookiePopupProtectionPreferences: cookiePopupProtectionPreferences
+            cookiePopupProtectionPreferences: cookiePopupProtectionPreferences,
+            aiChatPreferences: aiChatPreferences
         )
         aiChatSidebarPresenter = AIChatSidebarPresenter(
             sidebarHost: browserTabViewController,

--- a/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
@@ -24,18 +24,18 @@ import Foundation
 import PixelKit
 
 final class AIChatPreferences: ObservableObject {
-    static let shared = AIChatPreferences()
+
     private var storage: AIChatPreferencesStorage
     private var cancellables = Set<AnyCancellable>()
     private let learnMoreURL = URL(string: "https://duckduckgo.com/duckduckgo-help-pages/duckai/approach-to-ai")!
     private let searchAssistSettingsURL = URL(string: "https://duckduckgo.com/settings?return=aiFeatures#aifeatures")!
     private let aiChatMenuConfiguration: AIChatMenuVisibilityConfigurable
-    private var windowControllersManager: WindowControllersManager
+    private var windowControllersManager: WindowControllersManagerProtocol
     private let featureFlagger: FeatureFlagger
 
     init(storage: AIChatPreferencesStorage = DefaultAIChatPreferencesStorage(),
          aiChatMenuConfiguration: AIChatMenuVisibilityConfigurable = Application.appDelegate.aiChatMenuConfiguration,
-         windowControllersManager: WindowControllersManager = Application.appDelegate.windowControllersManager,
+         windowControllersManager: WindowControllersManagerProtocol = Application.appDelegate.windowControllersManager,
          featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger) {
         self.storage = storage
         self.aiChatMenuConfiguration = aiChatMenuConfiguration
@@ -152,7 +152,7 @@ final class AIChatPreferences: ObservableObject {
     }
 
     @MainActor func openLearnMoreLink() {
-        windowControllersManager.show(url: learnMoreURL, source: .ui, newTab: true)
+        windowControllersManager.show(url: learnMoreURL, source: .ui, newTab: true, selected: true)
     }
 
     @MainActor func openAIChatLink() {
@@ -160,6 +160,6 @@ final class AIChatPreferences: ObservableObject {
     }
 
     @MainActor func openSearchAssistSettings() {
-        windowControllersManager.show(url: searchAssistSettingsURL, source: .ui, newTab: true)
+        windowControllersManager.show(url: searchAssistSettingsURL, source: .ui, newTab: true, selected: true)
     }
 }

--- a/macOS/DuckDuckGo/Preferences/Model/PreferencesSidebarModel.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/PreferencesSidebarModel.swift
@@ -65,6 +65,7 @@ final class PreferencesSidebarModel: ObservableObject {
     let tabsPreferences: TabsPreferences
     let webTrackingProtectionPreferences: WebTrackingProtectionPreferences
     let cookiePopupProtectionPreferences: CookiePopupProtectionPreferences
+    let aiChatPreferences: AIChatPreferences
     let isUsingAuthV2: Bool
 
     @Published private(set) var currentSubscriptionState: PreferencesSidebarSubscriptionState = .init()
@@ -79,14 +80,13 @@ final class PreferencesSidebarModel: ObservableObject {
     public let paidAIChatUpdates: AnyPublisher<StatusIndicator, Never>
 
     public var aiFeaturesEnabledUpdates: AnyPublisher<Bool, Never> {
-        aiFeaturesStatusProvider.isAIFeaturesEnabledPublisher
+        aiChatPreferences.isAIFeaturesEnabledPublisher
     }
 
     private let notificationCenter: NotificationCenter
     private let pixelFiring: PixelFiring?
     private var isInitialSelectedPanePixelFired = false
     private let featureFlagger: FeatureFlagger
-    private let aiFeaturesStatusProvider: AIFeaturesStatusProviding
     private let winBackOfferVisibilityManager: WinBackOfferVisibilityManaging
 
     var selectedTabContent: AnyPublisher<Tab.TabContent, Never> {
@@ -113,7 +113,7 @@ final class PreferencesSidebarModel: ObservableObject {
         tabsPreferences: TabsPreferences,
         webTrackingProtectionPreferences: WebTrackingProtectionPreferences,
         cookiePopupProtectionPreferences: CookiePopupProtectionPreferences,
-        aiFeaturesStatusProvider: AIFeaturesStatusProviding,
+        aiChatPreferences: AIChatPreferences,
         winBackOfferVisibilityManager: WinBackOfferVisibilityManaging
     ) {
         self.loadSections = loadSections
@@ -131,7 +131,7 @@ final class PreferencesSidebarModel: ObservableObject {
         self.tabsPreferences = tabsPreferences
         self.webTrackingProtectionPreferences = webTrackingProtectionPreferences
         self.cookiePopupProtectionPreferences = cookiePopupProtectionPreferences
-        self.aiFeaturesStatusProvider = aiFeaturesStatusProvider
+        self.aiChatPreferences = aiChatPreferences
         self.winBackOfferVisibilityManager = winBackOfferVisibilityManager
 
         self.personalInformationRemovalUpdates = personalInformationRemovalSubject.eraseToAnyPublisher()
@@ -167,7 +167,7 @@ final class PreferencesSidebarModel: ObservableObject {
         tabsPreferences: TabsPreferences,
         webTrackingProtectionPreferences: WebTrackingProtectionPreferences,
         cookiePopupProtectionPreferences: CookiePopupProtectionPreferences,
-        aiFeaturesStatusProvider: AIFeaturesStatusProviding,
+        aiChatPreferences: AIChatPreferences,
         winBackOfferVisibilityManager: WinBackOfferVisibilityManaging
     ) {
         let loadSections = { currentSubscriptionFeatures in
@@ -193,7 +193,7 @@ final class PreferencesSidebarModel: ObservableObject {
                   tabsPreferences: tabsPreferences,
                   webTrackingProtectionPreferences: webTrackingProtectionPreferences,
                   cookiePopupProtectionPreferences: cookiePopupProtectionPreferences,
-                  aiFeaturesStatusProvider: aiFeaturesStatusProvider,
+                  aiChatPreferences: aiChatPreferences,
                   winBackOfferVisibilityManager: winBackOfferVisibilityManager
         )
     }
@@ -239,12 +239,12 @@ final class PreferencesSidebarModel: ObservableObject {
     }
 
     private func subscribeToAIChatFeaturesChanges() {
-        aiFeaturesStatusProvider.isAIFeaturesEnabledPublisher
+        aiChatPreferences.isAIFeaturesEnabledPublisher
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
-                paidAIChatSubject.send(currentSubscriptionState.isPaidAIChatEnabled && aiFeaturesStatusProvider.isAIFeaturesEnabled ? .on : .off)
+                paidAIChatSubject.send(currentSubscriptionState.isPaidAIChatEnabled && aiChatPreferences.isAIFeaturesEnabled ? .on : .off)
             }
             .store(in: &cancellables)
     }
@@ -299,7 +299,7 @@ final class PreferencesSidebarModel: ObservableObject {
         case .personalInformationRemoval:
             return personalInformationRemovalStatus()
         case .paidAIChat:
-            let initialStatus = currentSubscriptionState.isPaidAIChatEnabled && aiFeaturesStatusProvider.isAIFeaturesEnabled
+            let initialStatus = currentSubscriptionState.isPaidAIChatEnabled && aiChatPreferences.isAIFeaturesEnabled
             return PrivacyProtectionStatus(statusPublisher: paidAIChatUpdates, initialValue: initialStatus ? .on : .off) { status in
                 status
             }
@@ -376,7 +376,7 @@ final class PreferencesSidebarModel: ObservableObject {
                 }
 
                 if self.currentSubscriptionState.isPaidAIChatEnabled != updatedState.isPaidAIChatEnabled {
-                    paidAIChatSubject.send(updatedState.isPaidAIChatEnabled && aiFeaturesStatusProvider.isAIFeaturesEnabled ? .on : .off)
+                    paidAIChatSubject.send(updatedState.isPaidAIChatEnabled && aiChatPreferences.isAIFeaturesEnabled ? .on : .off)
                 }
 
                 if self.currentSubscriptionState.isIdentityTheftRestorationEnabled != updatedState.isIdentityTheftRestorationEnabled {

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesRootView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesRootView.swift
@@ -135,7 +135,7 @@ enum Preferences {
                     SyncView()
                 case .appearance:
                     AppearanceView(model: NSApp.delegateTyped.appearancePreferences,
-                                   aiChatModel: AIChatPreferences.shared,
+                                   aiChatModel: model.aiChatPreferences,
                                    themeManager: themeManager,
                                    isThemeSwitcherEnabled: featureFlagger.isFeatureOn(.themes))
                 case .dataClearing:
@@ -165,7 +165,7 @@ enum Preferences {
                 case .about:
                     AboutView(model: AboutPreferences.shared)
                 case .aiChat:
-                    AIChatView(model: AIChatPreferences.shared)
+                    AIChatView(model: model.aiChatPreferences)
                 }
             }
             .frame(maxWidth: Const.paneContentWidth, maxHeight: .infinity, alignment: .topLeading)
@@ -406,7 +406,7 @@ enum Preferences {
                     SyncView()
                 case .appearance:
                     AppearanceView(model: NSApp.delegateTyped.appearancePreferences,
-                                   aiChatModel: AIChatPreferences.shared,
+                                   aiChatModel: model.aiChatPreferences,
                                    themeManager: themeManager,
                                    isThemeSwitcherEnabled: featureFlagger.isFeatureOn(.themes))
                 case .dataClearing:
@@ -435,7 +435,7 @@ enum Preferences {
                 case .about:
                     AboutView(model: AboutPreferences.shared)
                 case .aiChat:
-                    AIChatView(model: AIChatPreferences.shared)
+                    AIChatView(model: model.aiChatPreferences)
                 }
             }
             .frame(maxWidth: Const.paneContentWidth, maxHeight: .infinity, alignment: .topLeading)

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesViewController.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesViewController.swift
@@ -53,6 +53,7 @@ final class PreferencesViewController: NSViewController {
         tabsPreferences: TabsPreferences,
         webTrackingProtectionPreferences: WebTrackingProtectionPreferences,
         cookiePopupProtectionPreferences: CookiePopupProtectionPreferences,
+        aiChatPreferences: AIChatPreferences,
         subscriptionManager: any SubscriptionAuthV1toV2Bridge,
         winBackOfferVisibilityManager: WinBackOfferVisibilityManaging
     ) {
@@ -73,7 +74,7 @@ final class PreferencesViewController: NSViewController {
                                         tabsPreferences: tabsPreferences,
                                         webTrackingProtectionPreferences: webTrackingProtectionPreferences,
                                         cookiePopupProtectionPreferences: cookiePopupProtectionPreferences,
-                                        aiFeaturesStatusProvider: AIChatPreferences.shared,
+                                        aiChatPreferences: aiChatPreferences,
                                         winBackOfferVisibilityManager: winBackOfferVisibilityManager)
         super.init(nibName: nil, bundle: nil)
     }

--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import AIChat
 import BrowserServicesKit
 import Cocoa
 import Combine
@@ -93,6 +94,7 @@ final class BrowserTabViewController: NSViewController {
     private let tabsPreferences: TabsPreferences
     private let webTrackingProtectionPreferences: WebTrackingProtectionPreferences
     private let cookiePopupProtectionPreferences: CookiePopupProtectionPreferences
+    private let aiChatPreferences: AIChatPreferences
     private let subscriptionManager: any SubscriptionAuthV1toV2Bridge
     private let winBackOfferVisibilityManager: WinBackOfferVisibilityManaging
 
@@ -147,6 +149,7 @@ final class BrowserTabViewController: NSViewController {
          tabsPreferences: TabsPreferences,
          webTrackingProtectionPreferences: WebTrackingProtectionPreferences,
          cookiePopupProtectionPreferences: CookiePopupProtectionPreferences,
+         aiChatPreferences: AIChatPreferences,
          subscriptionManager: any SubscriptionAuthV1toV2Bridge = NSApp.delegateTyped.subscriptionAuthV1toV2Bridge,
          winBackOfferVisibilityManager: WinBackOfferVisibilityManaging = NSApp.delegateTyped.winBackOfferVisibilityManager,
          tld: TLD = NSApp.delegateTyped.tld
@@ -168,6 +171,7 @@ final class BrowserTabViewController: NSViewController {
         self.tabsPreferences = tabsPreferences
         self.webTrackingProtectionPreferences = webTrackingProtectionPreferences
         self.cookiePopupProtectionPreferences = cookiePopupProtectionPreferences
+        self.aiChatPreferences = aiChatPreferences
         self.subscriptionManager = subscriptionManager
         self.winBackOfferVisibilityManager = winBackOfferVisibilityManager
 
@@ -1189,6 +1193,7 @@ final class BrowserTabViewController: NSViewController {
                 tabsPreferences: tabsPreferences,
                 webTrackingProtectionPreferences: webTrackingProtectionPreferences,
                 cookiePopupProtectionPreferences: cookiePopupProtectionPreferences,
+                aiChatPreferences: aiChatPreferences,
                 subscriptionManager: subscriptionManager,
                 winBackOfferVisibilityManager: winBackOfferVisibilityManager
             )
@@ -1734,11 +1739,12 @@ extension BrowserTabViewController {
     BrowserTabViewController(
         tabCollectionViewModel: TabCollectionViewModel(tabCollection: TabCollection(tabs: [.init(content: .url(.duckDuckGo, source: .ui))])),
         defaultBrowserPreferences: DefaultBrowserPreferences(),
-        downloadsPreferences: DownloadsPreferences(persistor: DownloadsPreferencesUserDefaultsPersistor()),
-        searchPreferences: SearchPreferences(persistor: SearchPreferencesUserDefaultsPersistor(), windowControllersManager: Application.appDelegate.windowControllersManager),
-        tabsPreferences: TabsPreferences(persistor: TabsPreferencesUserDefaultsPersistor(), windowControllersManager: Application.appDelegate.windowControllersManager),
-        webTrackingProtectionPreferences: WebTrackingProtectionPreferences(persistor: WebTrackingProtectionPreferencesUserDefaultsPersistor(), windowControllersManager: Application.appDelegate.windowControllersManager),
-        cookiePopupProtectionPreferences: CookiePopupProtectionPreferences(persistor: CookiePopupProtectionPreferencesUserDefaultsPersistor(), windowControllersManager: Application.appDelegate.windowControllersManager)
+        downloadsPreferences: Application.appDelegate.downloadsPreferences,
+        searchPreferences: Application.appDelegate.searchPreferences,
+        tabsPreferences: Application.appDelegate.tabsPreferences,
+        webTrackingProtectionPreferences: Application.appDelegate.webTrackingProtectionPreferences,
+        cookiePopupProtectionPreferences: Application.appDelegate.cookiePopupProtectionPreferences,
+        aiChatPreferences: Application.appDelegate.aiChatPreferences
     )
 }
 

--- a/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
+++ b/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import AIChat
 import BrowserServicesKit
 import Combine
 import Common
@@ -78,6 +79,51 @@ class MockCookiePopupProtectionPreferencesPersistor: CookiePopupProtectionPrefer
     var autoconsentEnabled: Bool = false
 }
 
+class MockAIChatPreferencesStorage: AIChatPreferencesStorage {
+    var isAIFeaturesEnabled: Bool = true
+    var didDisplayAIChatAddressBarOnboarding: Bool = true
+    var showShortcutOnNewTabPage: Bool = true
+    var showShortcutInApplicationMenu: Bool = true
+    var showShortcutInAddressBar: Bool = true
+    var showShortcutInAddressBarWhenTyping: Bool = true
+    var openAIChatInSidebar: Bool = true
+    var shouldAutomaticallySendPageContext: Bool = true
+
+    let isAIFeaturesEnabledPublisher: AnyPublisher<Bool, Never> = Empty().eraseToAnyPublisher()
+    let showShortcutOnNewTabPagePublisher: AnyPublisher<Bool, Never> = Empty().eraseToAnyPublisher()
+    let showShortcutInApplicationMenuPublisher: AnyPublisher<Bool, Never> = Empty().eraseToAnyPublisher()
+    let showShortcutInAddressBarPublisher: AnyPublisher<Bool, Never> = Empty().eraseToAnyPublisher()
+    let showShortcutInAddressBarWhenTypingPublisher: AnyPublisher<Bool, Never> = Empty().eraseToAnyPublisher()
+    let openAIChatInSidebarPublisher: AnyPublisher<Bool, Never> = Empty().eraseToAnyPublisher()
+    let shouldAutomaticallySendPageContextPublisher: AnyPublisher<Bool, Never> = Empty().eraseToAnyPublisher()
+
+    func reset() {
+        isAIFeaturesEnabled = true
+        showShortcutOnNewTabPage = true
+        showShortcutInApplicationMenu = true
+        showShortcutInAddressBar = true
+        showShortcutInAddressBarWhenTyping = true
+        didDisplayAIChatAddressBarOnboarding = true
+        openAIChatInSidebar = true
+        shouldAutomaticallySendPageContext = true
+    }
+}
+
+final class MockAIChatConfig: AIChatMenuVisibilityConfigurable {
+    var shouldDisplayNewTabPageShortcut = false
+    var shouldDisplayApplicationMenuShortcut = false
+    var shouldDisplayAddressBarShortcut = false
+    var shouldDisplayAnyAIChatFeature = false
+    var shouldOpenAIChatInSidebar = false
+    var shouldDisplaySummarizationMenuItem = false
+    var shouldDisplayTranslationMenuItem = false
+    var shouldAutomaticallySendPageContext = false
+    var shouldDisplayAddressBarShortcutWhenTyping: Bool = false
+    var shouldShowSettingsImprovements: Bool = false
+    var shouldAutomaticallySendPageContextTelemetryValue: Bool?
+    let valuesChangedPublisher = PassthroughSubject<Void, Never>()
+}
+
 @available(macOS 12.0, *)
 final class BrowserTabViewControllerOnboardingTests: XCTestCase {
 
@@ -125,7 +171,13 @@ final class BrowserTabViewControllerOnboardingTests: XCTestCase {
                 searchPreferences: SearchPreferences(persistor: MockSearchPreferencesPersistor(), windowControllersManager: windowControllersManager),
                 tabsPreferences: TabsPreferences(persistor: MockTabsPreferencesPersistor(), windowControllersManager: windowControllersManager),
                 webTrackingProtectionPreferences: WebTrackingProtectionPreferences(persistor: MockWebTrackingProtectionPreferencesPersistor(), windowControllersManager: windowControllersManager),
-                cookiePopupProtectionPreferences: CookiePopupProtectionPreferences(persistor: MockCookiePopupProtectionPreferencesPersistor(), windowControllersManager: windowControllersManager)
+                cookiePopupProtectionPreferences: CookiePopupProtectionPreferences(persistor: MockCookiePopupProtectionPreferencesPersistor(), windowControllersManager: windowControllersManager),
+                aiChatPreferences: AIChatPreferences(
+                    storage: MockAIChatPreferencesStorage(),
+                    aiChatMenuConfiguration: MockAIChatConfig(),
+                    windowControllersManager: windowControllersManager,
+                    featureFlagger: MockFeatureFlagger()
+                )
             )
             viewController.tabViewModel = tabViewModel
             _=viewController.view

--- a/macOS/UnitTests/Preferences/PreferencesSidebarModelTests.swift
+++ b/macOS/UnitTests/Preferences/PreferencesSidebarModelTests.swift
@@ -37,7 +37,7 @@ final class PreferencesSidebarModelTests: XCTestCase {
     private var mockPrivacyConfigurationManager: MockPrivacyConfigurationManager!
     private var mockSyncService: MockDDGSyncing!
     private var mockVPNGatekeeper: DefaultVPNFeatureGatekeeper!
-    private var mockAIChatPreferences: MockAIChatPreferences!
+    private var mockAIChatPreferences: AIChatPreferences!
     private var mockWinBackOfferVisibilityManager: MockWinBackOfferVisibilityManager!
     var cancellables = Set<AnyCancellable>()
 
@@ -46,7 +46,12 @@ final class PreferencesSidebarModelTests: XCTestCase {
         testNotificationCenter = NotificationCenter()
         mockDefaultBrowserPreferences = DefaultBrowserPreferences(defaultBrowserProvider: DefaultBrowserProviderMock())
         mockSubscriptionManager = SubscriptionAuthV1toV2BridgeMock()
-        mockAIChatPreferences = MockAIChatPreferences()
+        mockAIChatPreferences = AIChatPreferences(
+            storage: MockAIChatPreferencesStorage(),
+            aiChatMenuConfiguration: MockAIChatConfig(),
+            windowControllersManager: WindowControllersManagerMock(),
+            featureFlagger: MockFeatureFlagger()
+        )
         mockWinBackOfferVisibilityManager = MockWinBackOfferVisibilityManager()
         let startedAt = Date().startOfDay
         let expiresAt = Date().startOfDay.daysAgo(-10)
@@ -104,7 +109,7 @@ final class PreferencesSidebarModelTests: XCTestCase {
             tabsPreferences: TabsPreferences(persistor: MockTabsPreferencesPersistor(), windowControllersManager: windowControllersManager),
             webTrackingProtectionPreferences: WebTrackingProtectionPreferences(persistor: MockWebTrackingProtectionPreferencesPersistor(), windowControllersManager: windowControllersManager),
             cookiePopupProtectionPreferences: CookiePopupProtectionPreferences(persistor: MockCookiePopupProtectionPreferencesPersistor(), windowControllersManager: windowControllersManager),
-            aiFeaturesStatusProvider: mockAIChatPreferences,
+            aiChatPreferences: mockAIChatPreferences,
             winBackOfferVisibilityManager: mockWinBackOfferVisibilityManager
         )
     }
@@ -127,7 +132,7 @@ final class PreferencesSidebarModelTests: XCTestCase {
             tabsPreferences: TabsPreferences(persistor: MockTabsPreferencesPersistor(), windowControllersManager: windowControllersManager),
             webTrackingProtectionPreferences: WebTrackingProtectionPreferences(persistor: MockWebTrackingProtectionPreferencesPersistor(), windowControllersManager: windowControllersManager),
             cookiePopupProtectionPreferences: CookiePopupProtectionPreferences(persistor: MockCookiePopupProtectionPreferencesPersistor(), windowControllersManager: windowControllersManager),
-            aiFeaturesStatusProvider: mockAIChatPreferences,
+            aiChatPreferences: mockAIChatPreferences,
             winBackOfferVisibilityManager: mockWinBackOfferVisibilityManager
         )
     }
@@ -163,7 +168,7 @@ final class PreferencesSidebarModelTests: XCTestCase {
             tabsPreferences: TabsPreferences(persistor: MockTabsPreferencesPersistor(), windowControllersManager: windowControllersManager),
             webTrackingProtectionPreferences: WebTrackingProtectionPreferences(persistor: MockWebTrackingProtectionPreferencesPersistor(), windowControllersManager: windowControllersManager),
             cookiePopupProtectionPreferences: CookiePopupProtectionPreferences(persistor: MockCookiePopupProtectionPreferencesPersistor(), windowControllersManager: windowControllersManager),
-            aiFeaturesStatusProvider: mockAIChatPreferences,
+            aiChatPreferences: mockAIChatPreferences,
             winBackOfferVisibilityManager: mockWinBackOfferVisibilityManager
         )
     }
@@ -703,20 +708,5 @@ final class PreferencesSidebarModelTests: XCTestCase {
         XCTAssertTrue(model.isSidebarItemEnabled(for: .paidAIChat))
         let protectionStatus = model.protectionStatus(for: .paidAIChat)
         XCTAssertEqual(protectionStatus?.status, .off)
-    }
-
-}
-
-// MARK: - MockAIChatPreferences
-
-public class MockAIChatPreferences: AIFeaturesStatusProviding {
-    @Published public var isAIFeaturesEnabled: Bool = false
-
-    public var isAIFeaturesEnabledPublisher: AnyPublisher<Bool, Never> {
-        $isAIFeaturesEnabled.eraseToAnyPublisher()
-    }
-
-    public func simulateAIFeaturesChange(enabled: Bool) {
-        isAIFeaturesEnabled = enabled
     }
 }

--- a/macOS/UnitTests/Preferences/RootViewV2Tests.swift
+++ b/macOS/UnitTests/Preferences/RootViewV2Tests.swift
@@ -55,7 +55,12 @@ final class RootViewV2Tests: XCTestCase {
             tabsPreferences: TabsPreferences(persistor: MockTabsPreferencesPersistor(), windowControllersManager: windowControllersManager),
             webTrackingProtectionPreferences: WebTrackingProtectionPreferences(persistor: MockWebTrackingProtectionPreferencesPersistor(), windowControllersManager: windowControllersManager),
             cookiePopupProtectionPreferences: CookiePopupProtectionPreferences(persistor: MockCookiePopupProtectionPreferencesPersistor(), windowControllersManager: windowControllersManager),
-            aiFeaturesStatusProvider: MockAIChatPreferences(),
+            aiChatPreferences: AIChatPreferences(
+                storage: MockAIChatPreferencesStorage(),
+                aiChatMenuConfiguration: MockAIChatConfig(),
+                windowControllersManager: WindowControllersManagerMock(),
+                featureFlagger: MockFeatureFlagger()
+            ),
             winBackOfferVisibilityManager: mockWinBackOfferVisibilityManager
         )
         subscriptionManager = SubscriptionManagerMockV2()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211863121797481

### Description
This change replaces AIChatPreferences.shared with an AppDelegate-owned instance and updates
references to the singleton across the app with an instance injected via initializers.

### Testing Steps
1. Verify that CI is green
2. Verify that [this UI Tests workflow](https://github.com/duckduckgo/apple-browsers/actions/runs/19169864295) run is green.
3. Verify that the app doesn’t crash at launch.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces AIChatPreferences.shared with an AppDelegate-managed instance injected across controllers and models, updating references, link-opening behavior, and tests.
> 
> - **Core/App setup**:
>   - Add `AppDelegate.aiChatPreferences` and construct `AIChatPreferences` with `DefaultAIChatPreferencesStorage`, `aiChatMenuConfiguration`, `WindowControllersManagerProtocol`, and `FeatureFlagger`.
> - **Controllers/Views**:
>   - Inject `AIChatPreferences` into `MainViewController`, `BrowserTabViewController`, and `PreferencesViewController` constructors; pass through to `BrowserTabViewController` and SwiftUI views.
>   - Update previews to use `Application.appDelegate.aiChatPreferences`.
> - **Preferences**:
>   - Remove `AIChatPreferences.shared`; make it non-singleton (store `WindowControllersManagerProtocol`).
>   - Update `PreferencesSidebarModel` to depend on `AIChatPreferences` (replacing `AIFeaturesStatusProviding`) and use its publishers for AI features status.
>   - Update `PreferencesRootView` to use `model.aiChatPreferences` for `AppearanceView`/`AIChatView`.
> - **URL handling**:
>   - Use `NSApp.delegateTyped.aiChatPreferences.shouldShowAIFeatures` in `URL.makeSearchUrl`.
> - **Behavior tweaks**:
>   - `AIChatPreferences.openLearnMoreLink`/`openSearchAssistSettings` now open tabs as selected.
> - **Tests**:
>   - Add mocks (`MockAIChatPreferencesStorage`, `MockAIChatConfig`) and inject `AIChatPreferences` into tests.
>   - Remove obsolete `MockAIChatPreferences` type and update unit/integration tests accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 270ce2a7a8e8767b67a36c02c07adf2511cf14e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->