### PR TITLE
[macOS] Increase test timeouts

### DIFF
--- a/macOS/UnitTests/Freemium/DBP/FreemiumDBPPromotionViewCoordinatorTests.swift
+++ b/macOS/UnitTests/Freemium/DBP/FreemiumDBPPromotionViewCoordinatorTests.swift
@@ -293,7 +293,7 @@ final class FreemiumDBPPromotionViewCoordinatorTests: XCTestCase {
             }
             .store(in: &cancellables)
 
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 5.0)
 
         // Then
         XCTAssertTrue(sut.isHomePagePromotionVisible)
@@ -323,7 +323,7 @@ final class FreemiumDBPPromotionViewCoordinatorTests: XCTestCase {
             }
             .store(in: &cancellables)
 
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 5.0)
 
         // Then
         XCTAssertFalse(sut.isHomePagePromotionVisible)
@@ -353,7 +353,7 @@ final class FreemiumDBPPromotionViewCoordinatorTests: XCTestCase {
             }
             .store(in: &cancellables)
 
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 5.0)
 
         // Then
         XCTAssertFalse(sut.isHomePagePromotionVisible)
@@ -439,7 +439,7 @@ final class FreemiumDBPPromotionViewCoordinatorTests: XCTestCase {
 
         contextualOnboardingSubject.send(false)
 
-        await fulfillment(of: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 5)
 
         // Then
         XCTAssertEqual(sut.viewModel?.title, currentViewModel?.title)
@@ -453,7 +453,7 @@ final class FreemiumDBPPromotionViewCoordinatorTests: XCTestCase {
      * before cancelling the subscription.
      */
     @discardableResult @MainActor
-    private func waitForViewModelUpdate(for duration: TimeInterval = 1, _ block: () async -> Void = {}) async throws -> PromotionViewModel? {
+    private func waitForViewModelUpdate(for duration: TimeInterval = 5, _ block: () async -> Void = {}) async throws -> PromotionViewModel? {
         let expectation = self.expectation(description: "viewModelUpdate")
         let cancellable = sut.$viewModel.dropFirst().prefix(1).sink { _ in expectation.fulfill() }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1213034882778132?focus=true
Tech Design URL:
CC:

### Description

This PR fixes a flaky test failure that looks to be due to a low timeout value. It also bumps timeouts throughout the rest of the suite for consistency.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI is green

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to unit-test timing/await values and do not affect production behavior. Main risk is slightly longer CI runtime and potentially masking genuinely stalled async updates.
> 
> **Overview**
> **Reduces flakiness in `FreemiumDBPPromotionViewCoordinatorTests`** by increasing Combine/XCTest wait timeouts.
> 
> This bumps multiple `wait(for:)` and `fulfillment(of:)` timeouts to `5s` and increases the helper `waitForViewModelUpdate` default duration from `1s` to `5s` to give async state updates more time to complete.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2da2cf34a9a93571d6f9d1c434870f7d6077e402. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->