### PR TITLE
macOS: Add prompt pixels for AI Chat

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -173,6 +173,14 @@ enum AIChatPixel: PixelKitEvent {
     case aiChatSyncDecryptionError(reason: String)
     case aiChatSyncHistoryEnabledError(reason: String)
 
+    // MARK: - Prompt Metrics
+
+    /// Event Trigger: User submits their first prompt in a new Duck.ai conversation
+    case aiChatMetricStartNewConversation
+
+    /// Event Trigger: User submits a prompt in an ongoing Duck.ai conversation
+    case aiChatMetricSentPromptOngoingChat
+
     // MARK: - Onboarding
 
     /// Event Trigger: User enables the Duck.ai toggle during onboarding
@@ -293,6 +301,10 @@ enum AIChatPixel: PixelKitEvent {
             return "aichat_onboarding_finished_toggle_on"
         case .aiChatOnboardingFinishedToggleOff:
             return "aichat_onboarding_finished_toggle_off"
+        case .aiChatMetricStartNewConversation:
+            return "aichat_start_new_conversation"
+        case .aiChatMetricSentPromptOngoingChat:
+            return "aichat_sent_prompt_ongoing_chat"
         }
     }
 
@@ -336,7 +348,9 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatOnboardingTogglePreferenceOn,
                 .aiChatOnboardingTogglePreferenceOff,
                 .aiChatOnboardingFinishedToggleOn,
-                .aiChatOnboardingFinishedToggleOff:
+                .aiChatOnboardingFinishedToggleOff,
+                .aiChatMetricStartNewConversation,
+                .aiChatMetricSentPromptOngoingChat:
             return nil
         case .aiChatAddressBarButtonClicked(let action):
             return ["action": action.rawValue]
@@ -413,7 +427,9 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatOnboardingTogglePreferenceOn,
                 .aiChatOnboardingTogglePreferenceOff,
                 .aiChatOnboardingFinishedToggleOn,
-                .aiChatOnboardingFinishedToggleOff:
+                .aiChatOnboardingFinishedToggleOff,
+                .aiChatMetricStartNewConversation,
+                .aiChatMetricSentPromptOngoingChat:
             return [.pixelSource]
         }
     }

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -462,10 +462,15 @@ extension AIChatUserScriptHandler: AIChatMetricReportingHandling {
 
     func didReportMetric(_ metric: AIChatMetric, completion: (() -> Void)? = nil) {
         switch metric.metricName {
-        case .userDidSubmitFirstPrompt, .userDidSubmitPrompt:
-
+        case .userDidSubmitFirstPrompt:
             notificationCenter.post(name: .aiChatUserDidSubmitPrompt, object: nil)
-
+            pixelFiring?.fire(AIChatPixel.aiChatMetricStartNewConversation, frequency: .standard)
+            DispatchQueue.main.async { [self] in
+                refreshAtbs(completion: completion)
+            }
+        case .userDidSubmitPrompt:
+            notificationCenter.post(name: .aiChatUserDidSubmitPrompt, object: nil)
+            pixelFiring?.fire(AIChatPixel.aiChatMetricSentPromptOngoingChat, frequency: .standard)
             DispatchQueue.main.async { [self] in
                 refreshAtbs(completion: completion)
             }

--- a/macOS/PixelDefinitions/pixels/aichat_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/aichat_pixels.json5
@@ -75,5 +75,17 @@
         "triggers": ["other"],
         "suffixes": ["first_daily_count"],
         "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_aichat_start_new_conversation": {
+        "description": "Fired when user submits their first prompt in a new Duck.ai conversation",
+        "owners": ["pikorddg"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_aichat_sent_prompt_ongoing_chat": {
+        "description": "Fired when user submits a prompt in an ongoing Duck.ai conversation",
+        "owners": ["pikorddg"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210947754188321/task/1212461498640942?focus=true
Tech Design URL:
CC:

### Description
Adds `m_mac_aichat_start_new_conversation` and `m_mac_aichat_sent_prompt_ongoing_chat` pixels to macOS, matching the existing iOS implementation.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Build and run the macOS app
2. Open Xcode console, filter for `pixel`
3. Open Duck.ai (via sidebar, address bar, or menu)
4. Submit a prompt → verify `[Standard-Fired] m_mac_aichat_start_new_conversation appears in logs`
5. Submit another prompt in the same chat → verify `[Standard-Fired] m_mac_aichat_sent_prompt_ongoing_chat` appears
6. Close the chat, open a new one → verify first prompt fires start_new_conversation again
7. Verify ATB requests (below) still fire alongside pixels (no regression)
    1. atb.js?at=duckai
    2. atb search request

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
3. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
4. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low, this PR only adds sending pixels.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds prompt submission telemetry for Duck.ai on macOS.
> 
> - New pixels: `m_mac_aichat_start_new_conversation` and `m_mac_aichat_sent_prompt_ongoing_chat` defined in `aichat_pixels.json5`
> - `AIChatPixel` updated with `aiChatMetricStartNewConversation` and `aiChatMetricSentPromptOngoingChat` (no params; include `pixelSource`)
> - `AIChatUserScriptHandler.didReportMetric` now fires these pixels on `.userDidSubmitFirstPrompt` and `.userDidSubmitPrompt`, still posts `aiChatUserDidSubmitPrompt` and refreshes ATBs
> - Unit tests added to verify pixel firing for first/subsequent prompts and that non-prompt metrics do not fire pixels
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbbee50be12fcba44c0dae1738d3981c8afd0790. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->