### PR TITLE
macOS: Keep Deny button always enabled in Step 2 of permission flow

### DIFF
--- a/macOS/DuckDuckGo/Permissions/View/PermissionAuthorizationSwiftUIView.swift
+++ b/macOS/DuckDuckGo/Permissions/View/PermissionAuthorizationSwiftUIView.swift
@@ -448,7 +448,7 @@ struct PermissionAuthorizationSwiftUIView: View {
 
     @ViewBuilder
     private var stepTwoView: some View {
-        let allowEnabled = systemPermissionState == .authorized
+        let isAllowButtonEnabled = systemPermissionState == .authorized
 
         HStack(spacing: 12) {
             stepIndicator(step: 2, isActive: true)
@@ -469,14 +469,14 @@ struct PermissionAuthorizationSwiftUIView: View {
                 Button(action: onAllow) {
                     Text(UserText.permissionPopupAllowButton)
                         .font(.system(size: 13))
-                        .foregroundColor(allowEnabled ? Color(designSystemColor: .textPrimary) : Color(designSystemColor: .textSecondary))
+                        .foregroundColor(isAllowButtonEnabled ? Color(designSystemColor: .textPrimary) : Color(designSystemColor: .textSecondary))
                         .frame(maxWidth: .infinity)
                         .frame(height: 36)
-                        .background(allowEnabled ? Color(designSystemColor: .controlsFillPrimary) : Color(designSystemColor: .controlsFillSecondary))
+                        .background(isAllowButtonEnabled ? Color(designSystemColor: .controlsFillPrimary) : Color(designSystemColor: .controlsFillSecondary))
                         .cornerRadius(8)
                 }
                 .buttonStyle(PlainButtonStyle())
-                .disabled(!allowEnabled)
+                .disabled(!isAllowButtonEnabled)
                 .accessibilityIdentifier("PermissionAuthorizationSwiftUIView.allowButton")
             }
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213126191551536?focus=true

### Description

Keep Deny button always enabled in Step 2 of permission flow

### Testing Steps

Preparation and cleanup between tests:
- Before testing ensure feature flag `webNotifications` is enabled for you.
- Reset app permissions in System Settings.
- To clean app state up, click on the permissions dashboard and remove the notifications permission.

1. Trigger notification permission prompt on a website (like https://permission.site)
   - Verify "Deny" button is enabled immediately (don't need to complete Step 1)
   - Click "Deny" to confirm the popover dismisses
3. With system notifications disabled:
   - Trigger prompt again
   - Verify "Allow" button stays disabled until Step 1 is completed
   - Complete Step 1 (authorize system permission)
   - Verify "Allow" button becomes enabled
4. With system notifications already enabled in System Settings, but missing in app:
   - Reload site
   - Verify "Allow" button is enabled immediately
   - Click "Allow" to confirm it works

### Impact and Risks

High impact: allows us to re-enable web notifications for users.
Risks: logic could be wrong - but easy to test.

#### What could go wrong?

I could've made a mistake with the states.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI-state change in the permissions prompt; main risk is incorrect enable/disable behavior across edge permission states.
> 
> **Overview**
> Updates the two-step permissions popover (`PermissionAuthorizationSwiftUIView`) so **Step 2 is always active** and the **Deny** button is no longer gated on completion of the system-permission step.
> 
> The **Allow** button in Step 2 remains disabled (and visually secondary) until `systemPermissionState == .authorized`, after which it becomes enabled with primary styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59cc3e58699cd4fd1b8e932855a1c7ffc0955379. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->