### PR TITLE
Pixel definitions for external scheme and popups permissions corrected

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/permission_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/permission_pixels.json5
@@ -65,7 +65,7 @@
         "suffixes": [
             {
                 "description": "Permission type for which System Preferences is opened",
-                "enum": ["camera", "microphone", "geolocation", "popups", "notification", "external_scheme"]
+                "enum": ["camera", "microphone", "geolocation", "notification"]
             }
         ],
         "parameters": ["appVersion", "pixelSource"]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1213062459984044?focus=true
Tech Design URL:
CC:

### Description
Pixel definitions corrected based on [this report](https://app.asana.com/1/137249556945/project/1148564399326804/task/1213062459984044?focus=true)

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Make sure new pixel definitions for external scheme, popups, and notifications are correct.


### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates internal pixel definition metadata only, with no runtime logic changes; main risk is mismatched analytics naming if downstream consumers still expect the removed pixel keys.
> 
> **Overview**
> Updates macOS permission pixel definitions so `external_scheme` is treated like other permission types across authorization/changed/reset pixels.
> 
> Removes the dedicated `*_external_scheme` pixel entries and folds that coverage into the shared pixels by adding `external_scheme` to their suffix enums, and slightly generalizes the affected descriptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 709fde80632cb5bfb50525c02ac0c532811703df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->