### PR TITLE
swift-snapshot-testing and privacy dashboard update

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/privacy-dashboard",
       "state" : {
-        "revision" : "92c9c3970ddc6062fa2952e05098fdaea499ab6a",
-        "version" : "9.5.0"
+        "revision" : "0f8925a4fc8f2b98df6bc7294b49fc4c1561bf16",
+        "version" : "9.7.0"
       }
     },
     {

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -15586,8 +15586,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swift-snapshot-testing";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.18.1;
+				kind = exactVersion;
+				version = 1.18.7;
 			};
 		};
 		854007E52B57FB020001BD98 /* XCRemoteSwiftPackageReference "ZIPFoundation" */ = {

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -18710,7 +18710,7 @@
 			repositoryURL = "https://github.com/pointfreeco/swift-snapshot-testing";
 			requirement = {
 				kind = exactVersion;
-				version = 1.18.1;
+				version = 1.18.7;
 			};
 		};
 		B6DA44152616C13800DD1EC2 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */ = {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202500774821704/task/1212423308222119?focus=true

### Description

- swift-snapshot-testing 🟢  [patch] 1.18.1 → 1.18.7
- privacy-dashboard 🟡  [minor] 9.5.0 → 9.7.0

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `swift-snapshot-testing` to 1.18.7 (pinned exact) and bumps `privacy-dashboard` to 9.7.0.
> 
> - **Dependencies**:
>   - `swift-snapshot-testing`: pin to `1.18.7`.
>     - iOS project: change requirement to `exactVersion` (from `upToNextMajor` min `1.18.1`).
>     - macOS project: bump exact version `1.18.1` → `1.18.7`.
>   - `privacy-dashboard`: update in `Package.resolved` `9.5.0` → `9.7.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 262971bf195ad2e1701096590b1f7d11712605de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->