### PR TITLE
Fix VPN pixel parameter keys to match schema

### DIFF
--- a/SharedPackages/VPN/Sources/VPN/Subscription/VPNSubscriptionClientCheckPixel.swift
+++ b/SharedPackages/VPN/Sources/VPN/Subscription/VPNSubscriptionClientCheckPixel.swift
@@ -93,8 +93,8 @@ public enum VPNSubscriptionClientCheckPixel: PixelKitEvent, PixelKitEventWithCus
             }()
 
             return [
-                "isSubscriptionActive": isSubscriptionActiveString,
-                "authVersion": isAuthV2 ? "v2" : "v1"
+                "vpnSubscriptionActive": isSubscriptionActiveString,
+                "vpnAuthVersion": isAuthV2 ? "v2" : "v1"
             ]
         }
     }

--- a/SharedPackages/VPN/Tests/VPNTests/Subscription/VPNSubscriptionClientCheckPixelTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/Subscription/VPNSubscriptionClientCheckPixelTests.swift
@@ -104,8 +104,8 @@ final class VPNSubscriptionClientCheckPixelTests: XCTestCase {
 
         let parameters = pixel.parameters
         XCTAssertNotNil(parameters)
-        XCTAssertEqual(parameters?["isSubscriptionActive"], "true")
-        XCTAssertEqual(parameters?["authVersion"], "v2")
+        XCTAssertEqual(parameters?["vpnSubscriptionActive"], "true")
+        XCTAssertEqual(parameters?["vpnAuthVersion"], "v2")
     }
 
     func testParameters_activeSubscriptionAuthV1() {
@@ -117,8 +117,8 @@ final class VPNSubscriptionClientCheckPixelTests: XCTestCase {
 
         let parameters = pixel.parameters
         XCTAssertNotNil(parameters)
-        XCTAssertEqual(parameters?["isSubscriptionActive"], "true")
-        XCTAssertEqual(parameters?["authVersion"], "v1")
+        XCTAssertEqual(parameters?["vpnSubscriptionActive"], "true")
+        XCTAssertEqual(parameters?["vpnAuthVersion"], "v1")
     }
 
     func testParameters_inactiveSubscription() {
@@ -130,8 +130,8 @@ final class VPNSubscriptionClientCheckPixelTests: XCTestCase {
 
         let parameters = pixel.parameters
         XCTAssertNotNil(parameters)
-        XCTAssertEqual(parameters?["isSubscriptionActive"], "false")
-        XCTAssertEqual(parameters?["authVersion"], "v2")
+        XCTAssertEqual(parameters?["vpnSubscriptionActive"], "false")
+        XCTAssertEqual(parameters?["vpnAuthVersion"], "v2")
     }
 
     func testParameters_nilSubscription() {
@@ -143,8 +143,8 @@ final class VPNSubscriptionClientCheckPixelTests: XCTestCase {
 
         let parameters = pixel.parameters
         XCTAssertNotNil(parameters)
-        XCTAssertEqual(parameters?["isSubscriptionActive"], "no_subscription")
-        XCTAssertEqual(parameters?["authVersion"], "v2")
+        XCTAssertEqual(parameters?["vpnSubscriptionActive"], "no_subscription")
+        XCTAssertEqual(parameters?["vpnAuthVersion"], "v2")
     }
 
     func testParameters_failedPixel() {
@@ -158,8 +158,8 @@ final class VPNSubscriptionClientCheckPixelTests: XCTestCase {
 
         let parameters = pixel.parameters
         XCTAssertNotNil(parameters)
-        XCTAssertEqual(parameters?["isSubscriptionActive"], "true")
-        XCTAssertEqual(parameters?["authVersion"], "v1")
+        XCTAssertEqual(parameters?["vpnSubscriptionActive"], "true")
+        XCTAssertEqual(parameters?["vpnAuthVersion"], "v1")
     }
 
     // MARK: - Error Handling Tests
@@ -260,13 +260,13 @@ final class VPNSubscriptionClientCheckPixelTests: XCTestCase {
 
             let parameters = pixel.parameters
             XCTAssertNotNil(parameters, "Parameters should never be nil")
-            XCTAssertNotNil(parameters?["isSubscriptionActive"], "isSubscriptionActive should always be present")
-            XCTAssertNotNil(parameters?["authVersion"], "authVersion should always be present")
+            XCTAssertNotNil(parameters?["vpnSubscriptionActive"], "isSubscriptionActive should always be present")
+            XCTAssertNotNil(parameters?["vpnAuthVersion"], "authVersion should always be present")
 
             // Verify specific values
             let expectedSubscriptionValue = isActive != nil ? String(isActive!) : "no_subscription"
-            XCTAssertEqual(parameters?["isSubscriptionActive"], expectedSubscriptionValue)
-            XCTAssertEqual(parameters?["authVersion"], isAuthV2 ? "v2" : "v1")
+            XCTAssertEqual(parameters?["vpnSubscriptionActive"], expectedSubscriptionValue)
+            XCTAssertEqual(parameters?["vpnAuthVersion"], isAuthV2 ? "v2" : "v1")
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1212225750919133?focus=true

### Description

Update parameter keys in VPNSubscriptionClientCheckPixel.swift:
- 'isSubscriptionActive' → 'vpnSubscriptionActive'
- 'authVersion' → 'vpnAuthVersion'

These keys were renamed in the JSON schema during the 'Deduplicate common pixel parameters' refactor (7f9c219689) but the Swift code was not updated to match.

I notified possible dashboard DRIs [here](https://app.asana.com/1/137249556945/task/1212225750919133/comment/1212629003413431?focus=true).

### Testing Steps

Just make sure the CI goes green.

### Impact and Risks

Medium.  This could affect existing panels and dashboards.

#### What could go wrong?

Panels using these parameters could be affected.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns VPN subscription client check pixel parameter keys with the current schema.
> 
> - Rename `isSubscriptionActive` → `vpnSubscriptionActive` and `authVersion` → `vpnAuthVersion` in `VPNSubscriptionClientCheckPixel.swift`
> - Update unit tests to assert the new parameter keys in all cases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b430b8170da5bb0c2f713137255a9aa95badf14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->