### PR TITLE
[macOS] Fix animation glitch when feedback form resizes

### DIFF
--- a/macOS/DuckDuckGo/Feedback/New/ReportProblemFormView.swift
+++ b/macOS/DuckDuckGo/Feedback/New/ReportProblemFormView.swift
@@ -370,8 +370,9 @@ struct ProblemDetailFormView: View {
     }
 
     private func optionsPills() -> some View {
-        FlexibleView(
-            availableWidth: ReportProblemFormViewController.Constants.width,
+        let horizontalPadding: CGFloat = 24
+        return FlexibleView(
+            availableWidth: ReportProblemFormViewController.Constants.width - (horizontalPadding * 2),
             data: viewModel.availableOptions,
             spacing: 8,
             alignment: .leading
@@ -383,7 +384,7 @@ struct ProblemDetailFormView: View {
                 viewModel.toggleOption(option.id)
             }
         }
-        .padding([.leading, .trailing], 24)
+        .padding([.leading, .trailing], horizontalPadding)
         .padding(.bottom, 24)
         .background(
             GeometryReader { geometry in

--- a/macOS/DuckDuckGo/Feedback/New/RequestNewFeatureFormView.swift
+++ b/macOS/DuckDuckGo/Feedback/New/RequestNewFeatureFormView.swift
@@ -167,8 +167,9 @@ struct RequestNewFeatureFormView: View {
     }
 
     private func featurePills() -> some View {
-        FlexibleView(
-            availableWidth: RequestNewFeatureFormViewController.Constants.width,
+        let horizontalPadding: CGFloat = 24
+        return FlexibleView(
+            availableWidth: RequestNewFeatureFormViewController.Constants.width - (horizontalPadding * 2),
             data: viewModel.availableFeatures,
             spacing: 8,
             alignment: .leading
@@ -182,7 +183,7 @@ struct RequestNewFeatureFormView: View {
                 }
             }
         }
-        .padding([.leading, .trailing], 24)
+        .padding([.leading, .trailing], horizontalPadding)
         .padding(.bottom, 24)
         .background(
             GeometryReader { geometry in


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1212150065648320?focus=true

### Description

Fixes an animation glitch in the feedback forms that appeared with macOS 26. The form width was changing, and that change was being animated in a way that caused a weird jump. This fixes it by providing the correct available width for the option pills (taking into account the view padding) so the form width isn't resized.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Go to Debug -> Remove Internal User State.
2. In the address bar, open the "More" menu -> Send Feedback -> Report a Browser Problem.
3. Select a category.
4. Select and de-select various feedback options and confirm the form width doesn't change or animate.
5. Close the feedback form.
6. In the address bar, open the "More" menu -> Send Feedback -> Request a New Feature.
7. Select and de-select various feedback options and confirm the form width doesn't change or animate.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low: Minor visual changes, small bug fixes, improvement to existing features

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

Before:

https://github.com/user-attachments/assets/97f85cee-8bda-4438-92db-61222de32ea2

After:

https://github.com/user-attachments/assets/bd65f6d8-7729-47dc-aea6-4d4264211379

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts `FlexibleView` `availableWidth` to subtract horizontal padding in both feedback forms, stabilizing layout and stopping width animations during selection.
> 
> - **macOS Feedback Forms**:
>   - **Layout fix for pill sections**:
>     - `ReportProblemFormView` (`optionsPills`): sets `horizontalPadding = 24` and uses `ReportProblemFormViewController.Constants.width - (horizontalPadding * 2)` for `FlexibleView.availableWidth`; applies the same constant for leading/trailing padding.
>     - `RequestNewFeatureFormView` (`featurePills`): mirrors the change using `RequestNewFeatureFormViewController.Constants.width - (horizontalPadding * 2)` and reuses the constant for horizontal padding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f5ceb21c5f6727ce5c4b224a82da1bdbea191d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->