### PR TITLE
Hide keyboard accessory for duck.ai

### DIFF
--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -280,6 +280,7 @@ class TabViewController: UIViewController {
             updateTabModel()
             delegate?.tabLoadingStateDidChange(tab: self)
             checkLoginDetectionAfterNavigation()
+            updateInputAccessoryViewVisibility()
         }
     }
     
@@ -1920,6 +1921,12 @@ extension TabViewController: WKNavigationDelegate {
             saveLoginPromptIsPresenting = false
             shouldShowAutofillExtensionPrompt = false
         }
+    }
+
+    /// Hides the default keyboard input accessory view when on duck.ai pages.
+    private func updateInputAccessoryViewVisibility() {
+        guard let webView = webView as? WebView else { return }
+        webView.shouldHideDefaultInputAccessoryView = isAITab
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {

--- a/iOS/DuckDuckGo/WebView.swift
+++ b/iOS/DuckDuckGo/WebView.swift
@@ -24,7 +24,12 @@ import os.log
 final class WebView: WKWebView {
     private var customAccesoryView: UIView?
 
+    var shouldHideDefaultInputAccessoryView: Bool = false
+
     override var inputAccessoryView: UIView? {
+        if shouldHideDefaultInputAccessoryView {
+            return nil
+        }
         guard customAccesoryView != nil else {
             return super.inputAccessoryView
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/276630244458377/task/1212253671281035?focus=true

### Description
Hide keyboard accessory for duck.ai

### Testing Steps
1. Open any website that has text field to trigger the keyboard. Check if the accessory bar is there (it should)
2. Open duck.ai. Check if the keyboard accessory bar is there (it shouldn't)

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Remove the accessory when it shouldn't

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hides the default keyboard input accessory on duck.ai (AI tabs) by toggling a WebView flag during navigation.
> 
> - **iOS**:
>   - **`WebView`**:
>     - Add `shouldHideDefaultInputAccessoryView` flag and return `nil` from `inputAccessoryView` when true to hide the default accessory.
>   - **`TabViewController`**:
>     - On `url` change, call `updateInputAccessoryViewVisibility()`.
>     - Implement `updateInputAccessoryViewVisibility()` to set `webView.shouldHideDefaultInputAccessoryView = isAITab`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbde7bbef1a6dcd850b01299dc9f35eec8d57882. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->