### PR TITLE
Fix UI tests for fire window at startup

### DIFF
--- a/macOS/UITests/FireWindowByDefaultTests.swift
+++ b/macOS/UITests/FireWindowByDefaultTests.swift
@@ -24,7 +24,7 @@ class FireWindowByDefaultTests: UITestCase {
         continueAfterFailure = false
 
         // Assume feature flag is on by default
-        app = XCUIApplication.setUp(featureFlags: ["openFireWindowByDefault": true])
+        app = XCUIApplication.setUp()
 
         app.enforceSingleWindow()
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1212272758492073?focus=true
Tech Design URL:
CC:

### Description
Fixes a crash in the `FireWindowByDefaultTests` UI tests

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stop passing the `openFireWindowByDefault` feature flag in `setUp` and use default app setup for these UI tests.
> 
> - **macOS UI Tests**:
>   - Update `FireWindowByDefaultTests.setUpWithError` to use `XCUIApplication.setUp()` without the `openFireWindowByDefault` feature flag override.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 581d1c312aac2ce2566e0c35e97ac40a97b9de1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->