### PR TITLE
Mock parameter `internalUserDecider`

### DIFF
--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/ContentBlocking/MockDefaultScriptSourceProviderDependencies.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/ContentBlocking/MockDefaultScriptSourceProviderDependencies.swift
@@ -18,6 +18,7 @@
 //
 
 @testable import DuckDuckGo
+import BrowserServicesKitTestsUtils
 import PrivacyConfig
 
 extension DefaultScriptSourceProvider.Dependencies {
@@ -28,7 +29,8 @@ extension DefaultScriptSourceProvider.Dependencies {
              privacyConfigurationManager: PrivacyConfigurationManagerMock(),
              contentBlockingManager: ContentBlockerRulesManagerMock(),
              fireproofing: MockFireproofing(),
-             contentScopeExperimentsManager: MockContentScopeExperimentManager())
+             contentScopeExperimentsManager: MockContentScopeExperimentManager(),
+             internalUserDecider: MockInternalUserDecider())
     }
 
     static func makeMock(privacyConfig: PrivacyConfigurationManaging) -> Self {
@@ -37,6 +39,7 @@ extension DefaultScriptSourceProvider.Dependencies {
              privacyConfigurationManager: privacyConfig,
              contentBlockingManager: ContentBlockerRulesManagerMock(),
              fireproofing: MockFireproofing(),
-             contentScopeExperimentsManager: MockContentScopeExperimentManager())
+             contentScopeExperimentsManager: MockContentScopeExperimentManager(),
+             internalUserDecider: MockInternalUserDecider())
     }
 }


### PR DESCRIPTION
### Description
This PR addresses a compilation error in `WebViewUnitTests` related to `MockDefaultScriptSourceProviderDependencies.swift`. The `DefaultScriptSourceProvider.Dependencies` struct now requires an `internalUserDecider` parameter, which was missing in the mock's `makeMock()` methods.

This change updates `MockDefaultScriptSourceProviderDependencies.swift` to include the `internalUserDecider` parameter, using `MockInternalUserDecider` from `BrowserServicesKitTestsUtils`, resolving the compilation issue.

### Testing Steps
1. Run `WebViewUnitTests`.
2. Verify that the compilation error "missing argument for parameter 'internalUserDecider' in call" is no longer present.

### Impact and Risks
#### What could go wrong?
**Low:** This change is confined to test code (a mock object) and primarily resolves a compilation error. It is highly unlikely to introduce runtime issues or affect production code.

### Quality Considerations
This ensures the test suite can compile and execute correctly following updates to `DefaultScriptSourceProvider.Dependencies`.

### Notes to Reviewer
This is a straightforward fix to resolve a test compilation error caused by a new dependency in `DefaultScriptSourceProvider.Dependencies`.

---
<a href="https://cursor.com/background-agent?bcId=bc-98d7921d-539d-4bec-a530-d43b51dbbf6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-98d7921d-539d-4bec-a530-d43b51dbbf6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures test mocks match new `DefaultScriptSourceProvider.Dependencies` signature to restore test compilation.
> 
> - Adds `internalUserDecider: MockInternalUserDecider()` to both `makeMock()` helpers in `MockDefaultScriptSourceProviderDependencies.swift`
> - Imports `BrowserServicesKitTestsUtils` to access `MockInternalUserDecider`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa8e2476abbbc8ada47af444b0f9718aebb21d37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->