### PR TITLE
Show Sheet Browsing Menu in popover controller on iPad

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2757,7 +2757,14 @@ extension MainViewController: OmniBarDelegate {
                                             })
         )
 
-        controller.modalPresentationStyle = .pageSheet
+        let isiPad = UIDevice.current.userInterfaceIdiom == .pad
+        controller.modalPresentationStyle = isiPad ? .popover : .pageSheet
+
+        if let popoverController = controller.popoverPresentationController  {
+            popoverController.sourceView = omniBar.barView.menuButton
+            controller.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: 16, right: 0)
+        }
+
         if let sheet = controller.sheetPresentationController {
             sheet.detents = [.medium(), .large()]
             sheet.prefersGrabberVisible = true


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1212228792035796
Tech Design URL:
CC:

### Description

Adjusts presentation of Experimental Browsing Menu to a popover controller on iPad.

### Testing Steps
1. Launch app on iPad. Enable Sheet menu presentation in Appearance Settings.
2. Open browsing menu. Verify it displays in a popover controller or a constant height sheet when in compact size.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
Adaptive size adjustment will be done in upcoming PR.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> On iPad, the experimental browsing menu now presents as a popover anchored to the menu button; on iPhone it remains a page sheet.
> 
> - **UI (iOS)**:
>   - **Browsing Menu Presentation** (`iOS/DuckDuckGo/MainViewController.swift` → `launchSheetBrowsingMenu`):
>     - Use `.popover` on iPad, `.pageSheet` otherwise.
>     - Anchor popover to `omniBar.barView.menuButton` and set `additionalSafeAreaInsets` bottom padding.
>     - Keep sheet detents and grabber when using sheet presentation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cba4e2e21dd6d244d867fe4338bac9667fb9c3ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->