### PR TITLE
Add should-run-checks to memory tests workflow

### DIFF
--- a/.github/workflows/macos_memory_usage_tests.yml
+++ b/.github/workflows/macos_memory_usage_tests.yml
@@ -28,8 +28,12 @@ on:
       - '.xcode-version'
 
 concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
+  # When this workflow is called by another workflow (e.g. code freeze), `github.workflow` contains the name of the calling workflow,
+  # and the value of `${{ github.workflow }}-${{ github.ref }}` would be the same for PR Checks and Memory Tests, which would prevent them
+  # from being run concurrently. We're adding a suffix here to tell PR Checks and Memory Tests apart and allow for running the two
+  # side by side in the code freeze workflow.
+  group: ${{ github.workflow }}-${{ github.ref }}-memory-usage-tests
+  cancel-in-progress: true
 
 jobs:
   should-run-checks:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1213074135853250?focus=true

### Description
This change adds should-run-pr-checks workflow to the memory tests workflow to allow it to be skipped on draft PRs.

### Testing Steps
Verify that [this workflow](https://github.com/duckduckgo/apple-browsers/actions/runs/21600658256) didn’t run past the initial check because the PR was a draft.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: GitHub Actions-only changes that affect when jobs run and how concurrency is keyed, without touching product code. Main risk is accidentally skipping or cancelling memory tests due to the new gating/concurrency behavior.
> 
> **Overview**
> Adds a `should-run-checks` reusable-workflow gate to `macos_memory_usage_tests.yml`, and makes the notarized app build (and therefore downstream memory tests) run only when `should_run` is `true` (e.g., skip draft PRs unless allowed).
> 
> Updates workflow `concurrency` to use a distinct `group` suffix and enables `cancel-in-progress`, allowing memory tests to run alongside other PR checks when invoked via `workflow_call` while cancelling superseded runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 931b04d463ed92b9b32d81475ca9252857d09df4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->