### PR TITLE
macOS: Revert unwanted feature flag change

### DIFF
--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -326,7 +326,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .blurryAddressBarTahoeFix,
                 .pinnedTabsViewRewrite,
                 .vpnConnectionWidePixelMeasurement,
-                .showHideAIGeneratedImagesSection,
                 .allowPopupsForCurrentPage,
                 .extendedUserInitiatedPopupTimeout,
                 .suppressEmptyPopUpsOnApproval,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1212147936241395?focus=true
Tech Design URL:
CC:

### Description
There was an unwanted change in this PR: https://github.com/duckduckgo/apple-browsers/pull/2561/files#diff-282f6733c6b9d6c752869bb2444019f37317b0c1403d2ec9b3a65ee98aa7ad72, which added a default true a feature flag that was previously removed there.

### Testing Steps
1. Run the application
2. Go to Settings -> AI Features -> The Hide AI-Generated images should be hidden by defaults

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `showHideAIGeneratedImagesSection` from the default-on list so the flag now defaults to off.
> 
> - **Feature Flags**:
>   - Adjust `FeatureFlag.defaultValue`: remove `showHideAIGeneratedImagesSection` from the `true` group, making it default to `false`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cec376bca62b75bc641f71db6796723105ee8dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->