### PR TITLE
Fix crash in AdClickAttributionLogic when accessing vendor string

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionLogic.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentBlocking/AdClickAttribution/AdClickAttributionLogic.swift
@@ -328,15 +328,17 @@ public class AdClickAttributionLogic {
 
             self?.errorReporting?.fire(.adAttributionLogicRequestingAttributionTimedOut)
         }
-        self.attributionTimeout?.cancel()
+        let oldTimeout = self.attributionTimeout
         self.attributionTimeout = timeoutWorkItem
+        oldTimeout?.cancel()
         DispatchQueue.main.asyncAfter(deadline: .now() + 4.0,
                                       execute: timeoutWorkItem)
     }
 
     private func cancelTimeout() {
-        attributionTimeout?.cancel()
+        let timeout = attributionTimeout
         attributionTimeout = nil
+        timeout?.cancel()
     }
 
     /// Respond to new requests for attribution


### PR DESCRIPTION
## Summary
- Attempt to fix EXC_BAD_ACCESS crash when accessing vendor string in AdClickAttributionLogic's

## Changes
- Create a copy of the vendor string when storing in enum state to ensure proper retention
- Remove completionBlocks.count from debugDescription to prevent potential crashes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses a crash and tightens lifecycle handling in ad click attribution logic.
> 
> - Copy vendor strings before storing in `State.preparingAttribution` (in `onProvisionalNavigation` and `requestAttribution`) to ensure retention and avoid EXC_BAD_ACCESS
> - Simplify `State.debugDescription` for `.preparingAttribution` by removing `completionBlocks.count`
> - Make timeout handling safer by assigning new `DispatchWorkItem` before canceling the old one in `scheduleTimeout`, and clearing the reference before canceling in `cancelTimeout`
> - Comment out verbose state transition log in `willSet`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16495076b83206befab41c26f833bc4afef4e07d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->