### PR TITLE
Data Import: Copy tweaks

### DIFF
--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -1207,7 +1207,7 @@ struct UserText {
     static let importTypeSelectionTitleBookmarks = NSLocalizedString("import.type-selection.title.bookmarks", value: "Import Bookmarks", comment: "Title text for the button to select the type of data to import when bookmarks selected")
     static let importTypeSelectionTitlePasswords = NSLocalizedString("import.type-selection.title.passwords", value: "Import Passwords", comment: "Title text for the button to select the type of data to import when passwords selected")
 
-    static let importChromeAllowKeychainIntructions = NSLocalizedString("import.chrome.allow-keychain.instructions", value: "Click **Allow** to unlock your keychain using your Mac password (some devices might ask you twice). DuckDuckGo will not see your password.", comment: "Instructions shown to the user when Chrome needs to access their Keychain. Contains markdown for bold text.")
+    static let importChromeAllowKeychainIntructions = NSLocalizedString("import.chrome.allow-keychain.instructions", value: "Enter your device password and click **Allow** to complete the import. DuckDuckGo won't see your password.", comment: "Instructions shown to the user when Chrome needs to access their Keychain. Contains markdown for bold text.")
     static let importChromeAllowButtonTitle = NSLocalizedString("import.chrome.allow-keychain.allow.button.title", value: "Allow", comment: "Button title of example dialog demonstrating to the user what to click when the system needs to access their Keychain.")
 
     static let importLoginsCSV = NSLocalizedString("import.logins.csv.title", value: "CSV Passwords File (for other browsers)", comment: "Title text for the CSV importer")
@@ -1263,7 +1263,7 @@ struct UserText {
 
 
     static let passwordEntryHelpTitle = NSLocalizedString("import.password.entry.help.title", value: "Want to try again? macOS needs your permission to finish importing.", comment: "Title for the password entry help screen")
-    static let passwordEntryHelpInstructions = NSLocalizedString("import.password.entry.help.instructions", value: "Click **'Show macOS Message'** and select **'Allow'** when the macOS message appears.", comment: "Instructions for password entry help")
+    static let passwordEntryHelpInstructions = NSLocalizedString("import.password.entry.help.instructions", value: "Click **Show macOS Message** and select **Allow** when the macOS message appears.", comment: "Instructions for password entry help")
     static let passwordEntryHelpShowMacOSMessageButton = NSLocalizedString("import.password.entry.help.show.macos.message.button", value: "Show macOS Message", comment: "Button text to trigger the macOS keychain prompt")
     static let passwordEntryHelpDialogExampleText = NSLocalizedString("import.password.entry.help.dialog.example.text", value: "DuckDuckGo wants to use your confidential information stored in your keychain.", comment: "Explanatory text shown on an example of a system prompt that asks for the user's password.")
 

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -42582,7 +42582,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Click **Allow** to unlock your keychain using your Mac password (some devices might ask you twice). DuckDuckGo will not see your password."
+            "value" : "Enter your device password and click **Allow** to complete the import. DuckDuckGo won't see your password."
           }
         }
       }
@@ -45858,7 +45858,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Click **'Show macOS Message'** and select **'Allow'** when the macOS message appears."
+            "value" : "Click **Show macOS Message** and select **Allow** when the macOS message appears."
           }
         }
       }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211264967278501/task/1212292828507240?focus=true
Tech Design URL:
CC:

### Description

This PR just contains a couple of really small copy tweaks for the system password help prompts in the new data import flow.

1. Updated the popover text when the user is prompted for their system password:
<img width="299" height="117" alt="image" src="https://github.com/user-attachments/assets/08fe4e4c-c2a3-432c-86c6-bc211993f8f0" />
2. Removed the quote marks from the text on the password help screen:
<img width="434" height="458" alt="Screenshot 2025-12-03 at 14 31 17" src="https://github.com/user-attachments/assets/8da8aff3-cf99-4b50-94bb-20a41bc2977b" />

### Testing Steps

1. Build and run the Mac app
2. Ensure the `dataImportNewExperience` feature flag is enabled
3. Attempt to import passwords from a source that requires your system password, such as Brave or Chrome
4. You should see the above popover when you’re prompted for your password
5. Deny the password prompt and you should see the second screen
6. Check the copy!

### Impact and Risks

Low: Minor visual changes, small bug fixes, improvement to existing features

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines copy for the keychain allow prompt and password help screen in the data import flow.
> 
> - **Localization (Data Import prompts)**:
>   - Update `import.chrome.allow-keychain.instructions` to clarify entering device password and clicking `Allow`.
>   - Simplify `import.password.entry.help.instructions` by removing quote marks around bolded UI text.
>   - Changes applied in `macOS/DuckDuckGo/Common/Localizables/UserText.swift` and mirrored in `macOS/DuckDuckGo/Localization/Localizable.xcstrings`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9eb8bc17963ad99817ba7b2ea24188fcd558e6f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->