### PR TITLE
Favicons: Inactive Placeholder Alpha

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/LetterView.swift
+++ b/macOS/DuckDuckGo/TabBar/View/LetterView.swift
@@ -147,9 +147,6 @@ private extension LetterView {
     }
 
     func refreshActivationAlpha(isActive: Bool) {
-        let alphaWhenActive: CGFloat = 1
-        let alphaWhenInactive: CGFloat = 0.4
-
-        backgroundView.alphaValue = isActive ? alphaWhenActive : alphaWhenInactive
+        backgroundView.alphaValue = isActive ? .activeViewAlpha : .inactiveViewAlpha
     }
 }

--- a/macOS/LocalPackages/AppKitExtensions/Sources/AppKitExtensions/CGFloat+Alpha.swift
+++ b/macOS/LocalPackages/AppKitExtensions/Sources/AppKitExtensions/CGFloat+Alpha.swift
@@ -1,0 +1,25 @@
+//
+//  CGFloat+Alpha.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import Foundation
+
+public extension CGFloat {
+    static let activeViewAlpha: CGFloat = 1
+    static let inactiveViewAlpha: CGFloat = 0.4
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1212760936241056
Tech Design URL:
CC:

### Description
In this PR we're updating the Favicon Placeholders so that whenever the browser becomes inactive, an alpha value is applied.

### Testing Steps
1. Open `example.com`
2. Click on your desktop (so that the browser is inactive!)

- [ ] Verify the Favicon Placeholder gets dimmed

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing really!

### Quality Considerations
Nothing in particular

### Notes to Reviewer
Thank youuu!

### Screenshots

Inactive | Active
-|-
<img width="400" src="https://github.com/user-attachments/assets/87fbf138-c46c-490a-89c4-8cbb990a4a6d" /> | <img width="400" src="https://github.com/user-attachments/assets/9d033c58-0116-44f1-96ad-7bdbe5e67c3f" />


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds inactive-state dimming for favicon placeholders.
> 
> - `LetterView` now subscribes to `NSApp.isActivePublisher()` and toggles `backgroundView.alphaValue` via `refreshActivationAlpha(isActive:)`
> - Initializes the subscription in both initializers
> - Introduces `CGFloat` constants `activeViewAlpha` and `inactiveViewAlpha` in `AppKitExtensions/CGFloat+Alpha.swift`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccfe75967d94aa0078acd3877674b67eed0e4cb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->