### PR TITLE
[iOS] [Bugfix] Do not navigate to URL-like autocomplete phrase suggestions

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2521,7 +2521,7 @@ extension MainViewController: BrowserChromeDelegate {
         viewCoordinator.omniBar.cancel()
         switch suggestion {
         case .phrase(phrase: let phrase):
-            if let url = URL.makeSearchURL(query: phrase, useUnifiedLogic: isUnifiedURLPredictionEnabled) {
+            if let url = URL.makeSearchURL(query: phrase, useUnifiedLogic: isUnifiedURLPredictionEnabled, forceSearchQuery: true) {
                 loadUrl(url)
             } else {
                 Logger.lifecycle.error("Couldn't form URL for suggestion: \(phrase, privacy: .public)")


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1212236467730463
Tech Design URL:
CC: @ayoy 

### Description

Forces performing the search for a autocomplete `phrase` result instead of trying to perform navigation.

### Testing Steps
1. Type in `some.weird.url` into address bar and press "go".
2. Verify opening SERP with `some.weird.url` phrase.
3. Type in `some.weird.url` Into address bar. Select suggestion matching the input that's marked with magnifying glass (phrase result).
4. Verify opening SERP with `some.weird.url` phrase.
5. Type in `wikipedia.org` into address bar and press "go".
6. Verify navigation to a wikipedia website.
7. Type in `wikipedia.org` into address bar. Select suggestion matching the input that's marked with magnifying glass (phrase result).
8. Verify opening SERP with `wikipedia.org` phrase.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
9. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Proper links typed directly into search bar are going into SERP instead of navigating to a website. This should not happen as the enforcement is made only for `.phrase` type suggestions, not for direct inputs.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures selecting a phrase autocomplete suggestion always opens a search results page instead of navigating to URL-like inputs.
> 
> - **Autocomplete behavior (iOS)**:
>   - In `iOS/DuckDuckGo/MainViewController.swift`, updates `handleSuggestionSelected` for `.phrase` suggestions to call `URL.makeSearchURL(..., forceSearchQuery: true)` so phrase selections always perform a search rather than navigate to URL-like strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6158728f917485fd7d1f175add75af2ce91863e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->