### PR TITLE
[iOS] remove text zoom feature flag

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -108,9 +108,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866468784743
     case autocompleteTabs
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866711501880
-    case textZoom
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866711151217
     case adAttributionReporting
 
@@ -341,8 +338,7 @@ extension FeatureFlag: FeatureFlagDescribing {
 
     public var supportsLocalOverriding: Bool {
         switch self {
-        case .textZoom,
-             .privacyProAuthV2,
+        case .privacyProAuthV2,
              .scamSiteProtection,
              .maliciousSiteProtection,
              .autocompleteAttributeSupport,
@@ -505,8 +501,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.feature(.autofillSurveys))
         case .autocompleteTabs:
             return .remoteReleasable(.feature(.autocompleteTabs))
-        case .textZoom:
-            return .remoteReleasable(.feature(.textZoom))
         case .adAttributionReporting:
             return .remoteReleasable(.feature(.adAttributionReporting))
         case .dbpRemoteBrokerDelivery:

--- a/iOS/DuckDuckGo/SettingsAccessibilityView.swift
+++ b/iOS/DuckDuckGo/SettingsAccessibilityView.swift
@@ -28,14 +28,12 @@ struct SettingsAccessibilityView: View {
 
     var body: some View {
         List {
-            if viewModel.state.textZoom.enabled {
-                Section(footer: Text(UserText.textZoomDescription)) {
-                    // Text Size
-                    SettingsPickerCellView(useImprovedPicker: viewModel.useImprovedPicker,
-                                           label: UserText.settingsText,
-                                           options: TextZoomLevel.allCases,
-                                           selectedOption: viewModel.textZoomLevelBinding)
-                }
+            Section(footer: Text(UserText.textZoomDescription)) {
+                // Text Size
+                SettingsPickerCellView(useImprovedPicker: viewModel.useImprovedPicker,
+                                       label: UserText.settingsText,
+                                       options: TextZoomLevel.allCases,
+                                       selectedOption: viewModel.textZoomLevelBinding)
             }
 
             if viewModel.state.speechRecognitionAvailable {

--- a/iOS/DuckDuckGo/SettingsState.swift
+++ b/iOS/DuckDuckGo/SettingsState.swift
@@ -32,7 +32,6 @@ struct SettingsState {
     }
     
     struct TextZoom {
-        var enabled: Bool
         var level: TextZoomLevel
     }
 
@@ -127,7 +126,7 @@ struct SettingsState {
             appThemeStyle: .systemDefault,
             appIcon: AppIconManager.shared.appIcon,
             fireButtonAnimation: .fireRising,
-            textZoom: TextZoom(enabled: false, level: .percent100),
+            textZoom: TextZoom(level: .percent100),
             addressBar: AddressBar(enabled: false, position: .top),
             showsFullURL: false,
             isExperimentalAIChatEnabled: false,

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -727,7 +727,7 @@ extension SettingsViewModel {
             appThemeStyle: appSettings.currentThemeStyle,
             appIcon: AppIconManager.shared.appIcon,
             fireButtonAnimation: appSettings.currentFireButtonAnimation,
-            textZoom: SettingsState.TextZoom(enabled: textZoomCoordinator.isEnabled, level: appSettings.defaultTextZoomLevel),
+            textZoom: SettingsState.TextZoom(level: appSettings.defaultTextZoomLevel),
             addressBar: SettingsState.AddressBar(enabled: !isPad, position: appSettings.currentAddressBarPosition),
             showsFullURL: appSettings.showFullSiteAddress,
             isExperimentalAIChatEnabled: experimentalAIChatManager.isExperimentalAIChatSettingsEnabled,
@@ -1300,7 +1300,7 @@ extension SettingsViewModel {
                                                                   object: nil,
                                                                   queue: .main, using: { [weak self] _ in
             guard let self = self else { return }
-            self.state.textZoom = SettingsState.TextZoom(enabled: true, level: self.appSettings.defaultTextZoomLevel)
+            self.state.textZoom = SettingsState.TextZoom(level: self.appSettings.defaultTextZoomLevel)
         })
 
         if #available(iOS 18.2, *) {

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -211,8 +211,7 @@ final class MainCoordinator {
 
     private static func makeTextZoomCoordinator() -> TextZoomCoordinator {
         TextZoomCoordinator(appSettings: AppDependencyProvider.shared.appSettings,
-                            storage: TextZoomStorage(),
-                            featureFlagger: AppDependencyProvider.shared.featureFlagger)
+                            storage: TextZoomStorage()  )
     }
 
     private static func makeWebsiteDataManager(fireproofing: Fireproofing,

--- a/iOS/DuckDuckGoTests/TextZoomTests.swift
+++ b/iOS/DuckDuckGoTests/TextZoomTests.swift
@@ -125,36 +125,12 @@ final class TextZoomTests: XCTestCase {
         XCTAssertEqual(coordinator.textZoomLevel(forHost: host2), AppSettingsMock().defaultTextZoomLevel)
     }
 
-    func testWhenFeatureFlagEnabled_ThenCoordinatorIsEnabled() {
-        let controller = UIViewController()
-        let webView = WKWebView(frame: .zero, configuration: .nonPersistent())
-        webView.setValue(0.1, forKey: viewScaleKey)
-        XCTAssertEqual(0.1, webView.value(forKey: viewScaleKey) as? Double)
-
-        let featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags = [.textZoom]
-        let coordinator: TextZoomCoordinating = makeTextZoomCoordinator(featureFlagger: featureFlagger)
-        XCTAssertTrue(coordinator.isEnabled)
-
-        featureFlagger.enabledFeatureFlags = []
-        XCTAssertFalse(coordinator.isEnabled)
-        
-        coordinator.onNavigationCommitted(applyToWebView: webView)
-        coordinator.onTextZoomChange(applyToWebView: webView)
-        coordinator.onWebViewCreated(applyToWebView: webView)
-        XCTAssertNil(coordinator.makeBrowsingMenuEntry(forLink: makeLink(), inController: controller, forWebView: webView))
-
-        XCTAssertEqual(0.1, webView.value(forKey: viewScaleKey) as? Double)
-    }
-
     private func makeTextZoomCoordinator(
         appSettings: AppSettings = AppSettingsMock(),
-        storage: TextZoomStoring = MockTextZoomStorage(),
-        featureFlagger: FeatureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.textZoom])
+        storage: TextZoomStoring = MockTextZoomStorage()
     ) -> TextZoomCoordinating {
         return TextZoomCoordinator(appSettings: appSettings,
-                                   storage: storage,
-                                   featureFlagger: featureFlagger)
+                                   storage: storage)
     }
 
     private func makeLink(title: String? = "title", url: URL = .ddg, localPath: URL? = nil) -> Link {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1212066539407114?focus=true
Tech Design URL:
CC:

### Description
Remove text zoom feature flag.

### Testing Steps
1. Smoke test text zoom functionality.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Could break text zoom

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the text zoom feature flag and makes text zoom always available; updates settings UI, state model, coordinator, wiring, and tests accordingly.
> 
> - **Feature Flags**:
>   - Remove `FeatureFlag.textZoom` and related `supportsLocalOverriding` and `source` cases in `iOS/Core/FeatureFlag.swift`.
> - **Settings/UI**:
>   - `SettingsAccessibilityView`: always show Text Size section (no flag gating).
>   - `SettingsState.TextZoom`: remove `enabled`; defaults updated.
>   - `SettingsViewModel`: init/state updates and notification observer no longer set `enabled`.
> - **Text Zoom Coordination**:
>   - `TextZoomCoordinator`: remove `featureFlagger` and `isEnabled` checks; always apply zoom; constructor signature updated.
>   - `MainCoordinator`: update `makeTextZoomCoordinator` to new initializer.
> - **Tests**:
>   - Remove feature-flag-based enablement test; update helpers and usages to new coordinator API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 563b4498011dd2ee241eac74bd2a4e2e0516efd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->