### PR TITLE
Duck.ai chat suggestion icon change

### DIFF
--- a/macOS/DuckDuckGo/AIChat/Suggestions/AIChatSuggestionRowView.swift
+++ b/macOS/DuckDuckGo/AIChat/Suggestions/AIChatSuggestionRowView.swift
@@ -49,9 +49,9 @@ final class AIChatSuggestionRowView: NSView {
 
     private enum Constants {
         static let rowHeight: CGFloat = 32
-        static let horizontalPadding: CGFloat = 8
-        static let iconSize: CGFloat = 24
-        static let iconTitleSpacing: CGFloat = 2
+        static let horizontalPadding: CGFloat = 12
+        static let iconSize: CGFloat = 16
+        static let iconTitleSpacing: CGFloat = 6
         static let cornerRadius: CGFloat = 6
 
         // Colors matching SuggestionTableCellView
@@ -153,7 +153,7 @@ final class AIChatSuggestionRowView: NSView {
 
         let icon = suggestion.isPinned
             ? DesignSystemImages.Glyphs.Size16.pin
-            : DesignSystemImages.Glyphs.Size24.chat
+            : DesignSystemImages.Glyphs.Size16.history
         iconImageView.image = icon
         iconImageView.contentTintColor = Constants.iconColor
     }


### PR DESCRIPTION
Task/Issue URL:https://app.asana.com/1/137249556945/project/1148564399326804/task/1212974996732524?focus=true

### Description
Duck.ai suggestion icon change based on Ship Review

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Make sure regular Chats have `History-16` icon
2. Pinned chat icon remains the same

<img width="864" height="340" alt="Screenshot 2026-01-26 at 10 13 04" src="https://github.com/user-attachments/assets/3c0fc2c7-b56d-4d66-af96-1ca2ed3b317a" />


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Suggestion icons and spacing

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates AI chat suggestion row visuals in macOS app.
> 
> - Changes non-pinned chat icon to `DesignSystemImages.Glyphs.Size16.history`; keeps pinned icon as `Size16.pin`
> - Adjusts layout constants in `AIChatSuggestionRowView`: `horizontalPadding` 12, `iconSize` 16, `iconTitleSpacing` 6
> - Maintains selection/hover appearance and tint behavior; no logic changes beyond icon/spacing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e99259e3520aaf5baff5c3df97c0da67444fc26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->