### PR TITLE
Fix aichat test

### DIFF
--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualQuickActionTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualQuickActionTests.swift
@@ -37,7 +37,7 @@ final class AIChatContextualQuickActionTests: XCTestCase {
     // MARK: - Prompt Tests
 
     func testSummarizePromptIsExpectedValue() {
-        XCTAssertEqual(AIChatContextualQuickAction.summarize.prompt, "Summarize this page")
+        XCTAssertEqual(AIChatContextualQuickAction.summarize.prompt, "Summarize This Page")
     }
 
     // MARK: - Icon Tests


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only string expectation change; no production logic is modified.
> 
> **Overview**
> Updates `AIChatContextualQuickActionTests` to expect the summarize quick action prompt string `"Summarize This Page"` instead of `"Summarize this page"`, aligning the test with the current localized copy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a2d61918cf0a84bd7930f856a6f387864c64def. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->