### PR TITLE
[iOS][Feature Flags] Remove unused onboarding add to dock feature flag

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -96,9 +96,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866468468677
     case onboardingHighlights
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866468574274
-    case onboardingAddToDock
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866711364768
     case autofillSurveys
 
@@ -399,7 +396,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                .syncPromotionBookmarks,
                .syncPromotionPasswords,
                .onboardingHighlights,
-               .onboardingAddToDock,
                .autofillSurveys,
                .autocompleteTabs,
                .adAttributionReporting,
@@ -470,8 +466,6 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .syncPromotionPasswords:
             return .remoteReleasable(.subfeature(SyncPromotionSubfeature.passwords))
         case .onboardingHighlights:
-            return .internalOnly()
-        case .onboardingAddToDock:
             return .internalOnly()
         case .autofillSurveys:
             return .remoteReleasable(.feature(.autofillSurveys))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866468574274?focus=true
Tech Design URL:
CC:

### Description

Removed the unused feature flag for onboarding add to dock from the codebase. The onboarding add-to-dock feature was released to all users a long time ago, so the feature flag is no longer needed.

### Testing Steps
1. The feature flag was not used anywhere in the codebase so ensure only CI is green.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the unused `onboardingAddToDock` feature flag and its references from `iOS/Core/FeatureFlag.swift`.
> 
> - **iOS/Core**:
>   - Remove `FeatureFlag.onboardingAddToDock` enum case in `iOS/Core/FeatureFlag.swift`.
>   - Drop `onboardingAddToDock` from `supportsLocalOverriding`.
>   - Remove `onboardingAddToDock` handling from `source` mapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c268a85b020f76d7800854811579e340edab53e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->