### PR TITLE
[iOS] Fix PixelKit initialization in iOS VPN extension

### DIFF
--- a/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -23,6 +23,7 @@ import Common
 import Configuration
 import Core
 import Foundation
+import UIKit
 import NetworkExtension
 import Networking
 import os.log
@@ -667,7 +668,7 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
         PixelKit.setUp(
             dryRun: PixelKitConfig.isDryRun(isProductionBuild: BuildFlags.isProductionBuild),
             appVersion: AppVersion.shared.versionNumber,
-            source: "vpnExtension",
+            source: (UIDevice.current.userInterfaceIdiom == .phone ? PixelKit.Source.iOS : PixelKit.Source.iPadOS).rawValue,
             defaultHeaders: [:],
             defaults: .networkProtectionGroupDefaults
         ) { (pixelName: String, headers: [String: String], parameters: [String: String], _, _, onComplete: @escaping PixelKit.CompletionBlock) in


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1213185226715330
Tech Design URL:
CC:

### Description

This PR fixes PixelKit initialization in the iOS VPN.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that PixelKit initialization is the same as other targets

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the VPN extension’s telemetry initialization and pixel dispatch path; misconfiguration could drop pixels or introduce runtime issues in the tunnel provider at startup.
> 
> **Overview**
> Fixes PixelKit initialization inside the iOS Network Protection VPN extension.
> 
> The tunnel provider now imports `UIKit` to determine `PixelKit` source (`iOS` vs `iPadOS`), calls a new `setupPixelKit()` during `init`, and configures PixelKit with the extension’s app-group defaults and a networking closure that sends pixels via `APIRequestV2`/`DefaultAPIService`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08cfee05da168a54f2a0837a00663482d18b6dfb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->