### PR TITLE
htang/ios+mac/Update pixel definition

### DIFF
--- a/iOS/PixelDefinitions/pixels/data_import_wide_event.json5
+++ b/iOS/PixelDefinitions/pixels/data_import_wide_event.json5
@@ -43,7 +43,7 @@
                 "keyPattern": "feature\\.data\\.ext\\.(bookmarks|passwords|creditCards)_status_reason",
                 "type": "string",
                 "description": "Optional reason accompanying the per-type status",
-                "enum": ["partial_data", "timeout"]
+                "enum": ["partial_data", "timeout", "document_picker_cancelled"]
             },
             // Overall latency
             {

--- a/macOS/PixelDefinitions/pixels/data_import_wide_event.json5
+++ b/macOS/PixelDefinitions/pixels/data_import_wide_event.json5
@@ -63,7 +63,7 @@
                 "keyPattern": "feature\\.data\\.ext\\.(bookmarks|passwords|creditCards)_status_reason",
                 "type": "string",
                 "description": "Optional reason accompanying the per-type status",
-                "enum": ["partial_data", "timeout"]
+                "enum": ["partial_data", "timeout", "document_picker_cancelled"]
             },
             // Overall latency
             {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1212848539169539?focus=true

### Description
Update pixel definition after improvements on `DataImportWideEvent` in https://app.asana.com/1/137249556945/task/1212517390377752?focus=true

### Testing Steps
N/A

### Impact and Risks
None

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates analytics schema for data import wide event.
> 
> - Extends enum for `feature.data.ext.(bookmarks|passwords|creditCards)_status_reason` to include `document_picker_cancelled` in both iOS and macOS definitions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bfe1a90e4eff454eca861fd2a6a6f95c3df7574. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->