### PR TITLE
Update autofill to 19.0.0

### DIFF
--- a/SharedPackages/BrowserServicesKit/Package.resolved
+++ b/SharedPackages/BrowserServicesKit/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "8f6c384312a9b27824333e7d23382481ee1183e9",
-        "version" : "18.5.0"
+        "revision" : "c8ce2e7cdcca4226c96350dcd49323298b941592",
+        "version" : "19.0.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
         .library(name: "WKAbstractions", targets: ["WKAbstractions"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "18.5.0"),
+        .package(url: "https://github.com/duckduckgo/duckduckgo-autofill.git", exact: "19.0.0"),
         .package(url: "https://github.com/duckduckgo/TrackerRadarKit.git", exact: "3.0.1"),
         .package(url: "https://github.com/duckduckgo/sync_crypto", exact: "0.7.0"),
         .package(url: "https://github.com/gumob/PunycodeSwift.git", exact: "3.0.0"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212876728569385
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/19.0.0
Apple PR: 

## Description
Updates Autofill to version [19.0.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/19.0.0).

### Autofill 19.0.0 release notes
## What's Changed
* Add screenshot tests for debug-ui by @noisysocks in https://github.com/duckduckgo/duckduckgo-autofill/pull/918
* Add theme variant support for overlay (macOS/Windows) by @noisysocks in https://github.com/duckduckgo/duckduckgo-autofill/pull/916
* Use AccentContentPrimary for all text on hover and press by @noisysocks in https://github.com/duckduckgo/duckduckgo-autofill/pull/923

## New Contributors
* @noisysocks made their first contribution in https://github.com/duckduckgo/duckduckgo-autofill/pull/918

**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/18.5.0...19.0.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the Autofill dependency version.
> 
> - Bumps `duckduckgo-autofill` from `18.5.0` to `19.0.0` in `Package.swift` and `Package.resolved`
> - No source changes; dependency lockfile and manifest only
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d515ef48cfdfdc836ac9a769db75f15b567fea85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->