### PR TITLE
fix contextual onboarding bug

### DIFF
--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -616,7 +616,7 @@ final class BrowserTabViewController: NSViewController {
             // we mark the flag for dialog dismissed
             wasContextualOnboardingDialogDismissed = true
             delegate?.dismissViewHighlight()
-            removeExistingDialog()
+            self.removeChild(in: self.containerStackView, webViewContainer: webViewContainer)
             if let lastDialog = onboardingDialogTypeProvider.lastDialog {
                 self.onboardingPixelReporter.measureDialogDismissed(dialogType: lastDialog)
             }
@@ -1770,7 +1770,7 @@ private extension NSViewController {
         animateStackViewChanges(stackView)
     }
 
-    func removeChild(in stackView: NSStackView, webViewContainer: NSView) {
+    func removeChild(in stackView: NSStackView, webViewContainer: NSView?) {
         stackView.arrangedSubviews.filter({ $0 != webViewContainer }).forEach {
             stackView.removeArrangedSubview($0)
             $0.removeFromSuperview()


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210379416433601/task/1212259536816548?focus=true

### Description Fix a bug where when user dismiss a contxtual dialog while navigating from NTP to a site (after NTP is gone and before the website is loaded) cause the site not to load (or the view to be resized in case of a follow up dialog).
This seems to be caused by the addition of `delayedWebviewPresentation`

### Testing Steps
1. Go to debug -> reset Data -> reset contextual onoarding
2. Open a new tab you should see the first dialog
3. Visit a site and after NTP is gone and before the website is loaded dismiss the dialog
4. The dialog should be dismissed and the site should still be loaded
5. Generally smoke test the contextual onboarding

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Could disrupt the contextual onboarding
Could disrupt navigation during contextual onboarding

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 380ffe6750f9ed3ec32d41570ee80e1bfd9cc1ff. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY —>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes contextual onboarding dismissal by safely removing the dialog and tweaks web view container sizing to prevent layout issues.
> 
> - **Contextual Onboarding**:
>   - Use a single `onDismissAction` closure to mark dismissal, clear highlights, safely remove the dialog with `removeChild(in:webViewContainer:)`, and record dismissal via `onboardingPixelReporter`.
>   - Update `removeChild(in:webViewContainer:)` to accept `NSView?` to avoid crashes when `webViewContainer` is nil.
> - **Layout/Hierarchy**:
>   - In `addWebViewToViewHierarchy(_:, tab:)`, set `webViewContainer` vertical hugging to `.defaultLow` and compression resistance to `.defaultHigh`.
>   - Change `containerStackView.distribution` from `fillProportionally` to `fill` to prevent unintended resizing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce22dd8559041dc5a42f1a2159ef90c5b13705b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->