### PR TITLE
Fix for maestro test state_restoration

### DIFF
--- a/.maestro/browser_features/state_restoration.yaml
+++ b/.maestro/browser_features/state_restoration.yaml
@@ -31,9 +31,9 @@ tags:
     element: "Privacy Policy"
     timeout: 50000
     speed: 100
-# Make sure bottom bar is visible
+# Tap status bar to make sure bottom bar is visible
 - tapOn:
-    point: 80%, 99%
+    point: 90%, 1%
 - tapOn: "Browse Back"
 - assertVisible: "DuckDuckGo.*"
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1213079551970491?focus=true
Tech Design URL:
CC:

### Description
Update maestro test to change how bottom bar visibility is triggered

### Testing Steps
1. Confirm [CI is green](https://github.com/duckduckgo/apple-browsers/actions/runs/21651737992) (spoiler alert - it is!)

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to an internal Maestro UI test that only alters where a tap occurs to make the bottom bar visible.
> 
> **Overview**
> Updates the `state_restoration.yaml` Maestro flow to trigger bottom bar visibility by tapping the status bar (changing the tap coordinate from the bottom of the screen to the top) before navigating back, improving test reliability around bottom bar display.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df2825e3deef01e12859d91e6404947b053f9e54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->