### PR TITLE
fix bug when feature flag is off

### DIFF
--- a/iOS/DuckDuckGo/OmniBarViewController.swift
+++ b/iOS/DuckDuckGo/OmniBarViewController.swift
@@ -675,7 +675,12 @@ class OmniBarViewController: UIViewController, OmniBar {
 
         let largeIcon = dependencies.mobileCustomization.largeIconForButton(state.currentAddressBarButton)
         barView.customizableButton.setImage(largeIcon, for: .normal)
-        barView.isCustomizableButtonHidden = largeIcon == nil
+
+        if self.state.showCustomizableButton {
+            barView.isCustomizableButtonHidden = largeIcon == nil
+        } else {
+            barView.isCustomizableButtonHidden = true
+        }
     }
 
     func onQuerySubmitted() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1212255409190503?focus=true
Tech Design URL:
CC:

### Description
Fixes bug where share button would always be visible.

### Testing Steps
1. Run the app and open a new tab page page - no share button should be visible, go to web page, should be visible
2. Turn on the mobileCustomization feature flag - and repeat step 1. 
3. Change that button to "none" and repeat step 1 but the button should not appear
4. Also check with different buttons (e.g. fire) should not appear on home page but should appear when browsing
5. Disable the flag and re-test step 1

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Could break omni bar?

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure the customizable/share button visibility follows `state.showCustomizableButton` both when mobile customization is disabled and enabled.
> 
> - **OmniBar customization**:
>   - When mobile customization is disabled, set default icon but hide button based on `state.showCustomizableButton` instead of always showing.
>   - When enabled, only show the customizable button if `state.showCustomizableButton` is true and a valid `largeIcon` exists; otherwise hide.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae4aa79239719b2e17004b8ba22987ddaa3df719. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->