### PR TITLE
Fix memory tests workflow syntax

### DIFF
--- a/.github/workflows/macos_memory_usage_tests.yml
+++ b/.github/workflows/macos_memory_usage_tests.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         runner: [macos-15-xlarge]
         include:
-          - xcode-version: “16.4"
+          - xcode-version: 16.4
             runner: macos-15-xlarge
             os-version: 15
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1213009964917290?focus=true
CC: @jleandroperez 

### Description
Fix how Xcode version is passed as parameter to the matrix.

### Testing Steps
Verify that [this memory tests workflow](https://github.com/duckduckgo/apple-browsers/actions/runs/21435420747) is green.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes workflow matrix syntax so the job selects the intended Xcode.
> 
> - Updates `xcode-version` in `.github/workflows/macos_memory_usage_tests.yml` matrix `include` from a malformed quoted value to numeric `16.4`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43ea026695d8059d1c456a57bbe741bd8dd5b238. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->