### PR TITLE
Icon for pinned chat

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -100,6 +100,15 @@
       }
     },
     {
+      "identity" : "opencombine",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/OpenCombine/OpenCombine.git",
+      "state" : {
+        "revision" : "8576f0d579b27020beccbccc3ea6844f3ddfc2c2",
+        "version" : "0.14.0"
+      }
+    },
+    {
       "identity" : "privacy-dashboard",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/privacy-dashboard",

--- a/iOS/DuckDuckGo/BrowserChromeManager.swift
+++ b/iOS/DuckDuckGo/BrowserChromeManager.swift
@@ -55,7 +55,9 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
     private var observation: NSKeyValueObservation?
 
     private var startZoomScale: CGFloat = 0
-    
+
+    private var scrollToTop = true
+
     func attach(to scrollView: UIScrollView) {
         detach()
         
@@ -130,15 +132,25 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
     }
 
     func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
+        defer {
+            scrollToTop = true
+        }
+
         switch animator.barsState {
         case .hidden:
             animator.revealBars(animated: true)
             return false
+        case .transitioning:
+            return false
         default:
-            return true
+            return scrollToTop
         }
     }
-    
+
+    func preventNextScrollToTop() {
+        scrollToTop = false
+    }
+
     /// Bars should not be hidden in case ScrollView content is smaller than full (with bars hidden) viewport.
     private func canHideBars(for scrollView: UIScrollView) -> Bool {
         let heightAllowsHide = scrollView.bounds.height + (delegate?.barsMaxHeight ?? 0) < scrollView.contentSize.height

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -371,6 +371,12 @@ extension MainViewController: TabsBarDelegate {
   
     func tabsBar(_ controller: TabsBarViewController, didSelectTabAtIndex index: Int) {
         dismissOmniBar()
+
+        // Tabs bar is iPad only and this is to work around on a problem iOS 26 which will be fixed later with Xcode 26.
+        if index != self.tabManager.model.currentIndex {
+            chromeManager.preventNextScrollToTop()
+        }
+        
         select(tabAt: index)
     }
     
@@ -400,5 +406,5 @@ extension MainViewController: TabsBarDelegate {
     func tabsBarDidRequestTabSwitcher(_ controller: TabsBarViewController) {
         showTabSwitcher()
     }
-    
+
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1212928284130969?focus=true

### Description
This PR adds suggestion icon for pinned chat

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Make sure pinned Duck.ai chat has suggestion with the pin icon

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Duck.ai suggestion icons

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Display pin icon for pinned suggestions in `AIChatSuggestionRowView` (uses `Size16.pin`; falls back to `Size24.chat` when not pinned)
> - Wrap separator color update in `AIChatSuggestionsView` with `NSAppearance.withAppAppearance` to ensure correct theming
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ebbb44bb4aeab24265493b2cef21672410de5c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->