### PR TITLE
Remove VPN toolbar upsell feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -386,7 +386,6 @@ public enum PrivacyProSubfeature: String, Equatable, PrivacySubfeature {
     case privacyProAuthV2
     case privacyProOnboardingPromotion
     case paidAIChat
-    case vpnToolbarUpsell
     case supportsAlternateStripePaymentFlow
     case subscriptionPurchaseWidePixelMeasurement
     case vpnConnectionWidePixelMeasurement

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -251,7 +251,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             subscriptionManager: subscriptionAuthV1toV2Bridge,
             defaultBrowserProvider: SystemDefaultBrowserProvider(),
             contextualOnboardingPublisher: onboardingContextualDialogsManager.isContextualOnboardingCompletedPublisher.eraseToAnyPublisher(),
-            featureFlagger: featureFlagger,
             persistor: vpnUpsellUserDefaultsPersistor,
             timerDuration: vpnUpsellUserDefaultsPersistor.expectedUpsellTimeInterval
         )

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNUpsellVisibilityManager.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNUpsellNew/VPNUpsellVisibilityManager.swift
@@ -57,7 +57,6 @@ final class VPNUpsellVisibilityManager: ObservableObject {
     private let subscriptionManager: any SubscriptionAuthV1toV2Bridge
     private let defaultBrowserProvider: DefaultBrowserProvider
     private let contextualOnboardingPublisher: AnyPublisher<Bool, Never>
-    private let featureFlagger: FeatureFlagger
     private let timerDuration: TimeInterval
     private let autoDismissDays: Int
     private var persistor: VPNUpsellUserDefaultsPersisting
@@ -76,7 +75,6 @@ final class VPNUpsellVisibilityManager: ObservableObject {
          subscriptionManager: any SubscriptionAuthV1toV2Bridge,
          defaultBrowserProvider: DefaultBrowserProvider,
          contextualOnboardingPublisher: AnyPublisher<Bool, Never>,
-         featureFlagger: FeatureFlagger,
          persistor: VPNUpsellUserDefaultsPersisting,
          timerDuration: TimeInterval = Constants.timeIntervalBeforeShowingUpsell,
          autoDismissDays: Int = Constants.autoDismissDays,
@@ -86,7 +84,6 @@ final class VPNUpsellVisibilityManager: ObservableObject {
         self.subscriptionManager = subscriptionManager
         self.defaultBrowserProvider = defaultBrowserProvider
         self.contextualOnboardingPublisher = contextualOnboardingPublisher
-        self.featureFlagger = featureFlagger
         self.timerDuration = timerDuration
         self.autoDismissDays = autoDismissDays
         self.persistor = persistor
@@ -133,10 +130,6 @@ final class VPNUpsellVisibilityManager: ObservableObject {
 
     private var isUserEligible: Bool {
         isNewUser && !subscriptionManager.isUserAuthenticated
-    }
-
-    private var isFeatureOn: Bool {
-        featureFlagger.isFeatureOn(.vpnToolbarUpsell)
     }
 
     private var shouldDismiss: Bool {
@@ -322,7 +315,7 @@ final class VPNUpsellVisibilityManager: ObservableObject {
             return
         }
 
-        guard isFeatureOn, isUserEligible else {
+        guard isUserEligible else {
             state = .notEligible
             return
         }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -146,9 +146,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866476860577
     case newTabPageOmnibar
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866719732725
-    case vpnToolbarUpsell
-
     /// Loading New Tab Page in regular browsing webview
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866719013868
     case newTabPagePerTab
@@ -355,7 +352,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .newTabPageOmnibar,
                 .newTabPagePerTab,
                 .newTabPageTabIDs,
-                .vpnToolbarUpsell,
                 .supportsAlternateStripePaymentFlow,
                 .duckAISearchParameter,
                 .refactorOfSyncPreferences,
@@ -495,8 +491,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.updateSafariBookmarksImport))
         case .newTabPageOmnibar:
             return .remoteReleasable(.subfeature(HtmlNewTabPageSubfeature.omnibar))
-        case .vpnToolbarUpsell:
-            return .remoteReleasable(.subfeature(PrivacyProSubfeature.vpnToolbarUpsell))
         case .newTabPagePerTab:
             return .remoteReleasable(.subfeature(HtmlNewTabPageSubfeature.newTabPagePerTab))
         case .newTabPageTabIDs:

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlagCategory.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlagCategory.swift
@@ -76,7 +76,6 @@ extension FeatureFlag: FeatureFlagCategorization {
             return .updates
         case .networkProtectionAppStoreSysex,
                 .networkProtectionAppStoreSysexMessage,
-                .vpnToolbarUpsell,
                 .winBackOffer:
             return .vpn
         case .dbpEmailConfirmationDecoupling,

--- a/macOS/UnitTests/NetworkProtection/NetworkProtectionNavBarButtonModelTests.swift
+++ b/macOS/UnitTests/NetworkProtection/NetworkProtectionNavBarButtonModelTests.swift
@@ -189,10 +189,7 @@ final class NetworkProtectionNavBarButtonModelTests: XCTestCase {
 
     func testWhenFeatureFlagIsDisabled_ItDoesNotAffectTheButton() {
         // Given
-        let upsellManager = createUpsellManager(
-            shouldShowUpsell: false,
-            featureEnabled: false
-        )
+        let upsellManager = createUpsellManager(shouldShowUpsell: false)
         sut = createButtonModel(with: upsellManager)
 
         // When
@@ -231,24 +228,17 @@ final class NetworkProtectionNavBarButtonModelTests: XCTestCase {
 
 extension NetworkProtectionNavBarButtonModelTests {
     private func createUpsellManager(
-        shouldShowUpsell: Bool,
-        featureEnabled: Bool = true
+        shouldShowUpsell: Bool
     ) -> VPNUpsellVisibilityManager {
-        let mockFeatureFlagger = MockFeatureFlagger()
         let mockDefaultBrowserProvider = MockDefaultBrowserProvider()
         mockDefaultBrowserProvider.isDefault = true
 
-        if featureEnabled && shouldShowUpsell {
-            mockFeatureFlagger.enabledFeatureFlags = [.vpnToolbarUpsell]
-        }
-
         let manager = VPNUpsellVisibilityManager(
             isFirstLaunch: false,
-            isNewUser: true,
+            isNewUser: shouldShowUpsell,
             subscriptionManager: mockSubscriptionManager,
             defaultBrowserProvider: mockDefaultBrowserProvider,
             contextualOnboardingPublisher: Just(true).eraseToAnyPublisher(),
-            featureFlagger: mockFeatureFlagger,
             persistor: mockPersistor,
             timerDuration: 0.01
         )
@@ -268,7 +258,6 @@ extension NetworkProtectionNavBarButtonModelTests {
             onboardStatusPublisher: Just(.completed).eraseToAnyPublisher()
         )
         let statusReporter = TestNetworkProtectionStatusReporter()
-        let iconProvider = NavigationBarIconProvider()
 
         let themeManager = MockThemeManager()
         return NetworkProtectionNavBarButtonModel(

--- a/macOS/UnitTests/NetworkProtection/VPNPopoverPresenterTests.swift
+++ b/macOS/UnitTests/NetworkProtection/VPNPopoverPresenterTests.swift
@@ -43,15 +43,12 @@ final class VPNPopoverPresenterTests: XCTestCase {
         mockPersistor = MockVPNUpsellUserDefaultsPersistor()
         firedPixels = []
 
-        mockFeatureFlagger.enabledFeatureFlags = [.vpnToolbarUpsell]
-
         vpnUpsellVisibilityManager = VPNUpsellVisibilityManager(
             isFirstLaunch: false,
             isNewUser: true,
             subscriptionManager: mockSubscriptionManager,
             defaultBrowserProvider: mockDefaultBrowserProvider,
             contextualOnboardingPublisher: Just(true).eraseToAnyPublisher(),
-            featureFlagger: mockFeatureFlagger,
             persistor: mockPersistor,
             timerDuration: 0.01,
             autoDismissDays: 7,

--- a/macOS/UnitTests/NetworkProtection/VPNUpsellPopoverViewModelTests.swift
+++ b/macOS/UnitTests/NetworkProtection/VPNUpsellPopoverViewModelTests.swift
@@ -45,7 +45,6 @@ final class VPNUpsellPopoverViewModelTests: XCTestCase {
         mockPersistor = MockVPNUpsellUserDefaultsPersistor()
         firedPixels = []
 
-        mockFeatureFlagger.enabledFeatureFlags = [.vpnToolbarUpsell]
         mockSubscriptionManager.currentEnvironment = .init(serviceEnvironment: .staging, purchasePlatform: .stripe)
 
         vpnUpsellVisibilityManager = VPNUpsellVisibilityManager(
@@ -54,7 +53,6 @@ final class VPNUpsellPopoverViewModelTests: XCTestCase {
             subscriptionManager: mockSubscriptionManager,
             defaultBrowserProvider: mockDefaultBrowserProvider,
             contextualOnboardingPublisher: Just(true).eraseToAnyPublisher(),
-            featureFlagger: mockFeatureFlagger,
             persistor: mockPersistor,
             timerDuration: 0.01,
             autoDismissDays: 7,
@@ -230,7 +228,7 @@ final class VPNUpsellPopoverViewModelTests: XCTestCase {
     func testWhenListingPlusFeatures_AndAIChatIsEnabled_ItListsAIChat() throws {
         // Given
         let expectation = XCTestExpectation(description: "Feature set should be updated")
-        mockFeatureFlagger.enabledFeatureFlags = [.vpnToolbarUpsell, .paidAIChat]
+        mockFeatureFlagger.enabledFeatureFlags = [.paidAIChat]
 
         sut.$featureSet
             .dropFirst()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210594645229050/task/1211866719732725
Tech Design URL:
CC:

### Description

This PR removes feature-flag gating from the VPN toolbar upsell, as discussed in the linked task.

### Testing Steps
Please refer to [this task](https://app.asana.com/1/137249556945/project/1142021229838617/task/1210985001384926?focus=true).

### Impact and Risks
N/A

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes feature-flag gating for the VPN toolbar upsell, decouples visibility logic from FeatureFlagger, and updates configs/tests accordingly.
> 
> - **VPN Upsell**:
>   - Remove `FeatureFlagger` dependency from `VPNUpsellVisibilityManager` and drop flag checks; visibility now depends on user eligibility and timers only.
>   - Update initializer/signature and all call sites (e.g., `AppDelegate.vpnUpsellVisibilityManager`).
> - **Feature Flags & Privacy Config**:
>   - Delete `FeatureFlag.vpnToolbarUpsell` (case, default/source mapping, category references).
>   - Remove `PrivacyProSubfeature.vpnToolbarUpsell`.
> - **Tests**:
>   - Update VPN upsell-related tests to no longer set/check the removed flag and to use new manager initializer.
>   - Minor test adjustments (e.g., helper parameters, enabled flags limited to unrelated cases like `.paidAIChat`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6b5956bd4bd0b31aa7d92f0da08d467a91cb051. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->