### PR TITLE
Permission center refresh button fix

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -1901,8 +1901,12 @@ final class AddressBarButtonsViewController: NSViewController {
             reloadPage: { [weak tabViewModel] in
                 tabViewModel?.reload()
             },
+            setPermissionsNeedReload: { [weak tabViewModel] in
+                tabViewModel?.tab.permissions.setPermissionsNeedReload()
+            },
             hasTemporaryPopupAllowance: tabViewModel.tab.popupHandling?.popupsTemporarilyAllowedForCurrentPage ?? false,
-            pageInitiatedPopupOpened: tabViewModel.tab.popupHandling?.pageInitiatedPopupOpened ?? false
+            pageInitiatedPopupOpened: tabViewModel.tab.popupHandling?.pageInitiatedPopupOpened ?? false,
+            permissionsNeedReload: tabViewModel.permissionsNeedReload
         )
 
         let popover = PermissionCenterPopover(viewModel: viewModel)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1212808770316274

### Description
Fix of the permission reload button functionality and presentation

### Testing Steps

#### Test 1: Reload button in Permission Center actually reloads the page

  Steps:
  1. Navigate to https://permission.site
  2. Grant a permission and  change it in the Permission Center so the reload banner appears
  3. Click the "Reload" button in the reload banner

  Expected:
  • The page should reload
  • The Permission Center popover should close

#### Test 2: Reload banner persists when reopening Permission Center

  Steps:
  1. Open the Permission Center
  2. Change a permission setting (e.g., from "Always Ask" to "Always Allow")
  3. Verify the reload banner appears
  4. Close the Permission Center popover
  5. Reopen the Permission Center

  Expected:
  • The reload banner should still be visible after reopening
  • The banner should remain visible until the page is actually reloaded (either via the Reload button or browser refresh)

#### Test 3: Reload banner clears after page reload

  Steps:
  1. Follow Test 2 steps get the reload banner showing
  2. Reload the page using one of these methods:
    • Click the "Reload" button in the banner
    • Press Cmd+R
    • Click the refresh button in the address bar
  3. Open the Permission Center again

  Expected:
  • The reload banner should not be present (unless new permission changes were made)

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Permission Center behavior and state handling.
> 
> - Adds `reloadPage` callback (calls `tabViewModel.reload()`) and `setPermissionsNeedReload` to `PermissionCenterViewModel` wiring
> - Passes `permissionsNeedReload` into `PermissionCenterViewModel` to persist the reload banner across popover reopenings
> - Minor formatting adjustments (trailing commas)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13d1367040f2bdde63779213db868500b7c1af73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->