### PR TITLE
Remove unused pixels

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1344,8 +1344,6 @@ extension Pixel {
         case aiChatSettingsBrowserMenuTurnedOn
         case aiChatSettingsTabManagerTurnedOff
         case aiChatSettingsTabManagerTurnedOn
-        case aiChatSettingsSERPFollowupTurnedOff
-        case aiChatSettingsSERPFollowupTurnedOn
         case aiChatSettingsDisplayed
         case aiChatSettingsEnabled
         case aiChatSettingsDisabled
@@ -2695,8 +2693,6 @@ extension Pixel.Event {
         case .aiChatSettingsBrowserMenuTurnedOn: return "m_aichat_settings_browser_menu_turned_on"
         case .aiChatSettingsTabManagerTurnedOff: return "m_aichat_settings_tab_manager_turned_off"
         case .aiChatSettingsTabManagerTurnedOn: return "m_aichat_settings_tab_manager_turned_on"
-        case .aiChatSettingsSERPFollowupTurnedOff: return "m_aichat_settings_serp_followup_turned_off"
-        case .aiChatSettingsSERPFollowupTurnedOn: return "m_aichat_settings_serp_followup_turned_on"
         case .aiChatSettingsDisplayed: return "m_aichat_settings_displayed"
         case .aiChatSettingsEnabled: return "m_aichat_settings_enabled"
         case .aiChatSettingsDisabled: return "m_aichat_settings_disabled"

--- a/iOS/PixelDefinitions/pixels/ai_chat_settings.json5
+++ b/iOS/PixelDefinitions/pixels/ai_chat_settings.json5
@@ -1,18 +1,4 @@
 {
-    "m_aichat_settings_serp_followup_turned_on": {
-        "description": "Fires when the user enables the option to Ask Follow-up Questions on Duck.ai Shortcuts screen",
-        "owners": ["pikorddg"],
-        "triggers": ["other"],
-        "suffixes": ["platform", "form_factor", "first_daily_count"],
-        "parameters": ["appVersion"]
-    },
-    "m_aichat_settings_serp_followup_turned_off": {
-        "description": "Fires when the user disables the option to Ask Follow-up Questions on Duck.ai Shortcuts screen",
-        "owners": ["pikorddg"],
-        "triggers": ["other"],
-        "suffixes": ["platform", "form_factor", "first_daily_count"],
-        "parameters": ["appVersion"]
-    },
     "m_ios_aichat_history_delete_successful": {
         "description": "Fired when Duck.ai chat history is deleted successfully via fire button",
         "owners": ["Bunn"],


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210947754188321/task/1211945156300565?focus=true
Tech Design URL:
CC:

### Description
1. I got ping from Dax, that pixels I own are having issues
2. I noticed that this feature was removed in https://github.com/duckduckgo/apple-browsers/pull/2396 and pixels are not used, hence this PR deletes them and their documentation 

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
4. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None, pixels are not used

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove AI Chat SERP follow-up on/off pixels from `PixelEvent` and delete their JSON definitions.
> 
> - **Telemetry / Pixels**
>   - Remove AI Chat SERP follow-up settings pixels:
>     - Delete `Pixel.Event` cases `aiChatSettingsSERPFollowupTurnedOff` and `aiChatSettingsSERPFollowupTurnedOn` and their `name` mappings in `iOS/Core/PixelEvent.swift`.
>     - Remove corresponding definitions `m_aichat_settings_serp_followup_turned_off` and `m_aichat_settings_serp_followup_turned_on` from `iOS/PixelDefinitions/pixels/ai_chat_settings.json5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a69a466cea9d9d0601988f3fae599077836ecd8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->