### PR TITLE
Enables tabProgressIndicator for Internal Users

### DIFF
--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -561,7 +561,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .pinnedTabsViewRewrite:
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.pinnedTabsViewRewrite))
         case .tabProgressIndicator:
-            return .disabled
+            return .internalOnly()
         case .attributedMetrics:
             return .remoteReleasable(.feature(.attributedMetrics))
         case .vpnConnectionWidePixelMeasurement:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1211972883203644
Tech Design URL:
CC:

### Description
In this PR we're enabling the Tab Spinner Feature Flag for Internal Users

### Testing Steps
1. Install this branch
2. Enable the Internal User flag
3. Relaunch and open any website

- [ ] Verify that the Tab now renders a Spinner during page load
- [ ] Verify the Address Bar Activity Indicator is no longer being presented

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Worst case scenario, the Tab Spinner is enabled, when it shouldn't

### Quality Considerations
Nothing in particular

### Notes to Reviewer
Thank you!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `FeatureFlag.tabProgressIndicator` from disabled to internal-only availability.
> 
> - **Feature flags**:
>   - Change `FeatureFlag.source` for `tabProgressIndicator` from `.disabled` to `.internalOnly()` to enable it for internal users.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e056bd74f7f324b6ad8392f8c4e7cde584543f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->