### PR TITLE
Add profile existence check to PIR foreground scans

### DIFF
--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
@@ -256,6 +256,11 @@ extension DataBrokerProtectionIOSManager: DBPIOSInterface.AppLifecycleEventsDele
 
         guard await authenticationManager.isUserAuthenticated else { return }
 
+        guard (try? meetsProfileRunPrequisite) == true else {
+            Logger.dataBrokerProtection.log("No profile, skipping foreground operations")
+            return
+        }
+
         if featureFlagger.isForegroundRunningOnAppActiveFeatureOn {
             await startImmediateScanOperations()
         } else {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1212657034943466?focus=true
Tech Design URL:
CC: @edulpn @THISISDINOSAUR 

### Description

This fixes an issue where Scan complete notification fires without a PIR profile.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. In `DefaultDataBrokerProtectionUserNotificationService.sendFirstScanCompletedNotification`, comment out the `userDefaults` check
2. Build & run the app
3. Set up as internal user and restore your subscription
4. Background then foreground the app
5. You shouldn’t see the notification being sent to Notification Center.

(Without the fix, in Step 5 you’ll see the notification being incorrectly fired)

<!— 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
7. **If the Class Does Not Exist:**
   - Add a new entry
—>

### Impact and Risks

Low, but confusing to users. 

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents foreground PIR operations when no profile is present.
> 
> - Adds a `meetsProfileRunPrequisite` guard in `appDidBecomeActive` to skip foreground scans and email confirmation checks when the user lacks a profile, with a log message for visibility
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d577f60b5e0a6ff1fc6231406865343e08551ef1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->