### PR TITLE
Tabs: Favicon Resizing Animation

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabFaviconView.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabFaviconView.swift
@@ -116,14 +116,6 @@ private extension TabFaviconView {
             spinnerView.widthAnchor.constraint(equalTo: imageView.widthAnchor, constant: TabFaviconMetrics.spinnerPadding * 2),
             spinnerView.heightAnchor.constraint(equalTo: imageView.heightAnchor, constant: TabFaviconMetrics.spinnerPadding * 2)
         ])
-
-        spinnerView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            spinnerView.centerXAnchor.constraint(equalTo: centerXAnchor),
-            spinnerView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            spinnerView.widthAnchor.constraint(equalTo: imageView.widthAnchor, constant: TabFaviconMetrics.spinnerPadding * 2),
-            spinnerView.heightAnchor.constraint(equalTo: imageView.heightAnchor, constant: TabFaviconMetrics.spinnerPadding * 2)
-        ])
     }
 }
 
@@ -144,7 +136,7 @@ private extension TabFaviconView {
         layer.anchorPoint = TabFaviconMetrics.imageLayerAnchorPoint
         layer.position.x = targetPositionX
         layer.position.y = targetPositionY
-     }
+    }
 
     func resizeImageIfNeeded(scaleDown: Bool) {
         let targetRadius = imageCornerRadius(scaleDown: scaleDown)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211711035105395?focus=true
Tech Design URL:
CC:

### Description
In this PR we're implementing a mechanism that shrinks Favicons while the WebView is loading, in order to make room for the Spinner.

### Testing Steps
1. Enable the `tabProgressIndicator` Feature Flag
2. Open a new Window
3. Open any URL

- [ ] Verify the Favicon shows up shortly after, and that it's rounded
- [ ] Verify that upon completion, the Favicon grows in size, with an animation
- [ ] Verify that if you click on any link, the favicon shrinks again, making room for the Spinner

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
This new animation is behind a feature flag. Worst case scenario, the favicon gets an unexpected animation.

### Quality Considerations
Nothing in particular

### Notes to Reviewer
Thank you!!

### Demo

https://github.com/user-attachments/assets/d1a94e22-cc98-46d6-8057-4871fb3004ff

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds animated favicon shrink/rounding during page load to accommodate the spinner, with layer-centering and constants/constraints updates.
> 
> - **macOS Tab Bar**:
>   - **Favicon animation**: Introduces animated resize (scale to `0.75`) and rounded corners while loading; reverts when loading stops.
>   - **Spinner integration**: `displaySpinnerIfNeeded` now triggers resize; `stopSpinner` stops animation; padding constants updated.
>   - **Layer handling**: Centers image layer on `layout()` via `refreshImageLayerLocation`; sets `imageView.wantsLayer = true`; uses `imageLayerAnchorPoint`.
>   - **Constraints/metrics**: Switches to `TabFaviconMetrics.imageSize` and `spinnerPadding`; adds `FaviconAnimation` timing/duration constants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 407157960e6057b57ea066ffaa7859b0c60682a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->