### PR TITLE
Fix critical path e2e tests

### DIFF
--- a/macOS/SyncE2EUITests/CriticalPathsTests.swift
+++ b/macOS/SyncE2EUITests/CriticalPathsTests.swift
@@ -474,9 +474,9 @@ final class CriticalPathsTests: XCTestCase {
         XCTAssertTrue(creditCardsItem.waitForExistence(timeout: 5))
         creditCardsItem.click()
         let elementsQuery = currentWindow.popovers.scrollViews.otherElements
-        elementsQuery.buttons["Test Credit Card, Visa (1111)"].click()
-        elementsQuery.buttons["Credit card, MasterCard (1308)"].click()
-        elementsQuery.buttons["Debit card, Visa (4242)"].click()
+        elementsQuery.buttons["Test Credit Card, •••• 1111"].click()
+        elementsQuery.buttons["Credit card, •••• 1308 Expires: 07/2032"].click()
+        elementsQuery.buttons["Debit card, •••• 4242 Expires: 10/2030"].click()
         app.typeKey(XCUIKeyboardKey.escape.rawValue, modifierFlags: [])
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211264967278501/task/1213035815917713?focus=true
Tech Design URL:
CC:

### Description

This PR simply fixes the failing e2e tests, which needed updating for the new format in which we display card numbers and expiry dates.

### Testing Steps

1. If you're able to run the critical path e2e tests locally, then ensure they pass.
2. You can also see a passing run of this branch here: https://github.com/duckduckgo/apple-browsers/actions/runs/21589824562

### Impact and Risks

None: Internal tooling, documentation


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates UI test string matchers for credit card rows to align with the new masked-number/expiry text, with no production code changes.
> 
> **Overview**
> Updates the Sync critical path macOS UI test `checkCreditCards()` to match the new credit card row labels (masked numbers and included expiry dates), fixing previously failing E2E assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0abcc0887c29d665ab897d5202cbe9f3f5dc7a2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->