### PR TITLE
[iOS] Do not show toolbar divider on the iPad

### DIFF
--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -706,7 +706,7 @@ class TabViewController: UIViewController {
             /// The container already follows the toolbar position
             webViewBottomAnchorConstraint?.constant = 0
         }
-        borderView.bottomAlpha = AppWidthObserver.shared.isPad ? 0 : barsVisibilityPercent
+        borderView.bottomAlpha = AppWidthObserver.shared.isLargeWidth ? 0 : barsVisibilityPercent
     }
 
     private func observeNetPConnectionStatusChanges() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1212992420482876?focus=true
Tech Design URL:
CC:

### Description
Do not show toolbar divider on the iPad

### Testing Steps
1. Open the app on the iPad
2. Make sure we're not showing a divider line where the toolbar is on iPhone mode
3. Check if the divider is visible on iPhone

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Divider is displayed on the iPad

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change gated behind `AppWidthObserver.shared.isLargeWidth`, affecting only iPad (or large-width) layouts. Potential risk is an unintended missing divider/alpha behavior on some large-width configurations.
> 
> **Overview**
> Stops showing the toolbar divider (`borderView.bottomAlpha`) on large-width (iPad) layouts by forcing the bottom border alpha to `0` when `AppWidthObserver.shared.isLargeWidth` is true, while preserving the existing fade behavior on smaller widths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c9ab2c3c8a2e9a200584b1e229b4e81dbdb30b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->