### PR TITLE
Restore deleted translations for Experimental Browser Menu

### DIFF
--- a/iOS/DuckDuckGo/bg.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/bg.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Позиция на адресната лента";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Експериментално меню на браузъра";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Отваряне на връзките в свързаните приложения";
 

--- a/iOS/DuckDuckGo/cs.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/cs.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Pozice adresního řádku";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Experimentální nabídka prohlížeče";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Otevřít odkazy v přidružených aplikacích";
 

--- a/iOS/DuckDuckGo/da.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/da.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Placering af adresselinje";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Eksperimentel browsermenu";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Åbn links i tilknyttede apps";
 

--- a/iOS/DuckDuckGo/de.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/de.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Position der Adressleiste";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Experimentelles Browser-Menü";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Links in den dazugehörigen Apps öffnen";
 

--- a/iOS/DuckDuckGo/el.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/el.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Θέση γραμμής διευθύνσεων";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Πειραματικό μενού προγράμματος περιήγησης";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Ανοίξτε τους συνδέσμους στις σχετικές εφαρμογές";
 

--- a/iOS/DuckDuckGo/es.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/es.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Posición de la barra de direcciones";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Menú del navegador experimental";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Abrir enlaces en aplicaciones asociadas";
 

--- a/iOS/DuckDuckGo/et.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/et.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Aadressiriba asukoht";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Eksperimentaalne brauseri menüü";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Ava lingid seotud rakendustes";
 

--- a/iOS/DuckDuckGo/fi.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fi.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Osoitepalkin sijainti";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Kokeellinen selainvalikko";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Avaa linkit liittyvissä sovelluksissa";
 

--- a/iOS/DuckDuckGo/fr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fr.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Position de la barre d'adresse";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Menu expérimental du navigateur";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Ouvrir les liens dans les applications associées";
 

--- a/iOS/DuckDuckGo/hr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hr.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Položaj adresne trake";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Eksperimentalni izbornik preglednika";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Otvori veze u povezanim aplikacijama";
 

--- a/iOS/DuckDuckGo/hu.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hu.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Címsor elhelyezkedése";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Kísérleti böngészési menü";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Hivatkozások megnyitása társított alkalmazásokban";
 

--- a/iOS/DuckDuckGo/it.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/it.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Posizione Barra degli indirizzi";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Menu sperimentale del browser";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Apri i collegamenti nelle loro app associate";
 

--- a/iOS/DuckDuckGo/lt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lt.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Adreso juostos padėtis";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Eksperimentinis naršyklės meniu";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Atidaryti nuorodas susijusiose programose";
 

--- a/iOS/DuckDuckGo/lv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lv.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Adreses joslas pozīcija";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Eksperimentāla pārlūka izvēlne";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Atvērt saites saistītajās lietotnēs";
 

--- a/iOS/DuckDuckGo/nb.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nb.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Plassering av adressefelt";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Eksperimentell nettlesermeny";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Åpne lenker i tilknyttede apper";
 

--- a/iOS/DuckDuckGo/nl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nl.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Positie van adresbalk";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Experimenteel browsermenu";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Links openen in bijbehorende apps";
 

--- a/iOS/DuckDuckGo/pl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pl.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Pozycja paska adresu";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Eksperymentalne menu przeglądarki";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Otwieraj łącza w powiązanych aplikacjach";
 

--- a/iOS/DuckDuckGo/pt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pt.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Posição da barra de endereços";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Menu experimental do navegador";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Abrir links nas aplicações associadas";
 

--- a/iOS/DuckDuckGo/ro.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ro.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Poziția barei de adrese";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Meniu browser experimental";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Deschide linkuri în aplicațiile asociate";
 

--- a/iOS/DuckDuckGo/ru.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ru.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Положение адресной строки";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Пробное меню браузера";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Открывать ссылки в связанных приложениях";
 

--- a/iOS/DuckDuckGo/sk.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sk.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Poloha riadku s adresou";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Experimentálna ponuka prehliadača";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Otvárať odkazy v pridružených aplikáciách";
 

--- a/iOS/DuckDuckGo/sl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sl.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Položaj naslovne vrstice";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Eksperimentalni meni brskalnika";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Odpri povezave v povezanih aplikacijah";
 

--- a/iOS/DuckDuckGo/tr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/tr.lproj/Localizable.strings
@@ -2968,6 +2968,9 @@
 /* Settings screen cell text for addess bar position */
 "settings.appearance.address.bar" = "Adres Çubuğu Konumu";
 
+/* Settings screen cell text for experimental menu */
+"settings.appearance.experimental.menu" = "Deneysel Tarayıcı Menüsü";
+
 /* Settings screen cell for opening links in associated apps */
 "settings.associated.apps" = "Bağlantıları İlişkili Uygulamalarda Aç";
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1212408003723690?focus=true
Tech Design URL:
CC:

### Description

Restores strings deleted in https://github.com/duckduckgo/apple-browsers/pull/2791

### Testing Steps
1. Make sure `settings.appearance.experimental.menu` string is translated in all languages

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores the `settings.appearance.experimental.menu` localized string in iOS `Localizable.strings` for multiple languages.
> 
> - **i18n**:
>   - Restore `settings.appearance.experimental.menu` string across multiple locales in `iOS/DuckDuckGo/*/Localizable.strings`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9421b7c22b92b7ee3cd8f70026dd7ab55b171ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->