### PR TITLE
macOS VPN: Mitigate VPN toggle issue

### DIFF
--- a/iOS/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -300,8 +300,8 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
             resetControllerStartWideEventMeasurement()
             try await startWithError()
         case .connected:
-            // Intentional no-op
-            break
+            Logger.networkProtection.error("Start requested while already connected - stopping VPN to allow recovery")
+            await stop()
         default:
             try await start(tunnelManager)
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1212293594200883?focus=true

### Description



### Testing Steps

**Preparation Steps**

Apply these temporary changes to simulate the issue:
- In VPNEnabledObserverThroughSession.swift:
a) Add counter variables:

```
   #if DEBUG
   private static var simulateNilSessionCounter = 0
   private static let simulateNilSessionEveryN = 3  // Fail every 3rd call
   #endif
```

b) Add simulation logic at the start of `handleNotification`:

```
   #if DEBUG
   Self.simulateNilSessionCounter += 1
   if Self.simulateNilSessionCounter % Self.simulateNilSessionEveryN == 0 {
       // Simulate activeSession() returning nil
       if subject.value != false {
           subject.send(false)
       }
       return
   }
   #endif
```

This forces the observer to report "disconnected" every 3rd notification, which on the first run is usually "Connected".

c) Start the VPN once to install the extension, then In macOS `NetworkProtectionTunnelController.swift` - comment out `activateSystemExtension` call as in DEBUG builds it allows the toggle to recover the connection by reinstalling the extension each time - we want to simulate release.

### Impact and Risks

Low.

#### What could go wrong?

I truly don't think there's any significant risk here.  Adding stop in the VPN start calls isn't great... but I think that's well limited.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> On both iOS and macOS, starting while already connected now logs and stops the VPN to allow recovery; removed the macOS-specific “connectionAlreadyStarted” error.
> 
> - **Network Protection (start behavior)**:
>   - iOS `NetworkProtectionTunnelController.startWithError`: when `connection.status == .connected`, now logs and calls `stop()` to recover instead of no-op.
>   - macOS `NetworkProtectionTunnelController.start(isFirstAttempt:)`: when already connected, now logs and calls `stop()` to recover instead of throwing an error.
> - **Error handling (macOS)**:
>   - Removed `StartError.connectionAlreadyStarted` case and all associated codes/descriptions/usages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b766086de9807706e0a508dd109eccdb6ea01a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->