### PR TITLE
htang/PixelDefinition/Fix pixel param enum values

### DIFF
--- a/iOS/PixelDefinitions/pixels/vpn_events.json5
+++ b/iOS/PixelDefinitions/pixels/vpn_events.json5
@@ -64,11 +64,13 @@
                 "description": "How the VPN setup or connection was initiated",
                 "enum": ["automatic_on_demand", "manual_by_main_app", "manual_by_the_system"]
             },
+            // As of iOS 7.197.0, `is_setup` uses the normalized values "yes", "no", and "unknown".
+            // Previous versions may still report legacy values ("true", "false").
             {
                 "key": "feature.data.ext.is_setup",
                 "type": "string",
                 "description": "Is the current flow setup or reconnection",
-                "enum": ["yes", "no", "unknown"]
+                "enum": ["yes", "no", "unknown", "true", "false"]
             },
             // Overall latency
             {

--- a/macOS/PixelDefinitions/pixels/vpn_events.json5
+++ b/macOS/PixelDefinitions/pixels/vpn_events.json5
@@ -63,11 +63,13 @@
                 "description": "How the VPN setup or connection was initiated",
                 "enum": ["automatic_on_demand", "manual_by_main_app", "manual_by_the_system"]
             },
+            // As of MacOS 1.167.0, `is_setup` uses the normalized values "yes", "no", and "unknown".
+            // Previous versions may still report legacy values ("true", "false").
             {
                 "key": "feature.data.ext.is_setup",
                 "type": "string",
                 "description": "Is the current flow setup or reconnection",
-                "enum": ["yes", "no", "unknown"]
+                "enum": ["yes", "no", "unknown", "true", "false"]
             },
             {
                 "key": "feature.data.ext.onboarding_status",


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1212238027472841?focus=true

### Description
Fixing `is_setup` value to include legacy “true"/“false” values from legacy versions

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
N/A

### Impact and Risks
None

#### What could go wrong?
None

### Quality Considerations
- Include inline comment to avoid confusion

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expand `feature.data.ext.is_setup` enum to include legacy "true"/"false" for iOS and macOS VPN connection pixels.
> 
> - **Pixels**:
>   - **iOS** (`iOS/PixelDefinitions/pixels/vpn_events.json5`):
>     - Expand `feature.data.ext.is_setup` enum to include `"true"`, `"false"`.
>     - Add version note clarifying normalized vs. legacy values.
>   - **macOS** (`macOS/PixelDefinitions/pixels/vpn_events.json5`):
>     - Expand `feature.data.ext.is_setup` enum to include `"true"`, `"false"`.
>     - Add version note clarifying normalized vs. legacy values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c289163038b262b6b5d18321e18d1abe6781cc6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->