### PR TITLE
iOS: Set showHideAIGeneratedImagesSection feature flag false by default

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -245,8 +245,7 @@ extension FeatureFlag: FeatureFlagDescribing {
              .syncCreditCards,
              .unifiedURLPredictor,
              .forgetAllInSettings,
-             .vpnConnectionWidePixelMeasurement,
-             .showHideAIGeneratedImagesSection:
+             .vpnConnectionWidePixelMeasurement:
             true
         default:
             false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1199230911884351/task/1211999471341927?focus=true
Tech Design URL:
CC:

### Description
Turns off the `showHideAIGeneratedImagesSection` by default

### Testing Steps
1. Launch the iOS application
2. Go to Settings -> AI Features
3. Check the Hide-AI generated images section is not visible

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Turns off `showHideAIGeneratedImagesSection` by default by removing it from the `defaultValue` true list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 372556719ec36b9067e92bc586f2c8b7d4ade8d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->