### PR TITLE
[macOS] Ensure SAD/ATT banner persists until dismissed

### DIFF
--- a/macOS/DuckDuckGo/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptPresenting.swift
+++ b/macOS/DuckDuckGo/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptPresenting.swift
@@ -98,6 +98,13 @@ final class DefaultBrowserAndDockPromptPresenter: DefaultBrowserAndDockPromptPre
                 guard let window = inactiveUserModalWindowProvider() else { return }
                 showInactiveUserModal(over: window)
             }
+
+            // Keep track of what type of prompt is shown.
+            // If the user modify the SAD/ATT state outside of the banner we need to know the type of prompt it was shown to save its visualisation date.
+            currentShownPrompt = type
+            // Start subscribing to status updates for SAD/ATT.
+            // It's possible that the user may set SAD/ATT outside the prompt (e.g. from Settings). If that happens we want to dismiss the prompt.
+            subscribeToStatusUpdates()
         }
 
         // If we are switching prompt types, ensure the previous prompt is dismissed before showing the new one.
@@ -106,13 +113,6 @@ final class DefaultBrowserAndDockPromptPresenter: DefaultBrowserAndDockPromptPre
         } else {
             showPrompt()
         }
-
-        // Keep track of what type of prompt is shown.
-        // If the user modify the SAD/ATT state outside of the banner we need to know the type of prompt it was shown to save its visualisation date.
-        currentShownPrompt = type
-        // Start subscribing to status updates for SAD/ATT.
-        // It's possible that the user may set SAD/ATT outside the prompt (e.g. from Settings). If that happens we want to dismiss the prompt.
-        subscribeToStatusUpdates()
     }
 
     // MARK: - Private


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1211981458947026?focus=true
Tech Design URL:
CC:

### Description

We started dismissing any visible SAD/ATT prompt before showing a new one, to avoid collisions between different prompts. However, as a side effect this caused the banner prompt to be alternately shown and dismissed when a window already showing it regained focus.

This fixes the banner prompt by only dismissing a visible prompt if it’s a different prompt type from the once requested. This way, the banner prompt will persist when the same window regains focus and a new banner will be shown when a new window is opened. The other prompts retain the same behavior (they are only shown once).

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Clear the Application Support to simulate a new install (this helps when overriding the date while testing).
2. Build and run the app.
2. Go to ‘Debug Menu’ → ’SAD/ATT Prompts’ → ‘Reset Prompts and Today’s Date.’
3. Check the date for ‘Popover prompt will show’.
4. Select ‘Override Today’s Date’ and enter that date.
5. Focus outside the window and focus again.
6. Confirm the popover prompt for active users is shown and select ’Not now.'
7. Go to ‘Debug Menu’ → ’SAD/ATT Prompts’ and check the date for ‘First banner will show.'
8. Select ‘Override Today’s Date’ and enter the day **before** that date, to simulate an active user.
9. Select ‘Override Today’s Date’ and enter the date for the first banner.
10. Focus outside the window and focus again.
11. Confirm the banner prompt for active users is shown.
12. Focus outside the window and focus again, and confirm the banner persists.
13. Open a new window and confirm the banner appears in the new window as well.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
Tested scenarios:
* Each prompt is presented when expected.
* When a prompt is visible (e.g. banner) and a different prompt (e.g. inactive user) is requested, only the new prompt is shown.
* When the banner is visible, the window can lose and regain focus and a new window can be opened and the banner persists.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Persist banner across focus changes by dismissing existing prompt only when the requested prompt type changes.
> 
> - **macOS – SAD/ATT prompt presentation**:
>   - Only dismiss existing prompt when switching types (`type != currentShownPrompt`); otherwise keep current prompt (e.g., banner persists across focus changes).
>   - Refactor `tryToShowPrompt` with a `showPrompt` helper while retaining status update subscription and prompt tracking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4413ca8955ea0c26bb7dfd2626635da0fc4a3fbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->