### PR TITLE
Fix autoconsent pixel schema errors

### DIFF
--- a/iOS/PixelDefinitions/pixels/autoconsent.json5
+++ b/iOS/PixelDefinitions/pixels/autoconsent.json5
@@ -124,12 +124,12 @@
                 "type": "number"
             },
             {
-                "key": "error-multiple-popups",
+                "key": "error_multiple-popups",
                 "description": "Number of autoconsent error-multiple-popups pixels fired.",
                 "type": "number"
             },
             {
-                "key": "error-optout",
+                "key": "error_optout",
                 "description": "Number of autoconsent error-optout pixels fired.",
                 "type": "number"
             },
@@ -144,7 +144,7 @@
                 "type": "number"
             },
             {
-                "key": "done-cosmetic",
+                "key": "done_cosmetic",
                 "description": "Number of autoconsent done-cosmetic pixels fired.",
                 "type": "number"
             },
@@ -154,7 +154,7 @@
                 "type": "number"
             },
             {
-                "key": "animation-shown-cosmetic",
+                "key": "animation-shown_cosmetic",
                 "description": "Number of autoconsent animation-shown-cosmetic pixels fired.",
                 "type": "number"
             },

--- a/macOS/PixelDefinitions/pixels/autoconsent.json5
+++ b/macOS/PixelDefinitions/pixels/autoconsent.json5
@@ -154,12 +154,12 @@
                 "type": "number"
             },
             {
-                "key": "error-multiple-popups",
+                "key": "error_multiple-popups",
                 "description": "Number of autoconsent error-multiple-popups pixels fired.",
                 "type": "number"
             },
             {
-                "key": "error-optout",
+                "key": "error_optout",
                 "description": "Number of autoconsent error-optout pixels fired.",
                 "type": "number"
             },
@@ -174,7 +174,7 @@
                 "type": "number"
             },
             {
-                "key": "done-cosmetic",
+                "key": "done_cosmetic",
                 "description": "Number of autoconsent done-cosmetic pixels fired.",
                 "type": "number"
             },
@@ -184,7 +184,7 @@
                 "type": "number"
             },
             {
-                "key": "animation-shown-cosmetic",
+                "key": "animation-shown_cosmetic",
                 "description": "Number of autoconsent animation-shown-cosmetic pixels fired.",
                 "type": "number"
             },


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1211957253602633?focus=true
Tech Design URL:
CC:

### Description
The parameters for autoconsent_summary pixels were failing validation. The schema does not match the implementation for these cases. This PR updates the parameter names to match what is actually sent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes several `m_autoconsent_summary` parameter keys (hyphens -> underscores) across iOS and macOS pixel definitions.
> 
> - **Pixels (iOS/macOS)**
>   - Standardize `m_autoconsent_summary` parameter keys:
>     - `error-multiple-popups` -> `error_multiple-popups`
>     - `error-optout` -> `error_optout`
>     - `done-cosmetic` -> `done_cosmetic`
>     - `animation-shown-cosmetic` -> `animation-shown_cosmetic`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9ca1d574c58d79e20ef1a78f1c3316d0b970674. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->