### PR TITLE
[Hotfix PR] Cache returning user attribution at app launch

### DIFF
--- a/iOS/Core/DefaultVariantManager.swift
+++ b/iOS/Core/DefaultVariantManager.swift
@@ -108,11 +108,15 @@ public class DefaultVariantManager: VariantManager {
     }
 
     public convenience init() {
+        self.init(returningUserMeasurement: KeychainReturnUserMeasurement())
+    }
+
+    public convenience init(returningUserMeasurement: ReturnUserMeasurement) {
         self.init(
             variants: VariantIOS.defaultVariants,
             storage: StatisticsUserDefaults(),
             rng: Arc4RandomUniformVariantRNG(),
-            returningUserMeasurement: KeychainReturnUserMeasurement(),
+            returningUserMeasurement: returningUserMeasurement,
             variantNameOverride: LaunchOptionsHandler()
         )
     }

--- a/iOS/Core/ReturnUserMeasurement.swift
+++ b/iOS/Core/ReturnUserMeasurement.swift
@@ -21,7 +21,7 @@ import Foundation
 import BrowserServicesKit
 
 /// This is only intended to be used during the install (first run after downloading from the app store).
-protocol ReturnUserMeasurement {
+public protocol ReturnUserMeasurement {
 
     /// Based on the value in the keychain, so if you use this after the install process it will return true.
     ///  If you really want to know if the user is "returning" then look at the variant in the `StatisticsStore`
@@ -32,7 +32,7 @@ protocol ReturnUserMeasurement {
 
 }
 
-class KeychainReturnUserMeasurement: ReturnUserMeasurement {
+public class KeychainReturnUserMeasurement: ReturnUserMeasurement {
 
     static let SecureATBKeychainName = "returning-user-atb"
 
@@ -43,17 +43,28 @@ class KeychainReturnUserMeasurement: ReturnUserMeasurement {
 
     }
 
-    /// Called from the `VariantManager` to determine which variant to use
-    var isReturningUser: Bool {
-        return hasAnyKeychainItems()
+    private var cachedIsReturningUser: Bool?
+
+    /// The result is cached on first access to avoid being affected by later Keychain writes.
+    public var isReturningUser: Bool {
+        if let cached = cachedIsReturningUser {
+            return cached
+        }
+
+        let result = hasAnyKeychainItems()
+        cachedIsReturningUser = result
+
+        return result
     }
 
-    func installCompletedWithATB(_ atb: Atb) {
+    public init() {}
+
+    public func installCompletedWithATB(_ atb: Atb) {
         writeSecureATB(atb.version)
     }
 
     /// Update the stored ATB with an even more generalised version of the ATB, if present.
-    func updateStoredATB(_ atb: Atb) {
+    public func updateStoredATB(_ atb: Atb) {
         guard let atb = atb.updateVersion else { return }
         writeSecureATB(atb)
     }

--- a/iOS/DuckDuckGo/AppConfiguration/ATBAndVariantConfiguration.swift
+++ b/iOS/DuckDuckGo/AppConfiguration/ATBAndVariantConfiguration.swift
@@ -23,7 +23,16 @@ import BrowserServicesKit
 
 final class ATBAndVariantConfiguration {
 
-    lazy var variantManager = DefaultVariantManager()
+    private let returningUserMeasurement = KeychainReturnUserMeasurement()
+
+    lazy var variantManager: DefaultVariantManager = {
+        DefaultVariantManager(returningUserMeasurement: returningUserMeasurement)
+    }()
+
+    init() {
+        // Deliberately trigger this early so that `isReturningUser` can be cached.
+        _ = returningUserMeasurement.isReturningUser
+    }
 
     func cleanUpATBAndAssignVariant(onVariantAssigned: () -> Void) {
         AtbAndVariantCleanup.cleanup()

--- a/iOS/DuckDuckGo/AppConfiguration/AppConfiguration.swift
+++ b/iOS/DuckDuckGo/AppConfiguration/AppConfiguration.swift
@@ -29,9 +29,9 @@ struct AppConfiguration {
 
     private let featureFlagger = AppDependencyProvider.shared.featureFlagger
 
+    let atbAndVariantConfiguration = ATBAndVariantConfiguration()
     let persistentStoresConfiguration = PersistentStoresConfiguration()
     let onboardingConfiguration = OnboardingConfiguration()
-    let atbAndVariantConfiguration = ATBAndVariantConfiguration()
     private let appKeyValueStore: ThrowingKeyValueStoring
 
     init(appKeyValueStore: ThrowingKeyValueStoring) {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1212502463446339?focus=true
Tech Design URL:
CC:

### Description

This PR updates returning user attribution to be cached at app launch. This is done because SecureVault now initializes earlier than before, and populates the Keychain before we can determine attribution.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Reset your simulator entirely
2. Set a breakpoint on `if returningUserMeasurement.isReturningUser {` in `DefaultVariantManager`
3. Run the app and check that `isReturningUser` is false at this point
4. Now let the app resume from the breakpoint
5. Delete the app from the simulator (but don't reset the simulator entirely)
6. Run the app and when you hit the same breakpoint, check that `returningUserMeasurement.isReturningUser` is true this time

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
7. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cache returning-user status from Keychain at app launch and inject it into `DefaultVariantManager` to ensure correct variant assignment.
> 
> - **Core**:
>   - **Returning-user measurement**: Make `ReturnUserMeasurement` and `KeychainReturnUserMeasurement` public; cache `isReturningUser` on first access; add public init and expose methods.
>   - **Variant manager**: Add convenience init accepting `ReturnUserMeasurement`; default init uses `KeychainReturnUserMeasurement`; wire measurement into selection logic.
> - **App Configuration**:
>   - **ATB/Variant setup**: Instantiate `KeychainReturnUserMeasurement`, eagerly read `isReturningUser` to cache, and inject into `DefaultVariantManager`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2ccd4b7fc8b89accd08dbd41581b607fe0752f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->