### PR TITLE
Add a CPM pixel to measure on-device heuristic performance

### DIFF
--- a/macOS/DuckDuckGo/Autoconsent/AutoconsentPixels.swift
+++ b/macOS/DuckDuckGo/Autoconsent/AutoconsentPixels.swift
@@ -27,6 +27,7 @@ enum AutoconsentPixel: PixelKitEvent {
     case popupFound
     case done
     case doneCosmetic
+    case doneHeuristic
     case animationShown
     case animationShownCosmetic
     case disabledForSite
@@ -53,6 +54,7 @@ enum AutoconsentPixel: PixelKitEvent {
         .popupFound,
         .done,
         .doneCosmetic,
+        .doneHeuristic,
         .animationShown,
         .animationShownCosmetic,
         .disabledForSite,
@@ -79,6 +81,7 @@ enum AutoconsentPixel: PixelKitEvent {
         case .popupFound: "autoconsent_popup-found"
         case .done: "autoconsent_done"
         case .doneCosmetic: "autoconsent_done_cosmetic"
+        case .doneHeuristic: "autoconsent_done_heuristic"
         case .animationShown: "autoconsent_animation-shown"
         case .animationShownCosmetic: "autoconsent_animation-shown_cosmetic"
         case .disabledForSite: "autoconsent_disabled-for-site"
@@ -128,6 +131,7 @@ enum AutoconsentPixel: PixelKitEvent {
                 .popupFound,
                 .done,
                 .doneCosmetic,
+                .doneHeuristic,
                 .animationShown,
                 .animationShownCosmetic,
                 .disabledForSite,

--- a/macOS/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
+++ b/macOS/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
@@ -536,7 +536,11 @@ extension AutoconsentUserScript {
             consentRule: messageData.cmp,
             consentHeuristicEnabled: consentHeuristicEnabled
         )
-        firePixel(pixel: messageData.isCosmetic ? .doneCosmetic : .done)
+        if messageData.cmp == "HEURISTIC" {
+            firePixel(pixel: .doneHeuristic)
+        } else {
+            firePixel(pixel: messageData.isCosmetic ? .doneCosmetic : .done)
+        }
 
         popupManagedSubject.send(messageData)
 

--- a/macOS/PixelDefinitions/pixels/autoconsent.json5
+++ b/macOS/PixelDefinitions/pixels/autoconsent.json5
@@ -49,6 +49,13 @@
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource"]
     },
+    "m_mac_autoconsent_done_heuristic_daily": {
+        "description": "Fires when autoconsent on-device heuristic successfully dismisses a popup.",
+        "owners": ["muodov"],
+        "triggers": ["page_load"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
     "m_mac_autoconsent_animation-shown_daily": {
         "description": "Fires when the autoconsent URLbar \"Consent Managed\" animation is shown.",
         "owners": ["sammacbeth"],
@@ -153,6 +160,11 @@
             {
                 "key": "done_cosmetic",
                 "description": "Number of autoconsent done-cosmetic pixels fired.",
+                "type": "number"
+            },
+            {
+                "key": "done_heuristic",
+                "description": "Number of autoconsent done-heuristic pixels fired.",
                 "type": "number"
             },
             {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1212546811372812?focus=true
Tech Design URL:
CC:

### Description

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. ensure you'r ein the treatment cohort for the heuristic experiment (can override in debug menu)
2. navigate to https://privacy-test-pages.site/features/autoconsent/heuristic.html, make sure that the Reject button is clicked
3. Verify that `m_mac_autoconsent_done_heuristic_daily` is fired
4. wait for up to 2m for `m_mac_autoconsent_summary` pixel. Validate that "done_heuristic" parameter is there and is >0

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a dedicated pixel to track successful heuristic-based dismissals.
> 
> - Adds `doneHeuristic` to `AutoconsentPixel` (included in `summaryPixels`, `name`, and `standardParameters`)
> - In `AutoconsentUserScript.handleAutoconsentDone`, fires `doneHeuristic` when `cmp == "HEURISTIC"`; otherwise retains existing `done`/`doneCosmetic` behavior
> - Defines `m_mac_autoconsent_done_heuristic_daily` in `pixels/autoconsent.json5` and includes `done_heuristic` in `m_mac_autoconsent_summary` parameters
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 921cb0745d0b4aa8ce55b6e9483bc64eed1503b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->