### PR TITLE
Reinstate permissions screen for bookmarks import

### DIFF
--- a/macOS/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
+++ b/macOS/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
@@ -70,6 +70,7 @@ struct DataImportViewModel {
         case profilePicker
         case moreInfo
         case passwordEntryHelp
+        case getReadPermission(URL)
         case fileImport(dataType: DataType, summary: DataImportSummary = [:])
         case archiveImport(dataTypes: Set<DataType>, summary: DataImportSummary? = nil)
         case summary(DataImportSummary)
@@ -458,6 +459,12 @@ struct DataImportViewModel {
                     PixelKit.fire(GeneralPixel.dataImportFailed(source: importSource.pixelSourceParameterName, sourceVersion: importSource.installedAppsMajorVersionDescription(selectedProfile: selectedProfile), error: importError), frequency: .dailyAndStandard)
                 }
 
+                // On macOS < 15.2, show permission request screen to let user grant access
+                if #unavailable(macOS 15.2) {
+                    screen = .getReadPermission(url)
+                    return true
+                }
+
             default: continue
             }
         }
@@ -840,6 +847,8 @@ extension DataImportViewModel {
             return .continue
         case .moreInfo:
             return initiateImport()
+        case .getReadPermission:
+            return nil
         case .passwordEntryHelp:
             return nil
 
@@ -867,7 +876,7 @@ extension DataImportViewModel {
             switch screen {
             case .sourceAndDataTypesPicker:
                 return .cancel
-            case .archiveImport, .profilePicker, .moreInfo:
+            case .archiveImport, .profilePicker, .moreInfo, .getReadPermission:
                 return .back
             case .passwordEntryHelp:
                 return .cancel

--- a/macOS/DuckDuckGo/DataImport/View/DataImportView.swift
+++ b/macOS/DuckDuckGo/DataImport/View/DataImportView.swift
@@ -117,6 +117,12 @@ struct DataImportView: ModalView {
                 )
             case .moreInfo:
                 NewImportMoreInfoView()
+            case .getReadPermission(let url):
+                RequestFilePermissionView(source: model.importSource, url: url, requestDataDirectoryPermission: SafariDataImporter.requestDataDirectoryPermission) { _ in
+                    model.initiateImport()
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 12)
             case .passwordEntryHelp:
                 PasswordEntryRetryPromptView(
                     onRetry: {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1212512950412402?focus=true
Tech Design URL:
CC:

### Description

This PR reinstates the Safari permissions screen for the new import flow for macOS versions older than 15.2. These versions use the legacy Safari import which requires access to Safari's bookmarks plist. The previous legacy flow had a screen it showed if we did not have access to this file, allowing the user to select their Safari folder and proceed. This was left out of the new import experience, meaning that these users would just see a 'failed to import bookmarks' error – although they would be given the opportunity to manually import a zip file:

| Current error | Reinstated permissions dialog | Selecting Safari folder | Successful import |
|--------------|--------------|--------------|--------------|
| <img alt="Screenshot 2026-01-08 at 08 31 30" src="https://github.com/user-attachments/assets/62bc1ccb-1377-40dc-b145-81ba39630ed9" /> | <img alt="Screenshot 2026-01-08 at 08 11 09" src="https://github.com/user-attachments/assets/7068e644-edd8-4ce7-9498-d0d33c2d6c8b" /> | <img alt="Screenshot 2026-01-08 at 08 11 15" src="https://github.com/user-attachments/assets/f1d55010-0b59-4520-8dbb-0b5b9afb1896" /> | <img alt="Screenshot 2026-01-08 at 08 11 20" src="https://github.com/user-attachments/assets/de66bbb2-5f95-455a-91cc-a38b5b0a1d83" /> |

### Testing Steps

1. Verify the Safari bookmarks import flow still works correctly on iOS 15.2+
2. Create a virtual machine on 15.1 or lower (I used VirtualBuddy). Create some bookmarks in Safari. Transfer a copy of the app to it, and try importing Safari bookmarks. You should see the permissions screen shown above. Click through, select your Safari folder (this should be preselected) and ensure your bookmarks are imported.

### Impact and Risks

Medium: Could disrupt specific features or user flows

I think this should just be an improvement to the existing Safari flow for users on older versions of macOS, and should not affect users on newer versions.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores the legacy permission-grant flow so users on older macOS can proceed with Safari bookmarks import after a file access denial.
> 
> - Adds `Screen.getReadPermission(URL)` and routes to it on `.fileReadNoPermission` for `#unavailable(macOS 15.2)`
> - Displays `RequestFilePermissionView` in `DataImportView` and re-initiates import after permission is granted
> - Updates button logic: no primary action on `getReadPermission`, `Back` provided as secondary
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 842567c19d551b5f93d24eb0230b80f27664eda5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->