### PR TITLE
Capture currentTab weakly in NavigationBarBadgeAnimator to prevent a leak

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/Animations/BadgeAnimations/NavigationBarBadgeAnimator.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/Animations/BadgeAnimations/NavigationBarBadgeAnimator.swift
@@ -53,7 +53,7 @@ final class NavigationBarBadgeAnimator: NSObject {
     private(set) var animationQueue: [QueuedAnimation] = []
     private(set) var currentAnimationPriority: AnimationPriority?
     private(set) var currentAnimationType: NavigationBarBadgeAnimationView.AnimationType?
-    private var currentTab: Tab?
+    private weak var currentTab: Tab?
     private var shouldAutoProcessNextAnimation = true
     private weak var currentButtonsContainer: NSView?
     private weak var currentNotificationContainer: NavigationBarBadgeAnimationView?


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207340338530322/task/1212406587163796?focus=true

### Description
This change fixes a memory leak when using a youtube tab in full screen

### Testing Steps
1. Disable Duck Player
2. Open a new tab with a youtube video (so that you have 2 tabs in total)
3. Enter full screen
4. Exit full screen and close youtube tab.
5. Verify that the audio stopped playing.
6. Verify that navigation bar animations work fine now that the tab is captured weakly.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> Make `currentTab` a weak reference to avoid retaining `Tab` during badge animations and prevent a memory leak.
> 
> - **macOS / Navigation Bar Animations**:
>   - Change `currentTab` from strong to `weak` in `NavigationBarBadgeAnimator` to prevent retaining `Tab` instances and leaking when tabs close.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed1432a3c4eefbde7af65ed1c7724470c9d25ced. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY —>