### PR TITLE
Keychain access error source cleanup

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Storage/SubscriptionTokenKeychainStorage.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Storage/SubscriptionTokenKeychainStorage.swift
@@ -25,7 +25,6 @@ public enum KeychainErrorSource: String {
     case browser
     case vpn
     case pir
-    case shared
 }
 
 public enum KeychainErrorAuthVersion: String {

--- a/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
@@ -142,7 +142,6 @@ final class AppDependencyProvider: DependencyProvider {
         let subscriptionUserDefaults = UserDefaults(suiteName: subscriptionAppGroup)!
         let subscriptionEnvironment = DefaultSubscriptionManager.getSavedOrDefaultEnvironment(userDefaults: subscriptionUserDefaults)
         var tokenHandler: any SubscriptionTokenHandling
-        var accessTokenProvider: () async -> String?
         var authenticationStateProvider: (any SubscriptionAuthenticationStateProvider)!
 
         let keychainType = KeychainType.dataProtection(.named(subscriptionAppGroup))
@@ -226,10 +225,6 @@ final class AppDependencyProvider: DependencyProvider {
         }
 
         self.subscriptionManager = subscriptionManager
-
-        accessTokenProvider = {
-            { return try? await subscriptionManager.getTokenContainer(policy: .localValid).accessToken }
-        }()
         tokenHandler = subscriptionManager
         authenticationStateProvider = subscriptionManager
 

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -605,7 +605,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let tokenStorage = SubscriptionTokenKeychainStorage(keychainManager: keychainManager, userDefaults: .subs) { accessType, error in
             PixelKit.fire(SubscriptionErrorPixel.subscriptionKeychainAccessError(accessType: accessType,
                                                                                  accessError: error,
-                                                                                 source: KeychainErrorSource.shared,
+                                                                                 source: KeychainErrorSource.browser,
                                                                                  authVersion: KeychainErrorAuthVersion.v2),
                           frequency: .legacyDailyAndCount)
         }

--- a/macOS/DuckDuckGo/Subscription/SubscriptionManager+StandardConfiguration.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionManager+StandardConfiguration.swift
@@ -31,7 +31,8 @@ extension DefaultSubscriptionManager {
                             environment: SubscriptionEnvironment,
                             featureFlagger: FeatureFlagger? = nil,
                             userDefaults: UserDefaults,
-                            pixelHandlingSource: SubscriptionPixelHandler.Source) {
+                            pixelHandlingSource: SubscriptionPixelHandler.Source,
+                            source: KeychainErrorSource) {
 
         let pixelHandler: SubscriptionPixelHandling = SubscriptionPixelHandler(source: pixelHandlingSource)
         let keychainManager = KeychainManager(attributes: SubscriptionTokenKeychainStorage.defaultAttributes(keychainType: keychainType), pixelHandler: pixelHandler)
@@ -41,7 +42,7 @@ extension DefaultSubscriptionManager {
                                                               userDefaults: userDefaults) { accessType, error in
             PixelKit.fire(SubscriptionErrorPixel.subscriptionKeychainAccessError(accessType: accessType,
                                                                              accessError: error,
-                                                                             source: KeychainErrorSource.shared,
+                                                                             source: source,
                                                                              authVersion: KeychainErrorAuthVersion.v2),
                           frequency: .legacyDailyAndCount)
         }

--- a/macOS/DuckDuckGoDBPBackgroundAgent/DuckDuckGoDBPBackgroundAgentAppDelegate.swift
+++ b/macOS/DuckDuckGoDBPBackgroundAgent/DuckDuckGoDBPBackgroundAgentAppDelegate.swift
@@ -99,9 +99,10 @@ final class DuckDuckGoDBPBackgroundAgentAppDelegate: NSObject, NSApplicationDele
         let subscriptionUserDefaults = UserDefaults(suiteName: subscriptionAppGroup)!
         let subscriptionEnvironment = DefaultSubscriptionManager.getSavedOrDefaultEnvironment(userDefaults: subscriptionUserDefaults)
         subscriptionManager = DefaultSubscriptionManager(keychainType: .dataProtection(.named(subscriptionAppGroup)),
-                                                           environment: subscriptionEnvironment,
-                                                           userDefaults: subscriptionUserDefaults,
-                                                           pixelHandlingSource: .dbp)
+                                                         environment: subscriptionEnvironment,
+                                                         userDefaults: subscriptionUserDefaults,
+                                                         pixelHandlingSource: .dbp,
+                                                         source: .pir)
     }
 
     @MainActor

--- a/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
+++ b/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppDelegate.swift
@@ -58,9 +58,10 @@ final class DuckDuckGoVPNApplication: NSApplication {
         let subscriptionEnvironment = DefaultSubscriptionManager.getSavedOrDefaultEnvironment(userDefaults: subscriptionUserDefaults)
         let keychainType = KeychainType.dataProtection(.named(subscriptionAppGroup))
         subscriptionManager = DefaultSubscriptionManager(keychainType: keychainType,
-                                                             environment: subscriptionEnvironment,
-                                                             userDefaults: subscriptionUserDefaults,
-                                                             pixelHandlingSource: .vpnApp)
+                                                         environment: subscriptionEnvironment,
+                                                         userDefaults: subscriptionUserDefaults,
+                                                         pixelHandlingSource: .vpnApp,
+                                                         source: .vpn)
 
         _delegate = DuckDuckGoVPNAppDelegate(subscriptionManager: subscriptionManager,
                                              subscriptionEnvironment: subscriptionEnvironment)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209882303470922/task/1213038465595604?focus=true

### Description

Removes the "shared" keychain access error source and uses the correct one

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates only keychain error reporting metadata (pixels) and initializer plumbing; no changes to token storage or auth logic.
> 
> **Overview**
> **Cleans up keychain-access error source reporting for subscription token storage.** The `KeychainErrorSource.shared` case is removed and callers now report the correct per-app source (`.browser`, `.vpn`, `.pir`).
> 
> On macOS, `DefaultSubscriptionManager`’s standard configuration initializer now takes a `KeychainErrorSource` parameter and forwards it into the keychain error pixel; the VPN agent and DBP background agent pass their respective sources. A small iOS dependency setup cleanup removes an unused `accessTokenProvider` closure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 690a50bcc1e99cc12e2cdfeed92c1170320e66bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->