### PR TITLE
Do not include the popover related pixels into summary pixel

### DIFF
--- a/macOS/DuckDuckGo/Autoconsent/AutoconsentPixels.swift
+++ b/macOS/DuckDuckGo/Autoconsent/AutoconsentPixels.swift
@@ -61,12 +61,7 @@ enum AutoconsentPixel: PixelKitEvent {
         .detectedOnlyRules,
         .selfTestOk,
         .selfTestFail,
-        .errorReloadLoop,
-        .popoverShown,
-        .popoverClosed,
-        .popoverClicked,
-        .popoverNewTabOpened,
-        .popoverAutoDismissed
+        .errorReloadLoop
     ]
 
     var name: String {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1212644338991237?focus=true
Tech Design URL:
CC:

### Description
Do not include the popover related pixels into summary pixel.

### Testing Steps
Verify that `m_mac_autoconsent_summary` is not including any of `popover` pixels as a parameters.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Wrong data in pixels.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes popover-related events from the autoconsent summary payload.
> 
> - Updates `AutoconsentPixel.summaryPixels` to omit `popover*` events so `autoconsent_summary` (and `m_mac_autoconsent_summary`) no longer include popover metrics
> - No changes to event definitions, names, or standard parameters
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3247a60230861f6b645945ad27169249d74e13a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->