### PR TITLE
Fix Fire animation crash from unbalanced dispatch_group_leave

### DIFF
--- a/macOS/DuckDuckGo/Fire/Model/Fire.swift
+++ b/macOS/DuckDuckGo/Fire/Model/Fire.swift
@@ -304,6 +304,13 @@ final class Fire: FireProtocol {
                     includeCookiesAndSiteData: Bool,
                     includeChatHistory: Bool,
                     completion: (@MainActor () -> Void)?) {
+        // Prevent re-entry if burn is already in progress
+        guard dispatchGroup == nil, burningData == nil else {
+            assertionFailure("burnEntity called while burn already in progress")
+            completion?()
+            return
+        }
+
         Logger.fire.debug("Fire started")
 
         let group = DispatchGroup()
@@ -386,6 +393,13 @@ final class Fire: FireProtocol {
                  includeCookiesAndSiteData: Bool,
                  includeChatHistory: Bool,
                  completion: (@MainActor () -> Void)?) {
+        // Prevent re-entry if burn is already in progress
+        guard dispatchGroup == nil, burningData == nil else {
+            assertionFailure("burnAll called while burn already in progress")
+            completion?()
+            return
+        }
+
         Logger.fire.debug("Fire started")
 
         let group = DispatchGroup()
@@ -526,6 +540,7 @@ final class Fire: FireProtocol {
         assert(dispatchGroup != nil)
 
         dispatchGroup?.leave()
+        dispatchGroup = nil
     }
 
     // MARK: - Closing windows

--- a/macOS/DuckDuckGo/Fire/View/FireCoordinator.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireCoordinator.swift
@@ -119,6 +119,11 @@ final class FireCoordinator {
     }
 
     func fireButtonAction() {
+        // Don't open dialog if burn is already in progress
+        guard fireViewModel.fire.burningData == nil else {
+            return
+        }
+
         // There must be a window when the Fire button is clicked
         guard let lastKeyMainWindowController = windowControllersManager.lastKeyMainWindowController,
               let burningWindow = lastKeyMainWindowController.window else {
@@ -141,6 +146,11 @@ final class FireCoordinator {
     }
 
     func showFirePopover(relativeTo positioningView: NSView, tabCollectionViewModel: TabCollectionViewModel) {
+        // Don't open popover if burn is already in progress
+        guard fireViewModel.fire.burningData == nil else {
+            return
+        }
+
         guard !(firePopover?.isShown ?? false) else {
             firePopover?.close()
             return
@@ -156,6 +166,11 @@ extension FireCoordinator {
     /// Unified Fire dialog presenter for all entry points
     @MainActor
     func presentFireDialog(mode: FireDialogViewModel.Mode, in window: NSWindow? = nil, scopeVisits providedVisits: [Visit]? = nil, settings: FireDialogViewSettings? = nil) async -> FireDialogView.Response {
+        // Don't open dialog if burn is already in progress
+        guard fireViewModel.fire.burningData == nil else {
+            return .noAction
+        }
+
         let targetWindow = window ?? windowControllersManager.lastKeyMainWindowController?.window
         guard let parentWindow = targetWindow,
               let tabCollectionViewModel = tabViewModelGetter(parentWindow) else { return .noAction }

--- a/macOS/DuckDuckGo/Fire/View/FireViewController.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireViewController.swift
@@ -211,9 +211,9 @@ final class FireViewController: NSViewController {
     private func animateFire(burningData: Fire.BurningData) async {
         var playFireAnimation = true
 
-        // Animate just on the active window
+        // Animate just on the active window, don't animate if animation is already playing on another window
         let lastKeyWindowController = Application.appDelegate.windowControllersManager.lastKeyMainWindowController
-        if view.window?.windowController !== lastKeyWindowController {
+        if view.window?.windowController !== lastKeyWindowController || fireViewModel.isAnimationPlaying {
             playFireAnimation = false
         }
 

--- a/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -481,7 +481,7 @@ extension MainWindowController: NSWindowDelegate {
         }
 #if DEBUG
         // Check that the window controller deallocates after close
-        self.ensureObjectDeallocated(after: 1.0, do: .interrupt)
+        self.ensureObjectDeallocated(after: 4.0, do: .interrupt)
 #endif
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1212784083611408
Tech Design URL: N/A
CC: N/A

### Description
- Add re-entry guards to `burnEntity()` and `burnAll()` to prevent crash when multiple burn operations overlap
- Block Fire dialog/popover from opening during active burn to prevent race conditions
- Maintain single-window animation check to prevent multiple windows animating simultaneously
- Fix unbalanced `dispatch_group_leave()` crash reported in Sentry

### Testing Steps
**Scenario 1: Verify UI-level blocking (first line of defense)**
1. In `FireViewController.swift`, change `fireAnimationSpeed = 0.3` (slow down animation 4x)
2. Open Fire dialog (Cmd+Shift+Delete) and click "Burn" button
3. While animation is playing, try to open Fire dialog again (Cmd+Shift+Delete)
4. **Expected:** Nothing happens (dialog doesn't open, blocked by FireCoordinator checks)

**Scenario 2: Verify guard safety net (prevents crash if UI blocking bypassed)**
1. Keep slow animation from scenario 1
2. In `FireCoordinator.swift`, comment out the `guard fireViewModel.fire.burningData == nil` checks in `fireButtonAction()`, `showFirePopover()`, and `presentFireDialog()`
3. In `Fire.swift`, comment out the `assertionFailure()` calls in `burnEntity()` and `burnAll()` guards
4. Open Fire dialog (Cmd+Shift+Delete) and click "Burn" button
5. While animation playing, open Fire dialog again and click "Burn" button
6. **Expected:** Second burn is blocked by guards (exits early without crashing), completion callback fires immediately

**How the crash occurred before this fix:**
- No guards to prevent overlapping burns
- Multiple `dispatchGroup.enter()` calls from concurrent burns
- Animation completion handlers calling `leave()` on mismatched or nil groups
- Result: "unbalanced call to dispatch_group_leave()" crash

### Impact and Risks
**Impact Level: Medium**

#### What could go wrong?
- Users might notice Fire button becomes unresponsive during burn (intended behavior to prevent crash)
- Rapid Fire dialog attempts are now blocked if burn is in progress
- **Mitigation:** This is safer than crashing, and burn operations complete quickly

### Quality Considerations
- **Edge cases:** Handles rapid Fire clicks, new window opening during burn, overlapping burn attempts
- **Performance:** Minimal impact - just guard checks
- **Monitoring:** Crash should disappear from Sentry (issue #669236)
- **Privacy/security:** No privacy impact

### Notes to Reviewer
The crash was intermittent and hard to reproduce in production. The slow animation change helps reproduce the race condition window but should not be committed. The fix uses two-layer defense: UI blocking + guard safety net.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix overlapping Fire operations and crash**
> 
> - Add re-entry guards in `Fire.burnEntity(...)` and `Fire.burnAll(...)` to exit early if a burn is already in progress; invoke `completion` immediately and assert in debug
> - Prevent Fire UI from opening during a burn by guarding in `FireCoordinator.fireButtonAction()`, `showFirePopover(...)`, and `presentFireDialog(...)`
> - Avoid simultaneous animations by skipping `animateFire` when `fireViewModel.isAnimationPlaying` or window is not active
> - Ensure dispatch group balance by nullifying `dispatchGroup` in `fireAnimationDidFinish()`; minor debug tweak to deallocation timing in `MainWindowController`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22b2987a226b88a13000fc384530c049791218c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->