### PR TITLE
Do not dismiss popover while writing

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -226,7 +226,6 @@ final class AddressBarButtonsViewController: NSViewController {
     var textFieldValue: AddressBarTextField.Value? {
         didSet {
             updateButtons()
-            dismissTogglePopoverIfTyping()
         }
     }
     var isMouseOverNavigationBar = false {
@@ -1782,17 +1781,6 @@ final class AddressBarButtonsViewController: NSViewController {
                 isNewUser: AppDelegate.isNewUser,
                 userDidInteractWithToggle: UserDefaults.standard.hasInteractedWithSearchDuckAIToggle
             )
-        }
-    }
-
-    private func dismissTogglePopoverIfTyping() {
-        guard let value = textFieldValue, value.isUserTyped, !value.isEmpty else {
-            return
-        }
-        /// Defer dismissal to the next run loop cycle so the toggle collapse animation
-        /// can start first, then both animations run concurrently without interference
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-            self?.aiChatTogglePopoverCoordinator?.dismissPopover()
         }
     }
 

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -362,6 +362,8 @@ final class AddressBarTextField: NSTextField {
     }
 
     func addressBarEnterPressed() {
+        aiChatTogglePopoverCoordinator?.dismissPopover()
+
         let selectedRowContent = suggestionContainerViewModel?.selectedRowContent
         let selectedSuggestion = suggestionContainerViewModel?.selectedSuggestionViewModel?.suggestion
         let selectedSuggestionCategory = selectedSuggestion.flatMap { SuggestionPixelCategory(from: $0) }
@@ -1430,6 +1432,8 @@ private extension NSMenuItem {
 extension AddressBarTextField: SuggestionViewControllerDelegate {
 
     func suggestionViewControllerDidConfirmSelection(_ suggestionViewController: SuggestionViewController) {
+        aiChatTogglePopoverCoordinator?.dismissPopover()
+
         let selectedRowContent = suggestionContainerViewModel?.selectedRowContent
         let selectedSuggestion = suggestionContainerViewModel?.selectedSuggestionViewModel?.suggestion
         let selectedSuggestionCategory = selectedSuggestion.flatMap { SuggestionPixelCategory(from: $0) }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1212480681349505?focus=true
Tech Design URL:
CC:

### Description
Do not dismiss popover while writing

### Testing Steps
1. Return false on the isNewUser on AppDelegate
2. Go to debug menu, AI Chat, Toggle, Show toggle when the address bar is selected
3. Start typing, check that the popover don't go away
4. Submit a query, check that the popover goes away

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Popover not being dismissed on submission

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops dismissing the AI Chat toggle popover while typing and dismisses it only on submission (Enter) or confirmed suggestion.
> 
> - **Navigation Bar (macOS)**:
>   - **AI Chat Toggle Popover Behavior**:
>     - Removed typing-triggered dismissal by deleting `dismissTogglePopoverIfTyping` and its invocation in `AddressBarButtonsViewController`.
>     - Added explicit dismissal on submission flows in `AddressBarTextField` (`addressBarEnterPressed`, `suggestionViewControllerDidConfirmSelection`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 589946978b5736980694b0e13b0b6ca1e542f6fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->