### PR TITLE
Theming: Save Password Popover

### DIFF
--- a/macOS/DuckDuckGo/SecureVault/View/PasswordManager.storyboard
+++ b/macOS/DuckDuckGo/SecureVault/View/PasswordManager.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="24412" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24412"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -28,7 +28,7 @@
                                         <rect key="frame" x="0.0" y="464" width="600" height="5"/>
                                     </box>
                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Rbb-3S-qEY">
-                                        <rect key="frame" x="18" y="478" width="57" height="20"/>
+                                        <rect key="frame" x="18" y="477" width="57" height="20"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" title="Autofill" id="S3u-aq-6OE">
                                             <font key="font" metaFont="system" size="17"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -76,10 +76,10 @@
                                                         </constraints>
                                                     </customView>
                                                     <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="2" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c1y-SB-65g">
-                                                        <rect key="frame" x="110" y="0.0" width="60" height="58"/>
+                                                        <rect key="frame" x="108" y="0.0" width="64" height="58"/>
                                                         <subviews>
                                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="k2f-2R-tqE">
-                                                                <rect key="frame" x="-7" y="23" width="74" height="40"/>
+                                                                <rect key="frame" x="0.0" y="30" width="64" height="28"/>
                                                                 <buttonCell key="cell" type="push" title="Import" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="HLU-9T-4Gh">
                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                     <font key="font" metaFont="system"/>
@@ -93,7 +93,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oSn-jP-PIt">
-                                                                <rect key="frame" x="-7" y="-7" width="74" height="40"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="64" height="28"/>
                                                                 <buttonCell key="cell" type="push" title="Sync" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="7f1-1f-vtR">
                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                     <font key="font" metaFont="system"/>
@@ -143,7 +143,7 @@
                                         </constraints>
                                     </customView>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="Z1F-D2-M9A" userLabel="Add Button" customClass="MouseOverButton" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target">
-                                        <rect key="frame" x="358" y="474" width="28" height="28"/>
+                                        <rect key="frame" x="358" y="473" width="28" height="28"/>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="Add" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="aBc-CG-rrF">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -169,7 +169,7 @@
                                         </connections>
                                     </button>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="zlt-eX-SI5" customClass="MouseOverButton" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target">
-                                        <rect key="frame" x="562" y="474" width="28" height="28"/>
+                                        <rect key="frame" x="562" y="473" width="28" height="28"/>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="Settings" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="KQT-Gh-t0V">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -196,7 +196,7 @@
                                         </connections>
                                     </button>
                                     <searchField wantsLayer="YES" focusRingType="none" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8tS-Kw-TcR">
-                                        <rect key="frame" x="396" y="477" width="156" height="22"/>
+                                        <rect key="frame" x="396" y="475" width="156" height="24"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="156" id="TId-HM-R1Y"/>
                                         </constraints>
@@ -452,11 +452,11 @@
             <objects>
                 <viewController storyboardIdentifier="SaveCredentials" id="fGn-92-O2G" customClass="SaveCredentialsViewController" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="B3X-Kr-GS1">
-                        <rect key="frame" x="0.0" y="0.0" width="340" height="302"/>
+                        <rect key="frame" x="0.0" y="0.0" width="340" height="306"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <box boxType="custom" borderType="none" cornerRadius="4" title="Box" id="mIu-8I-uxh">
-                                <rect key="frame" x="-92" y="-85" width="527" height="483"/>
+                            <box boxType="custom" borderType="none" cornerRadius="4" title="Box" id="mIu-8I-uxh" userLabel="Background Box">
+                                <rect key="frame" x="-92" y="-81" width="527" height="483"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <view key="contentView" id="ndk-Tl-GjK">
                                     <rect key="frame" x="0.0" y="0.0" width="527" height="483"/>
@@ -465,7 +465,7 @@
                                 <color key="fillColor" name="PopoverBackgroundColor"/>
                             </box>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="jFJ-kO-Cvc">
-                                <rect key="frame" x="0.0" y="258" width="340" height="44"/>
+                                <rect key="frame" x="0.0" y="262" width="340" height="44"/>
                                 <subviews>
                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JGJ-to-6ws" userLabel="Title Label">
                                         <rect key="frame" x="50" y="13" width="272" height="19"/>
@@ -494,10 +494,10 @@
                                 </constraints>
                             </customView>
                             <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Yxz-ka-dem">
-                                <rect key="frame" x="0.0" y="256" width="340" height="5"/>
+                                <rect key="frame" x="0.0" y="260" width="340" height="5"/>
                             </box>
                             <customView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IW5-vR-XCv">
-                                <rect key="frame" x="0.0" y="258" width="340" height="44"/>
+                                <rect key="frame" x="0.0" y="262" width="340" height="44"/>
                                 <subviews>
                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Fna-rm-TfE" userLabel="Title Label">
                                         <rect key="frame" x="50" y="17" width="181" height="19"/>
@@ -535,7 +535,7 @@
                                 </constraints>
                             </customView>
                             <customView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kVM-zS-wtC">
-                                <rect key="frame" x="0.0" y="258" width="340" height="44"/>
+                                <rect key="frame" x="0.0" y="262" width="340" height="44"/>
                                 <subviews>
                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="OEf-hT-7kz">
                                         <rect key="frame" x="20" y="10" width="24" height="24"/>
@@ -565,7 +565,7 @@
                                 </constraints>
                             </customView>
                             <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="PJE-OH-k14">
-                                <rect key="frame" x="22" y="227" width="16" height="16"/>
+                                <rect key="frame" x="22" y="231" width="16" height="16"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="16" id="DdL-aN-BSR"/>
                                     <constraint firstAttribute="width" constant="16" id="pIG-m8-jId"/>
@@ -573,7 +573,7 @@
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="Logo" id="whs-D8-lOQ"/>
                             </imageView>
                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsExpansionToolTips="YES" preferredMaxLayoutWidth="278" translatesAutoresizingMaskIntoConstraints="NO" id="HEP-bz-HhW">
-                                <rect key="frame" x="44" y="227" width="282" height="16"/>
+                                <rect key="frame" x="44" y="231" width="282" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingMiddle" title="Label" id="GsI-y3-C4i">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -581,7 +581,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wxi-3R-xRg">
-                                <rect key="frame" x="20" y="196" width="66" height="16"/>
+                                <rect key="frame" x="20" y="200" width="66" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Username" id="f5Z-Pd-bCB">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -589,7 +589,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ibe-8n-iFx">
-                                <rect key="frame" x="20" y="166" width="300" height="22"/>
+                                <rect key="frame" x="20" y="168" width="300" height="24"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" bezelStyle="round" id="PpY-FL-ZM0">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -597,7 +597,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Q6k-W1-mHc">
-                                <rect key="frame" x="20" y="138" width="63" height="16"/>
+                                <rect key="frame" x="20" y="140" width="63" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Password" id="bdS-tD-wAb">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -605,7 +605,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EIo-j5-p5Y">
-                                <rect key="frame" x="20" y="108" width="278" height="22"/>
+                                <rect key="frame" x="20" y="108" width="278" height="24"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" bezelStyle="round" id="dDD-I5-wve">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -613,7 +613,7 @@
                                 </textFieldCell>
                             </textField>
                             <secureTextField focusRingType="none" verticalHuggingPriority="750" textCompletion="NO" contentType="oneTimeCode" translatesAutoresizingMaskIntoConstraints="NO" id="vTO-BL-OkT">
-                                <rect key="frame" x="20" y="108" width="278" height="22"/>
+                                <rect key="frame" x="20" y="108" width="278" height="24"/>
                                 <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" usesSingleLineMode="YES" bezelStyle="round" id="kgY-kh-qxi">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -624,7 +624,7 @@
                                 </secureTextFieldCell>
                             </secureTextField>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="Z5y-mU-9wm">
-                                <rect key="frame" x="298" y="109" width="30" height="20"/>
+                                <rect key="frame" x="298" y="110" width="30" height="20"/>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="SecureEyeToggle" imagePosition="only" alignment="center" inset="2" id="rKf-uz-UmT">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -641,7 +641,7 @@
                                 <rect key="frame" x="20" y="60" width="320" height="33"/>
                                 <subviews>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="NmT-4X-rSL">
-                                        <rect key="frame" x="-2" y="16" width="88" height="18"/>
+                                        <rect key="frame" x="0.0" y="17" width="84" height="16"/>
                                         <buttonCell key="cell" type="check" title="Fireproof?" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="xGf-rb-i8X">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -673,7 +673,7 @@
                                 <rect key="frame" x="0.0" y="42" width="340" height="5"/>
                             </box>
                             <button hidden="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eiY-Kq-70Z">
-                                <rect key="frame" x="263" y="5" width="64" height="32"/>
+                                <rect key="frame" x="267" y="12" width="53" height="20"/>
                                 <buttonCell key="cell" type="push" title="Save" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="GrT-0l-ZWK">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -686,7 +686,7 @@ DQ
                                 </connections>
                             </button>
                             <segmentedControl hidden="YES" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="7ot-Jg-LOR">
-                                <rect key="frame" x="158" y="10" width="107" height="24"/>
+                                <rect key="frame" x="158" y="10" width="101" height="24"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="101" id="MlH-vi-bhe"/>
                                 </constraints>
@@ -702,7 +702,7 @@ DQ
                                 </connections>
                             </segmentedControl>
                             <button hidden="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DIw-JQ-5Ie">
-                                <rect key="frame" x="248" y="5" width="79" height="32"/>
+                                <rect key="frame" x="252" y="12" width="68" height="20"/>
                                 <buttonCell key="cell" type="push" title="Update" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="vpe-dC-QU8">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -718,7 +718,7 @@ DQ
                                 </connections>
                             </button>
                             <button hidden="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5fV-VD-sxc">
-                                <rect key="frame" x="196" y="5" width="131" height="32"/>
+                                <rect key="frame" x="199" y="12" width="121" height="20"/>
                                 <buttonCell key="cell" type="push" title="Open Bitwarden" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="PwZ-dh-AVo">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -734,7 +734,7 @@ DQ
                                 </connections>
                             </button>
                             <button hidden="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wIW-tZ-7h0">
-                                <rect key="frame" x="135" y="5" width="115" height="32"/>
+                                <rect key="frame" x="135" y="12" width="105" height="20"/>
                                 <buttonCell key="cell" type="push" title="Don't Update" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="rnd-a2-F2F">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -747,7 +747,7 @@ DQ
                                 </connections>
                             </button>
                             <button hidden="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Z0F-Ts-HRV" userLabel="Done Button">
-                                <rect key="frame" x="233" y="5" width="94" height="32"/>
+                                <rect key="frame" x="240" y="12" width="80" height="20"/>
                                 <buttonCell key="cell" type="push" title="Done" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Ra6-bt-RXd">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -763,7 +763,7 @@ DQ
                                 </connections>
                             </button>
                             <button hidden="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="iys-vI-xsR" userLabel="Edit Button">
-                                <rect key="frame" x="177" y="5" width="58" height="32"/>
+                                <rect key="frame" x="181" y="12" width="47" height="20"/>
                                 <buttonCell key="cell" type="push" title="Edit" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="dzW-7A-903">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -776,7 +776,7 @@ DQ
                                 </connections>
                             </button>
                             <button hidden="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HMM-rP-dRp">
-                                <rect key="frame" x="104" y="5" width="94" height="32"/>
+                                <rect key="frame" x="107" y="12" width="80" height="24"/>
                                 <buttonCell key="cell" type="push" title="Not Now" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="jHW-gh-omb">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -826,6 +826,7 @@ DQ
                         </subviews>
                         <constraints>
                             <constraint firstItem="kVM-zS-wtC" firstAttribute="top" secondItem="B3X-Kr-GS1" secondAttribute="top" id="0z1-RP-CKI"/>
+                            <constraint firstItem="eiY-Kq-70Z" firstAttribute="centerY" secondItem="7ot-Jg-LOR" secondAttribute="centerY" id="1Tg-Jg-A9J"/>
                             <constraint firstItem="5fV-VD-sxc" firstAttribute="leading" secondItem="HMM-rP-dRp" secondAttribute="trailing" constant="12" symbolic="YES" id="2WJ-ji-UWJ"/>
                             <constraint firstItem="Z0F-Ts-HRV" firstAttribute="leading" secondItem="iys-vI-xsR" secondAttribute="trailing" constant="12" symbolic="YES" id="4jO-oF-F2P"/>
                             <constraint firstAttribute="trailing" secondItem="5fV-VD-sxc" secondAttribute="trailing" constant="20" symbolic="YES" id="4qK-4B-hck"/>
@@ -866,7 +867,6 @@ DQ
                             <constraint firstItem="wIW-tZ-7h0" firstAttribute="centerY" secondItem="DIw-JQ-5Ie" secondAttribute="centerY" id="ekJ-xj-NCF"/>
                             <constraint firstItem="eiY-Kq-70Z" firstAttribute="top" secondItem="yiH-18-x9b" secondAttribute="bottom" constant="12" id="f5K-fC-B2H"/>
                             <constraint firstItem="Q6k-W1-mHc" firstAttribute="top" secondItem="ibe-8n-iFx" secondAttribute="bottom" constant="12" id="g7s-bP-Ect"/>
-                            <constraint firstItem="7ot-Jg-LOR" firstAttribute="top" secondItem="yiH-18-x9b" secondAttribute="bottom" constant="12" id="gs0-qI-5q3"/>
                             <constraint firstItem="ibe-8n-iFx" firstAttribute="leading" secondItem="B3X-Kr-GS1" secondAttribute="leading" constant="20" symbolic="YES" id="h6U-i3-Zbn"/>
                             <constraint firstItem="P0f-Xc-jcq" firstAttribute="centerY" secondItem="Z0F-Ts-HRV" secondAttribute="centerY" id="i1Y-LG-aaj"/>
                             <constraint firstItem="EIo-j5-p5Y" firstAttribute="leading" secondItem="B3X-Kr-GS1" secondAttribute="leading" constant="20" symbolic="YES" id="iKT-Mj-flT"/>
@@ -887,6 +887,7 @@ DQ
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="backgroundBox" destination="mIu-8I-uxh" id="yyk-o0-eNd"/>
                         <outlet property="ddgPasswordManagerTitle" destination="jFJ-kO-Cvc" id="McM-KU-2Kk"/>
                         <outlet property="domainLabel" destination="HEP-bz-HhW" id="LdW-iU-fhi"/>
                         <outlet property="doneButton" destination="Z0F-Ts-HRV" id="a7e-bw-YzS"/>
@@ -924,11 +925,11 @@ DQ
             <objects>
                 <viewController storyboardIdentifier="SaveIdentity" id="peg-Ci-kmi" customClass="SaveIdentityViewController" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="b4t-QK-2lD">
-                        <rect key="frame" x="0.0" y="0.0" width="340" height="173"/>
+                        <rect key="frame" x="0.0" y="0.0" width="340" height="177"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OHW-Gu-BCa">
-                                <rect key="frame" x="14" y="142" width="284" height="19"/>
+                                <rect key="frame" x="14" y="146" width="284" height="19"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Save Address?" id="xWe-8F-g7D">
                                     <font key="font" metaFont="systemMedium" size="15"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -936,10 +937,10 @@ DQ
                                 </textFieldCell>
                             </textField>
                             <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="eap-hQ-OGK">
-                                <rect key="frame" x="0.0" y="127" width="340" height="5"/>
+                                <rect key="frame" x="0.0" y="131" width="340" height="5"/>
                             </box>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dep-LE-rxg" customClass="MouseOverButton" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target">
-                                <rect key="frame" x="304" y="142" width="20" height="20"/>
+                                <rect key="frame" x="304" y="146" width="20" height="20"/>
                                 <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="Settings-16" imagePosition="overlaps" alignment="center" imageScaling="proportionallyDown" inset="2" id="YHV-w7-s8Q">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -953,14 +954,14 @@ DQ
                                 </connections>
                             </button>
                             <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="0ck-vZ-Zvs">
-                                <rect key="frame" x="16" y="81" width="32" height="32"/>
+                                <rect key="frame" x="16" y="85" width="32" height="32"/>
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="Identity" id="gTJ-Ob-xXQ"/>
                             </imageView>
                             <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="SCQ-X6-vcJ">
-                                <rect key="frame" x="0.0" y="42" width="340" height="5"/>
+                                <rect key="frame" x="0.0" y="46" width="340" height="5"/>
                             </box>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AhU-y6-peF">
-                                <rect key="frame" x="267" y="5" width="64" height="32"/>
+                                <rect key="frame" x="271" y="12" width="53" height="24"/>
                                 <buttonCell key="cell" type="push" title="Save" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="V23-s8-exf">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -973,7 +974,7 @@ DQ
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PUd-Oq-V8t">
-                                <rect key="frame" x="186" y="5" width="87" height="32"/>
+                                <rect key="frame" x="186" y="12" width="77" height="24"/>
                                 <buttonCell key="cell" type="push" title="Not Now" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="bGZ-xE-rUo">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -983,7 +984,7 @@ DQ
                                 </connections>
                             </button>
                             <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bh2-5e-fbe">
-                                <rect key="frame" x="64" y="63" width="260" height="50"/>
+                                <rect key="frame" x="64" y="67" width="260" height="50"/>
                                 <subviews>
                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TTK-QS-hfm">
                                         <rect key="frame" x="-2" y="0.0" width="85" height="50"/>
@@ -1045,11 +1046,11 @@ DQ
             <objects>
                 <viewController storyboardIdentifier="SavePaymentMethod" id="T31-R4-ek1" customClass="SavePaymentMethodViewController" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="Eyi-2G-hbn">
-                        <rect key="frame" x="0.0" y="0.0" width="340" height="153"/>
+                        <rect key="frame" x="0.0" y="0.0" width="340" height="157"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Eqg-CC-0GJ">
-                                <rect key="frame" x="14" y="122" width="284" height="19"/>
+                                <rect key="frame" x="14" y="126" width="284" height="19"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="280" id="za5-LG-v7l"/>
                                 </constraints>
@@ -1060,10 +1061,10 @@ DQ
                                 </textFieldCell>
                             </textField>
                             <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="qD6-zH-UZb">
-                                <rect key="frame" x="0.0" y="107" width="340" height="5"/>
+                                <rect key="frame" x="0.0" y="111" width="340" height="5"/>
                             </box>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="U0k-3U-unj" customClass="MouseOverButton" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target">
-                                <rect key="frame" x="304" y="122" width="20" height="20"/>
+                                <rect key="frame" x="304" y="126" width="20" height="20"/>
                                 <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="Settings-16" imagePosition="overlaps" alignment="center" imageScaling="proportionallyDown" inset="2" id="Cmm-mg-qXg">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -1077,7 +1078,7 @@ DQ
                                 </connections>
                             </button>
                             <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="SKs-VT-HEN">
-                                <rect key="frame" x="16" y="61" width="32" height="32"/>
+                                <rect key="frame" x="16" y="65" width="32" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="32" id="Bqd-il-KjF"/>
                                     <constraint firstAttribute="width" constant="32" id="GTv-nd-eZM"/>
@@ -1085,10 +1086,10 @@ DQ
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="Card" id="RCC-RI-3DA"/>
                             </imageView>
                             <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="kBq-7r-kQp">
-                                <rect key="frame" x="0.0" y="42" width="340" height="5"/>
+                                <rect key="frame" x="0.0" y="46" width="340" height="5"/>
                             </box>
                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HQY-7q-6hU">
-                                <rect key="frame" x="62" y="69" width="88" height="16"/>
+                                <rect key="frame" x="62" y="73" width="88" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Visa ••••1234" usesSingleLineMode="YES" id="Tdw-9J-6Db">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1096,7 +1097,7 @@ DQ
                                 </textFieldCell>
                             </textField>
                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="sIL-gJ-z15">
-                                <rect key="frame" x="162" y="69" width="54" height="16"/>
+                                <rect key="frame" x="162" y="73" width="54" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="01/2022" usesSingleLineMode="YES" id="vkx-i1-ewA">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -1104,7 +1105,7 @@ DQ
                                 </textFieldCell>
                             </textField>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0mC-0d-eru">
-                                <rect key="frame" x="267" y="5" width="64" height="32"/>
+                                <rect key="frame" x="271" y="12" width="53" height="24"/>
                                 <buttonCell key="cell" type="push" title="Save" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="sne-x8-MZS">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -1117,7 +1118,7 @@ DQ
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TMF-K3-fOT">
-                                <rect key="frame" x="186" y="5" width="87" height="32"/>
+                                <rect key="frame" x="186" y="12" width="77" height="24"/>
                                 <buttonCell key="cell" type="push" title="Not Now" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="tq2-g9-8av">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>

--- a/macOS/DuckDuckGo/SecureVault/View/SaveCredentialsViewController.swift
+++ b/macOS/DuckDuckGo/SecureVault/View/SaveCredentialsViewController.swift
@@ -84,9 +84,13 @@ final class SaveCredentialsViewController: NSViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    private(set) var themeManager: ThemeManaging = NSApp.delegateTyped.themeManager
+    var themeUpdateCancellable: AnyCancellable?
+
     private let backfilledKey = GeneralPixel.AutofillParameterKeys.backfilled
     private let fireproofDomains: FireproofDomains
 
+    @IBOutlet var backgroundBox: NSBox!
     @IBOutlet var ddgPasswordManagerTitle: NSView!
     @IBOutlet var titleLabel: NSTextField!
     @IBOutlet var passwordManagerTitle: NSView!
@@ -159,6 +163,9 @@ final class SaveCredentialsViewController: NSViewController {
         updateSaveSegmentedControl()
         setUpStrings()
         setUpSecurityInfoViews()
+
+        subscribeToThemeChanges()
+        applyThemeStyle()
     }
 
     override func viewWillAppear() {
@@ -558,5 +565,11 @@ final class SaveCredentialsViewController: NSViewController {
         let pixel = action == .confirmed ? confirmedPixel : dismissedPixel
         PixelKit.fire(pixel, withAdditionalParameters: [backfilledKey: String(describing: backfilled)])
     }
+}
 
+extension SaveCredentialsViewController: ThemeUpdateListening {
+
+    func applyThemeStyle(theme: any ThemeStyleProviding) {
+        backgroundBox.fillColor = theme.colorsProvider.popoverBackgroundColor
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1212557304334587?focus=true
Tech Design URL:
CC:

### Description
In this PR we're adjusting the **Save Credentials** popover's background color, so that it matches the active Theme.
I also noticed the `Don't Save` button was vertically misaligned, and patched that as well.

### Testing Steps
1. Open https://www.lantean.co/wp-admin/
2. Type any username / password

- [ ] Verify the `Save Password` popover shows up
- [ ] Verify the popover's style matches your active theme

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing really, we're updating a background color

### Quality Considerations
Nothing in particular

### Notes to Reviewer
Thank you!

### Screenshots
Before | Now
-|-
<img width="350" src="https://github.com/user-attachments/assets/ba7ec2c1-bd35-4872-81c3-898daab35bf1" /> | <img width="350" src="https://github.com/user-attachments/assets/138e82e1-742d-4c0d-aebe-fac25bafb1a8" />


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns the Save Credentials UI with the active theme and cleans up layout.
> 
> - Hooks `SaveCredentialsViewController` into theming: subscribes to theme updates and applies `theme.colorsProvider.popoverBackgroundColor` to `backgroundBox` via `applyThemeStyle`; adds `backgroundBox` outlet and connects it in `PasswordManager.storyboard`
> - Small storyboard layout tweaks: align `"Don't Save"` segmented control with action buttons, adjust control heights/positions, and slightly increase popover heights for Save Credentials/Identity/Payment Method
> - Updates Xcode storyboard metadata (tools version) with no functional behavior changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 822daea6d54ca21cab19ff3d4a0bf55228e69024. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->