### PR TITLE
attributed_metric_data_store_error definition fix

### DIFF
--- a/iOS/PixelDefinitions/pixels/attributed_metric.json5
+++ b/iOS/PixelDefinitions/pixels/attributed_metric.json5
@@ -273,6 +273,6 @@
         "owners": ["federicocappelli"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
+        "parameters": ["errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain", "appVersion", "pixelSource"]
     }
 }

--- a/macOS/PixelDefinitions/pixels/attributed_metric.json5
+++ b/macOS/PixelDefinitions/pixels/attributed_metric.json5
@@ -273,6 +273,6 @@
         "owners": ["federicocappelli"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
+        "parameters": ["errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain", "appVersion", "pixelSource"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205842942115003/task/1212599958906615

### Description

attributed_metric_data_store_error definition fix

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends the attributed metric data store error pixel definitions to capture additional context.
> 
> - iOS `iOS/PixelDefinitions/pixels/attributed_metric.json5`: `attributed_metric_data_store_error` now includes `appVersion` and `pixelSource` in `parameters`
> - macOS `macOS/PixelDefinitions/pixels/attributed_metric.json5`: `m_mac_attributed_metric_data_store_error` now includes `appVersion` and `pixelSource` in `parameters`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b49bce2dcf6b241f277fbb15f9ebc2582aafc8f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->