### PR TITLE
[macOS] Time out the UI test run if the app fails to launch

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1701,7 +1701,6 @@ private extension FeatureFlagLocalOverrides {
             if currentValue(for: featureFlag)! != value {
                 toggleOverride(for: featureFlag)
             }
-            fatalError("Simulate fatalError when applying feature flags")
         }
     }
 

--- a/macOS/UITests/Common/XCUIApplicationExtension.swift
+++ b/macOS/UITests/Common/XCUIApplicationExtension.swift
@@ -117,7 +117,7 @@ extension XCUIApplication {
 
         // Fail early if the app isn't able to launch:
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 60), "App did not reach runningForeground within 60s")
-        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10), "No window appeared after launch")
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 30), "No window appeared after launch")
 
         return app
     }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1212273567661378?focus=true
Tech Design URL:
CC:

### Description

This PR updates the macOS UI tests to time out early if the app fails to run.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Confirm that UI tests in [this workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/19875759148) failed (some are marked as success even though they did fail - not sure why that is yet, but it's not related to this branch)
2. TODO: Add a successful UI test run after removing the forced crash

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
4. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add fail-fast assertions in `XCUIApplication.setUp` to ensure the app reaches `.runningForeground` and a window appears after launch.
> 
> - **macOS UI tests**:
>   - Update `XCUIApplicationExtension.setUp` to assert app launch readiness:
>     - Wait for `.runningForeground` (60s) and first window existence (30s) post `app.launch()`; fail early if not met.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74f3662d9b298222d0ccffe3f32dc6df3743a919. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->