### PR TITLE
Revert "Create placeholder ios_upload_version_metadata.yml (#3270)"

### DIFF
--- a/.github/workflows/ios_upload_version_metadata.yml
+++ b/.github/workflows/ios_upload_version_metadata.yml
@@ -1,1 +1,0 @@
-# Placeholder to be able to test from branch.


### PR DESCRIPTION
Revert #3270

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts the addition of a placeholder GitHub Actions workflow.
> 
> - Deletes `.github/workflows/ios_upload_version_metadata.yml`, which contained only placeholder content added previously
> - Restores CI to pre-#3270 state with no new workflow introduced
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 836da968c3f3d0950580656b7039c855565e807b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->