### PR TITLE
Revert "[iOS] Fix padding when scrolling websites (#3333)"

### DIFF
--- a/iOS/DuckDuckGo/Base.lproj/Tab.storyboard
+++ b/iOS/DuckDuckGo/Base.lproj/Tab.storyboard
@@ -123,7 +123,7 @@
                             <constraint firstAttribute="trailing" secondItem="ypz-s2-KJB" secondAttribute="trailing" id="bXU-Fx-c7D"/>
                             <constraint firstAttribute="trailing" secondItem="Wfg-yB-zj4" secondAttribute="trailing" id="bpw-ay-E03"/>
                             <constraint firstItem="Kd4-Oi-JP2" firstAttribute="centerX" secondItem="t0t-53-xVf" secondAttribute="centerX" id="oFL-Ft-NQV"/>
-                            <constraint firstAttribute="bottom" secondItem="Wfg-yB-zj4" secondAttribute="bottom" id="reE-gN-ecB"/>
+                            <constraint firstItem="t0t-53-xVf" firstAttribute="bottom" secondItem="Wfg-yB-zj4" secondAttribute="bottom" id="reE-gN-ecB"/>
                             <constraint firstAttribute="bottom" secondItem="gSI-9K-1Ti" secondAttribute="bottom" id="t3k-1K-dv4"/>
                             <constraint firstItem="ypz-s2-KJB" firstAttribute="leading" secondItem="Sgm-Wo-lho" secondAttribute="leading" id="ugB-DM-Oye"/>
                         </constraints>

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1473,7 +1473,6 @@ class MainViewController: UIViewController {
         chromeManager.attach(to: tab.webView.scrollView)
         themeColorManager.attach(to: tab)
         tab.chromeDelegate = self
-        tab.updateWebViewBottomAnchor(for: viewCoordinator.toolbar.alpha)
 
         refreshControls()
     }
@@ -2479,7 +2478,6 @@ extension MainViewController: BrowserChromeDelegate {
         let updateBlock = {
             self.updateToolbarConstant(percent)
             self.updateNavBarConstant(percent)
-            self.currentTab?.updateWebViewBottomAnchor(for: percent)
 
             self.viewCoordinator.navigationBarContainer.alpha = percent
             self.viewCoordinator.tabBarContainer.alpha = percent

--- a/iOS/DuckDuckGo/StyledTopBottomBorderView.swift
+++ b/iOS/DuckDuckGo/StyledTopBottomBorderView.swift
@@ -127,7 +127,6 @@ extension StyledTopBottomBorderView {
 
     func updateForAddressBarPosition(_ addressBarPosition: AddressBarPosition) {
         isTopVisible = addressBarPosition == .top
-        isBottomVisible = addressBarPosition == .bottom
     }
 
 }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -640,7 +640,7 @@ class TabViewController: UIViewController {
         }
 
         observeNetPConnectionStatusChanges()
-
+        
         // Link DuckPlayer to current Tab
         duckPlayerNavigationHandler.setHostViewController(self)
     }
@@ -693,19 +693,8 @@ class TabViewController: UIViewController {
     }
 
     private func updateWebViewBottomAnchor() {
-        updateWebViewBottomAnchor(for: 1.0)
-    }
-
-    func updateWebViewBottomAnchor(for barsVisibilityPercent: CGFloat) {
-        if appSettings.currentAddressBarPosition == .bottom {
-            /// When address bar is at bottom, offset webview to make room for the bars
-            let targetHeight = chromeDelegate?.barsMaxHeight ?? 0.0
-            webViewBottomAnchorConstraint?.constant = -targetHeight * barsVisibilityPercent
-        } else {
-            /// When address bar is at top, webview fills the container
-            /// The container already follows the toolbar position
-            webViewBottomAnchorConstraint?.constant = 0
-        }
+        let targetHeight = chromeDelegate?.barsMaxHeight ?? 0.0
+        webViewBottomAnchorConstraint?.constant = appSettings.currentAddressBarPosition == .bottom ? -targetHeight : 0
     }
 
     private func observeNetPConnectionStatusChanges() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213014667457844?focus=true
Tech Design URL:
CC:

### Description
This reverts commit e01767cbb36a7655c8ea5247b25345298868a312.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core browsing UI layout/constraints (web view + browser chrome) and can regress page insets/scroll behavior, though it’s UI-only with no security/data impact.
> 
> **Overview**
> Reverts the dynamic web view bottom inset behavior tied to browser chrome visibility by removing calls to `updateWebViewBottomAnchor(for:)` from `MainViewController` and simplifying `TabViewController.updateWebViewBottomAnchor()` to a static offset when the address bar is at the bottom.
> 
> Tweaks the `Tab.storyboard` bottom constraint to be driven from the safe area guide, and updates `StyledTopBottomBorderView` to no longer toggle the bottom border based on address bar position.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 964ef53ee0a13d0cf3b1dd3b91d824c643b325d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->