### PR TITLE
Fixes some pixel definitions

### DIFF
--- a/macOS/PixelDefinitions/pixels/navigation.json5
+++ b/macOS/PixelDefinitions/pixels/navigation.json5
@@ -71,22 +71,22 @@
             "appVersion",
             "pixelSource",
             {
-                "key": "webKitFirstVisualLayoutMs",
+                "key": "first_visual_layout_ms",
                 "type": "integer",
                 "description": "Time in milliseconds from navigation start to first visual layout"
             },
             {
-                "key": "webKitFirstMeaningfulPaintMs",
+                "key": "first_meaningful_paint_ms",
                 "type": "integer",
                 "description": "Time in milliseconds from navigation start to first meaningful paint"
             },
             {
-                "key": "webKitDocumentCompleteMs",
+                "key": "document_complete_ms",
                 "type": "integer",
                 "description": "Time in milliseconds from navigation start to document complete"
             },
             {
-                "key": "webKitAllResourcesCompleteMs",
+                "key": "all_resources_complete_ms",
                 "type": "integer",
                 "description": "Time in milliseconds from navigation start to all resources complete"
             }

--- a/macOS/PixelDefinitions/pixels/serp_settings_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/serp_settings_pixels.json5
@@ -4,21 +4,21 @@
         "description": "Fired when converting SERP settings dictionary to JSON fails during serialization",
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
-        "suffixes": ["daily", "count"],
+        "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource"]
     },
     "m_mac_serp_settings_keyvalue_store_read_error": {
         "description": "Fired when reading SERP settings from persistent storage fails",
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
-        "suffixes": ["daily", "count"],
+        "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource"]
     },
     "m_mac_serp_settings_keyvalue_store_write_error": {
         "description": "Fired when writing SERP settings to persistent storage fails",
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
-        "suffixes": ["daily", "count"],
+        "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource"]
     }
 }

--- a/macOS/PixelDefinitions/pixels/update_flow_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/update_flow_pixels.json5
@@ -184,7 +184,7 @@
         "description": "Fired once after successful app update on first launch",
         "owners": ["diegoreymendez"],
         "triggers": ["other"],
-        "suffixes": ["daily", "count"],
+        "suffixes": ["daily_count"],
         "parameters": [
             {
                 "key": "sourceVersion",
@@ -231,7 +231,7 @@
         "description": "Fired when expected Sparkle update fails to complete",
         "owners": ["diegoreymendez"],
         "triggers": ["other"],
-        "suffixes": ["daily", "count"],
+        "suffixes": ["daily_count"],
         "parameters": [
             {
                 "key": "sourceVersion",
@@ -294,7 +294,7 @@
         "description": "Fired when app update is detected outside Sparkle flow (not initiated by our update mechanism)",
         "owners": ["diegoreymendez"],
         "triggers": ["other"],
-        "suffixes": ["daily", "count"],
+        "suffixes": ["daily_count"],
         "parameters": [
             {
                 "key": "targetVersion",

--- a/macOS/PixelDefinitions/pixels/vpn_sub_client_check_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/vpn_sub_client_check_pixels.json5
@@ -16,7 +16,7 @@
                 "key": "isSubscriptionActive",
                 "type": "string",
                 "description": "Whether the subscription is active",
-                "enum": ["true", "false"]
+                "enum": ["true", "false", "no_subscription"]
             },
             "appVersion",
             "pixelSource"
@@ -38,7 +38,7 @@
                 "key": "isSubscriptionActive",
                 "type": "string",
                 "description": "Whether the subscription is active",
-                "enum": ["true", "false"]
+                "enum": ["true", "false", "no_subscription"]
             },
             "appVersion",
             "pixelSource"
@@ -60,7 +60,7 @@
                 "key": "isSubscriptionActive",
                 "type": "string",
                 "description": "Whether the subscription is active",
-                "enum": ["true", "false"]
+                "enum": ["true", "false", "no_subscription"]
             },
             "appVersion",
             "pixelSource"
@@ -82,7 +82,7 @@
                 "key": "isSubscriptionActive",
                 "type": "string",
                 "description": "Whether the subscription is active",
-                "enum": ["true", "false"]
+                "enum": ["true", "false", "no_subscription"]
             },
             "appVersion",
             "pixelSource"
@@ -104,7 +104,7 @@
                 "key": "isSubscriptionActive",
                 "type": "string",
                 "description": "Whether the subscription is active",
-                "enum": ["true", "false"]
+                "enum": ["true", "false", "no_subscription"]
             },
             "appVersion",
             "pixelSource"
@@ -126,7 +126,7 @@
                 "key": "isSubscriptionActive",
                 "type": "string",
                 "description": "Whether the subscription is active",
-                "enum": ["true", "false"]
+                "enum": ["true", "false", "no_subscription"]
             },
             "appVersion",
             "pixelSource"
@@ -148,7 +148,7 @@
                 "key": "isSubscriptionActive",
                 "type": "string",
                 "description": "Whether the subscription is active",
-                "enum": ["true", "false"]
+                "enum": ["true", "false", "no_subscription"]
             },
             "appVersion",
             "pixelSource"

--- a/macOS/PixelDefinitions/pixels/vpn_sub_notification_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/vpn_sub_notification_pixels.json5
@@ -16,7 +16,7 @@
                 "key": "isSubscriptionActive",
                 "type": "string",
                 "description": "Whether the subscription is active",
-                "enum": ["true", "false"]
+                "enum": ["true", "false", "no_subscription"]
             },
             {
                 "key": "notificationObjectClass",
@@ -43,7 +43,7 @@
                 "key": "isSubscriptionActive",
                 "type": "string",
                 "description": "Whether the subscription is active",
-                "enum": ["true", "false"]
+                "enum": ["true", "false", "no_subscription"]
             },
             {
                 "key": "notificationObjectClass",
@@ -70,7 +70,7 @@
                 "key": "isSubscriptionActive",
                 "type": "string",
                 "description": "Whether the subscription is active",
-                "enum": ["true", "false"]
+                "enum": ["true", "false", "no_subscription"]
             },
             {
                 "key": "notificationObjectClass",
@@ -97,7 +97,7 @@
                 "key": "isSubscriptionActive",
                 "type": "string",
                 "description": "Whether the subscription is active",
-                "enum": ["true", "false"]
+                "enum": ["true", "false", "no_subscription"]
             },
             {
                 "key": "notificationObjectClass",

--- a/macOS/PixelDefinitions/suffixes_dictionary.json5
+++ b/macOS/PixelDefinitions/suffixes_dictionary.json5
@@ -26,5 +26,10 @@
         "type": "string",
         "description": "Count pixel schedule type",
         "enum": ["count"]
+    },
+    "daily_count": {
+        "type": "string",
+        "description": "Daily and count pixel schedule type",
+        "enum": ["daily", "count"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1211945142360641?focus=true

### Description

Fixes some pixel definitions to address the feedback from [this report](https://app.asana.com/1/137249556945/project/1203108348835387/task/1211945142360641?focus=true).

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->

Review the changes comparing to the report.
Make sure CI is green.

### Impact and Risks

Low.

#### What could go wrong?

A new report could come my way...

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes pixel suffixes to `daily_count`, adds `no_subscription` to VPN subscription enums, and renames site loading timing keys to snake_case.
> 
> - **Pixel schema**:
>   - Replace `suffixes: ["daily", "count"]` with `suffixes: ["daily_count"]` in `serp_settings_pixels.json5` and update pixels in `update_flow_pixels.json5` (`m_mac_update_application_{success,failure,unexpected}`).
>   - Add `daily_count` to `suffixes_dictionary.json5`.
> - **VPN subscription pixels**:
>   - Expand `isSubscriptionActive` enum to include `"no_subscription"` across client check pixels in `vpn_sub_client_check_pixels.json5` (including wake/failed variants) and all notification pixels in `vpn_sub_notification_pixels.json5`.
> - **Navigation timing metrics**:
>   - Rename parameters in `m_mac_site_loading_timing` (`navigation.json5`):
>     - `webKitFirstVisualLayoutMs` → `first_visual_layout_ms`
>     - `webKitFirstMeaningfulPaintMs` → `first_meaningful_paint_ms`
>     - `webKitDocumentCompleteMs` → `document_complete_ms`
>     - `webKitAllResourcesCompleteMs` → `all_resources_complete_ms`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c75f498287c4a328797651d1c8c120602fab4735. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->