### PR TITLE
Updates Privacy Dashboard to Mark 9.5.0

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/privacy-dashboard",
       "state" : {
-        "revision" : "fd3b7e2d8194e265c537f227c706de7db3085da5",
-        "version" : "9.4.0"
+        "revision" : "92c9c3970ddc6062fa2952e05098fdaea499ab6a",
+        "version" : "9.5.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -57,7 +57,7 @@ let package = Package(
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit.git", exact: "3.0.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.7.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "3.0.0"),
-        .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "9.4.0"),
+        .package(url: "https://github.com/duckduckgo/privacy-dashboard", exact: "9.5.0"),
         .package(url: "https://github.com/httpswift/swifter.git", exact: "1.5.0"),
         .package(url: "https://github.com/1024jp/GzipSwift.git", exact: "6.0.1"),
         .package(url: "https://github.com/vapor/jwt-kit.git", exact: "4.13.4"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1212321931107015?focus=true
Tech Design URL:
CC:

### Description
In this PR we're bumping the Privacy Dashboard to Mk 9.5.0

@jotaemepereira I'm manually bumping the Privacy Dashboard to 9.5.0, as this release supports the new Themes Messages.
I've noticed the last time this was updated, dependabot posted the PR (which didn't happen this time round).

Is this something we do manually? (Thank you!!)

### Testing Steps
- [ ] Verify the CI is green please!

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Possibly a regression in the Privacy Dashboard itself. Zero native code was modified in this PR

### Quality Considerations
Nothing in particular!

### Notes to Reviewer
Thank you!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the `privacy-dashboard` dependency to 9.5.0 and aligns the lockfile.
> 
> - **Dependencies**:
>   - Update `privacy-dashboard` from `9.4.0` to `9.5.0` in `SharedPackages/BrowserServicesKit/Package.swift` and `DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50387aad2baf909a93f6e5fe04c3f4620f4d5678. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->