### PR TITLE
Delete visualUpdates feature flags

### DIFF
--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -83,12 +83,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866474590440
     case privacyProAuthV2
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866717504694
-    case visualUpdates
-
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866616568109
-    case visualUpdatesInternalOnly
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866614764239
     case tabCrashDebugging
 
@@ -297,8 +291,7 @@ public enum FeatureFlag: String, CaseIterable {
 extension FeatureFlag: FeatureFlagDescribing {
     public var defaultValue: Bool {
         switch self {
-        case .visualUpdatesInternalOnly,
-                .importChromeShortcuts,
+        case .importChromeShortcuts,
                 .updateSafariBookmarksImport,
                 .updateFirefoxBookmarksImport,
                 .supportsAlternateStripePaymentFlow,
@@ -345,8 +338,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .updatesWontAutomaticallyRestartApp,
                 .privacyProAuthV2,
                 .scamSiteProtection,
-                .visualUpdates,
-                .visualUpdatesInternalOnly,
                 .tabCrashDebugging,
                 .maliciousSiteProtection,
                 .delayedWebviewPresentation,
@@ -470,10 +461,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(SetAsDefaultAndAddToDockSubfeature.scheduledDefaultBrowserAndDockPrompts))
         case .privacyProAuthV2:
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.privacyProAuthV2))
-        case .visualUpdates:
-            return .remoteReleasable(.subfeature(ExperimentalThemingSubfeature.visualUpdates))
-        case .visualUpdatesInternalOnly:
-            return .internalOnly()
         case .tabCrashDebugging:
             return .disabled
         case .delayedWebviewPresentation:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1211866717504694?focus=true
Tech Design URL:
CC:

### Description
Deletes the `visualUpdates` and `visualUpdatesInternalOnly` feature flags

### Testing Steps
1. Run the application
2. Make sure it rusn

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing. The feature flags are not being used.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `visualUpdates` and `visualUpdatesInternalOnly` flags and cleans up related default, override, and source mappings.
> 
> - **Feature flags**:
>   - Remove `visualUpdates` and `visualUpdatesInternalOnly` from `FeatureFlag`.
>   - Clean up references in `defaultValue`, `supportsLocalOverriding`, and `source` switch cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d87558d1808e9fdfa7fcaf8899efedd90adf7cee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->