### PR TITLE
[macOS] Fix border color for duck.ai togle on the fire window

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -1713,8 +1713,15 @@ final class AddressBarButtonsViewController: NSViewController {
         toggleControl.backgroundColor = NSColor(designSystemColor: .controlsRaisedBackdrop)
         toggleControl.focusedBackgroundColor = NSColor(designSystemColor: .controlsRaisedBackdrop)
         toggleControl.selectionColor = NSColor(designSystemColor: .controlsRaisedFillPrimary)
-        toggleControl.focusBorderColor = theme.colorsProvider.accentPrimaryColor
-        toggleControl.outerBorderColor = NSColor(designSystemColor: .controlsRaisedBackdrop)
+
+        if tabCollectionViewModel.isBurner {
+            toggleControl.focusBorderColor = NSColor.burnerAccent.withAlphaComponent(0.8)
+            toggleControl.outerBorderColor = NSColor.burnerAccent.withAlphaComponent(0.2)
+        } else {
+            toggleControl.focusBorderColor = theme.colorsProvider.accentPrimaryColor
+            toggleControl.outerBorderColor = NSColor(designSystemColor: .controlsRaisedBackdrop)
+        }
+
         toggleControl.outerBorderWidth = 2.0
         toggleControl.selectionInnerBorderColor = NSColor(designSystemColor: .shadowSecondary)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1212069556581084?focus=true

### Description
Fix border color for duck.ai togle on the fire window

### Testing Steps
1. Enable the aiChatOmnibarToggle feature flag
2. Open a fire window
3. Select the address bar and press TAB
4. Check the border color is the same as the address bar border color for the fire window

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Wrong color

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts `CustomToggleControl` border colors to use burner window accents when `tabCollectionViewModel.isBurner` is active.
> 
> - **Theming (macOS Navigation Bar)**
>   - `AddressBarButtonsViewController.applyThemeToToggleControl(_)`:
>     - For burner windows (`tabCollectionViewModel.isBurner`): set `focusBorderColor` to `NSColor.burnerAccent` (0.8 alpha) and `outerBorderColor` to `NSColor.burnerAccent` (0.2 alpha).
>     - Otherwise: retain existing colors (`theme.colorsProvider.accentPrimaryColor` and `designSystemColor: .controlsRaisedBackdrop`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a60d46374b4e48a47f374b3a209a324e46ba17e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->