### PR TITLE
[iOS/MacOS][FeatureFlag]Remove-VPNConnectionWidePixelMeasurement

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/PrivacyConfig/Features/PrivacyFeature.swift
@@ -412,7 +412,6 @@ public enum PrivacyProSubfeature: String, Equatable, PrivacySubfeature {
     case privacyProOnboardingPromotion
     case paidAIChat
     case supportsAlternateStripePaymentFlow
-    case vpnConnectionWidePixelMeasurement
     case winBackOffer
     case vpnMenuItem
     case blackFridayCampaign

--- a/SharedPackages/VPN/Sources/VPN/NetworkProtectionOptionKey.swift
+++ b/SharedPackages/VPN/Sources/VPN/NetworkProtectionOptionKey.swift
@@ -37,5 +37,4 @@ public enum NetworkProtectionOptionKey {
     public static let tunnelMemoryCrashSimulation = "tunnelMemoryCrashSimulation"
     public static let connectionTesterEnabled = "connectionTesterEnabled"
     public static let settings = "settings"
-    public static let isConnectionWideEventMeasurementEnabled = "isConnectionWideEventMeasurementEnabled"
 }

--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -390,7 +390,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
     // MARK: - WideEvent
 
     private var wideEvent: WideEventManaging
-    private var isConnectionWideEventMeasurementEnabled: Bool = false
     private var connectionWideEventData: VPNConnectionWideEventData?
     private let connectionTunnelTimeoutInterval: TimeInterval = .minutes(15)
 
@@ -670,7 +669,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
         let startupOptions = StartupOptions(options: options ?? [:])
         Logger.networkProtection.log("Starting tunnel with options: \(startupOptions.description, privacy: .public)")
-        isConnectionWideEventMeasurementEnabled = startupOptions.isConnectionWideEventMeasurementEnabled
         setupAndStartConnectionWideEvent(with: startupOptions.startupMethod)
 
         // Reset snooze if the VPN is restarting.
@@ -1894,7 +1892,6 @@ extension WireGuardAdapterError: LocalizedError, CustomDebugStringConvertible {
 extension PacketTunnelProvider {
 
     func setupAndStartConnectionWideEvent(with startupMethod: StartupOptions.StartupMethod) {
-        guard isConnectionWideEventMeasurementEnabled else { return }
         completeAllPendingVPNConnectionPixels()
         // Already measured
         guard startupMethod != .manualByMainApp else { return }
@@ -1913,7 +1910,7 @@ extension PacketTunnelProvider {
     }
 
     func completeAndCleanupConnectionWideEvent(with error: Error? = nil, description: String? = nil) {
-        guard isConnectionWideEventMeasurementEnabled, let data = self.connectionWideEventData else { return }
+        guard let data = self.connectionWideEventData else { return }
         data.tunnelStartDuration?.complete()
         data.overallDuration?.complete()
         if let error {

--- a/SharedPackages/VPN/Sources/VPN/StartupOptions.swift
+++ b/SharedPackages/VPN/Sources/VPN/StartupOptions.swift
@@ -158,7 +158,6 @@ public struct StartupOptions {
     public let tokenContainer: StoredOption<TokenContainer>
 #endif
     let enableTester: StoredOption<Bool>
-    let isConnectionWideEventMeasurementEnabled: Bool
 
     init(options: [String: Any]) {
         let startupMethod: StartupMethod = {
@@ -176,8 +175,6 @@ public struct StartupOptions {
         simulateError = options[NetworkProtectionOptionKey.tunnelFailureSimulation] as? Bool ?? false
         simulateCrash = options[NetworkProtectionOptionKey.tunnelFatalErrorCrashSimulation] as? Bool ?? false
         simulateMemoryCrash = options[NetworkProtectionOptionKey.tunnelMemoryCrashSimulation] as? Bool ?? false
-        // This is added as an emergency turnoff option. As this guards a very low risk pixel measurement, we keep it enabled as default
-        isConnectionWideEventMeasurementEnabled = options[NetworkProtectionOptionKey.isConnectionWideEventMeasurementEnabled] as? Bool ?? true
 
         let resetStoredOptionsIfNil = startupMethod == .manualByMainApp
 #if os(macOS)
@@ -199,7 +196,6 @@ public struct StartupOptions {
             simulateMemoryCrash: \(self.simulateMemoryCrash.description),
             vpnSettings: \(self.vpnSettings.description),
             enableTester: \(self.enableTester),
-            isConnectionWideEventMeasurementEnabled: \(self.isConnectionWideEventMeasurementEnabled),
         """
 #if os(macOS)
         result += """

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -240,9 +240,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211654189969294/task/1211652685709099?focus=true
     case onboardingSearchExperience
 
-    /// https://app.asana.com/1/137249556945/project/72649045549333/task/1211388368219934?focus=true
-    case vpnConnectionWidePixelMeasurement
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866472842661
     case storeSerpSettings
 
@@ -312,7 +309,6 @@ extension FeatureFlag: FeatureFlagDescribing {
              .dbpForegroundRunningWhenDashboardOpen,
              .syncCreditCards,
              .unifiedURLPredictor,
-             .vpnConnectionWidePixelMeasurement,
              .migrateKeychainAccessibility,
              .dataImportWideEventMeasurement,
              .browsingMenuSheetPresentation,
@@ -371,7 +367,6 @@ extension FeatureFlag: FeatureFlagDescribing {
              .fullDuckAIMode,
              .fadeOutOnToggle,
              .attributedMetrics,
-             .vpnConnectionWidePixelMeasurement,
              .storeSerpSettings,
              .showHideAIGeneratedImagesSection,
              .standaloneMigration,
@@ -577,8 +572,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(AIChatSubfeature.fadeOutOnToggle))
         case .attributedMetrics:
             return .remoteReleasable(.feature(.attributedMetrics))
-        case .vpnConnectionWidePixelMeasurement:
-            return .remoteReleasable(.subfeature(PrivacyProSubfeature.vpnConnectionWidePixelMeasurement))
         case .onboardingSearchExperience:
             return .remoteReleasable(.subfeature(AIChatSubfeature.onboardingSearchExperience))
         case .storeSerpSettings:

--- a/iOS/DuckDuckGo/AppServices/WideEventService.swift
+++ b/iOS/DuckDuckGo/AppServices/WideEventService.swift
@@ -47,7 +47,6 @@ final class WideEventService {
     // Runs at app launch, and sends pixels which were abandoned during a flow, such as the user exiting the app during
     // the flow, or the app crashing.
     func sendAbandonedPixels(completion: @escaping () -> Void) {
-        let shouldSendVPNConnectionWidePixel = featureFlagger.isFeatureOn(.vpnConnectionWidePixelMeasurement)
         let shouldSendDataImportWideEvent = featureFlagger.isFeatureOn(.dataImportWideEventMeasurement)
         
         sendQueue.async { [weak self] in
@@ -57,9 +56,8 @@ final class WideEventService {
                 await self.sendAbandonedSubscriptionRestorePixels()
 
                 await self.sendAbandonedSubscriptionPurchasePixels()
-                if shouldSendVPNConnectionWidePixel {
-                    await self.sendAbandonedVPNConnectionPixels()
-                }
+                
+                await self.sendAbandonedVPNConnectionPixels()
                 
                 if shouldSendDataImportWideEvent {
                     await self.sendAbandonedDatImportPixels()
@@ -74,7 +72,6 @@ final class WideEventService {
 
     // Sends pixels which are currently incomplete but may complete later.
     func sendDelayedPixels(completion: @escaping () -> Void) {
-        let shouldSendVPNConnectionWidePixel = featureFlagger.isFeatureOn(.vpnConnectionWidePixelMeasurement)
         let shouldSendDataImportWideEvent = featureFlagger.isFeatureOn(.dataImportWideEventMeasurement)
 
         sendQueue.async { [weak self] in
@@ -84,9 +81,9 @@ final class WideEventService {
                 await self.sendDelayedSubscriptionRestorePixels()
 
                 await self.sendDelayedSubscriptionPurchasePixels()
-                if shouldSendVPNConnectionWidePixel {
-                    await self.sendDelayedVPNConnectionPixels()
-                }
+                
+                await self.sendDelayedVPNConnectionPixels()
+                
                 if shouldSendDataImportWideEvent {
                     await self.sendDelayedDataImportPixels()
                 }

--- a/iOS/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -148,10 +148,6 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
                 }
         }
     }
-    
-    private var isConnectionWideEventMeasurementEnabled: Bool {
-        featureFlagger.isFeatureOn(.vpnConnectionWidePixelMeasurement)
-    }
 
     // MARK: - Initializers
 
@@ -320,7 +316,6 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
         }
 
         options["activationAttemptId"] = UUID().uuidString as NSString
-        options[NetworkProtectionOptionKey.isConnectionWideEventMeasurementEnabled] = NSNumber(value: isConnectionWideEventMeasurementEnabled)
 
         
         do {
@@ -521,7 +516,6 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
 private extension NetworkProtectionTunnelController {
     
     func setupAndStartConnectionWideEvent() {
-        guard isConnectionWideEventMeasurementEnabled else { return }
         let data = VPNConnectionWideEventData(
             extensionType: .app,
             startupMethod: .manualByMainApp,
@@ -547,7 +541,7 @@ private extension NetworkProtectionTunnelController {
     }
 
     func completeAndCleanupConnectionWideEvent(with error: Error? = nil, description: String? = nil) {
-        guard isConnectionWideEventMeasurementEnabled, let data = self.connectionWideEventData else { return }
+        guard let data = self.connectionWideEventData else { return }
         data.overallDuration?.complete()
         if let error {
             data.errorData = .init(error: error, description: description)

--- a/macOS/DuckDuckGo/Application/WideEventService.swift
+++ b/macOS/DuckDuckGo/Application/WideEventService.swift
@@ -44,10 +44,8 @@ final class WideEventService {
         await sendAbandonedSubscriptionRestorePixels()
         await sendDelayedSubscriptionRestorePixels()
 
-        if featureFlagger.isFeatureOn(.vpnConnectionWidePixelMeasurement) {
-            await sendAbandonedVPNConnectionPixels()
-            await sendDelayedVPNConnectionPixels()
-        }
+        await sendAbandonedVPNConnectionPixels()
+        await sendDelayedVPNConnectionPixels()
 
         if featureFlagger.isFeatureOn(.dataImportWideEventMeasurement) {
             await sendAbandonedDatImportPixels()

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/NetworkProtectionIPCTunnelController.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/NetworkProtectionIPCTunnelController.swift
@@ -84,10 +84,6 @@ final class NetworkProtectionIPCTunnelController {
     private var vpnConnectionWideEventOverallStartTime: Date?
 
     // MARK: - Wide Event
-
-    private var isConnectionWideEventMeasurementEnabled: Bool {
-        featureFlagger.isFeatureOn(.vpnConnectionWidePixelMeasurement)
-    }
     private var connectionWideEventData: VPNConnectionWideEventData?
 
     init(featureGatekeeper: VPNFeatureGatekeeper = DefaultVPNFeatureGatekeeper(subscriptionManager: Application.appDelegate.subscriptionAuthV1toV2Bridge),
@@ -321,7 +317,6 @@ extension NetworkProtectionIPCTunnelController {
 private extension NetworkProtectionIPCTunnelController {
 
     func setupAndStartConnectionWideEvent() {
-        guard isConnectionWideEventMeasurementEnabled else { return }
         let data = VPNConnectionWideEventData(
             // Only the main tunnel controller can know whether a system extension is being used.
             // At this step we don't know the type of extension yet
@@ -337,13 +332,13 @@ private extension NetworkProtectionIPCTunnelController {
     }
 
     func passthroughConnectionWideEventData() {
-        guard isConnectionWideEventMeasurementEnabled, let data = self.connectionWideEventData else { return }
+        guard let data = self.connectionWideEventData else { return }
         vpnConnectionWideEventBrowserStartTime = data.browserStartDuration?.start
         vpnConnectionWideEventOverallStartTime = data.overallDuration?.start
     }
 
     func completeAndCleanupConnectionWideEvent(with error: Error, description: String? = nil) {
-        guard isConnectionWideEventMeasurementEnabled, let data = self.connectionWideEventData else { return }
+        guard let data = self.connectionWideEventData else { return }
         data.browserStartDuration?.complete()
         data.overallDuration?.complete()
         data.browserStartError = .init(error: error, description: description)
@@ -355,7 +350,7 @@ private extension NetworkProtectionIPCTunnelController {
     }
 
     func discardWideEvent() {
-        guard isConnectionWideEventMeasurementEnabled, let data = self.connectionWideEventData else { return }
+        guard let data = self.connectionWideEventData else { return }
         wideEvent.discardFlow(data)
         self.connectionWideEventData = nil
     }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -210,9 +210,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1205842942115003/task/1210884473312053
     case attributedMetrics
 
-    /// https://app.asana.com/1/137249556945/project/72649045549333/task/1211388368219934?focus=true
-    case vpnConnectionWidePixelMeasurement
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866721557461
     case showHideAIGeneratedImagesSection
 
@@ -290,7 +287,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .fireDialogIndividualSitesLink,
                 .historyViewSitesSection,
                 .blurryAddressBarTahoeFix,
-                .vpnConnectionWidePixelMeasurement,
                 .allowPopupsForCurrentPage,
                 .extendedUserInitiatedPopupTimeout,
                 .suppressEmptyPopUpsOnApproval,
@@ -367,7 +363,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .dataImportNewExperience,
                 .tabProgressIndicator,
                 .attributedMetrics,
-                .vpnConnectionWidePixelMeasurement,
                 .showHideAIGeneratedImagesSection,
                 .standaloneMigration,
                 .blackFridayCampaign,
@@ -524,8 +519,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.tabProgressIndicator))
         case .attributedMetrics:
             return .remoteReleasable(.feature(.attributedMetrics))
-        case .vpnConnectionWidePixelMeasurement:
-            return .remoteReleasable(.subfeature(PrivacyProSubfeature.vpnConnectionWidePixelMeasurement))
         case .showHideAIGeneratedImagesSection:
             return .remoteReleasable(.subfeature(AIChatSubfeature.showHideAiGeneratedImages))
         case .standaloneMigration:

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlagCategory.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlagCategory.swift
@@ -81,7 +81,6 @@ extension FeatureFlag: FeatureFlagCategorization {
             return .dbp
         case .paidAIChat,
                 .supportsAlternateStripePaymentFlow,
-                .vpnConnectionWidePixelMeasurement,
                 .blackFridayCampaign,
                 .tierMessagingEnabled,
                 .allowProTierPurchase:


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1212452020073752?focus=true

### Description
Remove`VPNConnectionWideEventMeasurement` feature flag now this feature has been stable in prod

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Build and run both apps. Verify both apps work as expected
2. Manually trigger a few VPN setup/connection events. Verify events are triggered as expected

### Impact and Risks
Low to None

#### What could go wrong?
VPN setup/connection wide event not triggered

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `vpnConnectionWideEventMeasurement` feature flag and related options, always enabling VPN connection wide-event measurement across iOS and macOS.
> 
> - **VPN (shared)**:
>   - Removes option keys and startup option support for `isConnectionWideEventMeasurementEnabled` in `NetworkProtectionOptionKey` and `StartupOptions`.
>   - Drops flag checks and guards in `PacketTunnelProvider` so connection wide-event flows always start/complete.
> - **iOS app**:
>   - Deletes `FeatureFlag.vpnConnectionWidePixelMeasurement` and its mappings/defaults.
>   - `WideEventService`: always sends abandoned/delayed VPN connection pixels (no feature flag gating).
>   - `NetworkProtectionTunnelController`: removes flag usage and guards; wide-event flow always recorded; startup options no longer pass the flag.
> - **macOS app**:
>   - Deletes `FeatureFlag.vpnConnectionWidePixelMeasurement` and category/mapping references.
>   - `WideEventService`: always processes VPN connection pixels.
>   - `NetworkProtectionTunnelController` (both app targets and IPC): removes flag checks/guards; wide-event data always started/completed; startup options no longer include the flag.
> - **Privacy config**:
>   - Removes `PrivacyProSubfeature.vpnConnectionWidePixelMeasurement`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d192058e3ab6c4108cccb6b967b9e20ffee4fd9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->