### PR TITLE
Fix flaky HTTPS Upgrade Store test

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/SmarterEncryption/AppHTTPSUpgradeStoreTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/SmarterEncryption/AppHTTPSUpgradeStoreTests.swift
@@ -150,7 +150,7 @@ final class AppHTTPSUpgradeStoreTests: XCTestCase {
         let specification = try JSONDecoder().decode(HTTPSBloomFilterSpecification.self, from: specificationData)
         let bloomData = try Data(contentsOf: Resource.bloomFilter)
 
-        let iterations = 100
+        let iterations = 50
         let queue = DispatchQueue(label: "test.concurrent.writes", attributes: .concurrent)
         let group = DispatchGroup()
 
@@ -178,7 +178,7 @@ final class AppHTTPSUpgradeStoreTests: XCTestCase {
             expectation.fulfill()
         }
 
-        wait(for: [expectation], timeout: 10)
+        wait(for: [expectation], timeout: 30)
         XCTAssertNotNil(testee.loadBloomFilter())
     }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1193060753475688/task/1212214876614923?focus=true
Tech Design URL:
CC:

### Description

This PR reduces the time it takes for the HTTPS upgrade store test to run, reducing the likelihood that it will encounter a timeout. The HTTPS upgrade store was recently updated to serialize its operations internally, making it take slightly longer when being stress tested as much as this unit test does.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI is green
2. Check that the tests pass after many iterations locally

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

None, unit test change only

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tweak HTTPS upgrade store concurrency test by halving iterations and increasing timeout to reduce flakiness.
> 
> - **Tests**:
>   - Update `testConcurrentReadsAndWritesRemainConsistent` in `SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/SmarterEncryption/AppHTTPSUpgradeStoreTests.swift`:
>     - Reduce `iterations` from `100` to `50`.
>     - Increase `wait` timeout from `10` to `30`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cb9c483a34dbd8a4ca1c5f1e4e559f2ac46e27b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->