### PR TITLE
iOS: Bugfix - Replace layoutIfNeeded with setNeedsLayout in AI Chat omnibar

### DIFF
--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -749,7 +749,7 @@ extension DefaultOmniBarView {
         NSLayoutConstraint.activate(aiChatModeConstraints)
         searchAreaContainerView.bringSubviewToFront(aiChatLeftButton)
 
-        layoutIfNeeded()
+        setNeedsLayout()
     }
 
     /// Restores the omnibar UI to regular browse mode. Hides AI Chat buttons, shows search elements.
@@ -763,7 +763,7 @@ extension DefaultOmniBarView {
         searchAreaView.textField.alpha = 1.0
         searchAreaView.revealButtons()
 
-        layoutIfNeeded()
+        setNeedsLayout()
     }
 
     // Used to mask shadows going outside of bounds to prevent them covering other content


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1212295344452777?focus=true

### Description
Replace `layoutIfNeeded` with `setNeedsLayout` in AI Chat omnibar transitions to defer layout until the view hierarchy is in a consistent state, preventing a crash in NSTextLayoutManager during navigation callbacks.

### Testing Prerequisites
Enable full mode duck.ai in debug

### Testing Steps
1. Open a search tab
2. Switch to AI chat full mode by entering a prompt or tapping the omnibar ai chat button
3. Ensure the omnibar changes it’s UI to ai chat mode (Icon and “Duck.ai” in the center)
4. Tap omnibar and enter a search, hit go
5. Ensure the omnibar changes it’s UI to search mode (standard omnibar appearance)

### Impact and Risks
Low, bugfix for bug with one occurance

#### What could go wrong?
AI Chat omnibar does not behave as expected

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace `layoutIfNeeded()` with `setNeedsLayout()` in `showAIChatOmnibar()` and `hideAIChatOmnibar()` to defer layout updates during AI Chat mode transitions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bea472f71e32a65c347e9718b4adb844c640417. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->