### PR TITLE
Remove amp feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/LinkProtection/AMPCanonicalExtractor.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/LinkProtection/AMPCanonicalExtractor.swift
@@ -62,7 +62,6 @@ public final class AMPCanonicalExtractor: NSObject {
     private let privacyManager: PrivacyConfigurationManaging
     private let contentBlockingManager: CompiledRuleListsSource
     private let errorReporting: EventMapping<AMPProtectionDebugEvents>?
-    private let useBackgroundTaskProtection: Bool
 
     private var privacyConfig: PrivacyConfiguration { privacyManager.privacyConfig }
 
@@ -72,13 +71,11 @@ public final class AMPCanonicalExtractor: NSObject {
     public init(linkCleaner: LinkCleaner,
                 privacyManager: PrivacyConfigurationManaging,
                 contentBlockingManager: CompiledRuleListsSource,
-                errorReporting: EventMapping<AMPProtectionDebugEvents>? = nil,
-                useBackgroundTaskProtection: Bool = false) {
+                errorReporting: EventMapping<AMPProtectionDebugEvents>? = nil) {
         self.linkCleaner = linkCleaner
         self.privacyManager = privacyManager
         self.contentBlockingManager = contentBlockingManager
         self.errorReporting = errorReporting
-        self.useBackgroundTaskProtection = useBackgroundTaskProtection
 
         super.init()
 
@@ -136,13 +133,7 @@ public final class AMPCanonicalExtractor: NSObject {
 
         let ampKeywords = settings.ampKeywords
 
-        if useBackgroundTaskProtection {
-            return performAMPDetectionWithBackgroundTask(urlStr: urlStr, ampKeywords: ampKeywords)
-        } else {
-            return ampKeywords.contains { keyword in
-                return urlStr.contains(keyword)
-            }
-        }
+        return performAMPDetectionWithBackgroundTask(urlStr: urlStr, ampKeywords: ampKeywords)
     }
 
     private func performAMPDetectionWithBackgroundTask(urlStr: String, ampKeywords: [String]) -> Bool {

--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/LinkProtection/LinkProtection.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/LinkProtection/LinkProtection.swift
@@ -29,14 +29,12 @@ public struct LinkProtection {
 
     public init(privacyManager: PrivacyConfigurationManaging,
                 contentBlockingManager: CompiledRuleListsSource,
-                errorReporting: EventMapping<AMPProtectionDebugEvents>,
-                useBackgroundTaskProtection: Bool = false) {
+                errorReporting: EventMapping<AMPProtectionDebugEvents>) {
         linkCleaner = LinkCleaner(privacyManager: privacyManager)
         ampExtractor = AMPCanonicalExtractor(linkCleaner: linkCleaner,
                                              privacyManager: privacyManager,
                                              contentBlockingManager: contentBlockingManager,
-                                             errorReporting: errorReporting,
-                                             useBackgroundTaskProtection: useBackgroundTaskProtection)
+                                             errorReporting: errorReporting)
     }
 
     private func makeNewRequest(changingUrl url: URL, inRequest request: URLRequest) -> URLRequest {

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -177,9 +177,6 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/72649045549333/task/1211660503405838?focus=true
     case forgetAllInSettings
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212397873940926?focus=true
-    case ampBackgroundTaskSupport
-
     /// https://app.asana.com/1/137249556945/project/481882893211075/task/1212057154681076?focus=true
     case productTelemetrySurfaceUsage
 

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -218,9 +218,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866614199859
     case forgetAllInSettings
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212397873940926?focus=true
-    case ampBackgroundTaskSupport
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866470156149
     case duckAiDataClearing
     
@@ -306,7 +303,6 @@ extension FeatureFlag: FeatureFlagDescribing {
              .migrateKeychainAccessibility,
              .dataImportWideEventMeasurement,
              .browsingMenuSheetPresentation,
-             .ampBackgroundTaskSupport,
              .appRatingPrompt,
              .autofillPasswordSearchPrioritizeDomain,
              .showWhatsNewPromptOnDemand:
@@ -373,7 +369,6 @@ extension FeatureFlag: FeatureFlagDescribing {
              .autofillPasswordSearchPrioritizeDomain,
              .granularFireButtonOptions,
              .dataImportWideEventMeasurement,
-             .ampBackgroundTaskSupport,
              .appRatingPrompt,
              .contextualDuckAIMode,
              .aiChatSync,
@@ -552,8 +547,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.vpnMenuItem))
         case .forgetAllInSettings:
             return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.forgetAllInSettings))
-        case .ampBackgroundTaskSupport:
-            return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.ampBackgroundTaskSupport))
         case .duckAiDataClearing:
             return .remoteReleasable(.feature(.duckAiDataClearing))
         case .fullDuckAIMode:

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/jwt-kit.git",
       "state" : {
-        "revision" : "c2595b9ad7f512d7f334830b4df1fed6e917946a",
-        "version" : "4.13.4"
+        "revision" : "13e7513b3ba0afa13967daf77af2fb4ad087306c",
+        "version" : "4.13.5"
       }
     },
     {
@@ -88,15 +88,6 @@
       "state" : {
         "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
         "version" : "9.1.0"
-      }
-    },
-    {
-      "identity" : "opencombine",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/OpenCombine/OpenCombine.git",
-      "state" : {
-        "revision" : "8576f0d579b27020beccbccc3ea6844f3ddfc2c2",
-        "version" : "0.14.0"
       }
     },
     {

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -359,8 +359,7 @@ class TabViewController: UIViewController {
     private lazy var linkProtection: LinkProtection = {
         LinkProtection(privacyManager: privacyConfigurationManager,
                        contentBlockingManager: ContentBlocking.shared.contentBlockingManager,
-                       errorReporting: Self.debugEvents,
-                       useBackgroundTaskProtection: featureFlagger.isFeatureOn(.ampBackgroundTaskSupport))
+                       errorReporting: Self.debugEvents)
     }()
     
     private lazy var referrerTrimming: ReferrerTrimming = {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212683300462209?focus=true

### Description
Remove feature flag for amp protection in bg tasks (now is always on)

### Testability Challenges
Make sure the app compiles

### Impact and Risks
None: Internal tooling, documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes AMP background-task protection always on and removes the related feature flag and code paths.
> 
> - Deletes `ampBackgroundTaskSupport` from feature definitions (`PrivacyFeature`, `FeatureFlag` defaults/support/source)
> - Simplifies `AMPCanonicalExtractor` and `LinkProtection` initializers by removing `useBackgroundTaskProtection`; `urlContainsAMPKeyword` now always uses background-task detection
> - Updates `TabViewController` to construct `LinkProtection` without the feature flag
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b2e16bcf701366fde99f6641b538688cd9dfe8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->