### PR TITLE
Speed up archive.sh in CI

### DIFF
--- a/macOS/scripts/archive.sh
+++ b/macOS/scripts/archive.sh
@@ -5,7 +5,12 @@ set -eo pipefail
 if ! [[ $common_sh ]]; then
 	cwd="$(dirname "${BASH_SOURCE[0]}")"
 	source "${cwd}/helpers/common.sh"
-	execute_from_tmp "${BASH_SOURCE[0]}" "$@"
+
+	# If not running in CI, execute the script from a temporary directory
+	# to allow for changing the code while building the app.
+	if [[ -z $CI ]]; then
+		execute_from_tmp "${BASH_SOURCE[0]}" "$@"
+	fi
 fi
 
 developer_apple_id_keychain_identifier="developer-apple-id"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1212516517201069?focus=true

### Description
This change skips copying the code to a temporary directory while the script is running in CI.
That steps is only helpful when building locally.

### Testing Steps
Verify that [this workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/20344166449/job/58451707384) succeeded.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Only run `execute_from_tmp` in `macOS/scripts/archive.sh` when not in CI, skipping temp directory usage in CI to speed builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce0f077d1707fde5664619e1b3e13e3705241afc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->