### PR TITLE
Fix forget all pixel suffix definition

### DIFF
--- a/iOS/PixelDefinitions/pixels/forget_all.json5
+++ b/iOS/PixelDefinitions/pixels/forget_all.json5
@@ -3,7 +3,7 @@
         "description": "Fired when user pressed the button to clear data in Data Clearing Settings",
         "owners": ["dus7"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1211957301022474?focus=true
Tech Design URL:
CC:

### Description

Add missing suffix definition for forget all pixel

### Testing Steps
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add "platform" and "form_factor" suffixes to `m_forget-all-pressed_settings` pixel definition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e609e73f5e2856648bdec4d416a79ff3b8ef6b27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->