### PR TITLE
Fix: Onboarding Background Color

### DIFF
--- a/SharedPackages/Onboarding/Sources/Onboarding/DaxDialogs/DaxDialogView.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/DaxDialogs/DaxDialogView.swift
@@ -132,7 +132,7 @@ public struct DaxDialogView<Content: View>: View {
 #if os(iOS)
         let backgroundColor = Color(designSystemColor: .surface)
 #else
-        let backgroundColor = Color(designSystemColor: .surfacePrimary)
+        let backgroundColor = Color(designSystemColor: .surfaceTertiary)
 #endif
         let shadowColors: (Color, Color) = colorScheme == .light
         ? (.black.opacity(0.08), .black.opacity(0.1))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1212720967674023?focus=true
Tech Design URL:
CC:

### Description
In this PR we're updating the Onboarding Banner background colors to `surfaceTertiary`, as requested b our Design friends.

### Testing Steps
1. Launch the browser
2. `Debug > Reset Data > Reset Onboarding`
3. Open a new Tab

- [ ] Verify the Onboarding UI looks great

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing really

### Quality Considerations
Nothing in particular

### Notes to Reviewer
This change is based on Design Feedback, on the Themes Ship Review

### Screenshots

Before | Now
-|-
<img width="400" alt="Old Dark" src="https://github.com/user-attachments/assets/2b01b701-1044-4eb4-a569-3d70916d4c13" /> | <img width="400" alt="Now Dark" src="https://github.com/user-attachments/assets/18a99ca2-3768-428a-97bb-3d08b0d1e3e6" />
<img width="400" alt="Old Light" src="https://github.com/user-attachments/assets/9409304e-6abe-461e-9b7e-07193caa088a" /> | <img width="400" alt="Now Light" src="https://github.com/user-attachments/assets/8023a051-6242-46a9-af18-1777940ac160" />







---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts the onboarding dialog background on non‑iOS platforms for visual consistency.
> 
> - In `DaxDialogView.swift`, changes non‑iOS `backgroundColor` from `surfacePrimary` to `surfaceTertiary` for `wrappedContent`
> - Scope: purely visual; no behavior or API changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccbd6b9ad5dc5c5d142d358f3b68edebb47f5a35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->