### PR TITLE
iOS: Change Duck.ai keyboard to show Go button instead of Return

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -268,8 +268,8 @@ class SwitchBarTextEntryView: UIView {
             disableAutoCorrectionAndSpellChecking()
         case .aiChat:
             if handler.isUsingFadeOutAnimation {
-                textView.keyboardType = .default
-                textView.returnKeyType = .default
+                textView.keyboardType = .webSearch
+                textView.returnKeyType = .go
                 if textView.text.isEmpty {
                     disableAutoCorrectionAndSpellChecking()
                 } else {
@@ -497,8 +497,8 @@ class SwitchBarTextEntryView: UIView {
         if isTextEmpty {
             disableAutoCorrectionAndSpellChecking()
         } else {
-            textView.keyboardType = .default
-            textView.returnKeyType = .default
+            textView.keyboardType = .webSearch
+            textView.returnKeyType = .go
             enableAutoCorrectionAndSpellChecking()
         }
 
@@ -564,10 +564,6 @@ extension SwitchBarTextEntryView: UITextViewDelegate {
 
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         if text == "\n" {
-            if handler.isUsingFadeOutAnimation && currentMode == .aiChat {
-                return true
-            }
-
             fireKeyboardGoPressedPixel()
             /// https://app.asana.com/1/137249556945/project/1204167627774280/task/1210629837418046?focus=true
             let currentText = textView.text ?? ""


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212886154735029

### Description
Reverts the keyboard behavior from PR #2651 to show a "Go" button instead of "Return" in Duck.ai mode when using the fadeOutOnToggle animation. Pressing "Go" now submits the text instead of inserting a newline.

### Testing Prerequisites
1. Enable ’toggle’ input

### Testing Steps

#### Test 1 - Go Button Displayed
1. Tap on the address bar to focus it
2. Switch to Duck.ai mode (swipe or tap toggle)
3. Verify the keyboard shows a blue “go" button (not "Return")

#### Test 2 - Go Button Submits Text
1. Focus the Duck.ai input field
2. Type a question like "What is the weather today?"
3. Tap the "go" button on the keyboard
4. Verify the text is submitted and Duck.ai responds
5. Verify no newline is inserted in the input field

#### Test 3 - Empty Input Does Not Submit
1. Focus the Duck.ai input field with no text
2. Tap the "go" button
3. Verify nothing happens (no submission, no crash)

#### Test 4 - Search Mode Still Works
1. Switch to Search mode
2. Verify keyboard shows "go" button
3. Type a query and tap "go"
4. Verify search is performed correctly

#### Test 5 - Bottom Bar Position
1. Change address bar to bottom position in Settings
2. Repeat Test 1 and Test 2
3. Verify “go" button appears and submits correctly

### Impact and Risks
Low - This is a targeted change to keyboard configuration only, reverting to previously working behavior.

#### What could go wrong?
- Keyboard type change could affect autocorrect/spell check behavior (already tested in PR #2651)

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts Duck.ai input to use the keyboard’s Go action and submit behavior.
> 
> - In `aiChat` mode (including when `fadeOutOnToggle` is enabled), set `textView.keyboardType` to `webSearch` and `returnKeyType` to `go`
> - Pressing Return/Go now submits via `handler.submitText(...)` and no longer inserts a newline
> - Autocorrect/spell-check still disabled when empty and enabled when text exists; keeps `reloadInputViews()` guarded to avoid autocomplete issues
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d80e773707f5737bfb3b4665c679184bccac946d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->