### PR TITLE
Bookmarks Popover: Fixing Hit target

### DIFF
--- a/macOS/DuckDuckGo/Bookmarks/View/Dialog/BookmarkDialogButtonsView.swift
+++ b/macOS/DuckDuckGo/Bookmarks/View/Dialog/BookmarkDialogButtonsView.swift
@@ -57,11 +57,12 @@ struct BookmarkDialogButtonsView: View {
             Text(action.title)
                 .frame(height: viewState.height)
                 .frame(maxWidth: viewState.maxWidth)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
                 .foregroundColor(Color(designSystemColor: foregroundColor))
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
         .background(
             Color(designSystemColor: backgroundColor)
                 .cornerRadius(6)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/inbox/1211150618028591/item/1212714285694597/story/1212715577503435?focus=true
Tech Design URL:
CC:

### Description
In this PR we're fixing an issue causing the `Bookmark Popover` buttons not to be responsive

**Important!**
I've logged an issue for the misplaced popover in Xcode 26 here https://app.asana.com/1/137249556945/project/1201048563534612/task/1212718084146907?focus=true


### Testing Steps
1. Launch the browser
2. Open any website
3. Click on the Bookmark button in the navbar

- [ ] Verify the `Done` button accepts clicks anywhere
- [ ] Verify the `Delete` button also accepts clicks anywhere

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing really

### Quality Considerations
Nothing in particular

### Notes to Reviewer
Thanks in advance!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves button interactivity in the bookmark dialog by expanding the clickable area.
> 
> - Moves button padding from the button modifier to the `Text` label and adds `contentShape(Rectangle())` so the visible button area is fully clickable
> - Retains styling (`.buttonStyle(.plain)`, background with corner radius/opacity) and existing behavior (shortcuts, disabled state, accessibility identifiers)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da6eca37703afc644078b3c5e884e4d70c94cafc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->