### PR TITLE
Fix SpinnerView visibility handling and update UI tests for progress indicator

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/SpinnerView.swift
+++ b/macOS/DuckDuckGo/TabBar/View/SpinnerView.swift
@@ -150,6 +150,7 @@ private extension SpinnerView {
 
     func setupInitialState() {
         gradientLayer.isHidden = hidesWhenStopped
+        self.isHidden = hidesWhenStopped
     }
 
     func refreshGradientBounds() {
@@ -167,10 +168,11 @@ private extension SpinnerView {
     }
 
     func ensureGradientLayerIsVisible() {
-        guard gradientLayer.isHidden || gradientLayer.opacity < 1 else {
+        guard isHidden || gradientLayer.isHidden || gradientLayer.opacity < 1 else {
             return
         }
 
+        self.isHidden = false
         gradientLayer.isHidden = false
         gradientLayer.opacity = 1
     }
@@ -191,6 +193,7 @@ private extension SpinnerView {
     func removeRotationAnimationAndHide() {
         gradientLayer.removeAnimation(forKey: SpinnerConstants.rotationAnimationKey)
         gradientLayer.isHidden = hidesWhenStopped
+        self.isHidden = true
     }
 }
 

--- a/macOS/UITests/Common/XCUIApplicationExtension.swift
+++ b/macOS/UITests/Common/XCUIApplicationExtension.swift
@@ -340,7 +340,7 @@ extension XCUIApplication {
             )
         }
         let tab = windows.firstMatch.tabs.element(matching: \.isSelected, equalTo: true)
-        let progressIndicator = windows.firstMatch.progressIndicators["LoadingProgressIndicator"]
+        let progressIndicator = tab.progressIndicators["TabFaviconView.spinner"]
 
         let naked = (url.nakedString ?? url.absoluteString).droppingWwwPrefix()
         let scheme = url.navigationalScheme?.separated() ?? ""
@@ -353,8 +353,9 @@ extension XCUIApplication {
             ]), timeout: UITests.Timeouts.navigation),
             "Tab did not change URL to \(url.absoluteString) in a reasonable timeframe (current URL: \(tab.url ?? "<nil>"))."
         )
+        _=progressIndicator.waitForExistence(timeout: 1)
         XCTAssertTrue(
-            progressIndicator.wait(for: .keyPath(\.value, equalTo: 1.0), timeout: UITests.Timeouts.navigation),
+            progressIndicator.waitForNonExistence(timeout: UITests.Timeouts.navigation),
             "Progress did not reach 100% in a reasonable timeframe (current value: \(progressIndicator.value as? Double ??? "<nil>"))."
         )
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213145779023333
Tech Design URL: N/A
CC: N/A

### Description
- Made spinner view visibility synchronization by ensuring `self.isHidden` is properly set alongside `gradientLayer.isHidden` when starting/stopping animations
- Updated UI test assertions to use correct progress indicator identifier (`TabFaviconView.spinner` instead of `LoadingProgressIndicator`)
- Changed UI test assertion from checking progress value to waiting for progress indicator non-existence, matching actual spinner behavior

### Testing Steps
- Verify CI run is green https://github.com/duckduckgo/apple-browsers/actions/runs/21745375139

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- UI tests may fail if progress indicator identifier changes again
- Spinner visibility may not sync correctly if view hierarchy changes
- Mitigation: Changes are isolated to spinner visibility logic and test assertions

### Quality Considerations
- Edge cases: Handles both animated and non-animated stop scenarios
- Performance: No performance impact, only visibility state synchronization
- Testing: UI tests updated to match actual implementation behavior

### Notes to Reviewer
This fixes the UI test failures related to progress indicator detection and ensures SpinnerView visibility is properly synchronized with its internal gradient layer state.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI visibility and test assertion changes; risk is mainly limited to potential regressions if the spinner identifier/behavior changes again.
> 
> **Overview**
> Fixes spinner visibility by keeping `SpinnerView.isHidden` in sync with `gradientLayer.isHidden` when initializing, starting, and stopping animations, preventing cases where the layer is hidden but the view still participates in layout/hit-testing.
> 
> Updates the `openURL` UI test helper to target the tab’s spinner progress indicator (`TabFaviconView.spinner`) and assert completion by waiting for the spinner to disappear (with a brief optional existence wait) instead of polling a numeric progress value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b850d6e2cf18893bef0fca1eefb892d6c9fe25b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->