### PR TITLE
[iOS] Fix "forget all" pixels definitions

### DIFF
--- a/iOS/PixelDefinitions/pixels/forget_all.json5
+++ b/iOS/PixelDefinitions/pixels/forget_all.json5
@@ -46,13 +46,6 @@
             }
         ]
     },
-    "mf_t": {
-        "description": "Fired after Fire button action with timing information",
-        "owners": ["dus7", "hassaanelgarem"],
-        "triggers": ["other"],
-        "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion"]
-    },
     "m_forget-all-pressed_browsing_daily": {
         "description": "Fired daily when user pressed the Fire button while browsing",
         "owners": ["dus7", "hassaanelgarem"],


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1212644357181110?focus=true
Tech Design URL:
CC:

### Description

Fix definitions for forget-all action pixels.
Add definition for `mf_dc` and `mf_t` so these are not captured as additional suffix.

### Testing Steps
1. Run actions for updated pixels and make sure definitions are matching with reported pixels.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
ATB is not required in parameters as it's an opt-in for some time already. Old versions can still send ATB information in pixels, but that should now be ignored with update of `product.json` file.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix/Update forget-all pixel definitions**
> 
> - Add `mf_dc` pixel fired after data clearing completes with parameters `appVersion`, `dur` (duration seconds), and `tc` (tab count); uses `platform`/`form_factor` suffixes
> - Reorder `suffixes` for `m_forget-all-pressed_settings` to `["daily_standard", "platform", "form_factor"]`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 941af12b41f22ae3c513a1358d52c176f65cccd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->