### PR TITLE
[iOS] Fix pixel definition

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -2838,8 +2838,8 @@ extension Pixel.Event {
         case .aiChatLegacyOmnibarBackButtonPressed: return "m_aichat_legacy_omnibar_back_button_pressed"
         
         // MARK: AI Chat History Deletion
-        case .aiChatHistoryDeleteSuccessful: return "m_ios_aichat_history_delete_successful"
-        case .aiChatHistoryDeleteFailed: return "m_ios_aichat_history_delete_failed"
+        case .aiChatHistoryDeleteSuccessful: return "m_aichat_history_delete_successful"
+        case .aiChatHistoryDeleteFailed: return "m_aichat_history_delete_failed"
 
         // MARK: Lifecycle
         case .appDidTransitionToUnexpectedState: return "m_debug_app-did-transition-to-unexpected-state-4"

--- a/iOS/PixelDefinitions/pixels/ai_chat_settings.json5
+++ b/iOS/PixelDefinitions/pixels/ai_chat_settings.json5
@@ -1,12 +1,12 @@
 {
-    "m_ios_aichat_history_delete_successful": {
+    "m_aichat_history_delete_successful": {
         "description": "Fired when Duck.ai chat history is deleted successfully via fire button",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor", "first_daily_count"],
         "parameters": ["appVersion"]
     },
-    "m_ios_aichat_history_delete_failed": {
+    "m_aichat_history_delete_failed": {
         "description": "Fired when Duck.ai chat history fails to be deleted via fire button",
         "owners": ["Bunn"],
         "triggers": ["other"],


### PR DESCRIPTION
Task/Issue URL:https://app.asana.com/1/137249556945/project/1204167627774280/task/1212225750615960?focus=true
Tech Design URL:
CC:

### Description

Fix pixel definition

### Testing Steps
CI is green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames AI Chat history deletion pixels to m_aichat_history_delete_{successful,failed} and updates definitions accordingly.
> 
> - **Pixels/Telemetry**
>   - **AI Chat History Deletion**:
>     - Update `Pixel.Event` mappings to `m_aichat_history_delete_successful` and `m_aichat_history_delete_failed` in `iOS/Core/PixelEvent.swift`.
>     - Align keys in `iOS/PixelDefinitions/pixels/ai_chat_settings.json5` to the same identifiers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23cd34d40d2d3bd191e50a9fe04677cdcff03080. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->