### PR TITLE
Update copy for duck.ai suggestions settings

### DIFF
--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -1936,9 +1936,9 @@ public struct UserText {
 
     public static let settingsAutomaticPageContextSubtitle = NSLocalizedString("settings.aifeatures.automatic.context.subtitle", value: "Automatically send page context to Duck.ai", comment: "Settings screen cell subtitle for enabling automatic page context")
 
-    public static let settingsChatSuggestionsTitle = NotLocalizedString("settings.aifeatures.chat.suggestions.title", value: "Chat Suggestions", comment: "Settings screen cell title for enabling chat suggestions")
+    public static let settingsChatSuggestionsTitle = NSLocalizedString("settings.aifeatures.chat.suggestions.title", value: "Chat Suggestions", comment: "Settings screen cell title for enabling chat suggestions")
 
-    public static let settingsChatSuggestionsSubtitle = NotLocalizedString("settings.aifeatures.chat.suggestions.subtitle", value: "Show recent Duck.ai chats", comment: "Settings screen cell subtitle for enabling chat suggestions")
+    public static let settingsChatSuggestionsSubtitle = NSLocalizedString("settings.aifeatures.chat.suggestions.subtitle", value: "Show suggestions from your chat history as you type in Duck.ai", comment: "Settings screen cell subtitle for enabling chat suggestions")
 
     public static let settingsAiFeaturesSearchAssist = NSLocalizedString("settings.aifeatures.assist", value: "Search Assist Settings", comment: "Title of search assist settings link")
 

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -2887,6 +2887,12 @@ Take back control of your personal information with the browser designed for dat
 /* Settings screen cell title for enabling automatic page context */
 "settings.aifeatures.automatic.context.title" = "Automatically Send Context";
 
+/* Settings screen cell subtitle for enabling chat suggestions */
+"settings.aifeatures.chat.suggestions.subtitle" = "Show suggestions from your chat history as you type in Duck.ai";
+
+/* Settings screen cell title for enabling chat suggestions */
+"settings.aifeatures.chat.suggestions.title" = "Chat Suggestions";
+
 /* Title of hide AI-generated images settings link */
 "settings.aifeatures.hide.ai.generated.images" = "Hide AI-Generated Images";
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1212999512069468?focus=true
Tech Design URL:
CC:

### Description
Update copy for duck.ai suggestions settings

### Testing Steps
1. Go to Settings -> AI Features. Check if the updated copy is there

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Wrong copy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk text-only change that updates and localizes the Duck.ai chat suggestions setting label/subtitle; no behavioral or data handling logic is modified.
> 
> **Overview**
> Updates the Duck.ai *Chat Suggestions* setting to use localized strings (switching from `NotLocalizedString` to `NSLocalizedString`) and adds the missing `Localizable.strings` entries.
> 
> Rewords the subtitle copy to clarify that suggestions come from the user’s chat history as they type in Duck.ai.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79267f6e6f096c51340388dd1a8d38c11c711917. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->