### PR TITLE
Revert "Hide keyboard accessory for duck.ai (#2992)"

### DIFF
--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -280,7 +280,6 @@ class TabViewController: UIViewController {
             updateTabModel()
             delegate?.tabLoadingStateDidChange(tab: self)
             checkLoginDetectionAfterNavigation()
-            updateInputAccessoryViewVisibility()
         }
     }
     
@@ -1948,12 +1947,6 @@ extension TabViewController: WKNavigationDelegate {
             saveLoginPromptIsPresenting = false
             shouldShowAutofillExtensionPrompt = false
         }
-    }
-
-    /// Hides the default keyboard input accessory view when on duck.ai pages.
-    private func updateInputAccessoryViewVisibility() {
-        guard let webView = webView as? WebView else { return }
-        webView.shouldHideDefaultInputAccessoryView = isAITab
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {

--- a/iOS/DuckDuckGo/WebView.swift
+++ b/iOS/DuckDuckGo/WebView.swift
@@ -24,12 +24,7 @@ import os.log
 final class WebView: WKWebView {
     private var customAccesoryView: UIView?
 
-    var shouldHideDefaultInputAccessoryView: Bool = false
-
     override var inputAccessoryView: UIView? {
-        if shouldHideDefaultInputAccessoryView {
-            return nil
-        }
         guard customAccesoryView != nil else {
             return super.inputAccessoryView
         }


### PR DESCRIPTION

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1212891659258516?focus=true
Tech Design URL:
CC:

### Description
This reverts commit e0e175b2cdaea24deac0c1f8dfe4672fdcfffb46.

### Testing Steps
1. Open any website that has text field to trigger the keyboard. Check if the accessory bar is there (it should)
2. Open duck.ai. Check if the keyboard accessory bar is there (it should)

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-enables the system keyboard accessory bar across the app, including on `duck.ai`.
> 
> - Removes `updateInputAccessoryViewVisibility` in `TabViewController` and the `WebView.shouldHideDefaultInputAccessoryView` flag
> - `WebView.inputAccessoryView` no longer returns `nil`; now always shows the default accessory unless a custom view is set
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 773c5407f8c59fab81e8b569b61bca2fbd674037. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->