### PR TITLE
iOS: Duck.ai Contextual Part 8c - Keyboard Improvement & Quick Action Summary

### DIFF
--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -107,6 +107,9 @@ final class AIChatContextualSheetViewController: UIViewController {
     /// The current active web view controller showing the chat
     private weak var currentWebViewController: AIChatContextualWebViewController?
 
+    /// Tracks the current sheet detent for syncing with web view
+    private var isCurrentlyMediumDetent = true
+
     /// Hosting controller for the onboarding overlay
     private var onboardingHostingController: UIHostingController<AIChatContextualOnboardingView>?
 
@@ -389,6 +392,7 @@ private extension AIChatContextualSheetViewController {
         embedChildViewController(webVC)
         currentWebViewController = webVC
         existingWebViewController = nil
+        webVC.setMediumDetent(isCurrentlyMediumDetent)
     }
 
     func showWebViewWithPrompt(_ prompt: String) {
@@ -435,7 +439,7 @@ extension AIChatContextualSheetViewController: AIChatContextualInputViewControll
     func contextualInputViewController(_ viewController: AIChatContextualInputViewController, didSelectQuickAction action: AIChatContextualQuickAction) {
         switch action {
         case .summarize:
-            delegate?.aiChatContextualSheetViewControllerDidRequestAttachPage(self)
+            attachPageContext()
         }
         contextualInputViewController.setText(action.prompt)
     }
@@ -624,6 +628,7 @@ extension AIChatContextualSheetViewController: UISheetPresentationControllerDele
 
     func sheetPresentationControllerDidChangeSelectedDetentIdentifier(_ sheetPresentationController: UISheetPresentationController) {
         let isMediumDetent = sheetPresentationController.selectedDetentIdentifier == .medium
+        isCurrentlyMediumDetent = isMediumDetent
         currentWebViewController?.setMediumDetent(isMediumDetent)
     }
 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
@@ -68,6 +68,7 @@ final class AIChatContextualWebViewController: UIViewController {
     /// Constraint for adjusting WebView bottom when keyboard appears
     private var webViewBottomConstraint: NSLayoutConstraint?
     private var isMediumDetent = true
+    private var lastKnownKeyboardFrame: CGRect?
 
     /// URL to load on viewDidLoad instead of the default AI chat URL (for cold restore).
     var initialRestoreURL: URL?
@@ -185,13 +186,24 @@ final class AIChatContextualWebViewController: UIViewController {
 
     /// Updates the sheet detent. Keyboard fix only applies in medium detent.
     func setMediumDetent(_ isMediumDetent: Bool) {
+        let wasInMediumDetent = self.isMediumDetent
         self.isMediumDetent = isMediumDetent
-        if !isMediumDetent && webViewBottomConstraint?.constant != 0 {
+
+        if isMediumDetent && !wasInMediumDetent {
+            // Transitioning TO medium: recalculate keyboard overlap if keyboard is visible
+            recalculateKeyboardOverlapIfNeeded()
+        } else if !isMediumDetent && webViewBottomConstraint?.constant != 0 {
+            // Transitioning FROM medium: animate constraint reset
             UIView.animate(withDuration: 0.25) {
                 self.webViewBottomConstraint?.constant = 0
                 self.view.layoutIfNeeded()
             }
         }
+    }
+
+    private func recalculateKeyboardOverlapIfNeeded() {
+        guard let keyboardFrame = lastKnownKeyboardFrame else { return }
+        adjustForKeyboard(frame: keyboardFrame, duration: 0.25, options: .curveEaseInOut)
     }
 
     // MARK: - Private Methods
@@ -234,25 +246,25 @@ final class AIChatContextualWebViewController: UIViewController {
     }
 
     @objc private func keyboardWillChangeFrame(_ notification: Notification) {
-        guard isMediumDetent else { return }
         guard let userInfo = notification.userInfo,
               let keyboardFrame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue else { return }
+
+        lastKnownKeyboardFrame = keyboardFrame
+
+        guard isMediumDetent, view.window != nil else { return }
 
         let duration = (userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue ?? 0
         let animationCurveRaw = (userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? NSNumber)?.uintValue ?? UIView.AnimationOptions.curveEaseInOut.rawValue
         let animationCurve = UIView.AnimationOptions(rawValue: animationCurveRaw)
 
-        let keyboardFrameInView = view.convert(keyboardFrame, from: nil)
-        let keyboardOverlap = max(0, view.bounds.height - keyboardFrameInView.origin.y)
-
-        webViewBottomConstraint?.constant = -keyboardOverlap
-
-        UIView.animate(withDuration: duration, delay: 0, options: animationCurve) {
-            self.view.layoutIfNeeded()
-        }
+        adjustForKeyboard(frame: keyboardFrame, duration: duration, options: animationCurve)
     }
 
     @objc private func keyboardWillHide(_ notification: Notification) {
+        lastKnownKeyboardFrame = nil
+
+        guard view.window != nil else { return }
+
         let userInfo = notification.userInfo
         let duration = (userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue ?? 0
         let animationCurveRaw = (userInfo?[UIResponder.keyboardAnimationCurveUserInfoKey] as? NSNumber)?.uintValue ?? UIView.AnimationOptions.curveEaseInOut.rawValue
@@ -261,6 +273,17 @@ final class AIChatContextualWebViewController: UIViewController {
         webViewBottomConstraint?.constant = 0
 
         UIView.animate(withDuration: duration, delay: 0, options: animationCurve) {
+            self.view.layoutIfNeeded()
+        }
+    }
+
+    private func adjustForKeyboard(frame keyboardFrame: CGRect, duration: TimeInterval, options: UIView.AnimationOptions) {
+        let keyboardFrameInView = view.convert(keyboardFrame, from: nil)
+        let keyboardOverlap = max(0, view.bounds.height - keyboardFrameInView.origin.y)
+
+        webViewBottomConstraint?.constant = -keyboardOverlap
+
+        UIView.animate(withDuration: duration, delay: 0, options: options) {
             self.view.layoutIfNeeded()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212978620506222

### Description
This PR adds two improvements to the contextual AI chat sheet: fixes keyboard overlap when the sheet is in medium detent, and auto-attaches page context when the "Summarize This Page" quick action is tapped.

### Testing Prerequisites
1. Enable Duck AI Contextual Mode in feature flags

### Testing Steps

#### Test 1 - Keyboard Fix
1. Navigate to a webpage with content
2. Tap the AI chat icon to open the contextual sheet
3. Sheet opens in medium detent
4. Tap the input field to bring up the keyboard
5. Verify the WebView content adjusts so it's not obscured by keyboard
6. Expand sheet to large detent (full screen)
7. Verify keyboard behavior is normal (system handles it)
8. Collapse back to medium detent with keyboard still open
9. Verify WebView adjusts correctly again

#### Test 2 - Summarize Quick Action (Auto-Attach OFF)
1. Disable "Automatic Context Attachment" in AI Chat settings
2. Navigate to a webpage with content, tap AI chat icon
3. Verify no context chip appears initially
4. Tap "Summarize This Page" quick action
5. Verify context chip appears (auto-attached)
6. Verify "summarize this page" prompt appears in input field
7. Submit the prompt
8. Verify summarization works with page context

#### Test 3 - Summarize Quick Action (Auto-Attach ON)
1. Enable "Automatic Context Attachment" in AI Chat settings
2. Navigate to a webpage, tap AI chat icon
3. Verify context chip already appears
4. Tap "Summarize This Page" quick action
5. Verify prompt appears in input field and context remains attached
6. Submit the prompt
7. Verify summarization works correctly

### Impact and Risks
Low risk - isolated changes to keyboard handling and quick action behavior. No changes to core chat functionality.

#### What could go wrong?
- Keyboard adjustment animation could be janky on older devices
- Context re-collection after tab switch could add slight latency

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances the contextual AI chat sheet UX with better keyboard behavior and smarter quick action handling.
> 
> - **Keyboard handling (medium detent only):** Adds WebView bottom constraint adjustments and keyboard observers in `AIChatContextualWebViewController`; introduces `setMediumDetent(_:)` and tracks keyboard frame to avoid overlap; removes observers on deinit
> - **Detent sync:** `AIChatContextualSheetViewController` tracks current detent via `UISheetPresentationControllerDelegate` and propagates changes to the web view
> - **Quick action:** Auto-attaches page context when `.summarize` is selected and sets the prompt
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b87a3a070e52cac41a0d7ab68af7d5d068c91a05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->