### PR TITLE
Revert "[macOS] Increase Sparkle delta update coverage from 2 to 10 versions"

### DIFF
--- a/macOS/scripts/appcast_manager/appcastManager.swift
+++ b/macOS/scripts/appcast_manager/appcastManager.swift
@@ -794,8 +794,8 @@ func writeAppcastContent(_ content: String, to filePath: URL) {
 // MARK: - Generating of New Appcast
 
 func runGenerateAppcast(with versionNumber: String, channel: String? = nil, rolloutInterval: String? = nil, keyFile: String? = nil) {
-    let maximumVersions = "10"
-    let maximumDeltas = "10"
+    let maximumVersions = "2"
+    let maximumDeltas = "2"
 
     var commandComponents: [String] = []
     commandComponents.append("generate_appcast")


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/task/1213087292905784

### Description

Reverts a Sparkle appcast generation change.

### Testing Steps

None.

### Impact and Risks

Low.

#### What could go wrong?

NA

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts parameters passed to `generate_appcast`, but may increase CI time/disk usage and appcast size due to generating more historical versions/deltas.
> 
> **Overview**
> Increases Sparkle appcast generation coverage by raising `--maximum-versions` and `--maximum-deltas` from 2 to 10 in `appcastManager.swift`, enabling delta updates for users across the last 10 releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b88597349c7a992af3f9fe9e38f688f977c21b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->