### PR TITLE
Add additional check to make sure db is actually being created when we mark BoolMarker

### DIFF
--- a/iOS/Core/BookmarksStateValidation.swift
+++ b/iOS/Core/BookmarksStateValidation.swift
@@ -28,7 +28,8 @@ public protocol BookmarksStateValidation {
     func validateInitialState(context: NSManagedObjectContext,
                               validationError: BookmarksStateValidator.ValidationError) -> Bool
 
-    func validateBookmarksStructure(context: NSManagedObjectContext)
+    @discardableResult
+    func validateBookmarksStructure(context: NSManagedObjectContext) -> Bool
 }
 
 public class BookmarksStateValidator: BookmarksStateValidation {
@@ -70,7 +71,7 @@ public class BookmarksStateValidator: BookmarksStateValidation {
         return true
     }
 
-    public func validateBookmarksStructure(context: NSManagedObjectContext) {
+    public func validateBookmarksStructure(context: NSManagedObjectContext) -> Bool {
         let isMarkedAsInitialized = keyValueStore.object(forKey: Constants.bookmarksDBIsInitialized) != nil
         if isMarkedAsInitialized == false {
             keyValueStore.set(true, forKey: Constants.bookmarksDBIsInitialized)
@@ -96,10 +97,14 @@ public class BookmarksStateValidator: BookmarksStateValidation {
                 additionalParams["is-marked-as-initialized"] = isMarkedAsInitialized ? "true" : "false"
 
                 errorHandler(.bookmarksStructureBroken, additionalParams)
+                return false
             }
         } catch {
             errorHandler(.validatorError(error), nil)
+            return false
         }
+        
+        return true
     }
 
 }

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "d6674948bfd8017e21c016da497b6066feed3c46",
-        "version" : "12.30.0"
+        "revision" : "647406e99129be6828fb4e2db0fe47d22e8065e9",
+        "version" : "12.31.0"
       }
     },
     {
@@ -97,15 +97,6 @@
       "state" : {
         "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
         "version" : "9.1.0"
-      }
-    },
-    {
-      "identity" : "opencombine",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/OpenCombine/OpenCombine.git",
-      "state" : {
-        "revision" : "8576f0d579b27020beccbccc3ea6844f3ddfc2c2",
-        "version" : "0.14.0"
       }
     },
     {

--- a/iOS/DuckDuckGo/BookmarksDatabaseSetup.swift
+++ b/iOS/DuckDuckGo/BookmarksDatabaseSetup.swift
@@ -25,7 +25,7 @@ import Persistence
 import Common
 
 public extension BoolFileMarker.Name {
-    static let hasSuccessfullySetupBookmarksDatabaseBefore = BoolFileMarker.Name(rawValue: "bookmarks-db-setup-successfully-2")
+    static let hasSuccessfullySetupBookmarksDatabaseBefore = BoolFileMarker.Name(rawValue: "bookmarks-db-setup-successfully-3")
 }
 
 struct BookmarksDatabaseSetup {
@@ -55,7 +55,7 @@ struct BookmarksDatabaseSetup {
                     enhancedParams["occurrence-count"] = String(newCount)
                 }
                 if let isBookmarksDBFilePresent {
-                    enhancedParams["is-bookmarks-db-file-present"] = String(isBookmarksDBFilePresent)
+                    enhancedParams["is-bookmarks-db-file-present-2"] = String(isBookmarksDBFilePresent)
                 }
 
                 DailyPixel.fireDailyAndCount(pixel: .debugBookmarksStructureLost,
@@ -123,12 +123,16 @@ struct BookmarksDatabaseSetup {
 
         // Perform post-setup validation
         let contextForValidation = bookmarksDatabase.makeContext(concurrencyType: .privateQueueConcurrencyType)
+        var validationPassed = false
         contextForValidation.performAndWait {
-            validator.validateBookmarksStructure(context: contextForValidation)
+            validationPassed = validator.validateBookmarksStructure(context: contextForValidation)
             repairDeletedFlag(context: contextForValidation)
         }
 
-        BoolFileMarker(name: .hasSuccessfullySetupBookmarksDatabaseBefore)?.mark()
+        // Only mark as successfully setup if validation passed
+        if validationPassed {
+            BoolFileMarker(name: .hasSuccessfullySetupBookmarksDatabaseBefore)?.mark()
+        }
 
         if migrationHappened {
             do {

--- a/iOS/DuckDuckGoTests/BookmarksDatabaseSetupTests.swift
+++ b/iOS/DuckDuckGoTests/BookmarksDatabaseSetupTests.swift
@@ -95,8 +95,9 @@ class BookmarksStateValidationMock: BookmarksStateValidation {
     }
 
     var onValidateBookmarksStructure: () -> Void = { }
-    func validateBookmarksStructure(context: NSManagedObjectContext) {
+    func validateBookmarksStructure(context: NSManagedObjectContext) -> Bool {
         onValidateBookmarksStructure()
+        return true
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1212960419985368?focus=true

### Description
Add additional check to make sure db is actually being created when we mark BoolMarker

### Impact and Risks
None: Internal tooling, documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens bookmarks DB setup and validation flow.
> 
> - `validateBookmarksStructure` now returns `Bool` (with `@discardableResult`) and returns `false` on invalid roots or errors
> - `BookmarksDatabaseSetup`: runs structure validation and only marks `hasSuccessfullySetupBookmarksDatabaseBefore` when validation succeeds; marker key bumped to `bookmarks-db-setup-successfully-3`
> - Telemetry: rename pixel param `is-bookmarks-db-file-present` → `is-bookmarks-db-file-present-2`
> - Tests updated to handle new return type
> - Dependencies: bump `content-scope-scripts` to 12.31.0; remove `OpenCombine` pin from `Package.resolved`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be6a7c019c3caace4ba23d198144971cf91eb2b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->