### PR TITLE
iOS: Make scroll to Sync in the debug screen more robust (maestro)

### DIFF
--- a/.maestro/shared/copy_recovery_code_from_settings.yaml
+++ b/.maestro/shared/copy_recovery_code_from_settings.yaml
@@ -9,6 +9,8 @@ appId: com.duckduckgo.mobile.ios
 
 - scrollUntilVisible:
     element: Sync
+    direction: DOWN
+    centerElement: true
 - tapOn: Sync
 - tapOn: Paste and Copy Recovery Code
 - inputText: ${CODE}

--- a/.maestro/shared/set_sync_dev_environment.yaml
+++ b/.maestro/shared/set_sync_dev_environment.yaml
@@ -9,6 +9,8 @@ appId: com.duckduckgo.mobile.ios
 
 - scrollUntilVisible:
     element: Sync
+    direction: DOWN
+    centerElement: true
 - tapOn: Sync
 - tapOn: Production
 - tapOn: Debug


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201462886803403/task/1211867112605779?focus=true
Tech Design URL:
CC:

### Description
Updates the scroll behaviour in the debug Sync screen to be more robust as more items get added

### Testing Steps
1. Confirm CI run passes -> https://github.com/duckduckgo/apple-browsers/actions/runs/19230124627

### Impact and Risks
None: Internal tooling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `direction: DOWN` and `centerElement: true` to `scrollUntilVisible` for the `Sync` item in Maestro debug flows.
> 
> - **Maestro flows**:
>   - Update `scrollUntilVisible` for `Sync` to include `direction: DOWN` and `centerElement: true`:
>     - `.maestro/shared/copy_recovery_code_from_settings.yaml`
>     - `.maestro/shared/set_sync_dev_environment.yaml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f97ae2cafd64c38cfc96b581aadd81865401ff3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->