### PR TITLE
[macOS][Feature Flags] Create firstTimeQuitSurvey feature flag

### DIFF
--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -279,6 +279,10 @@ public enum FeatureFlag: String, CaseIterable {
     /// Tab closing event recreation (failsafe for removing private API)
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212206087745586?focus=true
     case tabClosingEventRecreation
+
+    /// Shows a survey when quitting the app for the first time in a determined period
+    /// https://app.asana.com/1/137249556945/project/1204006570077678/task/1212242893241885?focus=true
+    case firstTimeQuitSurvey
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -389,7 +393,8 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .allowPopupsForCurrentPage,
                 .popupPermissionButtonPersistence,
                 .webNotifications,
-                .newPermissionView:
+                .newPermissionView,
+                .firstTimeQuitSurvey:
             return true
         case .sslCertificatesBypass,
                 .appendAtbToSerpQueries,
@@ -570,6 +575,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.newPermissionView))
         case .tabClosingEventRecreation:
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.tabClosingEventRecreation))
+        case .firstTimeQuitSurvey:
+            return .disabled
         }
 
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1212242893241885
Tech Design URL:
CC:

### Description
Create the firstTimeQuitSurvey feature flag, disabled by default, and that can be overridden.

### Testing Steps
Nothing to test.

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing.

### Quality Considerations
Nothing.

### Notes to Reviewer
Nothing.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `firstTimeQuitSurvey` feature flag, default off, locally overridable, and mapped to `.disabled` source.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4930730f44180111fbb32c1552dc8ad854ee0b6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->