### PR TITLE
[macOS] Add physical footprint to memory monitor

### DIFF
--- a/macOS/DuckDuckGo/AppHealth/MemoryUsageMonitor.swift
+++ b/macOS/DuckDuckGo/AppHealth/MemoryUsageMonitor.swift
@@ -53,11 +53,6 @@ final class MemoryUsageMonitor: @unchecked Sendable {
         /// Physical footprint in gigabytes.
         var physFootprintGB: Double { Double(physFootprintBytes) / Double(Self.oneGB) }
 
-        /// Legacy compatibility: use resident_size as default.
-        var usedBytes: UInt64 { residentBytes }
-        var usedMB: Double { residentMB }
-        var usedGB: Double { residentGB }
-
         var residentMemoryString: String {
             if residentBytes > Self.oneGB {
                 let formattedValue = Self.gbFormatter.string(from: NSNumber(value: residentGB)) ?? String(residentGB)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1212979631544085
Tech Design URL:
CC:

### Description
Adds the

### Testing Steps
1. Run the application, turn on the `memoryUsageMonitor` feature flag
2. You should both the residence and physical footprint in the address bar (like the image attached)
3. Check that the memory indicated in `F` is the same as shown in Activity Monitor only for the DuckDuckGo debug application.

<img width="262" height="105" alt="Screenshot" src="https://github.com/user-attachments/assets/590395c2-b8b6-441a-b8d1-78b1914fab15" />

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing is internal.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: internal debug memory monitor only; changes are limited to metric collection/formatting and could at worst misreport values or add minor overhead.
> 
> **Overview**
> Updates the macOS memory monitor to report **two metrics** instead of one: *resident memory* and *physical footprint* (Activity Monitor–aligned).
> 
> `MemoryUsageMonitor.getCurrentMemoryUsage()` now queries both `MACH_TASK_BASIC_INFO` and `TASK_VM_INFO` and emits them via an expanded `MemoryReport`. Logging and the on-screen label are updated to display a combined `R:… | F:…` string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8476b5502ecfc7e1a2524d29af6d0cb3b288979. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->