### PR TITLE
Optimize sites section performance

### DIFF
--- a/macOS/DuckDuckGo/History/Model/HistoryViewDataProvider.swift
+++ b/macOS/DuckDuckGo/History/Model/HistoryViewDataProvider.swift
@@ -301,7 +301,8 @@ final class HistoryViewDataProvider: HistoryViewDataProviding {
         }
         let domains = historyDictionary.grouped(by: { $0.value.etldPlusOne ?? $0.key.host ?? "" })
         return domains.compactMap { domain, entries in
-            guard let preferredEntry = bestMatchingEntry(from: entries.lazy.map(\.value), forDomain: domain) else { return nil }
+            guard !domain.isEmpty,
+                  let preferredEntry = bestMatchingEntry(from: entries.lazy.map(\.value), forDomain: domain) else { return nil }
             let url = preferredURL(for: preferredEntry)
             let title = bestTitle(for: preferredEntry)
             return DataModel.HistoryItem(siteDomain: domain, url: url, title: title)

--- a/macOS/UnitTests/History/Services/HistoryViewDataProviderTests.swift
+++ b/macOS/UnitTests/History/Services/HistoryViewDataProviderTests.swift
@@ -1152,7 +1152,6 @@ final class HistoryViewDataProviderTests: XCTestCase {
         XCTAssertEqual(preferred, try XCTUnwrap("https://example.com".url))
     }
 
-
     // MARK: - chat history
 
     func testWhenDeleteVisitsIsCalledWithDeleteChatsThenBurnChatsIsCalled() async throws {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1211983105673223
Tech Design URL: N/A
CC: N/A

### Description
Optimizes sites section by fixing bestMatchingEntry sorting logic and adding comprehensive tests. Fixes title comparison bug where entries with titles weren't properly preferred over entries without titles.

### Testing Steps
1. Validate sites section works correctly
2. Validate performance is acceptable when many history items are created (1000+ entries with multiple visits)

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- Sites section might show incorrect preferred URLs or titles if sorting logic has edge cases
- Performance degradation with very large history datasets
- Mitigation: Added comprehensive unit tests covering all sorting paths and performance test

### Quality Considerations
- Edge cases: All sorting criteria tested (title preference, HTTPS, root path, domain matching, recency)
- Performance: Added performance test for sitesSectionItems() with 1000 entries across 5 domains, each with 1000 visits
- Tests: Comprehensive test coverage for bestMatchingEntry, preferredURL, and bestTitle functions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes the Sites section by introducing a best-match selection algorithm and helpers, refactoring title/URL resolution, updating counts, and adding extensive unit/performance tests.
> 
> - **HistoryViewDataProvider**:
>   - **Best-match selection**: Add `bestMatchingEntry` (prefers non-empty `title` → HTTPS → root path → bare/www domain → most recent `lastVisit`).
>   - **Refactors**: Split `bestTitle`/`preferredURL` into helper overloads; return URL when title empty; use entry URL directly.
>   - **Sites section**: Add `sitesSectionItems()` to produce one item per eTLD+1 via grouped history; update population to use it.
>   - **Counts**: Compute `.allSites` count via `historyDictionary.keys.convertedToETLDPlus1(...)` fallback.
>   - **Cleanup**: Remove `uniqueETLDPlus1Domains()`.
> - **Tests**:
>   - Add extensive unit tests covering sorting priorities (title presence, HTTPS, root, domain match, recency, multiple visits) and Sites behavior; add (skipped) performance test.
>   - Update existing tests to include additional domains and new expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4be0ca2e85305716594201a1128f8ae436b8b604. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->