### PR TITLE
Privacy Dashboard: Wiring new onThemeUpdate Message 

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/PrivacyDashboardController.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/PrivacyDashboardController.swift
@@ -62,7 +62,12 @@ public protocol PrivacyDashboardControllerDelegate: AnyObject {
 
     public weak var delegate: PrivacyDashboardControllerDelegate?
 
+    /// Deprecated: Preserved for backwards compatibility. Please use the `style` property instead
     @Published public var theme: PrivacyDashboardTheme?
+
+    /// Sets the Theme + Appearance of the Privacy Dashboard
+    @Published public var style: PrivacyDashboardStyle?
+
     @Published public var allowedPermissions: [AllowedPermission] = []
     public var preferredLocale: String?
     public var dashboardHtmlName: String {
@@ -199,7 +204,6 @@ public protocol PrivacyDashboardControllerDelegate: AnyObject {
     func didRequestClose() {
         delegate?.privacyDashboardControllerDidRequestClose(self)
     }
-
 }
 
 // MARK: - WKNavigationDelegate
@@ -218,6 +222,7 @@ extension PrivacyDashboardController: WKNavigationDelegate {
         cancellables.removeAll()
 
         subscribeToTheme()
+        subscribeToStyle()
         subscribeToTrackerInfo()
         subscribeToConnectionUpgradedTo()
         subscribeToServerTrust()
@@ -233,6 +238,17 @@ extension PrivacyDashboardController: WKNavigationDelegate {
             .sink(receiveValue: { [weak self] themeName in
                 guard let self, let webView else { return }
                 script.setTheme(themeName, webView: webView)
+            })
+            .store(in: &cancellables)
+    }
+
+    private func subscribeToStyle() {
+        $style
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { [weak self] style in
+                guard let self, let webView, let style else { return }
+                script.setThemeStyle(style, webView: webView)
             })
             .store(in: &cancellables)
     }

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/PrivacyDashboardUserScript.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/PrivacyDashboardUserScript.swift
@@ -47,10 +47,18 @@ protocol PrivacyDashboardUserScriptDelegate: AnyObject {
 }
 
 public enum PrivacyDashboardTheme: String, Encodable {
-
     case light
     case dark
+}
 
+public struct PrivacyDashboardStyle: Equatable, Encodable {
+    let theme: String
+    let themeVariant: String
+
+    public init(theme: String, themeVariant: String) {
+        self.theme = theme
+        self.themeVariant = themeVariant
+    }
 }
 
 public enum Screen: String, Decodable, CaseIterable {
@@ -364,6 +372,15 @@ final class PrivacyDashboardUserScript: NSObject, StaticUserScript {
             return
         }
         evaluate(js: "window.onChangeTheme(\(themeJson))", in: webView)
+    }
+
+    func setThemeStyle(_ style: PrivacyDashboardStyle, webView: WKWebView) {
+        guard let styleJson = try? JSONEncoder().encode(style).utf8String() else {
+            assertionFailure("Can't encode themeStyle into JSON")
+            return
+        }
+
+        evaluate(js: "window.onChangeTheme(\(styleJson))", in: webView)
     }
 
     func setServerTrust(_ serverTrustViewModel: ServerTrustViewModel, webView: WKWebView) {

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -2906,6 +2906,8 @@
 		B5C2886C2EC6206100A572F2 /* CASpringAnimationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C2886A2EC6206100A572F2 /* CASpringAnimationExtension.swift */; };
 		B5CBB60B2EC4F80A006C3F54 /* TabTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CBB60A2EC4F80A006C3F54 /* TabTitleView.swift */; };
 		B5CBB60C2EC4F80A006C3F54 /* TabTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CBB60A2EC4F80A006C3F54 /* TabTitleView.swift */; };
+		B5CF899B2EEC771F006B97DF /* PrivacyDashboardStyleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CF899A2EEC771F006B97DF /* PrivacyDashboardStyleExtension.swift */; };
+		B5CF899C2EEC771F006B97DF /* PrivacyDashboardStyleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CF899A2EEC771F006B97DF /* PrivacyDashboardStyleExtension.swift */; };
 		B5DE8DA92EBE292F005C5EF4 /* SpinnerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DE8DA82EBE292F005C5EF4 /* SpinnerView.swift */; };
 		B5DE8DAA2EBE292F005C5EF4 /* SpinnerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DE8DA82EBE292F005C5EF4 /* SpinnerView.swift */; };
 		B5E197EB2E8C645500C447CC /* ThemeManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E197E92E8C645500C447CC /* ThemeManagerTests.swift */; };
@@ -5698,6 +5700,7 @@
 		B5BD99632EE8DA2E00E7DD99 /* ThemedTextFieldStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemedTextFieldStyle.swift; sourceTree = "<group>"; };
 		B5C2886A2EC6206100A572F2 /* CASpringAnimationExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CASpringAnimationExtension.swift; sourceTree = "<group>"; };
 		B5CBB60A2EC4F80A006C3F54 /* TabTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTitleView.swift; sourceTree = "<group>"; };
+		B5CF899A2EEC771F006B97DF /* PrivacyDashboardStyleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyDashboardStyleExtension.swift; sourceTree = "<group>"; };
 		B5DE8DA82EBE292F005C5EF4 /* SpinnerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerView.swift; sourceTree = "<group>"; };
 		B5E197E92E8C645500C447CC /* ThemeManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManagerTests.swift; sourceTree = "<group>"; };
 		B5E7B6BF2ED4A52C00094EDF /* TitleDisplayPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleDisplayPolicy.swift; sourceTree = "<group>"; };
@@ -10998,6 +11001,14 @@
 			path = Tools;
 			sourceTree = "<group>";
 		};
+		B5CF89992EEC770E006B97DF /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				B5CF899A2EEC771F006B97DF /* PrivacyDashboardStyleExtension.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		B5E197EA2E8C645500C447CC /* VisualRefresh */ = {
 			isa = PBXGroup;
 			children = (
@@ -11458,6 +11469,7 @@
 		B6FA893A269C414900588ECD /* PrivacyDashboard */ = {
 			isa = PBXGroup;
 			children = (
+				B5CF89992EEC770E006B97DF /* Extensions */,
 				B6FA893B269C41ED00588ECD /* View */,
 				1E7E2E8F29029A2A00C01B54 /* ContentBlockingRulesUpdateObserver.swift */,
 				1E7E2E932902AC0E00C01B54 /* PrivacyDashboardPermissionHandler.swift */,
@@ -14131,6 +14143,7 @@
 				4B9DB0362A983B24000927DB /* WaitlistTermsAndConditionsView.swift in Sources */,
 				37197EA82942443D00394917 /* BrowserTabViewController.swift in Sources */,
 				3706FB39293F65D500E42796 /* PrivacyDashboardPopover.swift in Sources */,
+				B5CF899B2EEC771F006B97DF /* PrivacyDashboardStyleExtension.swift in Sources */,
 				467D16672D0C98D5007C020A /* CrashReportSenderExtensions.swift in Sources */,
 				3706FB3D293F65D500E42796 /* FocusRingView.swift in Sources */,
 				EE650D5E2EB112CA00B3D1D7 /* NewProfilePickerView.swift in Sources */,
@@ -15846,6 +15859,7 @@
 				B6106BAD26A7BF390013B453 /* PermissionState.swift in Sources */,
 				371C0A2927E33EDC0070591F /* FeedbackPresenter.swift in Sources */,
 				B66260DD29AC5D4300E9E3EE /* NavigationProtectionTabExtension.swift in Sources */,
+				B5CF899C2EEC771F006B97DF /* PrivacyDashboardStyleExtension.swift in Sources */,
 				1D1A33492A6FEB170080ACED /* BurnerMode.swift in Sources */,
 				14505A08256084EF00272CC6 /* UserAgent.swift in Sources */,
 				841BE93E2C6F236000E9C2B5 /* BookmarkDragDropManager.swift in Sources */,

--- a/macOS/DuckDuckGo/PrivacyDashboard/Extensions/PrivacyDashboardStyleExtension.swift
+++ b/macOS/DuckDuckGo/PrivacyDashboard/Extensions/PrivacyDashboardStyleExtension.swift
@@ -1,0 +1,28 @@
+//
+//  PrivacyDashboardStyleExtension.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import AppKit
+import PrivacyDashboard
+
+extension PrivacyDashboardStyle {
+
+    init(themeName: ThemeName, appearance: ThemeAppearance) {
+        self.init(theme: appearance.rawValue, themeVariant: themeName.rawValue)
+    }
+}

--- a/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
+++ b/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
@@ -44,6 +44,9 @@ final class PrivacyDashboardViewController: NSViewController {
     private var privacyDashboardDidTriggerDismiss: Bool = false
     private let contentBlocking: ContentBlockingProtocol
 
+    private let themeManager: ThemeManaging
+    private var cancellables = Set<AnyCancellable>()
+
     public let rulesUpdateObserver: ContentBlockingRulesUpdateObserver
 
     private let brokenSiteReporter: BrokenSiteReporter
@@ -84,6 +87,7 @@ final class PrivacyDashboardViewController: NSViewController {
          entryPoint: PrivacyDashboardEntryPoint = .dashboard,
          contentBlocking: ContentBlockingProtocol,
          permissionManager: PermissionManagerProtocol,
+         themeManager: ThemeManaging = NSApp.delegateTyped.themeManager,
          webTrackingProtectionPreferences: WebTrackingProtectionPreferences
     ) {
         let toggleReportingConfiguration = ToggleReportingConfiguration(privacyConfigurationManager: contentBlocking.privacyConfigurationManager)
@@ -95,6 +99,8 @@ final class PrivacyDashboardViewController: NSViewController {
                                                                      entryPoint: entryPoint,
                                                                      toggleReportingManager: toggleReportingManager,
                                                                      eventMapping: privacyDashboardEvents)
+
+        self.themeManager = themeManager
         self.contentBlocking = contentBlocking
         // swiftlint:disable:next force_cast
         self.rulesUpdateObserver = ContentBlockingRulesUpdateObserver(userContentUpdating: (contentBlocking as! AppContentBlocking).userContentUpdating)
@@ -151,6 +157,9 @@ final class PrivacyDashboardViewController: NSViewController {
         privacyDashboardController.setup(for: webView)
         privacyDashboardController.delegate = self
         privacyDashboardController.preferredLocale = Bundle.main.preferredLocalizations.first
+
+        subscribeToThemeChanges()
+        refreshDashboardStyle()
     }
 
     override func viewWillDisappear() {
@@ -224,6 +233,34 @@ final class PrivacyDashboardViewController: NSViewController {
 
         let completionToken = contentBlocking.contentBlockingManager.scheduleCompilation()
         rulesUpdateObserver.startCompilation(for: domain, token: completionToken)
+    }
+}
+
+private extension PrivacyDashboardViewController {
+
+    private func subscribeToThemeChanges() {
+        themeManager.themePublisher
+            .removeDuplicates { old, new in
+                old.name == new.name
+            }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.refreshDashboardStyle()
+            }
+            .store(in: &cancellables)
+
+        themeManager.effectiveAppearancePublisher
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.refreshDashboardStyle()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func refreshDashboardStyle() {
+        let style = PrivacyDashboardStyle(themeName: themeManager.theme.name, appearance: themeManager.effectiveAppearance)
+        privacyDashboardController.style = style
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1212325726923320?focus=true
Tech Design URL:
CC:

### Description
In this PR we're wiring the new Privacy Dashboard Theme API(s)

### Testing Steps
1. Open two Browser windows
2. **[Window A]** Open any website and click on the Privacy Dashboard button
3. **[Window B]** Open Settings > Apperance

- [ ] Verify that the Privacy Dashboard UI reacts instantly whenever you switch to a different Theme
- [ ] Verify that the Privacy Dashboard UI reacts instantly whenever you switch to a different Appearance (Light / Dark)

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The incorrect Style could be applied to the Privacy Dashboard

### Quality Considerations
Nothing in particular!

### Notes to Reviewer
Thank youuuu

### Demo
https://github.com/user-attachments/assets/76074e25-aef0-4f49-b67f-c976e04b8065

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `PrivacyDashboardStyle` and wire live theme/appearance updates so the dashboard reacts instantly to theme changes.
> 
> - **Privacy Dashboard (Shared)**:
>   - Add `@Published` `style: PrivacyDashboardStyle?` to `PrivacyDashboardController` (keep deprecated `theme` for BC) and subscribe to it, sending updates via `script.setThemeStyle`.
>   - `PrivacyDashboardUserScript`: add `PrivacyDashboardStyle` (theme + themeVariant) and new `setThemeStyle` that calls `window.onChangeTheme(...)`.
> - **macOS App**:
>   - Add `PrivacyDashboardStyle` extension to init from `ThemeName` and `ThemeAppearance`.
>   - `PrivacyDashboardViewController`: inject `ThemeManaging`, subscribe to `themePublisher` and `effectiveAppearancePublisher`, and set `privacyDashboardController.style` on changes.
>   - Project: include new `PrivacyDashboardStyleExtension.swift` in build.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5329501dc0ae8bfb091c595e8b2cc1977e0cc23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->