### PR TITLE
iOS: Implement Toggle Choice Screen for new user experience (remove from iPad)

### DIFF
--- a/iOS/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/Manager/OnboardingManager.swift
@@ -114,11 +114,7 @@ final class OnboardingManager {
     }
 
     private func iPadFlow() -> [OnboardingIntroStep] {
-        if featureFlagger.isFeatureOn(.onboardingSearchExperience) {
-            return iPadFlowWithSearchExperience
-        } else {
-            return iPadFlowWithoutSearchExperience
-        }
+        return iPadFlowWithoutSearchExperience
     }
 }
 

--- a/iOS/DuckDuckGoTests/OnboardingManagerTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingManagerTests.swift
@@ -80,7 +80,7 @@ struct OnboardingManagerTests {
             let featureFlagger = MockFeatureFlagger()
             featureFlagger.enabledFeatureFlags = [.onboardingSearchExperience]
             let sut = OnboardingManager(appDefaults: AppSettingsMock(), featureFlagger: featureFlagger, variantManager: variantManagerMock, isIphone: false)
-            let expectedSteps = OnboardingStepsHelper.expectedIPadStepsWithSearchExperience(isReturningUser: false)
+            let expectedSteps = OnboardingStepsHelper.expectedIPadSteps(isReturningUser: false)
 
             // WHEN
             let result = sut.newUserSteps(isIphone: false)
@@ -148,7 +148,7 @@ struct OnboardingManagerTests {
             let featureFlagger = MockFeatureFlagger()
             featureFlagger.enabledFeatureFlags = [.onboardingSearchExperience]
             let sut = OnboardingManager(appDefaults: AppSettingsMock(), featureFlagger: featureFlagger, variantManager: variantManagerMock, isIphone: false)
-            let expectedSteps = OnboardingStepsHelper.expectedIPadStepsWithSearchExperience(isReturningUser: true)
+            let expectedSteps = OnboardingStepsHelper.expectedIPadSteps(isReturningUser: true)
 
             // WHEN
             let result = sut.returningUserSteps(isIphone: false)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1211654189969294/task/1211991080857365?focus=true
Tech Design URL:
CC:

### Description
Removes onboarding choice screen from the iPad

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
**Prerequisite**
- In `FeatureFlag.swift` for `onboardingSearchExperience` return `.enabled` instead of `.internalOnly` (internal user is not enabled by default)
- Delete the app from the simulator

**iPhone**
1. Run the app. Onboarding should consist of 5 screens and it should contain newly added onboarding screen
<details>
<summary>🚩 Click here to see screenshot</summary>

| iPhone |
|--------|
| <img width="1206" height="2622" alt="New copy (Nov 18) - iPhone" src="https://github.com/user-attachments/assets/e1045ad2-d37a-449b-b52b-2fbba7729119" />
</details>

**iPad**
1. Run the app. Onboarding should consist of 2 screens and it should not contain newly added onboarding screen

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
4. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

Low: already behind a feature flag.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always use the iPad onboarding flow without the search experience step and update tests accordingly.
> 
> - **Onboarding (iOS)**:
>   - **iPad flow**: Always returns `iPadFlowWithoutSearchExperience`; removes feature-flag-based inclusion of `searchExperienceSelection`.
> - **Tests**:
>   - Update iPad expectations (new and returning users) to `expectedIPadSteps` even when `.onboardingSearchExperience` is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22bede9b16df0600712fef272a03520f5a319da1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->