### PR TITLE
Fix: Drops deprecated Feature Flag from XCUIApplicationExtension Initializer

### DIFF
--- a/macOS/UITests/Common/XCUIApplicationExtension.swift
+++ b/macOS/UITests/Common/XCUIApplicationExtension.swift
@@ -99,7 +99,7 @@ extension XCUIApplication {
     }
 
     static func setUp(environment: [String: String]? = nil,
-                      featureFlags: [String: Bool] = [:], //"visualUpdates": true],
+                      featureFlags: [String: Bool] = [:],
                       arguments: [String]? = nil) -> XCUIApplication {
         let app = XCUIApplication()
         if let environment {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1212221165750759
Tech Design URL:
CC:

### Description
In this PR we're dropping a flag from a `XCUIApplicationExtension` extension, which is breaking local UI Tests

### Testing Steps
- [ ] Verify the UI Tests can run locally (any suite would do the trick!)

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing really, this change affects the UI Tests target

### Quality Considerations
None

### Notes to Reviewer
Thank you!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the default "visualUpdates" feature flag from `XCUIApplication.setUp` by setting `featureFlags` default to empty.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 219461684a4965788af4f48ab65f75a4d0c0bf48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->