### PR TITLE
Bump timeouts for tests

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -173,7 +173,7 @@ final class DDGSyncTests: XCTestCase {
         syncService.scheduler.requestSyncImmediately()
         syncService.scheduler.requestSyncImmediately()
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 5)
 
         XCTAssertEqual(recordedEvents, [
             .started(1),
@@ -216,7 +216,7 @@ final class DDGSyncTests: XCTestCase {
 
         syncService.scheduler.requestSyncImmediately()
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 5)
 
         XCTAssertEqual(recordedEvents, [
             .started(1),
@@ -299,7 +299,7 @@ final class DDGSyncTests: XCTestCase {
         syncService.scheduler.requestSyncImmediately()
         syncService.scheduler.requestSyncImmediately()
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 5)
 
         XCTAssertEqual(recordedEvents, [
             .started(1),
@@ -438,7 +438,7 @@ final class DDGSyncTests: XCTestCase {
         syncService.scheduler.requestSyncImmediately()
         try dependencies.secureStore.removeAccount()
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 5)
 
         XCTAssertEqual(recordedEvents, [
             .started(1),
@@ -499,7 +499,7 @@ final class DDGSyncTests: XCTestCase {
 
         syncService.scheduler.requestSyncImmediately()
 
-        waitForExpectations(timeout: 2)
+        waitForExpectations(timeout: 5)
 
         XCTAssertEqual(recordedEvents, [
             .started(1),


### PR DESCRIPTION
… problem

<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/856498667320406/task/1212531308606843?focus=true
Tech Design URL:
CC:

### Description

Bump timeouts to determine if failures are timing issue or some other problem.

### Testing Steps

Sanity check.
<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase waitForExpectations timeouts to 5s in several DDGSync tests to mitigate flakiness.
> 
> - **Tests (`SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift`)**:
>   - Increase `waitForExpectations` timeouts from 1–2s to 5s across multiple sync-related tests to reduce timing-related failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55c6cfcbb2f18ed00b6158237ff1d6c800d52101. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->