### PR TITLE
[BSK] Fix flaky testInstantlyOpenEmptyUrlInNewWindow

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/NavigationTests/DistributedNavigationDelegateTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/NavigationTests/DistributedNavigationDelegateTests.swift
@@ -412,9 +412,8 @@ class DistributedNavigationDelegateTests: DistributedNavigationDelegateTestsBase
         let uiDelegate = WKUIDelegateMock()
         var newWebView: WKWebView!
         let eDidRequestNewWindow = expectation(description: "eDidRequestNewWindow")
-        uiDelegate.createWebViewWithConfig = { [unowned navigationDelegateProxy] config, _, _ in
+        uiDelegate.createWebViewWithConfig = { config, _, _ in
             newWebView = WKWebView(frame: .zero, configuration: config)
-            newWebView.navigationDelegate = navigationDelegateProxy
             DispatchQueue.main.async {
                 eDidRequestNewWindow.fulfill()
             }
@@ -430,12 +429,8 @@ class DistributedNavigationDelegateTests: DistributedNavigationDelegateTestsBase
         try server.start(8084)
 
         let eDidFinish = expectation(description: "onDidFinish")
-        var counter = 0
         responder(at: 0).onDidFinish = { [weak self] _ in
-            counter += 1
-            if counter == 1 {
-                self!._webView!.evaluateJavaScript("window.open('')")
-            }
+            self!._webView!.evaluateJavaScript("window.open('')")
             eDidFinish.fulfill()
         }
         var newFrameIdentity: FrameHandle!


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1212011206212187?focus=true

### Description

Fix flaky testInstantlyOpenEmptyUrlInNewWindow by removing counter logic and not assigning navigationDelegate to new window.

The test was failing with "API violation - multiple calls to fulfill()" because the new window was sharing the same responder through navigationDelegateProxy, causing onDidFinish to fire for both windows.

- Remove navigationDelegate assignment from new window creation
- Simplify onDidFinish callback to only trigger window.open and fulfill once
- Remove unnecessary counter variable

### Testing Steps

1. Validate CI is green

### Impact and Risks

**Impact Level: Low**

#### What could go wrong?

Test infrastructure change only, no production code affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deflakes `testInstantlyOpenEmptyUrlInNewWindow` by not assigning a navigation delegate to the new window and simplifying the finish handler to trigger `window.open('')` once.
> 
> - **Tests**
>   - Update `SharedPackages/BrowserServicesKit/Tests/NavigationTests/DistributedNavigationDelegateTests.swift`
>     - `testInstantlyOpenEmptyUrlInNewWindow`:
>       - Do not set `navigationDelegate` on newly created `WKWebView` in `createWebViewWithConfig`.
>       - Simplify `onDidFinish`: remove counter; directly call `window.open('')` and fulfill once.
>       - Remove `[unowned navigationDelegateProxy]` capture from `createWebViewWithConfig`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28f0ac2d88e0304840df5e09a27489d972d4ac9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->