### PR TITLE
Temporarily disable flaky autofill related tests

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Autofill/AutofillVaultUserScriptTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Autofill/AutofillVaultUserScriptTests.swift
@@ -505,7 +505,7 @@ class AutofillVaultUserScriptTests: XCTestCase {
         XCTAssertEqual(autofillData.credentials?.password, password)
     }
 
-    func testWhenGetAutofilldataIsCall_ThenMainAndSubtypesAreUsed() {
+    func testWhenGetAutofilldataIsCall_ThenMainAndSubtypesAreUsed() throws {
         throw XCTSkip("Flaky test")
 
         let delegate = MockSecureVaultDelegate()
@@ -566,7 +566,7 @@ class AutofillVaultUserScriptTests: XCTestCase {
         XCTAssertNil(delegate.lastSubtype)
     }
 
-    func testWhenGetAutofillDataForCreditCardsCalled_ThenDelegateMethodCalled() {
+    func testWhenGetAutofillDataForCreditCardsCalled_ThenDelegateMethodCalled() throws {
         throw XCTSkip("Flaky test")
         class CreditCardDelegate: MockSecureVaultDelegate {
             var didRequestCreditCardCalled = false
@@ -766,7 +766,7 @@ class AutofillVaultUserScriptTests: XCTestCase {
         wait(for: expectations, timeout: 2.0)
     }
 
-    func testWhenMultipleRequestsForSameMessageType_PreviousRepliesAreCancelled() {
+    func testWhenMultipleRequestsForSameMessageType_PreviousRepliesAreCancelled() throws {
         throw XCTSkip("Flaky test")
         class SlowFocusDelegate: MockSecureVaultDelegate {
             var completionHandlers: [(SecureVaultModels.CreditCard?, RequestVaultDataAction) -> Void] = []


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1207089015348518?focus=true
Tech Design URL:
CC:

### Description
Disables flaky tests in AutofillVaultUserScriptTests temporarily

### Testing Steps
1. Confirm CI is green


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables unstable autofill-related tests to reduce CI flakiness.
> 
> - Marked several tests in `AutofillVaultUserScriptTests.swift` as `throws` and immediately `XCTSkip("Flaky test")`, including `getAutofillData`, credit card request/focus flows, cancellation handling, and pending replies cancellation paths
> - No production code changes; only test behavior adjusted to skip execution
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e516b5f89c8ed061dd802618189c789cde1f5e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->