### PR TITLE
[macOS][Feature Flags] Delete openFireWindowAtStartup feature flag

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1107,7 +1107,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
            !urlEventHandlerResult.willOpenWindows && WindowsManager.windows.first(where: { $0 is MainWindow }) == nil {
             // Use startup window preferences if not restoring previous session
             if !startupPreferences.restorePreviousSession {
-                let burnerMode = startupPreferences.startupBurnerMode(featureFlagger: featureFlagger)
+                let burnerMode = startupPreferences.startupBurnerMode()
                 WindowsManager.openNewWindow(burnerMode: burnerMode, lazyLoadTabs: true)
             } else {
                 WindowsManager.openNewWindow(lazyLoadTabs: true)
@@ -1339,7 +1339,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if Application.appDelegate.windowControllersManager.mainWindowControllers.isEmpty,
            case .normal = AppVersion.runType {
             // Use startup window preferences when reopening from dock
-            let burnerMode = startupPreferences.startupBurnerMode(featureFlagger: featureFlagger)
+            let burnerMode = startupPreferences.startupBurnerMode()
             WindowsManager.openNewWindow(burnerMode: burnerMode)
             return true
         }

--- a/macOS/DuckDuckGo/Fire/Model/VisualizeFireSettingsDecider.swift
+++ b/macOS/DuckDuckGo/Fire/Model/VisualizeFireSettingsDecider.swift
@@ -62,23 +62,13 @@ final class DefaultVisualizeFireSettingsDecider: VisualizeFireSettingsDecider {
     }
 
     var isOpenFireWindowByDefaultEnabled: Bool {
-        if featureFlagger.isFeatureOn(.openFireWindowByDefault) {
-            return dataClearingPreferences.shouldOpenFireWindowByDefault
-        } else {
-            return false
-        }
+        return dataClearingPreferences.shouldOpenFireWindowByDefault
     }
 
     var shouldShowOpenFireWindowByDefaultPublisher: AnyPublisher<Bool, Never> {
         dataClearingPreferences.$shouldOpenFireWindowByDefault
-            .map { [weak self] openFireWindowByDefault in
-                guard let self = self else { return true }
-
-                if self.featureFlagger.isFeatureOn(.openFireWindowByDefault) {
-                    return openFireWindowByDefault
-                } else {
-                    return false
-                }
+            .map { openFireWindowByDefault in
+                return openFireWindowByDefault
             }
             .eraseToAnyPublisher()
     }

--- a/macOS/DuckDuckGo/Preferences/Model/DataClearingPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/DataClearingPreferences.swift
@@ -79,10 +79,6 @@ final class DataClearingPreferences: ObservableObject, PreferencesTabOpening {
         featureFlagger.isFeatureOn(.disableFireAnimation)
     }
 
-    var shouldShowOpenFirewindowByDefaultSection: Bool {
-        featureFlagger.isFeatureOn(.openFireWindowByDefault)
-    }
-
     @objc func toggleWarnBeforeClearing() {
         isWarnBeforeClearingEnabled.toggle()
     }

--- a/macOS/DuckDuckGo/Preferences/Model/StartupPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/StartupPreferences.swift
@@ -36,14 +36,13 @@ enum StartupWindowType: String, CaseIterable {
     }
 
     /// Returns the corresponding BurnerMode for this window type
-    /// - Parameter isFeatureEnabled: Whether the fire window by default feature is enabled
     /// - Returns: The appropriate BurnerMode
-    func toBurnerMode(isFeatureEnabled: Bool) -> BurnerMode {
+    func toBurnerMode() -> BurnerMode {
         switch self {
         case .window:
             return .regular
         case .fireWindow:
-            return isFeatureEnabled ? BurnerMode(isBurner: true) : .regular
+            return BurnerMode(isBurner: true)
         }
     }
 }
@@ -177,10 +176,9 @@ final class StartupPreferences: ObservableObject, PreferencesTabOpening {
     }
 
     /// Determines the appropriate BurnerMode for new windows based on startup preferences and feature flags
-    /// - Parameter featureFlagger: The feature flag provider to check if fire window by default is enabled
     /// - Returns: The appropriate BurnerMode for the startup window
-    func startupBurnerMode(featureFlagger: FeatureFlagger) -> BurnerMode {
-        return startupWindowType.toBurnerMode(isFeatureEnabled: featureFlagger.isFeatureOn(.openFireWindowByDefault))
+    func startupBurnerMode() -> BurnerMode {
+        return startupWindowType.toBurnerMode()
     }
 
     func isValidURL(_ text: String) -> Bool {

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesDataClearingView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesDataClearingView.swift
@@ -49,25 +49,23 @@ extension Preferences {
                 }
 
                 // SECTION 2: Fire Window Default
-                if model.shouldShowOpenFirewindowByDefaultSection {
-                    PreferencePaneSection(UserText.fireWindow) {
-                        PreferencePaneSubSection {
-                            ToggleMenuItem(UserText.openFireWindowByDefault, isOn: $model.shouldOpenFireWindowByDefault)
-                                .accessibilityIdentifier("PreferencesDataClearingView.openFireWindowByDefault")
+                PreferencePaneSection(UserText.fireWindow) {
+                    PreferencePaneSubSection {
+                        ToggleMenuItem(UserText.openFireWindowByDefault, isOn: $model.shouldOpenFireWindowByDefault)
+                            .accessibilityIdentifier("PreferencesDataClearingView.openFireWindowByDefault")
 
-                            if model.shouldOpenFireWindowByDefault && startupModel.restorePreviousSession {
-                                VStack(alignment: .leading, spacing: 1) {
-                                    TextMenuItemCaption(UserText.fireWindowSessionRestoreWarning)
-                                    TextButton(UserText.showStartupSettings) {
-                                        model.show(url: .settingsPane(.general))
-                                    }
-                                }
-                                .padding(.leading, 19)
-                            }
-
+                        if model.shouldOpenFireWindowByDefault && startupModel.restorePreviousSession {
                             VStack(alignment: .leading, spacing: 1) {
-                                TextMenuItemCaption(UserText.openFireWindowByDefaultExplanation(newFireWindowShortcut: "⌘N", newRegularWindowShortcut: "⇧⌘N"))
+                                TextMenuItemCaption(UserText.fireWindowSessionRestoreWarning)
+                                TextButton(UserText.showStartupSettings) {
+                                    model.show(url: .settingsPane(.general))
+                                }
                             }
+                            .padding(.leading, 19)
+                        }
+
+                        VStack(alignment: .leading, spacing: 1) {
+                            TextMenuItemCaption(UserText.openFireWindowByDefaultExplanation(newFireWindowShortcut: "⌘N", newRegularWindowShortcut: "⇧⌘N"))
                         }
                     }
                 }

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesGeneralView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesGeneralView.swift
@@ -100,35 +100,30 @@ extension Preferences {
 
                     PreferencePaneSubSection {
                         Picker(selection: $startupModel.restorePreviousSession, content: {
-                            if featureFlagger.isFeatureOn(.openFireWindowByDefault) {
-                                VStack(alignment: .leading, spacing: 4) {
-                                    HStack(spacing: 0) {
-                                        Text(UserText.openANew)
-                                        Picker("", selection: $startupModel.startupWindowType) {
-                                            ForEach(StartupWindowType.allCases, id: \.self) { windowType in
-                                                Text(windowType.displayName).tag(windowType)
-                                                    .accessibilityIdentifier({
-                                                        switch windowType {
-                                                        case .window:
-                                                            "PreferencesGeneralView.stateRestorePicker.openANewWindow.regular"
-                                                        case .fireWindow:
-                                                            "PreferencesGeneralView.stateRestorePicker.openANewWindow.fireWindow"
-                                                        }
-                                                    }())
-                                            }
+                            VStack(alignment: .leading, spacing: 4) {
+                                HStack(spacing: 0) {
+                                    Text(UserText.openANew)
+                                    Picker("", selection: $startupModel.startupWindowType) {
+                                        ForEach(StartupWindowType.allCases, id: \.self) { windowType in
+                                            Text(windowType.displayName).tag(windowType)
+                                                .accessibilityIdentifier({
+                                                    switch windowType {
+                                                    case .window:
+                                                        "PreferencesGeneralView.stateRestorePicker.openANewWindow.regular"
+                                                    case .fireWindow:
+                                                        "PreferencesGeneralView.stateRestorePicker.openANewWindow.fireWindow"
+                                                    }
+                                                }())
                                         }
-                                        .pickerStyle(.menu)
-                                        .fixedSize()
-                                        .disabled(startupModel.restorePreviousSession)
                                     }
+                                    .pickerStyle(.menu)
+                                    .fixedSize()
+                                    .disabled(startupModel.restorePreviousSession)
                                 }
-                                .tag(false)
-                                .padding(.bottom, 4)
-                            } else {
-                                Text(UserText.showHomePage).tag(false)
-                                    .padding(.bottom, 4)
-                                    .accessibilityIdentifier("PreferencesGeneralView.stateRestorePicker.openANewWindow")
                             }
+                            .tag(false)
+                            .padding(.bottom, 4)
+
                             Text(UserText.reopenAllWindowsFromLastSession).tag(true)
                                 .accessibilityIdentifier("PreferencesGeneralView.stateRestorePicker.reopenAllWindowsFromLastSession")
                         }, label: {})

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -170,9 +170,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Note: 'Failsafe' feature flag. See https://app.asana.com/1/137249556945/project/1202500774821704/task/1210572145398078?focus=true
     case supportsAlternateStripePaymentFlow
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866720037380
-    case openFireWindowByDefault
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866473926615
     case duckAISearchParameter
 
@@ -367,7 +364,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .newTabPageTabIDs,
                 .vpnToolbarUpsell,
                 .supportsAlternateStripePaymentFlow,
-                .openFireWindowByDefault,
                 .duckAISearchParameter,
                 .refactorOfSyncPreferences,
                 .newSyncEntryPoints,
@@ -519,8 +515,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(HtmlNewTabPageSubfeature.newTabPageTabIDs))
         case .supportsAlternateStripePaymentFlow:
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.supportsAlternateStripePaymentFlow))
-        case .openFireWindowByDefault:
-            return .remoteReleasable(.feature(.openFireWindowByDefault))
         case .duckAISearchParameter:
             return .enabled
         case .subscriptionPurchaseWidePixelMeasurement:

--- a/macOS/UnitTests/Fire/DefaultVisualizeFireSettingsDeciderTests.swift
+++ b/macOS/UnitTests/Fire/DefaultVisualizeFireSettingsDeciderTests.swift
@@ -98,7 +98,6 @@ final class DefaultVisualizeFireSettingsDeciderTests: XCTestCase {
         let featureFlagger = MockFeatureFlagger()
 
         persistor.shouldOpenFireWindowByDefault = true
-        featureFlagger.enabledFeatureFlags = [.openFireWindowByDefault]
 
         let dataClearingPreferences: DataClearingPreferences = .init(
             persistor: persistor,
@@ -121,30 +120,6 @@ final class DefaultVisualizeFireSettingsDeciderTests: XCTestCase {
         let featureFlagger = MockFeatureFlagger()
 
         persistor.shouldOpenFireWindowByDefault = false
-        featureFlagger.enabledFeatureFlags = [.openFireWindowByDefault]
-
-        let dataClearingPreferences: DataClearingPreferences = .init(
-            persistor: persistor,
-            fireproofDomains: MockFireproofDomains(domains: []),
-            faviconManager: FaviconManagerMock(),
-            windowControllersManager: WindowControllersManagerMock(),
-            featureFlagger: featureFlagger,
-            pixelFiring: nil,
-            aiChatHistoryCleaner: MockAIChatHistoryCleaner()
-        )
-
-        let sut = DefaultVisualizeFireSettingsDecider(featureFlagger: featureFlagger, dataClearingPreferences: dataClearingPreferences)
-
-        XCTAssertFalse(sut.isOpenFireWindowByDefaultEnabled)
-    }
-
-    @MainActor
-    func testWhenFeatureFlagIsOff_thenOpenFireWindowByDefaultIsFalse() {
-        let persistor = MockFireButtonPreferencesPersistor()
-        let featureFlagger = MockFeatureFlagger()
-
-        persistor.shouldOpenFireWindowByDefault = true
-        featureFlagger.enabledFeatureFlags = []
 
         let dataClearingPreferences: DataClearingPreferences = .init(
             persistor: persistor,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1211866720037380?focus=true
Tech Design URL:
CC:

### Description
Delete `openFireWindowAtStartup` feature flag. The feature has been out long enough, so it is time to delete it.

### Testing Steps
1. Make sure that you see the feature in Settings -> General -> On Startup -> Open a New Fire Window
2. Make sure that you see the feature in Settings -> Data Clearing -> Open Fire Window by Default

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `openFireWindowByDefault` feature flag, always honoring the user setting, and simplifies startup burner-mode logic; updates UI, app flow, and tests accordingly.
> 
> - **Feature Flags**:
>   - Delete `FeatureFlag.openFireWindowByDefault` and associated default/source mappings in `FeatureFlag.swift`.
> - **Startup & Fire Window Behavior**:
>   - Simplify `StartupWindowType.toBurnerMode()` to return `.regular` or burner unconditionally (no flag checks).
>   - Update `StartupPreferences.startupBurnerMode()` to drop `featureFlagger` parameter and use `startupWindowType.toBurnerMode()`.
>   - Use new API in `AppDelegate` when opening windows on launch/reopen.
> - **Settings/UI**:
>   - Always show "Open Fire Window by Default" section in `PreferencesDataClearingView` (no flag gating).
>   - Always show startup "Open a New" picker with `StartupWindowType` in `PreferencesGeneralView` (no flag gating).
>   - `VisualizeFireSettingsDecider`: `isOpenFireWindowByDefaultEnabled` and its publisher now mirror `DataClearingPreferences.shouldOpenFireWindowByDefault` directly (no flag checks).
> - **Tests**:
>   - Remove flag-dependent tests; update tests to new `startupBurnerMode()` and decider behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 768bd9d0b488df71523798c7e7ff642e7a8b6a98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->