### PR TITLE
PoC: Fix media permission domain for embedded requests

### DIFF
--- a/macOS/DuckDuckGo/Tab/Model/Tab+UIDelegate.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab+UIDelegate.swift
@@ -112,7 +112,12 @@ extension Tab: WKUIDelegate, PrintingUserScriptDelegate {
             return
         }
 
-        self.permissions.permissions(permissions, requestedForDomain: origin.host, decisionHandler: decisionHandler)
+        // Prefer the initiating frame request host over `origin.host`.
+        // In some embed scenarios the origin passed by WebKit can differ from the frame that actually
+        // initiates the permission request, which results in storing/showing the wrong domain.
+        let url = frame.safeRequest?.url
+        let requestedDomain = url?.isFileURL == true ? .localhost : (url?.host ?? origin.host)
+        self.permissions.permissions(permissions, requestedForDomain: requestedDomain, url: url, decisionHandler: decisionHandler)
     }
 
     // https://github.com/WebKit/WebKit/blob/9d7278159234e0bfa3d27909a19e695928f3b31e/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h#L126


### PR DESCRIPTION
Key camera/mic permission prompts and persistence off the initiating frame host (fallback to origin), to avoid granting the top-level site when an embedded cross-site frame requests getUserMedia.

<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209253361096901/task/1212344951296192?focus=true
Tech Design URL:
CC:

### Description

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1.
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prefer the initiating frame URL/host (with file URLs mapped to localhost) for camera/mic permission prompts and storage, and add a unit test to validate it.
> 
> - **Permissions (macOS)**:
>   - Update `Tab+UIDelegate.swift` `webView(_:requestMediaCapturePermissionFor:initiatedByFrame:type:decisionHandler:)` to derive `requestedDomain` from the initiating frame `url` (fallback to `origin.host`, map file URLs to `localhost`) and pass `url` into `permissions(...)`.
> - **Tests**:
>   - Add `testWhenMediaCaptureRequestOriginDiffersFromInitiatingFrameThenFrameDomainIsUsed_macOS12` to assert the initiating frame host is used for media capture.
>   - Mirror updated logic in test delegate: compute `requestedDomain` from frame `url`, pass `url` to `model.permissions(...)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6e7527eb5f8d29dd7530a048a9833bd228cd935. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->