### PR TITLE
Remove automatic switch to duck.ai

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextEditor.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextEditor.swift
@@ -171,14 +171,6 @@ final class AddressBarTextEditor: NSTextView {
     }
 
     override func paste(_ sender: Any?) {
-        /// Check if pasted text contains newlines and should switch to AI chat mode
-        if let pastedString = NSPasteboard.general.string(forType: .string),
-           pastedString.contains("\n"),
-           let addressBar = addressBar,
-           addressBar.handleMultilinePaste(pastedString) {
-            return
-        }
-
         // Fixes an issue when url-name instead of url is pasted
         if let url = NSPasteboard.general.url {
             super.pasteAsPlainText(url.absoluteString)

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -418,26 +418,6 @@ final class AddressBarTextField: NSTextField {
         PixelKit.fire(pixel, frequency: .dailyAndCount, includeAppVersionParameter: true)
     }
 
-    /// Handles paste of multiline text by switching to AI chat mode if conditions are met
-    /// - Parameter text: The pasted text containing newlines
-    /// - Returns: `true` if the text was handled by switching to AI chat mode, `false` otherwise
-    func handleMultilinePaste(_ text: String) -> Bool {
-        guard Application.appDelegate.featureFlagger.isFeatureOn(.aiChatOmnibarToggle),
-              let aiChatPreferences = aiChatPreferences,
-              aiChatPreferences.isAIFeaturesEnabled,
-              aiChatPreferences.showSearchAndDuckAIToggle,
-              let toggleControl = customToggleControl as? CustomToggleControl,
-              !toggleControl.isHidden,
-              toggleControl.isEnabled,
-              toggleControl.selectedSegment == 0 else {
-            return false
-        }
-
-        sharedTextState?.updateText(text, markInteraction: true)
-        toggleControl.selectedSegment = 1
-        return true
-    }
-
     private func navigate(suggestion: Suggestion?) {
         switch suggestion {
         case .bookmark,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1212659307786438?focus=true

### Description
Remove automatic switch to duck.ai when pasting text with multiple lines

### Testing Steps
1. Make sure the duck.ai toggle is enabled
2. Paste a text in the search bar that contains a new line
3. Make sure we DO NOT automatically switch to duck.ai


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
Regression when pasting text

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the automatic AI chat toggle when multiline text is pasted into the address bar.
> 
> - Deletes `handleMultilinePaste(_:)` from `AddressBarTextField`
> - Removes multiline-paste interception in `AddressBarTextEditor.paste(_:)`
> - Paste now uses existing behavior: if pasteboard has a `URL`, inserts its string via `pasteAsPlainText`, otherwise performs standard paste
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fafc08da8c68fc835346535e70a43a1f3aa3785. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->