### PR TITLE
Fix updated string in maestro tests

### DIFF
--- a/.maestro/shared/sync_create.yaml
+++ b/.maestro/shared/sync_create.yaml
@@ -7,7 +7,7 @@ appId: com.duckduckgo.mobile.ios
 - inputText: "0000"
 - pressKey: Enter
 - assertVisible: You can sync with your other devices later.
-- tapOn: Turn On Sync & Back Up
+- tapOn: Turn On Sync & Backup
 - assertVisible: Save Recovery Code
 - tapOn: Copy Code
 - tapOn: Next


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1212852951334312?focus=true
Tech Design URL:
CC:

### Description

This PR just updates a string in our e2e Maestro tests to reflect a recent change we made in the app.

### Testing Steps

1. Ensure the Maestro e2e iOS tests are happy!

### Impact and Risks

None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Maestro iOS e2e flow to match revised copy.
> 
> - In `.maestro/shared/sync_create.yaml`, changes tap target from `Turn On Sync & Back Up` to `Turn On Sync & Backup` to align with the app’s updated label
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b0ae851bcb20a1ea8675e1f850ebf4a62b92058. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->