### PR TITLE
iOS: Full Duck.ai Mode - Remove Temporary Experimental User Setting

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/iOS/PublicAPI/AIChatSettingsProvider.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/iOS/PublicAPI/AIChatSettingsProvider.swift
@@ -44,9 +44,6 @@ public protocol AIChatSettingsProvider {
     /// The user settings state for the AI Chat in tab manager
     var isAIChatTabSwitcherUserSettingsEnabled: Bool { get }
 
-    /// The user settings state for AI Chats as Tabs experimental feature
-    var isAIChatFullModeEnabled: Bool { get }
-
     /// The user settings state for automatically attaching page context
     var isAutomaticContextAttachmentEnabled: Bool { get }
 
@@ -67,9 +64,6 @@ public protocol AIChatSettingsProvider {
 
     /// Updates the user settings state for the AI Chat Search Input
     func enableAIChatSearchInputUserSettings(enable: Bool)
-
-    /// Updates the user settings state for the AI Chats as Tabs experimental feature
-    func enableAIChatFullModeSetting(enable: Bool)
 
     /// Updates the user settings state for the AI Chat automatic page context
     func enableAutomaticContextAttachment(enable: Bool)

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -317,9 +317,6 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Controls showing the Hide AI section in Settings -> AI Features
     case showHideAiGeneratedImages
 
-    /// Controls showing the AI Chat as Tabs Experiment Setting in Settings -> AI Features
-    case fullDuckAIModeExperimentalSetting
-
     /// Controls different input sizes and fade out animation for toggle.
     case fadeOutOnToggle
 

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -272,12 +272,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212229431540900
     case granularFireButtonOptions
 
-    /// https://app.asana.com/1/137249556945/project/72649045549333/task/1212281244797425?focus=true
-    case fullDuckAIModeExperimentalSetting
-    
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212305240287488?focus=true
     case dataImportWideEventMeasurement
-    
+
     /// Sort domain matches higher than other matches when searching saved passwords
     case autofillPasswordSearchPrioritizeDomain
 
@@ -379,7 +376,6 @@ extension FeatureFlag: FeatureFlagDescribing {
              .canPromoteAutofillExtensionInPasswordManagement,
              .autofillPasswordSearchPrioritizeDomain,
              .granularFireButtonOptions,
-             .fullDuckAIModeExperimentalSetting,
              .dataImportWideEventMeasurement,
              .ampBackgroundTaskSupport,
              .appRatingPrompt,
@@ -598,8 +594,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.productTelemetrySurfaceUsage))
         case .granularFireButtonOptions:
             return .disabled
-        case .fullDuckAIModeExperimentalSetting:
-            return .remoteReleasable(.subfeature(AIChatSubfeature.fullDuckAIModeExperimentalSetting))
         case .dataImportWideEventMeasurement:
             return .remoteReleasable(.subfeature(DataImportSubfeature.dataImportWideEventMeasurement))
         case .autofillPasswordSearchPrioritizeDomain:

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1384,8 +1384,6 @@ extension Pixel {
         case aiChatSettingsDisplayed
         case aiChatSettingsEnabled
         case aiChatSettingsDisabled
-        case aiChatSettingsFullModeEnabled
-        case aiChatSettingsFullModeDisabled
 
         case aiChatOpen
         case aiChatMetricStartNewConversation
@@ -2818,8 +2816,6 @@ extension Pixel.Event {
         case .aiChatSettingsDisabled: return "m_aichat_settings_disabled"
         case .aiChatSettingsSearchInputTurnedOff: return "m_aichat_settings_search_input_turned_off"
         case .aiChatSettingsSearchInputTurnedOn: return "m_aichat_settings_search_input_turned_on"
-        case .aiChatSettingsFullModeEnabled: return "m_aichat_settings_full_mode_enabled"
-        case .aiChatSettingsFullModeDisabled: return "m_aichat_settings_full_mode_disabled"
 
         case .aiChatOpen: return "m_aichat_open"
         case .aiChatMetricStartNewConversation: return "m_aichat_start_new_conversation"

--- a/iOS/DuckDuckGo/AIChat/AIChatFullMode/AIChatFullModeFeature.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatFullMode/AIChatFullModeFeature.swift
@@ -17,7 +17,6 @@
 //  limitations under the License.
 //
 
-import AIChat
 import Foundation
 import PrivacyConfig
 import Common
@@ -28,7 +27,7 @@ protocol AIChatFullModeFeatureProviding {
     /// Whether Duck AI full chat mode is available on this device.
     ///
     /// Returns `true` only when both conditions are met:
-    /// - The `fullDuckAIMode` feature flag is enabled OR the AI Chat as Tab experimental user setting is enabled
+    /// - The `fullDuckAIMode` feature flag is enabled
     /// - The device is running on an iPhone (not iPad or other devices)
     var isAvailable: Bool { get }
 }
@@ -46,25 +45,21 @@ struct AIChatFullModeFeature: AIChatFullModeFeatureProviding {
 
     private let featureFlagger: any FeatureFlagger
     private let devicePlatform: DevicePlatformProviding.Type
-    private let aiChatSettings: AIChatSettingsProvider
 
     /// Initializes with dependencies.
     ///
     /// - Parameters:
     ///   - featureFlagger: The feature flag provider. Defaults to the shared app dependency provider.
     ///   - devicePlatform: The device platform provider. Defaults to the actual `DevicePlatform`.
-    init(featureFlagger: any FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
-         devicePlatform: DevicePlatformProviding.Type = DevicePlatform.self,
-         aiChatSettings: AIChatSettingsProvider = AIChatSettings()) {
+    init(featureFlagger: any FeatureFlagger = AppDependencyProvider.shared.featureFlagger, devicePlatform: DevicePlatformProviding.Type = DevicePlatform.self) {
         self.featureFlagger = featureFlagger
         self.devicePlatform = devicePlatform
-        self.aiChatSettings = aiChatSettings
     }
 
     /// Whether Duck AI full chat mode is available.
     ///
-    /// Returns `true` only when both the feature flag OR experimental user setting is enabled AND the device is an iPhone.
+    /// Returns `true` only when both the feature flag is enabled AND the device is an iPhone.
     var isAvailable: Bool {
-        (featureFlagger.isFeatureOn(.fullDuckAIMode) || aiChatSettings.isAIChatFullModeEnabled) && devicePlatform.isIphone
+        featureFlagger.isFeatureOn(.fullDuckAIMode) && devicePlatform.isIphone
     }
 }

--- a/iOS/DuckDuckGo/AIChat/AIChatSettings.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatSettings.swift
@@ -131,11 +131,7 @@ final class AIChatSettings: AIChatSettingsProvider {
         keyValueStore.bool(.showAIChatExperimentalSearchInputKey, defaultValue: .showAIChatExperimentalSearchInputDefaultValue)
                             && isAIChatEnabled && featureFlagger.isFeatureOn(.experimentalAddressBar)
     }
-    
-    var isAIChatFullModeEnabled: Bool {
-        keyValueStore.bool(.isAIChatFullModeEnabledKey, defaultValue: .isAIChatFullModeEnabledDefaultValue)
-    }
-    
+
     var isAutomaticContextAttachmentEnabled: Bool {
         keyValueStore.bool(.isAIChatAutomaticContextAttachmentEnabledKey, defaultValue: .isAIChatAutomaticContextAttachmentDefaultValue)
     }
@@ -211,17 +207,6 @@ final class AIChatSettings: AIChatSettingsProvider {
             DailyPixel.fireDailyAndCount(pixel: .aiChatSettingsTabManagerTurnedOff)
         }
     }
-
-    func enableAIChatFullModeSetting(enable: Bool) {
-        keyValueStore.set(enable, forKey: .isAIChatFullModeEnabledKey)
-        triggerSettingsChangedNotification()
-        
-        if enable {
-            DailyPixel.fireDailyAndCount(pixel: .aiChatSettingsFullModeEnabled)
-        } else {
-            DailyPixel.fireDailyAndCount(pixel: .aiChatSettingsFullModeDisabled)
-        }
-    }
     
     func enableAutomaticContextAttachment(enable: Bool) {
         keyValueStore.set(enable, forKey: .isAIChatAutomaticContextAttachmentEnabledKey)
@@ -265,7 +250,6 @@ private extension String {
     static let showAIChatVoiceSearchKey = "aichat.settings.showAIChatVoiceSearch"
     static let showAIChatTabSwitcherKey = "aichat.settings.showAIChatTabSwitcher"
     static let showAIChatExperimentalSearchInputKey = "aichat.settings.showAIChatExperimentalSearchInput"
-    static let isAIChatFullModeEnabledKey = "aichat.settings.isAIChatFullModeEnabled"
     static let isAIChatAutomaticContextAttachmentEnabledKey = "aichat.settings.isAIChatAutomaticContextAttachmentEnabled"
 }
 
@@ -290,7 +274,6 @@ private extension Bool {
     static let showAIChatVoiceSearchDefaultValue = true
     static let showAIChatTabSwitcherDefaultValue = true
     static let showAIChatExperimentalSearchInputDefaultValue = false
-    static let isAIChatFullModeEnabledDefaultValue = false
     static let isAIChatAutomaticContextAttachmentDefaultValue = true
 
 }

--- a/iOS/DuckDuckGo/AIChat/ExperimentalAIChatManager.swift
+++ b/iOS/DuckDuckGo/AIChat/ExperimentalAIChatManager.swift
@@ -42,10 +42,6 @@ struct ExperimentalAIChatManager {
     var isExperimentalAIChatFeatureFlagEnabled: Bool {
         featureFlagger.isFeatureOn(for: FeatureFlag.experimentalAddressBar, allowOverride: true)
     }
-    
-    var fullDuckAIModeExperimentalSettingFlagEnabled: Bool {
-        featureFlagger.isFeatureOn(for: FeatureFlag.fullDuckAIModeExperimentalSetting, allowOverride: true) && devicePlatform.isIphone
-    }
 
     var isExperimentalAIChatSettingsEnabled: Bool {
         get {

--- a/iOS/DuckDuckGo/SettingsAIFeaturesView.swift
+++ b/iOS/DuckDuckGo/SettingsAIFeaturesView.swift
@@ -162,16 +162,6 @@ struct SettingsAIFeaturesView: View {
                     }
                 }
             }
-            
-            if viewModel.experimentalAIChatManager.fullDuckAIModeExperimentalSettingFlagEnabled {
-                Section {
-                    SettingsCellView(label: UserText.settingsEnableDuckAIFullModeTitle,
-                                     subtitle: UserText.settingsEnableDuckAIFullModeSubtitle,
-                                     accessory: .toggle(isOn: viewModel.isAIChatFullModeEnabled),
-                                     optionalBadgeText: UserText.settingsItemPreviewBadge)
-                }
-            }
-            
         }.applySettingsListModifiers(title: UserText.settingsAiFeatures,
                                      displayMode: .inline,
                                      viewModel: viewModel)

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -1471,19 +1471,7 @@ extension SettingsViewModel {
             }
         )
     }
-    
-    var isAIChatFullModeEnabled: Binding<Bool> {
-        Binding<Bool>(
-            get: { self.aiChatSettings.isAIChatFullModeEnabled },
-            set: { newValue in
-                withAnimation {
-                    self.objectWillChange.send()
-                    self.aiChatSettings.enableAIChatFullModeSetting(enable: newValue)
-                }
-            }
-        )
-    }
-    
+
     var isAutomaticContextAttachmentEnabled: Binding<Bool> {
         Binding<Bool>(
             get: { self.aiChatSettings.isAutomaticContextAttachmentEnabled },

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -35,8 +35,7 @@ public struct UserText {
     public static let webFavoriteRemoved = NSLocalizedString("web.url.remove.favorite.done", value: "Favorite removed", comment: "Confirmation message")
     public static let webSaveBookmarkNone = NSLocalizedString("web.url.save.bookmark.none", value: "No webpage to bookmark", comment: "Floating message indicating failure")
 
-    public static let settingsItemNewBadge = NSLocalizedString("settings.item.badge.new", value: "New", comment: "Copy for badge on settings item to show an item is new")
-    public static let settingsItemPreviewBadge = NSLocalizedString("settings.item.badge.preview", value: "Preview", comment: "Copy for badge on settings item to show an item is experimental")
+    public static let settingsItemNewBadge = NSLocalizedString("settings.item.badge.new", value: "New", comment: "Copy for budge on settings item to show an item is new")
     public static let actionPasteAndGo = NSLocalizedString("action.title.pasteAndGo", value: "Paste & Go", comment: "Paste and Go action")
     public static let actionRefresh = NSLocalizedString("action.title.refresh", value: "Refresh", comment: "Refresh action - button shown in alert")
     public static let actionAdd = NSLocalizedString("action.title.add", value: "Add", comment: "Add action - button shown in alert")
@@ -1852,13 +1851,9 @@ public struct UserText {
     public static let settingsEnableAiChat = NSLocalizedString("settings.enable.aichat", value: "Duck.ai", comment: "Settings screen cell text for enabling AI chat")
 
     public static let settingsEnableAiChatSubtitle = NSLocalizedString("settings.enable.aichat.subtitle", value: "Chat privately with popular 3rd-party AI models", comment: "A description of what the AI Chat toggle does")
-    
-    public static let settingsEnableDuckAIFullModeTitle = NSLocalizedString("settings.aifeatures.full.mode.title", value: "Duck.ai Tabs Mode", comment: "Settings screen cell title for enabling Duck.ai as tabs")
-    
-    public static let settingsEnableDuckAIFullModeSubtitle = NSLocalizedString("settings.aifeatures.full.mode.subtitle", value: "Show new Duck.ai Chats as tabs in the browser", comment: "Settings screen cell subtitle for enabling Duck.ai as tabs")
-    
+
     public static let settingsAutomaticPageContextTitle = NSLocalizedString("settings.aifeatures.automatic.context.title", value: "Automatically Send Context", comment: "Settings screen cell title for enabling automatic page context")
-    
+
     public static let settingsAutomaticPageContextSubtitle = NSLocalizedString("settings.aifeatures.automatic.context.subtitle", value: "Automatically send page context to Duck.ai", comment: "Settings screen cell subtitle for enabling automatic page context")
 
     public static let settingsAiFeaturesSearchAssist = NSLocalizedString("settings.aifeatures.assist", value: "Search Assist Settings", comment: "Title of search assist settings link")

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -2827,12 +2827,6 @@ Take back control of your personal information with the browser designed for dat
 /* Settings screen cell title for enabling automatic page context */
 "settings.aifeatures.automatic.context.title" = "Automatically Send Context";
 
-/* Settings screen cell subtitle for enabling Duck.ai as tabs */
-"settings.aifeatures.full.mode.subtitle" = "Show new Duck.ai Chats as tabs in the browser";
-
-/* Settings screen cell title for enabling Duck.ai as tabs */
-"settings.aifeatures.full.mode.title" = "Duck.ai Tabs Mode";
-
 /* Title of hide AI-generated images settings link */
 "settings.aifeatures.hide.ai.generated.images" = "Hide AI-Generated Images";
 
@@ -3036,9 +3030,6 @@ Take back control of your personal information with the browser designed for dat
 
 /* Copy for badge on settings item to show an item is new */
 "settings.item.badge.new" = "New";
-
-/* Copy for badge on settings item to show an item is experimental */
-"settings.item.badge.preview" = "Preview";
 
 /* Settings screen cell for Keyboard */
 "settings.keyboard" = "Keyboard";

--- a/iOS/DuckDuckGoTests/AIChat/AIChatFullModeFeatureTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatFullModeFeatureTests.swift
@@ -35,102 +35,60 @@ final class AIChatFullModeFeatureTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testIsAvailableWhenFeatureFlagOnAndIphone() {
+    func testIsAvailableWhenFeatureOnAndIphone() {
         // Given
         let mockFlagger = MockFeatureFlagger(enabledFeatureFlags: [.fullDuckAIMode])
-        let mockSettings = MockAIChatSettingsProvider(isAIChatFullModeEnabled: false)
         MockDevicePlatform.shared.mockIsIphone = true
 
         // When
         let feature = AIChatFullModeFeature(
             featureFlagger: mockFlagger,
-            devicePlatform: MockDevicePlatform.self,
-            aiChatSettings: mockSettings
+            devicePlatform: MockDevicePlatform.self
         )
 
         // Then
         XCTAssertTrue(feature.isAvailable)
     }
 
-    func testIsNotAvailableWhenFeatureFlagOnButNotIphone() {
+    func testIsNotAvailableWhenFeatureOnButNotIphone() {
         // Given
         let mockFlagger = MockFeatureFlagger(enabledFeatureFlags: [.fullDuckAIMode])
-        let mockSettings = MockAIChatSettingsProvider()
         MockDevicePlatform.shared.mockIsIphone = false
 
         // When
         let feature = AIChatFullModeFeature(
             featureFlagger: mockFlagger,
-            devicePlatform: MockDevicePlatform.self,
-            aiChatSettings: mockSettings
+            devicePlatform: MockDevicePlatform.self
         )
 
         // Then
         XCTAssertFalse(feature.isAvailable)
     }
 
-    func testIsNotAvailableWhenFeatureFlagOffAndUserSettingOffButIsIphone() {
+    func testIsNotAvailableWhenFeatureOffButIsIphone() {
         // Given
         let mockFlagger = MockFeatureFlagger(enabledFeatureFlags: [])
-        let mockSettings = MockAIChatSettingsProvider(isAIChatFullModeEnabled: false)
         MockDevicePlatform.shared.mockIsIphone = true
 
         // When
         let feature = AIChatFullModeFeature(
             featureFlagger: mockFlagger,
-            devicePlatform: MockDevicePlatform.self,
-            aiChatSettings: mockSettings
+            devicePlatform: MockDevicePlatform.self
         )
 
         // Then
         XCTAssertFalse(feature.isAvailable)
     }
 
-    func testIsNotAvailableWhenFeatureFlagOffAndUserSettingOffAndNotIphone() {
+    func testIsNotAvailableWhenFeatureOffAndNotIphone() {
         // Given
         let mockFlagger = MockFeatureFlagger(enabledFeatureFlags: [])
-        let mockSettings = MockAIChatSettingsProvider(isAIChatFullModeEnabled: false)
         MockDevicePlatform.shared.mockIsIphone = false
 
         // When
         let feature = AIChatFullModeFeature(
             featureFlagger: mockFlagger,
-            devicePlatform: MockDevicePlatform.self,
-            aiChatSettings: mockSettings
-        )
-
-        // Then
-        XCTAssertFalse(feature.isAvailable)
-    }
-
-    func testIsAvailableWhenFeatureFlagOffButUserSettingOnAndIphone() {
-        // Given
-        let mockFlagger = MockFeatureFlagger(enabledFeatureFlags: [])
-        let mockSettings = MockAIChatSettingsProvider(isAIChatFullModeEnabled: true)
-        MockDevicePlatform.shared.mockIsIphone = true
-
-        // When
-        let feature = AIChatFullModeFeature(
-            featureFlagger: mockFlagger,
-            devicePlatform: MockDevicePlatform.self,
-            aiChatSettings: mockSettings
-        )
-
-        // Then
-        XCTAssertTrue(feature.isAvailable)
-    }
-
-    func testIsNotAvailableWhenFeatureFlagOffAndUserSettingOnButNotIphone() {
-        // Given
-        let mockFlagger = MockFeatureFlagger(enabledFeatureFlags: [])
-        let mockSettings = MockAIChatSettingsProvider(isAIChatFullModeEnabled: true)
-        MockDevicePlatform.shared.mockIsIphone = false
-
-        // When
-        let feature = AIChatFullModeFeature(
-            featureFlagger: mockFlagger,
-            devicePlatform: MockDevicePlatform.self,
-            aiChatSettings: mockSettings
+            devicePlatform: MockDevicePlatform.self
         )
 
         // Then

--- a/iOS/PixelDefinitions/pixels/ai_chat_settings.json5
+++ b/iOS/PixelDefinitions/pixels/ai_chat_settings.json5
@@ -12,19 +12,5 @@
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor", "first_daily_count"],
         "parameters": ["appVersion"]
-    },
-    "m_aichat_settings_full_mode_enabled": {
-        "description": "Fired when user enables the Duck.ai Tabs Mode experimental setting in Settings > AI Features",
-        "owners": ["aataraxiaa"],
-        "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
-    },
-    "m_aichat_settings_full_mode_disabled": {
-        "description": "Fired when user disables the Duck.ai Tabs Mode experimental setting in Settings > AI Features",
-        "owners": ["aataraxiaa"],
-        "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
     }
 }

--- a/iOS/SharedTestUtils/Mocks/AIChat/MockAIChatSettingsProvider.swift
+++ b/iOS/SharedTestUtils/Mocks/AIChat/MockAIChatSettingsProvider.swift
@@ -31,7 +31,6 @@ public class MockAIChatSettingsProvider: AIChatSettingsProvider {
     public var isAIChatTabSwitcherUserSettingsEnabled: Bool
     public var sessionTimerInMinutes: Int
     public var isAIChatSearchInputUserSettingsEnabled: Bool
-    public var isAIChatFullModeEnabled: Bool
     public var isAutomaticContextAttachmentEnabled: Bool
 
     public init(aiChatURL: URL = URL(string: "https://example.com")!,
@@ -43,7 +42,6 @@ public class MockAIChatSettingsProvider: AIChatSettingsProvider {
                 isAIChatVoiceSearchUserSettingsEnabled: Bool = false,
                 isAIChatTabSwitcherUserSettingsEnabled: Bool = false,
                 isAIChatSearchInputUserSettingsEnabled: Bool = false,
-                isAIChatFullModeEnabled: Bool = false,
                 isAutomaticContextAttachmentEnabled: Bool = false,
                 sessionTimerInMinutes: Int = 60) {
 
@@ -55,7 +53,6 @@ public class MockAIChatSettingsProvider: AIChatSettingsProvider {
         self.isAIChatVoiceSearchUserSettingsEnabled = isAIChatVoiceSearchUserSettingsEnabled
         self.isAIChatTabSwitcherUserSettingsEnabled = isAIChatTabSwitcherUserSettingsEnabled
         self.isAIChatSearchInputUserSettingsEnabled = isAIChatSearchInputUserSettingsEnabled
-        self.isAIChatFullModeEnabled = isAIChatFullModeEnabled
         self.isAutomaticContextAttachmentEnabled = isAutomaticContextAttachmentEnabled
         self.sessionTimerInMinutes = sessionTimerInMinutes
     }
@@ -84,10 +81,6 @@ public class MockAIChatSettingsProvider: AIChatSettingsProvider {
         isAIChatSearchInputUserSettingsEnabled = enable
     }
 
-    public func enableAIChatFullModeSetting(enable: Bool) {
-        isAIChatFullModeEnabled = enable
-    }
-    
     public func enableAutomaticContextAttachment(enable: Bool) {
         isAutomaticContextAttachmentEnabled = enable
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212628942827006

### Description
This removes an experimental full duck.ai mode user setting by reverting commit 6b54e7229589ab3cb81b57cecad56f33edfb0ce5.

### Testing Steps
1. Navigate to Settings -> AI Features
2. Scroll through the entire screen
3. Expected: There should be NO "Duck.ai Tabs Mode" toggle anywhere on this screen

### Impact and Risks
Low

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the experimental Duck.ai Tabs Mode user toggle and consolidates full mode gating to the `fullDuckAIMode` feature flag on iPhone.
> 
> - Deletes `isAIChatFullModeEnabled` and `enableAIChatFullModeSetting` from `AIChatSettingsProvider` and their storage, pixels, and mocks
> - Removes the settings UI section, localized strings, and preview badge string used by the toggle
> - Drops feature flag/subfeature references for the experimental setting (e.g., `fullDuckAIModeExperimentalSetting`) and checks in `ExperimentalAIChatManager`
> - Updates `AIChatFullModeFeature` to depend solely on `featureFlagger.isFeatureOn(.fullDuckAIMode)` and iPhone; adjusts tests accordingly
> - Cleans up pixel definitions for full mode enabled/disabled
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d017434f84833e23b9e6f86e06182b61082eacf2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->