### PR TITLE
Fix: Adds missing Pixel Parameter to schema

### DIFF
--- a/macOS/PixelDefinitions/pixels/theme_pixels.json
+++ b/macOS/PixelDefinitions/pixels/theme_pixels.json
@@ -5,6 +5,6 @@
         "owners": ["jleandroperez"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["pixelSource", "themeName"]
+        "parameters": ["appVersion", "pixelSource", "themeName"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1212599947170615
Tech Design URL:
CC:

### Description
In this PR we're updating the `m_mac_theme_name_daily` pixel schema definition, so that it accounts for the `appVersion` parameter

### Testing Steps
- [ ] Verify the CI is green please!

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing really. This PR changes zero executable code

### Quality Considerations
Nothing in particular

### Notes to Reviewer
Thank you!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds missing schema field for the daily theme pixel.
> 
> - Updates `macOS/PixelDefinitions/pixels/theme_pixels.json` to include `appVersion` in `m_mac_theme_name_daily` pixel `parameters`
> - No runtime code changes; schema/documentation-only update
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2166122ce797f3b5d6802d237053bb42e4dc9d95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->