### PR TITLE
Remove AccessibilityPreferences singleton

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -132,6 +132,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let webTrackingProtectionPreferences: WebTrackingProtectionPreferences
     let cookiePopupProtectionPreferences: CookiePopupProtectionPreferences
     let aboutPreferences: AboutPreferences
+    let accessibilityPreferences: AccessibilityPreferences
 
     let database: Database!
     let bookmarkDatabase: BookmarkDatabase
@@ -742,6 +743,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             featureFlagger: featureFlagger,
             windowControllersManager: windowControllersManager
         )
+        accessibilityPreferences = AccessibilityPreferences()
         newTabPageCustomizationModel = NewTabPageCustomizationModel(themeManager: themeManager, appearancePreferences: appearancePreferences)
 
         fireCoordinator = FireCoordinator(tld: tld,

--- a/macOS/DuckDuckGo/Fire/Model/Fire.swift
+++ b/macOS/DuckDuckGo/Fire/Model/Fire.swift
@@ -245,7 +245,7 @@ final class Fire: FireProtocol {
     init(cacheManager: WebCacheManager? = nil,
          historyCoordinating: HistoryCoordinating? = nil,
          permissionManager: PermissionManagerProtocol? = nil,
-         savedZoomLevelsCoordinating: SavedZoomLevelsCoordinating = AccessibilityPreferences.shared,
+         savedZoomLevelsCoordinating: SavedZoomLevelsCoordinating? = nil,
          downloadListCoordinator: DownloadListCoordinator? = nil,
          windowControllersManager: WindowControllersManagerProtocol? = nil,
          faviconManagement: FaviconManagement? = nil,
@@ -269,7 +269,7 @@ final class Fire: FireProtocol {
         self.webCacheManager = cacheManager ?? NSApp.delegateTyped.webCacheManager
         self.historyCoordinating = historyCoordinating ?? NSApp.delegateTyped.historyCoordinator
         self.permissionManager = permissionManager ?? NSApp.delegateTyped.permissionManager
-        self.savedZoomLevelsCoordinating = savedZoomLevelsCoordinating
+        self.savedZoomLevelsCoordinating = savedZoomLevelsCoordinating ?? NSApp.delegateTyped.accessibilityPreferences
         self.downloadListCoordinator = downloadListCoordinator ?? NSApp.delegateTyped.downloadListCoordinator
         self.windowControllersManager = windowControllersManager ?? Application.appDelegate.windowControllersManager
         self.faviconManagement = faviconManagement ?? NSApp.delegateTyped.faviconManager

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -119,6 +119,7 @@ final class MainViewController: NSViewController {
          cookiePopupProtectionPreferences: CookiePopupProtectionPreferences = NSApp.delegateTyped.cookiePopupProtectionPreferences,
          aiChatPreferences: AIChatPreferences = NSApp.delegateTyped.aiChatPreferences,
          aboutPreferences: AboutPreferences = NSApp.delegateTyped.aboutPreferences,
+         accessibilityPreferences: AccessibilityPreferences = NSApp.delegateTyped.accessibilityPreferences,
          themeManager: ThemeManager = NSApp.delegateTyped.themeManager,
          fireCoordinator: FireCoordinator = NSApp.delegateTyped.fireCoordinator,
          pixelFiring: PixelFiring? = PixelKit.shared,
@@ -203,7 +204,8 @@ final class MainViewController: NSViewController {
             webTrackingProtectionPreferences: webTrackingProtectionPreferences,
             cookiePopupProtectionPreferences: cookiePopupProtectionPreferences,
             aiChatPreferences: aiChatPreferences,
-            aboutPreferences: aboutPreferences
+            aboutPreferences: aboutPreferences,
+            accessibilityPreferences: accessibilityPreferences
         )
         aiChatSidebarPresenter = AIChatSidebarPresenter(
             sidebarHost: browserTabViewController,
@@ -249,7 +251,8 @@ final class MainViewController: NSViewController {
                                                                          sessionRestorePromptCoordinator: sessionRestorePromptCoordinator,
                                                                          defaultBrowserPreferences: defaultBrowserPreferences,
                                                                          downloadsPreferences: downloadsPreferences,
-                                                                         tabsPreferences: tabsPreferences)
+                                                                         tabsPreferences: tabsPreferences,
+                                                                         accessibilityPreferences: accessibilityPreferences)
 
         findInPageViewController = FindInPageViewController.create()
         fireViewController = FireViewController.create(tabCollectionViewModel: tabCollectionViewModel, fireViewModel: fireCoordinator.fireViewModel, visualizeFireAnimationDecider: visualizeFireAnimationDecider)

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -237,7 +237,7 @@ final class AddressBarButtonsViewController: NSViewController {
           bookmarkManager: BookmarkManager,
           privacyConfigurationManager: PrivacyConfigurationManaging,
           permissionManager: PermissionManagerProtocol,
-          accessibilityPreferences: AccessibilityPreferences = AccessibilityPreferences.shared,
+          accessibilityPreferences: AccessibilityPreferences,
           tabsPreferences: TabsPreferences,
           popovers: NavigationBarPopovers?,
           onboardingPixelReporter: OnboardingAddressBarReporting = OnboardingPixelReporter(),

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -87,6 +87,7 @@ final class AddressBarViewController: NSViewController {
     private let aiChatSidebarPresenter: AIChatSidebarPresenting
     private let searchPreferences: SearchPreferences
     private let tabsPreferences: TabsPreferences
+    private let accessibilityPreferences: AccessibilityPreferences
     private let featureFlagger: FeatureFlagger
 
     private var aiChatSettings: AIChatPreferencesStorage
@@ -156,6 +157,7 @@ final class AddressBarViewController: NSViewController {
           popovers: NavigationBarPopovers?,
           searchPreferences: SearchPreferences,
           tabsPreferences: TabsPreferences,
+          accessibilityPreferences: AccessibilityPreferences,
           themeManager: ThemeManaging = NSApp.delegateTyped.themeManager,
           onboardingPixelReporter: OnboardingAddressBarReporting = OnboardingPixelReporter(),
           aiChatSettings: AIChatPreferencesStorage = DefaultAIChatPreferencesStorage(),
@@ -184,6 +186,7 @@ final class AddressBarViewController: NSViewController {
         self.aiChatSettings = aiChatSettings
         self.searchPreferences = searchPreferences
         self.tabsPreferences = tabsPreferences
+        self.accessibilityPreferences = accessibilityPreferences
         self.themeManager = themeManager
         self.aiChatMenuConfig = aiChatMenuConfig
         self.aiChatSidebarPresenter = aiChatSidebarPresenter
@@ -198,6 +201,7 @@ final class AddressBarViewController: NSViewController {
                                                          bookmarkManager: bookmarkManager,
                                                          privacyConfigurationManager: privacyConfigurationManager,
                                                          permissionManager: permissionManager,
+                                                         accessibilityPreferences: accessibilityPreferences,
                                                          tabsPreferences: tabsPreferences,
                                                          popovers: popovers,
                                                          aiChatTabOpener: NSApp.delegateTyped.aiChatTabOpener,

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -157,6 +157,7 @@ final class NavigationBarViewController: NSViewController {
     private let defaultBrowserPreferences: DefaultBrowserPreferences
     private let downloadsPreferences: DownloadsPreferences
     private let tabsPreferences: TabsPreferences
+    private let accessibilityPreferences: AccessibilityPreferences
     private let showTab: (Tab.TabContent) -> Void
 
     let themeManager: ThemeManaging
@@ -230,6 +231,7 @@ final class NavigationBarViewController: NSViewController {
                        defaultBrowserPreferences: DefaultBrowserPreferences,
                        downloadsPreferences: DownloadsPreferences,
                        tabsPreferences: TabsPreferences,
+                       accessibilityPreferences: AccessibilityPreferences,
                        showTab: @escaping (Tab.TabContent) -> Void = { content in
                            Task { @MainActor in
                                Application.appDelegate.windowControllersManager.showTab(with: content)
@@ -264,6 +266,7 @@ final class NavigationBarViewController: NSViewController {
                 defaultBrowserPreferences: defaultBrowserPreferences,
                 downloadsPreferences: downloadsPreferences,
                 tabsPreferences: tabsPreferences,
+                accessibilityPreferences: accessibilityPreferences,
                 showTab: showTab
             )
         }!
@@ -296,6 +299,7 @@ final class NavigationBarViewController: NSViewController {
         defaultBrowserPreferences: DefaultBrowserPreferences,
         downloadsPreferences: DownloadsPreferences,
         tabsPreferences: TabsPreferences,
+        accessibilityPreferences: AccessibilityPreferences,
         showTab: @escaping (Tab.TabContent) -> Void
     ) {
 
@@ -336,6 +340,7 @@ final class NavigationBarViewController: NSViewController {
         self.defaultBrowserPreferences = defaultBrowserPreferences
         self.downloadsPreferences = downloadsPreferences
         self.tabsPreferences = tabsPreferences
+        self.accessibilityPreferences = accessibilityPreferences
         self.showTab = showTab
         self.vpnUpsellVisibilityManager = vpnUpsellVisibilityManager
         self.sessionRestorePromptCoordinator = sessionRestorePromptCoordinator
@@ -402,6 +407,7 @@ final class NavigationBarViewController: NSViewController {
                                                                       popovers: popovers,
                                                                       searchPreferences: searchPreferences,
                                                                       tabsPreferences: tabsPreferences,
+                                                                      accessibilityPreferences: accessibilityPreferences,
                                                                       onboardingPixelReporter: onboardingPixelReporter,
                                                                       aiChatMenuConfig: aiChatMenuConfig,
                                                                       aiChatSidebarPresenter: aiChatSidebarPresenter) else {

--- a/macOS/DuckDuckGo/Preferences/Model/AccessibilityPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AccessibilityPreferences.swift
@@ -67,8 +67,6 @@ enum DefaultZoomValue: CGFloat, CaseIterable {
 }
 
 final class AccessibilityPreferences: ObservableObject {
-    static let shared = AccessibilityPreferences()
-
     @Published var defaultPageZoom: DefaultZoomValue {
         didSet {
             persistor.defaultPageZoom = defaultPageZoom.rawValue

--- a/macOS/DuckDuckGo/Preferences/Model/PreferencesSidebarModel.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/PreferencesSidebarModel.swift
@@ -67,6 +67,7 @@ final class PreferencesSidebarModel: ObservableObject {
     let cookiePopupProtectionPreferences: CookiePopupProtectionPreferences
     let aiChatPreferences: AIChatPreferences
     let aboutPreferences: AboutPreferences
+    let accessibilityPreferences: AccessibilityPreferences
     let isUsingAuthV2: Bool
 
     @Published private(set) var currentSubscriptionState: PreferencesSidebarSubscriptionState = .init()
@@ -116,6 +117,7 @@ final class PreferencesSidebarModel: ObservableObject {
         cookiePopupProtectionPreferences: CookiePopupProtectionPreferences,
         aiChatPreferences: AIChatPreferences,
         aboutPreferences: AboutPreferences,
+        accessibilityPreferences: AccessibilityPreferences,
         winBackOfferVisibilityManager: WinBackOfferVisibilityManaging
     ) {
         self.loadSections = loadSections
@@ -135,6 +137,7 @@ final class PreferencesSidebarModel: ObservableObject {
         self.cookiePopupProtectionPreferences = cookiePopupProtectionPreferences
         self.aiChatPreferences = aiChatPreferences
         self.aboutPreferences = aboutPreferences
+        self.accessibilityPreferences = accessibilityPreferences
         self.winBackOfferVisibilityManager = winBackOfferVisibilityManager
 
         self.personalInformationRemovalUpdates = personalInformationRemovalSubject.eraseToAnyPublisher()
@@ -172,6 +175,7 @@ final class PreferencesSidebarModel: ObservableObject {
         cookiePopupProtectionPreferences: CookiePopupProtectionPreferences,
         aiChatPreferences: AIChatPreferences,
         aboutPreferences: AboutPreferences,
+        accessibilityPreferences: AccessibilityPreferences,
         winBackOfferVisibilityManager: WinBackOfferVisibilityManaging
     ) {
         let loadSections = { currentSubscriptionFeatures in
@@ -199,6 +203,7 @@ final class PreferencesSidebarModel: ObservableObject {
                   cookiePopupProtectionPreferences: cookiePopupProtectionPreferences,
                   aiChatPreferences: aiChatPreferences,
                   aboutPreferences: aboutPreferences,
+                  accessibilityPreferences: accessibilityPreferences,
                   winBackOfferVisibilityManager: winBackOfferVisibilityManager
         )
     }

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesRootView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesRootView.swift
@@ -159,7 +159,7 @@ enum Preferences {
                 case .autofill:
                     AutofillView(model: AutofillPreferencesModel())
                 case .accessibility:
-                    AccessibilityView(model: AccessibilityPreferences.shared)
+                    AccessibilityView(model: model.accessibilityPreferences)
                 case .duckPlayer:
                     DuckPlayerView(model: .shared)
                 case .otherPlatforms:
@@ -433,7 +433,7 @@ enum Preferences {
                 case .autofill:
                     AutofillView(model: AutofillPreferencesModel())
                 case .accessibility:
-                    AccessibilityView(model: AccessibilityPreferences.shared)
+                    AccessibilityView(model: model.accessibilityPreferences)
                 case .duckPlayer:
                     DuckPlayerView(model: .shared)
                 case .otherPlatforms:

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesViewController.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesViewController.swift
@@ -55,6 +55,7 @@ final class PreferencesViewController: NSViewController {
         cookiePopupProtectionPreferences: CookiePopupProtectionPreferences,
         aiChatPreferences: AIChatPreferences,
         aboutPreferences: AboutPreferences,
+        accessibilityPreferences: AccessibilityPreferences,
         subscriptionManager: any SubscriptionAuthV1toV2Bridge,
         winBackOfferVisibilityManager: WinBackOfferVisibilityManaging
     ) {
@@ -77,6 +78,7 @@ final class PreferencesViewController: NSViewController {
                                         cookiePopupProtectionPreferences: cookiePopupProtectionPreferences,
                                         aiChatPreferences: aiChatPreferences,
                                         aboutPreferences: aboutPreferences,
+                                        accessibilityPreferences: accessibilityPreferences,
                                         winBackOfferVisibilityManager: winBackOfferVisibilityManager)
         super.init(nibName: nil, bundle: nil)
     }

--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -96,6 +96,7 @@ final class BrowserTabViewController: NSViewController {
     private let cookiePopupProtectionPreferences: CookiePopupProtectionPreferences
     private let aiChatPreferences: AIChatPreferences
     private let aboutPreferences: AboutPreferences
+    private let accessibilityPreferences: AccessibilityPreferences
     private let subscriptionManager: any SubscriptionAuthV1toV2Bridge
     private let winBackOfferVisibilityManager: WinBackOfferVisibilityManaging
 
@@ -152,6 +153,7 @@ final class BrowserTabViewController: NSViewController {
          cookiePopupProtectionPreferences: CookiePopupProtectionPreferences,
          aiChatPreferences: AIChatPreferences,
          aboutPreferences: AboutPreferences,
+         accessibilityPreferences: AccessibilityPreferences,
          subscriptionManager: any SubscriptionAuthV1toV2Bridge = NSApp.delegateTyped.subscriptionAuthV1toV2Bridge,
          winBackOfferVisibilityManager: WinBackOfferVisibilityManaging = NSApp.delegateTyped.winBackOfferVisibilityManager,
          tld: TLD = NSApp.delegateTyped.tld
@@ -175,6 +177,7 @@ final class BrowserTabViewController: NSViewController {
         self.cookiePopupProtectionPreferences = cookiePopupProtectionPreferences
         self.aiChatPreferences = aiChatPreferences
         self.aboutPreferences = aboutPreferences
+        self.accessibilityPreferences = accessibilityPreferences
         self.subscriptionManager = subscriptionManager
         self.winBackOfferVisibilityManager = winBackOfferVisibilityManager
 
@@ -1198,6 +1201,7 @@ final class BrowserTabViewController: NSViewController {
                 cookiePopupProtectionPreferences: cookiePopupProtectionPreferences,
                 aiChatPreferences: aiChatPreferences,
                 aboutPreferences: aboutPreferences,
+                accessibilityPreferences: accessibilityPreferences,
                 subscriptionManager: subscriptionManager,
                 winBackOfferVisibilityManager: winBackOfferVisibilityManager
             )
@@ -1749,7 +1753,8 @@ extension BrowserTabViewController {
         webTrackingProtectionPreferences: Application.appDelegate.webTrackingProtectionPreferences,
         cookiePopupProtectionPreferences: Application.appDelegate.cookiePopupProtectionPreferences,
         aiChatPreferences: Application.appDelegate.aiChatPreferences,
-        aboutPreferences: Application.appDelegate.aboutPreferences
+        aboutPreferences: Application.appDelegate.aboutPreferences,
+        accessibilityPreferences: Application.appDelegate.accessibilityPreferences
     )
 }
 

--- a/macOS/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
+++ b/macOS/DuckDuckGo/Tab/ViewModel/TabViewModel.swift
@@ -129,7 +129,7 @@ final class TabViewModel: NSObject {
 
     init(tab: Tab,
          appearancePreferences: AppearancePreferences = NSApp.delegateTyped.appearancePreferences,
-         accessibilityPreferences: AccessibilityPreferences = .shared,
+         accessibilityPreferences: AccessibilityPreferences = NSApp.delegateTyped.accessibilityPreferences,
          featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger) {
         self.tab = tab
         self.appearancePreferences = appearancePreferences

--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
@@ -128,6 +128,7 @@ final class TabCollectionViewModel: NSObject {
 
     private var tabsPreferences: TabsPreferences
     private var startupPreferences: StartupPreferences
+    private var accessibilityPreferences: AccessibilityPreferences
     private var homePage: Tab.TabContent {
         var homePage: Tab.TabContent = .newtab
         if startupPreferences.launchToCustomHomePage,
@@ -161,6 +162,7 @@ final class TabCollectionViewModel: NSObject {
         burnerMode: BurnerMode = .regular,
         startupPreferences: StartupPreferences = NSApp.delegateTyped.startupPreferences,
         tabsPreferences: TabsPreferences = NSApp.delegateTyped.tabsPreferences,
+        accessibilityPreferences: AccessibilityPreferences = NSApp.delegateTyped.accessibilityPreferences,
         windowControllersManager: WindowControllersManagerProtocol? = nil
     ) {
         assert(!tabCollection.isPopup || windowControllersManager != nil, "Cannot create TabCollectionViewModel with a popup tab collection without a window controllers manager")
@@ -169,6 +171,7 @@ final class TabCollectionViewModel: NSObject {
         self.burnerMode = burnerMode
         self.startupPreferences = startupPreferences
         self.tabsPreferences = tabsPreferences
+        self.accessibilityPreferences = accessibilityPreferences
         self.windowControllersManager = windowControllersManager
         super.init()
 

--- a/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
+++ b/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
@@ -178,7 +178,8 @@ final class BrowserTabViewControllerOnboardingTests: XCTestCase {
                     windowControllersManager: windowControllersManager,
                     featureFlagger: MockFeatureFlagger()
                 ),
-                aboutPreferences: AboutPreferences(internalUserDecider: featureFlagger.internalUserDecider, featureFlagger: featureFlagger, windowControllersManager: windowControllersManager)
+                aboutPreferences: AboutPreferences(internalUserDecider: featureFlagger.internalUserDecider, featureFlagger: featureFlagger, windowControllersManager: windowControllersManager),
+                accessibilityPreferences: AccessibilityPreferences()
             )
             viewController.tabViewModel = tabViewModel
             _=viewController.view

--- a/macOS/IntegrationTests/Tab/AddressBarTests.swift
+++ b/macOS/IntegrationTests/Tab/AddressBarTests.swift
@@ -1025,7 +1025,7 @@ class AddressBarTests: XCTestCase {
     func test_ZoomLevelDefault_ThenZoomButtonIsNotVisible() async throws {
         // GIVEN
         let tab = Tab(content: .url(.duckDuckGo, credential: nil, source: .userEntered("")), webViewConfiguration: schemeHandler.webViewConfiguration(), maliciousSiteDetector: MockMaliciousSiteProtectionManager())
-        tab.webView.zoomLevel = AccessibilityPreferences.shared.defaultPageZoom
+        tab.webView.zoomLevel = NSApp.delegateTyped.accessibilityPreferences.defaultPageZoom
         let viewModel = TabCollectionViewModel(tabCollection: TabCollection(tabs: [tab]))
         viewModel.selectedTabViewModel?.zoomWasSet(to: .percent100)
         let tabLoadedPromise = tab.webViewDidFinishNavigationPublisher.timeout(5).first().promise()

--- a/macOS/UnitTests/Preferences/PreferencesSidebarModelTests.swift
+++ b/macOS/UnitTests/Preferences/PreferencesSidebarModelTests.swift
@@ -111,6 +111,7 @@ final class PreferencesSidebarModelTests: XCTestCase {
             cookiePopupProtectionPreferences: CookiePopupProtectionPreferences(persistor: MockCookiePopupProtectionPreferencesPersistor(), windowControllersManager: windowControllersManager),
             aiChatPreferences: mockAIChatPreferences,
             aboutPreferences: AboutPreferences(internalUserDecider: mockFeatureFlagger.internalUserDecider, featureFlagger: mockFeatureFlagger, windowControllersManager: windowControllersManager),
+            accessibilityPreferences: AccessibilityPreferences(),
             winBackOfferVisibilityManager: mockWinBackOfferVisibilityManager
         )
     }
@@ -135,6 +136,7 @@ final class PreferencesSidebarModelTests: XCTestCase {
             cookiePopupProtectionPreferences: CookiePopupProtectionPreferences(persistor: MockCookiePopupProtectionPreferencesPersistor(), windowControllersManager: windowControllersManager),
             aiChatPreferences: mockAIChatPreferences,
             aboutPreferences: AboutPreferences(internalUserDecider: mockFeatureFlagger.internalUserDecider, featureFlagger: mockFeatureFlagger, windowControllersManager: windowControllersManager),
+            accessibilityPreferences: AccessibilityPreferences(),
             winBackOfferVisibilityManager: mockWinBackOfferVisibilityManager
         )
     }
@@ -172,6 +174,7 @@ final class PreferencesSidebarModelTests: XCTestCase {
             cookiePopupProtectionPreferences: CookiePopupProtectionPreferences(persistor: MockCookiePopupProtectionPreferencesPersistor(), windowControllersManager: windowControllersManager),
             aiChatPreferences: mockAIChatPreferences,
             aboutPreferences: AboutPreferences(internalUserDecider: mockFeatureFlagger.internalUserDecider, featureFlagger: mockFeatureFlagger, windowControllersManager: windowControllersManager),
+            accessibilityPreferences: AccessibilityPreferences(),
             winBackOfferVisibilityManager: mockWinBackOfferVisibilityManager
         )
     }

--- a/macOS/UnitTests/Preferences/RootViewV2Tests.swift
+++ b/macOS/UnitTests/Preferences/RootViewV2Tests.swift
@@ -63,6 +63,7 @@ final class RootViewV2Tests: XCTestCase {
                 featureFlagger: MockFeatureFlagger()
             ),
             aboutPreferences: AboutPreferences(internalUserDecider: featureFlagger.internalUserDecider, featureFlagger: featureFlagger, windowControllersManager: windowControllersManager),
+            accessibilityPreferences: AccessibilityPreferences(),
             winBackOfferVisibilityManager: mockWinBackOfferVisibilityManager
         )
         subscriptionManager = SubscriptionManagerMockV2()

--- a/macOS/UnitTests/Tab/ViewModel/TabViewModelTests.swift
+++ b/macOS/UnitTests/Tab/ViewModel/TabViewModelTests.swift
@@ -34,8 +34,14 @@ final class TabViewModelTests: XCTestCase {
 
     let maliciousSite = URL("https://www.google.com")!
     var cancellables = Set<AnyCancellable>()
+    var accessibilityPreferences: AccessibilityPreferences!
+
+    override func setUp() {
+        accessibilityPreferences = AccessibilityPreferences()
+    }
 
     override func tearDown() {
+        accessibilityPreferences = nil
         cancellables = []
     }
 
@@ -529,10 +535,10 @@ final class TabViewModelTests: XCTestCase {
     @MainActor
     func testWhenPreferencesDefaultZoomLevelIsSetThenTabsWebViewZoomLevelIsUpdated() {
         UserDefaultsWrapper<Any>.clearAll()
-        let tabVM = TabViewModel(tab: Tab())
-        let filteredCases = DefaultZoomValue.allCases.filter { $0 != AccessibilityPreferences.shared.defaultPageZoom }
+        let tabVM = TabViewModel(tab: Tab(), accessibilityPreferences: accessibilityPreferences)
+        let filteredCases = DefaultZoomValue.allCases.filter { $0 != accessibilityPreferences.defaultPageZoom }
         let randomZoomLevel = filteredCases.randomElement()!
-        AccessibilityPreferences.shared.defaultPageZoom = randomZoomLevel
+        accessibilityPreferences.defaultPageZoom = randomZoomLevel
 
         XCTAssertEqual(tabVM.tab.webView.zoomLevel, randomZoomLevel)
     }
@@ -540,9 +546,9 @@ final class TabViewModelTests: XCTestCase {
     @MainActor
     func testWhenPreferencesDefaultZoomLevelIsSetAndANewTabIsOpenThenItsWebViewHasTheLatestValueOfZoomLevel() throws {
         UserDefaultsWrapper<Any>.clearAll()
-        let filteredCases = DefaultZoomValue.allCases.filter { $0 != AccessibilityPreferences.shared.defaultPageZoom }
+        let filteredCases = DefaultZoomValue.allCases.filter { $0 != accessibilityPreferences.defaultPageZoom }
         let randomZoomLevel = filteredCases.randomElement()!
-        AccessibilityPreferences.shared.defaultPageZoom = randomZoomLevel
+        accessibilityPreferences.defaultPageZoom = randomZoomLevel
 
         let tabVM = TabViewModel(
             tab: Tab(),
@@ -550,7 +556,8 @@ final class TabViewModelTests: XCTestCase {
                 keyValueStore: try MockKeyValueFileStore(),
                 privacyConfigurationManager: MockPrivacyConfigurationManager(),
                 featureFlagger: MockFeatureFlagger()
-            )
+            ),
+            accessibilityPreferences: accessibilityPreferences
         )
 
         XCTAssertEqual(tabVM.tab.webView.zoomLevel, randomZoomLevel)
@@ -562,16 +569,16 @@ final class TabViewModelTests: XCTestCase {
         UserDefaultsWrapper<Any>.clearAll()
         let url = URL(string: "https://app.asana.com/0/1")!
         let hostURL = "https://app.asana.com/"
-        let filteredCases = DefaultZoomValue.allCases.filter { $0 != AccessibilityPreferences.shared.defaultPageZoom }
+        let filteredCases = DefaultZoomValue.allCases.filter { $0 != accessibilityPreferences.defaultPageZoom }
         let randomZoomLevel = filteredCases.randomElement()!
-        AccessibilityPreferences.shared.updateZoomPerWebsite(zoomLevel: randomZoomLevel, url: hostURL)
+        accessibilityPreferences.updateZoomPerWebsite(zoomLevel: randomZoomLevel, url: hostURL)
         var tab = Tab(url: url)
-        var tabVM = TabViewModel(tab: tab)
+        var tabVM = TabViewModel(tab: tab, accessibilityPreferences: accessibilityPreferences)
 
         // WHEN
-        AccessibilityPreferences.shared.defaultPageZoom = .percent50
+        accessibilityPreferences.defaultPageZoom = .percent50
         tab = Tab(url: url)
-        tabVM = TabViewModel(tab: tab)
+        tabVM = TabViewModel(tab: tab, accessibilityPreferences: accessibilityPreferences)
 
         // THEN
         XCTAssertEqual(tabVM.tab.webView.zoomLevel, randomZoomLevel)
@@ -583,19 +590,19 @@ final class TabViewModelTests: XCTestCase {
         UserDefaultsWrapper<Any>.clearAll()
         let url = URL(string: "https://app.asana.com/0/1")!
         let hostURL = "https://app.asana.com/"
-        let filteredCases = DefaultZoomValue.allCases.filter { $0 != AccessibilityPreferences.shared.defaultPageZoom }
+        let filteredCases = DefaultZoomValue.allCases.filter { $0 != accessibilityPreferences.defaultPageZoom }
         let randomZoomLevel = filteredCases.randomElement()!
-        AccessibilityPreferences.shared.updateZoomPerWebsite(zoomLevel: randomZoomLevel, url: hostURL)
+        accessibilityPreferences.updateZoomPerWebsite(zoomLevel: randomZoomLevel, url: hostURL)
         let tab = Tab(url: url)
-        var tabVM = TabViewModel(tab: tab)
+        var tabVM = TabViewModel(tab: tab, accessibilityPreferences: accessibilityPreferences)
 
         // WHEN
-        AccessibilityPreferences.shared.defaultPageZoom = .percent50
+        accessibilityPreferences.defaultPageZoom = .percent50
         let burnerTab = Tab(content: .url(url, credential: nil, source: .ui), burnerMode: BurnerMode(isBurner: true))
-        tabVM = TabViewModel(tab: burnerTab)
+        tabVM = TabViewModel(tab: burnerTab, accessibilityPreferences: accessibilityPreferences)
 
         // THEN
-        XCTAssertEqual(tabVM.tab.webView.zoomLevel, AccessibilityPreferences.shared.defaultPageZoom)
+        XCTAssertEqual(tabVM.tab.webView.zoomLevel, accessibilityPreferences.defaultPageZoom)
     }
 
     @MainActor
@@ -604,9 +611,9 @@ final class TabViewModelTests: XCTestCase {
         UserDefaultsWrapper<Any>.clearAll()
         let url = URL(string: "https://app.asana.com/0/1")!
         let hostURL = "https://app.asana.com/"
-        let filteredCases = DefaultZoomValue.allCases.filter { $0 != AccessibilityPreferences.shared.defaultPageZoom }
+        let filteredCases = DefaultZoomValue.allCases.filter { $0 != accessibilityPreferences.defaultPageZoom }
         let randomZoomLevel = filteredCases.randomElement()!
-        AccessibilityPreferences.shared.updateZoomPerWebsite(zoomLevel: randomZoomLevel, url: hostURL)
+        accessibilityPreferences.updateZoomPerWebsite(zoomLevel: randomZoomLevel, url: hostURL)
 
         // WHEN
         let tab = Tab(url: url)
@@ -616,7 +623,8 @@ final class TabViewModelTests: XCTestCase {
                 keyValueStore: try MockKeyValueFileStore(),
                 privacyConfigurationManager: MockPrivacyConfigurationManager(),
                 featureFlagger: MockFeatureFlagger()
-            )
+            ),
+            accessibilityPreferences: accessibilityPreferences
         )
 
         // THEN
@@ -629,9 +637,9 @@ final class TabViewModelTests: XCTestCase {
         UserDefaultsWrapper<Any>.clearAll()
         let url = URL(string: "https://app.asana.com/0/1")!
         let hostURL = "https://app.asana.com/"
-        let filteredCases = DefaultZoomValue.allCases.filter { $0 != AccessibilityPreferences.shared.defaultPageZoom }
+        let filteredCases = DefaultZoomValue.allCases.filter { $0 != accessibilityPreferences.defaultPageZoom }
         let randomZoomLevel = filteredCases.randomElement()!
-        AccessibilityPreferences.shared.updateZoomPerWebsite(zoomLevel: randomZoomLevel, url: hostURL)
+        accessibilityPreferences.updateZoomPerWebsite(zoomLevel: randomZoomLevel, url: hostURL)
 
         // WHEN
         let burnerTab = Tab(content: .url(url, credential: nil, source: .ui), burnerMode: BurnerMode(isBurner: true))
@@ -641,11 +649,12 @@ final class TabViewModelTests: XCTestCase {
                 keyValueStore: try MockKeyValueFileStore(),
                 privacyConfigurationManager: MockPrivacyConfigurationManager(),
                 featureFlagger: MockFeatureFlagger()
-            )
+            ),
+            accessibilityPreferences: accessibilityPreferences
         )
 
         // THEN
-        XCTAssertEqual(tabVM.tab.webView.zoomLevel, AccessibilityPreferences.shared.defaultPageZoom)
+        XCTAssertEqual(tabVM.tab.webView.zoomLevel, accessibilityPreferences.defaultPageZoom)
     }
 
     @MainActor
@@ -655,12 +664,12 @@ final class TabViewModelTests: XCTestCase {
         let url = URL(string: "https://app.asana.com/0/1")!
         let hostURL = "https://app.asana.com/"
         let tab = Tab(url: url)
-        let tabVM = TabViewModel(tab: tab)
-        let filteredCases = DefaultZoomValue.allCases.filter { $0 != AccessibilityPreferences.shared.defaultPageZoom }
+        let tabVM = TabViewModel(tab: tab, accessibilityPreferences: accessibilityPreferences)
+        let filteredCases = DefaultZoomValue.allCases.filter { $0 != accessibilityPreferences.defaultPageZoom }
         let randomZoomLevel = filteredCases.randomElement()!
 
         // WHEN
-        AccessibilityPreferences.shared.updateZoomPerWebsite(zoomLevel: randomZoomLevel, url: hostURL)
+        accessibilityPreferences.updateZoomPerWebsite(zoomLevel: randomZoomLevel, url: hostURL)
 
         // THEN
         await MainActor.run {
@@ -675,16 +684,16 @@ final class TabViewModelTests: XCTestCase {
         let url = URL(string: "https://app.asana.com/0/1")!
         let hostURL = "https://app.asana.com/"
         let burnerTab = Tab(content: .url(url, credential: nil, source: .ui), burnerMode: BurnerMode(isBurner: true))
-        let tabVM = TabViewModel(tab: burnerTab)
-        let filteredCases = DefaultZoomValue.allCases.filter { $0 != AccessibilityPreferences.shared.defaultPageZoom }
+        let tabVM = TabViewModel(tab: burnerTab, accessibilityPreferences: accessibilityPreferences)
+        let filteredCases = DefaultZoomValue.allCases.filter { $0 != accessibilityPreferences.defaultPageZoom }
         let randomZoomLevel = filteredCases.randomElement()!
 
         // WHEN
-        AccessibilityPreferences.shared.updateZoomPerWebsite(zoomLevel: randomZoomLevel, url: hostURL)
+        accessibilityPreferences.updateZoomPerWebsite(zoomLevel: randomZoomLevel, url: hostURL)
 
         // THEN
         await MainActor.run {
-            XCTAssertEqual(tabVM.tab.webView.zoomLevel, AccessibilityPreferences.shared.defaultPageZoom)
+            XCTAssertEqual(tabVM.tab.webView.zoomLevel, accessibilityPreferences.defaultPageZoom)
         }
     }
 
@@ -695,15 +704,15 @@ final class TabViewModelTests: XCTestCase {
         let hostURL = "https://app.asana.com/"
         UserDefaultsWrapper<Any>.clearAll()
         let tab = Tab(url: url)
-        let tabVM = TabViewModel(tab: tab)
-        let filteredCases = DefaultZoomValue.allCases.filter { $0 !=  AccessibilityPreferences.shared.defaultPageZoom }
+        let tabVM = TabViewModel(tab: tab, accessibilityPreferences: accessibilityPreferences)
+        let filteredCases = DefaultZoomValue.allCases.filter { $0 !=  accessibilityPreferences.defaultPageZoom }
         let randomZoomLevel = filteredCases.randomElement()!
 
         // WHEN
         tabVM.zoomWasSet(to: randomZoomLevel)
 
         // THEN
-        XCTAssertEqual(AccessibilityPreferences.shared.zoomPerWebsite(url: hostURL), randomZoomLevel)
+        XCTAssertEqual(accessibilityPreferences.zoomPerWebsite(url: hostURL), randomZoomLevel)
     }
 
     @MainActor
@@ -711,11 +720,11 @@ final class TabViewModelTests: XCTestCase {
         // GIVEN
         let url = URL(string: "https://app.asana.com/0/1")!
         let hostURL = "https://app.asana.com/"
-        AccessibilityPreferences.shared.updateZoomPerWebsite(zoomLevel: AccessibilityPreferences.shared.defaultPageZoom, url: hostURL)
+        accessibilityPreferences.updateZoomPerWebsite(zoomLevel: accessibilityPreferences.defaultPageZoom, url: hostURL)
         UserDefaultsWrapper<Any>.clearAll()
         let burnerTab = Tab(content: .url(url, credential: nil, source: .ui), burnerMode: BurnerMode(isBurner: true))
-        let tabVM = TabViewModel(tab: burnerTab)
-        let filteredCases = DefaultZoomValue.allCases.filter { $0 !=  AccessibilityPreferences.shared.defaultPageZoom }
+        let tabVM = TabViewModel(tab: burnerTab, accessibilityPreferences: accessibilityPreferences)
+        let filteredCases = DefaultZoomValue.allCases.filter { $0 !=  accessibilityPreferences.defaultPageZoom }
         let randomZoomLevel = filteredCases.randomElement()!
 
         // WHEN
@@ -723,7 +732,7 @@ final class TabViewModelTests: XCTestCase {
         tabVM.zoomWasSet(to: randomZoomLevel)
 
         // THEN
-        XCTAssertEqual(AccessibilityPreferences.shared.zoomPerWebsite(url: hostURL), nil)
+        XCTAssertEqual(accessibilityPreferences.zoomPerWebsite(url: hostURL), nil)
     }
 
     @MainActor
@@ -732,17 +741,17 @@ final class TabViewModelTests: XCTestCase {
         let url = URL(string: "https://app.asana.com/0/1")!
         let hostURL = "https://app.asana.com/"
         UserDefaultsWrapper<Any>.clearAll()
-        let filteredCases = DefaultZoomValue.allCases.filter { $0 != AccessibilityPreferences.shared.defaultPageZoom }
+        let filteredCases = DefaultZoomValue.allCases.filter { $0 != accessibilityPreferences.defaultPageZoom }
         let randomZoomLevel = filteredCases.randomElement()!
-        AccessibilityPreferences.shared.updateZoomPerWebsite(zoomLevel: randomZoomLevel, url: hostURL)
+        accessibilityPreferences.updateZoomPerWebsite(zoomLevel: randomZoomLevel, url: hostURL)
         let tab = Tab(url: url)
-        let tabView = TabViewModel(tab: tab)
+        let tabView = TabViewModel(tab: tab, accessibilityPreferences: accessibilityPreferences)
 
         // WHEN
         tabView.tab.webView.resetZoomLevel()
 
         // THEN
-        XCTAssertEqual(AccessibilityPreferences.shared.zoomPerWebsite(url: hostURL), nil)
+        XCTAssertEqual(accessibilityPreferences.zoomPerWebsite(url: hostURL), nil)
     }
 
     @MainActor
@@ -754,20 +763,20 @@ final class TabViewModelTests: XCTestCase {
         let (randomZoomLevel, nextZoomLevel, _) = randomLevelAndAdjacent()
         let window = MockWindow()
         window.contentView = NSView(frame: window.contentRect(forFrameRect: window.frame))
-        AccessibilityPreferences.shared.updateZoomPerWebsite(zoomLevel: randomZoomLevel, url: hostURL)
+        accessibilityPreferences.updateZoomPerWebsite(zoomLevel: randomZoomLevel, url: hostURL)
         let tab = Tab(url: url)
         window.contentView?.addSubview(tab.webView)
         tab.webView.frame = window.contentView!.bounds
-        let tabView = TabViewModel(tab: tab)
+        let tabView = TabViewModel(tab: tab, accessibilityPreferences: accessibilityPreferences)
 
         // WHEN
         tabView.tab.webView.zoomIn()
 
         // THEN
-        if nextZoomLevel == AccessibilityPreferences.shared.defaultPageZoom {
-            XCTAssertNil(AccessibilityPreferences.shared.zoomPerWebsite(url: hostURL))
+        if nextZoomLevel == accessibilityPreferences.defaultPageZoom {
+            XCTAssertNil(accessibilityPreferences.zoomPerWebsite(url: hostURL))
         } else {
-            XCTAssertEqual(AccessibilityPreferences.shared.zoomPerWebsite(url: hostURL), nextZoomLevel)
+            XCTAssertEqual(accessibilityPreferences.zoomPerWebsite(url: hostURL), nextZoomLevel)
         }
     }
 
@@ -780,20 +789,20 @@ final class TabViewModelTests: XCTestCase {
         let (randomZoomLevel, _, previousZoomLevel) = randomLevelAndAdjacent()
         let window = MockWindow()
         window.contentView = NSView(frame: window.contentRect(forFrameRect: window.frame))
-        AccessibilityPreferences.shared.updateZoomPerWebsite(zoomLevel: randomZoomLevel, url: hostURL)
+        accessibilityPreferences.updateZoomPerWebsite(zoomLevel: randomZoomLevel, url: hostURL)
         let tab = Tab(url: url)
         window.contentView?.addSubview(tab.webView)
         tab.webView.frame = window.contentView!.bounds
-        let tabView = TabViewModel(tab: tab)
+        let tabView = TabViewModel(tab: tab, accessibilityPreferences: accessibilityPreferences)
 
         // WHEN
         tabView.tab.webView.zoomOut()
 
         // THEN
-        if previousZoomLevel == AccessibilityPreferences.shared.defaultPageZoom {
-            XCTAssertNil(AccessibilityPreferences.shared.zoomPerWebsite(url: hostURL))
+        if previousZoomLevel == accessibilityPreferences.defaultPageZoom {
+            XCTAssertNil(accessibilityPreferences.zoomPerWebsite(url: hostURL))
         } else {
-            XCTAssertEqual(AccessibilityPreferences.shared.zoomPerWebsite(url: hostURL), previousZoomLevel)
+            XCTAssertEqual(accessibilityPreferences.zoomPerWebsite(url: hostURL), previousZoomLevel)
         }
     }
 
@@ -816,7 +825,7 @@ extension TabViewModel {
     @MainActor
     static var aTabViewModel: TabViewModel {
         let tab = Tab()
-        return TabViewModel(tab: tab)
+        return TabViewModel(tab: tab, accessibilityPreferences: AccessibilityPreferences())
     }
 
     @MainActor
@@ -842,7 +851,7 @@ extension TabViewModel {
                 featureFlagger: featureFlagger
             )
         } else {
-            return TabViewModel(tab: tab)
+            return TabViewModel(tab: tab, accessibilityPreferences: AccessibilityPreferences())
         }
     }
 

--- a/macOS/UnitTests/Tab/WebViewTests.swift
+++ b/macOS/UnitTests/Tab/WebViewTests.swift
@@ -141,10 +141,11 @@ final class WebViewTests: XCTestCase {
 
     @MainActor
     func testThatResetZoomLevelResetsZoom() {
-        let tabVM = TabViewModel(tab: Tab(content: .none))
+        let accessibilityPreferences = AccessibilityPreferences()
+        let tabVM = TabViewModel(tab: Tab(content: .none), accessibilityPreferences: accessibilityPreferences)
         let randomZoomLevel = DefaultZoomValue.percent300
         // Select Default zoom
-        AccessibilityPreferences.shared.defaultPageZoom = randomZoomLevel
+        accessibilityPreferences.defaultPageZoom = randomZoomLevel
 
         // Zooming out
         tabVM.tab.webView.zoomOut()
@@ -157,7 +158,7 @@ final class WebViewTests: XCTestCase {
         XCTAssertEqual(tabVM.tab.webView.zoomLevel, randomZoomLevel)
 
         // Set new default zoom
-        AccessibilityPreferences.shared.defaultPageZoom = .percent75
+        accessibilityPreferences.defaultPageZoom = .percent75
         XCTAssertEqual(tabVM.tab.webView.zoomLevel, .percent75)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211863121797480

### Description:
This change replaces AccessibilityPreferences.shared with an AppDelegate-owned property that is injected
to objects that need it via initializers.

### Testing Steps
1. Verify that CI is green
2. Verify that [this UI tests workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/19428847947) is green.
3. Verify that the app doesn’t crash on launch.
4. Verify that page zoom settings work fine.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces AccessibilityPreferences.shared with an AppDelegate-owned instance threaded through controllers, view models, and preferences; adjusts Fire initializer for @MainActor safety and updates tests and docs.
> 
> - **Core/Composition**:
>   - Add `AppDelegate.accessibilityPreferences` and construct it during setup.
>   - Update `Fire` init to use optional `savedZoomLevelsCoordinating` with fallback to `NSApp.delegateTyped.accessibilityPreferences` (fixes `@MainActor` default-arg issue).
> - **View Controllers**:
>   - Thread `accessibilityPreferences` through `MainViewController` → `NavigationBarViewController` → `AddressBarViewController` → `AddressBarButtonsViewController` and `BrowserTabViewController`.
> - **Preferences Chain**:
>   - Pass `accessibilityPreferences` through `PreferencesViewController` → `PreferencesSidebarModel` → `PreferencesRootView` (SwiftUI now uses `model.accessibilityPreferences` instead of `.shared`).
> - **View Models**:
>   - Change defaults to `NSApp.delegateTyped.accessibilityPreferences` in `TabViewModel` and add dependency to `TabCollectionViewModel`.
> - **Tests**:
>   - Update integration/unit tests to construct and pass `AccessibilityPreferences()` (incl. shared test property patterns and helper methods); adjust usages from `.shared` to `NSApp.delegateTyped` or injected instances.
> - **Docs**:
>   - Expand singleton removal guide with rules, `@MainActor` default-arg workaround, protocol notes, examples, and test checklists for `AccessibilityPreferences`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f11c1f6407f6697140edd622ca9016bf359f9eae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->