### PR TITLE
[macOS] Do not send empty space on Shift + Enter if first character

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
@@ -308,6 +308,13 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
         textView.insertNewlineIgnoringFieldEditor(nil)
     }
 
+    func insertNewlineIfHasContent(addressBarText: String) {
+        guard !addressBarText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return
+        }
+        insertNewline()
+    }
+
     func updateScrollingBehavior(maxHeight: CGFloat) {
         let desiredHeight = calculateDesiredPanelHeight()
         let effectiveMaxHeight = min(maxHeight, Constants.maximumPanelHeight)

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -1011,7 +1011,8 @@ extension MainViewController {
             let isSwitchingToAIChatMode = buttonsViewController.searchModeToggleControl?.selectedSegment == 0
             buttonsViewController.toggleSearchMode()
             if isSwitchingToAIChatMode {
-                self.aiChatOmnibarTextContainerViewController.insertNewline()
+                let currentText = navigationBarViewController.addressBarViewController?.addressBarTextField.stringValueWithoutSuffix ?? ""
+                self.aiChatOmnibarTextContainerViewController.insertNewlineIfHasContent(addressBarText: currentText)
             }
             return true
         } else if flags.contains(.control),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1212517897644786?focus=true
Tech Design URL:
CC:

### Description
 Do not send empty space on Shift + Enter if first character

### Testing Steps
1. On the search field, press SHIFT + Enter on an empty case. Toggle should change to duck.ai without a new line
2.On the search field, press SHIFT + Enter with some text on it. Toggle should change to duck.ai adding a new line at the end of it

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Adding the new line at the wrong case

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> When switching to AI Chat with Shift/Option+Enter, append a newline only if the address bar has non-whitespace text.
> 
> - **AI Chat Omnibar**:
>   - Add `insertNewlineIfHasContent(addressBarText:)` in `AIChat/AIChatOmnibarTextContainerViewController.swift` to insert a newline only when input is non-empty.
> - **Main Window**:
>   - Update `MainViewController.handleReturnKey` to call the new method when toggling to AI Chat, preventing empty newlines on Shift/Option+Enter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6ac4103c3cbe1281ea0ea4b6defd40b9a99d1ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->