### PR TITLE
fix asana page crash on `window.getSelection().collapseToStart()` call

### DIFF
--- a/macOS/DuckDuckGo/Common/Extensions/WKWebViewExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/WKWebViewExtension.swift
@@ -370,13 +370,21 @@ extension WKWebView {
 
     /// Collapses page text selection to the start of the first range in the selection.
     @MainActor
-    func collapsSelectionToStart() async throws {
-        try await evaluateJavaScript("window.getSelection().collapseToStart()") as Void?
+    func collapseSelectionToStart() async throws {
+        try await evaluateJavaScript("""
+            try {
+                window.getSelection().collapseToStart()
+            } catch {}
+        """) as Void?
     }
 
     @MainActor
     func deselectAll() async throws {
-        try await evaluateJavaScript("window.getSelection().removeAllRanges()") as Void?
+        try await evaluateJavaScript("""
+            try {
+                window.getSelection().removeAllRanges()
+            } catch {}
+        """) as Void?
     }
 
     var addsVisitedLinks: Bool {

--- a/macOS/DuckDuckGo/Tab/TabExtensions/FindInPageTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/FindInPageTabExtension.swift
@@ -128,7 +128,7 @@ final class FindInPageTabExtension: TabExtension {
 
         // reset text selection to the selection start so Find In Page finds the same result
         if options.contains(.noIndexChange) {
-            try? await webView?.collapsSelectionToStart()
+            try? await webView?.collapseSelectionToStart()
         }
 
         var options = options.union([.caseInsensitive, .wrapAround, .showFindIndicator])


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1213122991159742?focus=true

### Description
- Fixes Asana tab crash on new Find In Page search after tab switching

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Open 2 Asana tabs
2. Open Find In Page
3. Enter something, search twice (result 2/N)
4. Switch to another Asana tab and back
5. When the Find In Page text field gets selected, enter other search string
6. Validate the text is searched, Asana doesn't crash

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
7. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to Find In Page selection-reset behavior; main risk is silently skipping selection collapse on pages where it previously worked, potentially affecting match continuity.
> 
> **Overview**
> Prevents Find In Page crashes caused by `window.getSelection().collapseToStart()`/`removeAllRanges()` throwing in some pages by wrapping both calls in `try/catch` inside the evaluated JavaScript.
> 
> Renames the WKWebView helper from `collapsSelectionToStart` to `collapseSelectionToStart` and updates the Find In Page tab extension to use the new method name when preserving match index across searches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe21b25ebe6518d86372a1ab62399c0ae42b38de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->