### PR TITLE
[macOS] Fix leak in interactionEventsPublisher on PopupHandlingTabExtension

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/PopupHandlingTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PopupHandlingTabExtension.swift
@@ -99,9 +99,10 @@ final class PopupHandlingTabExtension {
         self.isInPopUpWindow = isInPopUpWindow
 
         interactionEventsPublisher
-            .filter { [featureFlagger] event in
+            .filter { [weak featureFlagger] event in
                 Logger.navigation.debug("PopupHandlingTabExtension.interactionEventsPublisher.filter: event: \(String(describing: event))")
-                guard featureFlagger.isFeatureOn(.popupBlocking),
+                guard let featureFlagger,
+                      featureFlagger.isFeatureOn(.popupBlocking),
                       featureFlagger.isFeatureOn(.extendedUserInitiatedPopupTimeout) else { return false }
 
                 switch event {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207340338530322/task/1212423256533717?focus=true
Tech Design URL:
CC:

### Description
The featureFlagger stored property inside the closure given that it doesn’t have a capture list, so Swift implicitly captures self strongly to access that property. So featureFlagger is actually self.featureFlagger.

### Testing Steps
1. Check the app works normally

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Weakly capture and unwrap `featureFlagger` in the interaction events filter to prevent a strong self capture/leak.
> 
> - **macOS popup handling**:
>   - Weakly capture `featureFlagger` in `interactionEventsPublisher.filter` and unwrap with `guard let featureFlagger` to avoid retaining `self`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0e94b7eb479ee43f87c8ec9e2f13282d2e24066. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->