### PR TITLE
Remove TabDrapAndDropManager singleton

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -95,6 +95,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     let faviconManager: FaviconManager
     let pinnedTabsManager = PinnedTabsManager()
+    let tabDragAndDropManager: TabDragAndDropManager
     let pinnedTabsManagerProvider: PinnedTabsManagerProvider
     private(set) var stateRestorationManager: AppStateRestorationManager!
     private var grammarFeaturesManager = GrammarFeaturesManager()
@@ -963,6 +964,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             windowControllersManager: windowControllersManager
         )
 #endif
+
+        tabDragAndDropManager = TabDragAndDropManager()
 
         blackFridayCampaignProvider = DefaultBlackFridayCampaignProvider(
             privacyConfigurationManager: privacyConfigurationManager,

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -126,6 +126,7 @@ final class MainViewController: NSViewController {
          duckPlayer: DuckPlayer = NSApp.delegateTyped.duckPlayer,
          themeManager: ThemeManager = NSApp.delegateTyped.themeManager,
          fireCoordinator: FireCoordinator = NSApp.delegateTyped.fireCoordinator,
+         tabDragAndDropManager: TabDragAndDropManager = NSApp.delegateTyped.tabDragAndDropManager,
          pixelFiring: PixelFiring? = PixelKit.shared,
          visualizeFireAnimationDecider: VisualizeFireSettingsDecider = NSApp.delegateTyped.visualizeFireSettingsDecider,
          vpnUpsellPopoverPresenter: VPNUpsellPopoverPresenter = NSApp.delegateTyped.vpnUpsellPopoverPresenter,
@@ -153,7 +154,8 @@ final class MainViewController: NSViewController {
             bookmarkManager: bookmarkManager,
             fireproofDomains: fireproofDomains,
             activeRemoteMessageModel: NSApp.delegateTyped.activeRemoteMessageModel,
-            featureFlagger: featureFlagger
+            featureFlagger: featureFlagger,
+            tabDragAndDropManager: tabDragAndDropManager
         )
         bookmarksBarVisibilityManager = BookmarksBarVisibilityManager(selectedTabPublisher: tabCollectionViewModel.$selectedTabViewModel.eraseToAnyPublisher())
 

--- a/macOS/DuckDuckGo/TabBar/View/TabDragAndDropManager.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabDragAndDropManager.swift
@@ -22,10 +22,6 @@ import Foundation
 @MainActor
 final class TabDragAndDropManager {
 
-    static let shared = TabDragAndDropManager()
-
-    private init() { }
-
     struct Unit {
         weak var tabCollectionViewModel: TabCollectionViewModel?
         var index: TabIndex


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1211998662678836

### Description
This change replaces TabDragAndDropManager with an AppDelegate-owned instance that is passed
to TabBarViewController via the initializer

### Testing Steps
1. Verify that CI is green.
2. Verify that [this UI Tests workflow](https://github.com/duckduckgo/apple-browsers/actions/runs/19518886897) is green.
3. Launch the app and verify that drag & drop on tabs works fine.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the TabDragAndDropManager singleton with an AppDelegate-owned instance injected through MainViewController into TabBarViewController, updating all usages.
> 
> - **Refactor (Dependency Injection)**:
>   - Introduce AppDelegate-owned `TabDragAndDropManager` and pass it via `MainViewController` to `TabBarViewController`.
>   - Remove singleton usage: delete `shared` and `private init` from `TabDragAndDropManager`; replace `TabDragAndDropManager.shared` calls with instance `tabDragAndDropManager`.
>   - Update initializers and factory methods:
>     - `MainViewController.init(...)` accepts `tabDragAndDropManager` and forwards it.
>     - `TabBarViewController.create(...)` and `init(...)` now require `tabDragAndDropManager`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae6bacac9a3fef93d5d5b1e1bfb5603ac4c3e093. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->