### PR TITLE
Remove aiFeaturesSettingsUpdate flag

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -180,9 +180,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866467213996
     case createFireproofFaviconUpdaterSecureVaultInBackground
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866609233733
-    case aiFeaturesSettingsUpdate
-
     /// Adds kbg=-1 parameter to search URLs when DuckAI is disabled
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866714302194
     case duckAISearchParameter
@@ -295,7 +292,6 @@ extension FeatureFlag: FeatureFlagDescribing {
              .canInterceptSyncSetupUrls,
              .supportsAlternateStripePaymentFlow,
              .createFireproofFaviconUpdaterSecureVaultInBackground,
-             .aiFeaturesSettingsUpdate,
              .duckAISearchParameter,
              .daxEasterEggLogos,
              .daxEasterEggPermanentLogo,
@@ -413,7 +409,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                .syncSeamlessAccountSwitching,
                .experimentalAddressBar,
                .aiChatKeepSession,
-               .aiFeaturesSettingsUpdate,
                .widgetReporting,
                .canPromoteImportPasswordsInBrowser,
                .canPromoteImportPasswordsInPasswordManagement,
@@ -528,8 +523,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(DBPSubfeature.pirRollout))
         case .createFireproofFaviconUpdaterSecureVaultInBackground:
             return .remoteReleasable(.subfeature(AutofillSubfeature.createFireproofFaviconUpdaterSecureVaultInBackground))
-        case .aiFeaturesSettingsUpdate:
-            return .remoteReleasable(.subfeature(AIChatSubfeature.aiFeaturesSettingsUpdate))
         case .duckAISearchParameter:
             return .remoteReleasable(.subfeature(AIChatSubfeature.duckAISearchParameter))
         case .inactivityNotification:

--- a/iOS/DuckDuckGo/SettingsAIFeaturesView.swift
+++ b/iOS/DuckDuckGo/SettingsAIFeaturesView.swift
@@ -33,13 +33,9 @@ struct SettingsAIFeaturesView: View {
         List {
 
             VStack(alignment: .center) {
-                if viewModel.isUpdatedAIFeaturesSettingsEnabled {
-                    Image(.settingAIFeaturesHero)
-                        .padding(.top, -20)
-                } else {
-                    Image(.settingsAIChatHero)
-                        .padding(.top, -20)
-                }
+                Image(.settingAIFeaturesHero)
+                    .padding(.top, -20)
+
                 Text(UserText.settingsAiFeatures)
                     .daxTitle3()
 
@@ -73,36 +69,28 @@ struct SettingsAIFeaturesView: View {
             if viewModel.isAiChatEnabledBinding.wrappedValue {
                 if viewModel.experimentalAIChatManager.isExperimentalAIChatFeatureFlagEnabled {
 
-                    if viewModel.isUpdatedAIFeaturesSettingsEnabled {
-                        Section {
-                            HStack {
-                                SettingsAIExperimentalPickerView(isDuckAISelected: viewModel.aiChatSearchInputEnabledBinding)
-                                    .padding(.vertical, 8)
-                            }
-                            .frame(maxWidth: .infinity, alignment: .center)
-                        } footer: {
-                            Text(footerAttributedString)
-                                .environment(\.openURL, OpenURLAction { url in
-                                    switch FooterAction.from(url) {
-                                    case .shareFeedback?:
-                                        viewModel.presentLegacyView(.feedback)
-                                        return .handled
-                                    case nil:
-                                        return .systemAction
-                                    }
-                                })
+                    Section {
+                        HStack {
+                            SettingsAIExperimentalPickerView(isDuckAISelected: viewModel.aiChatSearchInputEnabledBinding)
+                                .padding(.vertical, 8)
                         }
-                        .listRowBackground(Color(designSystemColor: .surface))
-                    } else {
-                        Section {
-                            SettingsCellView(label: UserText.settingsAiChatSearchInput,
-                                             accessory: .toggle(isOn: viewModel.aiChatSearchInputEnabledBinding))
-                        } footer: {
-                            Text(UserText.settingsAiChatSearchInputFooter)
-                        }
+                        .frame(maxWidth: .infinity, alignment: .center)
+                    } footer: {
+                        Text(footerAttributedString)
+                            .environment(\.openURL, OpenURLAction { url in
+                                switch FooterAction.from(url) {
+                                case .shareFeedback?:
+                                    viewModel.presentLegacyView(.feedback)
+                                    return .handled
+                                case nil:
+                                    return .systemAction
+                                }
+                            })
                     }
+                    .listRowBackground(Color(designSystemColor: .surface))
+
                 }
-                
+
                 if viewModel.experimentalAIChatManager.isContextualDuckAIModeEnabled {
                     Section {
                         SettingsCellView(label: UserText.settingsAutomaticPageContextTitle,
@@ -111,30 +99,13 @@ struct SettingsAIFeaturesView: View {
                     }
                 }
 
-                if viewModel.isUpdatedAIFeaturesSettingsEnabled {
-                    Section {
-                        NavigationLink(destination: SettingsAIChatShortcutsView().environmentObject(viewModel)) {
-                            SettingsCellView(label: UserText.settingsManageAIChatShortcuts)
-                        }
-                    }
-                    .listRowBackground(Color(designSystemColor: .surface))
-                } else {
-                    Section(header: Text(UserText.aiChatSettingsBrowserShortcutsSectionTitle)) {
-                        SettingsCellView(label: UserText.aiChatSettingsEnableBrowsingMenuToggle,
-                                         accessory: .toggle(isOn: viewModel.aiChatBrowsingMenuEnabledBinding))
-
-                        SettingsCellView(label: UserText.aiChatSettingsEnableAddressBarToggle,
-                                         accessory: .toggle(isOn: viewModel.aiChatAddressBarEnabledBinding))
-
-                        if viewModel.state.voiceSearchEnabled {
-                            SettingsCellView(label: UserText.aiChatSettingsEnableVoiceSearchToggle,
-                                             accessory: .toggle(isOn: viewModel.aiChatVoiceSearchEnabledBinding))
-                        }
-
-                        SettingsCellView(label: UserText.aiChatSettingsEnableTabSwitcherToggle,
-                                         accessory: .toggle(isOn: viewModel.aiChatTabSwitcherEnabledBinding))
+                Section {
+                    NavigationLink(destination: SettingsAIChatShortcutsView().environmentObject(viewModel)) {
+                        SettingsCellView(label: UserText.settingsManageAIChatShortcuts)
                     }
                 }
+                .listRowBackground(Color(designSystemColor: .surface))
+
             }
 
             if !viewModel.openedFromSERPSettingsButton {

--- a/iOS/DuckDuckGo/SettingsMainSettingsView.swift
+++ b/iOS/DuckDuckGo/SettingsMainSettingsView.swift
@@ -73,8 +73,7 @@ struct SettingsMainSettingsView: View {
         @ViewBuilder func buildAIFeatures(viewModel: SettingsViewModel) -> AnyView {
             AnyView(NavigationLink(destination: SettingsAIFeaturesView().environmentObject(viewModel)) {
                 SettingsCellView(label: UserText.settingsAiFeatures,
-                                 image: Image(uiImage: DesignSystemImages.Color.Size24.aiGeneral),
-                                 optionalBadgeText: viewModel.isUpdatedAIFeaturesSettingsEnabled ? UserText.settingsItemNewBadge : nil)
+                                 image: Image(uiImage: DesignSystemImages.Color.Size24.aiGeneral))
             })
         }
 

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -149,10 +149,6 @@ final class SettingsViewModel: ObservableObject {
         }
     }
 
-    var isUpdatedAIFeaturesSettingsEnabled: Bool {
-        featureFlagger.isFeatureOn(.aiFeaturesSettingsUpdate)
-    }
-
     var shouldShowHideAIGeneratedImagesSection: Bool {
         featureFlagger.isFeatureOn(.showHideAIGeneratedImagesSection)
     }


### PR DESCRIPTION

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1211866609233733?focus=true

### Description
Remove aiFeaturesSettingsUpdate flag

### Testing Steps
1. Go to Settings -> AI Features. Validate that we're displaying the option with the 2 images for the address bar

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
Regression on settings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `aiFeaturesSettingsUpdate` feature flag and unifies the AI Features settings to the new design.
> 
> - Deletes `aiFeaturesSettingsUpdate` from `FeatureFlag` and all switch cases
> - Simplifies `SettingsAIFeaturesView` to always show the new hero image and the experimental input picker (when experimental flag is on), and always include the "Manage AI Chat Shortcuts" link; removes legacy toggles/variants
> - Removes `isUpdatedAIFeaturesSettingsEnabled` from `SettingsViewModel` and drops the "NEW" badge in main settings
> - Minor UI cleanup (consistent list row backgrounds)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f5109f8932a68ffca4955b73fc4bde2d00e5bce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->