### PR TITLE
[iOS][Dependency Update] Update combine-schedulers to 1.1.0

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers.git",
       "state" : {
-        "revision" : "5928286acce13def418ec36d05a001a9641086f2",
-        "version" : "1.0.3"
+        "revision" : "fd16d76fd8b9a976d88bfb6cacc05ca8d19c91b6",
+        "version" : "1.1.0"
       }
     },
     {

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -15663,7 +15663,7 @@
 			repositoryURL = "https://github.com/pointfreeco/combine-schedulers.git";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.3;
+				version = 1.1.0;
 			};
 		};
 		B6F997C22B8F374300476735 /* XCRemoteSwiftPackageReference "apple-toolbox" */ = {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1212477682739016?focus=true
Tech Design URL:
CC:

### Description

Update Pointfree combine-schedulers library to [1.1.0](https://github.com/pointfreeco/combine-schedulers/releases/tag/1.1.0). 

What's Changed

- Added: Combine Support on non-Apple platforms via OpenCombine (thanks @mmllr, https://github.com/pointfreeco/combine-schedulers/pull/107).
- Infrastructure: Fix tests with Xcode 26 (thanks @piercifani, https://github.com/pointfreeco/combine-schedulers/pull/104).
- Infrastructure: Update CI (https://github.com/pointfreeco/combine-schedulers/pull/108).
- Infrastructure: Update versioned package files to reflect SPM recommendation (https://github.com/pointfreeco/combine-schedulers/pull/109).

### Testing Steps
1. Ensure CI is green. It is a minor update so no risks

### Impact and Risks
None

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `combine-schedulers` from 1.0.3 to 1.1.0 in SPM `Package.resolved` and Xcode project package requirement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14dbbce435502a163239498d3d055ea3dcc4918e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->