### PR TITLE
Revert "Remove AdAttributionPixelReporter"

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -63,6 +63,7 @@ public enum PrivacyFeature: String {
     case aiChat
     case contextualOnboarding
     case textZoom
+    case adAttributionReporting
     case forceOldAppDelegate
     case htmlHistoryPage
     case tabManager

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -99,6 +99,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866468784743
     case autocompleteTabs
 
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866711151217
+    case adAttributionReporting
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866610480266
     case dbpRemoteBrokerDelivery
 
@@ -384,6 +387,7 @@ extension FeatureFlag: FeatureFlagDescribing {
                .syncPromotionPasswords,
                .autofillSurveys,
                .autocompleteTabs,
+               .adAttributionReporting,
                .crashReportOptInStatusResetting,
                .syncSeamlessAccountSwitching,
                .experimentalAddressBar,
@@ -455,6 +459,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.feature(.autofillSurveys))
         case .autocompleteTabs:
             return .remoteReleasable(.feature(.autocompleteTabs))
+        case .adAttributionReporting:
+            return .remoteReleasable(.feature(.adAttributionReporting))
         case .dbpRemoteBrokerDelivery:
             return .remoteReleasable(.subfeature(DBPSubfeature.remoteBrokerDelivery))
         case .dbpEmailConfirmationDecoupling:

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1959,6 +1959,8 @@
 		F1617C151E57336D00DEDCAF /* TabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1617C141E57336D00DEDCAF /* TabManager.swift */; };
 		F1617C191E573EA800DEDCAF /* TabSwitcherDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1617C181E573EA800DEDCAF /* TabSwitcherDelegate.swift */; };
 		F16393FF1ECCB9CC00DDD653 /* FileLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16393FE1ECCB9CC00DDD653 /* FileLoader.swift */; };
+		F164BCD42E3CFAF9001DF95A /* AdAttributionPixelReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F164BCD12E3CFAF9001DF95A /* AdAttributionPixelReporterTests.swift */; };
+		F164BCD52E3CFAF9001DF95A /* AdAttributionFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F164BCD02E3CFAF9001DF95A /* AdAttributionFetcherTests.swift */; };
 		F164BCD62E3CFAF9001DF95A /* AdClickExternalOpenDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F164BCD22E3CFAF9001DF95A /* AdClickExternalOpenDetectorTests.swift */; };
 		F1668BCE1E798081008CBA04 /* BookmarksViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1668BCD1E798081008CBA04 /* BookmarksViewController.swift */; };
 		F176699F1E40BC86003D3222 /* Settings.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F176699D1E40BC86003D3222 /* Settings.storyboard */; };
@@ -1978,6 +1980,9 @@
 		F194FAED1F14E2B3009B4DF8 /* UIFontExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F194FAEC1F14E2B3009B4DF8 /* UIFontExtension.swift */; };
 		F194FAFB1F14E622009B4DF8 /* UIFontExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F194FAFA1F14E622009B4DF8 /* UIFontExtensionTests.swift */; };
 		F1970B5A2DF1F356008F18BC /* AdClickExternalOpenDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1970B582DF1F356008F18BC /* AdClickExternalOpenDetector.swift */; };
+		F1970B5B2DF1F356008F18BC /* AdAttributionReporterStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1970B572DF1F356008F18BC /* AdAttributionReporterStorage.swift */; };
+		F1970B5C2DF1F356008F18BC /* AdAttributionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1970B552DF1F356008F18BC /* AdAttributionFetcher.swift */; };
+		F1970B5D2DF1F356008F18BC /* AdAttributionPixelReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1970B562DF1F356008F18BC /* AdAttributionPixelReporter.swift */; };
 		F198D78E1E39762C0088DA8A /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F198D78D1E39762C0088DA8A /* StringExtensionTests.swift */; };
 		F19B98672EAFA799000FF209 /* AttributedMetric in Frameworks */ = {isa = PBXBuildFile; productRef = F19B98662EAFA799000FF209 /* AttributedMetric */; };
 		F1A83D862E0AB27E00054B03 /* MockFeatureFlagger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A83D852E0AB27E00054B03 /* MockFeatureFlagger.swift */; };
@@ -4349,6 +4354,8 @@
 		F1617C181E573EA800DEDCAF /* TabSwitcherDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabSwitcherDelegate.swift; sourceTree = "<group>"; };
 		F16393F41ECCA85900DDD653 /* DomainsProtectionUserDefaultsStoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainsProtectionUserDefaultsStoreTests.swift; sourceTree = "<group>"; };
 		F16393FE1ECCB9CC00DDD653 /* FileLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileLoader.swift; sourceTree = "<group>"; };
+		F164BCD02E3CFAF9001DF95A /* AdAttributionFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdAttributionFetcherTests.swift; sourceTree = "<group>"; };
+		F164BCD12E3CFAF9001DF95A /* AdAttributionPixelReporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdAttributionPixelReporterTests.swift; sourceTree = "<group>"; };
 		F164BCD22E3CFAF9001DF95A /* AdClickExternalOpenDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdClickExternalOpenDetectorTests.swift; sourceTree = "<group>"; };
 		F1668BCD1E798081008CBA04 /* BookmarksViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksViewController.swift; sourceTree = "<group>"; };
 		F176699E1E40BC86003D3222 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Settings.storyboard; sourceTree = "<group>"; };
@@ -4367,6 +4374,9 @@
 		F189AEE31F18FDAF001EBAE1 /* LinkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkTests.swift; sourceTree = "<group>"; };
 		F194FAEC1F14E2B3009B4DF8 /* UIFontExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIFontExtension.swift; sourceTree = "<group>"; };
 		F194FAFA1F14E622009B4DF8 /* UIFontExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIFontExtensionTests.swift; sourceTree = "<group>"; };
+		F1970B552DF1F356008F18BC /* AdAttributionFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdAttributionFetcher.swift; sourceTree = "<group>"; };
+		F1970B562DF1F356008F18BC /* AdAttributionPixelReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdAttributionPixelReporter.swift; sourceTree = "<group>"; };
+		F1970B572DF1F356008F18BC /* AdAttributionReporterStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdAttributionReporterStorage.swift; sourceTree = "<group>"; };
 		F1970B582DF1F356008F18BC /* AdClickExternalOpenDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdClickExternalOpenDetector.swift; sourceTree = "<group>"; };
 		F197EA3B1E6885F20029BDC1 /* TextFieldWithInsets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TextFieldWithInsets.swift; path = ../Core/TextFieldWithInsets.swift; sourceTree = "<group>"; };
 		F198D78D1E39762C0088DA8A /* StringExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
@@ -9274,6 +9284,8 @@
 		F164BCD32E3CFAF9001DF95A /* AdAttribution */ = {
 			isa = PBXGroup;
 			children = (
+				F164BCD02E3CFAF9001DF95A /* AdAttributionFetcherTests.swift */,
+				F164BCD12E3CFAF9001DF95A /* AdAttributionPixelReporterTests.swift */,
 				F164BCD22E3CFAF9001DF95A /* AdClickExternalOpenDetectorTests.swift */,
 			);
 			path = AdAttribution;
@@ -9368,6 +9380,9 @@
 		F1970B592DF1F356008F18BC /* AdAttribution */ = {
 			isa = PBXGroup;
 			children = (
+				F1970B552DF1F356008F18BC /* AdAttributionFetcher.swift */,
+				F1970B562DF1F356008F18BC /* AdAttributionPixelReporter.swift */,
+				F1970B572DF1F356008F18BC /* AdAttributionReporterStorage.swift */,
 				F1970B582DF1F356008F18BC /* AdClickExternalOpenDetector.swift */,
 			);
 			path = AdAttribution;
@@ -10981,7 +10996,10 @@
 				988AC355257E47C100793C64 /* RequeryLogic.swift in Sources */,
 				6FCF65142DF8481F00C7F35F /* OmniBarEditingStateViewController.swift in Sources */,
 				F1970B5A2DF1F356008F18BC /* AdClickExternalOpenDetector.swift in Sources */,
+				F1970B5B2DF1F356008F18BC /* AdAttributionReporterStorage.swift in Sources */,
+				F1970B5C2DF1F356008F18BC /* AdAttributionFetcher.swift in Sources */,
 				C12B671E2EC0ABEB003B80DD /* AIChatContentHandler.swift in Sources */,
+				F1970B5D2DF1F356008F18BC /* AdAttributionPixelReporter.swift in Sources */,
 				6FBF0F8B2BD7C0A900136CF0 /* AllProtectedCell.swift in Sources */,
 				9F254AFF2CF9FA1B0063B308 /* WebViewNavigationHandling.swift in Sources */,
 				1E4F4A5A297193DE00625985 /* MainViewController+CookiesManaged.swift in Sources */,
@@ -11975,6 +11993,8 @@
 				56C23F6A2E0AD97300FD63C6 /* MockUnifiedMetadataCollector.swift in Sources */,
 				85010504292FFB080033978F /* FireproofFaviconUpdaterTests.swift in Sources */,
 				F1D477C91F2139410031ED49 /* SmallOmniBarStateTests.swift in Sources */,
+				F164BCD42E3CFAF9001DF95A /* AdAttributionPixelReporterTests.swift in Sources */,
+				F164BCD52E3CFAF9001DF95A /* AdAttributionFetcherTests.swift in Sources */,
 				F164BCD62E3CFAF9001DF95A /* AdClickExternalOpenDetectorTests.swift in Sources */,
 				987130C9294AAB9F00AB05E0 /* BookmarkUtilsTests.swift in Sources */,
 				C1BF0BA929B63E2200482B73 /* AutofillLoginPromptViewModelTests.swift in Sources */,

--- a/iOS/DuckDuckGo/AdAttribution/AdAttributionFetcher.swift
+++ b/iOS/DuckDuckGo/AdAttribution/AdAttributionFetcher.swift
@@ -1,0 +1,151 @@
+//
+//  AdAttributionFetcher.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AdServices
+import os.log
+
+protocol AdAttributionFetcher {
+    func fetch() async -> (String, AdServicesAttributionResponse)?
+}
+
+/// Fetches ad attribution data for from Apple.
+///
+/// DuckDuckGo uses the AdServices framework to fetch and monitor anonymous install attribution data from Apple. No personally identifiable data is involved.
+/// DuckDuckGo does not use the App Tracking Transparency framework at any point, and only uses the “standard” attribution payload.
+/// See https://developer.apple.com/documentation/adservices/aaattribution/attributiontoken()#Attribution-payload-descriptions for details.
+struct DefaultAdAttributionFetcher: AdAttributionFetcher {
+
+    typealias TokenGetter = () throws -> String
+
+    private let tokenGetter: TokenGetter
+    private let urlSession: URLSession
+    private let retryInterval: TimeInterval
+
+    init(tokenGetter: @escaping TokenGetter = Self.fetchAttributionToken,
+         urlSession: URLSession = .shared,
+         retryInterval: TimeInterval = .seconds(5)) {
+        self.tokenGetter = tokenGetter
+        self.urlSession = urlSession
+        self.retryInterval = retryInterval
+    }
+
+    func fetch() async -> (String, AdServicesAttributionResponse)? {
+        var lastToken: String?
+
+        for _ in 0..<Constant.maxRetries {
+            do {
+                try Task.checkCancellation()
+
+                let token = try (lastToken ?? tokenGetter())
+                lastToken = token
+                return try await fetchAttributionData(using: token)
+            } catch let error as AdAttributionFetcherError {
+                Logger.adAttribution.error("AdAttributionFetcher failed to fetch attribution data: \(error.localizedDescription, privacy: .public). Retrying.")
+
+                if error == .invalidToken {
+                    lastToken = nil
+                }
+
+                if error.allowsRetry {
+                    try? await Task.sleep(interval: retryInterval)
+                    continue
+                } else {
+                    break
+                }
+            } catch {
+                Logger.adAttribution.error("AdAttributionFetcher failed to fetch attribution data: \(error.localizedDescription, privacy: .public)")
+
+                // Do not retry
+                break
+            }
+        }
+
+        return nil
+    }
+
+    private func fetchAttributionData(using token: String) async throws -> (String, AdServicesAttributionResponse) {
+        let request = createAttributionDataRequest(with: token)
+        let (data, response) = try await urlSession.data(for: request)
+
+        guard let response = response as? HTTPURLResponse else {
+            throw AdAttributionFetcherError.invalidResponse
+        }
+
+        switch response.statusCode {
+        case 200:
+            let decoder = JSONDecoder()
+            let decoded = try decoder.decode(AdServicesAttributionResponse.self, from: data)
+
+            return (token, decoded)
+        case 400:
+            throw AdAttributionFetcherError.invalidToken
+        case 404:
+            throw AdAttributionFetcherError.invalidResponse
+        default:
+            throw AdAttributionFetcherError.unknown
+        }
+    }
+
+    private func createAttributionDataRequest(with token: String) -> URLRequest {
+        var request = URLRequest(url: Constant.attributionServiceURL)
+        request.httpMethod = "POST"
+        request.setValue("text/plain", forHTTPHeaderField: "Content-Type")
+        request.httpBody = token.data(using: .utf8)
+
+        return request
+    }
+
+    private struct Constant {
+        static let attributionServiceURL = URL(string: "https://api-adservices.apple.com/api/v1/")!
+        static let maxRetries = 3
+    }
+}
+
+extension AdAttributionFetcher {
+    static func fetchAttributionToken() throws -> String {
+        return try AAAttribution.attributionToken()
+    }
+}
+
+struct AdServicesAttributionResponse: Decodable {
+    let attribution: Bool
+    let orgId: Int?
+    let campaignId: Int?
+    let conversionType: String?
+    let adGroupId: Int?
+    let countryOrRegion: String?
+    let keywordId: Int?
+    let adId: Int?
+}
+
+enum AdAttributionFetcherError: Error {
+    case attributionUnsupported
+    case invalidResponse
+    case invalidToken
+    case unknown
+
+    var allowsRetry: Bool {
+        switch self {
+        case .invalidToken, .invalidResponse:
+            return true
+        case .unknown, .attributionUnsupported:
+            return false
+        }
+    }
+}

--- a/iOS/DuckDuckGo/AdAttribution/AdAttributionPixelReporter.swift
+++ b/iOS/DuckDuckGo/AdAttribution/AdAttributionPixelReporter.swift
@@ -1,0 +1,143 @@
+//
+//  AdAttributionPixelReporter.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Core
+import BrowserServicesKit
+
+final actor AdAttributionPixelReporter {
+
+    private var fetcherStorage: AdAttributionReporterStorage
+    private let attributionFetcher: AdAttributionFetcher
+    private let featureFlagger: FeatureFlagger
+    private let privacyConfigurationManager: PrivacyConfigurationManaging
+    private let variantManager: VariantManager
+    private let pixelFiring: PixelFiringAsync.Type
+    private var isSendingAttribution: Bool = false
+
+    private var shouldReport: Bool {
+        get async {
+            return await !fetcherStorage.wasAttributionReportSuccessful
+        }
+    }
+
+    init(fetcherStorage: AdAttributionReporterStorage = UserDefaultsAdAttributionReporterStorage(),
+         attributionFetcher: AdAttributionFetcher = DefaultAdAttributionFetcher(),
+         featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
+         privacyConfigurationManager: PrivacyConfigurationManaging,
+         variantManager: VariantManager = AppDependencyProvider.shared.variantManager,
+         pixelFiring: PixelFiringAsync.Type = Pixel.self) {
+        self.fetcherStorage = fetcherStorage
+        self.attributionFetcher = attributionFetcher
+        self.featureFlagger = featureFlagger
+        self.privacyConfigurationManager = privacyConfigurationManager
+        self.variantManager = variantManager
+        self.pixelFiring = pixelFiring
+    }
+
+    @discardableResult
+    func reportAttributionIfNeeded() async -> Bool {
+        guard featureFlagger.isFeatureOn(.adAttributionReporting) else {
+            return false
+        }
+
+        guard await shouldReport else {
+            return false
+        }
+
+        guard !isSendingAttribution else {
+            return false
+        }
+
+        isSendingAttribution = true
+
+        defer {
+            isSendingAttribution = false
+        }
+
+        if let (token, attributionData) = await self.attributionFetcher.fetch() {
+            if attributionData.attribution {
+                let settings = AdAttributionReporterSettings(privacyConfigurationManager.privacyConfig)
+                let token = settings.includeToken ? token : nil
+                let isReinstall = variantManager.isIndicatingReturningUser
+                let parameters = self.pixelParametersForAttribution(attributionData, isReinstall: isReinstall, attributionToken: token)
+                do {
+                    try await pixelFiring.fire(
+                        pixel: .appleAdAttribution,
+                        withAdditionalParameters: parameters,
+                        includedParameters: [.appVersion]
+                    )
+                } catch {
+                    return false
+                }
+            }
+
+            await markAttributionReportSuccessful()
+
+            return true
+        }
+
+        return false
+    }
+
+    private func markAttributionReportSuccessful() async {
+        await fetcherStorage.markAttributionReportSuccessful()
+    }
+
+    private func pixelParametersForAttribution(_ attribution: AdServicesAttributionResponse, isReinstall: Bool, attributionToken: String?) -> [String: String] {
+        var params: [String: String] = [:]
+
+        params[PixelParameters.adAttributionAdGroupID] = attribution.adGroupId.map(String.init)
+        params[PixelParameters.adAttributionOrgID] = attribution.orgId.map(String.init)
+        params[PixelParameters.adAttributionCampaignID] = attribution.campaignId.map(String.init)
+        params[PixelParameters.adAttributionConversionType] = attribution.conversionType
+        params[PixelParameters.adAttributionAdGroupID] = attribution.adGroupId.map(String.init)
+        params[PixelParameters.adAttributionCountryOrRegion] = attribution.countryOrRegion
+        params[PixelParameters.adAttributionKeywordID] = attribution.keywordId.map(String.init)
+        params[PixelParameters.adAttributionAdID] = attribution.adId.map(String.init)
+        params[PixelParameters.adAttributionToken] = attributionToken
+        params[PixelParameters.adAttributionIsReinstall] = isReinstall ? "1" : "0"
+
+        return params
+    }
+}
+
+private extension BoolFileMarker.Name {
+    static let isAttrbutionReportSuccessful = BoolFileMarker.Name(rawValue: "ad-attribution-successful")
+}
+
+private struct AdAttributionReporterSettings {
+    var includeToken: Bool
+
+    init(_ configuration: PrivacyConfiguration) {
+        let featureSettings = configuration.settings(for: .adAttributionReporting)
+
+        self.includeToken = featureSettings[Key.includeToken] as? Bool ?? false
+    }
+
+    private enum Key {
+        static let includeToken = "includeToken"
+    }
+}
+
+private extension VariantManager {
+    var isIndicatingReturningUser: Bool {
+        currentVariant?.name == VariantIOS.returningUser.name
+    }
+}

--- a/iOS/DuckDuckGo/AdAttribution/AdAttributionReporterStorage.swift
+++ b/iOS/DuckDuckGo/AdAttribution/AdAttributionReporterStorage.swift
@@ -1,0 +1,38 @@
+//
+//  AdAttributionReporterStorage.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Core
+import Foundation
+
+protocol AdAttributionReporterStorage {
+    var wasAttributionReportSuccessful: Bool { get async }
+
+    func markAttributionReportSuccessful() async
+}
+
+final class UserDefaultsAdAttributionReporterStorage: AdAttributionReporterStorage {
+    @MainActor
+    @UserDefaultsWrapper(key: .appleAdAttributionReportCompleted, defaultValue: false)
+    var wasAttributionReportSuccessful: Bool
+
+    @MainActor
+    func markAttributionReportSuccessful() async {
+        wasAttributionReportSuccessful = true
+    }
+}

--- a/iOS/DuckDuckGo/AppServices/ReportingService.swift
+++ b/iOS/DuckDuckGo/AppServices/ReportingService.swift
@@ -41,6 +41,7 @@ final class ReportingService {
     let attributedMetricManager: AttributedMetricManager
     
     private var cancellables = Set<AnyCancellable>()
+    let adAttributionPixelReporter: AdAttributionPixelReporter
     let privacyConfigurationManager: PrivacyConfigurationManaging
     let productSurfaceTelemetry: ProductSurfaceTelemetry
 
@@ -61,6 +62,7 @@ final class ReportingService {
         self.privacyConfigurationManager = privacyConfigurationManager
         self.featureFlagging = featureFlagging
         self.subscriptionDataReporter = SubscriptionDataReporter(fireproofing: fireproofing)
+        self.adAttributionPixelReporter = AdAttributionPixelReporter(privacyConfigurationManager: privacyConfigurationManager)
 
         // AttributedMetric initialisation
         let errorHandler = AttributedMetricErrorHandler(pixelKit: pixelKit)
@@ -160,6 +162,7 @@ final class ReportingService {
 
     private func onStatisticsLoaded() {
         Pixel.fire(pixel: .appLaunch, includedParameters: [.appVersion, .atb])
+        reportAdAttribution()
         reportWidgetUsage()
         productSurfaceTelemetry.dailyActiveUser()
         onboardingPixelReporter.fireEnqueuedPixelsIfNeeded()
@@ -222,6 +225,12 @@ private extension ReportingService {
             case .failure(let error):
                 DailyPixel.fire(pixel: .widgetReportFailure, error: error)
             }
+        }
+    }
+
+    func reportAdAttribution() {
+        Task.detached(priority: .background) {
+            await self.adAttributionPixelReporter.reportAttributionIfNeeded()
         }
     }
     

--- a/iOS/DuckDuckGoTests/AdAttribution/AdAttributionFetcherTests.swift
+++ b/iOS/DuckDuckGoTests/AdAttribution/AdAttributionFetcherTests.swift
@@ -1,0 +1,184 @@
+//
+//  AdAttributionFetcherTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+@testable import DuckDuckGo
+import PersistenceTestingUtils
+import NetworkingTestingUtils
+
+final class AdAttributionFetcherTests: XCTestCase {
+
+    private let mockSession: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+
+        return session
+    }()
+
+    override func setUpWithError() throws {
+        MockURLProtocol.requestHandler = MockURLProtocol.defaultHandler
+    }
+
+    override func tearDownWithError() throws {
+        MockURLProtocol.requestHandler = nil
+    }
+
+    func testMakesRequestWithToken() async throws {
+        let testToken = "foo"
+        let sut = DefaultAdAttributionFetcher(tokenGetter: { testToken }, urlSession: mockSession, retryInterval: .leastNonzeroMagnitude)
+
+        _ = await sut.fetch()
+
+        let requestStream = try XCTUnwrap(MockURLProtocol.lastRequest?.httpBodyStream)
+        let requestBody = try Data(reading: requestStream)
+
+        XCTAssertEqual(String(data: requestBody, encoding: .utf8), testToken)
+    }
+
+    func testRetriesRequest() async throws {
+        let testToken = "foo"
+        let sut = DefaultAdAttributionFetcher(tokenGetter: { testToken }, urlSession: mockSession, retryInterval: .leastNonzeroMagnitude)
+        let retryExpectation = XCTestExpectation()
+        retryExpectation.expectedFulfillmentCount = 3
+        retryExpectation.assertForOverFulfill = true
+
+        MockURLProtocol.requestHandler = { request in
+            retryExpectation.fulfill()
+            let handler = MockURLProtocol.handler(with: 404)
+            return try handler(request)
+        }
+
+        _ = await sut.fetch()
+
+        let requestStream = try XCTUnwrap(MockURLProtocol.lastRequest?.httpBodyStream)
+        let requestBody = try Data(reading: requestStream)
+
+        XCTAssertEqual(String(data: requestBody, encoding: .utf8), testToken)
+
+        await fulfillment(of: [retryExpectation])
+    }
+
+    func testRefreshesTokenOnRetry() async throws {
+        let retryExpectation = XCTestExpectation()
+        retryExpectation.expectedFulfillmentCount = 3
+        retryExpectation.assertForOverFulfill = true
+
+        let refreshExpectation = XCTestExpectation()
+
+        let testToken = "foo"
+        let sut = DefaultAdAttributionFetcher(tokenGetter: {
+            refreshExpectation.fulfill()
+            return testToken
+        }, urlSession: mockSession, retryInterval: .leastNonzeroMagnitude)
+
+        MockURLProtocol.requestHandler = { request in
+            retryExpectation.fulfill()
+            let handler = MockURLProtocol.handler(with: 400)
+            return try handler(request)
+        }
+
+        _ = await sut.fetch()
+
+        let requestStream = try XCTUnwrap(MockURLProtocol.lastRequest?.httpBodyStream)
+        let requestBody = try Data(reading: requestStream)
+
+        XCTAssertEqual(String(data: requestBody, encoding: .utf8), testToken)
+
+        await fulfillment(of: [retryExpectation])
+    }
+
+    func testDoesNotRetry_WhenUnrecoverable() async throws {
+        let testToken = "foo"
+        let sut = DefaultAdAttributionFetcher(tokenGetter: { testToken }, urlSession: mockSession, retryInterval: .leastNonzeroMagnitude)
+        let noRetryExpectation = XCTestExpectation()
+        noRetryExpectation.expectedFulfillmentCount = 1
+        noRetryExpectation.assertForOverFulfill = true
+
+        MockURLProtocol.requestHandler = { request in
+            noRetryExpectation.fulfill()
+            let handler = MockURLProtocol.handler(with: 500)
+            return try handler(request)
+        }
+
+        _ = await sut.fetch()
+
+        let requestStream = try XCTUnwrap(MockURLProtocol.lastRequest?.httpBodyStream)
+        let requestBody = try Data(reading: requestStream)
+
+        XCTAssertEqual(String(data: requestBody, encoding: .utf8), testToken)
+
+        await fulfillment(of: [noRetryExpectation])
+    }
+
+    func testRespectsRetryInterval() async throws {
+        let testToken = "foo"
+        let sut = DefaultAdAttributionFetcher(tokenGetter: { testToken }, urlSession: mockSession, retryInterval: .milliseconds(30))
+
+        MockURLProtocol.requestHandler = { request in
+            let handler = MockURLProtocol.handler(with: 404)
+            return try handler(request)
+        }
+
+        let startTime = Date()
+        _ = await sut.fetch()
+
+        XCTAssertGreaterThanOrEqual(Date().timeIntervalSince(startTime), .milliseconds(90))
+    }
+}
+
+private extension MockURLProtocol {
+    typealias RequestHandler = (URLRequest) throws -> (HTTPURLResponse, Data?)
+
+    static func handler(with statusCode: Int, data: Data? = nil) -> RequestHandler {
+        return { request in
+            (HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil)!, data)
+        }
+    }
+
+    static let defaultHandler = handler(with: 300)
+}
+
+private extension Data {
+    init(reading input: InputStream, size: Int = 1024) throws {
+        self.init()
+        input.open()
+        defer {
+            input.close()
+        }
+
+        let bufferSize = size
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer {
+            buffer.deallocate()
+        }
+        while input.hasBytesAvailable {
+            let read = input.read(buffer, maxLength: bufferSize)
+            if read < 0 {
+                // Stream error occured
+                throw input.streamError!
+            } else if read == 0 {
+                // EOF
+                break
+            }
+            self.append(buffer, count: read)
+        }
+    }
+}

--- a/iOS/DuckDuckGoTests/AdAttribution/AdAttributionPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/AdAttribution/AdAttributionPixelReporterTests.swift
@@ -1,0 +1,268 @@
+//
+//  AdAttributionPixelReporterTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2024 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Core
+import XCTest
+
+@testable import DuckDuckGo
+
+final class AdAttributionPixelReporterTests: XCTestCase {
+
+    private var attributionFetcher: AdAttributionFetcherMock!
+    private var fetcherStorage: AdAttributionReporterStorageMock!
+    private var featureFlagger: MockFeatureFlagger!
+    private var privacyConfigurationManager: PrivacyConfigurationManagerMock!
+    private var variantManager: MockVariantManager!
+
+    private let fileMarker = BoolFileMarker(name: .init(rawValue: "ad-attribution-successful"))!
+
+    override func setUpWithError() throws {
+        attributionFetcher = AdAttributionFetcherMock()
+        fetcherStorage = AdAttributionReporterStorageMock()
+        featureFlagger = MockFeatureFlagger()
+        privacyConfigurationManager = PrivacyConfigurationManagerMock()
+        variantManager = MockVariantManager()
+
+        featureFlagger.enabledFeatureFlags.append(.adAttributionReporting)
+        fileMarker.unmark()
+    }
+
+    override func tearDownWithError() throws {
+        attributionFetcher = nil
+        fetcherStorage = nil
+        featureFlagger = nil
+        privacyConfigurationManager = nil
+
+        PixelFiringMock.tearDown()
+    }
+
+    func testReportsAttribution() async {
+        let sut = createSUT()
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(attribution: true))
+
+        let result = await sut.reportAttributionIfNeeded()
+
+        XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.appleAdAttribution.name)
+        XCTAssertTrue(result)
+    }
+
+    func testReportsOnce() async {
+        let sut = createSUT()
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(attribution: true))
+
+        await fetcherStorage.markAttributionReportSuccessful()
+        let result = await sut.reportAttributionIfNeeded()
+
+        XCTAssertNil(PixelFiringMock.lastPixelName)
+        XCTAssertFalse(result)
+    }
+
+    func testPixelName() async {
+        let sut = createSUT()
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(attribution: true))
+
+        let result = await sut.reportAttributionIfNeeded()
+
+        XCTAssertEqual(PixelFiringMock.lastPixelName, "m_apple-ad-attribution")
+        XCTAssertTrue(result)
+    }
+
+    func testPixelAttributesNaming() async throws {
+        let sut = createSUT()
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(attribution: true))
+        (privacyConfigurationManager.privacyConfig as? PrivacyConfigurationMock)?.settings[.adAttributionReporting] = ["includeToken": true]
+
+        await sut.reportAttributionIfNeeded()
+
+        let pixelAttributes = try XCTUnwrap(PixelFiringMock.lastParams)
+
+        XCTAssertEqual(pixelAttributes["org_id"], "1")
+        XCTAssertEqual(pixelAttributes["campaign_id"], "2")
+        XCTAssertEqual(pixelAttributes["conversion_type"], "conversionType")
+        XCTAssertEqual(pixelAttributes["ad_group_id"], "3")
+        XCTAssertEqual(pixelAttributes["country_or_region"], "countryOrRegion")
+        XCTAssertEqual(pixelAttributes["keyword_id"], "4")
+        XCTAssertEqual(pixelAttributes["ad_id"], "5")
+        XCTAssertEqual(pixelAttributes["attribution_token"], "example")
+        XCTAssertEqual(pixelAttributes["is_reinstall"], "0")
+    }
+
+    func testReinstallTrueWhenReturningUserVariantPresent() async throws {
+        let sut = createSUT(with: .returningUser)
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(attribution: true))
+        (privacyConfigurationManager.privacyConfig as? PrivacyConfigurationMock)?.settings[.adAttributionReporting] = ["includeToken": true]
+
+        await sut.reportAttributionIfNeeded()
+
+        let pixelAttributes = try XCTUnwrap(PixelFiringMock.lastParams)
+
+        XCTAssertEqual(pixelAttributes["is_reinstall"], "1")
+    }
+
+    func testPixelAdditionalParameters() async throws {
+        let sut = createSUT()
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(attribution: true))
+
+        await sut.reportAttributionIfNeeded()
+
+        let pixelAttributes = try XCTUnwrap(PixelFiringMock.lastIncludedParams)
+
+        XCTAssertEqual(pixelAttributes, [.appVersion])
+    }
+
+    func testPixelAttributes_WhenPartialAttributionData() async throws {
+        let sut = createSUT()
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(
+            attribution: true,
+            orgId: 1,
+            campaignId: 2,
+            conversionType: "conversionType",
+            adGroupId: nil,
+            countryOrRegion: nil,
+            keywordId: nil,
+            adId: nil
+        ))
+
+        await sut.reportAttributionIfNeeded()
+
+        let pixelAttributes = try XCTUnwrap(PixelFiringMock.lastParams)
+
+        XCTAssertEqual(pixelAttributes["org_id"], "1")
+        XCTAssertEqual(pixelAttributes["campaign_id"], "2")
+        XCTAssertEqual(pixelAttributes["conversion_type"], "conversionType")
+        XCTAssertNil(pixelAttributes["ad_group_id"])
+        XCTAssertNil(pixelAttributes["country_or_region"])
+        XCTAssertNil(pixelAttributes["keyword_id"])
+        XCTAssertNil(pixelAttributes["ad_id"])
+    }
+
+    func testPixelNotFiredAndMarksReport_WhenAttributionFalse() async {
+        let sut = createSUT()
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(attribution: false))
+
+        let result = await sut.reportAttributionIfNeeded()
+
+        XCTAssertNil(PixelFiringMock.lastPixelName)
+        XCTAssertTrue(fetcherStorage.wasAttributionReportSuccessful)
+        XCTAssertTrue(result)
+    }
+
+    func testPixelNotFiredAndReportNotMarked_WhenAttributionUnavailable() async {
+        let sut = createSUT()
+        attributionFetcher.fetchResponse = nil
+
+        let result = await sut.reportAttributionIfNeeded()
+
+        XCTAssertNil(PixelFiringMock.lastPixelName)
+        XCTAssertFalse(fetcherStorage.wasAttributionReportSuccessful)
+        XCTAssertFalse(result)
+    }
+
+    func testDoesNotMarkSuccessful_WhenPixelFiringFailed() async {
+        let sut = createSUT()
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(attribution: true))
+        PixelFiringMock.expectedFireError = NSError(domain: "PixelFailure", code: 1)
+
+        let result = await sut.reportAttributionIfNeeded()
+
+        XCTAssertFalse(fetcherStorage.wasAttributionReportSuccessful)
+        XCTAssertFalse(result)
+    }
+
+    func testDoesNotReportIfFeatureDisabled() async {
+        let sut = createSUT()
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(attribution: true))
+        featureFlagger.enabledFeatureFlags = []
+
+        await fetcherStorage.markAttributionReportSuccessful()
+        let result = await sut.reportAttributionIfNeeded()
+
+        XCTAssertNil(PixelFiringMock.lastPixelName)
+        XCTAssertFalse(result)
+        XCTAssertFalse(attributionFetcher.wasFetchCalled)
+    }
+
+    func testDoesNotIncludeTokenWhenSettingMissing() async throws {
+        let sut = createSUT()
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(attribution: true))
+        featureFlagger.enabledFeatureFlags = [.adAttributionReporting]
+
+        await sut.reportAttributionIfNeeded()
+
+        let pixelAttributes = try XCTUnwrap(PixelFiringMock.lastParams)
+
+        XCTAssertNil(pixelAttributes["attribution_token"])
+    }
+
+    func testIncludesTokenWhenSettingEnabled() async throws {
+        let sut = createSUT()
+        attributionFetcher.fetchResponse = ("example", AdServicesAttributionResponse(attribution: true))
+        featureFlagger.enabledFeatureFlags = [.adAttributionReporting]
+
+        (privacyConfigurationManager.privacyConfig as? PrivacyConfigurationMock)?.settings[.adAttributionReporting] = ["includeToken": true]
+
+        await sut.reportAttributionIfNeeded()
+
+        let pixelAttributes = try XCTUnwrap(PixelFiringMock.lastParams)
+
+        XCTAssertNotNil(pixelAttributes["attribution_token"])
+    }
+
+    private func createSUT(with variant: VariantIOS? = nil) -> AdAttributionPixelReporter {
+        AdAttributionPixelReporter(fetcherStorage: fetcherStorage,
+                                   attributionFetcher: attributionFetcher,
+                                   featureFlagger: featureFlagger,
+                                   privacyConfigurationManager: privacyConfigurationManager,
+                                   variantManager: MockVariantManager(isSupportedReturns: false, currentVariant: variant),
+                                   pixelFiring: PixelFiringMock.self)
+    }
+}
+
+private class AdAttributionReporterStorageMock: AdAttributionReporterStorage {
+    func markAttributionReportSuccessful() async {
+        wasAttributionReportSuccessful = true
+    }
+    
+    private(set) var wasAttributionReportSuccessful: Bool = false
+}
+
+private class AdAttributionFetcherMock: AdAttributionFetcher {
+    var wasFetchCalled: Bool = false
+
+    var fetchResponse: (String, AdServicesAttributionResponse)?
+    func fetch() async -> (String, AdServicesAttributionResponse)? {
+        wasFetchCalled = true
+        return fetchResponse
+    }
+}
+
+private extension AdServicesAttributionResponse {
+    init(attribution: Bool) {
+        self.init(
+            attribution: attribution,
+            orgId: 1,
+            campaignId: 2,
+            conversionType: "conversionType",
+            adGroupId: 3,
+            countryOrRegion: "countryOrRegion",
+            keywordId: 4,
+            adId: 5
+        )
+    }
+}


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1212377116232725?focus=true
Tech Design URL:
CC:

### Description

Reverts duckduckgo/apple-browsers#2873

See https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866711151217?focus=true for details. 

### Testing Steps
1. Make sure CI is green.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
None: Was in the codebase before, reverting the removal.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores Apple ad attribution reporting (gated by `adAttributionReporting`) with fetcher/storage, integrates reporting on app launch, and adds unit tests.
> 
> - **iOS**:
>   - **Ad Attribution**: Reintroduces `AdAttributionFetcher`, `AdAttributionPixelReporter`, and `UserDefaultsAdAttributionReporterStorage` under `iOS/DuckDuckGo/AdAttribution`.
>   - **Integration**: Wires reporter into `ReportingService` (`reportAdAttribution` on statistics load) and constructs it in init.
>   - **Feature Flags/Privacy Config**:
>     - Adds `FeatureFlag.adAttributionReporting` mapped to `PrivacyFeature.adAttributionReporting`.
> - **Tests**:
>   - Adds unit tests for `AdAttributionFetcher` and `AdAttributionPixelReporter`.
> - **Project**:
>   - Updates Xcode project to include new sources and tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1917a09e37960eb7dc100ef5d39fea376b06c701. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->