### PR TITLE
[iOS] Update new fire button accessibility identifier

### DIFF
--- a/iOS/DuckDuckGo/Fire/ScopedFireConfirmationView.swift
+++ b/iOS/DuckDuckGo/Fire/ScopedFireConfirmationView.swift
@@ -98,7 +98,7 @@ struct ScopedFireConfirmationView: View {
                 Text(UserText.scopedFireConfirmationDeleteAllButton)
             }
             .buttonStyle(PrimaryDestructiveButtonStyle())
-            .accessibilityIdentifier("Fire.Confirmation.Button.AllTabs")
+            .accessibilityIdentifier("alert.forget-data.confirm")
             
             // This Tab button - Secondary Destructive (outline)
             if viewModel.canBurnSingleTab {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213038644233636

### Description
This PR updates the accessibility identifier of the new fire button to match the old one. This ensures UI tests don't break when "burn single tabs" is released.

### Testing Steps
No testing needed.

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-string accessibility identifier change with no behavior or data-flow impact; risk is limited to potential UI test selector mismatch if other code still expects the old identifier.
> 
> **Overview**
> Updates the scoped fire confirmation view so the primary destructive “All Tabs” button uses the legacy `alert.forget-data.confirm` accessibility identifier instead of `Fire.Confirmation.Button.AllTabs`, aligning it with the existing forget-data alert identifier used by UI tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b44e3319d9b48969604fcca83f25399761e04cf8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->