### PR TITLE
improve bottom constraint when installing suggestion controller

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
@@ -141,7 +141,7 @@ final class SuggestionTrayManager: NSObject {
             controller.view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
             controller.view.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
             controller.view.topAnchor.constraint(equalTo: containerView.topAnchor),
-            // Bottom constraint does not appear to be required and causes a problem with iPad in portrait mode
+            controller.view.bottomAnchor.constraint(lessThanOrEqualTo: containerView.safeAreaLayoutGuide.bottomAnchor)
         ])
 
         controller.autocompleteDelegate = self


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1212716392242742?focus=true
Tech Design URL:
CC: @hanyutang-sandra 

### Description
Fixes weirdly large input on iPad in portrait mode by removing an unnecessary constraint when adding the suggestion controller.

### Testing Steps
1. Enable Duck.ai and the search input toggle
2. On iPad in landscape and portrait smoke test the input for search and chat
3. Repeat on iPhone to validate no breakage

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Could break the Duck.ai input in some unexpected way.

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts layout to prevent the suggestion tray from overexpanding.
> 
> - In `SuggestionTrayManager.swift`, changes the bottom anchor from `equalTo` to `lessThanOrEqualTo` the `safeAreaLayoutGuide`, allowing the tray to size naturally without being forced to the bottom.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50ab9978dd483fc607f87f938dcdd8b950030ad4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->