### PR TITLE
Update AI Chat Maestro test for full mode

### DIFF
--- a/.maestro/release_tests/ai-chat.yaml
+++ b/.maestro/release_tests/ai-chat.yaml
@@ -1,4 +1,4 @@
-# bookmarks.yaml
+# ai-chat.yaml
 appId: com.duckduckgo.mobile.ios
 tags:
     - iphone
@@ -6,44 +6,49 @@ tags:
 
 ---
 
-# Set up 
-- runFlow: 
+# Set up
+- runFlow:
     file: ../shared/setup.yaml
 
-# New tab screen
+# New tab screen - tap Duck.ai button
 - assertVisible: "Duck.ai"
 - tapOn: "Duck.ai"
 - assertVisible:
-    id: "AIChatViewController"
-- tapOn: "Close 24"
+    id: "AIChatFullModeBranding"
 
-# Browsing
+# Navigate away via Tab Switcher to test browsing menu access
+- tapOn: "Tab Switcher"
+- tapOn: "New Tab"
+- tapOn: "Cancel"
 - assertVisible:
     id: "searchEntry"
 - tapOn:
     id: "searchEntry"
 - inputText: "https://privacy-test-pages.site"
 - pressKey: Enter
-- assertVisible: "Duck.ai"
-- tapOn: "Duck.ai"
-- assertVisible:
-    id: "AIChatViewController"
-- tapOn: "Close 24"
+- assertVisible: ".*Privacy Test Pages.*"
 
-# Tab Switcher
+# Browsing - test Duck.ai access from browsing menu (shows as "New Chat" in full mode)
+- tapOn: "Browsing Menu"
+- assertVisible: "New Chat"
+- tapOn: "New Chat"
+- assertVisible:
+    id: "AIChatFullModeBranding"
+
+# Tab Switcher - test Duck.ai access
 - tapOn: "Tab Switcher"
 - assertVisible: "Duck.ai"
 - tapOn: "Duck.ai"
 - assertVisible:
-    id: "AIChatViewController"
-- tapOn: "Close 24"
+    id: "AIChatFullModeBranding"
+- tapOn: "Tab Switcher"
 - tapOn: "New Tab"
 
 # Turn it off
 - tapOn: "Cancel"
 - tapOn: "Browsing Menu"
 - tapOn: "Settings"
-- scrollUntilVisible: 
+- scrollUntilVisible:
     element: "AI Features"
     direction: DOWN
 - tapOn: "AI Features"
@@ -53,20 +58,24 @@ tags:
 - tapOn: "Settings"
 - tapOn: "Done"
 
-# New tab screen
+# New tab screen - Duck.ai should not be visible
 - assertNotVisible: "Duck.ai"
 
-# Browsing
+# Browsing - New Chat should not be visible in menu
 - assertVisible:
     id: "searchEntry"
 - tapOn:
     id: "searchEntry"
 - inputText: "https://privacy-test-pages.site"
 - pressKey: Enter
-- assertNotVisible: "Duck.ai"
+- assertVisible: ".*Privacy Test Pages.*"
+- tapOn: "Browsing Menu"
+- assertNotVisible: "New Chat"
+# Dismiss menu by tapping Settings then backing out
+- tapOn: "Settings"
+- tapOn: "Done"
 
-# Tab Switcher
+# Tab Switcher - Duck.ai should not be visible
 - tapOn: "Tab Switcher"
 - assertNotVisible: "Duck.ai"
-
 

--- a/iOS/DuckDuckGo/AIChat/AIChatFullMode/AIChatFullModeOmniBrandingView.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatFullMode/AIChatFullModeOmniBrandingView.swift
@@ -47,6 +47,7 @@ final class AIChatFullModeOmniBrandingView: UIView {
 
     private func setupViews() {
         backgroundColor = .clear
+        accessibilityIdentifier = "AIChatFullModeBranding"
 
         stackView.axis = .horizontal
         stackView.alignment = .center


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1212653482894595?focus=true

### Description
Updates the AI Chat Maestro test to work with Duck.ai full mode. The existing test was failing because full mode uses a webpage in a tab instead of the modal `AIChatViewController`, requiring different element identifiers and navigation patterns.

### Testing Steps

#### Test - Maestro AI Chat Test Passes
1. Run `./.maestro/run_ui_tests.sh .maestro/release_tests/ai-chat.yaml`
2. Verify the test passes with all assertions completing successfully

### Impact and Risks
Low risk - This only modifies test infrastructure and adds an accessibility identifier to an existing view.

#### What could go wrong?
N/A - Changes are isolated to test infrastructure.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns the AI Chat Maestro flow with full-mode behavior and add a stable identifier for assertions.
> 
> - Rewrites `.maestro/release_tests/ai-chat.yaml` to navigate via Tab Switcher and Browsing Menu, assert "New Chat" in full mode, and verify Duck.ai visibility on enable/disable states; asserts now target `AIChatFullModeBranding` and page content
> - Sets `accessibilityIdentifier = "AIChatFullModeBranding"` in `AIChatFullModeOmniBrandingView` for reliable UI testing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5db23b74f6340c9c00a40c8084e989b9ba2796ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->