### PR TITLE
iOS: Restore Duck.ai Shortcut on NTP for Full Duck.ai Mode

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3595,11 +3595,13 @@ extension MainViewController: TabSwitcherDelegate {
 
     func tabSwitcherDidRequestAIChat(tabSwitcher: TabSwitcherViewController) {
         fireAIChatUsagePixelAndSetFeatureUsed(.openAIChatFromTabManager)
-        if aichatFullModeFeature.isAvailable {
-            openAIChat()
-        } else {
-            self.aiChatViewControllerManager.openAIChat(on: tabSwitcher)
-        }
+        self.aiChatViewControllerManager.openAIChat(on: tabSwitcher)
+    }
+    
+    func tabSwitcherDidRequestAIChatTab(tabSwitcher: TabSwitcherViewController) {
+        fireAIChatUsagePixelAndSetFeatureUsed(.openAIChatFromTabManager)
+        newTab(allowingKeyboard: false)
+        openAIChat()
     }
 }
 

--- a/iOS/DuckDuckGo/TabSwitcherDelegate.swift
+++ b/iOS/DuckDuckGo/TabSwitcherDelegate.swift
@@ -38,5 +38,7 @@ protocol TabSwitcherDelegate: AnyObject {
     func tabSwitcherDidBulkCloseTabs(tabSwitcher: TabSwitcherViewController)
 
     func tabSwitcherDidRequestAIChat(tabSwitcher: TabSwitcherViewController)
-
+    
+    /// Called when the tab switcher requests to open a new tab in AI Chat mode
+    func tabSwitcherDidRequestAIChatTab(tabSwitcher: TabSwitcherViewController)
 }

--- a/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
@@ -489,9 +489,10 @@ extension TabSwitcherViewController {
         barsHandler.duckChatButton.primaryAction = action(image: DesignSystemImages.Glyphs.Size24.aiChat, { [weak self] in
             guard let self else { return }
             if self.aichatFullModeFeature.isAvailable {
-                self.addNewTab()
+                addNewAIChatTab()
+            } else {
+                self.delegate.tabSwitcherDidRequestAIChat(tabSwitcher: self)
             }
-            self.delegate.tabSwitcherDidRequestAIChat(tabSwitcher: self)
         })
     }
 

--- a/iOS/DuckDuckGo/TabSwitcherViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController.swift
@@ -363,6 +363,15 @@ class TabSwitcherViewController: UIViewController {
         // If these calls are switched it'll be immediately dismissed along with this controller.
         delegate.tabSwitcherDidRequestNewTab(tabSwitcher: self)
     }
+    
+    func addNewAIChatTab() {
+        guard !isProcessingUpdates else { return }
+        canUpdateCollection = false
+        
+        dismiss()
+        
+        self.delegate.tabSwitcherDidRequestAIChatTab(tabSwitcher: self)
+    }
 
     func bookmarkTabs(withIndexPaths indexPaths: [IndexPath], viewModel: MenuBookmarksInteracting) -> BookmarkAllResult {
         let tabs = self.tabsModel.tabs


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212642307173601

### Description
This PR restores the Duck AI shortcut on a new tab page. When full Duck AI mode is enabled, this button will open a new tab with Duck AI. When full mode is disabled, it will go back to the old behavior of opening the sheet. 

### Testing Steps
### Test 1 - Open a new Duck AI tab when full mode is enabled. 
1. Ensure full duck.ai feature flag is enabled (it defaults to enabled for internal users)
2. Open the new tab page. 
3. Tap the Duck.ai shortcut in the top right. 
4. Ensure a new tab has opened with Dook AI. 

### Test 2 - Open the sheet when full Duck.ai mode is disabled
1. Ensure full duck.ai feature flag is disabled (it defaults to enabled for internal users)
2. Open the new tab page. 
3. Tap the Duck.ai shortcut in the top right. 
4. Ensure a Duck.ai sheet is opened

#### What could go wrong?
Incorrect behavior for a particular feature flag setting. 

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces full-mode-aware AI Chat entry from the Tab Switcher.
> 
> - Adds `tabSwitcherDidRequestAIChatTab` to `TabSwitcherDelegate` and implements it in `MainViewController` to `newTab(allowingKeyboard: false)` then `openAIChat()`
> - Adds `addNewAIChatTab()` in `TabSwitcherViewController` to dismiss and trigger the new delegate path
> - Updates AI Chat button action in `TabSwitcherViewController+MultiSelect` to branch: open new AI Chat tab when `aichatFullModeFeature.isAvailable`, else call existing `tabSwitcherDidRequestAIChat`
> - Shows the AI Chat button based on `aiChatSettings.isAIChatTabSwitcherUserSettingsEnabled` only (removes previous `!aichatFullModeFeature.isAvailable` condition)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05c2b3ef83b426c74e6bcbbf18224cbf3f30094a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->