### PR TITLE
[iOS] Fix Subscriptions flaky test

### DIFF
--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionSettingsViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionSettingsViewModelTests.swift
@@ -634,10 +634,11 @@ final class SubscriptionSettingsViewModelTests: XCTestCase {
     }
 
     private func waitForSubscriptionUpdate() async {
-        let expectation = expectation(description: "Subscription info updated")
+        let expectation = expectation(description: "Subscription details updated")
 
         sut.$state
-            .compactMap { $0.subscriptionInfo }
+            .map { $0.subscriptionDetails }
+            .filter { !$0.isEmpty }  // Wait for subscriptionDetails to be non-empty
             .first()
             .sink { _ in expectation.fulfill() }
             .store(in: &cancellables)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1212852884404133?focus=true

### Description
This PR fixes a flaky test caused by a race condition. The original test waited for the subscription info to be updated and then asserted on the subscription details. The fix adjusts the waiting logic to wait for the subscription details instead.

### Testing Steps
No testing needed. This only updates unit tests.

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
N/A

### Quality Considerations
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes a flaky unit test by updating the wait logic.
> 
> - In `SubscriptionSettingsViewModelTests.swift`, `waitForSubscriptionUpdate` now observes `state.subscriptionDetails`, filtering for non-empty values before fulfilling
> - Renames expectation description to "Subscription details updated"
> - No production code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 656a852940c64d94e76eb85f9695176bce1af872. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->