### PR TITLE
fix UI tests

### DIFF
--- a/macOS/UITests/Fire/FireDialogUITestsBase.swift
+++ b/macOS/UITests/Fire/FireDialogUITestsBase.swift
@@ -34,8 +34,7 @@ extension FireDialogUITests {
 
     func setUpFireDialogUITests() {
         continueAfterFailure = false
-        // Enable feature flags for new Fire dialog
-        app = XCUIApplication.setUp(featureFlags: ["fireDialog": true])
+        app = XCUIApplication.setUp()
         app.enforceSingleWindow()
 
         // Reset fireproof sites


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1212969300360107?focus=true

### Description Fix UI test by removing old feature flag from the test setup 

### Testing Steps
1. UI test pass (https://github.com/duckduckgo/apple-browsers/actions/runs/21478090253)

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only macOS UI test initialization and does not affect production app behavior. Risk is limited to potentially altering which UI variant the tests exercise if the flag is still required in some environments.
> 
> **Overview**
> Updates `FireDialogUITestsBase.setUpFireDialogUITests()` to stop enabling the `fireDialog` feature flag and instead use the default `XCUIApplication.setUp()` launch configuration, aligning the Fire Dialog UI tests with the current app defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3411ed263ec40d03b794acc42793be9c6178659. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->