### PR TITLE
Fix VPN notification pixel parameter names to match schema

### DIFF
--- a/SharedPackages/VPN/Sources/VPN/Subscription/VPNSubscriptionStatusPixel.swift
+++ b/SharedPackages/VPN/Sources/VPN/Subscription/VPNSubscriptionStatusPixel.swift
@@ -66,8 +66,8 @@ public enum VPNSubscriptionStatusPixel: PixelKitEvent, PixelKitEventWithCustomPr
             }()
 
             return [
-                "isSubscriptionActive": isSubscriptionActiveString,
-                "authVersion": "v2",
+                "vpnSubscriptionActive": isSubscriptionActiveString,
+                "vpnAuthVersion": "v2",
                 "notificationObjectClass": Self.sourceClass(from: sourceObject)
             ]
         }

--- a/SharedPackages/VPN/Tests/VPNTests/Subscription/VPNSubscriptionStatusPixelTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/Subscription/VPNSubscriptionStatusPixelTests.swift
@@ -95,8 +95,8 @@ final class VPNSubscriptionStatusPixelTests: XCTestCase {
 
         let parameters = pixel.parameters
         XCTAssertNotNil(parameters)
-        XCTAssertEqual(parameters?["isSubscriptionActive"], "true")
-        XCTAssertEqual(parameters?["authVersion"], "v2")
+        XCTAssertEqual(parameters?["vpnSubscriptionActive"], "true")
+        XCTAssertEqual(parameters?["vpnAuthVersion"], "v2")
         XCTAssertEqual(parameters?["notificationObjectClass"], "TestSourceObject")
     }
 
@@ -109,8 +109,8 @@ final class VPNSubscriptionStatusPixelTests: XCTestCase {
 
         let parameters = pixel.parameters
         XCTAssertNotNil(parameters)
-        XCTAssertEqual(parameters?["isSubscriptionActive"], "false")
-        XCTAssertEqual(parameters?["authVersion"], "v2")
+        XCTAssertEqual(parameters?["vpnSubscriptionActive"], "false")
+        XCTAssertEqual(parameters?["vpnAuthVersion"], "v2")
         XCTAssertEqual(parameters?["notificationObjectClass"], "AnotherTestObject")
     }
 
@@ -122,8 +122,8 @@ final class VPNSubscriptionStatusPixelTests: XCTestCase {
 
         let parameters = pixel.parameters
         XCTAssertNotNil(parameters)
-        XCTAssertEqual(parameters?["isSubscriptionActive"], "no_subscription")
-        XCTAssertEqual(parameters?["authVersion"], "v2")
+        XCTAssertEqual(parameters?["vpnSubscriptionActive"], "no_subscription")
+        XCTAssertEqual(parameters?["vpnAuthVersion"], "v2")
         // NSString implementation can vary between OS versions (__NSCFConstantString vs NSTaggedPointerString)
         let objectClass = parameters?["notificationObjectClass"]
         XCTAssertTrue(objectClass?.contains("String") == true, "Expected string class name, got: \(objectClass ?? "nil")")
@@ -249,14 +249,14 @@ final class VPNSubscriptionStatusPixelTests: XCTestCase {
                     // Verify parameters are always present
                     let parameters = pixel.parameters
                     XCTAssertNotNil(parameters, "Parameters should never be nil")
-                    XCTAssertNotNil(parameters?["isSubscriptionActive"], "isSubscriptionActive should always be present")
-                    XCTAssertNotNil(parameters?["authVersion"], "authVersion should always be present")
+                    XCTAssertNotNil(parameters?["vpnSubscriptionActive"], "vpnSubscriptionActive should always be present")
+                    XCTAssertNotNil(parameters?["vpnAuthVersion"], "vpnAuthVersion should always be present")
                     XCTAssertNotNil(parameters?["notificationObjectClass"], "notificationObjectClass should always be present")
 
                     // Verify specific values
                     let expectedSubscriptionValue = subscriptionState != nil ? String(subscriptionState!) : "no_subscription"
-                    XCTAssertEqual(parameters?["isSubscriptionActive"], expectedSubscriptionValue)
-                    XCTAssertEqual(parameters?["authVersion"], "v2")
+                    XCTAssertEqual(parameters?["vpnSubscriptionActive"], expectedSubscriptionValue)
+                    XCTAssertEqual(parameters?["vpnAuthVersion"], "v2")
 
                     // Verify source object class
                     if sourceObject == nil {
@@ -294,8 +294,8 @@ final class VPNSubscriptionStatusPixelTests: XCTestCase {
         let firstPixelParams = pixels[0].parameters!
         for pixel in pixels.dropFirst() {
             let params = pixel.parameters!
-            XCTAssertEqual(params["isSubscriptionActive"], firstPixelParams["isSubscriptionActive"])
-            XCTAssertEqual(params["authVersion"], firstPixelParams["authVersion"])
+            XCTAssertEqual(params["vpnSubscriptionActive"], firstPixelParams["vpnSubscriptionActive"])
+            XCTAssertEqual(params["vpnAuthVersion"], firstPixelParams["vpnAuthVersion"])
             XCTAssertEqual(params["notificationObjectClass"], firstPixelParams["notificationObjectClass"])
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1212957258624827?focus=true

### Description

Fixes pixel alerts

### Testing Steps

Just make sure the changes look good and consistent with the alert.

### Impact and Risks

Low impact, low risk.

#### What could go wrong?

Might affect existing panels.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns VPN notification pixel parameters with the expected schema.
> 
> - Renames `isSubscriptionActive` ➜ `vpnSubscriptionActive` and `authVersion` ➜ `vpnAuthVersion` in `VPNSubscriptionStatusPixel`
> - Updates all related unit tests to assert the new parameter keys and values
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c52b3eaf53b4cd9ab805dff7f55eb594e644c553. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->