### PR TITLE
Update RMF pixels definitions to match reality

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/remote_messaging_framework.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/remote_messaging_framework.json5
@@ -11,7 +11,8 @@
                 "key": "message",
                 "description": "The identifier for the message, sourced from the remote message configuration",
                 "type": "string"
-            }
+            },
+            "pixelSource"
         ],
         "privacyReview": ["https://app.asana.com/1/137249556945/project/69071770703008/task/1207725476477177?focus=true"]
     },
@@ -26,7 +27,8 @@
                 "key": "message",
                 "description": "The identifier for the message, sourced from the remote message configuration",
                 "type": "string"
-            }
+            },
+            "pixelSource"
         ],
         "privacyReview": ["https://app.asana.com/1/137249556945/project/69071770703008/task/1207725476477177?focus=true"]
     },
@@ -41,7 +43,8 @@
                 "key": "message",
                 "description": "The identifier for the message, sourced from the remote message configuration",
                 "type": "string"
-            }
+            },
+            "pixelSource"
         ],
         "privacyReview": ["https://app.asana.com/1/137249556945/project/69071770703008/task/1207725476477177?focus=true"]
     },
@@ -56,7 +59,8 @@
                 "key": "message",
                 "description": "The identifier for the message, sourced from the remote message configuration",
                 "type": "string"
-            }
+            },
+            "pixelSource"
         ],
         "privacyReview": ["https://app.asana.com/1/137249556945/project/69071770703008/task/1207725476477177?focus=true"]
     },
@@ -71,7 +75,8 @@
                 "key": "message",
                 "description": "The identifier for the message, sourced from the remote message configuration",
                 "type": "string"
-            }
+            },
+            "pixelSource"
         ],
         "privacyReview": ["https://app.asana.com/1/137249556945/project/69071770703008/task/1207725476477177?focus=true"]
     },
@@ -86,7 +91,8 @@
                 "key": "message",
                 "description": "The identifier for the message, sourced from the remote message configuration",
                 "type": "string"
-            }
+            },
+            "pixelSource"
         ],
         "privacyReview": ["https://app.asana.com/1/137249556945/project/69071770703008/task/1207725476477177?focus=true"]
     },


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1213062458756642?focus=true

### Description
This change updates RMF pixels definition with the pixelSource parameter that has always been sent,
just not included in the json file.

### Testing Steps
Verify that CI is green.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates pixel definition metadata to include an already-sent `pixelSource` parameter, without changing runtime behavior.
> 
> **Overview**
> Updates macOS RMF pixel definitions (`remote_messaging_framework.json5`) to include the `pixelSource` parameter for all remote-message display/click/dismiss events, aligning the schema with what telemetry already sends.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 610df57f9b175111d633fae33a8793a156c7c1c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->