### PR TITLE
Remove autocompleteTabs feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -59,7 +59,6 @@ public enum PrivacyFeature: String {
     case syncPromotion
     case autofillSurveys
     case marketplaceAdPostback
-    case autocompleteTabs
     case networkProtection
     case aiChat
     case contextualOnboarding

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -94,9 +94,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866711364768
     case autofillSurveys
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866468784743
-    case autocompleteTabs
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866711151217
     case adAttributionReporting
 
@@ -413,7 +410,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                .syncPromotionBookmarks,
                .syncPromotionPasswords,
                .autofillSurveys,
-               .autocompleteTabs,
                .adAttributionReporting,
                .crashReportOptInStatusResetting,
                .syncSeamlessAccountSwitching,
@@ -481,8 +477,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(SyncPromotionSubfeature.passwords))
         case .autofillSurveys:
             return .remoteReleasable(.feature(.autofillSurveys))
-        case .autocompleteTabs:
-            return .remoteReleasable(.feature(.autocompleteTabs))
         case .adAttributionReporting:
             return .remoteReleasable(.feature(.adAttributionReporting))
         case .dbpRemoteBrokerDelivery:

--- a/iOS/DuckDuckGo/AutocompleteSuggestionsDataSource.swift
+++ b/iOS/DuckDuckGo/AutocompleteSuggestionsDataSource.swift
@@ -81,10 +81,7 @@ final class AutocompleteSuggestionsDataSource: SuggestionLoadingDataSource {
     }
 
     func openTabs(for suggestionLoading: any SuggestionLoading) -> [BrowserTab] {
-        if featureFlagger.isFeatureOn(.autocompleteTabs) {
-            return candidateOpenTabs
-        }
-        return []
+        return candidateOpenTabs
     }
 
     func suggestionLoading(_ suggestionLoading: Suggestions.SuggestionLoading, suggestionDataFromUrl url: URL, withParameters parameters: [String: String], completion: @escaping (Data?, Error?) -> Void) {

--- a/iOS/DuckDuckGoTests/Autocomplete/AutocompleteSuggestionsDataSourceTests.swift
+++ b/iOS/DuckDuckGoTests/Autocomplete/AutocompleteSuggestionsDataSourceTests.swift
@@ -54,20 +54,12 @@ final class AutocompleteSuggestionsDataSourceTests: XCTestCase {
 
     @MainActor
     func testDataSourceReturnsHistory() {
-        let dataSource = makeDataSource(tabsEnabled: false)
+        let dataSource = makeDataSource()
         XCTAssertEqual(dataSource.history(for: MockSuggestionLoading()).count, 2)
     }
 
     @MainActor
-    func testWhenSuggestTabsFeatureIsDisable_ThenNoTabsReturned() {
-        let dataSource = makeDataSource(tabsEnabled: false)
-
-        let result = dataSource.openTabs(for: MockSuggestionLoading())
-        XCTAssertTrue(result.isEmpty)
-    }
-
-    @MainActor
-    func testWhenSuggestTabsFeatureIsEnabled_ThenProvidesOpenTabsExcludingCurrent() {
+    func testDataSourceProvidesOpenTabsExcludingCurrent() {
         let dataSource = makeDataSource()
 
         // Current tab is the last one added, which has two tabs with the same URL, so only 2 of the 4 will be returned.
@@ -91,7 +83,7 @@ final class AutocompleteSuggestionsDataSourceTests: XCTestCase {
     }
 
     @MainActor
-    private func makeDataSource(tabsEnabled: Bool = true) -> AutocompleteSuggestionsDataSource {
+    private func makeDataSource() -> AutocompleteSuggestionsDataSource {
 
         var mockHistoryCoordinator = MockHistoryCoordinator()
         mockHistoryCoordinator.history = [
@@ -103,18 +95,10 @@ final class AutocompleteSuggestionsDataSourceTests: XCTestCase {
         return AutocompleteSuggestionsDataSource(
             historyManager: MockHistoryManager(historyCoordinator: mockHistoryCoordinator, isEnabledByUser: true, historyFeatureEnabled: true),
             bookmarksDatabase: db,
-            featureFlagger: makeFeatureFlagger(tabsEnabled: tabsEnabled),
+            featureFlagger: MockFeatureFlagger(),
             tabsModel: makeTabsModel()) { _, completion in
                 completion("[]".data(using: .utf8), nil)
         }
-    }
-
-    private func makeFeatureFlagger(tabsEnabled: Bool = true) -> FeatureFlagger {
-        let mock = MockFeatureFlagger()
-        if tabsEnabled {
-            mock.enabledFeatureFlags.append(.autocompleteTabs)
-        }
-        return mock
     }
 
     private func makeTabsModel() -> TabsModel {

--- a/iOS/DuckDuckGoTests/Autocomplete/SuggestionJsonScenarioTests.swift
+++ b/iOS/DuckDuckGoTests/Autocomplete/SuggestionJsonScenarioTests.swift
@@ -110,7 +110,6 @@ final class SuggestionJsonScenarioTests: XCTestCase {
         
         // Set up feature flagger
         let featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags.append(.autocompleteTabs)
         
         // Create the real data source with test dependencies
         let dataSource = AutocompleteSuggestionsDataSource(

--- a/macOS/DuckDuckGo/Suggestions/Model/SuggestionContainer.swift
+++ b/macOS/DuckDuckGo/Suggestions/Model/SuggestionContainer.swift
@@ -256,7 +256,6 @@ extension SuggestionContainer: SuggestionLoadingDataSource {
     }
 
     @MainActor func openTabs(for suggestionLoading: any Suggestions.SuggestionLoading) -> [any Suggestions.BrowserTab] {
-        guard featureFlagger.isFeatureOn(.autocompleteTabs) else { return [] }
         return openTabsProvider()
     }
 

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -65,9 +65,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866715515023
     case autofillPartialFormSaves
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866714296474
-    case autocompleteTabs
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866474376005
     case webExtensions
 
@@ -337,7 +334,6 @@ extension FeatureFlag: FeatureFlagDescribing {
     public var supportsLocalOverriding: Bool {
         switch self {
         case .autofillPartialFormSaves,
-                .autocompleteTabs,
                 .networkProtectionAppStoreSysex,
                 .networkProtectionAppStoreSysexMessage,
                 .syncSeamlessAccountSwitching,
@@ -449,8 +445,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(UpdatesSubfeature.simplifiedFlow))
         case .autofillPartialFormSaves:
             return .remoteReleasable(.subfeature(AutofillSubfeature.partialFormSaves))
-        case .autocompleteTabs:
-            return .remoteReleasable(.feature(.autocompleteTabs))
         case .webExtensions:
             return .internalOnly()
         case .syncSeamlessAccountSwitching:

--- a/macOS/UnitTests/Suggestions/Model/SuggestionContainerTests.swift
+++ b/macOS/UnitTests/Suggestions/Model/SuggestionContainerTests.swift
@@ -206,7 +206,6 @@ final class SuggestionContainerTests: XCTestCase {
                                                                         selectedWindow: selectedWindow)
 
         let mockFeatureFlagger = MockFeatureFlagger()
-        mockFeatureFlagger.enabledFeatureFlags.append(.autocompleteTabs)
         mockFeatureFlagger.enabledFeatureFlags.append(.paidAIChat)
 
         // Tested object

--- a/macOS/UnitTests/Suggestions/ViewModel/SuggestionContainerViewModelTests.swift
+++ b/macOS/UnitTests/Suggestions/ViewModel/SuggestionContainerViewModelTests.swift
@@ -44,7 +44,6 @@ final class SuggestionContainerViewModelTests: XCTestCase {
         historyProviderMock = HistoryProviderMock()
         bookmarkProviderMock = SuggestionsBookmarkProvider(bookmarkManager: MockBookmarkManager())
         featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags = [.autocompleteTabs]
         suggestionContainer = SuggestionContainer(openTabsProvider: { [] },
                                                   suggestionLoading: suggestionLoadingMock,
                                                   historyProvider: historyProviderMock,
@@ -385,7 +384,7 @@ final class SuggestionContainerViewModelTests: XCTestCase {
     @MainActor
     func testWhenAIChatToggleEnabledAndNoAutoSelection_ThenSearchAndAIChatCellsAppearAtTop() {
         // Setup with AI chat toggle enabled and AI features enabled
-        featureFlagger.enabledFeatureFlags = [.autocompleteTabs, .aiChatOmnibarToggle, .aiChatOmnibarCluster]
+        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle, .aiChatOmnibarCluster]
         let aiChatStorage = MockAIChatPreferencesStorage()
         aiChatStorage.isAIFeaturesEnabled = true
 
@@ -418,7 +417,7 @@ final class SuggestionContainerViewModelTests: XCTestCase {
     @MainActor
     func testWhenAIChatToggleEnabledAndHasAutoSelectedSuggestion_ThenAIChatCellAppearsAtBottom() {
         // Setup with AI chat toggle enabled and AI features enabled
-        featureFlagger.enabledFeatureFlags = [.autocompleteTabs, .aiChatOmnibarToggle, .aiChatOmnibarCluster]
+        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle, .aiChatOmnibarCluster]
         let aiChatStorage = MockAIChatPreferencesStorage()
         aiChatStorage.isAIFeaturesEnabled = true
 
@@ -454,7 +453,7 @@ final class SuggestionContainerViewModelTests: XCTestCase {
     @MainActor
     func testWhenAIChatToggleEnabledAndUserInputIsURL_ThenVisitCellAtTopAndAIChatCellAtBottom() {
         // Setup with AI chat toggle enabled and AI features enabled
-        featureFlagger.enabledFeatureFlags = [.autocompleteTabs, .aiChatOmnibarToggle, .aiChatOmnibarCluster]
+        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle, .aiChatOmnibarCluster]
         let aiChatStorage = MockAIChatPreferencesStorage()
         aiChatStorage.isAIFeaturesEnabled = true
 
@@ -490,7 +489,6 @@ final class SuggestionContainerViewModelTests: XCTestCase {
     @MainActor
     func testWhenAIChatToggleDisabled_ThenNoSearchOrAIChatCells() {
         // Setup without AI chat toggle
-        featureFlagger.enabledFeatureFlags = [.autocompleteTabs]
 
         suggestionContainerViewModel = SuggestionContainerViewModel(
             isHomePage: false,
@@ -519,7 +517,7 @@ final class SuggestionContainerViewModelTests: XCTestCase {
     @MainActor
     func testWhenAIChatToggleEnabledButAIFeaturesDisabled_ThenOnlySearchCellAppears() {
         // Setup with AI chat toggle enabled but AI features disabled
-        featureFlagger.enabledFeatureFlags = [.autocompleteTabs, .aiChatOmnibarToggle, .aiChatOmnibarCluster]
+        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle, .aiChatOmnibarCluster]
         let aiChatStorage = MockAIChatPreferencesStorage()
         aiChatStorage.isAIFeaturesEnabled = false
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1211834678943996/1211866714296474
Tech Design URL: N/A
CC: N/A

### Description
- Remove `autocompleteTabs` from FeatureFlag enum (iOS & macOS)
- Remove `autocompleteTabs` from PrivacyFeature enum  
- Remove feature flag checks from iOS AutocompleteSuggestionsDataSource
- Remove feature flag checks from macOS SuggestionContainer
- Update unit tests to remove feature flag setup

### Testing Steps
1. Build and run iOS browser
2. Test autocomplete in address bar - open tabs should appear in suggestions
3. Build and run macOS browser
4. Test autocomplete in address bar - open tabs should appear in suggestions
5. Verify all unit tests pass

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- Minimal risk as the feature has been enabled by default and stable in production since April 2025
- No user-facing changes expected as functionality remains the same

### Quality Considerations
- Removed 4 feature flag definitions across platforms
- Cleaned up test setup code that enabled the flag
- No behavior changes - feature is now permanently enabled

### Notes to Reviewer
This is a straightforward feature flag graduation. The `autocompleteTabs` feature has been stable in production for months and is ready to be permanently enabled by removing the flag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Graduates open-tab suggestions by deleting the `autocompleteTabs` flag and its checks across platforms.
> 
> - Removes `autocompleteTabs` from iOS/macOS `FeatureFlag` enums and from `PrivacyFeature`
> - iOS: `AutocompleteSuggestionsDataSource.openTabs` now always returns `candidateOpenTabs`
> - macOS: `SuggestionContainer.openTabs` now always returns `openTabsProvider()`
> - Cleans up unit tests to drop flag setup and disabled-path tests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71ff64274098a23448f7993d8d90e983bd2aebe5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->