### PR TITLE
[macOS] Remove memory pressure warning pixel

### DIFF
--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -852,7 +852,6 @@ final class MainMenu: NSMenu {
             }
 
             NSMenuItem(title: "Simulate memory pressure event") {
-                NSMenuItem(title: "Warning", action: #selector(AppDelegate.simulateMemoryPressureWarning))
                 NSMenuItem(title: "Critical", action: #selector(AppDelegate.simulateMemoryPressureCritical))
             }
 

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -619,10 +619,6 @@ extension AppDelegate {
         throwTestCppException()
     }
 
-    @objc func simulateMemoryPressureWarning(_ sender: Any?) {
-        memoryPressureReporter.simulateMemoryPressureEvent(level: .warning)
-    }
-
     @objc func simulateMemoryPressureCritical(_ sender: Any?) {
         memoryPressureReporter.simulateMemoryPressureEvent(level: .critical)
     }

--- a/macOS/PixelDefinitions/pixels/definitions/memory_pressure_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/memory_pressure_pixels.json5
@@ -1,12 +1,5 @@
 // See https://app.asana.com/0/72649045549333/1208001118995887/f.
 {
-    "m_mac_memory_pressure_warning": {
-        "description": "Sent when the operating system reports warning level memory pressure.",
-        "owners": ["ayoy"],
-        "triggers": ["other"],
-        "suffixes": ["daily"],
-        "parameters": ["appVersion"]
-    },
     "m_mac_memory_pressure_critical": {
         "description": "Sent when the operating system reports critical level memory pressure.",
         "owners": ["ayoy"],

--- a/macOS/UnitTests/AppHealth/MemoryPressureReporterTests.swift
+++ b/macOS/UnitTests/AppHealth/MemoryPressureReporterTests.swift
@@ -47,14 +47,6 @@ final class MemoryPressureReporterTests: XCTestCase {
 
     // MARK: - Pixel Name Tests
 
-    func testMemoryPressureWarningPixelName() {
-        // Given/When
-        let pixel = MemoryPressurePixel.memoryPressureWarning
-
-        // Then
-        XCTAssertEqual(pixel.name, "m_mac_memory_pressure_warning")
-    }
-
     func testMemoryPressureCriticalPixelName() {
         // Given/When
         let pixel = MemoryPressurePixel.memoryPressureCritical
@@ -65,38 +57,14 @@ final class MemoryPressureReporterTests: XCTestCase {
 
     func testMemoryPressurePixelParameters() {
         // Given/When
-        let warningPixel = MemoryPressurePixel.memoryPressureWarning
         let criticalPixel = MemoryPressurePixel.memoryPressureCritical
 
         // Then
-        XCTAssertNil(warningPixel.parameters)
         XCTAssertNil(criticalPixel.parameters)
-        XCTAssertNil(warningPixel.standardParameters)
         XCTAssertNil(criticalPixel.standardParameters)
     }
 
     // MARK: - Notification + Pixel tests
-
-    func testWhenWarningEventProcessed_ThenPostsWarningNotificationAndFiresWarningPixel() {
-        // Given
-        mockFeatureFlagger.enabledFeatureFlags = [.memoryPressureReporting]
-        sut = MemoryPressureReporter(featureFlagger: mockFeatureFlagger,
-                                     pixelFiring: mockPixelFiring,
-                                     notificationCenter: notificationCenter)
-
-        let notificationExpectation = expectation(forNotification: .memoryPressureWarning, object: nil, notificationCenter: notificationCenter) { notification in
-            return notification.object as AnyObject? === self.sut
-        }
-
-        // When
-        sut.processMemoryPressureEventForTesting(.warning)
-
-        // Then
-        wait(for: [notificationExpectation], timeout: 1.0)
-        XCTAssertEqual(mockPixelFiring.actualFireCalls.count, 1)
-        XCTAssertEqual(mockPixelFiring.actualFireCalls.first?.pixel.name, "m_mac_memory_pressure_warning")
-        XCTAssertEqual(mockPixelFiring.actualFireCalls.first?.frequency, .dailyAndStandard)
-    }
 
     func testWhenCriticalEventProcessed_ThenPostsCriticalNotificationAndFiresCriticalPixel() {
         // Given
@@ -126,9 +94,6 @@ final class MemoryPressureReporterTests: XCTestCase {
                                      pixelFiring: mockPixelFiring,
                                      notificationCenter: notificationCenter)
 
-        let warningNotificationExpectation = expectation(forNotification: .memoryPressureWarning, object: nil, notificationCenter: notificationCenter, handler: nil)
-        warningNotificationExpectation.isInverted = true
-
         let criticalNotificationExpectation = expectation(forNotification: .memoryPressureCritical, object: nil, notificationCenter: notificationCenter, handler: nil)
         criticalNotificationExpectation.isInverted = true
 
@@ -136,7 +101,7 @@ final class MemoryPressureReporterTests: XCTestCase {
         sut.processMemoryPressureEventForTesting(.normal)
 
         // Then
-        wait(for: [warningNotificationExpectation, criticalNotificationExpectation], timeout: 0.2)
+        wait(for: [criticalNotificationExpectation], timeout: 0.2)
         XCTAssertTrue(mockPixelFiring.actualFireCalls.isEmpty)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1212979631544086?focus=true
Tech Design URL:
CC:

### Description
Removes warning memory pressure pixel because it is too noisy.

### Testing Steps
- Make sure there is no code related to the pixel.
- Check that the critical pixel is unaffected

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a noisy telemetry event and associated debug/test hooks; the remaining critical-level monitoring path is unchanged aside from narrowing the dispatch source mask.
> 
> **Overview**
> Stops reporting *warning-level* memory pressure by removing the `memoryPressureWarning` notification and `m_mac_memory_pressure_warning` pixel, and by listening only for `.critical` events in `MemoryPressureReporter`.
> 
> Updates debug tooling and tests accordingly (removes the debug menu/action to simulate warning events, deletes the warning pixel definition, and drops unit tests/assertions for warning handling) while keeping the critical pixel and notification behavior intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bacfb2d0daec2f4f2904f1b4ade629dc6fd2edeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->