### PR TITLE
update pixel definition

### DIFF
--- a/iOS/PixelDefinitions/pixels/definitions/subscription.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/subscription.json5
@@ -140,16 +140,8 @@
                 "description": "Error code: 12201, 12202, 12203, 12204, 12205, 12206",
                 "type": "string"
             },
-            {
-                "key": "ud",
-                "description": "Underlying Error type: com.duckduckgo.subscription.SubscriptionEndpointServiceError",
-                "type": "string"
-            },
-            {
-                "key": "ue",
-                "description": "Underlying Error code: 12300, 12301, 12302",
-                "type": "string"
-            }
+            "underlyingErrorDomain",
+            "underlyingErrorCode"
         ]
     },
     "m_subscription_tier-options_unexpected-pro-tier": {

--- a/macOS/PixelDefinitions/pixels/definitions/subscription.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/subscription.json5
@@ -158,16 +158,8 @@
                 "type": "string",
                 "description": "Error Code: 12700, 12701, 12702, 12703, 12704, 12705, 12706"
             },
-            {
-                "key": "ud",
-                "type": "string",
-                "description": "Error Type: com.duckduckgo.subscription.SubscriptionEndpointServiceError"
-            },
-            {
-                "key": "ue",
-                "type": "string",
-                "description": "Error Code: 12300, 12301, 12302"
-            }
+            "underlyingErrorDomain",
+            "underlyingErrorCode"
         ]
     },
     "m_mac_direct_subscription_tier-options_unexpected-pro-tier": {
@@ -211,16 +203,8 @@
                 "type": "string",
                 "description": "Error Code: 12700, 12701, 12702, 12703, 12704, 12705, 12706"
             },
-            {
-                "key": "ud",
-                "type": "string",
-                "description": "Error Type: com.duckduckgo.subscription.SubscriptionEndpointServiceError"
-            },
-            {
-                "key": "ue",
-                "type": "string",
-                "description": "Error Code: 12300, 12301, 12302"
-            }
+            "underlyingErrorDomain",
+            "underlyingErrorCode"
         ]
     },
     "m_mac_store_subscription_tier-options_unexpected-pro-tier": {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1212848526834326?focus=true

### Description Update pixel validation

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. N/A

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates subscription tier-options failure pixel parameter names to standardize underlying error fields.
> 
> - iOS: In `m_subscription_tier-options_failure`, replaces `ud`/`ue` object parameters with `underlyingErrorDomain` and `underlyingErrorCode`
> - macOS: In both direct and App Store `m_mac_*_subscription_tier-options_failure`, replaces `ud`/`ue` object parameters with `underlyingErrorDomain` and `underlyingErrorCode`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a44d3134e51674f01397399477afa3765579e876. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->