### PR TITLE
Change SHIFT ENTER shortcut action

### DIFF
--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -1002,7 +1002,7 @@ extension MainViewController {
             return false
         }
 
-        if flags.contains(.shift) || flags.contains(.option),
+        if flags.contains(.option),
            featureFlagger.isFeatureOn(.aiChatOmnibarToggle),
            let buttonsViewController = navigationBarViewController.addressBarViewController?.addressBarButtonsViewController {
             let isSwitchingToAIChatMode = buttonsViewController.searchModeToggleControl?.selectedSegment == 0
@@ -1011,7 +1011,7 @@ extension MainViewController {
                 self.aiChatOmnibarTextContainerViewController.insertNewline()
             }
             return true
-        } else if flags.contains(.control),
+        } else if flags.contains(.shift) || flags.contains(.control),
                   featureFlagger.isFeatureOn(.aiChatOmnibarToggle) {
             navigationBarViewController.addressBarViewController?.addressBarTextField.openAIChatWithPrompt()
             return true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1212305224632394?focus=true

### Description
Change SHIFT ENTER shortcut action

### Testing Steps
1. Enable the aiChatOmnibarToggle feature flag
2. Write something in the address bar, press SHIFT+ ENTER
3. Make sure the text is submitted directly to duck.ai

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Shortcut won't work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust Return key behavior: Option+Enter toggles search mode; Shift+Enter or Control+Enter opens AI Chat with the current prompt (feature-flagged).
> 
> - **Keyboard shortcuts**
>   - In `MainViewController.handleReturnKey(...)`:
>     - `Option+Enter` toggles search mode (and inserts newline when switching to AI Chat).
>     - `Shift+Enter` or `Control+Enter` opens AI Chat with the current prompt when `featureFlagger.isFeatureOn(.aiChatOmnibarToggle)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f574cab2eb72c507c62567afa3c938b53306c3ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->