### PR TITLE
Revert "[macOS] Add entitlements for adding the app to the dock"

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -321,7 +321,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var didFinishLaunching = false
 
     var updateController: UpdateController!
+#if SPARKLE
     var dockCustomization: DockCustomization?
+#endif
 
     @UserDefaultsWrapper(key: .firstLaunchDate, defaultValue: Date.monthAgo)
     static var firstLaunchDate: Date
@@ -1083,7 +1085,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // MARK: perform first time launch logic here
         }
 
+        #if SPARKLE
         dockCustomization = DockCustomizer()
+        #endif
 
         let statisticsLoader = AppVersion.runType.requiresEnvironment ? StatisticsLoader.shared : nil
         statisticsLoader?.load()
@@ -1252,7 +1256,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func fireDailyActiveUserPixels() {
         PixelKit.fire(NonStandardEvent(GeneralPixel.dailyActiveUser), frequency: .legacyDaily)
         PixelKit.fire(NonStandardEvent(GeneralPixel.dailyDefaultBrowser(isDefault: defaultBrowserPreferences.isDefault)), frequency: .daily)
+#if SPARKLE
         PixelKit.fire(NonStandardEvent(GeneralPixel.dailyAddedToDock(isAddedToDock: DockCustomizer().isAddedToDock)), frequency: .daily)
+#endif
     }
 
     private func fireDailyFireWindowConfigurationPixels() {

--- a/macOS/DuckDuckGo/Application/DockCustomizer.swift
+++ b/macOS/DuckDuckGo/Application/DockCustomizer.swift
@@ -21,7 +21,6 @@ import Combine
 import Common
 import os.log
 import Persistence
-import AppKit
 
 protocol DockCustomization {
     var isAddedToDock: Bool { get }
@@ -64,7 +63,7 @@ final class DockCustomizer: DockCustomization {
         startTimer()
     }
 
-    private var dockPlistURL: URL = URL.nonSandboxLibraryDirectoryURL.appending("Preferences/com.apple.dock.plist")
+    private var dockPlistURL: URL = URL(fileURLWithPath: NSString(string: "~/Library/Preferences/com.apple.dock.plist").expandingTildeInPath)
 
     private var dockPlistDict: [String: AnyObject]? {
         return NSDictionary(contentsOf: dockPlistURL) as? [String: AnyObject]
@@ -170,36 +169,10 @@ final class DockCustomizer: DockCustomization {
     }
 
     private func restartDock() {
-        let bundleID = "com.apple.dock"
-        var targetDesc = AEAddressDesc()
-        var event = AppleEvent()
-        var reply = AppleEvent()
-
-        // Create target descriptor for the Dock using bundle identifier
-        var status = AECreateDesc(
-            typeApplicationBundleID,
-            bundleID,
-            bundleID.utf8.count,
-            &targetDesc
-        )
-        guard status == noErr else { return }
-        defer { AEDisposeDesc(&targetDesc) }
-
-        // Create the quit application event
-        status = AECreateAppleEvent(
-            kCoreEventClass,
-            kAEQuitApplication,
-            &targetDesc,
-            AEReturnID(kAutoGenerateReturnID),
-            AETransactionID(kAnyTransactionID),
-            &event
-        )
-        guard status == noErr else { return }
-        defer { AEDisposeDesc(&event) }
-
-        // Send the event (no reply needed)
-        _ = AESendMessage(&event, &reply, AESendMode(kAENoReply), kAEDefaultTimeout)
-        AEDisposeDesc(&reply)
+        let task = Process()
+        task.launchPath = "/usr/bin/killall"
+        task.arguments = ["Dock"]
+        task.launch()
     }
 
     private func makeAppURLs(from persistentApps: [[String: AnyObject]]) -> [URL] {

--- a/macOS/DuckDuckGo/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptCoordinator.swift
+++ b/macOS/DuckDuckGo/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptCoordinator.swift
@@ -150,6 +150,7 @@ final class DefaultBrowserAndDockPromptCoordinator: DefaultBrowserAndDockPrompt 
     private let dockCustomization: DockCustomization
     private let defaultBrowserProvider: DefaultBrowserProvider
     private let pixelFiring: PixelFiring?
+    private let isSparkleBuild: Bool
     private let isOnboardingCompleted: () -> Bool
     private let dateProvider: () -> Date
     private let notificationPresenter: DefaultBrowserAndDockPromptNotificationPresenting?
@@ -161,6 +162,7 @@ final class DefaultBrowserAndDockPromptCoordinator: DefaultBrowserAndDockPrompt 
         isOnboardingCompleted: @escaping () -> Bool,
         dockCustomization: DockCustomization = DockCustomizer(),
         defaultBrowserProvider: DefaultBrowserProvider = SystemDefaultBrowserProvider(),
+        applicationBuildType: ApplicationBuildType = StandardApplicationBuildType(),
         pixelFiring: PixelFiring? = PixelKit.shared,
         dateProvider: @escaping () -> Date = Date.init
     ) {
@@ -169,6 +171,7 @@ final class DefaultBrowserAndDockPromptCoordinator: DefaultBrowserAndDockPrompt 
         self.isOnboardingCompleted = isOnboardingCompleted
         self.dockCustomization = dockCustomization
         self.defaultBrowserProvider = defaultBrowserProvider
+        self.isSparkleBuild = applicationBuildType.isSparkleBuild
         self.pixelFiring = pixelFiring
         self.dateProvider = dateProvider
         self.notificationPresenter = notificationPresenter
@@ -200,14 +203,18 @@ final class DefaultBrowserAndDockPromptCoordinator: DefaultBrowserAndDockPrompt 
         let isDefaultBrowser = defaultBrowserProvider.isDefault
         let isAddedToDock = dockCustomization.isAddedToDock
 
-        if isDefaultBrowser && isAddedToDock {
-            return nil
-        } else if isDefaultBrowser && !isAddedToDock {
-            return .addToDockPrompt
-        } else if !isDefaultBrowser && isAddedToDock {
-            return .setAsDefaultPrompt
+        if isSparkleBuild {
+            if isDefaultBrowser && isAddedToDock {
+                return nil
+            } else if isDefaultBrowser && !isAddedToDock {
+                return .addToDockPrompt
+            } else if !isDefaultBrowser && isAddedToDock {
+                return .setAsDefaultPrompt
+            } else {
+                return .bothDefaultBrowserAndDockPrompt
+            }
         } else {
-            return .bothDefaultBrowserAndDockPrompt
+            return isDefaultBrowser ? nil : .setAsDefaultPrompt
         }
     }
 

--- a/macOS/DuckDuckGo/DuckDuckGoAppStore.entitlements
+++ b/macOS/DuckDuckGo/DuckDuckGoAppStore.entitlements
@@ -53,14 +53,6 @@
 		<string>$(DBP_BACKGROUND_AGENT_BUNDLE_ID)</string>
 		<string>$(AGENT_BUNDLE_ID)</string>
 	</array>
-	<key>com.apple.security.temporary-exception.files.home-relative-path.read-write</key>
-	<array>
-		<string>/Library/Preferences/com.apple.dock.plist</string>
-	</array>
-	<key>com.apple.security.temporary-exception.apple-events</key>
-	<array>
-		<string>com.apple.dock</string>
-	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(DBP_APP_GROUP)</string>

--- a/macOS/DuckDuckGo/DuckDuckGoAppStoreAlpha.entitlements
+++ b/macOS/DuckDuckGo/DuckDuckGoAppStoreAlpha.entitlements
@@ -51,14 +51,6 @@
 		<string>$(DBP_BACKGROUND_AGENT_BUNDLE_ID)</string>
 		<string>$(AGENT_BUNDLE_ID)</string>
 	</array>
-	<key>com.apple.security.temporary-exception.files.home-relative-path.read-write</key>
-	<array>
-		<string>/Library/Preferences/com.apple.dock.plist</string>
-	</array>
-	<key>com.apple.security.temporary-exception.apple-events</key>
-	<array>
-		<string>com.apple.dock</string>
-	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(DBP_APP_GROUP)</string>

--- a/macOS/DuckDuckGo/DuckDuckGoAppStoreCI.entitlements
+++ b/macOS/DuckDuckGo/DuckDuckGoAppStoreCI.entitlements
@@ -26,14 +26,6 @@
 	<true/>
 	<key>com.apple.security.print</key>
 	<true/>
-	<key>com.apple.security.temporary-exception.files.home-relative-path.read-write</key>
-	<array>
-		<string>/Library/Preferences/com.apple.dock.plist</string>
-	</array>
-	<key>com.apple.security.temporary-exception.apple-events</key>
-	<array>
-		<string>com.apple.dock</string>
-	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>

--- a/macOS/DuckDuckGo/DuckDuckGoAppStoreDebug.entitlements
+++ b/macOS/DuckDuckGo/DuckDuckGoAppStoreDebug.entitlements
@@ -51,14 +51,6 @@
 		<string>$(DBP_BACKGROUND_AGENT_BUNDLE_ID)</string>
 		<string>$(AGENT_BUNDLE_ID)</string>
 	</array>
-	<key>com.apple.security.temporary-exception.files.home-relative-path.read-write</key>
-	<array>
-		<string>/Library/Preferences/com.apple.dock.plist</string>
-	</array>
-	<key>com.apple.security.temporary-exception.apple-events</key>
-	<array>
-		<string>com.apple.dock</string>
-	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(DBP_APP_GROUP)</string>

--- a/macOS/DuckDuckGo/DuckDuckGoAppStoreReview.entitlements
+++ b/macOS/DuckDuckGo/DuckDuckGoAppStoreReview.entitlements
@@ -51,14 +51,6 @@
 		<string>$(DBP_BACKGROUND_AGENT_BUNDLE_ID)</string>
 		<string>$(AGENT_BUNDLE_ID)</string>
 	</array>
-	<key>com.apple.security.temporary-exception.files.home-relative-path.read-write</key>
-	<array>
-		<string>/Library/Preferences/com.apple.dock.plist</string>
-	</array>
-	<key>com.apple.security.temporary-exception.apple-events</key>
-	<array>
-		<string>com.apple.dock</string>
-	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(DBP_APP_GROUP)</string>

--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -491,7 +491,11 @@ final class MainMenu: NSMenu {
     override func update() {
         super.update()
 
+#if SPARKLE
         addToDockMenuItem.isHidden = dockCustomizer.isAddedToDock
+#else
+        addToDockMenuItem.isHidden = true
+#endif
         setAsDefaultMenuItem.isHidden = defaultBrowserPreferences.isDefault
 
         // To be safe, hide the NetP shortcut menu item by default.

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -708,8 +708,10 @@ extension AppDelegate {
     }
 
     @objc func resetAddToDockFeatureNotification(_ sender: Any?) {
+#if SPARKLE
         guard let dockCustomizer = Application.appDelegate.dockCustomization else { return }
         dockCustomizer.resetData()
+#endif
     }
 
     @objc func resetLaunchDateToToday(_ sender: Any?) {

--- a/macOS/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
@@ -200,6 +200,7 @@ final class MoreOptionsMenu: NSMenu, NSMenuDelegate {
                                                    featureFlagger: featureFlagger)
         addItem(feedbackMenuItem)
 
+#if SPARKLE
         if let dockCustomizer = self.dockCustomizer {
             if dockCustomizer.isAddedToDock == false {
                 if dockCustomizer.shouldShowNotification {
@@ -222,7 +223,7 @@ final class MoreOptionsMenu: NSMenu, NSMenuDelegate {
                 }
             }
         }
-
+#endif
         if !defaultBrowserPreferences.isDefault {
             let setAsDefaultMenuItem = NSMenuItem(title: UserText.setAsDefaultBrowser, action: #selector(setAsDefault(_:)))
                 .targetting(self)

--- a/macOS/DuckDuckGo/NavigationBar/View/MoreOptionsMenuButton.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/MoreOptionsMenuButton.swift
@@ -23,7 +23,9 @@ import Common
 final class MoreOptionsMenuButton: MouseOverButton, NotificationDotProviding {
 
     private var updateController: UpdateController?
+#if SPARKLE
     private var dockCustomization: DockCustomization?
+#endif
 
     var notificationLayer: CALayer?
     private var cancellable: AnyCancellable?
@@ -46,7 +48,9 @@ final class MoreOptionsMenuButton: MouseOverButton, NotificationDotProviding {
 
         if AppVersion.runType != .uiTests {
             updateController = Application.appDelegate.updateController
+#if SPARKLE
             dockCustomization = Application.appDelegate.dockCustomization
+#endif
         }
         subscribeToUpdateInfo()
     }
@@ -58,8 +62,12 @@ final class MoreOptionsMenuButton: MouseOverButton, NotificationDotProviding {
 
     private func subscribeToUpdateInfo() {
         var dockPublisher: AnyPublisher<Bool, Never>
+#if SPARKLE
         guard let dockCustomization = dockCustomization else { return }
         dockPublisher = dockCustomization.shouldShowNotificationPublisher
+#else
+        dockPublisher = .init(Just(false))
+#endif
         guard let updateController else { return }
         cancellable = Publishers.CombineLatest3(updateController.hasPendingUpdatePublisher, updateController.notificationDotPublisher, dockPublisher)
             .receive(on: DispatchQueue.main)

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -1435,7 +1435,9 @@ final class NavigationBarViewController: NSViewController {
         let internalUserDecider = NSApp.delegateTyped.internalUserDecider
         let freemiumDBPFeature = Application.appDelegate.freemiumDBPFeature
         var dockCustomization: DockCustomization?
+#if SPARKLE
         dockCustomization = Application.appDelegate.dockCustomization
+#endif
         let menu = MoreOptionsMenu(tabCollectionViewModel: tabCollectionViewModel,
                                    bookmarkManager: bookmarkManager,
                                    historyCoordinator: historyCoordinator,

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesDefaultBrowserView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesDefaultBrowserView.swift
@@ -68,6 +68,7 @@ extension Preferences {
 
                     Spacer().frame(height: 16)
 
+#if SPARKLE
                     PreferencePaneSection(UserText.shortcuts, spacing: 4) {
                         PreferencePaneSubSection {
                             HStack {
@@ -100,6 +101,8 @@ extension Preferences {
                             }
                         }
                     }
+#endif
+
                 }
             }
         }

--- a/macOS/UnitTests/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptCoordinatorTests.swift
+++ b/macOS/UnitTests/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptCoordinatorTests.swift
@@ -26,6 +26,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
     private var promptTypeDeciderMock: MockDefaultBrowserAndDockPromptTypeDecider!
     private var defaultBrowserProviderMock: DefaultBrowserProviderMock!
     private var dockCustomizerMock: DockCustomizerMock!
+    private var applicationBuildTypeMock: ApplicationBuildTypeMock!
     private var storeMock: MockDefaultBrowserAndDockPromptStore!
     private var notificationPresenterMock: MockDefaultBrowserAndDockPromptNotificationPresenter!
     private var pixelKitMock: PixelKitMock!
@@ -39,6 +40,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
         promptTypeDeciderMock = MockDefaultBrowserAndDockPromptTypeDecider()
         defaultBrowserProviderMock = DefaultBrowserProviderMock()
         dockCustomizerMock = DockCustomizerMock()
+        applicationBuildTypeMock = ApplicationBuildTypeMock()
         storeMock = MockDefaultBrowserAndDockPromptStore()
         notificationPresenterMock = MockDefaultBrowserAndDockPromptNotificationPresenter()
         timeTraveller = TimeTraveller(date: Self.now)
@@ -48,6 +50,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
         promptTypeDeciderMock = nil
         defaultBrowserProviderMock = nil
         dockCustomizerMock = nil
+        applicationBuildTypeMock = nil
         storeMock = nil
         notificationPresenterMock = nil
         timeTraveller = nil
@@ -68,6 +71,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
             isOnboardingCompleted: { self.isOnboardingCompleted },
             dockCustomization: dockCustomizerMock,
             defaultBrowserProvider: defaultBrowserProviderMock,
+            applicationBuildType: applicationBuildTypeMock,
             pixelFiring: pixelKitMock,
             dateProvider: timeTraveller.getDate
         )
@@ -75,8 +79,9 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     // MARK: - Evaluate prompt eligibility tests
 
-    func testEvaluatePromptEligibility_DefaultBrowserAndAddedToDock_ReturnsNil() {
+    func testEvaluatePromptEligibility_SparkleBuild_DefaultBrowserAndAddedToDock_ReturnsNil() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = true
         dockCustomizerMock.dockStatus = true
         let sut = makeSUT()
@@ -85,8 +90,9 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
         XCTAssertNil(sut.evaluatePromptEligibility)
     }
 
-    func testEvaluatePromptEligibility_DefaultBrowserAndNotAddedToDock_ReturnsAddToDockPrompt() {
+    func testEvaluatePromptEligibility_SparkleBuild_DefaultBrowserAndNotAddedToDock_ReturnsAddToDockPrompt() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = true
         dockCustomizerMock.dockStatus = false
         let sut = makeSUT()
@@ -95,8 +101,9 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
         XCTAssertEqual(sut.evaluatePromptEligibility, .addToDockPrompt)
     }
 
-    func testEvaluatePromptEligibility_NotDefaultBrowserAndAddedToDock_ReturnsSetAsDefaultPrompt() {
+    func testEvaluatePromptEligibility_SparkleBuild_NotDefaultBrowserAndAddedToDock_ReturnsSetAsDefaultPrompt() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = true
         let sut = makeSUT()
@@ -105,14 +112,37 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
         XCTAssertEqual(sut.evaluatePromptEligibility, .setAsDefaultPrompt)
     }
 
-    func testEvaluatePromptEligibility_NotDefaultBrowserAndNotAddedToDock_ReturnsBothDefaultBrowserAndDockPrompt() {
+    func testEvaluatePromptEligibility_SparkleBuild_NotDefaultBrowserAndNotAddedToDock_ReturnsBothDefaultBrowserAndDockPrompt() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = false
         let sut = makeSUT()
 
         // THEN
         XCTAssertEqual(sut.evaluatePromptEligibility, .bothDefaultBrowserAndDockPrompt)
+    }
+
+    func testEvaluatePromptEligibility_AppStoreBuild_DefaultBrowser_ReturnsNil() {
+        // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = false
+        defaultBrowserProviderMock.isDefault = true
+        dockCustomizerMock.dockStatus = false
+        let sut = makeSUT()
+
+        // THEN
+        XCTAssertNil(sut.evaluatePromptEligibility)
+    }
+
+    func testEvaluatePromptEligibility_AppStoreBuild_NotDefaultBrowser_ReturnsSetAsDefaultPrompt() {
+        // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = false
+        defaultBrowserProviderMock.isDefault = false
+        dockCustomizerMock.dockStatus = false
+        let sut = makeSUT()
+
+        // THEN
+        XCTAssertEqual(sut.evaluatePromptEligibility, .setAsDefaultPrompt)
     }
 
     // MARK: - Get prompt type tests
@@ -174,6 +204,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
         // GIVEN
         defaultBrowserProviderMock.isDefault = true
         dockCustomizerMock.dockStatus = false
+        applicationBuildTypeMock.isSparkleBuild = true
         promptTypeDeciderMock.promptTypeToReturn = .active(.banner)
         let sut = makeSUT()
 
@@ -215,6 +246,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testConfirmActionCallsAddToDockAndSetAsDefaultBrowserWhenBothDefaultBrowserAndDockPromptType() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = false
         let sut = makeSUT()
@@ -229,6 +261,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testConfirmActionCallsAddToDockWhenAddToDockPromptType() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = true
         dockCustomizerMock.dockStatus = false
         let sut = makeSUT()
@@ -243,6 +276,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testConfirmActionCallsSetAsDefaultBrowserWhenSetAsDefaultPromptType() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = true
         let sut = makeSUT()
@@ -257,6 +291,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testConfirmActionDoesNothingWhenEvaluatePromptEligibilityIsNil() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = true
         dockCustomizerMock.dockStatus = true
         let sut = makeSUT()
@@ -271,6 +306,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testConfirmActionSetBannerSeen() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = false
         let sut = makeSUT()
@@ -289,6 +325,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testConfirmActionDoesNotSetPopoverSeen() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = false
         let sut = makeSUT()
@@ -307,6 +344,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testConfirmActionDoesNotSetInactiveUserModalSeen() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = false
         let sut = makeSUT()
@@ -327,6 +365,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testDismissActionShouldHidePermanentlyFalseSetBannerSeenAndDoesNotSetPermanentlyHiddenFlagToTrue() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = false
         let sut = makeSUT()
@@ -345,6 +384,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testDismissActionShouldHidePermanentlyTrueSetBannerSeenAndSetPermanentlyHiddenFlagToTrue() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = false
         let sut = makeSUT()
@@ -363,6 +403,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testDismissActionDoesNotSetPopoverSeen() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = false
         let sut = makeSUT()
@@ -461,6 +502,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFirePopoverSeenPixelTypeBothWhenPopoverPromptIsReturned() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         promptTypeDeciderMock.promptTypeToReturn = .active(.popover)
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = false
@@ -476,6 +518,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFirePopoverSeenPixelTypeSADOnlyWhenPopoverPromptIsReturned() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         promptTypeDeciderMock.promptTypeToReturn = .active(.popover)
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = true
@@ -491,6 +534,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFirePopoverSeenPixelTypeATTOnlyWhenPopoverPromptIsReturned() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         promptTypeDeciderMock.promptTypeToReturn = .active(.popover)
         defaultBrowserProviderMock.isDefault = true
         dockCustomizerMock.dockStatus = false
@@ -506,6 +550,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFirePopoverConfirmActionTypeBothWhenPopoverConfirmAction() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = false
         let expectedPixelCall = ExpectedFireCall(pixel: DefaultBrowserAndDockPromptPixelEvent.popoverConfirmButtonClicked(type: .bothDefaultBrowserAndDockPrompt), frequency: .standard)
@@ -520,6 +565,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFirePopoverConfirmActionTypeSADOnlyWhenPopoverConfirmAction() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = true
         let expectedPixelCall = ExpectedFireCall(pixel: DefaultBrowserAndDockPromptPixelEvent.popoverConfirmButtonClicked(type: .setAsDefaultPrompt), frequency: .standard)
@@ -534,6 +580,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFirePopoverConfirmActionTypeATTOnlyWhenPopoverConfirmAction() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = true
         dockCustomizerMock.dockStatus = false
         let expectedPixelCall = ExpectedFireCall(pixel: DefaultBrowserAndDockPromptPixelEvent.popoverConfirmButtonClicked(type: .addToDockPrompt), frequency: .standard)
@@ -548,6 +595,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFirePopoverDismissActionTypeBothWhenPopoverDismissAction() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = false
         let expectedPixelCall = ExpectedFireCall(pixel: DefaultBrowserAndDockPromptPixelEvent.popoverCloseButtonClicked(type: .bothDefaultBrowserAndDockPrompt), frequency: .standard)
@@ -562,6 +610,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFirePopoverDismissActionTypeSADOnlyWhenPopoverDismissAction() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = true
         let expectedPixelCall = ExpectedFireCall(pixel: DefaultBrowserAndDockPromptPixelEvent.popoverCloseButtonClicked(type: .setAsDefaultPrompt), frequency: .standard)
@@ -576,6 +625,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFirePopoverDismissActionTypeATTOnlyWhenPopoverDismissAction() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = true
         dockCustomizerMock.dockStatus = false
         let expectedPixelCall = ExpectedFireCall(pixel: DefaultBrowserAndDockPromptPixelEvent.popoverCloseButtonClicked(type: .addToDockPrompt), frequency: .standard)
@@ -590,6 +640,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFirePopoverDismissActionUponStatusUpdateThenDoesNotFireDismissPixel() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = true
         dockCustomizerMock.dockStatus = false
         let sut = makeSUT(expectedFireCalls: [])
@@ -605,6 +656,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireBannerSeenPixelTypeBothWhenBannerPromptIsReturned() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         promptTypeDeciderMock.promptTypeToReturn = .active(.banner)
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = false
@@ -621,6 +673,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireBannerSeenPixelTypeSADOnlyWhenBannerPromptIsReturned() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         promptTypeDeciderMock.promptTypeToReturn = .active(.banner)
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = true
@@ -637,6 +690,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireBannerSeenPixelTypeATTOnlyWhenBannerPromptIsReturned() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         promptTypeDeciderMock.promptTypeToReturn = .active(.banner)
         defaultBrowserProviderMock.isDefault = true
         dockCustomizerMock.dockStatus = false
@@ -653,6 +707,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireBannerConfirmActionTypeBothWhenPopoverConfirmAction() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = false
         storeMock.bannerShownOccurrences = 10
@@ -668,6 +723,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireBannerConfirmActionTypeSADOnlyWhenBannerConfirmAction() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = true
         storeMock.bannerShownOccurrences = 4
@@ -683,6 +739,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireBannerConfirmActionTypeATTOnlyWhenBannerConfirmAction() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = true
         dockCustomizerMock.dockStatus = false
         storeMock.bannerShownOccurrences = 5
@@ -698,6 +755,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireBannerConfirmActionSendsFixedParameterWhenNumberOfBannerShownIsMoreThanTen() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = false
         storeMock.bannerShownOccurrences = 25
@@ -713,6 +771,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireBannerDismissActionTypeBothWhenBannerDismissAction() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = false
         let expectedPixelCall = ExpectedFireCall(pixel: DefaultBrowserAndDockPromptPixelEvent.bannerCloseButtonClicked(type: .bothDefaultBrowserAndDockPrompt), frequency: .standard)
@@ -727,6 +786,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testBannerPopoverDismissActionTypeSADOnlyWhenBannerDismissAction() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = true
         let expectedPixelCall = ExpectedFireCall(pixel: DefaultBrowserAndDockPromptPixelEvent.bannerCloseButtonClicked(type: .setAsDefaultPrompt), frequency: .standard)
@@ -741,6 +801,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireBannerDismissActionTypeATTOnlyWhenBannerDismissAction() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = true
         dockCustomizerMock.dockStatus = false
         let expectedPixelCall = ExpectedFireCall(pixel: DefaultBrowserAndDockPromptPixelEvent.bannerCloseButtonClicked(type: .addToDockPrompt), frequency: .standard)
@@ -755,6 +816,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireBannerNeverAskAgainTypeBothWhenBannerDismissActionShouldPermanentlyDismissTrue() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = false
         let expectedPixelCall = ExpectedFireCall(pixel: DefaultBrowserAndDockPromptPixelEvent.bannerNeverAskAgainButtonClicked(type: .bothDefaultBrowserAndDockPrompt), frequency: .standard)
@@ -769,6 +831,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireBannerNeverAskAgainTypeSADOnlyWhenBannerDismissActionShouldPermanentlyDismissTrue() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = true
         let expectedPixelCall = ExpectedFireCall(pixel: DefaultBrowserAndDockPromptPixelEvent.bannerNeverAskAgainButtonClicked(type: .setAsDefaultPrompt), frequency: .standard)
@@ -783,6 +846,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireBannerNeverAskAgainTypeATTOnlyWhenBannerDismissActionShouldPermanentlyDismissTrue() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = true
         dockCustomizerMock.dockStatus = false
         let expectedPixelCall = ExpectedFireCall(pixel: DefaultBrowserAndDockPromptPixelEvent.bannerNeverAskAgainButtonClicked(type: .addToDockPrompt), frequency: .standard)
@@ -797,6 +861,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireBannerDismissActionUponStatusUpdateThenDoesNotFireDismissPixel() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = true
         dockCustomizerMock.dockStatus = false
         let sut = makeSUT(expectedFireCalls: [])
@@ -812,6 +877,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireInactiveUserModalSeenPixelTypeBothWhenInactiveUserModalPromptIsReturned() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         promptTypeDeciderMock.promptTypeToReturn = .inactive
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = false
@@ -827,6 +893,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireInactiveUserModalSeenPixelTypeSADOnlyWhenInactiveUserModalPromptIsReturned() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         promptTypeDeciderMock.promptTypeToReturn = .inactive
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = true
@@ -842,6 +909,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireInactiveUserModalSeenPixelTypeATDOnlyWhenInactiveUserModalPromptIsReturned() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         promptTypeDeciderMock.promptTypeToReturn = .inactive
         defaultBrowserProviderMock.isDefault = true
         dockCustomizerMock.dockStatus = false
@@ -857,6 +925,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireInactiveUserModalConfirmActionTypeBothWhenInactiveUserModalConfirmAction() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = false
         let expectedPixelCall = ExpectedFireCall(pixel: DefaultBrowserAndDockPromptPixelEvent.inactiveUserModalConfirmButtonClicked(type: .bothDefaultBrowserAndDockPrompt), frequency: .standard)
@@ -871,6 +940,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireInactiveUserModalConfirmActionTypeSADOnlyWheInactiveUserModalConfirmAction() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = true
         let expectedPixelCall = ExpectedFireCall(pixel: DefaultBrowserAndDockPromptPixelEvent.inactiveUserModalConfirmButtonClicked(type: .setAsDefaultPrompt), frequency: .standard)
@@ -885,6 +955,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireInactiveUserModalConfirmActionTypeATDOnlyWhenInactiveUserModalConfirmAction() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = true
         dockCustomizerMock.dockStatus = false
         let expectedPixelCall = ExpectedFireCall(pixel: DefaultBrowserAndDockPromptPixelEvent.inactiveUserModalConfirmButtonClicked(type: .addToDockPrompt), frequency: .standard)
@@ -899,6 +970,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireInactiveUserModalDismissedTypeBothWhenInactiveUserModalDismissAction() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = false
         let expectedPixelCall = ExpectedFireCall(pixel: DefaultBrowserAndDockPromptPixelEvent.inactiveUserModalDismissed(type: .bothDefaultBrowserAndDockPrompt), frequency: .standard)
@@ -913,6 +985,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireInactiveUserModalDismissedTypeSADOnlyWhenInactiveUserModalDismissAction() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = false
         dockCustomizerMock.dockStatus = true
         let expectedPixelCall = ExpectedFireCall(pixel: DefaultBrowserAndDockPromptPixelEvent.inactiveUserModalDismissed(type: .setAsDefaultPrompt), frequency: .standard)
@@ -927,6 +1000,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireInactiveUserModalDismissedTypeATDOnlyWhenInactiveUserModalDismissAction() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = true
         dockCustomizerMock.dockStatus = false
         let expectedPixelCall = ExpectedFireCall(pixel: DefaultBrowserAndDockPromptPixelEvent.inactiveUserModalDismissed(type: .addToDockPrompt), frequency: .standard)
@@ -941,6 +1015,7 @@ final class DefaultBrowserAndDockPromptCoordinatorTests: XCTestCase {
 
     func testFireInactiveUserModalDismissedUponStatusUpdateThenDoesNotFireDismissPixel() {
         // GIVEN
+        applicationBuildTypeMock.isSparkleBuild = true
         defaultBrowserProviderMock.isDefault = true
         dockCustomizerMock.dockStatus = false
         let sut = makeSUT(expectedFireCalls: [])

--- a/macOS/UnitTests/Menus/MainMenuTests.swift
+++ b/macOS/UnitTests/Menus/MainMenuTests.swift
@@ -137,6 +137,7 @@ class MainMenuTests: XCTestCase {
         XCTAssertTrue(duckDuckGoMenu.items[3].isHidden)
     }
 
+#if SPARKLE
     @MainActor
     func testWhenBrowserIsNotInTheDockThenMenuItemIsVisible() throws {
         let dockCustomizer = DockCustomizerMock()
@@ -195,6 +196,7 @@ class MainMenuTests: XCTestCase {
         XCTAssertEqual(duckDuckGoMenu.items[3].isHidden, true)
         XCTAssertEqual(duckDuckGoMenu.items[3].title, UserText.addDuckDuckGoToDock)
     }
+#endif
 
     // MARK: - Default Browser Action
 

--- a/macOS/UnitTests/Menus/MoreOptionsMenuTests.swift
+++ b/macOS/UnitTests/Menus/MoreOptionsMenuTests.swift
@@ -487,6 +487,7 @@ final class MoreOptionsMenuTests: XCTestCase {
 
     // MARK: - Default Browser Action and Add To Dock
 
+#if SPARKLE
     @MainActor
     func testWhenBrowserIsNotAddedToDockThenMenuItemIsVisible() {
         dockCustomizer.dockStatus = false
@@ -508,6 +509,7 @@ final class MoreOptionsMenuTests: XCTestCase {
         XCTAssertEqual(moreOptionsMenu.items[1].title, UserText.addDuckDuckGoToDock)
         XCTAssertEqual(moreOptionsMenu.items[2].title, UserText.setAsDefaultBrowser)
     }
+#endif
 
     @MainActor
     func testWhenBrowserIsAddedToDockThenMenuItemIsNotVisible() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212290893126634?focus=true

### Description

These new entitlements were rejected in app store review. Reverts duckduckgo/apple-browsers#2721.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1.
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes Dock-related entitlements and gates all “Add to Dock” features/UI to Sparkle builds, updates Dock logic, and adjusts prompt logic and tests accordingly.
> 
> - **Build gating (SPARKLE)**:
>   - Wrap `dockCustomization` property/init, daily pixel, menu items (Main menu, More Options), preferences "Add to Dock" section, and UI notification logic behind `#if SPARKLE`.
>   - `MoreOptionsMenuButton` uses a no-op publisher for Dock notification when not Sparkle.
> - **Prompt logic**:
>   - `DefaultBrowserAndDockPromptCoordinator` now checks build type: Sparkle can prompt for both default browser and dock; App Store only for default browser.
> - **Dock customization**:
>   - Update Dock plist path to `~/Library/Preferences/com.apple.dock.plist`.
>   - Change Dock restart from Apple Events to `killall Dock`.
> - **Entitlements**:
>   - Remove Dock-related exceptions: home-relative-path RW and apple-events for `com.apple.dock` from all App Store entitlement files.
> - **UI/menus**:
>   - Hide "Add DuckDuckGo to Dock" menu items when not Sparkle; maintain visibility based on `isAddedToDock` when Sparkle.
> - **Tests**:
>   - Update unit tests to account for Sparkle-only Dock UI and new prompt eligibility; add App Store vs Sparkle cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e4e979a5074598c442a4aed64583b2d47b557db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->