### PR TITLE
[iOS] Show Report Broken Site on New Menu when on error page

### DIFF
--- a/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
@@ -930,7 +930,7 @@ extension TabViewController: BrowsingMenuEntryBuilding {
     }
     
     func makeReportBrokenSiteEntry() -> BrowsingMenuEntry? {
-        guard validLink != nil else { return nil }
+        guard link != nil else { return nil }
         return buildReportBrokenSiteEntry(useSmallIcon: false)
     }
     


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1212513499285556?focus=true
Tech Design URL:
CC:

### Description

Fix a check preventing Report Broken Site option from being visible in New Menu.

### Testing Steps
1. Make sure Experimental Menu is enabled in Appearance settings.
2. Navigate to invalid link (e.g. https://asdfg.zxcvb).
3. Open menu and confirm Report Broken Site is visible and works.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
4. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes the "Report Broken Site" option available in the new browsing menu even when the current page is an error.
> 
> - In `TabViewControllerMenuBuilderExtension.swift`, `makeReportBrokenSiteEntry` now guards on `link` (was `validLink`) to allow showing `Report Broken Site` on error pages; no other behavior changed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85aff8250c272ec89449372b657395d7259a2e3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->