### PR TITLE
Fix names of daily fire window pixels

### DIFF
--- a/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -589,13 +589,13 @@ enum GeneralPixel: PixelKitEvent {
             return  "m_mac_\(isAddedToDock ? "added" : "not-added")-to-dock"
 
         case .dailyFireWindowConfigurationStartupFireWindowEnabled(startupFireWindow: let startupFireWindow):
-            return "m_mac_fire_window_configuration_startup_fire_window_is_\(startupFireWindow ? "enabled" : "disabled")"
+            return "m_mac_fire_window_configuration_startup-fire-window_\(startupFireWindow ? "enabled" : "disabled")"
 
         case .dailyFireWindowConfigurationOpenFireWindowByDefaultEnabled(openFireWindowByDefault: let openFireWindowByDefault):
-            return "m_mac_fire_window_configuration_open_fire_window_by_default_is_\(openFireWindowByDefault ? "enabled" : "disabled")"
+            return "m_mac_fire_window_configuration_open-fire-window-by-default_\(openFireWindowByDefault ? "enabled" : "disabled")"
 
         case .dailyFireWindowConfigurationFireAnimationEnabled(fireAnimationEnabled: let fireAnimationEnabled):
-            return "m_mac_fire_window_configuration_fire_animation_is_\(fireAnimationEnabled ? "enabled" : "disabled")"
+            return "m_mac_fire_window_configuration_fire-animation_\(fireAnimationEnabled ? "enabled" : "disabled")"
 
         case .navigation:
             return "m_mac_navigation"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1199230911884351/task/1211634786160239?focus=true
Tech Design URL:
CC:

### Description
Follow up to https://github.com/duckduckgo/apple-browsers/pull/2213 with update to pixel names. (See https://app.asana.com/1/137249556945/task/1211634786160239/comment/1211893345728437?focus=true)

### Testing Steps
Double check new pixel names consistency with docs and pixel definitions.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
Wrong pixel names.


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames three daily fire window configuration pixels to a new hyphenated format in `GeneralPixel.name`.
> 
> - **Statistics** (`macOS/DuckDuckGo/Statistics/GeneralPixel.swift`):
>   - Rename daily fire window configuration pixel names to hyphenated format:
>     - `startup-fire-window_(enabled|disabled)`
>     - `open-fire-window-by-default_(enabled|disabled)`
>     - `fire-animation_(enabled|disabled)`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1740cf612b1f9dddc14a008a9110b9c054af6aa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->