### PR TITLE
DesignSystemColor: Adds missing enum cases

### DIFF
--- a/SharedPackages/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SharedPalettes/SharedColorPaletteDefinition+DynamicColors.swift
+++ b/SharedPackages/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SharedPalettes/SharedColorPaletteDefinition+DynamicColors.swift
@@ -116,10 +116,22 @@ extension SharedColorPaletteDefinition {
             return containerFillSecondary
         case .containerFillTertiary:
             return containerFillTertiary
+        case .containerBorderPrimary:
+            return containerBorderPrimary
+        case .containerBorderSecondary:
+            return containerBorderSecondary
         case .containerBorderTertiary:
             return containerBorderTertiary
 
         /// Controls Colors
+        case .controlsBorderPrimary:
+            return controlsBorderPrimary
+        case .controlsBorderSecondary:
+            return controlsBorderSecondary
+        case .controlsBorderTertiary:
+            return controlsBorderTertiary
+        case .controlsBorderQuaternary:
+            return controlsBorderQuaternary
         case .controlsFillPrimary:
             return controlsFillPrimary
         case .controlsFillSecondary:

--- a/SharedPackages/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SharedPalettes/SharedColorPaletteDefinition.swift
+++ b/SharedPackages/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SharedPalettes/SharedColorPaletteDefinition.swift
@@ -74,9 +74,15 @@ protocol SharedColorPaletteDefinition {
     static var containerFillPrimary: DynamicColor { get }
     static var containerFillSecondary: DynamicColor { get }
     static var containerFillTertiary: DynamicColor { get }
+    static var containerBorderPrimary: DynamicColor { get }
+    static var containerBorderSecondary: DynamicColor { get }
     static var containerBorderTertiary: DynamicColor { get }
 
     // MARK: - Controls Colors
+    static var controlsBorderPrimary: DynamicColor { get }
+    static var controlsBorderSecondary: DynamicColor { get }
+    static var controlsBorderTertiary: DynamicColor { get }
+    static var controlsBorderQuaternary: DynamicColor { get }
     static var controlsFillPrimary: DynamicColor { get }
     static var controlsFillSecondary: DynamicColor { get }
     static var controlsFillTertiary: DynamicColor { get }

--- a/SharedPackages/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SharedPalettes/SharedDesignSystemColor.swift
+++ b/SharedPackages/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SharedPalettes/SharedDesignSystemColor.swift
@@ -76,9 +76,15 @@ public enum SharedDesignSystemColor {
     case containerFillPrimary
     case containerFillSecondary
     case containerFillTertiary
+    case containerBorderPrimary
+    case containerBorderSecondary
     case containerBorderTertiary
 
     // Controls
+    case controlsBorderPrimary
+    case controlsBorderSecondary
+    case controlsBorderTertiary
+    case controlsBorderQuaternary
     case controlsFillPrimary
     case controlsFillSecondary
     case controlsFillTertiary


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1212321498162755?focus=true
Tech Design URL:
CC:

### Description
In this PR we're adding missing `DesignSystemColor` enum cases, so that all of the Colors defined in each one of the Themes can be accessed.

Though these colors aren't currently in use, we're doing this for future UI requirements.

### Testing Steps
- [ ] Verify the CI is green

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing really. The newly added enum cases aren't currently being used anywhere.

### Quality Considerations
Nothing in particular

### Notes to Reviewer
Thank you!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new container and controls border color cases and wires them through the palette protocol and dynamic color resolver.
> 
> - **Colors / Design System**:
>   - **Enum extensions**: Add `containerBorderPrimary`, `containerBorderSecondary`, `controlsBorderPrimary`, `controlsBorderSecondary`, `controlsBorderTertiary`, `controlsBorderQuaternary` to `SharedDesignSystemColor`.
>   - **Protocol updates**: Declare corresponding getters in `SharedColorPaletteDefinition`.
>   - **Dynamic resolver**: Map new cases in `SharedColorPaletteDefinition+DynamicColors.dynamicColor(for:)` to their respective `DynamicColor` values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5a88f9e4ca485577ea96383c1a101d3dc485975. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->