### PR TITLE
Fix mailto: URL permission prompt not showing on New Tab Page

### DIFF
--- a/.cursor/rules/doc-bot.mdc
+++ b/.cursor/rules/doc-bot.mdc
@@ -58,6 +58,8 @@ Are you about to:
 - Write code? → Call doc_bot first
 - Explain something? → Call doc_bot first  
 - Search for info? → Call doc_bot first
+- Commit/push/create PR? → Call doc_bot first, follow PR template
+- Build/test? → Call doc_bot first for build commands
 - Literally anything? → Call doc_bot first
 
 ### FAILURE RECOVERY

--- a/doc-bot/pull-request-template.md
+++ b/doc-bot/pull-request-template.md
@@ -7,6 +7,15 @@ keywords: ["pull request", "pr", "template", "workflow", "code review", "assignm
 
 # Pull Request Guidelines & Workflow
 
+## 🚨 CRITICAL: Always Open PR URL After Creation
+
+**MANDATORY**: After creating or updating a PR, **IMMEDIATELY** run:
+```bash
+open <PR_URL>
+```
+
+This ensures the PR is accessible and properly formatted in the browser.
+
 ## Objective
 
 - **Maintain a clear and maintainable list** of open PRs in the Apple repositories
@@ -128,11 +137,11 @@ Use pre-defined labels to classify PR intention/state:
 
 ## Pull Request Template
 
-When creating Pull Requests, always follow this template structure:
+**MANDATORY**: When creating Pull Requests, ALWAYS follow this template structure:
 
 ```markdown
-Task/Issue URL: [Insert URL or ask user if not provided]
-Tech Design URL: [Insert URL, N/A, or ask user if not provided for significant changes]
+Task/Issue URL: [Insert URL in current line (not a newline); or ask user if not provided]
+Tech Design URL: [Insert URL in current line; N/A, or ask user if not provided for significant changes]
 CC: [Insert stakeholders or N/A]
 
 ### Description
@@ -181,6 +190,17 @@ CC: [Insert stakeholders or N/A]
 - **Documentation updates** required
 - **Privacy and security** considerations, if applicable
 
+## PR Creation Workflow
+
+**CRITICAL**: After creating or updating a PR, **ALWAYS open the PR URL** in the browser immediately.
+
+### Steps:
+1. Create PR with `gh pr create` or update with `gh pr edit`
+2. **Immediately run**: `open <PR_URL>` (the URL returned by gh command)
+3. Verify the PR appears correctly in the browser
+
+This ensures the PR is accessible and properly formatted.
+
 ## Review Process Best Practices
 
 ### For PR Authors
@@ -203,12 +223,14 @@ CC: [Insert stakeholders or N/A]
 1. Technical reviewer assigned by default
 2. Ready for review → Assign technical reviewer → Ping on Asana
 3. No MM posting required
+4. **Open PR URL in browser**
 
 ### For Tasks:
 1. Pre-agree on reviewer OR use auto-assignment
 2. Assign "Apple-dev" team for auto-assignment
 3. Create Asana task → Assign to reviewer → Ping on Asana
 4. Handle AFK reviewers by reassigning
+5. **Open PR URL in browser**
 
 ### For All PRs:
 1. Use feature flags for safe merging
@@ -217,6 +239,7 @@ CC: [Insert stakeholders or N/A]
 4. Set auto-merge if desired
 5. Follow template requirements
 6. Maintain clean draft PR list
+7. **ALWAYS open PR URL after creation/update**
 
 ---
 

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -599,7 +599,7 @@ final class AddressBarButtonsViewController: NSViewController {
         // since NTP has the address bar focused by default
         let hasRequestedPermission = tabViewModel.usedPermissions.values.contains(where: { $0.isRequested })
         let shouldShowWhileFocused = (tabViewModel.tab.content == .newtab) && hasRequestedPermission
-        
+
         permissionButtons.isShown = (shouldShowWhileFocused || !isTextFieldEditorFirstResponder)
         && !isAnyTrackerAnimationPlaying
         && !tabViewModel.isShowingErrorPage


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1211994371678921
Tech Design URL: N/A
CC: @ayoy

### Description
When pasting a `mailto:` URL into the address bar on the New Tab Page, the external app permission button wasn't visible because permission buttons are hidden when the address bar is focused. Since the NTP has the address bar focused by default, this prevented the permission popover from anchoring properly, resulting in an "orphaned" popover without a visible button.
+ slightly touched Cursor rules to better manage testing & opening PRs

The fix ensures permission buttons are shown on NTP even when the address bar is focused if there's a requested permission (like external scheme), while preserving the original behavior for regular pages where permission buttons remain hidden when the address bar is focused.

### Testing Steps
1. Open a New Tab Page
2. Paste `mailto:test@yahoo.com` into the address bar and press Enter
3. Verify the external app permission button appears in the address bar
4. Verify the permission popover anchors correctly to the button
5. Test on a regular page (e.g., duckduckgo.com) by focusing the address bar
6. Verify permission buttons are still hidden when address bar is focused on regular pages

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- Minimal risk as the change is scoped to NTP only
- Potential edge case: If other permissions are requested on NTP while address bar is focused, they would also show (expected behavior)
- Mitigation: The condition checks both NTP state and requested permission state

### Quality Considerations
- Edge case: Only affects NTP with focused address bar and requested permissions
- Performance: No performance impact, simple boolean checks
- Privacy/security: No privacy or security implications

### Notes to Reviewer
The key change is in `updatePermissionButtons()` where we now check if we're on NTP and have a requested permission before deciding to hide the permission buttons container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show permission buttons on New Tab when a permission is requested even if the address bar is focused; update PR/docs workflow to mandate opening the PR URL and stricter template usage.
> 
> - **macOS UI**:
>   - `AddressBarButtonsViewController.updatePermissionButtons`: Show `permissionButtons` on `newtab` when any `usedPermissions` state is `.isRequested`, even if the address bar is focused; keeps existing guards for animations/error pages.
> - **Docs/Workflow**:
>   - `.cursor/rules/doc-bot.mdc`: Add rules to call doc_bot before commit/push/PR/build/test.
>   - `doc-bot/pull-request-template.md`: Mandate opening PR URL after create/update and enforce inline fields; add explicit PR creation workflow steps and reminders in workflow summaries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b772cf851cf71f9fbcac8841b3d3a7b0e2b6836c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->