### PR TITLE
Fix TabBar height constraint breakage from fire window background changes

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBar.storyboard
+++ b/macOS/DuckDuckGo/TabBar/View/TabBar.storyboard
@@ -35,6 +35,9 @@
                             </visualEffectView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="efe-Pc-ueP" userLabel="Window Dragging View" customClass="WindowDraggingView" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="845" height="38"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="38" id="lYU-Qo-yiT"/>
+                                </constraints>
                             </customView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="G3d-9f-GhJ" userLabel="ShadowView" customClass="TabShadowView" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="845" height="38"/>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1211795906981754

The previous PR #2583 removed the burnerWindowBackgroundView from TabBar.storyboard to move it to NavigationBar. This imageView had top/bottom constraints that indirectly constrained the parent TabBar view to maintain a fixed height of 38 points.

When these constraints were removed, the TabBar lost its height constraint, causing it to change height during window resize operations.

This fix adds an explicit height constraint of 38 points directly to the TabBar view to restore the fixed height behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add an explicit 38pt height constraint to the Tab Bar window-dragging view to restore fixed bar height.
> 
> - **UI (macOS)**:
>   - Enforces fixed height by adding a `38pt` height constraint to the window-dragging view in `macOS/DuckDuckGo/TabBar/View/TabBar.storyboard` (`efe-Pc-ueP`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59124797f355267b448daffe7b83e87e901e132b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->