### PR TITLE
[Release PR] Fix VPN toggle status after launch

### DIFF
--- a/macOS/DuckDuckGoVPN/TunnelControllerIPCService.swift
+++ b/macOS/DuckDuckGoVPN/TunnelControllerIPCService.swift
@@ -184,6 +184,7 @@ extension TunnelControllerIPCService: XPCServerInterface {
     func register(version: String, bundlePath: String, completion: @escaping (Error?) -> Void) {
         server.serverInfoChanged(statusReporter.serverInfoObserver.recentValue)
         server.statusChanged(statusReporter.statusObserver.recentValue)
+        server.vpnEnableChanged(statusReporter.vpnEnabledObserver.isVPNEnabled)
         if self.version != version {
             let error = TunnelControllerIPCService.IPCError.versionMismatched
             NetworkProtectionKnownFailureStore().lastKnownFailure = KnownFailure(error)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1212330546750235?focus=true
Tech Design URL:
CC:

### Description

This PR fixes an issue where when you launch the app while the VPN is connected, the VPN UI shows as disabled. This issue did not manifest in local testing as it corrects itself when the agent restarts, which happens automatically on every app launch in debug builds.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->

First, you should reproduce this issue in the release build to confirm that this is legitimate. To do this, we first need to disable the following logic in `VPNAppEventsHandler`:

```
#if DEBUG || REVIEW // Since DEBUG and REVIEW builds may not change version No. we want them to always reset.
        restartTunnel()
#else
        if versionStore.lastAgentVersionRun != currentVersion {
            restartTunnel()
        }
#endif
```

Comment that whole block out, and then do the following:
1. Launch the app and connect the VPN
2. Kill the app and relaunch it
3. Check that the VPN UI in the app (not the status bar) shows the VPN as disabled, even though it's still connected

Now, do the same steps on this branch and confirm that the toggle shows in the correct state.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
5. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
6. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

High: Could impact usability of the VPN

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sends the current VPN enabled state to XPC clients during registration to ensure correct UI state on launch.
> 
> - **IPC/XPC Registration**
>   - In `TunnelControllerIPCService.register(version:bundlePath:completion:)`, now sends initial VPN enabled state via `server.vpnEnableChanged(statusReporter.vpnEnabledObserver.isVPNEnabled)` alongside existing server and status updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eeea31f6fb31b18b66c89cca71e3a51ed11afbc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->