### PR TITLE
Win-back offer: Revert 10-second cooldown hack

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/WinBackOffer/WinBackOfferVisibilityManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/WinBackOffer/WinBackOfferVisibilityManager.swift
@@ -49,6 +49,8 @@ public protocol WinBackOfferVisibilityManaging {
 
 extension WinBackOfferVisibilityManager {
     enum Constants {
+        // After redeeming the offer and churning again, the offer will be available again after 270 days
+        static let cooldownPeriod = 270 * TimeInterval.day
         // Offer will be available 3 days after the last churn date
         static let daysBeforeOfferAvailability = 3 * TimeInterval.day
         // Offer will be available for 5 days
@@ -62,7 +64,6 @@ public final class WinBackOfferVisibilityManager: WinBackOfferVisibilityManaging
     private var winbackOfferStore: any WinbackOfferStoring
     private var winbackOfferFeatureFlagProvider: any WinBackOfferFeatureFlagProvider
     private let calendar: Calendar
-    private let cooldownPeriod: TimeInterval
     private let dateProvider: () -> Date
 
     private var hasActiveSubscription: Bool = false
@@ -72,13 +73,11 @@ public final class WinBackOfferVisibilityManager: WinBackOfferVisibilityManaging
                 winbackOfferStore: any WinbackOfferStoring,
                 winbackOfferFeatureFlagProvider: any WinBackOfferFeatureFlagProvider,
                 calendar: Calendar = Calendar.current,
-                cooldownPeriod: TimeInterval = 270 * TimeInterval.day,
                 dateProvider: @escaping () -> Date = Date.init) {
         self.subscriptionManager = subscriptionManager
         self.winbackOfferStore = winbackOfferStore
         self.winbackOfferFeatureFlagProvider = winbackOfferFeatureFlagProvider
         self.calendar = calendar
-        self.cooldownPeriod = cooldownPeriod
         self.dateProvider = dateProvider
 
         observeSubscriptionDidChange()
@@ -225,7 +224,7 @@ public final class WinBackOfferVisibilityManager: WinBackOfferVisibilityManaging
         }
 
         let timeSinceLastChurn = now.timeIntervalSince(lastStoredChurnDate)
-        let cooldownHasPassed = timeSinceLastChurn > cooldownPeriod
+        let cooldownHasPassed = timeSinceLastChurn > Constants.cooldownPeriod
 
         if cooldownHasPassed {
             // Cooldown period has passed, mark churn.

--- a/iOS/DuckDuckGo/WinBackOffer/WinBackOfferDebugMenu.swift
+++ b/iOS/DuckDuckGo/WinBackOffer/WinBackOfferDebugMenu.swift
@@ -122,7 +122,7 @@ final class WinBackOfferDebugViewModel: ObservableObject {
 
     /// Complete the cooldown period and advance to the first day of the new offer window.
     func completeCooldown() {
-        let cooldownDuration = TimeInterval.seconds(10)
+        let cooldownDuration = TimeInterval(.days(270))
         let availabilityOffset = TimeInterval.days(3)
 
         let cooldownExpiryDate = debugStore.simulatedTodayDate.addingTimeInterval(cooldownDuration)

--- a/iOS/DuckDuckGo/WinBackOffer/WinBackOfferFactory.swift
+++ b/iOS/DuckDuckGo/WinBackOffer/WinBackOfferFactory.swift
@@ -34,7 +34,6 @@ enum WinBackOfferFactory {
             subscriptionManager: AppDependencyProvider.shared.subscriptionAuthV1toV2Bridge,
             winbackOfferStore: WinbackOfferStore(keyValueStore: keyValueFilesStore),
             winbackOfferFeatureFlagProvider: WinBackOfferFeatureFlagger(featureFlagger: featureFlagger),
-            cooldownPeriod: TimeInterval.seconds(10),
             dateProvider: { winBackOfferDebugStore.simulatedTodayDate }
         )
 #else

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -266,7 +266,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         winBackOfferVisibilityManager = WinBackOfferVisibilityManager(subscriptionManager: subscriptionAuthV1toV2Bridge,
                                                                       winbackOfferStore: winbackOfferStore,
                                                                       winbackOfferFeatureFlagProvider: winbackOfferFeatureFlagProvider,
-                                                                      cooldownPeriod: TimeInterval.seconds(10),
                                                                       dateProvider: dateProvider)
 #else
         winBackOfferVisibilityManager = WinBackOfferVisibilityManager(subscriptionManager: subscriptionAuthV1toV2Bridge,

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/WinBackOffer/WinBackOfferDebugMenu.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/WinBackOffer/WinBackOfferDebugMenu.swift
@@ -127,7 +127,7 @@ final class WinBackOfferDebugMenu: NSMenuItem {
 
     @objc
     func completeCooldown() {
-        let cooldownDuration = TimeInterval.seconds(10)
+        let cooldownDuration = TimeInterval(.days(270))
         let availabilityOffset = TimeInterval.days(3)
 
         let cooldownExpiryDate = debugStore.simulatedTodayDate.addingTimeInterval(cooldownDuration)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1211877878016460
Tech Design URL:
CC:

### Description

This PR just removes the (unnecessary) option to use a 10-second cooldown, that was breaking the debug flow on iOS. Given that the cooldown was too short, cooldown-checking logic in `WinBackOfferVisibilityManager` always passed, resetting the offer.

There are no changes to prod behavior in this PR, but it makes testing possible.

### Testing Steps
Follow [iOS testing instructions](https://app.asana.com/1/137249556945/task/1211825351785329) to test offer cooldown

### Impact and Risks
N/A

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes win-back offer cooldown to 270 days via a constant and removes the 10-second debug override across iOS/macOS, updating construction and debug flows.
> 
> - **Core (BrowserServicesKit)**:
>   - `WinBackOfferVisibilityManager`: Move cooldown to `Constants.cooldownPeriod` and reference it in churn handling; remove `cooldownPeriod` init parameter and stored property.
> - **iOS**:
>   - `WinBackOfferDebugMenu`: `completeCooldown()` now uses `.days(270)`; keeps 3-day availability offset.
>   - `WinBackOfferFactory`: Stop passing debug `cooldownPeriod`; provide only `dateProvider` in debug builds.
> - **macOS**:
>   - `WinBackOfferDebugMenu`: `completeCooldown()` now uses `.days(270)` with 3-day offset.
>   - `AppDelegate`: Stop passing debug `cooldownPeriod` when constructing `WinBackOfferVisibilityManager`; use `dateProvider` in debug builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a07d0c8dfb8d251e421ec165840b309dd92beb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->