### PR TITLE
[macOS] Remove blurryAddressBarTahoeFix feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -138,10 +138,6 @@ public enum MacOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212444166689969
     case warnBeforeQuit
 
-    /// Feature flag for a macOS Tahoe fix only
-    /// https://app.asana.com/1/137249556945/project/1204006570077678/task/1211448334620171?focus=true
-    case blurryAddressBarTahoeFix
-
     /// Tab closing event recreation feature flag (failsafe for removing private API)
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212206087745586?focus=true
     case tabClosingEventRecreation

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -581,7 +581,6 @@ final class AddressBarViewController: NSViewController {
     /// https://app.asana.com/1/137249556945/project/414235014887631/task/1211448334620171?focus=true
     @available(macOS 26.0, *)
     private func setInternalTextFieldLabelsAlpha(_ alpha: CGFloat, in textField: NSTextField) {
-        guard featureFlagger.isFeatureOn(.blurryAddressBarTahoeFix) else { return }
         for subview in textField.subviews where NSStringFromClass(type(of: subview)).contains("NSTextFieldSimpleLabel") {
             subview.alphaValue = alpha
         }
@@ -612,7 +611,7 @@ final class AddressBarViewController: NSViewController {
         passiveTextField.textColor = theme.colorsProvider.textPrimaryColor
 
         // Workaround for macOS 26.0 NSTextFieldSimpleLabel rendering bug
-        if #available(macOS 26.0, *), featureFlagger.isFeatureOn(.blurryAddressBarTahoeFix) {
+        if #available(macOS 26.0, *) {
             if addressBarTextField.isHidden {
                 forceHideInternalTextFieldLabels(in: addressBarTextField)
             }
@@ -880,7 +879,7 @@ final class AddressBarViewController: NSViewController {
             isFirstResponder = false
 
             // Restore internal text field labels when address bar loses focus
-            if #available(macOS 26.0, *), featureFlagger.isFeatureOn(.blurryAddressBarTahoeFix) {
+            if #available(macOS 26.0, *) {
                 restoreInternalTextFieldLabels(in: addressBarTextField)
             }
 
@@ -1298,7 +1297,7 @@ extension AddressBarViewController: AddressBarTextFieldFocusDelegate {
         addressBarButtonsViewController?.setupButtonPaddings(isFocused: false)
 
         // Restore internal text field labels when address bar loses focus
-        if #available(macOS 26.0, *), featureFlagger.isFeatureOn(.blurryAddressBarTahoeFix) {
+        if #available(macOS 26.0, *) {
             restoreInternalTextFieldLabels(in: addressBarTextField)
         }
     }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -182,9 +182,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866620653515
     case storeSerpSettings
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866620524141
-    case blurryAddressBarTahoeFix
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866477623612
     case dataImportNewExperience
 
@@ -297,7 +294,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .dataImportNewSafariFilePicker,
                 .fireDialog,
                 .fireDialogIndividualSitesLink,
-                .blurryAddressBarTahoeFix,
                 .allowPopupsForCurrentPage,
                 .extendedUserInitiatedPopupTimeout,
                 .suppressEmptyPopUpsOnApproval,
@@ -374,7 +370,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .aiChatDataClearing,
                 .dataImportNewSafariFilePicker,
                 .storeSerpSettings,
-                .blurryAddressBarTahoeFix,
                 .dataImportNewExperience,
                 .tabProgressIndicator,
                 .attributedMetrics,
@@ -519,8 +514,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.feature(.duckAiDataClearing))
         case .storeSerpSettings:
             return .remoteReleasable(.subfeature(SERPSubfeature.storeSerpSettings))
-        case .blurryAddressBarTahoeFix:
-            return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.blurryAddressBarTahoeFix))
         case .dataImportNewExperience:
             return .remoteReleasable(.subfeature(DataImportSubfeature.newDataImportExperience))
         case .scheduledDefaultBrowserAndDockPromptsInactiveUser:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1211866620524141?focus=true
Tech Design URL:
CC:

### Description
Removes the `blurryAddressBarTahoeFix` feature flag, now that sometime has passed since we introduced the fix for the double text address bar.

### Testing Steps
1. Run the macOS application on Tahoe
2. Check everything is working as expected

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing. The feature flag has been on for some time already.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the deprecated `blurryAddressBarTahoeFix` feature flag and simplifies the address bar rendering workaround.
> 
> - Deletes `blurryAddressBarTahoeFix` from feature flag enums, default values, and sources in `FeatureFlag.swift` and from `MacOSBrowserConfigSubfeature` in `PrivacyFeature.swift`
> - Ungates the macOS 26 `NSTextFieldSimpleLabel` alpha/hide/restore logic in `AddressBarViewController` (now always executed when available), removing conditional checks against the removed flag
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68556a80f507b401b22af8fcf9d99b531ff31448. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->