### PR TITLE
[macOS] Add feature flag for Next Steps single card iteration

### DIFF
--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -274,7 +274,8 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1201621853593513/task/1212068164128054?focus=true
     case heuristicAction
 
-    /// https://app.asana.com/1/137249556945/project/1209825025475019/task/1212292190049422?focus=true
+    /// Next Steps cards iteration with single card displayed on New Tab page
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212634388261605?focus=true
     case nextStepsSingleCardIteration
 }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1212359353583686?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1212359353583683?focus=true

### Description

This adds a feature flag for the new "Next Steps" iteration, which will show a single "Next Steps" card at a time for onboarding on the New Tab page. The new feature flag is currently disabled, with a local override option.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Go to Debug menu and set Internal User State.
2. Go to Debug -> Feature Flag Overrides -> Other and confirm there is a `nextStepsSingleCardIteration` feature flag defaulting to OFF.

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling, documentation

### Notes to Reviewer

The plan is to implement this as a fallback feature flag, so there won't be a corresponding privacy config flag unless we need to disable it after shipping. We will enable this for internal users when the implementation is ready to test, and release it remotely after ship review.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new feature flag for the Next Steps single-card onboarding iteration.
> 
> - Introduces `FeatureFlag.nextStepsSingleCardIteration` in `FeatureFlag.swift`
> - Defaults to OFF (`source: .disabled`) and supports local overriding
> - Included in `supportsLocalOverriding` switch for debug overrides
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7688f97a9e62d94f80b17068cad004d0925ce4c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->