### PR TITLE
[macOS] Remove duck.ai from base URL configuration

### DIFF
--- a/macOS/DuckDuckGo/Common/Extensions/BaseURLDebugMenu.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/BaseURLDebugMenu.swift
@@ -21,13 +21,12 @@ import Persistence
 
 /// Debug menu for configuring base URLs at runtime.
 ///
-/// This menu allows internal users to override the default DuckDuckGo base URLs
+/// This menu allows internal users to override the default DuckDuckGo base URL
 /// for testing purposes, such as pointing to local servers or dev instances.
 ///
 /// ## Available Options
 ///
 /// - **Set Custom BASE_URL**: Override the main DuckDuckGo base URL
-/// - **Set Custom DUCKAI_BASE_URL**: Override the Duck.ai base URL
 /// - **Reset to Defaults**: Clear all custom overrides
 ///
 /// ## Usage Notes
@@ -39,7 +38,6 @@ final class BaseURLDebugMenu: NSMenu {
     private let debugSettings: any KeyedStoring<BaseURLDebugSettings>
 
     private let baseURLLabelMenuItem = NSMenuItem(title: "")
-    private let duckAIURLLabelMenuItem = NSMenuItem(title: "")
     private let helpURLLabelMenuItem = NSMenuItem(title: "")
 
     init(_ debugSettings: (any KeyedStoring<BaseURLDebugSettings>)? = nil) {
@@ -50,9 +48,6 @@ final class BaseURLDebugMenu: NSMenu {
             NSMenuItem(title: "Set Custom BASE_URL", action: #selector(setCustomBaseURL))
                 .targetting(self)
 
-            NSMenuItem(title: "Set Custom DUCKAI_BASE_URL", action: #selector(setCustomDuckAIBaseURL))
-                .targetting(self)
-
             NSMenuItem.separator()
 
             NSMenuItem(title: "Reset to Defaults", action: #selector(resetToDefaults))
@@ -61,7 +56,6 @@ final class BaseURLDebugMenu: NSMenu {
             NSMenuItem.separator()
 
             baseURLLabelMenuItem
-            duckAIURLLabelMenuItem
             helpURLLabelMenuItem
 
             NSMenuItem.separator()
@@ -86,10 +80,6 @@ final class BaseURLDebugMenu: NSMenu {
         let isBaseCustom = debugSettings.customBaseURL != nil && !debugSettings.customBaseURL!.isEmpty
         baseURLLabelMenuItem.title = "BASE_URL: \(baseURL)\(isBaseCustom ? " (custom)" : "")"
 
-        let duckAIURL = debugSettings.effectiveDuckAIBaseURL
-        let isDuckAICustom = debugSettings.customDuckAIBaseURL != nil && !debugSettings.customDuckAIBaseURL!.isEmpty
-        duckAIURLLabelMenuItem.title = "DUCKAI_BASE_URL: \(duckAIURL)\(isDuckAICustom ? " (custom)" : "")"
-
         let helpURL = debugSettings.effectiveHelpBaseURL
         helpURLLabelMenuItem.title = "HELP_BASE_URL: \(helpURL)"
     }
@@ -112,26 +102,6 @@ final class BaseURLDebugMenu: NSMenu {
             guard let url = URL(string: value), url.isValid else { return false }
 
             self?.debugSettings.customBaseURL = value
-            return true
-        }
-    }
-
-    @objc func setCustomDuckAIBaseURL() {
-        showURLInputAlert(
-            title: "Set Custom DUCKAI_BASE_URL",
-            message: "Enter the base URL for Duck.ai (e.g., http://localhost:8081)",
-            currentValue: debugSettings.customDuckAIBaseURL
-        ) { [weak self] value in
-            guard let value = value else { return false }
-
-            if value.isEmpty {
-                self?.debugSettings.customDuckAIBaseURL = nil
-                return true
-            }
-
-            guard let url = URL(string: value), url.isValid else { return false }
-
-            self?.debugSettings.customDuckAIBaseURL = value
             return true
         }
     }

--- a/macOS/DuckDuckGo/Common/Extensions/BaseURLDebugSettings.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/BaseURLDebugSettings.swift
@@ -38,14 +38,12 @@ import Persistence
 /// ```
 struct BaseURLDebugSettings: StoringKeys {
     let customBaseURL = StorageKey<String>(.debugCustomBaseURL)
-    let customDuckAIBaseURL = StorageKey<String>(.debugCustomDuckAIBaseURL)
 }
 
 extension KeyedStoring where Keys == BaseURLDebugSettings {
 
     func reset() {
         self.customBaseURL = nil
-        self.customDuckAIBaseURL = nil
     }
 
     // MARK: - Computed Helpers
@@ -56,14 +54,6 @@ extension KeyedStoring where Keys == BaseURLDebugSettings {
             return custom
         }
         return ProcessInfo.processInfo.environment["BASE_URL", default: "https://duckduckgo.com"]
-    }
-
-    /// Returns the current Duck.ai base URL (custom override or environment variable or default)
-    var effectiveDuckAIBaseURL: String {
-        if let custom = self.customDuckAIBaseURL, !custom.isEmpty {
-            return custom
-        }
-        return ProcessInfo.processInfo.environment["DUCKAI_BASE_URL", default: "https://duck.ai"]
     }
 
     /// Returns the current help base URL (derived from base URL when overridden)
@@ -77,7 +67,6 @@ extension KeyedStoring where Keys == BaseURLDebugSettings {
 
     /// Returns true if any custom URL is currently set
     var hasCustomURLs: Bool {
-        return (self.customBaseURL != nil && !self.customBaseURL!.isEmpty) ||
-        (self.customDuckAIBaseURL != nil && !self.customDuckAIBaseURL!.isEmpty)
+        return self.customBaseURL != nil && !self.customBaseURL!.isEmpty
     }
 }

--- a/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
@@ -472,15 +472,14 @@ extension URL {
     /// Base URL for Duck.ai (overridable by internal users, CI, or UI tests only).
     ///
     /// For external users in production, this always returns `https://duck.ai`.
-    /// For internal users or test environments, this can be overridden via:
-    /// - The Debug menu (runtime)
-    /// - The `DUCKAI_BASE_URL` environment variable (launch time)
+    /// For internal users or test environments, this can be overridden via
+    /// the `DUCKAI_BASE_URL` environment variable (launch time).
     private static var duckAiBase: String {
         guard isOverrideAllowed else {
             return "https://duck.ai"
         }
 
-        return debugSettings.effectiveDuckAIBaseURL
+        return ProcessInfo.processInfo.environment["DUCKAI_BASE_URL", default: "https://duck.ai"]
     }
 
     /// Base URL for help pages (overridable by internal users, CI, or UI tests only).


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1212937095990442?focus=true
Tech Design URL:
CC:

### Description
Removes the debug option to change the Duck.ai base URL.

### Testing Steps
1. Run the app, set internal user state
2. Go to Debug -> Base URL Configuration
3. Make sure that only the SERP URL can be changed.

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing.

### Quality Considerations
Nothing.

### Notes to Reviewer
Nothing.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes runtime override for Duck.ai and simplifies base URL debug settings.
> 
> - Drops `DUCKAI_BASE_URL` option from `BaseURLDebugMenu` and related UI labels/actions
> - Removes `customDuckAIBaseURL` storage and `effectiveDuckAIBaseURL` helpers from `BaseURLDebugSettings`
> - Updates `URL.duckAiBase` to use only the `DUCKAI_BASE_URL` environment variable (no runtime override)
> - Keeps `BASE_URL` runtime override and derived `HELP_BASE_URL` behavior; `reset()` now clears only `BASE_URL`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b24e5b43f57bc9ba1e286577dddcf0c00c10ede. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->