### PR TITLE
Watchdog: Switching to Monotonic Time

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/Watchdog/Watchdog.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/Watchdog/Watchdog.swift
@@ -54,11 +54,11 @@ public final actor Watchdog {
     private var monitoringTask: Task<Void, Never>?
     private var heartbeatUpdateTask: Task<Void, Never>?
 
-    private var hangStartTime: Date?
+    private var hangStartTime: DispatchTime?
     private var hangState: HangState = .responsive {
         didSet {
             if hangState != oldValue {
-                let duration = currentHangDuration(currentTime: Date())
+                let duration = currentHangDuration(currentTime: .now())
                 hangStateSubject.send((hangState, duration))
             }
         }
@@ -212,7 +212,7 @@ public final actor Watchdog {
 
             // Sleep for check interval
             do {
-                let nanoseconds = UInt64(checkInterval * 1_000_000_000)
+                let nanoseconds = UInt64(checkInterval * .nanosecondsPerSecond)
                 try await Task.sleep(nanoseconds: nanoseconds)
             } catch {
                 // Task was cancelled
@@ -234,7 +234,7 @@ public final actor Watchdog {
     }
 
     private func handleHangDetection(timeSinceLastHeartbeat: TimeInterval) {
-        let now = Date()
+        let now = DispatchTime.now()
 
         // Skip hang detection checks if the watchdog is paused
         guard !isPaused else {
@@ -275,15 +275,13 @@ public final actor Watchdog {
 
     // MARK: - State transitions
 
-    private func transition(from currentState: HangState, to newState: HangState, at time: Date, timeSinceLastHeartbeat: TimeInterval) {
+    private func transition(from currentState: HangState, to newState: HangState, at time: DispatchTime, timeSinceLastHeartbeat: TimeInterval) {
         guard currentState != newState else { return }
 
         switch (currentState, newState) {
         case (.responsive, .hanging):
             hangState = .hanging
-            // Account for half the check interval - the hang will likely have started earlier than the last missed heartbeat
-            // The max() guards against potential negative values – if the time since last heartbeat is less than the check interval/2.
-            hangStartTime = time.addingTimeInterval(-max((timeSinceLastHeartbeat - checkInterval / 2), 0))
+            hangStartTime = calculateHangStartTime(currentTime: time, timeSinceLastHeartbeat: timeSinceLastHeartbeat)
             Self.logger.info("Main thread hang detected! Last heartbeat: \(timeSinceLastHeartbeat)s ago.")
         case (.hanging, .responsive):
             logHangDuration(message: "Main thread hang ended.", currentTime: time)
@@ -304,7 +302,7 @@ public final actor Watchdog {
         }
     }
 
-    private func handleRecoveryDetection(at time: Date, timeSinceLastHeartbeat: TimeInterval) {
+    private func handleRecoveryDetection(at time: DispatchTime, timeSinceLastHeartbeat: TimeInterval) {
         recoveryState.recordHeartbeat(at: time)
 
         if recoveryState.isRecovered {
@@ -314,7 +312,7 @@ public final actor Watchdog {
 
     // MARK: Event firing
 
-    private func fireHangEvent(_ eventFactory: (Int) -> Watchdog.Event, currentTime: Date) {
+    private func fireHangEvent(_ eventFactory: (Int) -> Watchdog.Event, currentTime: DispatchTime) {
         let actualHangDuration = currentHangDuration(currentTime: currentTime)
         let nearestSecond = hangDurationToNearestSecond(duration: actualHangDuration)
         let reportedSecond = max(Int(minimumHangDuration), min(nearestSecond, Int(maximumHangDuration)))
@@ -323,11 +321,17 @@ public final actor Watchdog {
 
     // MARK: Duration handling
 
-    private func currentHangDuration(currentTime: Date) -> TimeInterval {
-        guard let hangStartTime = hangStartTime else { return 0 }
+    private func calculateHangStartTime(currentTime: DispatchTime, timeSinceLastHeartbeat: TimeInterval) -> DispatchTime {
+        let adjustmentNanoseconds = UInt64(max((timeSinceLastHeartbeat - checkInterval / 2), 0) * .nanosecondsPerSecond)
+        return DispatchTime(uptimeNanoseconds: currentTime.uptimeNanoseconds - adjustmentNanoseconds)
+    }
+
+    private func currentHangDuration(currentTime: DispatchTime) -> TimeInterval {
+        guard let hangStartTime else { return 0 }
 
         let hangEndTime = recoveryState.hangEndTime ?? currentTime
-        return hangEndTime.timeIntervalSince(hangStartTime)
+        let deltaInNanoseconds = Double(hangEndTime.uptimeNanoseconds - hangStartTime.uptimeNanoseconds)
+        return TimeInterval(deltaInNanoseconds / .nanosecondsPerSecond)
     }
 
     private func hangDurationToNearestSecond(duration: TimeInterval) -> Int {
@@ -338,7 +342,7 @@ public final actor Watchdog {
         return String(format: "%.1f", duration)
     }
 
-    private func logHangDuration(message: String, currentTime: Date) {
+    private func logHangDuration(message: String, currentTime: DispatchTime) {
         guard hangStartTime != nil else { return }
 
         let hangDuration = currentHangDuration(currentTime: currentTime)
@@ -350,13 +354,13 @@ public final actor Watchdog {
 private final class RecoveryState {
     let requiredHeartbeats: Int
     private(set) var detectedResponsiveHeartbeats: Int = 0
-    private(set) var firstHeartbeatResponseTime: Date?
+    private(set) var firstHeartbeatResponseTime: DispatchTime?
 
     init(requiredHeartbeats: Int) {
         self.requiredHeartbeats = requiredHeartbeats
     }
 
-    func recordHeartbeat(at time: Date) {
+    func recordHeartbeat(at time: DispatchTime) {
         if detectedResponsiveHeartbeats == 0 {
             firstHeartbeatResponseTime = time
         }
@@ -372,28 +376,30 @@ private final class RecoveryState {
         firstHeartbeatResponseTime = nil
     }
 
-    var hangEndTime: Date? {
+    var hangEndTime: DispatchTime? {
         firstHeartbeatResponseTime
     }
 }
 
 /// Actor that manages the heartbeat timestamp in a thread-safe way
 private actor WatchdogMonitor {
-    private var lastHeartbeat = DispatchTime.now()
-    private let nanosecondsPerSecond = Double(NSEC_PER_SEC)
+    private var lastHeartbeat: DispatchTime = .now()
 
     func resetHeartbeat() {
-        lastHeartbeat = DispatchTime.now()
+        lastHeartbeat = .now()
     }
 
     func updateHeartbeat() {
-        lastHeartbeat = DispatchTime.now()
+        lastHeartbeat = .now()
     }
 
     func timeSinceLastHeartbeat() -> TimeInterval {
         let now = DispatchTime.now()
         let deltaInNanoseconds = Double(now.uptimeNanoseconds - lastHeartbeat.uptimeNanoseconds)
-
-        return TimeInterval(deltaInNanoseconds / nanosecondsPerSecond)
+        return TimeInterval(deltaInNanoseconds / .nanosecondsPerSecond)
     }
+}
+
+private extension Double {
+    static let nanosecondsPerSecond = Double(NSEC_PER_SEC)
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1212694851388868?focus=true
Tech Design URL:
CC:

### Description
Manually altering the System's date may trigger false positives, due to our reliance on `Date()`.

In this PR we're switching to a Monotonic Time API (`DispatchTime.now`), that will help us shield the Watchdog mechanism from this kind of scenarios.

### Testing Steps
1. `Debug > Hang Debugging > Toggle Watchdog Debugging`
2. `Debug > Hang Debugging > Simulate Hang > 15 seconds`

- [ ] Verify you see the `m_mac_ui_hang_not-recovered_*` pixel getting posted after ~5 seconds
- [ ] Verify the `WatchdogTests` Suite is green

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
This PR may not effectively fix the Watchdog Hang over-reporting issues.

### Quality Considerations
Nothing in particular!

### Notes to Reviewer
Thank you @frosty !!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches hang detection to monotonic time to avoid errors from system clock changes.
> 
> - Replace `Date` with `DispatchTime` for hang timing, heartbeat tracking, and recovery state
> - Add `calculateHangStartTime` and update `currentHangDuration` to use `uptimeNanoseconds`
> - Standardize time conversions via `.nanosecondsPerSecond`; adjust `Task.sleep` nanosecond calculation
> - Update transition, recovery, and event/logging methods to accept `DispatchTime`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e74d26f9f991104e608451e623c570a1966d4a28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->