### PR TITLE
Remove the NEW badge from AI Settings

### DIFF
--- a/iOS/DuckDuckGo/OnboardingExperiment/SearchExperiencePicker/OnboardingSearchExperiencePicker.swift
+++ b/iOS/DuckDuckGo/OnboardingExperiment/SearchExperiencePicker/OnboardingSearchExperiencePicker.swift
@@ -24,7 +24,6 @@ struct OnboardingSearchExperiencePicker: View {
 
     var body: some View {
         SettingsAIExperimentalPickerView(
-            isDuckAISelected: viewModel.isSearchAndAIChatEnabled,
-            showNewBadgeForDuckAI: false)
+            isDuckAISelected: viewModel.isSearchAndAIChatEnabled)
     }
 }

--- a/iOS/DuckDuckGo/SettingsAIExperimentalPickerView.swift
+++ b/iOS/DuckDuckGo/SettingsAIExperimentalPickerView.swift
@@ -24,11 +24,9 @@ import UIComponents
 
 struct SettingsAIExperimentalPickerView: View {
     @Binding var isDuckAISelected: Bool
-    let showNewBadgeForDuckAI: Bool
 
-    init(isDuckAISelected: Binding<Bool>, showNewBadgeForDuckAI: Bool = true) {
+    init(isDuckAISelected: Binding<Bool>) {
         self._isDuckAISelected = isDuckAISelected
-        self.showNewBadgeForDuckAI = showNewBadgeForDuckAI
     }
 
     var body: some View {
@@ -48,7 +46,7 @@ struct SettingsAIExperimentalPickerView: View {
                 selectedImage: .aiExperimentalOn,
                 unselectedImage: .aiExperimentalOff,
                 title: UserText.settingsAIPickerSearchAndDuckAI,
-                showNewBadge: showNewBadgeForDuckAI
+                showNewBadge: false
             ) {
                 isDuckAISelected = true
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1212776706065915?focus=true

### Description
Remove the NEW badge from AI Settings

### Testing Steps
1. Go to Settings -> AI Features. Check there's no NEW badge on the Search & Duck.ai option for the address bar

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Badge is still there

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the "NEW" badge from AI options and simplifies the picker API.
> 
> - `SettingsAIExperimentalPickerView`: remove `showNewBadgeForDuckAI` parameter and initializer arg; set `showNewBadge: false` for both options
> - `OnboardingSearchExperiencePicker`: update call to use the simplified `SettingsAIExperimentalPickerView` initializer
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 426dd6622e3f34cb712a826f0ff4f2dd9b1810d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->