### PR TITLE
[iOS][Feature Flags] Remove PIP Video Tutorial flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -153,10 +153,6 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     // Demonstrative case for default value. Remove once a real-world feature is added
     case intentionallyLocalOnlySubfeatureForTests
 
-    // Shows a PiP video when the user is redirect to the system settings to set DDG as the default browser.
-    // https://app.asana.com/1/137249556945/project/1206329551987282/task/1210806442029191?focus=true
-    case defaultBrowserTutorial
-
     case widgetReporting
 
     // Local inactivity provisional notifications delivered to Notification Center.

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -124,9 +124,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866469645735
     case privacyProAuthV2
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866610578312
-    case setAsDefaultBrowserPiPVideoTutorial
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866470028133
     case experimentalAddressBar
 
@@ -279,7 +276,6 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .canScanUrlBasedSyncSetupBarcodes,
              .canInterceptSyncSetupUrls,
              .supportsAlternateStripePaymentFlow,
-             .setAsDefaultBrowserPiPVideoTutorial,
              .createFireproofFaviconUpdaterSecureVaultInBackground,
              .daxEasterEggLogos,
              .subscriptionPurchaseWidePixelMeasurement,
@@ -319,7 +315,6 @@ extension FeatureFlag: FeatureFlagDescribing {
              .paidAIChat,
              .canInterceptSyncSetupUrls,
              .exchangeKeysToSyncWithAnotherDevice,
-             .setAsDefaultBrowserPiPVideoTutorial,
              .supportsAlternateStripePaymentFlow,
              .personalInformationRemoval,
              .createFireproofFaviconUpdaterSecureVaultInBackground,
@@ -471,8 +466,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(MaliciousSiteProtectionSubfeature.scamProtection))
         case .privacyProAuthV2:
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.privacyProAuthV2))
-        case .setAsDefaultBrowserPiPVideoTutorial:
-            return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.defaultBrowserTutorial))
         case .widgetReporting:
             return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.widgetReporting))
         case .experimentalAddressBar:

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -117,7 +117,7 @@ struct Launching: LaunchingHandling {
         let subscriptionService = SubscriptionService(privacyConfigurationManager: contentBlockingService.common.privacyConfigurationManager, featureFlagger: featureFlagger)
         let maliciousSiteProtectionService = MaliciousSiteProtectionService(featureFlagger: featureFlagger,
                                                                             privacyConfigurationManager: contentBlockingService.common.privacyConfigurationManager)
-        let systemSettingsPiPTutorialService = SystemSettingsPiPTutorialService(featureFlagger: featureFlagger)
+        let systemSettingsPiPTutorialService = SystemSettingsPiPTutorialService()
         let wideEventService = WideEventService(
             wideEvent: AppDependencyProvider.shared.wideEvent,
             featureFlagger: featureFlagger,

--- a/iOS/DuckDuckGo/AppServices/SystemSettingsPiPTutorialService.swift
+++ b/iOS/DuckDuckGo/AppServices/SystemSettingsPiPTutorialService.swift
@@ -39,9 +39,9 @@ final class SystemSettingsPiPTutorialService {
         return (playerView, videoPlayerCoordinator)
     }()
 
-    init(featureFlagger: FeatureFlagger) {
+    init() {
         // Register PiP Video URL providers
-        registerAllURLProviders(featureFlagger: featureFlagger)
+        registerAllURLProviders()
     }
 
 }
@@ -50,13 +50,9 @@ final class SystemSettingsPiPTutorialService {
 
 private extension SystemSettingsPiPTutorialService {
 
-    func registerAllURLProviders(featureFlagger: FeatureFlagger) {
-
+    func registerAllURLProviders() {
         // Register PiP URL Tutorial Provider for 'Set As Default' Browser destination.
-        if featureFlagger.isFeatureOn(.setAsDefaultBrowserPiPVideoTutorial) {
-            manager.register(DefaultBrowserPiPTutorialURLProvider(), for: .defaultBrowser)
-        }
-
+        manager.register(DefaultBrowserPiPTutorialURLProvider(), for: .defaultBrowser)
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1211866610578312?focus=true
Tech Design URL:
CC:

### Description

Removed pip video tutorial feature flag from the codebase. The feature was released to all users a while back and there are no issues, so the feature flag is no longer needed.

### Testing Steps
Prerequisites: **Test it on a real device**.
Smoke tests defined in [Asana](https://github.com/duckduckgo/apple-browsers/pull/1488) and ensure video plays

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the PiP video tutorial feature flag/subfeature and makes the tutorial always registered; updates enums and service initialization accordingly.
> 
> - **Feature flags**:
>   - Remove `FeatureFlag.setAsDefaultBrowserPiPVideoTutorial`, including default value, local override support, and `source` mapping in `iOS/Core/FeatureFlag.swift`.
> - **Privacy config**:
>   - Remove `iOSBrowserConfigSubfeature.defaultBrowserTutorial` from `PrivacyFeature.swift`.
> - **Services**:
>   - `SystemSettingsPiPTutorialService` no longer depends on `FeatureFlagger`; initializes without flags and unconditionally registers `DefaultBrowserPiPTutorialURLProvider()`.
>   - Update `Launching` to construct `SystemSettingsPiPTutorialService()` with no arguments and pass its manager where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07517805ec4f53e66405a46d552c08f08a386974. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->