### PR TITLE
Fix: Tab Item Title Overlap

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -1127,7 +1127,7 @@ final class TabBarViewItem: NSCollectionViewItem {
             let showCloseButton = (isMouseOver && (!widthStage.isCloseButtonHidden || NSApp.isCommandPressed)) || isSelected
             cell.closeButton.isShown = showCloseButton
             cell.faviconView.isShown = (widthStage != .withoutTitle || !showCloseButton)
-            cell.titleView.isShown = !widthStage.isTitleHidden || (cell.faviconView.displaysImage == false && !showCloseButton)
+            cell.titleView.isShown = !widthStage.isTitleHidden
         } else if isPinned {
             cell.closeButton.isShown = false
             cell.faviconImageView.isShown = cell.faviconImageView.image != nil

--- a/macOS/DuckDuckGo/TabBar/View/TabFaviconView.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabFaviconView.swift
@@ -26,10 +26,6 @@ final class TabFaviconView: NSView {
     private let placeholderView = LetterView()
     private let spinnerView = SpinnerView()
 
-    var displaysImage: Bool {
-        imageView.image != nil
-    }
-
     var imageTintColor: NSColor? {
         get {
             imageView.contentTintColor


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1212489595848548?focus=true
Tech Design URL:
CC:

### Description
In this PR we're fixing a layout issue affecting the Tab's Title, when in compact mode.

#### Details
Prior to the changes introduced via the `tabProgressIndicator` flag, the FaviconView wouldn't be rendered whenever a given website lacked a Favicon Image.

When the `tabProgressIndicator` flag is enabled, the `TabFaviconView` component will always be visible, since we'll display a placeholder view (where the favicon normally goes).

We've adjusted the logic that conceals the Tab Item's Title, so that it accounts for this difference, and thus, prevents overlapping labels due to space limitations.

### Testing Steps
1. Open (a large) number of Tabs
2. Try moving Tabs around

- [ ] Verify the Title is only rendered for active tabs
- [ ] Verify all "Inactive" Tabs only get their Favicon rendered

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
In the worst case scenario, the TabBar Item's Title is incorrectly hidden

### Quality Considerations
Nothing in particular

### Notes to Reviewer
Thanks in advance!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust tab title visibility logic when the tab progress indicator is enabled to avoid label overlap; remove an unused favicon view property.
> 
> - **Tab Bar (macOS)**:
>   - **Title visibility (compact/progress mode)**: `titleView.isShown` now depends solely on `!widthStage.isTitleHidden`, removing coupling to favicon presence/close button to prevent overlap.
> - **Cleanup**:
>   - Remove unused `TabFaviconView.displaysImage` property.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05ff2e6fee6e2649433f459549614a6b8a039833. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->