### PR TITLE
iOS: Hide autocomplete row if there’s no input for Duck.ai

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -461,7 +461,7 @@ class SwitchBarTextEntryView: UIView {
     }
 
     private func updateAutoCorrectionSetupForAIChat(for text: String) {
-        guard currentMode == .aiChat else { return }
+        guard handler.isUsingFadeOutAnimation && currentMode == .aiChat else { return }
 
         if text.isEmpty {
             disableAutoCorrectionAndSpellChecking()


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210947754188321/task/1212356360049641?focus=true
Tech Design URL:
CC:

### Description

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Enable `fadeOutOnToggle` and `fadeOutOnToggleSmallerBottomInput`
2. Set address bar to bottom position
3. Open search -> there should be no correction and no predictive text bar
4. Switch to Duck.ai -> there should be no correction and no predictive text bar
5. Write some text -> spellchecking and predictive text will appear
6. Clear text (either by backspace or clear button) -> text disappears and both spellchecking and predictive text bar disappear

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
7. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Most of them are low, because they’re contained within feature flags.
`disableAutoCorrectionAndSpellChecking` in some places it will also be called for code not behind a feature flag, but after checking I didn't find any regressions in the code


#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Dynamically toggles autocorrection/spell-check and keyboard config for Duck.ai input based on mode, fade-out state, and whether text is present, with helper methods and clear/text update hooks.
> 
> - **AI Chat input behavior**:
>   - Dynamically toggle `autocorrection`/`spellChecking` in `aiChat` when using fade-out: disabled for empty input, enabled for non-empty input; reloads input views accordingly.
>   - Refactors keyboard config: centralizes enable/disable via `disableAutoCorrectionAndSpellChecking()` and `enableAutoCorrectionAndSpellChecking()`; adjusts `keyboardType`/`returnKeyType` per mode and animation state.
>   - Hooks toggling into `onClearTapped` and `currentTextPublisher` updates to immediately reflect state.
> - **Misc**:
>   - Removes direct autocorrection/spell-check settings from `updateForCurrentMode` in favor of new helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 196c8516bb3a122e3e13482624a7fe5e0ce918ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->