### PR TITLE
Rename `feature.status_reason`

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/WideEvent/WideEventParameters.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/WideEvent/WideEventParameters.swift
@@ -58,7 +58,7 @@ public enum WideEventParameter {
     public enum Feature {
         public static let name = "feature.name"
         public static let status = "feature.status"
-        public static let statusReason = "feature.status_reason"
+        public static let statusReason = "feature.data.ext.status_reason"
 
         public static let errorDomain = "feature.data.error.domain"
         public static let errorCode = "feature.data.error.code"

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/WideEventSenderTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/WideEventSenderTests.swift
@@ -368,7 +368,7 @@ final class WideEventSenderTests: XCTestCase {
 
         let parameters = capturedPixels[0].parameters
         XCTAssertEqual(parameters["feature.status"], "SUCCESS")
-        XCTAssertNil(parameters["feature.status_reason"])
+        XCTAssertNil(parameters["feature.data.ext.status_reason"])
     }
 
     func testSendIncludesSuccessStatusWithReason() {
@@ -384,7 +384,7 @@ final class WideEventSenderTests: XCTestCase {
 
         let parameters = capturedPixels[0].parameters
         XCTAssertEqual(parameters["feature.status"], "SUCCESS")
-        XCTAssertEqual(parameters["feature.status_reason"], "completed_successfully")
+        XCTAssertEqual(parameters["feature.data.ext.status_reason"], "completed_successfully")
     }
 
     func testSendIncludesFailureStatus() {
@@ -400,7 +400,7 @@ final class WideEventSenderTests: XCTestCase {
 
         let parameters = capturedPixels[0].parameters
         XCTAssertEqual(parameters["feature.status"], "FAILURE")
-        XCTAssertNil(parameters["feature.status_reason"])
+        XCTAssertNil(parameters["feature.data.ext.status_reason"])
     }
 
     func testSendIncludesCancelledStatus() {
@@ -416,7 +416,7 @@ final class WideEventSenderTests: XCTestCase {
 
         let parameters = capturedPixels[0].parameters
         XCTAssertEqual(parameters["feature.status"], "CANCELLED")
-        XCTAssertNil(parameters["feature.status_reason"])
+        XCTAssertNil(parameters["feature.data.ext.status_reason"])
     }
 
     func testSendIncludesUnknownStatusWithReason() {
@@ -432,7 +432,7 @@ final class WideEventSenderTests: XCTestCase {
 
         let parameters = capturedPixels[0].parameters
         XCTAssertEqual(parameters["feature.status"], "UNKNOWN")
-        XCTAssertEqual(parameters["feature.status_reason"], "unexpected_state")
+        XCTAssertEqual(parameters["feature.data.ext.status_reason"], "unexpected_state")
     }
 
     // MARK: - POST Request Tests

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/WideEventTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/WideEventTests.swift
@@ -528,7 +528,7 @@ final class WideEventTests: XCTestCase {
         XCTAssert(capturedPixels.count >= 1 && capturedPixels.count <= 2)
         let params = capturedPixels[0].parameters
         XCTAssertEqual(params["feature.status"], "SUCCESS")
-        XCTAssertEqual(params["feature.status_reason"], "test_success_reason")
+        XCTAssertEqual(params["feature.data.ext.status_reason"], "test_success_reason")
     }
 
     func testFlowRestartWithSameContextID() throws {
@@ -987,6 +987,6 @@ final class DefaultWideEventSendingTests: XCTestCase {
         XCTAssertEqual(parameters["feature.data.ext.test_identifier"], "test-id")
         XCTAssertEqual(parameters["feature.data.ext.test_eligible"], "true")
         XCTAssertEqual(parameters["feature.status"], "SUCCESS")
-        XCTAssertEqual(parameters["feature.status_reason"], "test_reason")
+        XCTAssertEqual(parameters["feature.data.ext.status_reason"], "test_reason")
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionWideEventTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionWideEventTests.swift
@@ -339,7 +339,7 @@ final class SubscriptionWideEventTests: XCTestCase {
         XCTAssert(firedPixels.count >= 1 && firedPixels.count <= 2)
         let params = firedPixels[0].parameters
         XCTAssertEqual(params["feature.status"], "UNKNOWN")
-        XCTAssertEqual(params["feature.status_reason"], "activation_timeout")
+        XCTAssertEqual(params["feature.data.ext.status_reason"], "activation_timeout")
         XCTAssertEqual(params["feature.data.ext.account_activation_latency_ms_bucketed"], "300000") // Max bucket
     }
 

--- a/iOS/PixelDefinitions/pixels/definitions/subscription.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/subscription.json5
@@ -276,7 +276,7 @@
                 "enum": ["subscription-purchase"]
             },
             {
-                "key": "feature.status_reason",
+                "key": "feature.data.ext.status_reason",
                 "type": "string",
                 "description": "Reason string for the current status, when applicable - currently applied to UNKNOWN status pixels",
                 "enum": ["partial_data", "missing_entitlements", "missing_entitlements_delayed_activation"]
@@ -367,7 +367,7 @@
                 "enum": ["subscription-restore"]
             },
             {
-                "key": "feature.status_reason",
+                "key": "feature.data.ext.status_reason",
                 "type": "string",
                 "description": "Reason string for the current status, when applicable - currently applied to UNKNOWN status pixels",
                 "enum": ["partial_data", "timeout"]
@@ -446,7 +446,7 @@
                 "enum": ["subscription-plan-change"]
             },
             {
-                "key": "feature.status_reason",
+                "key": "feature.data.ext.status_reason",
                 "type": "string",
                 "description": "Reason string for the current status, when applicable - currently applied to UNKNOWN and SUCCESS status pixels",
                 "enum": ["partial_data", "missing_entitlements", "missing_entitlements_delayed_activation"]
@@ -536,7 +536,7 @@
                 "enum": ["authv2-token-refresh"]
             },
             {
-                "key": "feature.status_reason",
+                "key": "feature.data.ext.status_reason",
                 "type": "string",
                 "description": "Reason string for the current status, when applicable - currently applied to UNKNOWN status pixels",
                 "enum": ["partial_data"]

--- a/iOS/PixelDefinitions/pixels/definitions/vpn_events.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/vpn_events.json5
@@ -53,7 +53,7 @@
                 "enum": ["vpn-connection"]
             },
             {
-                "key": "feature.status_reason",
+                "key": "feature.data.ext.status_reason",
                 "type": "string",
                 "description": "Reason string for the current status",
                 "enum": ["partial_data", "timeout", "retried"]

--- a/iOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/iOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -92,7 +92,7 @@
         "enum": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"]
     },
     "wideEventFeatureStatusReason": {
-        "key": "feature.status_reason",
+        "key": "feature.data.ext.status_reason",
         "type": "string",
         "description": "Optional reason accompanying the feature status"
     },

--- a/macOS/PixelDefinitions/pixels/definitions/subscription.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/subscription.json5
@@ -304,7 +304,7 @@
                 "enum": ["subscription-purchase"]
             },
             {
-                "key": "feature.status_reason",
+                "key": "feature.data.ext.status_reason",
                 "type": "string",
                 "description": "Reason string for the current status, when applicable - currently applied to UNKNOWN status pixels",
                 "enum": ["partial_data", "missing_entitlements", "missing_entitlements_delayed_activation"]
@@ -397,7 +397,7 @@
                 "enum": ["subscription-restore"]
             },
             {
-                "key": "feature.status_reason",
+                "key": "feature.data.ext.status_reason",
                 "type": "string",
                 "description": "Reason string for the current status, when applicable - currently applied to UNKNOWN status pixels",
                 "enum": ["partial_data", "timeout"]
@@ -476,7 +476,7 @@
                 "enum": ["authv2-token-refresh"]
             },
             {
-                "key": "feature.status_reason",
+                "key": "feature.data.ext.status_reason",
                 "type": "string",
                 "description": "Reason string for the current status, when applicable - currently applied to UNKNOWN status events",
                 "enum": ["partial_data"]
@@ -537,7 +537,7 @@
                 "enum": ["subscription-plan-change"]
             },
             {
-                "key": "feature.status_reason",
+                "key": "feature.data.ext.status_reason",
                 "type": "string",
                 "description": "Reason string for the current status, when applicable - currently applied to UNKNOWN and SUCCESS status pixels",
                 "enum": ["partial_data", "missing_entitlements", "missing_entitlements_delayed_activation"]
@@ -626,7 +626,7 @@
                 "enum": ["authv2-token-adoption"]
             },
             {
-                "key": "feature.status_reason",
+                "key": "feature.data.ext.status_reason",
                 "type": "string",
                 "description": "Reason string for the current status, when applicable - currently applied to UNKNOWN status events",
                 "enum": ["partial_data"]

--- a/macOS/PixelDefinitions/pixels/definitions/vpn_events.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/vpn_events.json5
@@ -52,7 +52,7 @@
                 "enum": ["vpn-connection"]
             },
             {
-                "key": "feature.status_reason",
+                "key": "feature.data.ext.status_reason",
                 "type": "string",
                 "description": "Reason string for the current status",
                 "enum": ["partial_data", "timeout", "retried"]

--- a/macOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/macOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -97,7 +97,7 @@
         "enum": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"]
     },
     "wideEventFeatureStatusReason": {
-        "key": "feature.status_reason",
+        "key": "feature.data.ext.status_reason",
         "type": "string",
         "description": "Optional reason accompanying the feature status"
     },


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1212992408350126?focus=true
Tech Design URL:
CC:

### Description

This PR renames the wide event status reason field, which is no longer part of the common schema.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI is green and pixel validation succeeds

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low code risk (string-key rename), but it will change emitted analytics payloads and could break downstream consumers if they still expect `feature.status_reason`.
> 
> **Overview**
> Updates wide-event instrumentation to emit the optional status reason under `feature.data.ext.status_reason` instead of `feature.status_reason`.
> 
> Adjusts PixelKit wide-event parameter constants and updates wide-event tests plus iOS/macOS pixel definition schemas/param dictionaries to validate the new key.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f4a91ac986a0b0f22307274e420d3cdf36d5e87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->