### PR TITLE
Enables Themes Feature Flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -146,6 +146,10 @@ public enum MacOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866479296718
     case tabProgressIndicator
 
+    /// Feature flag for Themes
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866720557742
+    case themes
+
     /// Feature Flag for the First Time Quit Survey
     /// https://app.asana.com/1/137249556945/inbox/1203972458584425/item/1212200919350194/story/1212483080081687
     case firstTimeQuitSurvey

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -307,7 +307,8 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .dataImportWideEventMeasurement,
                 .tabProgressIndicator,
                 .firstTimeQuitSurvey,
-                .autofillPasswordSearchPrioritizeDomain:
+                .autofillPasswordSearchPrioritizeDomain,
+                .themes:
             true
         default:
             false
@@ -505,7 +506,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .syncFeatureLevel3:
             return .remoteReleasable(.subfeature(SyncSubfeature.level3AllowCreateAccount))
         case .themes:
-            return .internalOnly()
+            return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.themes))
         case .appStoreUpdateFlow:
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.appStoreUpdateFlow))
         case .unifiedURLPredictor:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211614056848693?focus=true
Tech Design URL:
CC:

### Description
Enable the Themes Feature Flag.

Thanks in advance @ayoy !! Will **only be merged** when the Ship Review gets green light.

### Testing Steps
1. Fresh install the Browser
2. Open `Settings > Appearance`

- [ ] Verify there's a `Themes` switcher
- [ ] Verify you can effectively change the active Theme
- [ ] Verify the `Reset` button gets you back to the default THeme

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
There have been (tons) of changes, individually reviewed, and tested in Internal for months.
I don't expect anything to go terribly wrong.

### Quality Considerations
Nothing in particular

### Notes to Reviewer
Thank you!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables Themes feature flag for macOS and wires it to remote config.
> 
> - Adds `themes` to `MacOSBrowserConfigSubfeature` in `PrivacyFeature.swift`
> - Sets `FeatureFlag.themes` `defaultValue` to `true`
> - Changes `FeatureFlag.themes` `source` from internal-only to `remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.themes))`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd95bebf47d88b13779803af5b9f0ae8993b0fc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->