### PR TITLE
[macOS] Fix conflicting Safari data import translation keys

### DIFF
--- a/macOS/DuckDuckGo/DataImport/View/FileImportView.swift
+++ b/macOS/DuckDuckGo/DataImport/View/FileImportView.swift
@@ -277,7 +277,7 @@ func fileImportInstructionsBuilder(source: DataImport.Source, dataType: DataImpo
 
     case (.safari, .passwords), (.safariTechnologyPreview, .passwords):
         if #available(macOS 15.2, *) {
-            NSLocalizedString("import.csv.instructions.safari.macos15-2", value: """
+            NSLocalizedString("import.csv.instructions.safari.macos15-2.old", value: """
             %d Open **Safari**
             %d Open the **File menu → Export Browsing Data to File...**
             %d Select **passwords** and save the file someplace you can find it (e.g., Desktop)

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -45579,7 +45579,7 @@
       }
     },
     "import.csv.instructions.safari.macos15-2" : {
-      "comment" : "Instructions to import Passwords as CSV from Safari zip file on >= macOS 15.2.\n%N$d - step number\n%5$@ - “Select Passwords CSV File” button\n**bold text**; _italic text_\nInstructions to import Passwords as CSV from Safari zip file on >= macOS 15.2.\n%N$d - step number\n**bold text**; _italic text_",
+      "comment" : "Instructions to import Passwords as CSV from Safari zip file on >= macOS 15.2.\n%N$d - step number\n**bold text**; _italic text_",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "de" : {
@@ -45634,6 +45634,66 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$d Откройте **Safari → Файл → Экспортировать данные браузера в файл...**\n%2$d Выберите **Пароли** и сохраните файл\n%3$d Двойным щелчком мыши распакуйте архив .zip и загрузите файл CSV в DuckDuckGo"
+          }
+        }
+      }
+    },
+    "import.csv.instructions.safari.macos15-2.old" : {
+      "comment" : "Instructions to import Passwords as CSV from Safari zip file on >= macOS 15.2.\n%N$d - step number\n%5$@ - “Select Passwords CSV File” button\n**bold text**; _italic text_",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d Öffne **Safari**\n%2$d Öffne das Menü **Datei → Browserdaten in Datei exportieren ...**\n%3$d Wähle **Passwörter** und speichere die Datei an einem Ort, an dem du sie wiederfindest (z. B. Desktop)\n%4$d Doppelklicke auf die .zip-Datei, um sie zu entpacken\n%5$d %6$@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$d Open **Safari**\n%2$d Open the **File menu → Export Browsing Data to File...**\n%3$d Select **passwords** and save the file someplace you can find it (e.g., Desktop)\n%4$d Double click the .zip file to unzip it\n%5$d %6$@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d Abre **Safari**\n%2$d Abre el menú **Archivo → Exportar datos de navegación a archivo...**\n%3$d Selecciona **contraseñas** y guarda el archivo en algún lugar donde puedas encontrarlo (por ejemplo, en el escritorio)\n%4$d Haz doble clic en el archivo .zip para descomprimirlo\n%5$d %6$@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d Ouvrez **Safari**\n%2$d Ouvrez le **menu Fichier → Exporter les données de navigation vers le fichier…**\n%3$d Sélectionnez **mots de passe** et enregistrez le fichier à un endroit où le trouver facilement (par exemple, sur le bureau)\n%4$d Double-cliquez sur le fichier .zip pour le décompresser\n%5$d %6$@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d Apri **Safari**\n%2$d Apri il menu **File → Esporta i dati di navigazione in un file...**\n%3$d Seleziona **password** e salva il file in una posizione che ti consenta di trovarlo (ad esempio, sul desktop)\n%4$d Fai doppio clic sul file .zip per decomprimerlo\n%5$d %6$@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d Open **Safari**\n%2$d Open het menu **Bestand → Browsergegevens exporteren naar bestand...**\n%3$d Selecteer **wachtwoorden** en sla het bestand op een plek op waar je het kunt vinden (bijv. je bureaublad)\n%4$d Dubbelklik op het .zip-bestand om het uit te pakken\n%5$d %6$@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d Otwórz **Safari**\n%2$d Otwórz menu **Plik → Eksportuj dane przeglądania do pliku...**\n%3$d Wybierz **hasła** i zapisz plik w łatwo dostępnym miejscu (np. na biurku)\n%4$d Kliknij dwukrotnie plik .zip w celu jego rozpakowania\n%5$d %6$@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d Abre o **Safari**\n%2$d Abre o menu **Ficheiro → Exportar dados de navegação para ficheiro...**\n%3$d Seleciona **palavras-passe** e guarda o ficheiro num local onde o possas encontrar (por exemplo, no ambiente de trabalho)\n%4$d Clica duas vezes no ficheiro .zip para o descomprimir\n%5$d %6$@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d Запустите **Safari**\n%2$d Откройте меню **Файл → Экспортировать данные просмотров в файл...**\n%3$d Выберите **пароли** и сохраните файл там, где вы легко его найдете (например, на рабочем столе)\n%4$d Дважды нажмите мышью файл .zip, чтобы распаковать его\n%5$d %6$@"
           }
         }
       }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1212329966317602?focus=true
Tech Design URL:
CC:

### Description
Updated old translation key to differentiate from new import copy, and brought old translations back 

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Confirm CI is green
2. Quickly test the Safari import flow with `.dataImportNewExperience` flag enabled / disabled confirming instructions are correctly displayed
3. Disable both `.dataImportNewExperience` and `.dataImportNewSafariFilePicker` and confirm the old Safari instructions display correctly

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Splits Safari macOS 15.2 passwords import string into a new `.old` key, updates the view to use it, and restores localized values.
> 
> - **Localization**:
>   - Add `import.csv.instructions.safari.macos15-2.old` with localized strings (de, en, es, fr, it, nl, pl, pt, ru).
>   - Trim comment on existing `import.csv.instructions.safari.macos15-2` to remove unused button placeholder reference.
> - **UI (FileImportView)**:
>   - For `.safari`/`.safariTechnologyPreview` passwords on macOS ≥ 15.2, switch key to `import.csv.instructions.safari.macos15-2.old`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c739d6fb0fd4c495bbbb510965aae49452e9124. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->