### PR TITLE
[PIR] Fix flaky opt out test

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileJobTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileJobTests.swift
@@ -73,6 +73,7 @@ final class BrokerProfileJobTests: XCTestCase {
         }
 
         job.start()
+        // Uses an extended timeout to allow for WebKit to warm up
         await fulfillment(of: [expectation], timeout: 15)
 
         XCTAssertTrue(job.isFinished)
@@ -102,6 +103,7 @@ final class BrokerProfileJobTests: XCTestCase {
         }
 
         job.start()
+        // Uses an extended timeout to allow for WebKit to warm up
         await fulfillment(of: [expectation], timeout: 15)
 
         XCTAssertTrue(job.isFinished)
@@ -159,6 +161,7 @@ final class BrokerProfileJobTests: XCTestCase {
         }
 
         job.start()
+        // Uses an extended timeout to allow for WebKit to warm up
         await fulfillment(of: [expectation], timeout: 15)
 
         XCTAssertTrue(job.isFinished)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1212231460263998?focus=true
Tech Design URL:
CC:

### Description

This PR attempts to fix a flaky PIR test. The test hits a timeout of 5 seconds, but I can see in one of the failed test run logs that the cold start takes longer than that:

```
[Process] Networking process (0x1370211a0) took 7.875769 seconds to launch
```

The second run passes, as it doesn't hit the same cold start problem. This PR just increases the timeout to something that should work more reliably for this test.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI is green

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase test timeouts from 5s to 15s in `BrokerProfileJobTests` to accommodate WebKit warm-up and reduce flakiness.
> 
> - **Tests**:
>   - Increase `await fulfillment(..., timeout:)` from `5` to `15` seconds (with comment) in three tests within `SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileJobTests.swift` to allow WebKit warm-up:
>     - `testWhenFetchingBrokerProfileQueryDataFails_ThenJobCompletesWithNoOutput`
>     - `testWhenScanDataIsPresent_ThenScanEventsAreCreated`
>     - `testWhenOptOutDataIsPresent_ThenOptOutEventsAreCreated`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7be461ec5fc227b5ca1d6a31a714060e161eeb77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->