### PR TITLE
CPM heuristic experiment (#2974)

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelFiring.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelFiring.swift
@@ -22,6 +22,10 @@ public protocol PixelFiring {
 
     func fire(_ event: PixelKitEvent,
               frequency: PixelKit.Frequency)
+
+    func fire(_ event: PixelKitEvent,
+              frequency: PixelKit.Frequency,
+              withAdditionalParameters: [String: String])
 }
 
 extension PixelKit: PixelFiring {
@@ -33,5 +37,11 @@ extension PixelKit: PixelFiring {
     public func fire(_ event: PixelKitEvent,
                      frequency: PixelKit.Frequency) {
         fire(event, frequency: frequency, onComplete: { _, _ in })
+    }
+
+    public func fire(_ event: PixelKitEvent,
+                     frequency: PixelKit.Frequency,
+                     withAdditionalParameters parameters: [String: String]) {
+        fire(event, frequency: frequency, withAdditionalParameters: parameters, onComplete: { _, _ in })
     }
 }

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKitTestingUtilities/PixelKitMock.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKitTestingUtilities/PixelKitMock.swift
@@ -39,7 +39,12 @@ public final class PixelKitMock: PixelFiring {
     }
 
     public func fire(_ event: PixelKitEvent, frequency: PixelKit.Frequency) {
-        let fireCall = ExpectedFireCall(pixel: event, frequency: frequency)
+        let fireCall = ExpectedFireCall(pixel: event, frequency: frequency, additionalParameters: nil)
+        actualFireCalls.append(fireCall)
+    }
+
+    public func fire(_ event: PixelKitEvent, frequency: PixelKit.Frequency, withAdditionalParameters: [String: String]) {
+        let fireCall = ExpectedFireCall(pixel: event, frequency: frequency, additionalParameters: withAdditionalParameters)
         actualFireCalls.append(fireCall)
     }
 
@@ -51,10 +56,12 @@ public final class PixelKitMock: PixelFiring {
 public struct ExpectedFireCall: Equatable {
     let pixel: PixelKitEvent
     let frequency: PixelKit.Frequency
+    let additionalParameters: [String: String]?
 
-    public init(pixel: PixelKitEvent, frequency: PixelKit.Frequency) {
+    public init(pixel: PixelKitEvent, frequency: PixelKit.Frequency, additionalParameters: [String: String]? = nil) {
         self.pixel = pixel
         self.frequency = frequency
+        self.additionalParameters = additionalParameters
     }
 
     public static func == (lhs: ExpectedFireCall, rhs: ExpectedFireCall) -> Bool {
@@ -62,5 +69,6 @@ public struct ExpectedFireCall: Equatable {
         && lhs.pixel.parameters == rhs.pixel.parameters
         && lhs.pixel.error == rhs.pixel.error
         && lhs.frequency == rhs.frequency
+        && lhs.additionalParameters == rhs.additionalParameters
     }
 }

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -404,6 +404,7 @@ public enum AutoconsentSubfeature: String, PrivacySubfeature {
 
     case onByDefault
     case filterlist
+    case heuristicAction
 }
 
 public enum PrivacyProSubfeature: String, Equatable, PrivacySubfeature {

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
@@ -269,6 +269,7 @@ public struct BrokenSiteReport {
             "consentOptoutFailed": boolToStringValue(cookieConsentInfo?.optoutFailed),
             "consentSelftestFailed": boolToStringValue(cookieConsentInfo?.selftestFailed),
             "consentReloadLoop": boolToStringValue(cookieConsentInfo?.consentReloadLoop),
+            "consentHeuristicEnabled": boolToStringValue(cookieConsentInfo?.consentHeuristicEnabled),
             "consentRule": cookieConsentInfo?.consentRule ?? "",
             "debugFlags": debugFlags,
             "contentScopeExperiments": privacyExperiments

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/Model/CookieConsentInfo.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/Model/CookieConsentInfo.swift
@@ -26,15 +26,17 @@ public struct CookieConsentInfo: Encodable {
     let selftestFailed: Bool?
     let consentReloadLoop: Bool?
     let consentRule: String?
+    let consentHeuristicEnabled: Bool?
     let configurable = true
 
-    public init(consentManaged: Bool, cosmetic: Bool?, optoutFailed: Bool?, selftestFailed: Bool?, consentReloadLoop: Bool?, consentRule: String?) {
+    public init(consentManaged: Bool, cosmetic: Bool?, optoutFailed: Bool?, selftestFailed: Bool?, consentReloadLoop: Bool?, consentRule: String?, consentHeuristicEnabled: Bool?) {
         self.consentManaged = consentManaged
         self.cosmetic = cosmetic
         self.optoutFailed = optoutFailed
         self.selftestFailed = selftestFailed
         self.consentReloadLoop = consentReloadLoop
         self.consentRule = consentRule
+        self.consentHeuristicEnabled = consentHeuristicEnabled
     }
 
 }

--- a/iOS/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
+++ b/iOS/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
@@ -90,7 +90,7 @@ final class AutoconsentUserScript: NSObject, WKScriptMessageHandlerWithReply, Us
     @MainActor
     func refreshDashboardState(consentManaged: Bool, cosmetic: Bool?, optoutFailed: Bool?, selftestFailed: Bool?, consentReloadLoop: Bool?, consentRule: String?) {
         let consentStatus = CookieConsentInfo(
-            consentManaged: consentManaged, cosmetic: cosmetic, optoutFailed: optoutFailed, selftestFailed: selftestFailed, consentReloadLoop: consentReloadLoop, consentRule: consentRule
+            consentManaged: consentManaged, cosmetic: cosmetic, optoutFailed: optoutFailed, selftestFailed: selftestFailed, consentReloadLoop: consentReloadLoop, consentRule: consentRule, consentHeuristicEnabled: nil
         )
         Logger.autoconsent.debug("Refreshing dashboard state: \(String(describing: consentStatus))")
         self.delegate?.autoconsentUserScript(consentStatus: consentStatus)

--- a/iOS/DuckDuckGoTests/BrokenSiteReportingTests.swift
+++ b/iOS/DuckDuckGoTests/BrokenSiteReportingTests.swift
@@ -120,7 +120,7 @@ final class BrokenSiteReportingTests: XCTestCase {
                                       jsPerformance: nil,
                                       userRefreshCount: 0,
                                       variant: "",
-                                      cookieConsentInfo: CookieConsentInfo(consentManaged: true, cosmetic: true, optoutFailed: true, selftestFailed: true, consentReloadLoop: nil, consentRule: "test-cmp"),
+                                      cookieConsentInfo: CookieConsentInfo(consentManaged: true, cosmetic: true, optoutFailed: true, selftestFailed: true, consentReloadLoop: nil, consentRule: "test-cmp", consentHeuristicEnabled: nil),
                                       debugFlags: "",
                                       privacyExperiments: "",
                                       isPirEnabled: nil)

--- a/macOS/DuckDuckGo/Autoconsent/AutoconsentPixels.swift
+++ b/macOS/DuckDuckGo/Autoconsent/AutoconsentPixels.swift
@@ -75,6 +75,7 @@ enum AutoconsentPixel: PixelKitEvent {
         case .missedPopup: "autoconsent_missed-popup"
         case .errorMultiplePopups: "autoconsent_error_multiple-popups"
         case .errorOptoutFailed: "autoconsent_error_optout"
+        case .errorReloadLoop: "autoconsent_error_reload-loop"
         case .popupFound: "autoconsent_popup-found"
         case .done: "autoconsent_done"
         case .doneCosmetic: "autoconsent_done_cosmetic"
@@ -86,7 +87,6 @@ enum AutoconsentPixel: PixelKitEvent {
         case .detectedOnlyRules: "autoconsent_detected-only-rules"
         case .selfTestOk: "autoconsent_self-test-ok"
         case .selfTestFail: "autoconsent_self-test-fail"
-        case .errorReloadLoop: "autoconsent_error_reload-loop"
         case .popoverShown: "autoconsent_popover-shown"
         case .popoverClosed: "autoconsent_popover-closed"
         case .popoverClicked: "autoconsent_popover-clicked"
@@ -124,6 +124,7 @@ enum AutoconsentPixel: PixelKitEvent {
                 .missedPopup,
                 .errorMultiplePopups,
                 .errorOptoutFailed,
+                .errorReloadLoop,
                 .popupFound,
                 .done,
                 .doneCosmetic,
@@ -135,7 +136,6 @@ enum AutoconsentPixel: PixelKitEvent {
                 .detectedOnlyRules,
                 .selfTestOk,
                 .selfTestFail,
-                .errorReloadLoop,
                 .popoverShown,
                 .popoverClosed,
                 .popoverClicked,

--- a/macOS/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
+++ b/macOS/DuckDuckGo/Autoconsent/AutoconsentUserScript.swift
@@ -24,6 +24,7 @@ import PrivacyConfig
 import PrivacyDashboard
 import UserScript
 import WebKit
+import FeatureFlags
 
 protocol AutoconsentUserScriptDelegate: AnyObject {
     func autoconsentUserScript(consentStatus: CookieConsentInfo)
@@ -50,6 +51,7 @@ final class AutoconsentUserScript: NSObject, WKScriptMessageHandlerWithReply, Us
     private var topUrl: URL?
     private let preferences: CookiePopupProtectionPreferences
     private let management: AutoconsentManagement
+    private let featureFlagger: FeatureFlagger
 
     public var messageNames: [String] { MessageName.allCases.map(\.rawValue) }
     let source: String
@@ -65,10 +67,12 @@ final class AutoconsentUserScript: NSObject, WKScriptMessageHandlerWithReply, Us
     // Reload loop detection state (per-tab)
     private var lastHandledCMPName: String?
     private var reloadLoopDetected: Bool = false
+    private var consentHeuristicEnabled: Bool?
 
     init(config: PrivacyConfiguration,
          management: AutoconsentManagement,
-         preferences: CookiePopupProtectionPreferences
+         preferences: CookiePopupProtectionPreferences,
+         featureFlagger: FeatureFlagger
     ) {
         Logger.autoconsent.debug("Initialising autoconsent userscript")
         do {
@@ -82,6 +86,7 @@ final class AutoconsentUserScript: NSObject, WKScriptMessageHandlerWithReply, Us
         self.config = config
         self.management = management
         self.preferences = preferences
+        self.featureFlagger = featureFlagger
     }
 
     func userContentController(_ userContentController: WKUserContentController,
@@ -90,9 +95,15 @@ final class AutoconsentUserScript: NSObject, WKScriptMessageHandlerWithReply, Us
     }
 
     @MainActor
-    func refreshDashboardState(consentManaged: Bool, cosmetic: Bool?, optoutFailed: Bool?, selftestFailed: Bool?, consentReloadLoop: Bool?, consentRule: String?) {
+    func refreshDashboardState(consentManaged: Bool, cosmetic: Bool?, optoutFailed: Bool?, selftestFailed: Bool?, consentReloadLoop: Bool?, consentRule: String?, consentHeuristicEnabled: Bool?) {
         let consentStatus = CookieConsentInfo(
-            consentManaged: consentManaged, cosmetic: cosmetic, optoutFailed: optoutFailed, selftestFailed: selftestFailed, consentReloadLoop: consentReloadLoop, consentRule: consentRule
+            consentManaged: consentManaged,
+            cosmetic: cosmetic,
+            optoutFailed: optoutFailed,
+            selftestFailed: selftestFailed,
+            consentReloadLoop: consentReloadLoop,
+            consentRule: consentRule,
+            consentHeuristicEnabled: consentHeuristicEnabled
         )
         Logger.autoconsent.debug("Refreshing dashboard state: \(String(describing: consentStatus))")
         self.delegate?.autoconsentUserScript(consentStatus: consentStatus)
@@ -268,6 +279,17 @@ extension AutoconsentUserScript {
     }
 
     @MainActor
+    func isHeuristicActionEnabled() -> Bool? {
+        if let cohort = featureFlagger.resolveCohort(for: FeatureFlag.heuristicAction) as? FeatureFlag.HeuristicActionCohort {
+            Logger.autoconsent.debug("heuristic action cohort: \(String(describing: cohort))")
+            return cohort == .treatment
+        } else {
+            Logger.autoconsent.debug("heuristic action not enrolled")
+            return nil
+        }
+    }
+
+    @MainActor
     func handleInit(message: WKScriptMessage, replyHandler: @escaping (Any?, String?) -> Void) {
         guard let messageData: InitMessage = decodeMessageBody(from: message.body),
               let url = URL(string: messageData.url) else {
@@ -288,6 +310,8 @@ extension AutoconsentUserScript {
             replyHandler([ "type": "ok" ], nil) // this is just to prevent a Promise rejection
             return
         }
+
+        self.consentHeuristicEnabled = isHeuristicActionEnabled()
 
         // do the navigation check before checking if the domain is allowlisted
         checkMainFrameNavigation(message: message, url: url)
@@ -311,7 +335,8 @@ extension AutoconsentUserScript {
                 optoutFailed: nil,
                 selftestFailed: nil,
                 consentReloadLoop: reloadLoopDetected,
-                consentRule: lastHandledCMPName // this will be non-null in case of a reload loop
+                consentRule: lastHandledCMPName, // this will be non-null in case of a reload loop
+                consentHeuristicEnabled: consentHeuristicEnabled
             )
             firePixel(pixel: .acInit)
         }
@@ -358,7 +383,8 @@ extension AutoconsentUserScript {
                 "detectRetries": 20,
                 "isMainWorld": false,
                 "enableFilterList": enableFilterList,
-                "enableHeuristicDetection": true
+                "enableHeuristicDetection": true,
+                "enableHeuristicAction": consentHeuristicEnabled ?? false // default to false if not enrolled
             ] as [String: Any?]
         ] as [String: Any?]
 
@@ -416,13 +442,31 @@ extension AutoconsentUserScript {
         Logger.autoconsent.debug("Cookie popup found: \(String(describing: messageData))")
         firePixel(pixel: .popupFound)
 
+        // measure: at least one popup handled within X days
+        PixelKit.fireExperimentPixel(for: AutoconsentSubfeature.heuristicAction.rawValue, metric: "popupHandled", conversionWindowDays: 0...1, value: "true")
+        PixelKit.fireExperimentPixel(for: AutoconsentSubfeature.heuristicAction.rawValue, metric: "popupHandled", conversionWindowDays: 0...5, value: "true")
+        PixelKit.fireExperimentPixel(for: AutoconsentSubfeature.heuristicAction.rawValue, metric: "popupHandled", conversionWindowDays: 0...10, value: "true")
+        // measure: at least N popups handled within 10 days
+        PixelKit.fireExperimentPixelIfThresholdReached(for: AutoconsentSubfeature.heuristicAction.rawValue, metric: "popupHandledMilestone", conversionWindowDays: 0...10, threshold: 10)
+        PixelKit.fireExperimentPixelIfThresholdReached(for: AutoconsentSubfeature.heuristicAction.rawValue, metric: "popupHandledMilestone", conversionWindowDays: 0...10, threshold: 5)
+        PixelKit.fireExperimentPixelIfThresholdReached(for: AutoconsentSubfeature.heuristicAction.rawValue, metric: "popupHandledMilestone", conversionWindowDays: 0...5, threshold: 10)
+        PixelKit.fireExperimentPixelIfThresholdReached(for: AutoconsentSubfeature.heuristicAction.rawValue, metric: "popupHandledMilestone", conversionWindowDays: 0...5, threshold: 5)
+
         // Check for reload loop
         detectReloadLoop(cmpName: messageData.cmp)
 
         // if popupFound is sent with "filterList", it indicates that cosmetic filterlist matched in the prehide stage,
         // but a real opt-out may still follow. See https://github.com/duckduckgo/autoconsent/blob/main/api.md#messaging-api
         if messageData.cmp == Constants.filterListCmpName {
-            refreshDashboardState(consentManaged: true, cosmetic: true, optoutFailed: false, selftestFailed: nil, consentReloadLoop: reloadLoopDetected, consentRule: messageData.cmp)
+            refreshDashboardState(
+                consentManaged: true,
+                cosmetic: true,
+                optoutFailed: false,
+                selftestFailed: nil,
+                consentReloadLoop: reloadLoopDetected,
+                consentRule: messageData.cmp,
+                consentHeuristicEnabled: consentHeuristicEnabled
+            )
             // trigger animation
             Logger.autoconsent.debug("Starting animation for cosmetic filters")
             // post popover notification
@@ -445,7 +489,15 @@ extension AutoconsentUserScript {
         Logger.autoconsent.debug("opt-out result: \(String(describing: messageData))")
 
         if !messageData.result {
-            refreshDashboardState(consentManaged: true, cosmetic: nil, optoutFailed: true, selftestFailed: nil, consentReloadLoop: reloadLoopDetected, consentRule: messageData.cmp)
+            refreshDashboardState(
+                consentManaged: true,
+                cosmetic: nil,
+                optoutFailed: true,
+                selftestFailed: nil,
+                consentReloadLoop: reloadLoopDetected,
+                consentRule: messageData.cmp,
+                consentHeuristicEnabled: consentHeuristicEnabled
+            )
             firePixel(pixel: .errorOptoutFailed)
         } else if messageData.scheduleSelfTest {
             // save a reference to the webview and frame for self-test
@@ -475,7 +527,15 @@ extension AutoconsentUserScript {
             isCosmetic: messageData.isCosmetic
         )
 
-        refreshDashboardState(consentManaged: true, cosmetic: messageData.isCosmetic, optoutFailed: false, selftestFailed: nil, consentReloadLoop: reloadLoopDetected, consentRule: messageData.cmp)
+        refreshDashboardState(
+            consentManaged: true,
+            cosmetic: messageData.isCosmetic,
+            optoutFailed: false,
+            selftestFailed: nil,
+            consentReloadLoop: reloadLoopDetected,
+            consentRule: messageData.cmp,
+            consentHeuristicEnabled: consentHeuristicEnabled
+        )
         firePixel(pixel: messageData.isCosmetic ? .doneCosmetic : .done)
 
         popupManagedSubject.send(messageData)
@@ -527,7 +587,15 @@ extension AutoconsentUserScript {
         }
         // store self-test result
         Logger.autoconsent.debug("self-test result: \(String(describing: messageData))")
-        refreshDashboardState(consentManaged: true, cosmetic: nil, optoutFailed: false, selftestFailed: messageData.result, consentReloadLoop: reloadLoopDetected, consentRule: messageData.cmp)
+        refreshDashboardState(
+            consentManaged: true,
+            cosmetic: nil,
+            optoutFailed: false,
+            selftestFailed: messageData.result,
+            consentReloadLoop: reloadLoopDetected,
+            consentRule: messageData.cmp,
+            consentHeuristicEnabled: consentHeuristicEnabled
+        )
         firePixel(pixel: messageData.result ? .selfTestOk : .selfTestFail)
         replyHandler([ "type": "ok" ], nil) // this is just to prevent a Promise rejection
     }
@@ -565,11 +633,16 @@ extension AutoconsentUserScript {
     }
 
     func firePixel(pixel: AutoconsentPixel) {
+        var additionalParams: [String: String] = [:]
+        if let enabled = consentHeuristicEnabled {
+            additionalParams["consentHeuristicEnabled"] = enabled ? "1" : "0"
+        }
+
         if management.pixelCounter.isEmpty {
             // Fire a summary pixel, containing counters of all other pixels, 2 minutes after
             // the first event is received.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 60*2) {
-                PixelKit.fire(AutoconsentPixel.summary(events: self.management.pixelCounter), frequency: .standard)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 60*2) { [additionalParams] in
+                PixelKit.fire(AutoconsentPixel.summary(events: self.management.pixelCounter), frequency: .standard, withAdditionalParameters: additionalParams)
                 self.management.pixelCounter = [:]
                 self.management.detectedByPatternsCache.removeAll()
                 self.management.detectedByBothCache.removeAll()
@@ -580,7 +653,7 @@ extension AutoconsentUserScript {
         management.pixelCounter[pixel.key, default: 0] += 1
 
         // fire daily pixel if needed
-        PixelKit.fire(pixel, frequency: .daily)
+        PixelKit.fire(pixel, frequency: .daily, withAdditionalParameters: additionalParams)
     }
 
     // MARK: - Reload Loop Detection

--- a/macOS/DuckDuckGo/InternalUserDecider/FeatureFlagOverridesMenu.swift
+++ b/macOS/DuckDuckGo/InternalUserDecider/FeatureFlagOverridesMenu.swift
@@ -298,7 +298,7 @@ final class FeatureFlagOverridesMenu: NSMenu {
         submenu.addItem(NSMenuItem.separator())
 
         // "Remove Override" only if an override exists
-        let removeOverrideItem = removeOverrideSubmenuItem(for: flag)
+        let removeOverrideItem = removeExperimentOverrideSubmenuItem(for: flag)
         removeOverrideItem.isHidden = currentOverride == nil
 
         submenu.addItem(removeOverrideItem)
@@ -316,6 +316,19 @@ final class FeatureFlagOverridesMenu: NSMenu {
         )
         removeOverrideItem.representedObject = flag
         removeOverrideItem.isHidden = featureFlagger.localOverrides?.override(for: flag) == nil
+        return removeOverrideItem
+    }
+
+    private func removeExperimentOverrideSubmenuItem(for flag: FeatureFlag) -> NSMenuItem {
+        let defaultCohortString = defaultExperimentValue(for: flag)
+
+        let removeOverrideItem = NSMenuItem(
+            title: "Reset to default: \(defaultCohortString)",
+            action: #selector(resetOverride(_:)),
+            target: self
+        )
+        removeOverrideItem.representedObject = flag
+        removeOverrideItem.isHidden = featureFlagger.localOverrides?.experimentOverride(for: flag) == nil
         return removeOverrideItem
     }
 

--- a/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
+++ b/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
@@ -25,6 +25,7 @@ import Common
 import PixelKit
 import PixelExperimentKit
 import os.log
+import FeatureFlags
 
 protocol PrivacyDashboardViewControllerSizeDelegate: AnyObject {
 
@@ -229,6 +230,9 @@ final class PrivacyDashboardViewController: NSViewController {
             SiteBreakageExperimentMetrics.fireTDSExperimentMetric(metricType: .privacyToggleUsed, etag: tdsEtag) { parameters in
                 PixelKit.fire(GeneralPixel.debugBreakageExperiment, frequency: .uniqueByName, withAdditionalParameters: parameters)
             }
+            PixelKit.fireExperimentPixel(for: AutoconsentSubfeature.heuristicAction.rawValue, metric: "privacyToggleUsed", conversionWindowDays: 0...1, value: "true")
+            PixelKit.fireExperimentPixel(for: AutoconsentSubfeature.heuristicAction.rawValue, metric: "privacyToggleUsed", conversionWindowDays: 0...5, value: "true")
+            PixelKit.fireExperimentPixel(for: AutoconsentSubfeature.heuristicAction.rawValue, metric: "privacyToggleUsed", conversionWindowDays: 0...10, value: "true")
         }
 
         let completionToken = contentBlocking.contentBlockingManager.scheduleCompilation()
@@ -333,6 +337,7 @@ extension PrivacyDashboardViewController: PrivacyDashboardControllerDelegate {
             } catch {
                 Logger.general.error("Failed to generate or send the broken site report: \(error.localizedDescription)")
             }
+            PixelKit.fireExperimentPixel(for: AutoconsentSubfeature.heuristicAction.rawValue, metric: "breakageReportSent", conversionWindowDays: 0...10, value: "true")
         }
     }
 
@@ -351,6 +356,7 @@ extension PrivacyDashboardViewController: PrivacyDashboardControllerDelegate {
             } catch {
                 Logger.general.error("Failed to generate or send the broken site report: \(error.localizedDescription)")
             }
+            PixelKit.fireExperimentPixel(for: AutoconsentSubfeature.heuristicAction.rawValue, metric: "breakageReportSent", conversionWindowDays: 0...10, value: "true")
         }
     }
 

--- a/macOS/DuckDuckGo/Tab/TabExtensions/NavigationPixelNavigationResponder.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/NavigationPixelNavigationResponder.swift
@@ -220,12 +220,18 @@ extension NavigationPixelNavigationResponder: NavigationResponder {
             allResourcesCompleteMs = Int(duration * 1000)
         }
 
+        // Pass CPM heuristic experiment cohort
+        var additionalParams: [String: String] = [:]
+        if let cohort = featureFlagger.resolveCohort(for: FeatureFlag.heuristicAction) as? FeatureFlag.HeuristicActionCohort {
+            additionalParams["consentHeuristicEnabled"] = cohort == .treatment ? "1" : "0"
+        }
+
         // Fire the updated pixel with comprehensive timing data
         pixelFiring?.fire(SiteLoadingPixel.siteLoadingTiming(
             firstVisualLayoutMs: firstVisualLayoutMs,
             firstMeaningfulPaintMs: firstMeaningfulPaintMs,
             documentCompleteMs: documentCompleteMs,
             allResourcesCompleteMs: allResourcesCompleteMs
-        ))
+        ), frequency: .standard, withAdditionalParameters: additionalParams)
     }
 }

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -118,7 +118,8 @@ final class UserScripts: UserScriptsProvider {
         autoconsentUserScript = AutoconsentUserScript(
             config: sourceProvider.privacyConfigurationManager.privacyConfig,
             management: sourceProvider.autoconsentManagement,
-            preferences: sourceProvider.cookiePopupProtectionPreferences
+            preferences: sourceProvider.cookiePopupProtectionPreferences,
+            featureFlagger: sourceProvider.featureFlagger
         )
 
         let lenguageCode = Locale.current.languageCode ?? "en"

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -269,9 +269,20 @@ public enum FeatureFlag: String, CaseIterable {
 
     /// https://app.asana.com/1/137249556945/project/1201462886803403/task/1211837879355661?focus=true
     case aiChatSync
+
+    /// Autoconsent heuristic action experiment
+    /// https://app.asana.com/1/137249556945/project/1201621853593513/task/1212068164128054?focus=true
+    case heuristicAction
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
+
+    /// Cohorts for the autoconsent heuristic action experiment
+    public enum HeuristicActionCohort: String, FeatureFlagCohortDescribing {
+        case control
+        case treatment
+    }
+
     public var defaultValue: Bool {
         switch self {
         case .supportsAlternateStripePaymentFlow,
@@ -301,6 +312,8 @@ extension FeatureFlag: FeatureFlagDescribing {
 
     public var cohortType: (any FeatureFlagCohortDescribing.Type)? {
         switch self {
+        case .heuristicAction:
+            return HeuristicActionCohort.self
         default:
             return nil
         }
@@ -376,7 +389,8 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .autofillPasswordSearchPrioritizeDomain,
                 .dataImportWideEventMeasurement,
                 .memoryUsageMonitor,
-                .aiChatSync:
+                .aiChatSync,
+                .heuristicAction:
             return true
         case .sslCertificatesBypass,
                 .appendAtbToSerpQueries,
@@ -549,6 +563,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .disabled
         case .aiChatSync:
             return .disabled
+        case .heuristicAction:
+            return .remoteReleasable(.subfeature(AutoconsentSubfeature.heuristicAction))
         }
     }
 }

--- a/macOS/PixelDefinitions/native_experiments.json5
+++ b/macOS/PixelDefinitions/native_experiments.json5
@@ -1,5 +1,27 @@
 {
     // This file will define pixels sent by the native experiments framework
     "defaultSuffixes": [],
-    "activeExperiments": {}
+    "activeExperiments": {
+        "heuristicAction": {
+            "cohorts": ["control", "treatment"],
+            "metrics": {
+                "popupHandled": {
+                    "description": "CPM detected a cookie popup within the conversion window",
+                    "enum": ["true"]
+                },
+                "popupHandledMilestone": {
+                    "description": "At least N popups handled within the first one or two weeks window",
+                    "enum": ["10", "5"]
+                },
+                "breakageReportSent": {
+                    "description": "Breakage report is sent within the conversion window",
+                    "enum": ["true"]
+                },
+                "privacyToggleUsed": {
+                    "description": "Privacy toggle is used to manage cookie consent",
+                    "enum": ["true"]
+                }
+            }
+        }
+    }
 }

--- a/macOS/PixelDefinitions/pixels/autoconsent.json5
+++ b/macOS/PixelDefinitions/pixels/autoconsent.json5
@@ -199,6 +199,11 @@
                 "key": "error_reload-loop",
                 "description": "Number of autoconsent error-reload-loop pixels fired.",
                 "type": "number"
+            },
+            {
+                "key": "consentHeuristicEnabled",
+                "description": "Whether the user is in CPM heuristic experiment treatment group",
+                "type": "number"
             }
         ]
     },

--- a/macOS/PixelDefinitions/pixels/navigation.json5
+++ b/macOS/PixelDefinitions/pixels/navigation.json5
@@ -89,6 +89,11 @@
                 "key": "all_resources_complete_ms",
                 "type": "integer",
                 "description": "Time in milliseconds from navigation start to all resources complete"
+            },
+            {
+                "key": "consentHeuristicEnabled",
+                "type": "integer",
+                "description": "Whether the user is in CPM heuristic experiment treatment group"
             }
         ]
     },

--- a/macOS/UITests/AutoconsentUITests.swift
+++ b/macOS/UITests/AutoconsentUITests.swift
@@ -71,6 +71,39 @@ class AutoconsentUITests: UITestCase {
         app.typeKey(.escape, modifierFlags: [])
     }
 
+    // Re-enable when experiment is shipped to 100%
+    func disabled_testAutoconsent_PrivacyTestPages_HeuristicModeWorks() throws {
+        // Navigate to DuckDuckGo's privacy test pages for autoconsent
+        let testURL = URL(string: "http://privacy-test-pages.site/features/autoconsent/heuristic.html")!
+        addressBarTextField.pasteURL(testURL, pressingEnter: true)
+
+        // Wait for autoconsent test page to load with specific content
+        let webView = app.webViews.firstMatch
+        let autoconsentPageContent = webView.staticTexts.containing(\.value, containing: "Tests for heuristic mode").firstMatch
+        XCTAssertTrue(autoconsentPageContent.waitForExistence(timeout: UITests.Timeouts.navigation), "Autoconsent test page should load with 'Tests for heuristic mode' text")
+
+        // Verify autoconsent automatically clicked the first button - should show "Reject was clicked!"
+        let clickedButton = webView.buttons.containing(\.title, containing: "Reject was clicked!").firstMatch
+        XCTAssertTrue(clickedButton.waitForExistence(timeout: UITests.Timeouts.elementExistence), "Autoconsent should have automatically clicked the first button, changing it to 'Reject was clicked!'")
+
+        // Check privacy dashboard for autoconsent status
+        let privacyButton = app.buttons.matching(identifier: "AddressBarButtonsViewController.privacyDashboardButton").firstMatch
+        XCTAssertTrue(privacyButton.waitForExistence(timeout: UITests.Timeouts.elementExistence), "Privacy button should be available")
+
+        privacyButton.click()
+
+        // Wait for privacy dashboard to open
+        let privacyDashboard = app.popovers.firstMatch
+        XCTAssertTrue(privacyDashboard.waitForExistence(timeout: UITests.Timeouts.elementExistence), "Privacy dashboard should open")
+
+        // Look for "Cookies Managed" in the privacy dashboard (for button clicking test)
+        let cookiesManagedInfo = privacyDashboard.groups.containing(.button, identifier: "Cookies Managed").firstMatch
+        XCTAssertTrue(cookiesManagedInfo.waitForExistence(timeout: UITests.Timeouts.elementExistence), "Privacy dashboard should show 'Cookies Managed' for autoconsent button clicking")
+
+        // Close privacy dashboard
+        app.typeKey(.escape, modifierFlags: [])
+    }
+
     func testAutoconsent_CookieBannerHiding_BannersAreHidden() throws {
         // Navigate to test page with cookie banner
         let bannerTestURL = URL(string: "http://privacy-test-pages.site/features/autoconsent/banner.html")!

--- a/macOS/UnitTests/Autoconsent/AutoconsentMessageProtocolTests.swift
+++ b/macOS/UnitTests/Autoconsent/AutoconsentMessageProtocolTests.swift
@@ -20,8 +20,9 @@ import BrowserServicesKit
 import Common
 import History
 import HistoryView
-import PrivacyConfigTestsUtils
 import PersistenceTestingUtils
+import PrivacyConfig
+import PrivacyConfigTestsUtils
 import WebKit
 import XCTest
 
@@ -41,7 +42,8 @@ class AutoconsentMessageProtocolTests: XCTestCase {
         userScript = AutoconsentUserScript(
             config: MockPrivacyConfiguration(),
             management: AutoconsentManagement(),
-            preferences: preferences
+            preferences: preferences,
+            featureFlagger: MockFeatureFlagger()
         )
     }
 

--- a/macOS/UnitTests/UserChurn/UserChurnServiceTests.swift
+++ b/macOS/UnitTests/UserChurn/UserChurnServiceTests.swift
@@ -22,14 +22,18 @@ import PersistenceTestingUtils
 @testable import DuckDuckGo_Privacy_Browser
 
 final class MockPixelFiring: PixelFiring {
-    var firedPixels: [(event: PixelKitEvent, frequency: PixelKit.Frequency)] = []
+    var firedPixels: [(event: PixelKitEvent, frequency: PixelKit.Frequency, additionalParameters: [String: String]?)] = []
 
     func fire(_ event: PixelKitEvent) {
         fire(event, frequency: .standard)
     }
 
     func fire(_ event: PixelKitEvent, frequency: PixelKit.Frequency) {
-        firedPixels.append((event: event, frequency: frequency))
+        firedPixels.append((event: event, frequency: frequency, additionalParameters: nil))
+    }
+
+    func fire(_ event: PixelKitEvent, frequency: PixelKit.Frequency, withAdditionalParameters: [String: String]) {
+        firedPixels.append((event: event, frequency: frequency, additionalParameters: withAdditionalParameters))
     }
 }
 

--- a/macOS/UnitTests/WebsiteBreakageReport/WebsiteBreakageReportTests.swift
+++ b/macOS/UnitTests/WebsiteBreakageReport/WebsiteBreakageReportTests.swift
@@ -130,7 +130,7 @@ class WebsiteBreakageReportTests: XCTestCase {
             vpnOn: false,
             jsPerformance: nil,
             userRefreshCount: 0,
-            cookieConsentInfo: CookieConsentInfo(consentManaged: true, cosmetic: true, optoutFailed: true, selftestFailed: true, consentReloadLoop: true, consentRule: "test-cmp"),
+            cookieConsentInfo: CookieConsentInfo(consentManaged: true, cosmetic: true, optoutFailed: true, selftestFailed: true, consentReloadLoop: true, consentRule: "test-cmp", consentHeuristicEnabled: true),
             debugFlags: "",
             privacyExperiments: "",
             isPirEnabled: true,
@@ -160,6 +160,7 @@ class WebsiteBreakageReportTests: XCTestCase {
         XCTAssertEqual(queryItems[valueFor: "consentOptoutFailed"], "1")
         XCTAssertEqual(queryItems[valueFor: "consentSelftestFailed"], "1")
         XCTAssertEqual(queryItems[valueFor: "consentReloadLoop"], "1")
+        XCTAssertEqual(queryItems[valueFor: "consentHeuristicEnabled"], "1")
         XCTAssertEqual(queryItems[valueFor: "consentRule"], "test-cmp")
         XCTAssertEqual(queryItems[valueFor: "isPirEnabled"], "true")
     }


### PR DESCRIPTION
Task/Issue URL:
https://app.asana.com/1/137249556945/project/481882893211075/task/1211718285496689?focus=true Tech Design URL:
https://app.asana.com/1/137249556945/project/1201621853593513/task/1212068164128054?focus=true CC: @SabrinaTardio @sammacbeth @jdorweiler 

### Description
Implements an A/B experiment for the new heuristic CPM mode

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app --> Prerequisites:
1. Build the app
2. Set the remote config URL to https://duckduckgo.github.io/privacy-configuration/pr-4271/v4/macos-config.json
3. Check that the cohort is assigned (via debug menu)
4. Open the logs in Xcode to verify pixels:
5. Open https://example.com.
6. Verify that the enrollment pixel is fired with the correct cohort.
7. Verify that the page load timing pixel (`m_mac_site_loading_timing`) includes `consentHeuristicEnabled=1` or `consentHeuristicEnabled=0`
8. Wait for up to 2 minutes for the Autoconsent Summary pixel to fire (`m_mac_autoconsent_summary`). Verify that it includes the `consentHeuristicEnabled` parameter
9. Override cohort to **control** (via debug menu)
10. Open this page: https://privacy-test-pages.site/features/autoconsent/heuristic.html.
11. Override cohort to **treatment**
12. Reload the page. Verify that Reject button is now clicked.
13. Verify that `popupHandled` metric has been fired after the handled test popup:
`m_mac_experiment_heuristicAction_[cohort]_popupHandled_true_[enrollmentDate]_[conversionWindow]` for conversion windows: `d0-1`, `d0-5`, `d0-10`
14. Navigate back and forth between https://privacy-test-pages.site/features/autoconsent/autoconsent-index.html and https://privacy-test-pages.site/features/autoconsent/heuristic.html a few times, to verify that milestone pixels fire for conversion windows of `d0-5` and `d0-10`:
    `..._popupHandledMilestone_5_...` after 5 popups
    `..._popupHandledMilestone_10_...` after 10 popups
15. Open Privacy Dashboard and toggle protection off. Verify experiment pixel fires:
`..._privacyToggleUsed_true_...` with conversion windows d0-1, d0-5, d0-10
15. Open Privacy Dashboard → Report a problem with this site. Submit a breakage report.
16. Verify experiment pixel fires: `..._breakageReportSent_true_...` with conversion window d0-10
17. Verify that the breakage pixel (`epbf_macos_desktop`) includes the `consentHeuristicEnabled` parameter

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
3. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
5. **If the Class Does Not Exist:**
   - Add a new entry -->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security? -->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of
Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering
Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design
Template](https://app.asana.com/0/59792373528535/184709971311943)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces the CPM heuristic-action experiment and plumbs cohort info across native, pixels, and reporting.
> 
> - Adds experiment flag/cohorts (`FeatureFlag.heuristicAction`) and subfeature `AutoconsentSubfeature.heuristicAction`; enables local cohort overrides
> - Extends pixel API (`PixelFiring`) with `withAdditionalParameters`, updates mocks/tests, and passes `consentHeuristicEnabled` to Autoconsent, navigation timing, and summary pixels; updates pixel definitions
> - Autoconsent (macOS): resolves cohort, exposes `enableHeuristicAction` to JS, tracks usage (popupHandled/milestones, privacyToggleUsed, breakageReportSent), includes heuristic flag in dashboard state and pixels; adds reload-loop param to summary
> - Broken site reporting: augments `CookieConsentInfo` and report payload with `consentHeuristicEnabled`; iOS/macOS tests updated
> - Wires feature flagger into user scripts and privacy dashboard; navigation timing pixel now includes cohort param
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8cdf364c65549159cef9978f4468636f4183c5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL:
Tech Design URL:
CC:

### Description

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1.
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
