### PR TITLE
macOS: Make showHideAIGeneratedImagesSection false by default

### DIFF
--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -314,8 +314,7 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .historyViewSitesSection,
                 .blurryAddressBarTahoeFix,
                 .pinnedTabsViewRewrite,
-                .vpnConnectionWidePixelMeasurement,
-                .showHideAIGeneratedImagesSection:
+                .vpnConnectionWidePixelMeasurement:
             true
         default:
             false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1211999471341927
Tech Design URL:
CC:

### Description
Makes `showHideAIGeneratedImagesSection` false by default.

### Testing Steps
1. Open the application
2. Remove internal state
3. Go to Settings -> AI Features
4. The Hide-AI-generated images shouldn’t be present

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Turns off `showHideAIGeneratedImagesSection` by default in `FeatureFlag.defaultValue`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2da67c2d357d469153baed60f0bf2c1a33e3bc7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->