### PR TITLE
[iOS] Fix Maestro AI Chat modal test

### DIFF
--- a/.maestro/release_tests/ai-chat.yaml
+++ b/.maestro/release_tests/ai-chat.yaml
@@ -13,7 +13,8 @@ tags:
 # New tab screen
 - assertVisible: "Duck.ai"
 - tapOn: "Duck.ai"
-- assertVisible: "Say hello to Duck.ai"
+- assertVisible:
+    id: "AIChatViewController"
 - tapOn: "Close 24"
 
 # Browsing
@@ -25,14 +26,16 @@ tags:
 - pressKey: Enter
 - assertVisible: "Duck.ai"
 - tapOn: "Duck.ai"
-- assertVisible: "Say hello to Duck.ai"
+- assertVisible:
+    id: "AIChatViewController"
 - tapOn: "Close 24"
 
 # Tab Switcher
 - tapOn: "Tab Switcher"
 - assertVisible: "Duck.ai"
 - tapOn: "Duck.ai"
-- assertVisible: "Say hello to Duck.ai"
+- assertVisible:
+    id: "AIChatViewController"
 - tapOn: "Close 24"
 - tapOn: "New Tab"
 

--- a/SharedPackages/AIChat/Sources/AIChat/iOS/PublicAPI/AIChatViewController.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/iOS/PublicAPI/AIChatViewController.swift
@@ -116,6 +116,7 @@ extension AIChatViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = .black
+        self.view.accessibilityIdentifier = "AIChatViewController"
 
         if presentationMode == .modal {
             setupTitleBar()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1212389717456830?focus=true
Tech Design URL:
CC:

### Description
Fix Maestro AI Chat modal test

### Testing Steps
1. Run the ai-chat.yaml file, check if it passes

### Impact and Risks
None: Internal tooling, documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Maestro AI Chat test to assert the modal by accessibility id and adds the corresponding identifier; extends the test to disable AI features and verify Duck.ai is hidden.
> 
> - **Tests (Maestro)**:
>   - Replace modal assertions with `assertVisible: id: "AIChatViewController"` across new tab, browsing, and tab switcher flows.
>   - Extend flow to disable `AI Features` in Settings and verify `Duck.ai` is not visible in new tab, browsing, and tab switcher.
> - **iOS (AI Chat)**:
>   - Set `self.view.accessibilityIdentifier = "AIChatViewController"` in `AIChatViewController.viewDidLoad` for reliable UI test targeting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6df41d3551efe1fcb22b9c76ecd28fee80b944be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->