### PR TITLE
Remove external scheme redirection pixel

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1311,9 +1311,6 @@ extension Pixel {
         // MARK: WebView Error Page Shown
         case webViewErrorPageShown
 
-        case webViewExternalSchemeNavigationXSafariHTTPSCancel
-        case webViewExternalSchemeNavigationXSafariHTTPSContinue
-
         // MARK: Browsing
         case stopPageLoad
 
@@ -2665,8 +2662,6 @@ extension Pixel.Event {
 
         // MARK: Browsing
         case .stopPageLoad: return "m_stop-page-load"
-        case .webViewExternalSchemeNavigationXSafariHTTPSCancel: return "m_webview_external-scheme-navigation_x-safari-https_cancel"
-        case .webViewExternalSchemeNavigationXSafariHTTPSContinue: return "m_webview_external-scheme-navigation_x-safari-https_continue"
 
         // MARK: Launch time
         case .appDidFinishLaunchingTime(let time): return "m_debug_app-did-finish-launching-time-\(time)"

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1320,7 +1320,6 @@ class TabViewController: UIViewController {
         
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: dontOpen, style: .cancel, handler: { _ in
-            self.reportExternalSchemePixelIfNeeded(url: url, openedExternally: false)
             if self.webView.url == nil {
                 self.delegate?.tabDidRequestClose(self)
             } else {
@@ -1328,7 +1327,6 @@ class TabViewController: UIViewController {
             }
         }))
         alert.addAction(UIAlertAction(title: open, style: .destructive, handler: { _ in
-            self.reportExternalSchemePixelIfNeeded(url: url, openedExternally: true)
             self.openExternally(url: url)
         }))
         delegate?.tab(self, didRequestPresentingAlert: alert)
@@ -3785,16 +3783,6 @@ private extension TabViewController {
         }
 
         return didRestoreWebViewState
-    }
-
-    private func reportExternalSchemePixelIfNeeded(url: URL, openedExternally: Bool) {
-        guard url.scheme == "x-safari-https" else { return }
-
-        if openedExternally {
-            DailyPixel.fireDailyAndCount(pixel: .webViewExternalSchemeNavigationXSafariHTTPSContinue)
-        } else {
-            DailyPixel.fireDailyAndCount(pixel: .webViewExternalSchemeNavigationXSafariHTTPSCancel)
-        }
     }
 }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1205278999335242/task/1211586296533807?focus=true
Tech Design URL:
CC:

### Description

Remove temporary pixel for measuring how often users are forced to Safari.

### Testing Steps
1. Make sure CI is green.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
N/A

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes x-safari-https external scheme pixel enums/mappings and related reporting from TabViewController.
> 
> - **Analytics/Telemetry**:
>   - Remove `Pixel.Event` cases and name mappings for `webViewExternalSchemeNavigationXSafariHTTPSCancel` and `...Continue` in `iOS/Core/PixelEvent.swift`.
> - **Browsing UI**:
>   - Remove pixel reporting for external app alert actions and delete `reportExternalSchemePixelIfNeeded` in `iOS/DuckDuckGo/TabViewController.swift`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7770903ae9e23ce57574f1d720158ffaf140726. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->