### PR TITLE
[iOS] Use Xcode 26.2 for ad-hoc experimental builds

### DIFF
--- a/.github/workflows/ios_adhoc.yml
+++ b/.github/workflows/ios_adhoc.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Select Xcode
         uses: ./.github/actions/select-xcode-version
+        with:
+          xcode-version: ${{ github.event.inputs.build-type == 'Experimental' && '26.2' || '' }}
 
       - name: Add commit SHA to plist
         run: |


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1213074229653597?focus=true
Tech Design URL:
CC:

### Description

This PR forces Experimental builds to use Xcode 26.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Confirm that [this workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/21639928058/job/62376261555) selected Xcode 26.2
2. Confirm that [this](https://github.com/duckduckgo/apple-browsers/actions/runs/21639936424/job/62376293955) and [this](https://github.com/duckduckgo/apple-browsers/actions/runs/21639941606/job/62376312814) workflow run selected 16.4 

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
3. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
4. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but it can break or change build outputs if Xcode 26.2 is unavailable or incompatible with the project/tooling.
> 
> **Overview**
> Updates the `ios_adhoc` GitHub Actions workflow to **force Experimental ad-hoc builds to run on Xcode 26.2**, while leaving other build types to use the default Xcode selection behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abf350072536e62b75c3e8934583cf3d1d548ff3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->