### PR TITLE
Remove appendAtbToSerpQueries feature flag

### DIFF
--- a/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
@@ -103,14 +103,6 @@ extension URL {
         queryItem.value = queryItem.value?.replacingOccurrences(of: " ", with: "+")
         var url = Self.duckDuckGo.appending(percentEncodedQueryItem: queryItem)
 
-        // Add experimental atb parameter to SERP queries for internal users to display Privacy Reminder
-        // https://app.asana.com/0/1199230911884351/1205979030848528/f
-        if case .normal = AppVersion.runType,
-           NSApp.delegateTyped.featureFlagger.isFeatureOn(.appendAtbToSerpQueries),
-           let atbWithVariant = LocalStatisticsStore().atbWithVariant {
-            url = url.appendingParameter(name: URL.DuckDuckGoParameters.ATB.atb, value: atbWithVariant + "-wb")
-        }
-
         /// Append the kbg disable parameter only when Duck AI features are not shown
         if !NSApp.delegateTyped.aiChatPreferences.shouldShowAIFeatures {
             url = url.appendingParameter(name: URL.DuckDuckGoParameters.KBG.kbg,

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -26,10 +26,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866473245911
     case scamSiteProtection
 
-    /// Add experimental atb parameter to SERP queries for internal users to display Privacy Reminder
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866472784764
-    case appendAtbToSerpQueries
-
     // https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866614987519
     case freemiumDBP
 
@@ -400,8 +396,7 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .heuristicAction,
                 .nextStepsSingleCardIteration:
             return true
-        case .appendAtbToSerpQueries,
-                .freemiumDBP,
+        case .freemiumDBP,
                 .contextualOnboarding,
                 .unknownUsernameCategorization,
                 .credentialsImportPromotionForExistingUsers,
@@ -415,8 +410,6 @@ extension FeatureFlag: FeatureFlagDescribing {
 
     public var source: FeatureFlagSource {
         switch self {
-        case .appendAtbToSerpQueries:
-            return .internalOnly()
         case .unknownUsernameCategorization:
             return .remoteReleasable(.subfeature(AutofillSubfeature.unknownUsernameCategorization))
         case .freemiumDBP:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866472784764
Tech Design URL: N/A
CC: @ellesullivan

### Description
- Remove `appendAtbToSerpQueries` feature flag definition from FeatureFlag.swift
- Remove flag-guarded ATB parameter appending logic from URLExtension.swift
- Clean up flag references from `supportsLocalOverriding` and `source` switch statements
- Per https://app.asana.com/1/137249556945/task/1205979030848528/comment/1207067990753085, the feature was released for all users and is no longer using this parameter

### Testing Steps
1. Build macOS Browser for testing (verify build succeeds)
2. Verify SERP searches function normally without the experimental ATB parameter
3. Confirm no compiler errors related to the removed flag

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- Risk: Minimal - flag was internal-only with default value `false`; feature released without needing this parameter
- Mitigation: Flag was disabled by default and the SERP Privacy Reminder feature is now live for all users without this experimental parameter

### Quality Considerations
- Build validated successfully with `xcodebuild build-for-testing`
- No references to the flag remain in codebase
- Obsolete internal testing code removed as planned

### Notes to Reviewer
This removes an internal-only feature flag used during SERP Privacy Reminder development. The feature was successfully released for all users without requiring this experimental ATB parameter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes obsolete internal-only flag and ATB parameter appending for SERP.
> 
> - Delete `appendAtbToSerpQueries` from `FeatureFlag` and clean up references in `supportsLocalOverriding` and `source`
> - Remove flag-guarded `atb` parameter addition in `URL.makeSearchUrl` (SERP queries no longer append experimental ATB)
> - Retains existing `kbg=-1` behavior when AI features are hidden
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b912f5d0516916c35f75c7d17b09b58806a40f0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->