### PR TITLE
Permission view adjusted for translations when popup section is visible

### DIFF
--- a/macOS/DuckDuckGo/Permissions/View/PermissionCenterView.swift
+++ b/macOS/DuckDuckGo/Permissions/View/PermissionCenterView.swift
@@ -27,27 +27,37 @@ struct PermissionCenterView: View {
 
     @ObservedObject var viewModel: PermissionCenterViewModel
 
-    static let widthWithPopups: [String?: CGFloat] = [
-        "ru": 630,
-        "pl": 590,
-        "es": 590,
-        "fr": 630,
-        "it": 490,
-        "nl": 490,
-        "de": 490,
-        "pt": 490,
-    ]
+    private enum PopoverWidth {
+        static let base: CGFloat = 360
+        static let withExternalApps: CGFloat = 380
+        static let withPopups: CGFloat = 450
+
+        /// Wider widths for languages with longer popup permission strings
+        static let withPopupsByLanguage: [String: CGFloat] = [
+            "de": 490,
+            "es": 590,
+            "fr": 630,
+            "it": 490,
+            "nl": 490,
+            "pl": 590,
+            "pt": 490,
+            "ru": 630,
+        ]
+    }
 
     /// Use a wider popover when popup or external app permissions are present due to longer content
     private var popoverWidth: CGFloat {
         let hasPopups = viewModel.permissionItems.contains { $0.permissionType == .popups }
         let hasExternalApps = viewModel.permissionItems.contains { $0.isGroupedExternalApps }
         if hasPopups {
-            return Self.widthWithPopups[Locale.current.languageCode] ?? 450
+            if let languageCode = Locale.current.languageCode {
+                return PopoverWidth.withPopupsByLanguage[languageCode] ?? PopoverWidth.withPopups
+            }
+            return PopoverWidth.withPopups
         } else if hasExternalApps {
-            return 380
+            return PopoverWidth.withExternalApps
         }
-        return 360
+        return PopoverWidth.base
     }
 
     var body: some View {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1212776466783198?focus=true

### Description
Permission view layout adjusted for translations

### Testing Steps
Setup: To speed things up, make sure you have session restoration enabled

1. Load a website 
2. Open development console (View → Developer → Open Developer Tools)
3. Type window.open("test") to the console
4. When the popup dialog disappears, click on permission center icon
5. Verify no label is truncated in permission center view

Repeat this test for every supported language of the app:
1. Open System Settings -> Language & Region and in the Applications section set a language for DuckDuckGo Debug (blue icon)
2. Relaunch the browser and verify no label is truncated in permission center view

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Layout in permission center

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves layout resilience in the Permission Center, especially with pop-ups and translations.
> 
> - Introduces `PopoverWidth` with base, pop-ups, external apps, and per-language widths; `popoverWidth` now selects width based on present permissions and `Locale.current.languageCode`
> - Applies `.fixedSize` to multiple `Text` labels (header, reload message, permission names, blocked pop-ups header, external apps rows) to prevent truncation
> - Minor spacing/visual tweaks to existing rows without changing behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e351861546b5634289d5a676f5a220888dd8f4f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->