### PR TITLE
Fix bottom toolbar divider line

### DIFF
--- a/iOS/DuckDuckGo/StyledTopBottomBorderView.swift
+++ b/iOS/DuckDuckGo/StyledTopBottomBorderView.swift
@@ -55,6 +55,15 @@ final class StyledTopBottomBorderView: UIView {
         }
     }
 
+    var bottomAlpha: CGFloat {
+        get {
+            bottomEdge.alpha
+        }
+        set {
+            bottomEdge.alpha = newValue
+        }
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
 
@@ -127,7 +136,6 @@ extension StyledTopBottomBorderView {
 
     func updateForAddressBarPosition(_ addressBarPosition: AddressBarPosition) {
         isTopVisible = addressBarPosition == .top
-        isBottomVisible = addressBarPosition == .bottom
     }
 
 }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -706,6 +706,7 @@ class TabViewController: UIViewController {
             /// The container already follows the toolbar position
             webViewBottomAnchorConstraint?.constant = 0
         }
+        borderView.bottomAlpha = barsVisibilityPercent
     }
 
     private func observeNetPConnectionStatusChanges() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213028514315622?focus=true

### Description
Fix bottom toolbar divider line

### Testing Steps
1. Move the address bar to the top
2. Check if the toolbar at the bottom correctly shows the divider line at the top, dividing the toolbar from the webview.
3. Move the address bar to the bottom
4. Check if the toolbar at the bottom correctly shows the divider line at the top, dividing the toolbar from the webview.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Don't display the divider line

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change that tweaks divider visibility behavior and ties it to toolbar show/hide animation; main risk is unintended divider opacity/visibility in edge UI states.
> 
> **Overview**
> Fixes the bottom toolbar divider behavior by no longer toggling `StyledTopBottomBorderView`’s bottom edge based on address bar position; only the top edge is controlled by `updateForAddressBarPosition`.
> 
> Adds a `bottomAlpha` API and updates `TabViewController.updateWebViewBottomAnchor(for:)` to fade the bottom divider with `barsVisibilityPercent`, keeping the divider present while matching toolbar visibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6be1a957ecc80cc27c595a777b8977fb72ca4f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->