### PR TITLE
Update URLPredictorRust to 0.3.13

### DIFF
--- a/SharedPackages/URLPredictor/Package.swift
+++ b/SharedPackages/URLPredictor/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
         .target(name: "URLPredictor", dependencies: ["URLPredictorRust"]),
         .binaryTarget(
             name: "URLPredictorRust",
-            url: "https://github.com/duckduckgo/url_predictor/releases/download/0.3.2/URLPredictorRust.xcframework.zip",
-            checksum: "17bcf2dc9829e0ee5e36eaae9729b866d0a7d1df387c219a5a01234540dd31cc"
+            url: "https://github.com/duckduckgo/url_predictor/releases/download/0.3.13/URLPredictorRust.xcframework.zip",
+            checksum: "64a9158d40ceb86946638a98206a736cfc32dff5af1a544250d506686ea4459a"
         ),
         .testTarget(name: "URLPredictorTests", dependencies: ["URLPredictor"])
     ]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1212403643721541?focus=true

### Description
This change updates URL Predictor binary to the version that fixes handling navigation to
bare top-level domains that are navigatable (e.g. blogspot.com).

### Testing Steps
In the iOS app, type blogspot.com in the address bar and verify that the app performs a navigation (it should redirect to blogger.com) and not a search.
macOS app was not affected by the bug.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Swift package to use URLPredictorRust 0.3.13 with the corresponding checksum.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41e0d318db05ed14c7139f114afefa62ba65690f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->