### PR TITLE
htang/Pixel Definition/Fix comment with correct versions

### DIFF
--- a/iOS/PixelDefinitions/pixels/vpn_events.json5
+++ b/iOS/PixelDefinitions/pixels/vpn_events.json5
@@ -64,7 +64,7 @@
                 "description": "How the VPN setup or connection was initiated",
                 "enum": ["automatic_on_demand", "manual_by_main_app", "manual_by_the_system"]
             },
-            // As of iOS 7.197.0, `is_setup` uses the normalized values "yes", "no", and "unknown".
+            // As of iOS 7.198.0, `is_setup` uses the normalized values "yes", "no", and "unknown".
             // Previous versions may still report legacy values ("true", "false").
             {
                 "key": "feature.data.ext.is_setup",

--- a/macOS/PixelDefinitions/pixels/vpn_events.json5
+++ b/macOS/PixelDefinitions/pixels/vpn_events.json5
@@ -63,7 +63,7 @@
                 "description": "How the VPN setup or connection was initiated",
                 "enum": ["automatic_on_demand", "manual_by_main_app", "manual_by_the_system"]
             },
-            // As of MacOS 1.167.0, `is_setup` uses the normalized values "yes", "no", and "unknown".
+            // As of MacOS 1.168.0, `is_setup` uses the normalized values "yes", "no", and "unknown".
             // Previous versions may still report legacy values ("true", "false").
             {
                 "key": "feature.data.ext.is_setup",


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1212269029586404?focus=true

### Description
Minor comment changes

### Testing Steps
N/A

### Impact and Risks
None

#### What could go wrong?
None

### Quality Considerations
N/A

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update comments in `vpn_events.json5` to reflect `is_setup` normalization starting in iOS 7.198.0 and macOS 1.168.0.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b1446291acd26ec6051576b24901d4de86db954. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->