### PR TITLE
Enables Tab Progress Indicator Feature Flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -86,6 +86,7 @@ public enum PrivacyFeature: String {
     case duckAiDataClearing
     case serp
     case popupBlocking
+    case tabProgressIndicator
 }
 
 /// An abstraction to be implemented by any "subfeature" of a given `PrivacyConfiguration` feature.

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -544,7 +544,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .scheduledDefaultBrowserAndDockPromptsInactiveUser:
             return .remoteReleasable(.subfeature(SetAsDefaultAndAddToDockSubfeature.scheduledDefaultBrowserAndDockPromptsInactiveUser))
         case .tabProgressIndicator:
-            return .internalOnly()
+            return .remoteReleasable(.feature(.tabProgressIndicator))
         case .attributedMetrics:
             return .remoteReleasable(.feature(.attributedMetrics))
         case .vpnConnectionWidePixelMeasurement:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1212228833025312?focus=true
Tech Design URL:
CC:

### Description
In this PR we're enabling the tabProgressIndicator Feature Flag

### Testing Steps
1. Install the Browser
2. Verify the Progress Indicator shows up in the Favicon area (within the Tab itself)

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
All of the changes gated behind this flag have been already reviewed.

### Quality Considerations
Nothing in particular

### Notes to Reviewer
Thank you!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes `tabProgressIndicator` remotely releasable and adds it to `PrivacyFeature`.
> 
> - **Feature Flags**:
>   - Map `FeatureFlag.tabProgressIndicator` to `remoteReleasable(.feature(.tabProgressIndicator))` (was internal-only).
> - **Privacy Config**:
>   - Add `PrivacyFeature.tabProgressIndicator` case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6747890ae4e52f201ccf33b0f78a7919acab4675. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->