### PR TITLE
History: Wiring new onThemeUpdate Message

### DIFF
--- a/macOS/DuckDuckGo/History/View/HistoryViewActionsManagerExtension.swift
+++ b/macOS/DuckDuckGo/History/View/HistoryViewActionsManagerExtension.swift
@@ -46,7 +46,8 @@ extension HistoryViewActionsManager {
                 styleProvider: styleProvider,
                 actionsHandler: HistoryViewActionsHandler(dataProvider: dataProvider, bookmarksHandler: bookmarksHandler),
                 errorHandler: HistoryViewErrorHandler()
-            )
+            ),
+            StyleClient(styleProviding: styleProvider)
         ])
     }
 }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
@@ -270,7 +270,9 @@ extension TabExtensionsBuilder {
                                 trackersPublisher: contentBlocking.trackersPublisher,
                                 urlPublisher: args.contentPublisher.map { content in content.displaysContentInWebView ? content.urlForWebView : nil },
                                 titlePublisher: args.titlePublisher,
-                                popupManagedPublisher: autoconsentTabExtension.popupManagedPublisher)
+                                popupManagedPublisher: autoconsentTabExtension.popupManagedPublisher,
+                                scriptsPublisher: userScripts.compactMap { $0 },
+                                webViewPublisher: args.webViewFuture)
         }
         add {
             PrivacyStatsTabExtension(

--- a/macOS/LocalPackages/HistoryView/Sources/HistoryView/DataClient.swift
+++ b/macOS/LocalPackages/HistoryView/Sources/HistoryView/DataClient.swift
@@ -29,12 +29,6 @@ public protocol DataProviding: AnyObject {
     func visitsBatch(for query: DataModel.HistoryQueryKind, source: DataModel.HistoryQuerySource, limit: Int, offset: Int) async -> DataModel.HistoryItemsBatch
 }
 
-public protocol StyleProviding: AnyObject {
-    var themeAppearance: String { get }
-    var themeName: String { get }
-    var themeStylePublisher: AnyPublisher<(appearance: String, themeName: String), Never> { get }
-}
-
 public enum HistoryViewEvent: Equatable {
     case historyViewError(message: String)
 }

--- a/macOS/LocalPackages/HistoryView/Sources/HistoryView/DataModel.swift
+++ b/macOS/LocalPackages/HistoryView/Sources/HistoryView/DataModel.swift
@@ -190,6 +190,11 @@ extension DataModel {
         }
     }
 
+    struct ThemeUpdate: Encodable {
+        var theme: String
+        var themeVariant: String
+    }
+
     struct Exception: Codable, Equatable {
         let message: String
     }

--- a/macOS/LocalPackages/HistoryView/Sources/HistoryView/StyleClient.swift
+++ b/macOS/LocalPackages/HistoryView/Sources/HistoryView/StyleClient.swift
@@ -1,0 +1,63 @@
+//
+//  StyleClient.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+import Combine
+import Common
+import os.log
+import UserScriptActionsManager
+import WebKit
+
+public protocol StyleProviding: AnyObject {
+    var themeAppearance: String { get }
+    var themeName: String { get }
+    var themeStylePublisher: AnyPublisher<(appearance: String, themeName: String), Never> { get }
+}
+
+public final class StyleClient: HistoryViewUserScriptClient {
+
+    private let styleProviding: StyleProviding
+    private var cancellables: Set<AnyCancellable> = []
+
+    public init(styleProviding: StyleProviding) {
+        self.styleProviding = styleProviding
+        super.init()
+
+        styleProviding.themeStylePublisher
+            .sink { [weak self] appearance, themeName in
+                Task { @MainActor in
+                    self?.notifyThemeStyle(appearance: appearance, themeName: themeName)
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    enum MessageName: String, CaseIterable {
+        case onThemeUpdate
+    }
+
+    public override func registerMessageHandlers(for userScript: HistoryViewUserScript) {
+        // NO-OP
+    }
+
+    @MainActor
+    private func notifyThemeStyle(appearance: String, themeName: String) {
+        let payload = DataModel.ThemeUpdate(theme: appearance, themeVariant: themeName)
+        pushMessage(named: MessageName.onThemeUpdate.rawValue, params: payload)
+    }
+}

--- a/macOS/UnitTests/TabExtensionsTests/HistoryTabExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/HistoryTabExtensionTests.swift
@@ -22,8 +22,13 @@ import Navigation
 import SharedTestUtilities
 import WebKit
 import XCTest
+import HistoryView
 
 @testable import DuckDuckGo_Privacy_Browser
+
+private struct MockScriptProvider: HistoryUserScriptProvider {
+    var historyViewUserScript: HistoryViewUserScript
+}
 
 class HistoryTabExtensionTests: XCTestCase {
 
@@ -35,7 +40,21 @@ class HistoryTabExtensionTests: XCTestCase {
         let urlPublisher: AnyPublisher<URL?, Never> = Empty().eraseToAnyPublisher()
         let titlePublisher: AnyPublisher<String?, Never> = Empty().eraseToAnyPublisher()
         let popupManagedPublisher: AnyPublisher<AutoconsentUserScript.AutoconsentDoneMessage, Never> = Empty().eraseToAnyPublisher()
-        let historyTabExtension = HistoryTabExtension(isCapturingHistory: false, historyCoordinating: historyCoordinatingMock, trackersPublisher: trackersPublisher, urlPublisher: urlPublisher, titlePublisher: titlePublisher, popupManagedPublisher: popupManagedPublisher)
+
+        let mockScriptProvider = MockScriptProvider(historyViewUserScript: HistoryViewUserScript())
+        let scriptsSubject = CurrentValueSubject<MockScriptProvider, Never>(mockScriptProvider)
+        let webViewSubject = PassthroughSubject<WKWebView, Never>()
+
+        let historyTabExtension = HistoryTabExtension(
+            isCapturingHistory: false,
+            historyCoordinating: historyCoordinatingMock,
+            trackersPublisher: trackersPublisher,
+            urlPublisher: urlPublisher,
+            titlePublisher: titlePublisher,
+            popupManagedPublisher: popupManagedPublisher,
+            scriptsPublisher: scriptsSubject.eraseToAnyPublisher(),
+            webViewPublisher: webViewSubject.eraseToAnyPublisher()
+        )
 
         let navigationIdentity = NavigationIdentity(nil)
         let responderChain = ResponderChain(responderRefs: [])


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1212325726923319?focus=true
Tech Design URL:
CC:

### Description
This PR adds support to dynamically refresh the `History View` Style, without requiring the need of relaunching the browser.

### Testing Steps
1. Enable the `Internal User` Flag
2. Open two Windows
3. **[Window A]** Press `CMD + Y` to open History
4. **[Window B]** Open Settings > Appearance

- [ ] Verify that if you update the Theme / Appearance, the History View reacts instantly

### Testing: System Appearance
1. Enable the `Internal User` Flag
2. Set the `System` Appearance
3. Open History

- [ ] Verify that if you toggle macOS into either Light or Dark Mode, the History UI adapts instantly

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The incorrect Style could be applied to the History UI

### Quality Considerations
Nothing in particular

### Notes to Reviewer
Thank you!

### Demo
https://github.com/user-attachments/assets/65987939-0a33-4261-add3-9bc1542a661a


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a StyleClient and plumbs HistoryView user script/webView into HistoryTabExtension to push onThemeUpdate for instant History UI theme changes.
> 
> - **History View integration**:
>   - Add `StyleClient` to `HistoryViewActionsManagerExtension` `scriptClients` to emit `onThemeUpdate`.
>   - Introduce `StyleClient` (new file) using `StyleProviding.themeStylePublisher` to push `DataModel.ThemeUpdate` messages.
>   - Move `StyleProviding` protocol to `StyleClient` and keep `DataClient` consuming it; no longer declares the protocol.
> - **Tab plumbing**:
>   - Add `HistoryUserScriptProvider` and store weak `historyViewUserScript` and `webView` in `HistoryTabExtension`.
>   - Subscribe to `scriptsPublisher` and `webViewPublisher` to attach the `webView` to `historyViewUserScript`.
>   - Update `TabExtensions.registerExtensions` to pass `scriptsPublisher` and `webViewPublisher` into `HistoryTabExtension`.
> - **Data model**:
>   - Add `DataModel.ThemeUpdate { theme, themeVariant }`.
> - **Tests**:
>   - Update `HistoryTabExtensionTests` to provide a mock `HistoryUserScriptProvider` and web view publishers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e99518ae89ed9ce91ece68f809ac98b24ad31986. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->