### PR TITLE
[macOS] Remove importChromeShortcuts feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -105,9 +105,6 @@ public enum MacOSBrowserConfigSubfeature: String, PrivacySubfeature {
     // Demonstrative case for default value. Remove once a real-world feature is added
     case intentionallyLocalOnlySubfeatureForTests
 
-    // Import Chrome's new tab shortcuts when bookmarks are imported
-    case importChromeShortcuts
-
     // Import Safari's bookmarks and favorites to better match Safari's behavior
     case updateSafariBookmarksImport
 

--- a/macOS/DuckDuckGo/DataImport/Logins/Chromium/ChromiumDataImporter.swift
+++ b/macOS/DuckDuckGo/DataImport/Logins/Chromium/ChromiumDataImporter.swift
@@ -30,22 +30,19 @@ internal class ChromiumDataImporter: DataImporter {
     private var source: DataImport.Source {
         profile.browser.importSource
     }
-    private let featureFlagger: FeatureFlagger
 
-    init(profile: DataImport.BrowserProfile, loginImporter: LoginImporter?, bookmarkImporter: BookmarkImporter, faviconManager: FaviconManagement, featureFlagger: FeatureFlagger) {
+    init(profile: DataImport.BrowserProfile, loginImporter: LoginImporter?, bookmarkImporter: BookmarkImporter, faviconManager: FaviconManagement) {
         self.profile = profile
         self.loginImporter = loginImporter
         self.bookmarkImporter = bookmarkImporter
         self.faviconManager = faviconManager
-        self.featureFlagger = featureFlagger
     }
 
-    convenience init(profile: DataImport.BrowserProfile, loginImporter: LoginImporter?, bookmarkImporter: BookmarkImporter, featureFlagger: FeatureFlagger) {
+    convenience init(profile: DataImport.BrowserProfile, loginImporter: LoginImporter?, bookmarkImporter: BookmarkImporter) {
         self.init(profile: profile,
                   loginImporter: loginImporter,
                   bookmarkImporter: bookmarkImporter,
-                  faviconManager: NSApp.delegateTyped.faviconManager,
-                  featureFlagger: featureFlagger)
+                  faviconManager: NSApp.delegateTyped.faviconManager)
     }
 
     var importableTypes: [DataImport.DataType] {
@@ -109,17 +106,13 @@ internal class ChromiumDataImporter: DataImporter {
                 return summary
             }
 
-            var markRootBookmarksAsFavoritesByDefault = true
-            if featureFlagger.isFeatureOn(.importChromeShortcuts) {
-                markRootBookmarksAsFavoritesByDefault = false
-                let newTabShortcuts = fetchShortcutsAsFavorites()
-                FavoritesImportProcessor.mergeBookmarksAndFavorites(bookmarks: &importedBookmarks, favorites: newTabShortcuts)
-            }
+            let newTabShortcuts = fetchShortcutsAsFavorites()
+            FavoritesImportProcessor.mergeBookmarksAndFavorites(bookmarks: &importedBookmarks, favorites: newTabShortcuts)
 
             try updateProgress(.importingBookmarks(numberOfBookmarks: importedBookmarks.numberOfBookmarks,
                                                    fraction: passwordsFraction + dataTypeFraction * 0.5))
 
-            let bookmarksSummary = bookmarkImporter.importBookmarks(importedBookmarks, source: .thirdPartyBrowser(source), markRootBookmarksAsFavoritesByDefault: markRootBookmarksAsFavoritesByDefault, maxFavoritesCount: nil)
+            let bookmarksSummary = bookmarkImporter.importBookmarks(importedBookmarks, source: .thirdPartyBrowser(source), markRootBookmarksAsFavoritesByDefault: false, maxFavoritesCount: nil)
 
             await importFavicons()
 

--- a/macOS/DuckDuckGo/DataImport/Logins/Chromium/YandexDataImporter.swift
+++ b/macOS/DuckDuckGo/DataImport/Logins/Chromium/YandexDataImporter.swift
@@ -26,8 +26,7 @@ final class YandexDataImporter: ChromiumDataImporter {
         super.init(profile: profile,
                    loginImporter: nil,
                    bookmarkImporter: bookmarkImporter,
-                   faviconManager: NSApp.delegateTyped.faviconManager,
-                   featureFlagger: featureFlagger)
+                   faviconManager: NSApp.delegateTyped.faviconManager)
     }
 
     override var importableTypes: [DataImport.DataType] {

--- a/macOS/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
+++ b/macOS/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
@@ -465,8 +465,7 @@ private func dataImporter(for source: DataImport.Source, fileDataType: DataImpor
     case .brave, .chrome, .chromium, .coccoc, .edge, .opera, .operaGX, .vivaldi:
         ChromiumDataImporter(profile: profile,
                              loginImporter: SecureVaultLoginImporter(loginImportState: AutofillLoginImportState()),
-                             bookmarkImporter: CoreDataBookmarkImporter(bookmarkManager: NSApp.delegateTyped.bookmarkManager),
-                             featureFlagger: Application.appDelegate.featureFlagger)
+                             bookmarkImporter: CoreDataBookmarkImporter(bookmarkManager: NSApp.delegateTyped.bookmarkManager))
     case .yandex:
         YandexDataImporter(profile: profile,
                            bookmarkImporter: CoreDataBookmarkImporter(bookmarkManager: NSApp.delegateTyped.bookmarkManager),

--- a/macOS/DuckDuckGo/DataImport/Model/LegacyDataImportViewModel.swift
+++ b/macOS/DuckDuckGo/DataImport/Model/LegacyDataImportViewModel.swift
@@ -465,8 +465,7 @@ private func dataImporter(for source: DataImport.Source, fileDataType: DataImpor
     case .brave, .chrome, .chromium, .coccoc, .edge, .opera, .operaGX, .vivaldi:
         ChromiumDataImporter(profile: profile,
                              loginImporter: SecureVaultLoginImporter(loginImportState: AutofillLoginImportState()),
-                             bookmarkImporter: CoreDataBookmarkImporter(bookmarkManager: NSApp.delegateTyped.bookmarkManager),
-                             featureFlagger: Application.appDelegate.featureFlagger)
+                             bookmarkImporter: CoreDataBookmarkImporter(bookmarkManager: NSApp.delegateTyped.bookmarkManager))
     case .yandex:
         YandexDataImporter(profile: profile,
                            bookmarkImporter: CoreDataBookmarkImporter(bookmarkManager: NSApp.delegateTyped.bookmarkManager),

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -140,9 +140,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866475316806
     case hangReporting
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866476547580
-    case importChromeShortcuts
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866618404342
     case updateSafariBookmarksImport
 
@@ -295,8 +292,7 @@ public enum FeatureFlag: String, CaseIterable {
 extension FeatureFlag: FeatureFlagDescribing {
     public var defaultValue: Bool {
         switch self {
-        case .importChromeShortcuts,
-                .updateSafariBookmarksImport,
+        case .updateSafariBookmarksImport,
                 .updateFirefoxBookmarksImport,
                 .supportsAlternateStripePaymentFlow,
                 .refactorOfSyncPreferences,
@@ -361,7 +357,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .aiChatImprovements,
                 .aiChatKeepSession,
                 .aiChatOmnibarToggle,
-                .importChromeShortcuts,
                 .updateSafariBookmarksImport,
                 .updateFirefoxBookmarksImport,
                 .disableFireAnimation,
@@ -505,8 +500,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.willSoonDropBigSurSupport))
         case .hangReporting:
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.hangReporting))
-        case .importChromeShortcuts:
-            return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.importChromeShortcuts))
         case .updateSafariBookmarksImport:
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.updateSafariBookmarksImport))
         case .updateFirefoxBookmarksImport:

--- a/macOS/UnitTests/DataImport/ChromiumDataImporterTests.swift
+++ b/macOS/UnitTests/DataImport/ChromiumDataImporterTests.swift
@@ -29,8 +29,7 @@ class ChromiumDataImporterTests {
         let loginImporter = MockLoginImporter()
         let faviconManager = FaviconManagerMock()
         let bookmarkImporter = MockBookmarkImporter(importBookmarks: { _, _, _, _ in .init(successful: 1, duplicates: 2, failed: 3) })
-        let featureFlagger = MockFeatureFlagger()
-        let importer = ChromiumDataImporter(profile: .init(browser: .chrome, profileURL: ChromiumBookmarkStore().resourceURL), loginImporter: loginImporter, bookmarkImporter: bookmarkImporter, faviconManager: faviconManager, featureFlagger: featureFlagger)
+        let importer = ChromiumDataImporter(profile: .init(browser: .chrome, profileURL: ChromiumBookmarkStore().resourceURL), loginImporter: loginImporter, bookmarkImporter: bookmarkImporter, faviconManager: faviconManager)
 
         let result = await importer.importData(types: [.bookmarks])
 
@@ -41,8 +40,8 @@ class ChromiumDataImporterTests {
         #expect(bookmarks.failed == 3)
     }
 
-    @Test("Check if only bookmarks are imported and bookmarks bar is favorited after importing bookmarks with feature flag disabled")
-    func whenImportingBookmarks_AndFeatureFlagDisabled_OnlyBookmarksAreMerged_AndBookmarksBarIsFavorited() async throws {
+    @Test("Check if bookmarks and custom shortcuts are merged and bookmarks bar is not favorited after importing bookmarks")
+    func whenImportingBookmarks_BookmarksAndCustomShortcutsAreMerged_AndBookmarksBarIsNotFavorited() async throws {
         var bookmarksToImport: ImportedBookmarks?
         var bookmarksBarMarkedAsFavorites: Bool?
 
@@ -53,30 +52,7 @@ class ChromiumDataImporterTests {
             bookmarksBarMarkedAsFavorites = markBookmarksBarAsFavorites
             return .init(successful: 1, duplicates: 2, failed: 3)
         })
-        let featureFlagger = MockFeatureFlagger()
-        let importer = ChromiumDataImporter(profile: .init(browser: .chrome, profileURL: ChromiumBookmarkStore.customShortcuts.resourceURL), loginImporter: loginImporter, bookmarkImporter: bookmarkImporter, faviconManager: faviconManager, featureFlagger: featureFlagger)
-
-        _ = await importer.importData(types: [.bookmarks])
-
-        #expect(bookmarksToImport?.numberOfBookmarks == 4)
-        #expect(bookmarksBarMarkedAsFavorites == true)
-    }
-
-    @Test("Check if bookmarks and custom shortcuts are merged and bookmarks bar is not favorited after importing bookmarks with feature flag enabled")
-    func whenImportingBookmarks_AndFeatureFlagEnabled_BookmarksAndCustomShortcutsAreMerged_AndBookmarksBarIsNotFavorited() async throws {
-        var bookmarksToImport: ImportedBookmarks?
-        var bookmarksBarMarkedAsFavorites: Bool?
-
-        let loginImporter = MockLoginImporter()
-        let faviconManager = FaviconManagerMock()
-        let bookmarkImporter = MockBookmarkImporter(importBookmarks: { bookmarks, _, markBookmarksBarAsFavorites, _ in
-            bookmarksToImport = bookmarks
-            bookmarksBarMarkedAsFavorites = markBookmarksBarAsFavorites
-            return .init(successful: 1, duplicates: 2, failed: 3)
-        })
-        let featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags.append(.importChromeShortcuts)
-        let importer = ChromiumDataImporter(profile: .init(browser: .chrome, profileURL: ChromiumBookmarkStore.customShortcuts.resourceURL), loginImporter: loginImporter, bookmarkImporter: bookmarkImporter, faviconManager: faviconManager, featureFlagger: featureFlagger)
+        let importer = ChromiumDataImporter(profile: .init(browser: .chrome, profileURL: ChromiumBookmarkStore.customShortcuts.resourceURL), loginImporter: loginImporter, bookmarkImporter: bookmarkImporter, faviconManager: faviconManager)
 
         _ = await importer.importData(types: [.bookmarks])
 
@@ -84,8 +60,8 @@ class ChromiumDataImporterTests {
         #expect(bookmarksBarMarkedAsFavorites == false)
     }
 
-    @Test("Check if bookmarks and top sites shortcuts are merged and bookmarks bar is not favorited after importing bookmarks with feature flag enabled")
-    func whenImportingBookmarks_AndFeatureFlagEnabled_BookmarksAndTopSitesShortcutsAreMerged_AndBookmarksBarIsNotFavorited() async throws {
+    @Test("Check if bookmarks and top sites shortcuts are merged and bookmarks bar is not favorited after importing bookmarks")
+    func whenImportingBookmarks_BookmarksAndTopSitesShortcutsAreMerged_AndBookmarksBarIsNotFavorited() async throws {
         var bookmarksToImport: ImportedBookmarks?
         var bookmarksBarMarkedAsFavorites: Bool?
 
@@ -96,9 +72,7 @@ class ChromiumDataImporterTests {
             bookmarksBarMarkedAsFavorites = markBookmarksBarAsFavorites
             return .init(successful: 1, duplicates: 2, failed: 3)
         })
-        let featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags.append(.importChromeShortcuts)
-        let importer = ChromiumDataImporter(profile: .init(browser: .chrome, profileURL: ChromiumBookmarkStore.topSitesShortcuts.resourceURL), loginImporter: loginImporter, bookmarkImporter: bookmarkImporter, faviconManager: faviconManager, featureFlagger: featureFlagger)
+        let importer = ChromiumDataImporter(profile: .init(browser: .chrome, profileURL: ChromiumBookmarkStore.topSitesShortcuts.resourceURL), loginImporter: loginImporter, bookmarkImporter: bookmarkImporter, faviconManager: faviconManager)
 
         _ = await importer.importData(types: [.bookmarks])
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866476547580

### Description

Remove the `importChromeShortcuts` feature flag and make Chrome shortcuts import permanently enabled.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
Set up Chrome:
1. Create a new Chrome profile if needed.
2. Add at least one bookmark (e.g. visit a site and tap the star to bookmark it).
3. Choose one of the following setup options:
   * Visit several sites and confirm they appear on the New Tab Page, but don’t edit the shortcuts list.
   * Open the New Tab Page and add some shortcuts using the + button or edit the shortcuts list using the “…” menu on each shortcut.
   * Tap “Customize Chrome” in the bottom right corner and disable the “Show shortcuts” setting.
   * Tap “Customize Chrome” in the bottom right corner and select the “Most-visited sites” option.
4. Follow the steps below to test the import.

Test the import:
1. Go to Bookmarks menu > Import bookmarks.
3. Follow the prompts in the UI to import Chrome bookmarks.
4. Confirm your new tab Favorites section shows the same items as the Chrome new tab shortcuts.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

**Low** - This is a feature flag cleanup. The behavior has already been rolled out and enabled by default. No functional change to users.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

- Existing unit tests updated to reflect the new permanent behavior

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Drops the `importChromeShortcuts` feature flag and its plumbing; Chromium bookmark import now always merges New Tab shortcuts and constructors/tests are updated accordingly.
> 
> - **Data Import (Chromium)**:
>   - Remove `FeatureFlagger` dependency from `ChromiumDataImporter` and related initializers; update call sites in `DataImportViewModel` and `LegacyDataImportViewModel`.
>   - Always merge New Tab shortcuts into imported bookmarks via `FavoritesImportProcessor` and set `markRootBookmarksAsFavoritesByDefault` to `false`.
>   - Update `YandexDataImporter` initializer to match parent changes.
> - **Feature Flags / Privacy Config**:
>   - Remove `FeatureFlag.importChromeShortcuts` and `MacOSBrowserConfigSubfeature.importChromeShortcuts`, deleting default/cohort/source mappings and references.
> - **Tests**:
>   - Simplify `ChromiumDataImporterTests` to reflect always-on shortcuts merge; remove flag-dependent setup and assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2619fc5b3ef2175bdbdaa84a6b29bddf9ae2cec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->