### PR TITLE
Fix: Pinned Tabs Leading in Fullscreen

### DIFF
--- a/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -73,7 +73,6 @@ final class MainWindowController: NSWindowController {
 
         setupWindow(window)
         setupToolbar()
-        subscribeToTrafficLightsAlpha()
         subscribeToBurningData()
         subscribeToResolutionChange()
         subscribeToFullScreenToolbarChanges()
@@ -189,23 +188,6 @@ final class MainWindowController: NSWindowController {
         window?.toolbar?.showsBaselineSeparator = true
         window?.toolbarStyle = .unifiedCompact
         moveTabBarView(toTitlebarView: true)
-    }
-
-    private var trafficLightsAlphaCancellable: AnyCancellable?
-    private func subscribeToTrafficLightsAlpha() {
-        let tabBarViewController = mainViewController.tabBarViewController
-
-        // slide tabs to the left in full screen
-        trafficLightsAlphaCancellable = window?.standardWindowButton(.closeButton)?
-            .publisher(for: \.alphaValue)
-            .map { alphaValue in
-                if #available(macOS 26, *) {
-                    return TabBarViewController.HorizontalSpace.pinnedTabsScrollViewPaddingMacOS26.rawValue * alphaValue
-                } else {
-                    return TabBarViewController.HorizontalSpace.pinnedTabsScrollViewPadding.rawValue * alphaValue
-                }
-            }
-            .assign(to: \.constant, onWeaklyHeld: tabBarViewController.pinnedTabsViewLeadingConstraint)
     }
 
     private var burningDataCancellable: AnyCancellable?

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -248,6 +248,7 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
         scrollView.updateScrollElasticity(with: tabMode)
         observeToScrollNotifications()
         subscribeToSelectionIndex()
+        setupConstraints()
         setupFireButton()
         setupPinnedTabsView()
         subscribeToTabModeChanges()
@@ -346,6 +347,15 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
                 tabCollectionViewModel.select(at: .pinned(0))
             }
         }
+    }
+
+    private func setupConstraints() {
+        var pinnedTabsLeadingSpace: TabBarViewController.HorizontalSpace = .pinnedTabsScrollViewPadding
+        if #available(macOS 26, *) {
+            pinnedTabsLeadingSpace = .pinnedTabsScrollViewPaddingMacOS26
+        }
+
+        pinnedTabsViewLeadingConstraint.constant = pinnedTabsLeadingSpace.rawValue
     }
 
     private func setupFireButton() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1213105634155183?focus=true
Tech Design URL:
CC:

### Description
In this PR we're setting a fixed Left Padding for the Pinned Tabs container.

### Testing Steps
1. Launch the browser
2. Set a couple Pinned Tabs
3. Enter Fullscreen

- [x] Verify the Pinned Tabs preserve the left padding, regardless of the Semaphore State
- [x] Verify that if you exit Fullscreen, the UI looks as expected

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing really

### Quality Considerations
None

### Notes to Reviewer
Thank you!

### Screenshots

Before | Now
-|-
<img width="300" height="92" alt="image" src="https://github.com/user-attachments/assets/0ec3bcd0-6d71-4376-a2d6-02bba0d4d256" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/e65a828c-9c85-4a5e-891c-1d7128f8c724" />


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual/layout change limited to tab bar constraints; main risk is unintended spacing differences across macOS versions or window states.
> 
> **Overview**
> Ensures pinned tabs keep a consistent left padding in fullscreen by **removing** the `MainWindowController` Combine subscription that adjusted padding based on the window buttons’ alpha.
> 
> `TabBarViewController` now **sets the pinned tabs leading constraint once** during `viewDidLoad`, choosing a fixed padding value (with a macOS 26-specific constant) instead of reacting to traffic-lights visibility changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d898bb3c081648438ca32e3cb705af98fb55965c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->