### PR TITLE
Fix: Address Bar Elements not applying active Theme

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -786,13 +786,18 @@ final class AddressBarViewController: NSViewController {
         self.updateMode()
         self.addressBarButtonsViewController?.updateButtons()
 
-        guard let window = view.window, window.sheets.isEmpty else {
-            // Hide suggestions when a Sheet is presented (Open panel, Fire dialog…)
-            addressBarTextField.hideSuggestionWindow()
+        guard let window = view.window else {
             return
         }
 
-        guard AppVersion.runType != .unitTests else { return }
+        guard AppVersion.runType != .unitTests else {
+            return
+        }
+
+        // Hide suggestions when a Sheet is presented (Open panel, Fire dialog…)
+        if window.sheets.isEmpty == false {
+            addressBarTextField.hideSuggestionWindow()
+        }
 
         addressBarTextField.refreshStyle()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1212561317505002?focus=true
Tech Design URL:
CC:

### Description
In this PR we're fixing a glitch that caused the Address Bar not to apply the latest Theme, whenever the Fire Dialogue was onscreen

### Testing Steps
1. Open two Windows
2. **[Window A]** Click on the Address Bar
3. **[Window A]** Click on the Fire Button
4. **[Window B]** Open Preferences > Appearance
5. **[Window B]** Switch to a different Theme

- [ ] Verify the Address Bar's background is refreshed
- [ ] Verify no UI elements in the Address Bar remains stuck, with the wrong color

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The wrong color could be rendered in the Address Bar

### Quality Considerations
Nothing in particular

### Notes to Reviewer
Thank youuu

### Demo
https://github.com/user-attachments/assets/109473fe-3f24-47be-995a-1b3bdf01f72e


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes the address bar not updating to the latest theme when a modal sheet is shown.
> 
> - Refactors `refreshAddressBarAppearance` guard flow to avoid early return on `window.sheets` and always refresh styles/backgrounds and borders
> - Keeps behavior to hide suggestions when a sheet is present
> - No logic changes elsewhere; minor guard/style cleanup for unit test check
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13c7a56424a452334f5fcba91d458fbef9dec316. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->