### PR TITLE
Refactor BaseURLDebugSettings to use KeyedStoring

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -19,12 +19,21 @@
       }
     },
     {
+      "identity" : "content-scope-scripts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
+      "state" : {
+        "revision" : "d6674948bfd8017e21c016da497b6066feed3c46",
+        "version" : "12.30.0"
+      }
+    },
+    {
       "identity" : "duckduckgo-autofill",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "8f6c384312a9b27824333e7d23382481ee1183e9",
-        "version" : "18.5.0"
+        "revision" : "c8ce2e7cdcca4226c96350dcd49323298b941592",
+        "version" : "19.0.0"
       }
     },
     {

--- a/macOS/DuckDuckGo/Common/Extensions/BaseURLDebugMenu.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/BaseURLDebugMenu.swift
@@ -17,6 +17,7 @@
 //
 
 import AppKit
+import Persistence
 
 /// Debug menu for configuring base URLs at runtime.
 ///
@@ -35,13 +36,14 @@ import AppKit
 /// - The menu displays the current effective URLs
 /// - A browser restart may be required for some cached URLs
 final class BaseURLDebugMenu: NSMenu {
-    private let debugSettings = BaseURLDebugSettings()
+    private let debugSettings: any KeyedStoring<BaseURLDebugSettings>
 
     private let baseURLLabelMenuItem = NSMenuItem(title: "")
     private let duckAIURLLabelMenuItem = NSMenuItem(title: "")
     private let helpURLLabelMenuItem = NSMenuItem(title: "")
 
-    init() {
+    init(_ debugSettings: (any KeyedStoring<BaseURLDebugSettings>)? = nil) {
+        self.debugSettings = if let debugSettings { debugSettings } else { UserDefaults.standard.keyedStoring() }
         super.init(title: "")
 
         buildItems {

--- a/macOS/DuckDuckGo/Common/Extensions/BaseURLDebugSettings.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/BaseURLDebugSettings.swift
@@ -17,79 +17,58 @@
 //
 
 import Foundation
+import Persistence
 
-/// Protocol for accessing and modifying base URL debug settings.
+/// Settings for accessing and modifying base URL overrides for debugging and development.
 ///
 /// These settings allow internal users to override the default DuckDuckGo base URLs
 /// for testing purposes (e.g., pointing to local servers or dev instances).
-public protocol BaseURLDebugSettingsRepresentable {
-    /// Custom BASE_URL override (e.g., "http://localhost:8080")
-    var customBaseURL: String? { get set }
-
-    /// Custom DUCKAI_BASE_URL override
-    var customDuckAIBaseURL: String? { get set }
-
-    /// Resets all custom URLs to defaults
-    func reset()
-}
-
-/// Default implementation of `BaseURLDebugSettingsRepresentable` using UserDefaults.
 ///
 /// ## Usage
 ///
 /// This is used by the Debug menu to allow internal users to change base URLs at runtime:
 ///
 /// ```swift
-/// let settings = BaseURLDebugSettings()
+/// let settings: any KeyedStoring<BaseURLDebugSettings> = UserDefaults.standard.keyedStoring()
 /// settings.customBaseURL = "http://localhost:8080"
 /// // All URLs using URL.base will now use this custom URL
 ///
 /// settings.reset()
 /// // URLs return to production defaults
 /// ```
-public final class BaseURLDebugSettings: BaseURLDebugSettingsRepresentable {
-    private let userDefaults: UserDefaults
+struct BaseURLDebugSettings: StoringKeys {
+    let customBaseURL = StorageKey<String>(.debugCustomBaseURL)
+    let customDuckAIBaseURL = StorageKey<String>(.debugCustomDuckAIBaseURL)
+}
 
-    public init(_ userDefaults: UserDefaults = .standard) {
-        self.userDefaults = userDefaults
-    }
+extension KeyedStoring where Keys == BaseURLDebugSettings {
 
-    public var customBaseURL: String? {
-        get { userDefaults[.debugCustomBaseURL] }
-        set { userDefaults[.debugCustomBaseURL] = newValue }
-    }
-
-    public var customDuckAIBaseURL: String? {
-        get { userDefaults[.debugCustomDuckAIBaseURL] }
-        set { userDefaults[.debugCustomDuckAIBaseURL] = newValue }
-    }
-
-    public func reset() {
-        customBaseURL = nil
-        customDuckAIBaseURL = nil
+    func reset() {
+        self.customBaseURL = nil
+        self.customDuckAIBaseURL = nil
     }
 
     // MARK: - Computed Helpers
 
     /// Returns the current base URL (custom override or environment variable or default)
-    public var effectiveBaseURL: String {
-        if let custom = customBaseURL, !custom.isEmpty {
+    var effectiveBaseURL: String {
+        if let custom = self.customBaseURL, !custom.isEmpty {
             return custom
         }
         return ProcessInfo.processInfo.environment["BASE_URL", default: "https://duckduckgo.com"]
     }
 
     /// Returns the current Duck.ai base URL (custom override or environment variable or default)
-    public var effectiveDuckAIBaseURL: String {
-        if let custom = customDuckAIBaseURL, !custom.isEmpty {
+    var effectiveDuckAIBaseURL: String {
+        if let custom = self.customDuckAIBaseURL, !custom.isEmpty {
             return custom
         }
         return ProcessInfo.processInfo.environment["DUCKAI_BASE_URL", default: "https://duck.ai"]
     }
 
     /// Returns the current help base URL (derived from base URL when overridden)
-    public var effectiveHelpBaseURL: String {
-        let baseURL = effectiveBaseURL
+    var effectiveHelpBaseURL: String {
+        let baseURL = self.effectiveBaseURL
         if baseURL != "https://duckduckgo.com" {
             return baseURL
         }
@@ -97,22 +76,8 @@ public final class BaseURLDebugSettings: BaseURLDebugSettingsRepresentable {
     }
 
     /// Returns true if any custom URL is currently set
-    public var hasCustomURLs: Bool {
-        return (customBaseURL != nil && !customBaseURL!.isEmpty) ||
-               (customDuckAIBaseURL != nil && !customDuckAIBaseURL!.isEmpty)
-    }
-}
-
-// MARK: - UserDefaults Extension
-
-private extension UserDefaults {
-    enum BaseURLDebugKey: String {
-        case debugCustomBaseURL = "debug.customBaseURL"
-        case debugCustomDuckAIBaseURL = "debug.customDuckAIBaseURL"
-    }
-
-    subscript<T>(key: BaseURLDebugKey) -> T? where T: Any {
-        get { value(forKey: key.rawValue) as? T }
-        set { set(newValue, forKey: key.rawValue) }
+    var hasCustomURLs: Bool {
+        return (self.customBaseURL != nil && !self.customBaseURL!.isEmpty) ||
+        (self.customDuckAIBaseURL != nil && !self.customDuckAIBaseURL!.isEmpty)
     }
 }

--- a/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
@@ -21,6 +21,7 @@ import BrowserServicesKit
 import Common
 import Foundation
 import AppKitExtensions
+import Persistence
 import URLPredictor
 import os.log
 #if !SANDBOX_TEST_TOOL
@@ -416,7 +417,7 @@ extension URL {
     // MARK: - Base URLs (Internal User Configurable)
 
     /// Shared debug settings instance for runtime URL overrides.
-    private static let debugSettings = BaseURLDebugSettings()
+    private static let debugSettings: any KeyedStoring<BaseURLDebugSettings> = UserDefaults.standard.keyedStoring()
 
     /// Determines if environment variable URL overrides are allowed.
     ///

--- a/macOS/DuckDuckGo/Common/Utilities/UserDefaultsKeys.swift
+++ b/macOS/DuckDuckGo/Common/Utilities/UserDefaultsKeys.swift
@@ -77,6 +77,11 @@ enum UserDefaultsKeys: String, StorageKeyDescribing {
     case syncManuallyDisabled = "com.duckduckgo.app.key.debug.SyncManuallyDisabled"
     case syncWasDisabledUnexpectedlyPixelFired = "com.duckduckgo.app.key.debug.SyncWasDisabledUnexpectedlyPixelFired"
 
+    // MARK: - BaseURLDebugSettings
+
+    case debugCustomBaseURL = "debug_customBaseURL"
+    case debugCustomDuckAIBaseURL = "debug_customDuckAIBaseURL"
+
     // MARK: - Add more app-wide keys here as they are migrated from UserDefaultsWrapper
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/276630244458377/task/1212923632314247?focus=true
CC: @mallexxx 

### Description
This change updates BaseURLDebugSettings and BaseURLDebugMenu to use KeyedStoring.

### Testing Steps
Same as for #3028 

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes base URL override plumbing using `Persistence`.
> 
> - Replaces `BaseURLDebugSettings` class/protocol with `StoringKeys` + `StorageKey` and `KeyedStoring` extension (`effectiveBaseURL`, `effectiveDuckAIBaseURL`, `effectiveHelpBaseURL`, `reset`, `hasCustomURLs`)
> - Updates `BaseURLDebugMenu` to accept `(any KeyedStoring<BaseURLDebugSettings>)` (defaults to `UserDefaults.standard.keyedStoring()`), and uses it for read/write + reset
> - `URLExtension`: switches static `debugSettings` to `UserDefaults.standard.keyedStoring()` and reads computed helpers from the new extension
> - Adds `UserDefaultsKeys` entries `debugCustomBaseURL` and `debugCustomDuckAIBaseURL`
> - SPM: adds `content-scope-scripts` and bumps `duckduckgo-autofill` to `19.0.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63eabe79cdd677edb202a315a6482acf200e2208. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->