### PR TITLE
Remove demonstrative failsafe feature flags

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -148,13 +148,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866610578312
     case setAsDefaultBrowserPiPVideoTutorial
 
-    // Demonstrative cases for default value. Remove once a real-world feature/subfeature is added
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866611361238
-    case failsafeExampleCrossPlatformFeature
-
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866611466455
-    case failsafeExamplePlatformSpecificSubfeature
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866470028133
     case experimentalAddressBar
 
@@ -292,9 +285,7 @@ public enum FeatureFlag: String {
 extension FeatureFlag: FeatureFlagDescribing {
     public var defaultValue: Bool {
         switch self {
-        case .failsafeExampleCrossPlatformFeature,
-             .failsafeExamplePlatformSpecificSubfeature,
-             .canScanUrlBasedSyncSetupBarcodes,
+        case .canScanUrlBasedSyncSetupBarcodes,
              .canInterceptSyncSetupUrls,
              .removeWWWInCanonicalizationInThreatProtection,
              .supportsAlternateStripePaymentFlow,
@@ -416,8 +407,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                .privacyProFreeTrialJan25,
                .webViewStateRestoration,
                .syncSeamlessAccountSwitching,
-               .failsafeExampleCrossPlatformFeature,
-               .failsafeExamplePlatformSpecificSubfeature,
                .experimentalAddressBar,
                .aiChatKeepSession,
                .aiFeaturesSettingsUpdate,
@@ -512,10 +501,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.privacyProAuthV2))
         case .setAsDefaultBrowserPiPVideoTutorial:
             return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.defaultBrowserTutorial))
-        case .failsafeExampleCrossPlatformFeature:
-            return .remoteReleasable(.feature(.intentionallyLocalOnlyFeatureForTests))
-        case .failsafeExamplePlatformSpecificSubfeature:
-            return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.intentionallyLocalOnlySubfeatureForTests))
         case .widgetReporting:
             return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.widgetReporting))
         case .experimentalAddressBar:

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -86,13 +86,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866474590440
     case privacyProAuthV2
 
-    // Demonstrative cases for default value. Remove once a real-world feature/subfeature is added
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866472271359
-    case failsafeExampleCrossPlatformFeature
-
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866717037699
-    case failsafeExamplePlatformSpecificSubfeature
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866717504694
     case visualUpdates
 
@@ -291,9 +284,7 @@ public enum FeatureFlag: String, CaseIterable {
 extension FeatureFlag: FeatureFlagDescribing {
     public var defaultValue: Bool {
         switch self {
-        case .failsafeExampleCrossPlatformFeature,
-                .failsafeExamplePlatformSpecificSubfeature,
-                .removeWWWInCanonicalizationInThreatProtection,
+        case .removeWWWInCanonicalizationInThreatProtection,
                 .visualUpdatesInternalOnly,
                 .importChromeShortcuts,
                 .updateSafariBookmarksImport,
@@ -341,8 +332,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .updatesWontAutomaticallyRestartApp,
                 .privacyProAuthV2,
                 .scamSiteProtection,
-                .failsafeExampleCrossPlatformFeature,
-                .failsafeExamplePlatformSpecificSubfeature,
                 .visualUpdates,
                 .visualUpdatesInternalOnly,
                 .tabCrashDebugging,
@@ -466,10 +455,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(SetAsDefaultAndAddToDockSubfeature.scheduledDefaultBrowserAndDockPrompts))
         case .privacyProAuthV2:
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.privacyProAuthV2))
-        case .failsafeExampleCrossPlatformFeature:
-            return .remoteReleasable(.feature(.intentionallyLocalOnlyFeatureForTests))
-        case .failsafeExamplePlatformSpecificSubfeature:
-            return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.intentionallyLocalOnlySubfeatureForTests))
         case .visualUpdates:
             return .remoteReleasable(.subfeature(ExperimentalThemingSubfeature.visualUpdates))
         case .visualUpdatesInternalOnly:


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1211992061067311
Tech Design URL:
CC:

### Description

Removal of example feature flags.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. CI is green

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
--

### Quality Considerations
--

### Notes to Reviewer
--

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes example failsafe feature flags and all associated switch cases across iOS and macOS FeatureFlag definitions.
> 
> - **Feature Flags**:
>   - **iOS (`iOS/Core/FeatureFlag.swift`)**:
>     - Remove `failsafeExampleCrossPlatformFeature` and `failsafeExamplePlatformSpecificSubfeature` from `FeatureFlag`.
>     - Clean up references in `defaultValue`, `supportsLocalOverriding`, and `source` switch cases.
>   - **macOS (`macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift`)**:
>     - Remove `failsafeExampleCrossPlatformFeature` and `failsafeExamplePlatformSpecificSubfeature` from `FeatureFlag`.
>     - Clean up references in `defaultValue`, `supportsLocalOverriding`, and `source` switch cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44002fbff9814460352520699119f8ead23be338. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->