### PR TITLE
Apple: Move to platform defined feature flags

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -86,8 +86,7 @@ public enum PrivacyFeature: String {
     case attributedMetrics
     case dataImport
     case duckAiDataClearing
-    case storeSerpSettings
-    case showHideAIGeneratedImagesSection
+    case serp
 }
 
 /// An abstraction to be implemented by any "subfeature" of a given `PrivacyConfiguration` feature.
@@ -284,6 +283,9 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
 
     /// Allows to present Search Experience choice screen during onboarding
     case onboardingSearchExperience
+
+    /// Controls showing the Hide AI section in Settings -> AI Features
+    case showHideAiGeneratedImages
 }
 
 public enum HtmlNewTabPageSubfeature: String, Equatable, PrivacySubfeature {
@@ -518,4 +520,13 @@ public enum DataImportSubfeature: String, PrivacySubfeature {
     public var parent: PrivacyFeature { .dataImport }
 
     case newSafariFilePicker
+}
+
+public enum SERPSubfeature: String, PrivacySubfeature {
+    public var parent: PrivacyFeature {
+        .serp
+    }
+
+    /// Global switch to disable New Tab Page search box
+    case storeSerpSettings
 }

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -531,9 +531,9 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .onboardingSearchExperience:
             return .internalOnly()
         case .storeSerpSettings:
-            return .remoteReleasable(.feature(.storeSerpSettings))
+            return .remoteReleasable(.subfeature(SERPSubfeature.storeSerpSettings))
         case .showHideAIGeneratedImagesSection:
-            return .remoteReleasable(.feature(.showHideAIGeneratedImagesSection))
+            return .remoteReleasable(.subfeature(AIChatSubfeature.showHideAiGeneratedImages))
         case .standaloneMigration:
             return .remoteReleasable(.subfeature(AIChatSubfeature.standaloneMigration))
         }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -557,7 +557,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .cpmCountPixel:
             return .internalOnly()
         case .storeSerpSettings:
-            return .remoteReleasable(.feature(.storeSerpSettings))
+            return .remoteReleasable(.subfeature(SERPSubfeature.storeSerpSettings))
         case .blurryAddressBarTahoeFix:
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.blurryAddressBarTahoeFix))
         case .dataImportNewExperience:
@@ -571,7 +571,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .vpnConnectionWidePixelMeasurement:
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.vpnConnectionWidePixelMeasurement))
         case .showHideAIGeneratedImagesSection:
-            return .remoteReleasable(.feature(.showHideAIGeneratedImagesSection))
+            return .remoteReleasable(.subfeature(AIChatSubfeature.showHideAiGeneratedImages))
         case .standaloneMigration:
             return .remoteReleasable(.subfeature(AIChatSubfeature.standaloneMigration))
         case .newTabPageAutoconsentStats:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1211967140961140?focus=true
Tech Design URL:
CC:

### Description
Changes the privacy config feature flags to match a platform definition.

- `showHideAIGeneratedImagesSection` is not a feature anymore, and just a subfeature of `aiChat`
- `storeSerpSettings` is not a feature anymore, and a subfeature of a new feature called `serp`

### Testing Steps
Nothing basically to test, this is just a rename.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `serp` feature and maps `storeSerpSettings` and AI images visibility to subfeatures across iOS and macOS feature flag sources.
> 
> - **Privacy Config**:
>   - Add top‑level feature `PrivacyFeature.serp`.
>   - Add `SERPSubfeature.storeSerpSettings` and `AIChatSubfeature.showHideAiGeneratedImages`.
>   - Remove top‑level features `storeSerpSettings` and `showHideAIGeneratedImagesSection`.
> - **Platform Feature Flags**:
>   - Update iOS/macOS `FeatureFlag.source` to reference subfeatures:
>     - `storeSerpSettings` -> `.subfeature(SERPSubfeature.storeSerpSettings)`.
>     - `showHideAIGeneratedImagesSection` -> `.subfeature(AIChatSubfeature.showHideAiGeneratedImages)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a259d7e9ca4c036f3474952f84673fc77df2156f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->