### PR TITLE
Fix: Refreshing Tab's Ramp Color

### DIFF
--- a/macOS/DuckDuckGo/Tab/View/RampView.swift
+++ b/macOS/DuckDuckGo/Tab/View/RampView.swift
@@ -37,7 +37,11 @@ final class RampView: NSView {
     }
 
     var isFlippedHorizontally: Bool = false
-    var rampColor: NSColor = .surfacePrimary
+    var rampColor: NSColor = .surfacePrimary {
+        didSet {
+            needsDisplay = true
+        }
+    }
 
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1213113084065054?focus=true
Tech Design URL:
CC:

### Description
In this PR we're ensuring that the Tab's `RampView` component gets re-rendered, anytime its color is changed

### Testing Steps
1. Launch the browser
2. Enter fullscreen
3. Open `Settings > Appearance`

- [ ] Verify that if you switch Themes, the "Ramp" color gets refreshed

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing really

### Quality Considerations
None

### Notes to Reviewer
Thank you!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized visual change that only forces a view redraw when `rampColor` changes; minimal behavioral impact outside tab rendering.
> 
> **Overview**
> Fixes a UI refresh bug where tab corner “ramp” colors could fail to update after theme changes.
> 
> `RampView.rampColor` now triggers a redraw via `needsDisplay = true` in `didSet`, so updates applied from theming (e.g., in `TabBarViewItem.applyThemeStyle`) are immediately reflected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 948f6d6311202fadcb4add8750cf641e28134be7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->