### PR TITLE
Fix: Consistent Tab Spinner Feature Flag State

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -198,9 +198,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     )
     let themeManager: ThemeManager
 
-    private(set) lazy var displaysLoadingProgressIndicator: Bool = {
-        featureFlagger.isFeatureOn(.tabProgressIndicator)
-    }()
+    let displaysTabsProgressIndicator: Bool
 
     let wideEvent: WideEventManaging
     let isUsingAuthV2: Bool
@@ -484,6 +482,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             featureFlagOverrides.applyUITestsFeatureFlagsIfNeeded()
         }
         self.featureFlagger = featureFlagger
+
+        displaysTabsProgressIndicator = featureFlagger.isFeatureOn(.tabProgressIndicator)
 
         aiChatSidebarProvider = AIChatSidebarProvider(featureFlagger: featureFlagger)
         aiChatMenuConfiguration = AIChatMenuConfiguration(

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -384,10 +384,10 @@ final class AddressBarViewController: NSViewController {
             .store(in: &tabViewModelCancellables)
     }
 
-    private let displaysLoadingProgressIndicator: Bool = NSApp.delegateTyped.displaysLoadingProgressIndicator == false
+    private let displaysTabsProgressIndicator: Bool = NSApp.delegateTyped.displaysTabsProgressIndicator == false
 
     private func subscribeToProgressEventsIfNeeded() {
-        guard let tabViewModel, displaysLoadingProgressIndicator else {
+        guard let tabViewModel, displaysTabsProgressIndicator else {
             progressIndicator.hide(animated: false)
             return
         }

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -141,7 +141,7 @@ final class TabBarItemCellView: NSView {
     let themeManager: ThemeManaging = NSApp.delegateTyped.themeManager
     var themeUpdateCancellable: AnyCancellable?
 
-    fileprivate let displaysTabsProgressIndicator: Bool = NSApp.delegateTyped.displaysLoadingProgressIndicator
+    fileprivate let displaysTabsProgressIndicator: Bool = NSApp.delegateTyped.displaysTabsProgressIndicator
     fileprivate lazy var faviconView = TabFaviconView()
     fileprivate lazy var titleView = TabTitleView()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211902211962363?focus=true
Tech Design URL:
CC:

### Description
In this PR we're setting the `displaysLoadingProgressIndicator` Feature Flag, once per session.
Flipping the Flag will require a relaunch for the Browser to react.

### Testing Steps
1. Launch the Browser
2. Enable the `displaysLoadingProgressIndicator` Flag

- [ ] Verify the Activity Indicator still shows up in the Address Bar area
- [ ] Verify that if you relaunch, the Spinner is presented in the Tab itself

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing I could think of!

### Quality Considerations
Nothing in particular!

### Notes to Reviewer
Thank youuu

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Caches the tab progress indicator feature flag in AppDelegate at launch and uses it in AddressBarViewController and TabBarViewItem to keep spinner placement consistent for the session.
> 
> - **Core**:
>   - Add `AppDelegate.displaysTabsProgressIndicator`, initialized once from `FeatureFlag.tabProgressIndicator`.
> - **Navigation Bar**:
>   - `AddressBarViewController`: replace per-use flag checks with `NSApp.delegateTyped.displaysTabsProgressIndicator` (inverted for address bar loading indicator) and update progress subscription guard.
> - **Tab Bar**:
>   - `TabBarViewItem`: read `displaysTabsProgressIndicator` from `AppDelegate` for favicon/title rendering and spinner behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfcbba112100f60a222cab03e6f836f865129a7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->