### PR TITLE
Make page context handling on main actor

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -183,14 +183,15 @@ final class PageContextTabExtension {
     /// This is the main place where page context handling happens.
     /// We always cache the latest context, and if sidebar is open,
     /// we're passing the context to it.
+    @MainActor
     private func handle(_ pageContext: AIChatPageContextData?) async {
         guard featureFlagger.isFeatureOn(.aiChatPageContext) else {
             return
         }
         shouldForceContextCollection = false
-        cachedPageContext = await replaceFaviconURLWithEncodedData(pageContext)
+        cachedPageContext = replaceFaviconURLWithEncodedData(pageContext)
         if let sidebarViewController = aiChatSidebarProvider.getSidebarViewController(for: tabID) {
-            await sidebarViewController.setPageContext(cachedPageContext)
+            sidebarViewController.setPageContext(cachedPageContext)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203936086921904/task/1212002779348364?focus=true
Tech Design URL:
CC:

### Description
Adjust `handle` call execution to most recent changes: method become async, and may be executed not on main thread but accesses view controller. 

### Testing Steps
Smoke test page context.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Page context (internal feature) not working properly.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks `handle` as `@MainActor` and updates favicon processing and sidebar context updates to run synchronously without `await`.
> 
> - **macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift**:
>   - Mark `handle(_:)` as `@MainActor` and remove `await` when setting `cachedPageContext` and updating the sidebar (`setPageContext`).
>   - Make `replaceFaviconURLWithEncodedData(_:)` non-async (now called directly) and annotate related helpers with `@MainActor`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f58430ee941822f4aa446ba6badef157225de276. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->