### PR TITLE
Clamp popup windows to visible screen

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -2234,6 +2234,8 @@
 		841BE93C2C6F1CB200E9C2B5 /* MenuItemNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 841BE93A2C6F1CB200E9C2B5 /* MenuItemNode.swift */; };
 		841BE93E2C6F236000E9C2B5 /* BookmarkDragDropManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 841BE93D2C6F235F00E9C2B5 /* BookmarkDragDropManager.swift */; };
 		841BE93F2C6F236000E9C2B5 /* BookmarkDragDropManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 841BE93D2C6F235F00E9C2B5 /* BookmarkDragDropManager.swift */; };
+		842303DE2ED075340025F26B /* WindowsManagerPopupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842303DD2ED075340025F26B /* WindowsManagerPopupTests.swift */; };
+		842303DF2ED075340025F26B /* WindowsManagerPopupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842303DD2ED075340025F26B /* WindowsManagerPopupTests.swift */; };
 		8426108D2C9811F30070D5F9 /* KeyEquivalentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8426108C2C9811EC0070D5F9 /* KeyEquivalentView.swift */; };
 		8426108E2C9811F30070D5F9 /* KeyEquivalentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8426108C2C9811EC0070D5F9 /* KeyEquivalentView.swift */; };
 		842FE38B2E0C28EF00E4F9E4 /* PrintingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842FE38A2E0C28EF00E4F9E4 /* PrintingTests.swift */; };
@@ -5121,6 +5123,7 @@
 		8402A7BA2E9F7CA000ACA20C /* FireCoordinatorIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireCoordinatorIntegrationTests.swift; sourceTree = "<group>"; };
 		841BE93A2C6F1CB200E9C2B5 /* MenuItemNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuItemNode.swift; sourceTree = "<group>"; };
 		841BE93D2C6F235F00E9C2B5 /* BookmarkDragDropManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarkDragDropManager.swift; sourceTree = "<group>"; };
+		842303DD2ED075340025F26B /* WindowsManagerPopupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowsManagerPopupTests.swift; sourceTree = "<group>"; };
 		8426108C2C9811EC0070D5F9 /* KeyEquivalentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyEquivalentView.swift; sourceTree = "<group>"; };
 		842FE38A2E0C28EF00E4F9E4 /* PrintingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintingTests.swift; sourceTree = "<group>"; };
 		8434E6B62DB014F0008FFA3D /* BrowserTabViewControllerOnboardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserTabViewControllerOnboardingTests.swift; sourceTree = "<group>"; };
@@ -6695,9 +6698,10 @@
 		1D6D041E2D953E11005BC23F /* MainWindow */ = {
 			isa = PBXGroup;
 			children = (
-				84DBC84D2DA6586B00903C7B /* LinkOpenBehaviorTests.swift */,
-				1D39F7272DCA2C9200F258F0 /* InitialWindowFrameProviderTests.swift */,
 				1D6D041F2D953E20005BC23F /* FullscreenControllerTests.swift */,
+				1D39F7272DCA2C9200F258F0 /* InitialWindowFrameProviderTests.swift */,
+				84DBC84D2DA6586B00903C7B /* LinkOpenBehaviorTests.swift */,
+				842303DD2ED075340025F26B /* WindowsManagerPopupTests.swift */,
 			);
 			path = MainWindow;
 			sourceTree = "<group>";
@@ -14616,6 +14620,7 @@
 				1D9FDEC42B9B63C90040B78C /* DataClearingPreferencesTests.swift in Sources */,
 				3706FE04293F661700E42796 /* TreeControllerTests.swift in Sources */,
 				56CE77622C7DFCF800AC1ED2 /* OnboardingSuggestedSearchesProviderTests.swift in Sources */,
+				842303DE2ED075340025F26B /* WindowsManagerPopupTests.swift in Sources */,
 				3706FE07293F661700E42796 /* PasswordManagementItemListModelTests.swift in Sources */,
 				3706FE08293F661700E42796 /* WKWebsiteDataStoreExtensionTests.swift in Sources */,
 				3706FE09293F661700E42796 /* VariantManagerTests.swift in Sources */,
@@ -16601,6 +16606,7 @@
 				84AECC522DFBFADC00438ACC /* AutoClearHandlerTests.swift in Sources */,
 				CD3301292C887B1C009AA127 /* URLTokenValidatorTests.swift in Sources */,
 				AAC9C01C24CB594C00AD1325 /* TabViewModelTests.swift in Sources */,
+				842303DF2ED075340025F26B /* WindowsManagerPopupTests.swift in Sources */,
 				84DC715B2C1C1E9000033B8C /* UserDefaultsWrapperTests.swift in Sources */,
 				567DA93F29E8045D008AC5EE /* MockEmailStorage.swift in Sources */,
 				37CD54B727F1B28A00F1F7B9 /* DefaultBrowserPreferencesTests.swift in Sources */,

--- a/macOS/DuckDuckGo/Windows/View/WindowsManager.swift
+++ b/macOS/DuckDuckGo/Windows/View/WindowsManager.swift
@@ -17,10 +17,16 @@
 //
 
 import Cocoa
-import BrowserServicesKit
 
 @MainActor
 final class WindowsManager {
+
+    internal enum Constants {
+        static let defaultPopUpWidth: CGFloat = 1024
+        static let defaultPopUpHeight: CGFloat = 752
+        static let minimumPopUpWidth: CGFloat = 512
+        static let minimumPopUpHeight: CGFloat = 258
+    }
 
     class var windows: [NSWindow] {
         NSApplication.shared.windows
@@ -177,9 +183,6 @@ final class WindowsManager {
                              popUp: tabCollection.isPopup)
     }
 
-    private static let defaultPopUpWidth: CGFloat = 1024
-    private static let defaultPopUpHeight: CGFloat = 752
-
     @discardableResult
     class func openPopUpWindow(with tab: Tab, origin: NSPoint?, contentSize: NSSize?, forcePopup: Bool = false) -> NSWindow? {
         if !forcePopup,
@@ -191,26 +194,58 @@ final class WindowsManager {
             return mainWindowController.window
 
         } else {
-            let screenFrame = (self.findPositioningSourceWindow(for: tab)?.screen ?? .main)?.visibleFrame ?? NSScreen.fallbackHeadlessScreenFrame
-
-            // limit popUp content size to screen visible frame
-            // fallback to default if nil or zero
-            var contentSize = contentSize ?? .zero
-            contentSize = NSSize(width: min(screenFrame.width, contentSize.width > 0 ? contentSize.width : Self.defaultPopUpWidth),
-                                 height: min(screenFrame.height, contentSize.height > 0 ? contentSize.height : Self.defaultPopUpHeight))
-
-            // if origin provided, popup should be fully positioned on screen
-            let origin = origin.map { origin in
-                NSPoint(x: max(screenFrame.minX, min(screenFrame.maxX - contentSize.width, screenFrame.minX + origin.x)),
-                        y: min(screenFrame.maxY, max(screenFrame.minY + contentSize.height, screenFrame.maxY - origin.y)))
-            }
-
-            let droppingPoint = origin.map { origin in
-                NSPoint(x: origin.x + contentSize.width / 2, y: origin.y)
-            }
-
-            return self.openNewWindow(with: tab, droppingPoint: droppingPoint, contentSize: contentSize, popUp: true)
+            let (droppingPoint, finalContentSize) = calculatePopupFrame(for: tab, origin: origin, contentSize: contentSize)
+            return self.openNewWindow(with: tab, droppingPoint: droppingPoint, contentSize: finalContentSize, popUp: true)
         }
+    }
+
+    /// Calculates the popup window frame for a given tab.
+    /// - Parameters:
+    ///   - tab: The tab that is creating the popup
+    ///   - origin: The popup origin in web coordinates (top-left, from window.open)
+    ///   - contentSize: The requested popup content size
+    /// - Returns: A tuple containing the dropping point (top-center) and final content size
+    private class func calculatePopupFrame(for tab: Tab, origin: NSPoint?, contentSize: NSSize?) -> (droppingPoint: NSPoint?, contentSize: NSSize) {
+        let sourceWindow = findPositioningSourceWindow(for: tab)
+        // Use visibleFrame to ensure popup doesn't go behind dock or menu bar
+        let screenFrame = (sourceWindow?.screen ?? .main)?.visibleFrame ?? NSScreen.fallbackHeadlessScreenFrame
+        return calculatePopupFrame(screenFrame: screenFrame, origin: origin, contentSize: contentSize)
+    }
+
+    /// Calculates the popup window frame with explicit screen and parent frame parameters.
+    /// This method is exposed as `internal` for unit testing purposes.
+    ///
+    /// - Parameters:
+    ///   - screenFrame: The visible frame of the screen (excluding dock and menu bar)
+    ///   - origin: The popup origin in web coordinates (top-left corner, as provided by window.open)
+    ///   - contentSize: The requested popup content size (may be nil or zero)
+    ///
+    /// - Returns: A tuple containing:
+    ///   - droppingPoint: The top-center point for window positioning (nil if no origin provided)
+    ///   - contentSize: The final content size after applying minimum dimensions and screen constraints
+    ///
+    /// - Note: The droppingPoint is in the top-center format expected by `NSRect.frameOrigin(fromDroppingPoint:)`
+    class func calculatePopupFrame(screenFrame: NSRect, origin: NSPoint?, contentSize: NSSize?) -> (droppingPoint: NSPoint?, contentSize: NSSize) {
+        // Calculate final content size: enforce minimum dimensions and constrain to screen
+        // If contentSize is nil or zero, use defaults
+        var contentSize = contentSize ?? .zero
+        contentSize = NSSize(
+            width: min(screenFrame.width, max(Constants.minimumPopUpWidth, contentSize.width > 0 ? contentSize.width : Constants.defaultPopUpWidth)),
+            height: min(screenFrame.height, max(Constants.minimumPopUpHeight, contentSize.height > 0 ? contentSize.height : Constants.defaultPopUpHeight))
+        )
+
+        // Calculate dropping point if origin is provided
+        // Popup should be fully positioned within visible screen bounds
+        // Origin is in web coordinates (x: from left, y: from top)
+        // droppingPoint is in AppKit coordinates (x: center of window, y: top of window)
+        let droppingPoint = origin.map { origin in
+            return NSPoint(
+                x: max(screenFrame.minX, min(screenFrame.maxX - contentSize.width, screenFrame.minX + origin.x)) + contentSize.width / 2,
+                y: max(screenFrame.minY + contentSize.height, min(screenFrame.maxY, screenFrame.maxY - origin.y))
+            )
+        }
+
+        return (droppingPoint, contentSize)
     }
 
     private class func makeNewWindow(tabCollectionViewModel: TabCollectionViewModel? = nil,

--- a/macOS/UnitTests/MainWindow/WindowsManagerPopupTests.swift
+++ b/macOS/UnitTests/MainWindow/WindowsManagerPopupTests.swift
@@ -1,0 +1,501 @@
+//
+//  WindowsManagerPopupTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import Cocoa
+
+@testable import DuckDuckGo_Privacy_Browser
+
+final class WindowsManagerPopupTests: XCTestCase {
+
+    // MARK: - Content Size Tests
+
+    @MainActor
+    func testWhenContentSizeIsZero_thenDefaultSizeIsUsed() {
+        let visibleScreenFrame = NSRect(x: 100, y: 50, width: 2000, height: 1500)
+
+        let (_, contentSize) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: nil,
+            contentSize: nil
+        )
+
+        XCTAssertEqual(contentSize.width, WindowsManager.Constants.defaultPopUpWidth)
+        XCTAssertEqual(contentSize.height, WindowsManager.Constants.defaultPopUpHeight)
+    }
+
+    @MainActor
+    func testWhenContentSizeIsBelowMinimum_thenMinimumSizeIsEnforced() {
+        let visibleScreenFrame = NSRect(x: -200, y: 100, width: 2000, height: 1500)
+
+        let (_, contentSize) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: nil,
+            contentSize: NSSize(width: 50, height: 50)
+        )
+
+        XCTAssertEqual(contentSize.width, WindowsManager.Constants.minimumPopUpWidth)
+        XCTAssertEqual(contentSize.height, WindowsManager.Constants.minimumPopUpHeight)
+    }
+
+    @MainActor
+    func testWhenOnlyWidthIsBelowMinimum_thenOnlyWidthIsEnforced() {
+        let visibleScreenFrame = NSRect(x: 0, y: 0, width: 2000, height: 1500)
+        // Width below minimum, height valid
+        let requestedSize = NSSize(width: 100, height: 600)
+
+        let (_, contentSize) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: nil,
+            contentSize: requestedSize
+        )
+
+        // Width should be enforced to minimum
+        XCTAssertEqual(contentSize.width, WindowsManager.Constants.minimumPopUpWidth)
+        // Height should remain as requested (valid)
+        XCTAssertEqual(contentSize.height, 600)
+    }
+
+    @MainActor
+    func testWhenOnlyHeightIsBelowMinimum_thenOnlyHeightIsEnforced() {
+        let visibleScreenFrame = NSRect(x: 200, y: -100, width: 2000, height: 1500)
+        // Width valid, height below minimum
+        let requestedSize = NSSize(width: 700, height: 100)
+
+        let (_, contentSize) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: nil,
+            contentSize: requestedSize
+        )
+
+        // Width should remain as requested (valid)
+        XCTAssertEqual(contentSize.width, 700)
+        // Height should be enforced to minimum
+        XCTAssertEqual(contentSize.height, WindowsManager.Constants.minimumPopUpHeight)
+    }
+
+    @MainActor
+    func testWhenContentSizeIsExactlyMinimum_thenSizeIsPreserved() {
+        let visibleScreenFrame = NSRect(x: 0, y: 0, width: 2000, height: 1500)
+        // Request exactly minimum dimensions
+        let requestedSize = NSSize(
+            width: WindowsManager.Constants.minimumPopUpWidth,
+            height: WindowsManager.Constants.minimumPopUpHeight
+        )
+
+        let (_, contentSize) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: nil,
+            contentSize: requestedSize
+        )
+
+        XCTAssertEqual(contentSize.width, WindowsManager.Constants.minimumPopUpWidth)
+        XCTAssertEqual(contentSize.height, WindowsManager.Constants.minimumPopUpHeight)
+    }
+
+    @MainActor
+    func testWhenContentSizeIsValidBetweenMinAndMax_thenSizeIsPreserved() {
+        let visibleScreenFrame = NSRect(x: 100, y: 50, width: 2000, height: 1500)
+        // Request valid size between minimum and screen
+        let requestedSize = NSSize(width: 800, height: 600)
+
+        let (_, contentSize) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: nil,
+            contentSize: requestedSize
+        )
+
+        // Size should be preserved as-is
+        XCTAssertEqual(contentSize.width, 800)
+        XCTAssertEqual(contentSize.height, 600)
+    }
+
+    @MainActor
+    func testWhenContentSizeExceedsScreen_thenSizeIsConstrainedToScreen() {
+        let visibleScreenFrame = NSRect(x: 0, y: 0, width: 800, height: 600)
+
+        let (_, contentSize) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: nil,
+            contentSize: NSSize(width: 2000, height: 1500)
+        )
+
+        XCTAssertEqual(contentSize.width, 800)
+        XCTAssertEqual(contentSize.height, 600)
+    }
+
+    @MainActor
+    func testWhenContentSizeExceedsScreenWithPositiveOrigin_thenSizeIsConstrainedToScreen() {
+        // Small screen with positive origin (secondary monitor scenario)
+        let visibleScreenFrame = NSRect(x: 1920, y: 200, width: 1024, height: 768)
+        // Request popup larger than screen
+        let requestedSize = NSSize(width: 3000, height: 2000)
+
+        let (_, contentSize) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: NSPoint(x: 100, y: 100),
+            contentSize: requestedSize
+        )
+
+        // Should be constrained to screen dimensions
+        XCTAssertEqual(contentSize.width, 1024)
+        XCTAssertEqual(contentSize.height, 768)
+    }
+
+    @MainActor
+    func testWhenContentSizeExceedsVerySmallScreen_thenMinimumIsEnforcedOverScreenSize() {
+        // Very small screen (smaller than minimum popup dimensions)
+        let visibleScreenFrame = NSRect(x: 500, y: 300, width: 400, height: 200)
+        // Request any size (even small)
+        let requestedSize = NSSize(width: 300, height: 150)
+
+        let (_, contentSize) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: NSPoint(x: 50, y: 50),
+            contentSize: requestedSize
+        )
+
+        // Minimum should still be enforced even if larger than screen
+        // Width: min is 512, screen is 400 -> should be 400 (screen wins)
+        XCTAssertEqual(contentSize.width, 400)
+        // Height: min is 258, screen is 200 -> should be 200 (screen wins)
+        XCTAssertEqual(contentSize.height, 200)
+    }
+
+    // MARK: - Dock and Menu Bar Tests
+
+    @MainActor
+    func testWhenScreenHasMenuBarAtTop_thenPopupStaysWithinVisibleFrame() {
+        // Simulate 1920x1080 screen with 25px menu bar at top
+        // visibleFrame in macOS coordinates: y=0 to y=1055 (1080 - 25)
+        let visibleScreenFrame = NSRect(x: 0, y: 0, width: 1920, height: 1055)
+        let contentSize = NSSize(width: 400, height: 300)
+
+        // Request popup at top of screen (y=0 in web coordinates = top of visible frame)
+        let origin = NSPoint(x: 500, y: 0)
+
+        let (droppingPoint, finalContentSize) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: origin,
+            contentSize: contentSize
+        )
+
+        XCTAssertNotNil(droppingPoint)
+        // droppingPoint.y is the TOP edge of the window
+        // It should not exceed visibleScreenFrame.maxY (menu bar boundary)
+        XCTAssertLessThanOrEqual(droppingPoint!.y, visibleScreenFrame.maxY)
+        // The bottom edge should not go below visibleScreenFrame.minY
+        XCTAssertGreaterThanOrEqual(droppingPoint!.y - finalContentSize.height, visibleScreenFrame.minY)
+    }
+
+    @MainActor
+    func testWhenScreenHasDockAtBottom_thenPopupStaysAboveDock() {
+        // Simulate 1920x1080 screen with 75px dock at bottom
+        // visibleFrame: starts at y=75 (dock height), extends to y=1080
+        let visibleScreenFrame = NSRect(x: 0, y: 75, width: 1920, height: 1005)
+        let contentSize = NSSize(width: 400, height: 300)
+
+        // Request popup near bottom of screen (high y in web coordinates = near bottom visually)
+        let origin = NSPoint(x: 500, y: 900)
+
+        let (droppingPoint, finalContentSize) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: origin,
+            contentSize: contentSize
+        )
+
+        XCTAssertNotNil(droppingPoint)
+        // droppingPoint.y is the TOP edge of the window
+        // The bottom edge (droppingPoint.y - height) should not go below visibleScreenFrame.minY (75)
+        XCTAssertGreaterThanOrEqual(droppingPoint!.y - finalContentSize.height, visibleScreenFrame.minY - 1.0)
+    }
+
+    @MainActor
+    func testWhenScreenHasDockOnLeft_thenPopupStaysRightOfDock() {
+        // Simulate 1920x1080 screen with 75px dock on left side
+        // visibleFrame: starts at x=75 (dock width)
+        let visibleScreenFrame = NSRect(x: 75, y: 0, width: 1845, height: 1080)
+        let contentSize = NSSize(width: 400, height: 300)
+
+        // Request popup at far left
+        let origin = NSPoint(x: 0, y: 500)
+
+        let (droppingPoint, finalContentSize) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: origin,
+            contentSize: contentSize
+        )
+
+        XCTAssertNotNil(droppingPoint)
+        // Popup should stay to the right of the dock
+        // The left edge should not go below visibleScreenFrame.minX (75)
+        XCTAssertGreaterThanOrEqual(droppingPoint!.x - finalContentSize.width / 2, visibleScreenFrame.minX - 1.0)
+    }
+
+    @MainActor
+    func testWhenScreenHasDockOnRight_thenPopupStaysLeftOfDock() {
+        // Simulate 1920x1080 screen with 75px dock on right side
+        // visibleFrame: width reduced by 75
+        let visibleScreenFrame = NSRect(x: 0, y: 0, width: 1845, height: 1080)
+        let contentSize = NSSize(width: 400, height: 300)
+
+        // Request popup at far right
+        let origin = NSPoint(x: 1900, y: 500)
+
+        let (droppingPoint, finalContentSize) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: origin,
+            contentSize: contentSize
+        )
+
+        XCTAssertNotNil(droppingPoint)
+        // Popup should stay to the left of the dock
+        // The right edge should not exceed visibleScreenFrame.maxX
+        XCTAssertLessThanOrEqual(droppingPoint!.x + finalContentSize.width / 2, visibleScreenFrame.maxX + 1.0)
+    }
+
+    // MARK: - Screen Boundary Tests
+
+    @MainActor
+    func testWhenPopupExceedsLeftBorder_thenItIsConstrainedToScreen() {
+        // Multi-monitor setup: second screen to the right of main
+        let visibleScreenFrame = NSRect(x: 1920, y: 100, width: 1920, height: 1080)
+        // Request size below minimum to test enforcement
+        let requestedSize = NSSize(width: 100, height: 50)
+
+        // Request popup far to the left of screen origin
+        let origin = NSPoint(x: -500, y: 200)
+
+        let (droppingPoint, finalContentSize) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: origin,
+            contentSize: requestedSize
+        )
+
+        XCTAssertNotNil(droppingPoint)
+        // Minimum dimensions should be enforced
+        XCTAssertGreaterThanOrEqual(finalContentSize.width, WindowsManager.Constants.minimumPopUpWidth)
+        XCTAssertGreaterThanOrEqual(finalContentSize.height, WindowsManager.Constants.minimumPopUpHeight)
+        // Left edge should not go below visibleScreenFrame.minX (1920)
+        let leftEdge = droppingPoint!.x - finalContentSize.width / 2
+        XCTAssertGreaterThanOrEqual(leftEdge, visibleScreenFrame.minX - 1.0)
+        XCTAssertLessThanOrEqual(droppingPoint!.x + finalContentSize.width / 2, visibleScreenFrame.maxX + 1.0)
+    }
+
+    @MainActor
+    func testWhenPopupExceedsRightBorder_thenItIsConstrainedToScreen() {
+        // Screen with negative origin (to the left of main)
+        let visibleScreenFrame = NSRect(x: -1920, y: 50, width: 1920, height: 1080)
+        // Request size below minimum to test enforcement
+        let requestedSize = NSSize(width: 200, height: 100)
+
+        // Request popup far to the right
+        let origin = NSPoint(x: 5000, y: 200)
+
+        let (droppingPoint, finalContentSize) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: origin,
+            contentSize: requestedSize
+        )
+
+        XCTAssertNotNil(droppingPoint)
+        // Minimum dimensions should be enforced
+        XCTAssertGreaterThanOrEqual(finalContentSize.width, WindowsManager.Constants.minimumPopUpWidth)
+        XCTAssertGreaterThanOrEqual(finalContentSize.height, WindowsManager.Constants.minimumPopUpHeight)
+        // Right edge should not exceed visibleScreenFrame.maxX (0)
+        let rightEdge = droppingPoint!.x + finalContentSize.width / 2
+        XCTAssertLessThanOrEqual(rightEdge, visibleScreenFrame.maxX + 1.0)
+        XCTAssertGreaterThanOrEqual(droppingPoint!.x - finalContentSize.width / 2, visibleScreenFrame.minX - 1.0)
+    }
+
+    @MainActor
+    func testWhenPopupExceedsTopBorder_thenItIsConstrainedToScreen() {
+        // Screen with positive Y origin
+        let visibleScreenFrame = NSRect(x: 100, y: 1200, width: 1920, height: 1080)
+        // Request size below minimum to test enforcement
+        let requestedSize = NSSize(width: 300, height: 150)
+
+        // Request popup very near top (y=0 means top in web coordinates)
+        let origin = NSPoint(x: 500, y: 0)
+
+        let (droppingPoint, finalContentSize) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: origin,
+            contentSize: requestedSize
+        )
+
+        XCTAssertNotNil(droppingPoint)
+        // Minimum dimensions should be enforced
+        XCTAssertGreaterThanOrEqual(finalContentSize.width, WindowsManager.Constants.minimumPopUpWidth)
+        XCTAssertGreaterThanOrEqual(finalContentSize.height, WindowsManager.Constants.minimumPopUpHeight)
+        // Top edge should not exceed visibleScreenFrame.maxY
+        XCTAssertLessThanOrEqual(droppingPoint!.y, visibleScreenFrame.maxY + 1.0)
+        // Bottom edge should not go below visibleScreenFrame.minY
+        XCTAssertGreaterThanOrEqual(droppingPoint!.y - finalContentSize.height, visibleScreenFrame.minY - 1.0)
+    }
+
+    @MainActor
+    func testWhenPopupExceedsBottomBorder_thenItIsConstrainedToScreen() {
+        // Screen with negative Y origin
+        let visibleScreenFrame = NSRect(x: 0, y: -1000, width: 1920, height: 900)
+        // Request size below minimum to test enforcement
+        let requestedSize = NSSize(width: 250, height: 200)
+
+        // Request popup near bottom (high y in web coordinates)
+        let origin = NSPoint(x: 500, y: 2000)
+
+        let (droppingPoint, finalContentSize) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: origin,
+            contentSize: requestedSize
+        )
+
+        XCTAssertNotNil(droppingPoint)
+        // Minimum dimensions should be enforced
+        XCTAssertGreaterThanOrEqual(finalContentSize.width, WindowsManager.Constants.minimumPopUpWidth)
+        XCTAssertGreaterThanOrEqual(finalContentSize.height, WindowsManager.Constants.minimumPopUpHeight)
+        // Bottom edge should not go below visibleScreenFrame.minY (-1000)
+        let bottomEdge = droppingPoint!.y - finalContentSize.height
+        XCTAssertGreaterThanOrEqual(bottomEdge, visibleScreenFrame.minY - 1.0)
+        // Top edge should not exceed visibleScreenFrame.maxY
+        XCTAssertLessThanOrEqual(droppingPoint!.y, visibleScreenFrame.maxY + 1.0)
+    }
+
+    @MainActor
+    func testWhenPopupExceedsAllBorders_thenItIsFullyConstrainedToScreen() {
+        // Screen with arbitrary positive origin
+        let visibleScreenFrame = NSRect(x: 500, y: 300, width: 1600, height: 1000)
+        // Request size below minimum to test enforcement
+        let requestedSize = NSSize(width: 150, height: 80)
+
+        // Request popup far outside all borders
+        let origin = NSPoint(x: -1000, y: -500)
+
+        let (droppingPoint, finalContentSize) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: origin,
+            contentSize: requestedSize
+        )
+
+        XCTAssertNotNil(droppingPoint)
+
+        // Minimum dimensions should be enforced even when exceeding all borders
+        XCTAssertGreaterThanOrEqual(finalContentSize.width, WindowsManager.Constants.minimumPopUpWidth)
+        XCTAssertGreaterThanOrEqual(finalContentSize.height, WindowsManager.Constants.minimumPopUpHeight)
+
+        // Validate all edges are within screen bounds
+        let leftEdge = droppingPoint!.x - finalContentSize.width / 2
+        let rightEdge = droppingPoint!.x + finalContentSize.width / 2
+        let topEdge = droppingPoint!.y
+        let bottomEdge = droppingPoint!.y - finalContentSize.height
+
+        XCTAssertGreaterThanOrEqual(leftEdge, visibleScreenFrame.minX - 1.0, "Left edge exceeds screen")
+        XCTAssertLessThanOrEqual(rightEdge, visibleScreenFrame.maxX + 1.0, "Right edge exceeds screen")
+        XCTAssertLessThanOrEqual(topEdge, visibleScreenFrame.maxY + 1.0, "Top edge exceeds screen")
+        XCTAssertGreaterThanOrEqual(bottomEdge, visibleScreenFrame.minY - 1.0, "Bottom edge exceeds screen")
+    }
+
+    @MainActor
+    func testWhenNoOriginProvided_thenDroppingPointIsNil() {
+        let visibleScreenFrame = NSRect(x: -500, y: 200, width: 2000, height: 1500)
+        // Use size above minimum to avoid enforcement
+        let requestedSize = NSSize(width: 600, height: 400)
+
+        let (droppingPoint, contentSize) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: nil,
+            contentSize: requestedSize
+        )
+
+        XCTAssertNil(droppingPoint)
+        XCTAssertEqual(contentSize.width, requestedSize.width)
+        XCTAssertEqual(contentSize.height, requestedSize.height)
+    }
+
+    // MARK: - Coordinate System Tests
+
+    @MainActor
+    func testCoordinateSystemConversion_zeroOriginScreen() {
+        // Test that web coordinates (top-left origin) are correctly converted to AppKit coordinates
+        let visibleScreenFrame = NSRect(x: 0, y: 0, width: 1920, height: 1080)
+        // Use size above minimum to test coordinate math without enforcement side-effects
+        let contentSize = NSSize(width: 600, height: 400)
+
+        // Web coordinates: (100, 50) means 100px from left, 50px from top
+        let webOrigin = NSPoint(x: 100, y: 50)
+
+        let (droppingPoint, _) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: webOrigin,
+            contentSize: contentSize
+        )
+
+        XCTAssertNotNil(droppingPoint)
+        // droppingPoint.x should be center: screenFrame.minX + 100 + 600/2 = 0 + 100 + 300 = 400
+        XCTAssertEqual(droppingPoint!.x, 400, accuracy: 1.0)
+        // droppingPoint.y should be top edge in AppKit: screenFrame.maxY - 50 = 1080 - 50 = 1030
+        XCTAssertEqual(droppingPoint!.y, 1030, accuracy: 1.0)
+    }
+
+    @MainActor
+    func testCoordinateSystemConversion_positiveOriginScreen() {
+        // Test coordinate conversion with screen at positive origin (second monitor)
+        let visibleScreenFrame = NSRect(x: 1920, y: 200, width: 1920, height: 1080)
+        // Use size above minimum to test coordinate math without enforcement side-effects
+        let contentSize = NSSize(width: 600, height: 400)
+
+        // Web coordinates: (150, 100)
+        let webOrigin = NSPoint(x: 150, y: 100)
+
+        let (droppingPoint, _) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: webOrigin,
+            contentSize: contentSize
+        )
+
+        XCTAssertNotNil(droppingPoint)
+        // droppingPoint.x: screenFrame.minX + 150 + 600/2 = 1920 + 150 + 300 = 2370
+        XCTAssertEqual(droppingPoint!.x, 2370, accuracy: 1.0)
+        // droppingPoint.y: screenFrame.maxY - 100 = (200 + 1080) - 100 = 1180
+        XCTAssertEqual(droppingPoint!.y, 1180, accuracy: 1.0)
+    }
+
+    @MainActor
+    func testCoordinateSystemConversion_negativeOriginScreen() {
+        // Test coordinate conversion with screen at negative origin (monitor to the left)
+        let visibleScreenFrame = NSRect(x: -1920, y: -100, width: 1920, height: 1080)
+        // Use size above minimum to test coordinate math without enforcement side-effects
+        let contentSize = NSSize(width: 600, height: 400)
+
+        // Web coordinates: (200, 80)
+        let webOrigin = NSPoint(x: 200, y: 80)
+
+        let (droppingPoint, _) = WindowsManager.calculatePopupFrame(
+            screenFrame: visibleScreenFrame,
+            origin: webOrigin,
+            contentSize: contentSize
+        )
+
+        XCTAssertNotNil(droppingPoint)
+        // droppingPoint.x: screenFrame.minX + 200 + 600/2 = -1920 + 200 + 300 = -1420
+        XCTAssertEqual(droppingPoint!.x, -1420, accuracy: 1.0)
+        // droppingPoint.y: screenFrame.maxY - 80 = (-100 + 1080) - 80 = 900
+        XCTAssertEqual(droppingPoint!.y, 900, accuracy: 1.0)
+    }
+
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1211533323876938?focus=true

Tech Design URL:
N/A

CC:
N/A

### Description
- add shared popup sizing constants and expose calculation helpers for reuse
- clamp requested popup window coordinates/sizes to each display's visible frame
- register new `WindowsManagerPopupTests` exercising extreme origin and size combinations

### Testing Steps
1. Build the macOS app from this branch.
2. Use [popup.html.zip](https://github.com/user-attachments/files/23673761/popup.html.zip) to configure ridiculous popup window sizes/coordinates and validate popup appears within the current display and enforces the minimum 512x258 content size.

### Impact and Risks
**Impact Level: Medium**

#### What could go wrong?
- Popup windows could still slip off-screen on unusual monitor geometries if we missed an edge case.
- Incorrect clamping might shrink legitimate popups too aggressively.
- Regression risk around non-popup windows if parameters are misapplied.

### Quality Considerations
- Edge cases: clamps min/max per axis, handles multi-monitor offsets, honors window.open origin semantics.
- Performance: pure math calculations only; no additional observers or allocations.
- Monitoring/Analytics: N/A.
- Documentation: unit tests describe expected boundary behavior.
- Privacy/Security: unchanged; no new data captured.

### Notes to Reviewer
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clamp popup window size/position to the visible screen via new calculation helpers and add comprehensive unit tests.
> 
> - **WindowsManager (`WindowsManager.swift`)**:
>   - Add `Constants` for popup defaults and minimums (`defaultPopUpWidth/Height`, `minimumPopUpWidth/Height`).
>   - Introduce `calculatePopupFrame(for:origin:contentSize:)` and `calculatePopupFrame(screenFrame:origin:contentSize:)` to compute popup `contentSize` and top-center `droppingPoint`, clamping to `NSScreen.visibleFrame` and enforcing minimums.
>   - Refactor `openPopUpWindow` to use the new helpers.
> - **Unit Tests**:
>   - Add `WindowsManagerPopupTests.swift` with comprehensive tests for size defaults/minimums, screen bounds clamping (including docks/menu bar, multi-monitor), and coordinate conversion.
> - **Project**:
>   - Add test file to `MainWindow` group and include in test targets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17160f7e9b6d910f62235935d77f2cb66f27bc9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->