### PR TITLE
Fix: Incorrect macOS Suggestions Color

### DIFF
--- a/macOS/DuckDuckGo/Suggestions/View/SuggestionTableCellView.swift
+++ b/macOS/DuckDuckGo/Suggestions/View/SuggestionTableCellView.swift
@@ -38,7 +38,7 @@ final class SuggestionTableCellView: NSTableCellView {
         static let suffixColor: NSColor = NSColor(designSystemColor: .accentTextPrimary)
         static let burnerSuffixColor: NSColor = .burnerAccent
         static let iconColor: NSColor = .suggestionIcon
-        static let selectedTintColor: NSColor = .selectedSuggestionTint
+        static let selectedTintColor: NSColor = NSColor(designSystemColor: .accentContentPrimary)
 
         static let switchToTabExtraSpace: CGFloat = 12 + 6 + 9 + 12
         static let switchToTabSuffixPadding: CGFloat = 8


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1212883214283193
Tech Design URL:
CC:

### Description
In this PR we're fixing an incorrect color in the Browser's Suggestions UI.

### Testing Steps
1. Launch the browser
2. Switch to any Theme in **dark mode**
3. Type anything in the search bar

- [ ] Verify the Highlighted Row is readable (the text color should be dark!)

### Screenshots

Before | Now
-|-
<img width="400" alt="Before" src="https://github.com/user-attachments/assets/2d053492-2847-471a-a114-2760027b807e" /> | <img width="400" alt="Now" src="https://github.com/user-attachments/assets/2c302629-2d1b-45c0-b18f-d344e1340645" />

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The incorrect color could be rendered

### Quality Considerations
None

### Notes to Reviewer
Thank you!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `selectedTintColor` in `SuggestionTableCellView` with `NSColor(designSystemColor: .accentContentPrimary)` to align selected-row text/icon and "Switch to Tab" visuals with the design system and improve readability (especially in dark mode).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed647ef3516cc46cd0e5b009109d3ba1fc2c3c19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->