### PR TITLE
Avoid shield animation on error pages

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -2567,6 +2567,7 @@ extension AddressBarButtonsViewController: NavigationBarBadgeAnimatorDelegate {
     private func playShieldAnimation(for url: URL) {
         guard let tabViewModel, !tabViewModel.isShowingErrorPage else {
             Logger.general.debug("BadgeAnimation: shield animation aborted (error page active)")
+            privacyDashboardButton.isAnimationEnabled = true
             buttonsBadgeAnimator.isShieldAnimationInProgress = false
             updatePrivacyEntryPointIcon()
             buttonsBadgeAnimator.processNextAnimation()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204099484721401/task/1212837978933910?focus=true
Tech Design URL:
CC:

### Description
- Skip shield animation when the tab is showing an error page or the privacy button is hidden.
- Add debug logs to confirm when the guard is hit and keep the badge queue progressing.

### Testing Steps
1. Run the macOS app
2. Turn of Wifi
3. Try to load a site

Confirm the "world" icon is visible in the url bar (theres no overlap)

**Before:**
<img width="276" height="216" alt="CleanShot 2026-01-23 at 15 57 24@2x" src="https://github.com/user-attachments/assets/01e6c58d-f4c5-4cfc-ad87-25223f587572" />

**After:**
<img width="486" height="300" alt="CleanShot 2026-01-23 at 15 57 56@2x" src="https://github.com/user-attachments/assets/aaa3f032-9382-4c9d-b0db-9128e04caca7" />


### Impact and Risks
Low

#### What could go wrong?
- Shield animation might be skipped in a narrow timing window; guard resets queue and updates icon state to keep UI consistent.

### Quality Considerations
- Handles error-page edge cases that bypass normal icon updates.
- Logging included for easy confirmation during repro.

### Notes to Reviewer
Focus on the guard/queue flow in `AddressBarButtonsViewController`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents shield animations from running in edge cases to avoid icon overlap and stuck queues.
> 
> - In `didFinishAnimating`, skip shield animation when tab is showing an error page or `privacyDashboardButton` is hidden; re-enable hover, reset `isShieldAnimationInProgress`, process next queued animation, and update icons
> - In `playShieldAnimation(for:)`, add early return if an error page is active, with the same state resets and updates
> - Add debug logs to trace when shield animation is skipped/aborted
> - No API/signature changes; behavior gated around existing animation flow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd5ea1672793e8548f8576fd9f81c685f6775e6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->