### PR TITLE
[iOS] Enable burn single tabs for internal users

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -659,7 +659,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .aiChatAtb:
             return .remoteReleasable(.subfeature(AIChatSubfeature.aiChatAtb))
         case .enhancedDataClearingSettings:
-            return .disabled
+            return .internalOnly()
         case .webViewFlashPrevention:
             return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.webViewFlashPrevention))
         case .wideEventPostEndpoint:
@@ -673,7 +673,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .tabSwitcherTrackerCount:
             return .internalOnly()
         case .burnSingleTab:
-            return .disabled
+            return .internalOnly()
         case .genericBackgroundTask:
             return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.genericBackgroundTask))
         case .crashCollectionDisableKeysSorting:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211767540372501/task/1213021985920327

### Description

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Make sure you're marked as internal
2. Validate that the new fire confrimation is shown
3. Validate that the new data clearing settings page is shown 

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to feature-flag sourcing; impact is restricted to internal users and does not alter production defaults.
> 
> **Overview**
> Updates `FeatureFlag.source` so `burnSingleTab` and `enhancedDataClearingSettings` are no longer hard-disabled and instead gated behind `.internalOnly()`, making these behaviors available to internal builds/users for testing while remaining off for external users.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37e30baec3e7a1f1fe8699dd37b0c9ed2eace0e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->