### PR TITLE
FireDialogView: Force re-render on Theme Change

### DIFF
--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -81,6 +81,7 @@ struct FireDialogView: ModalView {
     }
 
     @ObservedObject var viewModel: FireDialogViewModel
+    @ObservedObject private var themeManager: ThemeManager = NSApp.delegateTyped.themeManager
     private let showIndividualSitesLink: Bool
     private let onConfirm: ((FireDialogView.Response) -> Void)?
     @Environment(\.dismiss) private var dismiss
@@ -182,7 +183,7 @@ struct FireDialogView: ModalView {
             footerView
                 .zIndex(11)
                 .padding(.bottom, 10) // presenter sheet crops the padding 🤷‍♂️
-                .background(Color(designSystemColor: .surfaceSecondary))
+                .background(Color(designSystemColor: .surfaceSecondary, palette: themeManager.designColorPalette))
         }
         .readSize { size in
             // Set exact content height to avoid content shifting and animation jumping when sheet resizes


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1212560853666542?focus=true
Tech Design URL:
CC:

### Description
In this PR we're updating the Fire Dialog so that it dynamically reacts to new Theme Updates

### Testing Steps
1. Open two Windows
2. **[Window A]** Click on the Fire button
3. **[Window B]** Open Settings > Appearance

- [ ] Verify that if you change Themes in **Window B**, the Fire Dialog immediately re-renders with the new colors

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Honestly, hard to imagine!

### Quality Considerations
Nothing in particular

### Notes to Reviewer
TY!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the Fire dialog reflects live theme updates.
> 
> - Add `@ObservedObject` `themeManager` to trigger view updates when the theme changes
> - Pass `themeManager.designColorPalette` to the footer `background` color so it re-styles with the active theme
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec9915c3593286e7b78ce4a0ecce684953cb8afe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->