### PR TITLE
Fix: 2pt Gap when building with Xcode 16

### DIFF
--- a/macOS/DuckDuckGo/VisualRefresh/AddressBarStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/AddressBarStyleProviding.swift
@@ -131,7 +131,7 @@ final class LegacyAddressBarStyleProvider: AddressBarStyleProviding {
 
 final class CurrentAddressBarStyleProvider: AddressBarStyleProviding {
     let tabBarBackgroundTopPadding: CGFloat = {
-#if swift(>=6.2)
+#if compiler(>=6.2)
         if #available(macOS 26.0, *) {
             return 2
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1199230911884351/task/1212350106378479
Tech Design URL:
CC:

### Description
In this PR we're fixing a glitch resulting from building the Browser with Xcode 16 (rather than 26).

### Testing Steps
- [x] Verify this branch looks great when built with Xcode 26 + Tahoe
- [ ] Verify this branch looks great when built with Xcode 16 + Tahoe

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
In the worst case scenario, we'd affect the browser layout when built on Xcode 26

### Quality Considerations
Nothing in particular

### Notes to Reviewer
TY!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Apply 2pt `tabBarBackgroundTopPadding` only on compiler >= 6.2 with macOS 26; default to 0 otherwise.
> 
> - **UI (Address Bar)**:
>   - Gate `CurrentAddressBarStyleProvider.tabBarBackgroundTopPadding` with `#if compiler(>=6.2)` and `#available(macOS 26.0, *)`, returning `2`; fallback returns `0` for older compilers/platforms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2f78e40f6f43e2da3995149a86e62743d85eac6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->