### PR TITLE
[iOS] Remove VPN menu item pixel

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -156,7 +156,6 @@ extension Pixel {
         case browsingMenuAIChatNewTabPage
         case browsingMenuAIChatWebPage
         case browsingMenuRefreshPage
-        case browsingMenuVPN
 
         case addressBarShare
         case addressBarSettings
@@ -1618,7 +1617,6 @@ extension Pixel.Event {
         case .browsingMenuFireproof: return "mb_f"
         case .browsingMenuAutofill: return "m_nav_autofill_menu_item_pressed"
         case .browsingMenuRefreshPage: return "m_menu_refresh_page"
-        case .browsingMenuVPN: return "m_nav_vpn_menu_item_pressed"
 
         case .browsingMenuShare: return "m_browsingmenu_share"
         case .browsingMenuListPrint: return "m_browsing_menu_list_print"

--- a/iOS/DuckDuckGo/Subscription/FreeTrials/VPNSubscriptionPromotionHelper.swift
+++ b/iOS/DuckDuckGo/Subscription/FreeTrials/VPNSubscriptionPromotionHelper.swift
@@ -36,9 +36,6 @@ protocol VPNSubscriptionPromotionHelping {
 
     /// Records when the promo has been shown to the user.
     func subscriptionPromoWasShown()
-
-    /// Fires a pixel when the network protection promotion is tapped by the user.
-    func fireTapPixel()
 }
 
 enum VPNSubscriptionPromotionStatus {
@@ -126,10 +123,5 @@ struct VPNSubscriptionPromotionHelper: VPNSubscriptionPromotionHelping {
     func subscriptionPromoWasShown() {
         guard featureFlagger.isFeatureOn(.vpnMenuItem) else { return }
         freeTrialBadgePersistor.incrementViewCount()
-    }
-
-    /// Fires a pixel when the promotion is tapped by the user.
-    func fireTapPixel() {
-        pixelFiring.fire(.browsingMenuVPN, withAdditionalParameters: ["status": subscriptionPromoStatus.pixelParameter])
     }
 }

--- a/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
@@ -716,7 +716,6 @@ extension TabViewController {
     }
 
     private func onOpenVPNAction(with vpnPromoHelper: VPNSubscriptionPromotionHelper) {
-        vpnPromoHelper.fireTapPixel()
         switch vpnPromoHelper.subscriptionPromoStatus {
         case .promo, .noPromo:
             let urlComponents = vpnPromoHelper.subscriptionURLComponents()

--- a/iOS/DuckDuckGoTests/Subscription/FreeTrials/VPNSubscriptionPromotionHelperTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/FreeTrials/VPNSubscriptionPromotionHelperTests.swift
@@ -131,14 +131,4 @@ final class VPNSubscriptionPromotionHelperTests: XCTestCase {
         XCTAssertEqual(mockFreeTrialBadgePersistor.viewCount, 0)
     }
 
-    func testFireTapPixel() {
-        // When
-        sut.fireTapPixel()
-
-        // Then
-        XCTAssertEqual(PixelFiringMock.allPixelsFired.count, 1)
-        XCTAssertEqual(PixelFiringMock.allPixelsFired.first?.pixelName, Pixel.Event.browsingMenuVPN.name)
-        XCTAssertEqual(PixelFiringMock.lastParams, ["status": "no_pill"])
-    }
-
 }

--- a/iOS/PixelDefinitions/pixels/subscription.json5
+++ b/iOS/PixelDefinitions/pixels/subscription.json5
@@ -382,21 +382,5 @@
                 "type": "string"
             }
         ]
-    },
-    // Defined in https://app.asana.com/1/137249556945/project/72649045549333/task/1211526314174409?focus=true
-    "m_nav_vpn_menu_item_pressed": {
-        "description": "Fires when the VPN menu item in the new tab page menu is pressed",
-        "owners": ["rachelmcr"],
-        "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
-        "parameters": [
-            "appVersion",
-            {
-                "key": "status",
-                "type": "string",
-                "description": "Status associated with the VPN menu item",
-                "enum": ["pill", "no_pill", "subscribed"]
-            }
-        ]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1211666698694126?focus=true

### Description

Removes the temporary pixel from the VPN menu item.

⚠️ I'm double checking in [this comment](https://app.asana.com/1/137249556945/task/1211666698694126/comment/1212219103234854?focus=true) to confirm that we're ready to remove this pixel.

### Testing Steps

1. Open the browser menu on a new tab page.
2. Tap the VPN menu item.
3. Verify the menu item still works correctly.
4. Confirm the VPN menu item pixel is not fired.

### Impact and Risks

None: Internal tooling

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the VPN menu item tap pixel, its enum/definition, firing call, and related tests without changing menu behavior.
> 
> - **Pixels**:
>   - Remove `Pixel.Event.browsingMenuVPN` and its name mapping in `iOS/Core/PixelEvent.swift`.
>   - Delete pixel definition `"m_nav_vpn_menu_item_pressed"` from `iOS/PixelDefinitions/pixels/subscription.json5`.
> - **Subscription/VPN Promo**:
>   - Remove `fireTapPixel()` from `VPNSubscriptionPromotionHelping` protocol and `VPNSubscriptionPromotionHelper` implementation in `iOS/DuckDuckGo/Subscription/FreeTrials/VPNSubscriptionPromotionHelper.swift`.
> - **UI/Menu**:
>   - Stop firing the VPN tap pixel by removing the call in `onOpenVPNAction` within `iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift`.
> - **Tests**:
>   - Remove `testFireTapPixel` from `iOS/DuckDuckGoTests/Subscription/FreeTrials/VPNSubscriptionPromotionHelperTests.swift`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e21d44cff1425738d7518ee7654fe8985a87872f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->