### PR TITLE
Add accessibility identifiers for Maestro tests

### DIFF
--- a/iOS/DuckDuckGo/PrivacyIconView.swift
+++ b/iOS/DuckDuckGo/PrivacyIconView.swift
@@ -269,6 +269,8 @@ class PrivacyIconView: UIView {
             accessibilityTraits = .image
         case .shield, .shieldWithDot, .alert:
             accessibilityIdentifier = "privacy-icon-shield.button"
+            shieldAnimationView.accessibilityIdentifier = "privacy-icon-shield.button"
+            shieldDotAnimationView.accessibilityIdentifier = "privacy-icon-shield.button"
             accessibilityLabel = UserText.privacyIconShield
             accessibilityHint = UserText.privacyIconOpenDashboardHint
             accessibilityTraits = .button


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204099484721401/task/1212216156380627

### Description
Add accessibility identifiers to Lottie animation views to support Maestro UI testing.

### Testing Steps
1. Check [Maestro tests](https://github.com/duckduckgo/apple-browsers/actions/runs/19854501347) are 🥬 

### Impact and Risks
Low

#### What could go wrong?
Minimal risk - only adds accessibility identifiers.

### Notes to Reviewer
Simple change for UI testing support.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets accessibility identifiers on Lottie shield animation views to enable reliable UI testing.
> 
> - **iOS**
>   - `iOS/DuckDuckGo/PrivacyIconView.swift`:
>     - Assign `accessibilityIdentifier = "privacy-icon-shield.button"` to `shieldAnimationView` and `shieldDotAnimationView` when icon is `shield`, `shieldWithDot`, or `alert` to support UI tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0de6c96da1cbe1996cf08b3c11191519d5e1495c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->