### PR TITLE
Remove unifiedURLPredictor feature flag on iOS

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -209,9 +209,6 @@ public enum FeatureFlag: String {
     ///  https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866712760360
     case syncCreditCards
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866613993355
-    case unifiedURLPredictor
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866472511092
     case mobileCustomization
 
@@ -279,7 +276,6 @@ extension FeatureFlag: FeatureFlagDescribing {
              .newDeviceSyncPrompt,
              .authV2WideEventEnabled,
              .syncCreditCards,
-             .unifiedURLPredictor,
              .forgetAllInSettings,
              .vpnConnectionWidePixelMeasurement,
              .migrateKeychainAccessibility:
@@ -325,7 +321,6 @@ extension FeatureFlag: FeatureFlagDescribing {
              .authV2WideEventEnabled,
              .winBackOffer,
              .syncCreditCards,
-             .unifiedURLPredictor,
              .mobileCustomization,
              .vpnMenuItem,
              .forgetAllInSettings,
@@ -512,8 +507,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.blackFridayCampaign))
         case .syncCreditCards:
             return .remoteReleasable(.subfeature(SyncSubfeature.syncCreditCards))
-        case .unifiedURLPredictor:
-            return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.unifiedURLPredictor))
         case .mobileCustomization:
             return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.customization))
         case .vpnMenuItem:

--- a/iOS/DuckDuckGo/AutocompleteViewController.swift
+++ b/iOS/DuckDuckGo/AutocompleteViewController.swift
@@ -59,10 +59,6 @@ class AutocompleteViewController: UIHostingController<AutocompleteView> {
 
     private var task: URLSessionDataTask?
 
-    private var isUsingUnifiedPrediction: Bool {
-        featureFlagger.isFeatureOn(.unifiedURLPredictor)
-    }
-
     lazy var dataSource: AutocompleteSuggestionsDataSource = {
         return AutocompleteSuggestionsDataSource(
             historyManager: historyManager,
@@ -209,8 +205,8 @@ class AutocompleteViewController: UIHostingController<AutocompleteView> {
             // * converted URL is root (no path)
             // * the user typed the trailing "/"
             guard let self,
-                  let url = URL(trimmedAddressBarString: phrase, useUnifiedLogic: isUsingUnifiedPrediction),
-                  url.isValid(usingUnifiedLogic: self.isUsingUnifiedPrediction)
+                  let url = URL(trimmedAddressBarString: phrase, useUnifiedLogic: true),
+                  url.isValid(usingUnifiedLogic: true)
             else {
                 return true
             }

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -223,7 +223,7 @@ final class DefaultOmniBarViewController: OmniBarViewController {
         /// Determine whether the current text in the omnibar is a search query or a URL.
         /// - If the text is a URL, retrieve the full URL from the delegate and update the text with the full URL for display.
         /// - If the text is a search query, simply update the text with the query itself.
-        if URL(trimmedAddressBarString: currentText, useUnifiedLogic: isUsingUnifiedPredictor) != nil,
+        if URL(trimmedAddressBarString: currentText, useUnifiedLogic: true) != nil,
            let url = omniDelegate?.didRequestCurrentURL() {
             let urlText = AddressDisplayHelper.addressForDisplay(url: url, showsFullURL: true)
             switchBarHandler.updateCurrentText(urlText.string)
@@ -236,7 +236,7 @@ final class DefaultOmniBarViewController: OmniBarViewController {
 
     private func shouldAutoSelectTextForUrl(_ textField: UITextField) -> Bool {
         guard let textFieldText = textField.text else { return false }
-        return URL(trimmedAddressBarString: textFieldText.trimmingWhitespace(), useUnifiedLogic: isUsingUnifiedPredictor) != nil
+        return URL(trimmedAddressBarString: textFieldText.trimmingWhitespace(), useUnifiedLogic: true) != nil
     }
 }
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -82,10 +82,6 @@ class MainViewController: UIViewController {
         suggestionTrayController?.isShowingAutocompleteSuggestions == true
     }
 
-    var isUnifiedURLPredictionEnabled: Bool {
-        featureFlagger.isFeatureOn(.unifiedURLPredictor)
-    }
-
     lazy var emailManager: EmailManager = {
         let emailManager = EmailManager()
         emailManager.aliasPermissionDelegate = self
@@ -1043,7 +1039,7 @@ class MainViewController: UIViewController {
         launchTabObserver = LaunchTabNotification.addObserver(handler: { [weak self] urlString in
             guard let self = self else { return }
             viewCoordinator.omniBar.endEditing()
-            if let url = URL(trimmedAddressBarString: urlString, useUnifiedLogic: isUnifiedURLPredictionEnabled), url.isValid(usingUnifiedLogic: isUnifiedURLPredictionEnabled) {
+            if let url = URL(trimmedAddressBarString: urlString, useUnifiedLogic: true), url.isValid(usingUnifiedLogic: true) {
                 self.loadUrlInNewTab(url, inheritedAttribution: nil)
             } else {
                 self.loadQuery(urlString)
@@ -1247,7 +1243,7 @@ class MainViewController: UIViewController {
     ///   - reuseExisting: The policy for reusing an existing tab. Defaults to `none`, meaning no reuse.
     func loadQueryInNewTab(_ query: String, reuseExisting: ExistingTabReusePolicy? = .none) {
         dismissOmniBar()
-        guard let url = URL.makeSearchURL(query: query, useUnifiedLogic: isUnifiedURLPredictionEnabled) else {
+        guard let url = URL.makeSearchURL(query: query, useUnifiedLogic: true) else {
             Logger.lifecycle.error("Couldn't form URL for query: \(query, privacy: .public)")
             return
         }
@@ -1313,7 +1309,7 @@ class MainViewController: UIViewController {
     }
 
     fileprivate func loadQuery(_ query: String) {
-        guard let url = URL.makeSearchURL(query: query, useUnifiedLogic: isUnifiedURLPredictionEnabled, queryContext: currentTab?.url) else {
+        guard let url = URL.makeSearchURL(query: query, useUnifiedLogic: true, queryContext: currentTab?.url) else {
             Logger.general.error("Couldn't form URL for query \"\(query, privacy: .public)\" with context \"\(self.currentTab?.url?.absoluteString ?? "<nil>", privacy: .public)\"")
             return
         }
@@ -2521,7 +2517,7 @@ extension MainViewController: BrowserChromeDelegate {
         viewCoordinator.omniBar.cancel()
         switch suggestion {
         case .phrase(phrase: let phrase):
-            if let url = URL.makeSearchURL(query: phrase, useUnifiedLogic: isUnifiedURLPredictionEnabled, forceSearchQuery: true) {
+            if let url = URL.makeSearchURL(query: phrase, useUnifiedLogic: true, forceSearchQuery: true) {
                 loadUrl(url)
             } else {
                 Logger.lifecycle.error("Couldn't form URL for suggestion: \(phrase, privacy: .public)")

--- a/iOS/DuckDuckGo/OmniBarViewController.swift
+++ b/iOS/DuckDuckGo/OmniBarViewController.swift
@@ -60,9 +60,6 @@ class OmniBarViewController: UIViewController, OmniBar {
 
     // MARK: - Animation
 
-    var isUsingUnifiedPredictor: Bool {
-        dependencies.featureFlagger.isFeatureOn(.unifiedURLPredictor)
-    }
     var dismissButtonAnimator: UIViewPropertyAnimator?
     private var notificationAnimator = OmniBarNotificationAnimator()
     private let privacyIconContextualOnboardingAnimator = PrivacyIconContextualOnboardingAnimator()
@@ -694,7 +691,7 @@ class OmniBarViewController: UIViewController, OmniBar {
 
             DailyPixel.fireDailyAndCount(pixel: .aiChatLegacyOmnibarQuerySubmitted)
             
-            if let url = URL(trimmedAddressBarString: query, useUnifiedLogic: isUsingUnifiedPredictor), url.isValid(usingUnifiedLogic: isUsingUnifiedPredictor) {
+            if let url = URL(trimmedAddressBarString: query, useUnifiedLogic: true), url.isValid(usingUnifiedLogic: true) {
                 omniDelegate?.onOmniQuerySubmitted(url.absoluteString)
             } else {
                 omniDelegate?.onOmniQuerySubmitted(query)
@@ -934,7 +931,7 @@ extension OmniBarViewController {
 extension OmniBarViewController {
 
     private func decorate() {
-        if let url = textField.text.flatMap({ URL(trimmedAddressBarString: $0.trimmingWhitespace(), useUnifiedLogic: isUsingUnifiedPredictor) }) {
+        if let url = textField.text.flatMap({ URL(trimmedAddressBarString: $0.trimmingWhitespace(), useUnifiedLogic: true) }) {
             textField.attributedText = AddressDisplayHelper.addressForDisplay(url: url, showsFullURL: textField.isEditing)
         }
     }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1212338932559285?focus=true
Tech Design URL:
CC: @ayoy 

### Description

Remove unifiedURLPredictor failsafe feature flag on iOS.

### Testing Steps
1. Make sure CI is green

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `unifiedURLPredictor` feature flag and unconditionally enables unified URL parsing/search logic across omnibar, autocomplete, and launch flows.
> 
> - **Feature Flags**:
>   - Remove `FeatureFlag.unifiedURLPredictor` and all references (default, local overriding, source mapping) in `iOS/Core/FeatureFlag.swift`.
> - **Address Bar & Suggestions**:
>   - Standardize URL handling to unified logic by passing `useUnifiedLogic: true` in:
>     - `AutocompleteViewController` suggestion loading.
>     - `DefaultOmniBarViewController` switch bar text, auto-select logic.
>     - `MainViewController` launch tab handling, query-to-URL creation, suggestion selection, and internal search URL builders.
>     - `OmniBarViewController` query submission and display formatting.
>   - Remove now-unused `isUsingUnifiedPredictor`/`isUsingUnifiedPrediction` helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 179f2c77e95e10d37a48bdf450c30ecaade56143. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->