### PR TITLE
apply navigation bar tint in UIKit layer in settings

### DIFF
--- a/iOS/DuckDuckGo/MainViewController+Segues.swift
+++ b/iOS/DuckDuckGo/MainViewController+Segues.swift
@@ -415,6 +415,7 @@ extension MainViewController {
 
                 // We are still presenting legacy views, so use a Navcontroller
                 let navController = SettingsUINavigationController(rootViewController: settingsController)
+                navController.navigationBar.tintColor = UIColor(designSystemColor: .textPrimary)
                 settingsController.modalPresentationStyle = UIModalPresentationStyle.automatic
 
                 // Apply custom configuration (e.g. pre-navigate to specific screens before presentation)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1212884174567266?focus=true
Tech Design URL:
CC:

### Description
When deep linking to views in settings it would lose the back button tint. This fixes that.

### Testing Steps
1. Smoke test deep linking - e.g when browsing long press the fire button and choose customise. Back button should be correct color.
2. Check that regular access to those screens via settings is unaffected

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fixes back button tint when presenting Settings**
> 
> - In `MainViewController+Segues.swift`, set `SettingsUINavigationController.navigationBar.tintColor` to `UIColor(designSystemColor: .textPrimary)` when launching Settings
> - Ensures consistent back button color when deep linking into Settings while legacy UIKit views are still used
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19248536f1b929a33e1273bae8ac00528486919a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->