### PR TITLE
[macOS] Add memoryUsageReporting feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -172,6 +172,10 @@ public enum MacOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/1201048563534612/task/1212762049862427?focus=true
     case memoryPressureReporting
 
+    /// Memory Usage Reporting
+    /// https://app.asana.com/1/137249556945/project/72649045549333/task/1212762049862432?focus=true
+    case memoryUsageReporting
+
     /// Failsafe flag to bring back keys sorting in crash collector
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213037849588149
     case crashCollectionDisableKeysSorting

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -261,6 +261,10 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212783502979551?focus=true
     case memoryPressureReporting
 
+    /// Memory Usage Reporting
+    /// https://app.asana.com/1/137249556945/project/72649045549333/task/1212762049862432?focus=true
+    case memoryUsageReporting
+
     /// https://app.asana.com/1/137249556945/project/1201462886803403/task/1211837879355661?focus=true
     case aiChatSync
 
@@ -318,7 +322,8 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .memoryPressureReporting,
                 .themes,
                 .crashCollectionDisableKeysSorting,
-                .crashCollectionLimitCallStackTreeDepth:
+                .crashCollectionLimitCallStackTreeDepth,
+                .memoryUsageReporting:
             true
         default:
             false
@@ -404,6 +409,7 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .dataImportWideEventMeasurement,
                 .memoryUsageMonitor,
                 .memoryPressureReporting,
+                .memoryUsageReporting,
                 .aiChatSync,
                 .heuristicAction,
                 .nextStepsListWidget,
@@ -575,6 +581,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .disabled
         case .memoryPressureReporting:
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.memoryPressureReporting))
+        case .memoryUsageReporting:
+            return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.memoryUsageReporting))
         case .aiChatSync:
             return .disabled
         case .heuristicAction:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1212762049862432?focus=true
Tech Design URL:
CC:

### Description
Adds the `memoryUsageReporting` feature flag, enabled by default (https://app.asana.com/1/137249556945/project/1204006570077678/task/1210572145398078?focus=true)

### Testing Steps
Nothing to test, this is just the definition of the feature flag.

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing

### Quality Considerations
Nothing

### Notes to Reviewer
Nothing

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only defines and wires a new feature flag/subfeature, with the main impact being that it defaults to enabled and can be remotely controlled.
> 
> **Overview**
> Adds a new `memoryUsageReporting` privacy-config subfeature and corresponding macOS `FeatureFlag`.
> 
> The flag is **enabled by default**, supports local overrides, and is mapped to a remote-releasable source via `MacOSBrowserConfigSubfeature.memoryUsageReporting` so it can be controlled through privacy configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a70dc2ee070d85d7f44d38cbcef0889194e53cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->