### PR TITLE
Pixels validation fix

### DIFF
--- a/macOS/PixelDefinitions/pixels/new_tab_page_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/new_tab_page_pixels.json5
@@ -18,7 +18,7 @@
         "description": "Fires when a user switches between search and DuckAI mode in the omnibar. Used to understand mode preference.",
         "owners": ["tomasstrba"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily"],
         "parameters": [
             {
                 "key": "mode",

--- a/macOS/PixelDefinitions/pixels/suggestion_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/suggestion_pixels.json5
@@ -4,7 +4,7 @@
         "description": "Fires when the user selects a phrase suggestion from the autocomplete results.",
         "owners": ["tomasstrba"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily"],
         "parameters": [
             {
                 "key": "source",
@@ -20,7 +20,7 @@
         "description": "Fires when the user selects a website suggestion from the autocomplete results.",
         "owners": ["tomasstrba"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily"],
         "parameters": [
             {
                 "key": "source",
@@ -36,7 +36,7 @@
         "description": "Fires when the user selects a history entry from the autocomplete results.",
         "owners": ["tomasstrba"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily"],
         "parameters": [
             {
                 "key": "source",
@@ -52,7 +52,7 @@
         "description": "Fires when the user selects a bookmark from the autocomplete results.",
         "owners": ["tomasstrba"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily"],
         "parameters": [
             {
                 "key": "source",
@@ -68,7 +68,7 @@
         "description": "Fires when the user selects a favorite from the autocomplete results.",
         "owners": ["tomasstrba"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily"],
         "parameters": [
             {
                 "key": "source",
@@ -84,7 +84,7 @@
         "description": "Fires when the user selects an open tab from the autocomplete results.",
         "owners": ["tomasstrba"],
         "triggers": ["other"],
-        "suffixes": [],
+        "suffixes": ["daily"],
         "parameters": [
             {
                 "key": "source",


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1212225738647339?focus=true
CC:

### Description
Fixing pixel definitions which failed live validation.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Verify the new version of pixel definitions is valid

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts pixel definitions to pass live validation by standardizing suffixes.
> 
> - Adds `daily` suffix to `m_mac_new-tab-page_omnibar_mode_changed`
> - Adds `daily` suffix to autocomplete click pixels: `phrase`, `website`, `history`, `bookmark`, `favorite`, `opentab` in `suggestion_pixels.json5`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9928412a8f31fc2daf060fd939fb5dbb09de7447. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->