### PR TITLE
Disables Tab Title Alpha Animations

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -597,7 +597,6 @@ final class TabBarItemCellView: NSView {
     }
 
     func refreshProgressColors(rendered: Bool, url: URL?) {
-        titleView.refreshTitleColorIfNeeded(rendered: rendered, url: url)
         faviconView.refreshSpinnerColorsIfNeeded(rendered: rendered)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1212008179415394?focus=true
Tech Design URL:
CC:

### Description
Based on feedback, we'll be disabling the Tab Title Alpha animations.

### Testing Steps
1. Enable the `tabProgressIndicator` Feature Flag
2. Relaunch
3. Open any tab

- [ ] Verify the Title no longer displays a Fade In animation while it's loading

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing really, this PR disables an animation.

### Quality Considerations
Nothing in particular

### Notes to Reviewer
Thanks in advance!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables tab title alpha fade behavior and removes related color/alpha logic, leaving slide transitions and favicon spinner updates intact.
> 
> - **Tab Title Behavior**:
>   - Remove alpha fade-in/out, initial alpha, and color update logic in `TabTitleView`; delete `ColorAnimation` and `refreshTitleColorIfNeeded`.
>   - Adjust `displayTitleIfNeeded` to use `mustAnimateNewTitleFadeIn` and only fade when host changes; keep slide animations.
> - **Integration**:
>   - Stop calling `titleView.refreshTitleColorIfNeeded` from `TabBarViewItem.refreshProgressColors`; continue `faviconView` spinner color refresh.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aed0173e40e2a29ec4dec70f87274f754fddb505. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->