### PR TITLE
Remove debugMenu feature flag and replace with internal user check

### DIFF
--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -453,7 +453,7 @@ final class MainMenu: NSMenu {
         NSMenuItem(title: "Debug")
             .submenu(setupDebugMenu(featureFlagger: featureFlagger, historyCoordinator: historyCoordinator))
 #else
-        if featureFlagger.isFeatureOn(.debugMenu) {
+        if internalUserDecider.isInternalUser {
             NSMenuItem(title: "Debug")
                 .submenu(setupDebugMenu(featureFlagger: featureFlagger, historyCoordinator: historyCoordinator))
         } else {
@@ -928,7 +928,7 @@ final class MainMenu: NSMenu {
     }
 
     private func updateInternalUserItem() {
-        internalUserItem.title = NSApp.delegateTyped.internalUserDecider.isInternalUser ? "Remove Internal User State" : "Set Internal User State"
+        internalUserItem.title = internalUserDecider.isInternalUser ? "Remove Internal User State" : "Set Internal User State"
     }
 
     private func updateAutofillDebugScriptMenuItem() {

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -20,9 +20,6 @@ import Foundation
 import BrowserServicesKit
 
 public enum FeatureFlag: String, CaseIterable {
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866473003324
-    case debugMenu
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866715760000
     case sslCertificatesBypass
 
@@ -413,8 +410,7 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .blackFridayCampaign,
                 .newTabPageAutoconsentStats:
             return true
-        case .debugMenu,
-                .sslCertificatesBypass,
+        case .sslCertificatesBypass,
                 .appendAtbToSerpQueries,
                 .freemiumDBP,
                 .contextualOnboarding,
@@ -430,8 +426,6 @@ extension FeatureFlag: FeatureFlagDescribing {
 
     public var source: FeatureFlagSource {
         switch self {
-        case .debugMenu:
-            return .internalOnly()
         case .appendAtbToSerpQueries:
             return .internalOnly()
         case .sslCertificatesBypass:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1211866473003324
Tech Design URL: N/A
CC: N/A

### Description
Removed the `debugMenu` feature flag from macOS and replaced the check with `internalUserDecider.isInternalUser` check. The debug menu will now appear based on internal user state instead of a feature flag.

Changes:
- Removed `case debugMenu` from `macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift`
- Removed `.debugMenu` from `supportsLocalOverriding` switch
- Removed `.debugMenu` from `source` property switch
- Replaced `featureFlagger.isFeatureOn(.debugMenu)` with `internalUserDecider.isInternalUser` in `MainMenu.swift`
- Replaced `NSApp.delegateTyped.internalUserDecider` with stored `internalUserDecider` property for consistency

### Testing Steps
1. Build the macOS app successfully
2. Verify debug menu appears for internal users
3. Verify debug menu does not appear for non-internal users
4. Verify debug menu still appears in DEBUG/REVIEW/ALPHA builds

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- Debug menu might not appear for internal users if internal user state is not properly set
- Mitigation: Verified build succeeds and internal user check is already used elsewhere in the codebase

### Quality Considerations
- Edge cases: DEBUG/REVIEW/ALPHA builds still show debug menu regardless of internal user state (existing behavior preserved)
- Performance: No performance impact, simple boolean check
- Monitoring: No monitoring changes needed
- Documentation: N/A
- Privacy and security: No privacy/security impact

### Notes to Reviewer
This is a straightforward removal of a feature flag in favor of using the existing internal user check mechanism. The behavior remains the same for internal users, but now uses a more direct check rather than going through the feature flag system.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces Debug menu gating via feature flag with an internal user check and removes the obsolete `debugMenu` flag from FeatureFlags.
> 
> - **macOS**:
>   - Gate `Debug` menu by `internalUserDecider.isInternalUser` instead of `featureFlagger.isFeatureOn(.debugMenu)` in `MainMenu.buildDebugMenu`.
>   - Use stored `internalUserDecider` in `updateInternalUserItem`.
> - **FeatureFlags**:
>   - Remove `FeatureFlag.debugMenu` and its handling from `supportsLocalOverriding` and `source`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffdd659363522890cfcad6f9ee2418f5d8279673. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->