### PR TITLE
Deduplicate broker names on PIR dashboard

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/UIWeb/DBPUICommunicationModelScanStateExtensions.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/UIWeb/DBPUICommunicationModelScanStateExtensions.swift
@@ -223,7 +223,7 @@ private extension Array where Element == BrokerProfileQueryData {
             return [uiDataBroker] + uiMirrorSites
         }
 
-        let uniqued = brokers.uniqued()
+        let uniqued = brokers.uniqued(on: \.name)
         return uniqued.map { $0 }
     }
 
@@ -249,7 +249,7 @@ private extension Array where Element == BrokerProfileQueryData {
             return [uiDataBroker] + uiMirrorSites
         }
 
-        let uniqued = brokers.uniqued()
+        let uniqued = brokers.uniqued(on: \.name)
         return uniqued.map { $0 }
     }
 

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DBPUICommunicationViewModelScanStateExtensionsTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DBPUICommunicationViewModelScanStateExtensionsTests.swift
@@ -237,6 +237,33 @@ final class DBPUICommunicationViewModelScanStateExtensionsTests: XCTestCase {
         XCTAssertTrue(areDatesEqualsOnDayMonthAndYear(date1: Date().tomorrow, date2: Date(timeIntervalSince1970: result.scanSchedule.nextScan.date)))
     }
 
+    func testWhenLastScansContainDuplicateBrokerNames_thenOnlyOneEntryIsReturned() {
+        let brokerProfileQueryData: [BrokerProfileQueryData] = [
+            .mock(dataBrokerName: "Duplicate Broker", url: "broker1.com", lastRunDate: .nowMinus(hours: 24)),
+            .mock(dataBrokerName: "Duplicate Broker", url: "broker2.com", lastRunDate: .nowMinus(hours: 12)),
+            .mock(dataBrokerName: "Another Broker", url: "broker3.com", lastRunDate: .nowMinus(hours: 6))
+        ]
+
+        let result = DBPUIScanAndOptOutMaintenanceState(from: brokerProfileQueryData)
+
+        XCTAssertEqual(result.scanSchedule.lastScan.dataBrokers.count, 2)
+        XCTAssertEqual(Set(result.scanSchedule.lastScan.dataBrokers.map(\.name)), Set(["Duplicate Broker", "Another Broker"]))
+    }
+
+    func testWhenNextScansContainDuplicateBrokerNames_thenOnlyOneEntryIsReturned() {
+        let tomorrow = Date().tomorrow!
+        let brokerProfileQueryData: [BrokerProfileQueryData] = [
+            .mock(dataBrokerName: "Duplicate Broker", url: "broker1.com", preferredRunDate: tomorrow),
+            .mock(dataBrokerName: "Duplicate Broker", url: "broker2.com", preferredRunDate: tomorrow),
+            .mock(dataBrokerName: "Another Broker", url: "broker3.com", preferredRunDate: tomorrow)
+        ]
+
+        let result = DBPUIScanAndOptOutMaintenanceState(from: brokerProfileQueryData)
+
+        XCTAssertEqual(result.scanSchedule.nextScan.dataBrokers.count, 2)
+        XCTAssertEqual(Set(result.scanSchedule.nextScan.dataBrokers.map(\.name)), Set(["Duplicate Broker", "Another Broker"]))
+    }
+
     func testWhenMirrorSiteIsNotInRemovedPeriod_thenItShouldBeAddedToTotalScans() {
         let brokerProfileQueryWithMirrorSite: BrokerProfileQueryData = .mock(dataBrokerName: "Broker #1", mirrorSites: [.init(name: "mirror", url: "mirror1.com", addedAt: Date(), removedAt: nil)])
         let brokerProfileQueryData: [BrokerProfileQueryData] = [


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211997685068464?focus=true
Tech Design URL:
CC: @THISISDINOSAUR 

### Description

This prevents broker entries with the same name to be sent to FE. Since the code already contains a `uniqued()` call, I assume it’s the intention to handle this duplication there.

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/9a8976cf-b7c8-4f68-9a4a-a4e32b164ec1" />

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. CI passes
2. 

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure last/next scan broker lists are uniqued by broker name and add tests to verify deduplication.
> 
> - **DataBrokerProtectionCore**:
>   - Deduplicate `DBPUIDataBroker` lists by name using `uniqued(on: \.name)` in `uiBrokersSortedByScanLastRunDateWhereScansRanBetween` and `uiBrokersSortedByScanPreferredRunDateWhereDateIsBetween`.
> - **Tests**:
>   - Add tests to assert only one entry per broker name in `lastScan` and `nextScan` data (`testWhenLastScansContainDuplicateBrokerNames_thenOnlyOneEntryIsReturned`, `testWhenNextScansContainDuplicateBrokerNames_thenOnlyOneEntryIsReturned`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c27698dafa3f6231f4ce4ebe3ce1ddfe26cfef8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->