### PR TITLE
Fix dependencies check script

### DIFF
--- a/scripts/check-dependencies-updates.sh
+++ b/scripts/check-dependencies-updates.sh
@@ -337,7 +337,7 @@ resolve_workspace_packages() {
 # Detect DuckDuckGo.xcworkspace in . or ..
 detect_workspace() {
     local cwd
-    cwd=$(pwd)
+    cwd="$(dirname "${BASH_SOURCE[0]}")"
 
     if [[ -d "${cwd}/DuckDuckGo.xcworkspace" ]]; then
         WORKSPACE_PATH="${cwd}/DuckDuckGo.xcworkspace"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1213011634690279?focus=true

### Description

The check-dependencies-updates.sh is now more resilient:
- Searches for `Package.resolved` filse only in certain folders and not anywhere (this fixes the issue with the rogue ./DerivedData folder)
- Doesn't require a search path anymore and automatically detects the DuckDuckGo.xcworkspace path

### Testing Steps

1. run `./scripts/check-dependencies-updates.sh` from the project root
2. You should have 24 direct dependencies
3. Run `cd /scripts` and then `./check-dependencies-updates.sh`
4. You should have 24 direct dependencies

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes alter how the script discovers the workspace and which `Package.resolved` files are considered, which could change reported dependencies/updates across environments. It also invokes `xcodebuild` to resolve packages, which may behave differently on CI/local setups.
> 
> **Overview**
> Makes `check-dependencies-updates.sh` *workspace-aware* by auto-detecting `DuckDuckGo.xcworkspace` (from repo root or `scripts/`) and removing the positional search-path argument.
> 
> Restricts dependency discovery to expected roots (`SharedPackages`, `iOS`, `macOS`, workspace) to avoid picking up stray `Package.resolved` files (e.g., under `DerivedData`), and forces an `xcodebuild -resolvePackageDependencies` run before reading resolved files.
> 
> Cleans up temp-file handling (uses `rm -rf` instead of truncation) and slightly adjusts JSON projects formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88e452c4481c29c6b168dce88b2a8ae3df34ebcd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->