### PR TITLE
[macOS] Fix parameters for releaseMetadataFetchFailed pixel

### DIFF
--- a/macOS/PixelDefinitions/pixels/update_flow_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/update_flow_pixels.json5
@@ -39,10 +39,24 @@
         "triggers": ["other"],
         "parameters": [
             {
-                "key": "error",
+                "key": "e",
+                "type": "integer",
+                "description": "Error code of the LatestReleaseError enum"
+            },
+            {
+                "key": "d",
                 "type": "string",
-                "description": "Type of error that occurred",
-                "enum": ["network_error", "decoding_error", "invalid_url", "metadata_not_found", "unknown_error"]
+                "description": "Error description of the LatestReleaseError enum"
+            },
+            {
+                "key": "ud",
+                "type": "string",
+                "description": "Error domain of the LatestReleaseError enum"
+            },
+            {
+                "key": "ud2",
+                "type": "string",
+                "description": "Underlying error of the LatestReleaseError enum"
             },
             "appVersion",
             "pixelSource"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1212848526829681?focus=true
Tech Design URL:
CC:

### Description
Adds error parameters to the releaseMetadataFetchFailed pixel definition.

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing.

### Quality Considerations
Nothing.

### Notes to Reviewer
Nothing.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts update-flow pixel schema to capture richer error data.
> 
> - In `macOS/PixelDefinitions/pixels/update_flow_pixels.json5`, replaces `error` enum parameter with structured fields: `e` (integer code), `d` (description), `ud` (error domain), `ud2` (underlying error)
> - Keeps existing `appVersion` and `pixelSource` parameters unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2fd8c4ef5075abc7421aa43e373e9e7437cc20b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->