### PR TITLE
[macOS] Remove feature flag for post-crash session restore prompt

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -113,10 +113,6 @@ public enum MacOSBrowserConfigSubfeature: String, PrivacySubfeature {
     // Import Firefox's bookmarks and new tab shortcuts to better match Firefox's behavior
     case updateFirefoxBookmarksImport
 
-    /// Displays a restore session prompt after the app closes unexpectedly
-    /// https://app.asana.com/1/137249556945/project/72649045549333/task/1208994157946492?focus=true
-    case restoreSessionPrompt
-
     /// https://app.asana.com/1/137249556945/project/1206580121312550/task/1209808389662317?focus=true
     case willSoonDropBigSurSupport
 

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -215,7 +215,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     public let subscriptionUIHandler: SubscriptionUIHandling
 
-    private(set) lazy var sessionRestorePromptCoordinator = SessionRestorePromptCoordinator(pixelFiring: PixelKit.shared, featureFlagger: featureFlagger)
+    private(set) lazy var sessionRestorePromptCoordinator = SessionRestorePromptCoordinator(pixelFiring: PixelKit.shared)
 
     // MARK: - Freemium DBP
     public let freemiumDBPFeature: FreemiumDBPFeature

--- a/macOS/DuckDuckGo/StateRestoration/SessionRestorePromptCoordinator.swift
+++ b/macOS/DuckDuckGo/StateRestoration/SessionRestorePromptCoordinator.swift
@@ -36,13 +36,10 @@ final class SessionRestorePromptCoordinator: SessionRestorePromptCoordinating {
     }
 
     private let pixelFiring: PixelFiring?
-    private let featureFlagger: FeatureFlagger
     private var state: State = .initial
 
-    init(pixelFiring: PixelFiring?,
-         featureFlagger: FeatureFlagger) {
+    init(pixelFiring: PixelFiring?) {
         self.pixelFiring = pixelFiring
-        self.featureFlagger = featureFlagger
     }
 
     func markUIReady() {
@@ -74,7 +71,6 @@ final class SessionRestorePromptCoordinator: SessionRestorePromptCoordinating {
     }
 
     private func showPrompt(with restoreAction: @escaping (Bool) -> Void) {
-        guard featureFlagger.isFeatureOn(.restoreSessionPrompt) else { return }
         state = .promptShown
         let dismissPromptAction = { [weak self] restoreSession in
             self?.state = .promptDismissed

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -186,9 +186,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866720037380
     case openFireWindowByDefault
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866619027311
-    case restoreSessionPrompt
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866473926615
     case duckAISearchParameter
 
@@ -287,7 +284,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .updateSafariBookmarksImport,
                 .updateFirefoxBookmarksImport,
                 .supportsAlternateStripePaymentFlow,
-                .restoreSessionPrompt,
                 .refactorOfSyncPreferences,
                 .subscriptionPurchaseWidePixelMeasurement,
                 .subscriptionRestoreWidePixelMeasurement,
@@ -358,7 +354,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .newTabPageTabIDs,
                 .vpnToolbarUpsell,
                 .supportsAlternateStripePaymentFlow,
-                .restoreSessionPrompt,
                 .openFireWindowByDefault,
                 .duckAISearchParameter,
                 .refactorOfSyncPreferences,
@@ -514,8 +509,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.supportsAlternateStripePaymentFlow))
         case .openFireWindowByDefault:
             return .remoteReleasable(.feature(.openFireWindowByDefault))
-        case .restoreSessionPrompt:
-            return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.restoreSessionPrompt))
         case .duckAISearchParameter:
             return .enabled
         case .subscriptionPurchaseWidePixelMeasurement:


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1211866619027311?focus=true

### Description

This removes the feature flag for the prompt to restore the previous session after a crash.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
Tests in CI:
1. Confirm that PR checks are green.
2. Confirm that [this UI test run](https://github.com/duckduckgo/apple-browsers/actions/runs/19572042773) is green.

Manual test (also covered in UI tests):
1. Build and run a **non-debug** version of the app (the entire flow for the prompt is disabled in `AppStateRestorationManager` for the debug build).
4. Confirm that the session restore prompt appears after you forcibly crash the app or terminate it immediately (e.g. with the stop button in Xcode).

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low: Minor visual changes, small bug fixes, improvement to existing features

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

<img width="356" height="358" alt="Screenshot 2025-11-21 at 13 12 54" src="https://github.com/user-attachments/assets/36e45315-1603-4aa8-886f-ccdaac6c9661" />


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
