### PR TITLE
Fix: Unexpected Tab Bar Item Animation on macOS

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -144,6 +144,11 @@ final class TabBarItemCellView: NSView {
         static let trailingSpaceWithPermissionAndButton: CGFloat = 40
     }
 
+    private enum Metrics {
+        static let closeButtonWidth: CGFloat = 16
+        static let closeButtonHeight: CGFloat = 16
+    }
+
     let themeManager: ThemeManaging = NSApp.delegateTyped.themeManager
     var themeUpdateCancellable: AnyCancellable?
 
@@ -211,6 +216,7 @@ final class TabBarItemCellView: NSView {
 
     fileprivate lazy var closeButton = {
         let closeButton = MouseOverButton(image: .close, target: nil, action: #selector(TabBarViewItem.closeButtonAction))
+        closeButton.frame.size = NSSize(width: Metrics.closeButtonWidth, height: Metrics.closeButtonHeight)
         closeButton.bezelStyle = .shadowlessSquare
         closeButton.normalTintColor = .button
         closeButton.mouseDownColor = .buttonMouseDown
@@ -385,6 +391,13 @@ final class TabBarItemCellView: NSView {
 
     override func layout() {
         super.layout()
+
+        withoutAnimation {
+            layout(widthStage: widthStage)
+        }
+    }
+
+    private func layout(widthStage: WidthStage) {
         mouseOverView.frame = bounds
         if theme.tabStyleProvider.isRoundedBackgroundPresentOnHover {
             let padding: CGFloat = 4
@@ -445,7 +458,7 @@ final class TabBarItemCellView: NSView {
         }
         var maxX = bounds.maxX - 9
         if closeButton.isShown {
-            closeButton.frame = NSRect(x: maxX - 16, y: bounds.midY - 8, width: 16, height: 16)
+            closeButton.frame = NSRect(x: maxX - 16, y: bounds.midY - 8, width: Metrics.closeButtonWidth, height: Metrics.closeButtonHeight)
             maxX = closeButton.frame.minX - 4
         } else {
             maxX = max(maxX - 1 /* 28 title offset with favicon */, 12 /* without favicon */)
@@ -528,7 +541,7 @@ final class TabBarItemCellView: NSView {
         }
         if closeButton.isShown {
             // close button appears in place of favicon in compact mode
-            closeButton.frame = NSRect(x: x.rounded(), y: bounds.midY - 8, width: 16, height: 16)
+            closeButton.frame = NSRect(x: x.rounded(), y: bounds.midY - 8, width: Metrics.closeButtonWidth, height: Metrics.closeButtonHeight)
             x = closeButton.frame.maxX + spacing
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1212271405642125?focus=true
Tech Design URL:
CC:

### Description
In this PR we're preventing an unexpected animation in the Tab's `x` button

### Testing Steps
1. Open `Settings > General > On Startup`
2. Make sure `Reopen all windows from last session` is enabled
3. Open 3 Tabs
4. Quit + Relaunch
5. Press `CMD + ]` to switch across Tabs

- [ ] Verify the `x` button doesn't get an unexpected animation

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
In the worst case scenario, we no longer animate a TabBar subview we actually should

### Quality Considerations
Nothing in particular

### Notes to Reviewer
Thank you!!

### Demo: Before
https://github.com/user-attachments/assets/d631acc9-e25b-4f40-aca5-3a13d1768150

### Demo: Now
https://github.com/user-attachments/assets/7215d3a9-0b61-4c95-b108-15005b43c85e

## Details
Root cause of this issue is `TabBarCollectionView.scrollToSelected()`, which triggers a layout pass within an animation context.

<img width="427" height="778" src="https://github.com/user-attachments/assets/f6e588d0-e583-475d-9ca9-b99939228e0f" />


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops unintended close-button animations by running `layout` without animations and centralizes close button size via `Metrics`.
> 
> - **Tab bar layout (`macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift`)**:
>   - Run `layout(widthStage:)` inside `withoutAnimation` to prevent unintended animations.
>   - Extracted `layout(widthStage:)` from `layout()` for clarity.
>   - Introduced `Metrics` with `closeButtonWidth/Height` and applied to `closeButton` initialization and frame calculations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ef87300f55caa29d7ff61eff2e66176e27cb77a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->