### PR TITLE
Remove forgetAllInSettings feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -164,9 +164,6 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/392891325557410/task/1210869716452614?focus=true
     case customization
 
-    /// https://app.asana.com/1/137249556945/project/72649045549333/task/1211660503405838?focus=true
-    case forgetAllInSettings
-
     /// https://app.asana.com/1/137249556945/project/481882893211075/task/1212057154681076?focus=true
     case productTelemetrySurfaceUsage
 

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -224,9 +224,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866713701189
     case vpnMenuItem
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866614199859
-    case forgetAllInSettings
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866470156149
     case duckAiDataClearing
     
@@ -303,7 +300,6 @@ extension FeatureFlag: FeatureFlagDescribing {
              .dbpForegroundRunningWhenDashboardOpen,
              .syncCreditCards,
              .unifiedURLPredictor,
-             .forgetAllInSettings,
              .vpnConnectionWidePixelMeasurement,
              .migrateKeychainAccessibility,
              .dataImportWideEventMeasurement,
@@ -355,7 +351,6 @@ extension FeatureFlag: FeatureFlagDescribing {
              .unifiedURLPredictor,
              .mobileCustomization,
              .vpnMenuItem,
-             .forgetAllInSettings,
              .onboardingSearchExperience,
              .duckAiDataClearing,
              .fullDuckAIMode,
@@ -554,8 +549,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.customization))
         case .vpnMenuItem:
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.vpnMenuItem))
-        case .forgetAllInSettings:
-            return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.forgetAllInSettings))
         case .duckAiDataClearing:
             return .remoteReleasable(.feature(.duckAiDataClearing))
         case .fullDuckAIMode:

--- a/iOS/DuckDuckGo/SettingsDataClearingView.swift
+++ b/iOS/DuckDuckGo/SettingsDataClearingView.swift
@@ -62,27 +62,25 @@ struct SettingsDataClearingView: View {
                     Text(UserText.settingsClearAIChatHistoryFooter)
                 }
             }
-            
-            if viewModel.isForgetAllInSettingsEnabled {
-                Section(footer: Text(footnoteText)) {
-                    SettingsCellView(action: {
-                        Pixel.fire(pixel: .forgetAllPressedSettings)
-                        isShowingBurnAlert = true
-                    }, customView: {
-                        AnyView(
-                            HStack(alignment: .center) {
-                                Image(uiImage: DesignSystemImages.Glyphs.Size24.fireSolid)
-                                    .tintIfAvailable(Color(designSystemColor: .icons))
-                                Text(forgetAllTitle)
-                                    .foregroundStyle(Color(designSystemColor: .accent))
-                                Spacer()
-                            }
-                        )
-                    }, isButton: true)
-                    .accessibilityIdentifier("Settings.DataClearing.Button.ForgetAll")
-                    .forgetDataConfirmationDialog(isPresented: $isShowingBurnAlert,
-                                                  onConfirm: viewModel.forgetAll)
-                }
+
+            Section(footer: Text(footnoteText)) {
+                SettingsCellView(action: {
+                    Pixel.fire(pixel: .forgetAllPressedSettings)
+                    isShowingBurnAlert = true
+                }, customView: {
+                    AnyView(
+                        HStack(alignment: .center) {
+                            Image(uiImage: DesignSystemImages.Glyphs.Size24.fireSolid)
+                                .tintIfAvailable(Color(designSystemColor: .icons))
+                            Text(forgetAllTitle)
+                                .foregroundStyle(Color(designSystemColor: .accent))
+                            Spacer()
+                        }
+                    )
+                }, isButton: true)
+                .accessibilityIdentifier("Settings.DataClearing.Button.ForgetAll")
+                .forgetDataConfirmationDialog(isPresented: $isShowingBurnAlert,
+                                              onConfirm: viewModel.forgetAll)
             }
         }
         .applySettingsListModifiers(title: UserText.dataClearing,

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -136,10 +136,6 @@ final class SettingsViewModel: ObservableObject {
     // This affects UI: shows Done button and hides Search Assist link
     var openedFromSERPSettingsButton: Bool = false
 
-    var isForgetAllInSettingsEnabled: Bool {
-        featureFlagger.isFeatureOn(.forgetAllInSettings)
-    }
-
     // Indicates if the Paid AI Chat feature flag is enabled for the current user/session.
     var isPaidAIChatEnabled: Bool {
         featureFlagger.isFeatureOn(.paidAIChat)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1211755582376836?focus=true
Tech Design URL:
CC:

### Description

Remove `forgetAllInSettings` failsafe feature flag.

### Testing Steps
1. Verify Clear Data in Data Clearing Settings is visible and is clearing data as expected.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?


### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the forgetAllInSettings feature flag and always shows the Clear Data (Forget All) action in Data Clearing settings, pruning all related flag wiring.
> 
> - **Settings UI (iOS)**:
>   - Always display the `Forget All` action in `SettingsDataClearingView` (removed feature-flag gating).
> - **Feature Flags / Config**:
>   - Remove `FeatureFlag.forgetAllInSettings` (enum case, default values, local override support, and source mapping).
>   - Remove `iOSBrowserConfigSubfeature.forgetAllInSettings` from `PrivacyFeature` subfeatures.
>   - Drop related property `isForgetAllInSettingsEnabled` from `SettingsViewModel`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6c9472f1087f93dec8e40c50e9056335d97aae9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->