### PR TITLE
Update funnel for subscription next steps card

### DIFF
--- a/macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
@@ -47,7 +47,7 @@ enum SubscriptionFunnelOrigin: String {
     case winBackNewTabPage = "funnel_newtab_macos_winback"
 
     /// User entered the funnel via the New Tab Page next steps card.
-    case newTabPageNextStepsCard = "funnel_newtab_macos_nextstepscard"
+    case newTabPageNextStepsCard = "funnel_onboarding_macOS__nextstepscard"
 }
 
 /// Represents the origin point from which the user enters the subscription restore funnel in the macOS app.


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1212524523991884
Tech Design URL:
CC:

### Description

This PR updates the origin parameter:
* before: `funnel_newtab_macos_nextstepscard`
* after: `funnel_onboarding_macOS__nextstepscard`

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Remove subscription from your device
2. Reset next steps status via Debug > Reset Data > Reset MakeDuckDuckYours user settings
3. Relaunch the app -> Subscription next steps card should show up
4. Click on the card -> URL should contain the correct origin

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates analytics origin for the macOS subscription next-steps entry point.
> 
> - Changes `SubscriptionFunnelOrigin.newTabPageNextStepsCard` from `"funnel_newtab_macos_nextstepscard"` to `"funnel_onboarding_macOS__nextstepscard"`
> - No other code paths or enums modified
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be0a73a94cf4216f7f91cfe40c8bbe6e55cb64b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->