### PR TITLE
Fix: Missing Test Baseline for CI Hardware Specs

### DIFF
--- a/.github/workflows/macos_memory_usage_tests.yml
+++ b/.github/workflows/macos_memory_usage_tests.yml
@@ -153,7 +153,7 @@ jobs:
         log stream --debug --info --predicate 'process == "DuckDuckGo Review" OR process == "UI Tests-Runner"' --style syslog > app-console.log 2>&1 &
         echo $! > log_stream.pid
 
-    - name: Override XCTest Baseline HW Specs 
+    - name: Override XCTest Baseline HW Specs
       working-directory: macOS
       run: |
         ./scripts/override-test-baseline-specs.sh

--- a/macOS/scripts/override-test-baseline-specs.sh
+++ b/macOS/scripts/override-test-baseline-specs.sh
@@ -35,10 +35,18 @@ find "$SEARCH_DIR" -path "*/xcbaselines/*/Info.plist" | while read -r PLIST_PATH
 
   # Update each UUID entry
   for UUID in $UUIDS; do
-    /usr/libexec/PlistBuddy -c "Set :runDestinationsByUUID:${UUID}:localComputer:cpuKind '$CPU_KIND'" "$PLIST_PATH" || true
-    /usr/libexec/PlistBuddy -c "Set :runDestinationsByUUID:${UUID}:localComputer:logicalCPUCoresPerPackage $CPU_CORES" "$PLIST_PATH" || true
-    /usr/libexec/PlistBuddy -c "Set :runDestinationsByUUID:${UUID}:localComputer:physicalCPUCoresPerPackage $PHYSICAL_CORES" "$PLIST_PATH" || true
-    /usr/libexec/PlistBuddy -c "Set :runDestinationsByUUID:${UUID}:localComputer:modelCode '$MODEL'" "$PLIST_PATH" || true
+    if ! /usr/libexec/PlistBuddy -c "Set :runDestinationsByUUID:${UUID}:localComputer:cpuKind '$CPU_KIND'" "$PLIST_PATH"; then
+      echo "Warning: failed to update cpuKind for UUID $UUID in $PLIST_PATH" >&2
+    fi
+    if ! /usr/libexec/PlistBuddy -c "Set :runDestinationsByUUID:${UUID}:localComputer:logicalCPUCoresPerPackage $CPU_CORES" "$PLIST_PATH"; then
+      echo "Warning: failed to update logicalCPUCoresPerPackage for UUID $UUID in $PLIST_PATH" >&2
+    fi
+    if ! /usr/libexec/PlistBuddy -c "Set :runDestinationsByUUID:${UUID}:localComputer:physicalCPUCoresPerPackage $PHYSICAL_CORES" "$PLIST_PATH"; then
+      echo "Warning: failed to update physicalCPUCoresPerPackage for UUID $UUID in $PLIST_PATH" >&2
+    fi
+    if ! /usr/libexec/PlistBuddy -c "Set :runDestinationsByUUID:${UUID}:localComputer:modelCode '$MODEL'" "$PLIST_PATH"; then
+      echo "Warning: failed to update modelCode for UUID $UUID in $PLIST_PATH" >&2
+    fi
 
     echo "✅ Updated xcbaseline: CPU=$CPU_KIND, Cores=$CPU_CORES, Model=$MODEL, UUID=$UUID"
   done


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1213083335144230?focus=true
Tech Design URL:
CC:

### Description
This PR implements a workaround that helps us load up the Memory Test Baseline, when running on CI hardware.
Restores PR #3307 

### Testing Steps
Please run the CI workflow in this branch:

```
gh workflow run macos_memory_usage_tests.yml --ref lantean/memory-pressure-hw-baseline
```

- [x] Verify you see a log line indicating `✅ Updated xcbaseline: CPU=Apple M2 Pro (Virtual) (...)`
- [x] Verify the actual Test Cases print the baseline
   ```baselineName: "Local Baseline", baselineAverage: 178.200, polarity: prefers smaller, maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.000, maxStandardDeviation: 0.000```

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing, internal tooling

### Quality Considerations
None

### Notes to Reviewer
Thank you!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to CI workflow scripting and plist updates for performance baselines, with no product/runtime code impact. Main risk is inadvertently mutating baseline plists in unexpected locations or formats, which would affect test comparability rather than app behavior.
> 
> **Overview**
> Ensures macOS memory-usage performance tests can load/use XCTest baselines on CI by **overriding baseline hardware specs** to match the current GitHub runner.
> 
> The `macos_memory_usage_tests.yml` workflow now runs `./scripts/override-test-baseline-specs.sh` before building tests, and the SQL debug step name is cleaned up. The new script scans `*/xcbaselines/*/Info.plist` and updates `runDestinationsByUUID` entries (CPU kind, logical/physical core counts, model code) using `sysctl` + `PlistBuddy`, logging warnings on per-field failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ead2f83276a412b70d4999b238abcb25317f226. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->