### PR TITLE
[macOS] UI tests: Avoid test failure if system dialog is not on screen

### DIFF
--- a/macOS/UITests/DefaultBrowserAndDockPromptsUITests.swift
+++ b/macOS/UITests/DefaultBrowserAndDockPromptsUITests.swift
@@ -53,10 +53,12 @@ final class DefaultBrowserAndDockPromptsUITests: UITestCase {
         app.confirmButton.click()
         XCTAssertTrue(app.inactiveUserPrompt.waitForNonExistence(timeout: UITests.Timeouts.elementExistence), "Inactive user prompt should be dismissed after clicking confirm button")
 
-        // Dismiss the default browser dialog to prevent interference with other tests
+        // Dismiss the default browser dialog, if needed, to prevent interference with other tests
         let coreServicesUIAgent = XCUIApplication(bundleIdentifier: "com.apple.coreservices.uiagent")
         let defaultBrowserDialog = coreServicesUIAgent.dialogs.firstMatch
-        defaultBrowserDialog.buttons.element(boundBy: 1).clickAfterExistenceTestSucceeds()
+        if defaultBrowserDialog.waitForExistence(timeout: UITests.Timeouts.elementExistence) {
+            defaultBrowserDialog.buttons.element(boundBy: 1).click()
+        }
     }
 
     // Note that this test only covers the behavior in the app under test, not the system behavior.


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1212253220675595?focus=true

### Description

This improves the robustness of the "Set as Default/Add to Dock" confirmation UI test. At the end of the test we dismiss the system dialog to prevent it from interfering with other UI tests. However, in some runs on macOS 13 we observed that it didn't appear (apparently because we detected that the app was already set as default there, so the test didn't attempt to set it as default).

We removed macOS 13 from our UI test runs, and confirmed with manual tests that it behaves as expected on macOS 13. However, for the sake of avoiding spurious test failures the test now only tries to dismiss the system dialog if it appears, so it won't fail if the dialog doesn't appear (since we're not trying to test system behavior).

### Testing Steps

Confirm [UI tests in this workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/19858222998) pass.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make dismissal of the system default browser dialog in the UI test conditional on its existence.
> 
> - **UI Tests** (`macOS/UITests/DefaultBrowserAndDockPromptsUITests.swift`):
>   - After confirming the inactive user prompt, check for the system default browser dialog (`com.apple.coreservices.uiagent`) with `waitForExistence(...)` and click the second button only if present.
>   - Update the accompanying comment to indicate conditional dismissal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca140980e9938783fa4ed5973b56772140c94c7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->