### PR TITLE
[iOS] Update AIChat Sync fire button / auto clear behaviour 

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3797,12 +3797,20 @@ extension MainViewController: FireExecutorDelegate {
     }
 
     func willStartBurningAIHistory() {
-        // no op
+        if autoClearInProgress {
+            syncAIChatsCleaner.recordLocalClearFromAutoClearBackgroundTimestampIfPresent()
+        } else {
+            syncAIChatsCleaner.recordLocalClear(date: Date())
+        }
     }
 
     func didFinishBurningAIHistory() {
         Task {
             await aiChatViewControllerManager.killSessionAndResetTimer()
+        }
+
+        if syncService.authState != .inactive {
+            syncService.scheduler.requestSyncImmediately()
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1212520834680760?focus=true
Tech Design URL:
CC:

### Description
A refactor of the iOS burn logic required re-implementation of the AIChat Sync logic that sets the `until` timestamp and calls sync refresh

### Testing Steps
1. Set up AIChat Sync between 2 devices / apps
2. Confirm the fire button deletes all synced chats in both apps
3. Set up auto clear and confirm the same 

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
—

> [!NOTE]
> Records local AI Chat clear events (auto-clear aware) and requests immediate sync after AI history is cleared, while also resetting the AI session.
> 
> - **iOS / AI Chat clearing & sync**:
>   - `willStartBurningAIHistory`: record local clear via `syncAIChatsCleaner` (uses auto-clear background timestamp when applicable).
>   - `didFinishBurningAIHistory`: kill AI session and reset timer; request immediate sync when `syncService` is active.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4042ec87694c254cd3609e48b276c753160b49e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY —>