### PR TITLE
[macOS] - Make context page Opt-In instead of Opt-out

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/macOS/PublicAPI/AIChatPreferencesStorage.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/macOS/PublicAPI/AIChatPreferencesStorage.swift
@@ -169,7 +169,7 @@ private extension UserDefaults {
     static let showAIChatShortcutInAddressBarDefaultValue = true
     static let showAIChatShortcutInAddressBarWhenTypingDefaultValue = true
     static let openAIChatInSidebarDefaultValue = true
-    static let shouldAutomaticallySendPageContextDefaultValue = true
+    static let shouldAutomaticallySendPageContextDefaultValue = false
     static let showSearchAndDuckAIToggleDefaultValue = true
 
     @objc dynamic var isAIFeaturesEnabled: Bool {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1213016737610797?focus=true
Tech Design URL:
CC:

### Description
Make context page Opt-In instead of Opt-out

### Testing Steps
1. Clean up your settings with the cleanup script 
2. Run the app, make sure the context page settings is turned off (AI Features -> Automatically send page context to the sidebar)
3. Open a website, click the duck.ai button, check no context is attached

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches default of `shouldAutomaticallySendPageContext` from `true` to `false`, making page context sending opt-in.
> 
> - Updates `UserDefaults.shouldAutomaticallySendPageContextDefaultValue` and `reset()` in `DefaultAIChatPreferencesStorage` to honor the new default
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 692f9eaac3a776245f70ea7034c2e297148886e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->