### PR TITLE
Use iOS config subfeature to enable new menu rollout

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -222,6 +222,9 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// Failsafe flag for disabling call stack tree depth limiting in crash collector
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213037858764805
     case crashCollectionLimitCallStackTreeDepth
+
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212835969125260
+    case browsingMenuSheetEnabledByDefault
 }
 
 public enum TabManagerSubfeature: String, PrivacySubfeature {

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -620,7 +620,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .browsingMenuSheetPresentation:
             return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.experimentalBrowsingMenu))
         case .browsingMenuSheetEnabledByDefault:
-            return .internalOnly()
+            return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.browsingMenuSheetEnabledByDefault))
         case .autofillExtensionSettings:
             return .remoteReleasable(.subfeature(AutofillSubfeature.autofillExtensionSettings))
         case .canPromoteAutofillExtensionInBrowser:


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1213135508567654
Tech Design URL:
CC:

### Description

Changes internal-only flag to remote releasable, allowing incremental rollout of new browsing menu.

### Testing Steps
1. Override privacy config with https://duckduckgo.github.io/privacy-configuration/pr-4481/v4/ios-config.json
2. Enable internal user flag and verify new menu is enabled by default.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

Change is only affecting internal users. Flag default value is off.

#### What could go wrong?
Menu is no longer enabled for internal users by default. Will be mitigated by privacy config update.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes feature-flag sourcing so production behavior can be altered by remote config; a misconfigured privacy-config could unintentionally enable/disable the new menu for users.
> 
> **Overview**
> Enables remote rollout control for the new browsing menu by introducing the `iOSBrowserConfigSubfeature.browsingMenuSheetEnabledByDefault` privacy-config key.
> 
> Updates `FeatureFlag.browsingMenuSheetEnabledByDefault` to source from that remote subfeature (instead of `internalOnly()`), allowing the default-on behavior to be toggled via privacy configuration without app changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbc9b5bd3e6ba68a0e6e96b1d707aab4ac7448e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->