### PR TITLE
[CI] Add on-hold label to prevent PRs to be marked stale and closed by automation 

### DIFF
--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -17,4 +17,4 @@ jobs:
           days-before-pr-close: 7
           stale-pr-label: stale
           exempt-draft-pr: true
-          exempt-pr-labels: 'on-hold'
+          exempt-pr-labels: 'do-not-autoclose'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1212509490098503?focus=true
Tech Design URL:
CC: @ayoy 

### Description

This PR adds a new label, `do-not-autoclose`, to the list of labels to prevent automation from marking a PR as stale and closing it after 14 days of inactivity. This is helpful when team members go on leave and have valid work in progress.

### Testing Steps
1. Ensure CI is green

### Impact and Risks
None, internal tooling

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the stale PR workflow to skip auto-closing PRs labeled 'do-not-autoclose'.
> 
> - **CI/Workflows**:
>   - Update `.github/workflows/stale_pr.yml` to add `exempt-pr-labels: 'do-not-autoclose'` so labeled PRs aren’t marked stale or auto-closed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7495abe0b0807d6219018e7e996f004a05b45cdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->