### PR TITLE
iOS: Full Duck.ai Mode - Update Tabs on Subscription State Change

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1592,6 +1592,7 @@
 		C1641EAF2BC2F5140012607A /* ImportPasswordsViaSyncViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1641EAE2BC2F5140012607A /* ImportPasswordsViaSyncViewController.swift */; };
 		C1641EB12BC2F52B0012607A /* ImportPasswordsViaSyncView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1641EB02BC2F52B0012607A /* ImportPasswordsViaSyncView.swift */; };
 		C1641EB32BC2F53C0012607A /* ImportPasswordsViaSyncViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1641EB22BC2F53C0012607A /* ImportPasswordsViaSyncViewModel.swift */; };
+		C16670E42EE7301300C6105C /* SubscriptionAIChatStateHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C16670E32EE7301300C6105C /* SubscriptionAIChatStateHandlerTests.swift */; };
 		C167D9062DAD5BDA00FA1E70 /* SubscriptionFunnelOrigin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C167D9052DAD5BDA00FA1E70 /* SubscriptionFunnelOrigin.swift */; };
 		C17023AA2E589C6E00090178 /* DaxEasterEggLogoCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17023A92E589C6E00090178 /* DaxEasterEggLogoCache.swift */; };
 		C177D9F62CFDDFEB0039CBF7 /* UIAlertControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C177D9F52CFDDFEB0039CBF7 /* UIAlertControllerExtension.swift */; };
@@ -3917,6 +3918,7 @@
 		C1641EB22BC2F53C0012607A /* ImportPasswordsViaSyncViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportPasswordsViaSyncViewModel.swift; sourceTree = "<group>"; };
 		C164F9472D0861D600BAE88E /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		C164F9482D0861D600BAE88E /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
+		C16670E32EE7301300C6105C /* SubscriptionAIChatStateHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionAIChatStateHandlerTests.swift; sourceTree = "<group>"; };
 		C167D9052DAD5BDA00FA1E70 /* SubscriptionFunnelOrigin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionFunnelOrigin.swift; sourceTree = "<group>"; };
 		C17023A92E589C6E00090178 /* DaxEasterEggLogoCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaxEasterEggLogoCache.swift; sourceTree = "<group>"; };
 		C174E08E2D08625300ACE1AF /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -4984,6 +4986,7 @@
 				C124F0552E6879E7008D0F49 /* SwitchBarFunnelTests.swift */,
 				C14414782EB11A100057F921 /* AIChatFullModeFeatureTests.swift */,
 				C12B671F2EC0BDD9003B80DD /* AIChatContentHandlerTests.swift */,
+				C16670E32EE7301300C6105C /* SubscriptionAIChatStateHandlerTests.swift */,
 			);
 			path = AIChat;
 			sourceTree = "<group>";
@@ -11856,6 +11859,7 @@
 				9F387DD82EA86CE3006861F8 /* PromptCooldownStoreTests.swift in Sources */,
 				9F60CBBD2E98A13D004D2367 /* MockBrowserTabURLOpener.swift in Sources */,
 				EEC02C162B065BE00045CE11 /* NetworkProtectionVPNLocationViewModelTests.swift in Sources */,
+				C16670E42EE7301300C6105C /* SubscriptionAIChatStateHandlerTests.swift in Sources */,
 				9F60CBB82E989EDC004D2367 /* MockLastSearchStateRefresher.swift in Sources */,
 				9FF967B72E0E31D300E45B54 /* MockDefaultBrowserPromptUserTypeStoring.swift in Sources */,
 				987130C5294AAB9F00AB05E0 /* BookmarkEditorViewModelTests.swift in Sources */,

--- a/iOS/DuckDuckGo/AIChat/SubscriptionAIChatStateHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/SubscriptionAIChatStateHandler.swift
@@ -24,11 +24,14 @@ import Foundation
 ///
 /// When a user's subscription changes (sign-in, sign-out, or plan change),
 /// AI Chat needs to reload to reflect the new subscription features and limits.
-protocol SubscriptionAIChatStateHandling {
+protocol SubscriptionAIChatStateHandling: AnyObject {
     /// Indicates if AI Chat should refresh due to subscription changes.
     ///
     /// Becomes `true` when subscription status changes.
     var shouldForceAIChatRefresh: Bool { get }
+
+    /// Called when subscription state changes. Set this to react to changes immediately.
+    var onSubscriptionStateChanged: (() -> Void)? { get set }
 
     /// Clears the refresh flag after AI Chat has been reloaded.
     func reset()
@@ -36,6 +39,7 @@ protocol SubscriptionAIChatStateHandling {
 
 final class SubscriptionAIChatStateHandler: SubscriptionAIChatStateHandling {
     private(set) var shouldForceAIChatRefresh: Bool = false
+    var onSubscriptionStateChanged: (() -> Void)?
     private var subscriptionCancellables = Set<AnyCancellable>()
 
     init() {
@@ -65,8 +69,9 @@ final class SubscriptionAIChatStateHandler: SubscriptionAIChatStateHandling {
             .store(in: &subscriptionCancellables)
     }
 
-    private func handleSubscriptionStateChange(_ notification: Notification, ) {
+    private func handleSubscriptionStateChange(_ notification: Notification) {
         shouldForceAIChatRefresh = true
+        onSubscriptionStateChanged?()
     }
 
     func reset() {

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -490,6 +490,7 @@ class TabViewController: UIViewController {
     let aiChatFullModeFeature: AIChatFullModeFeatureProviding
     
     private(set) var aiChatContentHandler: AIChatContentHandling
+    let subscriptionAIChatStateHandler: SubscriptionAIChatStateHandling
 
     required init?(coder aDecoder: NSCoder,
                    tabModel: Tab,
@@ -553,11 +554,17 @@ class TabViewController: UIViewController {
         self.aiChatSettings = aiChatSettings
         self.aiChatFullModeFeature = aiChatFullModeFeature
         self.aiChatContentHandler = AIChatContentHandler(aiChatSettings: aiChatSettings, featureDiscovery: featureDiscovery)
+        self.subscriptionAIChatStateHandler = SubscriptionAIChatStateHandler()
 
         self.productSurfaceTelemetry = productSurfaceTelemetry
 
         super.init(coder: aDecoder)
-        
+
+        // Reload AI Chat when subscription state changes
+        subscriptionAIChatStateHandler.onSubscriptionStateChanged = { [weak self] in
+            self?.reloadAIChatIfNeeded()
+        }
+
         // Assign itself as tabNavigationHandler for DuckPlayer
         duckPlayerNavigationHandler.tabNavigationHandler = self
 

--- a/iOS/DuckDuckGo/TabViewControllerAIChatExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerAIChatExtension.swift
@@ -73,4 +73,10 @@ extension TabViewController: AITabController {
         let newChatURL = aiChatContentHandler.buildQueryURL(query: nil, autoSend: false, tools: nil)
         delegate?.tab(self, didRequestNewTabForUrl: newChatURL, openedByPage: false, inheritingAttribution: nil)
     }
+
+    /// Reloads the AI Chat if this is an AI tab.
+    func reloadAIChatIfNeeded() {
+        guard isAITab else { return }
+        webView.reload()
+    }
 }

--- a/iOS/DuckDuckGoTests/AIChat/SubscriptionAIChatStateHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/SubscriptionAIChatStateHandlerTests.swift
@@ -1,0 +1,139 @@
+//
+//  SubscriptionAIChatStateHandlerTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo
+
+final class SubscriptionAIChatStateHandlerTests: XCTestCase {
+
+    var sut: SubscriptionAIChatStateHandler!
+
+    override func setUp() {
+        super.setUp()
+        sut = SubscriptionAIChatStateHandler()
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    // MARK: - Initial State
+
+    func testInitialState_shouldForceAIChatRefreshIsFalse() {
+        XCTAssertFalse(sut.shouldForceAIChatRefresh)
+    }
+
+    func testInitialState_onSubscriptionStateChangedIsNil() {
+        XCTAssertNil(sut.onSubscriptionStateChanged)
+    }
+
+    // MARK: - Subscription Did Change
+
+    func testWhenSubscriptionDidChangeNotificationPosted_shouldForceAIChatRefreshBecomesTrue() {
+        let expectation = expectation(description: "flag set")
+        sut.onSubscriptionStateChanged = {
+            expectation.fulfill()
+        }
+
+        NotificationCenter.default.post(name: .subscriptionDidChange, object: nil)
+
+        waitForExpectations(timeout: 1.0)
+        XCTAssertTrue(sut.shouldForceAIChatRefresh)
+    }
+
+    func testWhenSubscriptionDidChangeNotificationPosted_onSubscriptionStateChangedIsCalled() {
+        let expectation = expectation(description: "onSubscriptionStateChanged called")
+        sut.onSubscriptionStateChanged = {
+            expectation.fulfill()
+        }
+
+        NotificationCenter.default.post(name: .subscriptionDidChange, object: nil)
+
+        waitForExpectations(timeout: 1.0)
+    }
+
+    // MARK: - Account Did Sign In
+
+    func testWhenAccountDidSignInNotificationPosted_shouldForceAIChatRefreshBecomesTrue() {
+        let expectation = expectation(description: "flag set")
+        sut.onSubscriptionStateChanged = {
+            expectation.fulfill()
+        }
+
+        NotificationCenter.default.post(name: .accountDidSignIn, object: nil)
+
+        waitForExpectations(timeout: 1.0)
+        XCTAssertTrue(sut.shouldForceAIChatRefresh)
+    }
+
+    func testWhenAccountDidSignInNotificationPosted_onSubscriptionStateChangedIsCalled() {
+        let expectation = expectation(description: "onSubscriptionStateChanged called")
+        sut.onSubscriptionStateChanged = {
+            expectation.fulfill()
+        }
+
+        NotificationCenter.default.post(name: .accountDidSignIn, object: nil)
+
+        waitForExpectations(timeout: 1.0)
+    }
+
+    // MARK: - Account Did Sign Out
+
+    func testWhenAccountDidSignOutNotificationPosted_shouldForceAIChatRefreshBecomesTrue() {
+        let expectation = expectation(description: "flag set")
+        sut.onSubscriptionStateChanged = {
+            expectation.fulfill()
+        }
+
+        NotificationCenter.default.post(name: .accountDidSignOut, object: nil)
+
+        waitForExpectations(timeout: 1.0)
+        XCTAssertTrue(sut.shouldForceAIChatRefresh)
+    }
+
+    func testWhenAccountDidSignOutNotificationPosted_onSubscriptionStateChangedIsCalled() {
+        let expectation = expectation(description: "onSubscriptionStateChanged called")
+        sut.onSubscriptionStateChanged = {
+            expectation.fulfill()
+        }
+
+        NotificationCenter.default.post(name: .accountDidSignOut, object: nil)
+
+        waitForExpectations(timeout: 1.0)
+    }
+
+    // MARK: - Reset
+
+    func testWhenResetCalled_shouldForceAIChatRefreshBecomesFalse() {
+        let expectation = expectation(description: "flag set")
+        sut.onSubscriptionStateChanged = {
+            expectation.fulfill()
+        }
+
+        NotificationCenter.default.post(name: .subscriptionDidChange, object: nil)
+
+        waitForExpectations(timeout: 1.0)
+        XCTAssertTrue(sut.shouldForceAIChatRefresh)
+
+        sut.reset()
+
+        XCTAssertFalse(sut.shouldForceAIChatRefresh)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1212324668439259

### Description
Ensure Duck.ai tabs react to Subscription changed state

### Testing Prerequisites
1. Enable full mode duck.ai in debug

### Testing Steps
#### Test 1 - Activate Subscription
1. Open a few duck.ai tabs and enter prompts
2. Go to app settings and add your subscription to the device
3. Ensure each tab has reloaed and duck.ai is showing a subscribed state

#### Test 1 - Deactivate Subscription
1. Open a few duck.ai tabs and enter prompts
2. Go to app settings and remove your subscription to the device
3. Ensure each tab has reloaed and duck.ai is showing a free state

#### What could go wrong?
Wrong subscription state in Duck.ai

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a subscription state handler and wire it to auto-reload Duck.ai tabs on sign-in/out or plan changes, with unit tests.
> 
> - **AI Chat**
>   - **Subscription refresh handling**: Add `SubscriptionAIChatStateHandler` and `SubscriptionAIChatStateHandling` (now `AnyObject`) to observe `.subscriptionDidChange`, `.accountDidSignIn`, `.accountDidSignOut`, set `shouldForceAIChatRefresh`, and expose `onSubscriptionStateChanged` callback; add `reset()`.
>   - **Tab integration**: In `TabViewController`, instantiate `SubscriptionAIChatStateHandler` and reload AI tabs on changes via `subscriptionAIChatStateHandler.onSubscriptionStateChanged` -> `reloadAIChatIfNeeded()`.
>   - **Helper**: Add `reloadAIChatIfNeeded()` in `TabViewControllerAIChatExtension.swift` to `reload()` when `isAITab`.
> - **Tests**
>   - Add `SubscriptionAIChatStateHandlerTests.swift` covering initial state, notifications, callback firing, and `reset()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d2870a9fa4f0422c53b399d16605e9f4a3f0488. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->