### PR TITLE
fix flash prevention bug

### DIFF
--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1767,6 +1767,9 @@ extension TabViewController: WKNavigationDelegate {
     private func onWebpageDidFinishLoading() {
         Logger.general.debug("webpageLoading finished")
 
+        // Flash prevention sets this false, but that breaks some websites.
+        webView?.isOpaque = true
+
         tabModel.link = link
         delegate?.tabLoadingStateDidChange(tab: self)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1212974232025317?focus=true
Tech Design URL:
CC: @aataraxiaa 

### Description
Reset the opaque flag when the webview did finish loading.

### Testing Steps
1. With dark mode enabled, visit https://bbc.com/news - should be legible once loading finishes.
2. Check with light mode enabled, should also be fine.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Might appear glitchy on first load of webview.

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fixes web view rendering after load**
> 
> - In `TabViewController.onWebpageDidFinishLoading`, explicitly sets `webView.isOpaque = true` to reverse flash-prevention’s non-opaque state that caused site rendering/readability issues (notably in dark mode).
> 
> - Scope: visual rendering only; no API or logic changes elsewhere.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba6b9bce8aef3e5a20f82aa6c910fc5a4f7e20b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->