### PR TITLE
Fix macOS sidebar context attachment

### DIFF
--- a/macOS/DuckDuckGo/AIChat/Sidebar/AIChatSidebar.swift
+++ b/macOS/DuckDuckGo/AIChat/Sidebar/AIChatSidebar.swift
@@ -48,7 +48,19 @@ final class AIChatSidebar: NSObject {
     var sidebarViewController: AIChatSidebarViewController? {
         didSet {
             subscribeToRestorationDataUpdates()
+            sidebarViewControllerSubject.send(sidebarViewController)
         }
+    }
+
+    private let sidebarViewControllerSubject = CurrentValueSubject<AIChatSidebarViewController?, Never>(nil)
+
+    /// Publisher that emits the current view controller's `pageContextRequestedPublisher` and automatically
+    /// switches to new view controller's publisher when the view controller changes.
+    var pageContextRequestedPublisher: AnyPublisher<Void, Never> {
+        sidebarViewControllerSubject
+            .compactMap { $0?.pageContextRequestedPublisher }
+            .switchToLatest()
+            .eraseToAnyPublisher()
     }
 
     /// Cancellables for Combine subscriptions

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -165,13 +165,14 @@ final class PageContextTabExtension {
             .store(in: &userScriptCancellables)
     }
 
+    /// handle view controller changes when the sidebar is closed and reopened.
     private func subscribeToCollectionRequest() {
         sidebarCancellables.removeAll()
-        guard let sidebarViewController = sidebar?.sidebarViewController else {
+        guard let sidebar else {
             return
         }
 
-        sidebarViewController.pageContextRequestedPublisher?
+        sidebar.pageContextRequestedPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 self?.shouldForceContextCollection = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1213027129021182?focus=true
Tech Design URL:
CC:

### Description
Fix macOS sidebar context attachment

### Testing Steps
1. Follow the steps [here](https://app.asana.com/1/137249556945/inbox/1211592734305017/item/1213029006511814/story/1213040111396790)
2. With the settings "Automatically send page context to sidebar" ON
3. Open a webpage
4. Click the duck.ai button in the address bar
5. Check if the sidebar opened and the context was correctly attached
6. Disable the settings on step 2
7. Open a page, check the context is not automatically attached
8. Click to attach the context
9. Close the sidebar
10. Open the sidebar again, check if you can still attach the context

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Issues attaching the context

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small Combine wiring change to ensure page-context request events keep flowing when the sidebar view controller is recreated; potential impact is limited to when/if context collection is triggered.
> 
> **Overview**
> Fixes page-context attachment after the macOS AI Chat sidebar is closed and reopened by **routing request events through `AIChatSidebar` instead of a single `AIChatSidebarViewController` instance**.
> 
> `AIChatSidebar` now publishes `pageContextRequestedPublisher` via a `CurrentValueSubject` and `switchToLatest`, and `PageContextTabExtension` subscribes to this wrapper publisher so it automatically follows view controller changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfe2507de3cc14f3d88d373aad38a4be7d32a9ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->