### PR TITLE
Update C-S-S to 12.4.1

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/ContentScopeScripts/Resources/pages/new-tab/dist/index.css
+++ b/SharedPackages/BrowserServicesKit/Sources/ContentScopeScripts/Resources/pages/new-tab/dist/index.css
@@ -2108,13 +2108,21 @@ body:not([data-background-kind=default]) .TabSwitcher_tabSwitcher {
 }
 .PrivacyStats_counterContainer {
   display: flex;
-  gap: 24px;
+  gap: 12px;
 }
 .PrivacyStats_counter {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  padding-right: 38px;
+  width: 196px;
+  padding-right: 18px;
+  box-sizing: content-box;
+}
+.PrivacyStats_counter:last-child {
+  padding-right: 0;
+}
+.PrivacyStats_cookiePopUpsCounter {
+  margin-left: 14px;
 }
 .PrivacyStats_title {
   color: var(--ntp-text-primary);
@@ -2130,6 +2138,8 @@ body:not([data-background-kind=default]) .TabSwitcher_tabSwitcher {
   line-height: 20px;
   padding-bottom: 4px;
   padding-top: 12px;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 .PrivacyStats_noRecentTitle {
   color: var(--ntp-text-muted);
@@ -2228,24 +2238,6 @@ body:not([data-background-kind=default]) .TabSwitcher_tabSwitcher {
 }
 [data-theme=dark] .PrivacyStats_fill {
   background: var(--color-white-at-9);
-}
-
-/* pages/new-tab/app/components/NewBadge.module.css */
-.NewBadge_badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: fit-content;
-  height: 16px;
-  padding: 0 8px;
-  background-color: #F9BE1A;
-  border-radius: 4px;
-  font-family: var(--theme-font-family, system-ui);
-  font-weight: 700;
-  font-size: 11px;
-  color: var(--color-black-at-96);
-  letter-spacing: -0.015em;
-  flex-shrink: 0;
 }
 
 /* pages/new-tab/app/components/Tooltip/Tooltip.module.css */

--- a/SharedPackages/BrowserServicesKit/Sources/ContentScopeScripts/Resources/pages/new-tab/dist/index.js
+++ b/SharedPackages/BrowserServicesKit/Sources/ContentScopeScripts/Resources/pages/new-tab/dist/index.js
@@ -9704,6 +9704,7 @@
         widgetExpander: "PrivacyStats_widgetExpander",
         counterContainer: "PrivacyStats_counterContainer",
         counter: "PrivacyStats_counter",
+        cookiePopUpsCounter: "PrivacyStats_cookiePopUpsCounter",
         title: "PrivacyStats_title",
         noRecentTitle: "PrivacyStats_noRecentTitle",
         subtitle: "PrivacyStats_subtitle",
@@ -9720,28 +9721,6 @@
         bar: "PrivacyStats_bar",
         fill: "PrivacyStats_fill"
       };
-    }
-  });
-
-  // pages/new-tab/app/components/NewBadge.module.css
-  var NewBadge_default;
-  var init_NewBadge = __esm({
-    "pages/new-tab/app/components/NewBadge.module.css"() {
-      NewBadge_default = {
-        badge: "NewBadge_badge"
-      };
-    }
-  });
-
-  // pages/new-tab/app/components/NewBadge.js
-  function NewBadge({ text: text2, ...rest }) {
-    return /* @__PURE__ */ _("span", { class: NewBadge_default.badge, ...rest }, text2?.toUpperCase() || "NEW");
-  }
-  var init_NewBadge2 = __esm({
-    "pages/new-tab/app/components/NewBadge.js"() {
-      "use strict";
-      init_preact_module();
-      init_NewBadge();
     }
   });
 
@@ -9900,7 +9879,7 @@
         UPPER_THRESHOLD: 40,
         LOWER_START_PERCENTAGE: 0.75,
         UPPER_START_PERCENTAGE: 0.85,
-        MAX_DISPLAY_COUNT: 9999
+        MAX_DISPLAY_COUNT: 9999999
       };
     }
   });
@@ -10049,6 +10028,8 @@
       {}
     );
     const ntp = useMessaging();
+    const locale = useLocale();
+    const formatter = T2(() => getLocalizedNumberFormatter(locale), [locale]);
     const headingRef = A2(
       /** @type {HTMLDivElement|null} */
       null
@@ -10081,7 +10062,7 @@
         onClick: onToggle,
         label: expansion === "expanded" ? t4("stats_hideLabel") : t4("stats_toggleLabel")
       }
-    ))), /* @__PURE__ */ _("div", { class: PrivacyStats_default.counterContainer, ref: counterContainerRef }, /* @__PURE__ */ _("div", { class: PrivacyStats_default.counter }, animatedTrackersBlocked === 0 && /* @__PURE__ */ _("h3", { class: PrivacyStats_default.noRecentTitle }, t4("protections_noRecent")), animatedTrackersBlocked > 0 && /* @__PURE__ */ _("h3", { class: PrivacyStats_default.title }, animatedTrackersBlocked, " ", /* @__PURE__ */ _("span", null, trackersBlockedHeading))), isCpmEnabled && animatedTrackersBlocked > 0 && totalCookiePopUpsBlocked > 0 && /* @__PURE__ */ _("div", { class: PrivacyStats_default.counter }, /* @__PURE__ */ _("h3", { class: PrivacyStats_default.title }, animatedCookiePopUpsBlocked, " ", /* @__PURE__ */ _("span", null, cookiePopUpsBlockedHeading)), /* @__PURE__ */ _(NewBadge, { text: t4("protections_newBadge") }))));
+    ))), /* @__PURE__ */ _("div", { class: PrivacyStats_default.counterContainer, ref: counterContainerRef }, /* @__PURE__ */ _("div", { class: PrivacyStats_default.counter }, animatedTrackersBlocked === 0 && /* @__PURE__ */ _("h3", { class: PrivacyStats_default.noRecentTitle }, t4("protections_noRecent")), animatedTrackersBlocked > 0 && /* @__PURE__ */ _("h3", { class: PrivacyStats_default.title }, formatter.format(animatedTrackersBlocked), " ", /* @__PURE__ */ _("span", null, trackersBlockedHeading))), isCpmEnabled && animatedTrackersBlocked > 0 && totalCookiePopUpsBlocked > 0 && /* @__PURE__ */ _("div", { class: (0, import_classnames9.default)(PrivacyStats_default.counter, PrivacyStats_default.cookiePopUpsCounter) }, /* @__PURE__ */ _("h3", { class: PrivacyStats_default.title }, formatter.format(animatedCookiePopUpsBlocked), " ", /* @__PURE__ */ _("span", null, cookiePopUpsBlockedHeading)))));
   }
   var import_classnames9;
   var init_ProtectionsHeading = __esm({
@@ -10093,10 +10074,11 @@
       import_classnames9 = __toESM(require_classnames(), 1);
       init_preact_module();
       init_Icons2();
-      init_NewBadge2();
       init_Tooltip2();
       init_useAnimatedCount();
       init_hooks_module();
+      init_utils3();
+      init_EnvironmentProvider();
     }
   });
 
@@ -33945,6 +33927,7 @@
   var url3 = new URL(window.location.href);
 
   // pages/new-tab/app/protections/mocks/protections.mock-transport.js
+  init_animateCount();
   var url4 = typeof window !== "undefined" ? new URL(window.location.href) : new URL("https://example.com");
 
   // pages/new-tab/app/omnibar/mocks/omnibar.mock-transport.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       ],
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.39.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.4.0"
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.4.1"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -101,6 +101,7 @@
       "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -143,6 +144,7 @@
       "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@babel/types": "^7.28.5",
@@ -160,6 +162,7 @@
       "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.27.2",
         "@babel/helper-validator-option": "^7.27.1",
@@ -177,6 +180,7 @@
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -187,6 +191,7 @@
       "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.27.1",
         "@babel/types": "^7.27.1"
@@ -201,6 +206,7 @@
       "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -219,6 +225,7 @@
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -239,6 +246,7 @@
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -249,6 +257,7 @@
       "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/template": "^7.27.2",
         "@babel/types": "^7.28.4"
@@ -263,6 +272,7 @@
       "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.28.5"
       },
@@ -279,6 +289,7 @@
       "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/parser": "^7.27.2",
@@ -294,6 +305,7 @@
       "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -313,6 +325,7 @@
       "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.28.5"
@@ -333,7 +346,7 @@
       }
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#6c78291d25eb6a22d647f4a58027935c946afa68",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#efae6db8605c388067c88b35164c4cb259d8f26a",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -643,6 +656,7 @@
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -830,7 +844,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -962,6 +975,7 @@
       "integrity": "sha512-OPz5aBThlyLFgxyhdwf/s2+8ab3OvT7AdTNvKHBwpXomIYeXqpUUuT8LrdtxZSsWJ4R4CU1un4XGh5Ez3nlTpw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
@@ -1124,7 +1138,8 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "CC-BY-4.0"
+      "license": "CC-BY-4.0",
+      "peer": true
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1355,7 +1370,8 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.262.tgz",
       "integrity": "sha512-NlAsMteRHek05jRUxUR0a5jpjYq9ykk6+kO0yRaMi5moe7u0fVIOeQ3Y30A8dIiWFBNUoQGi1ljb1i5VtS9WQQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -1442,7 +1458,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1825,6 +1840,7 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2203,6 +2219,7 @@
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -2297,6 +2314,7 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -2424,7 +2442,8 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -2738,7 +2757,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -2793,6 +2811,7 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -3139,6 +3158,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -3239,7 +3259,8 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   },
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.39.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.4.0"
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#12.4.1"
   }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211734332014683?focus=true
Tech Design URL:
CC:

### Description
This PR updates C-S-S from 12.4.0 to 12.4.1 that contains two cherry-picked changes for the "Protections Report" widgets on the NTP required for the upcoming release:
- Remove "NEW" badge from protections report (https://github.com/duckduckgo/content-scope-scripts/pull/2098)
- Increase tracker and cookie pop-up counter capacity (https://github.com/duckduckgo/content-scope-scripts/pull/2083)

### Testing Steps
- Smoke test NTP

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Visual glitches to NTP.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates content-scope-scripts to 12.4.1 and refines Protections Report counters: removes NEW badge, localizes numbers, increases max display, and tweaks layout.
> 
> - **NTP Protections Report**:
>   - Remove `NEW` badge component and related styles from bundle.
>   - Localize counter numbers via locale-aware formatter.
>   - Increase `MAX_DISPLAY_COUNT` to `9,999,999`.
>   - Layout/spacing tweaks: adjust gaps, widths, padding; add `cookiePopUpsCounter` class; enable word/overflow wrapping in titles.
> - **Dependencies**:
>   - Bump `@duckduckgo/content-scope-scripts` to `12.4.1` in `package.json` and lockfile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 631c598395efbb69b721405db8db118a89366e3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->