### PR TITLE
iOS: Contextual Duck.ai - Summarize This Prompt text input behavior

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/iOS/Views/NativeInput/AIChatNativeInputView.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/iOS/Views/NativeInput/AIChatNativeInputView.swift
@@ -77,6 +77,13 @@ public final class AIChatNativeInputView: UIView {
         delegate?.nativeInputViewDidChangeText(self, text: text)
     }
 
+    /// Appends text to the existing content, adding a space separator if needed.
+    public func appendText(_ text: String) {
+        let current = self.text
+        let newText = current.isEmpty ? text : current + " " + text
+        setText(newText)
+    }
+
     public var placeholder = "" {
         didSet { placeholderLabel.text = placeholder }
     }

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatNativeInputViewTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatNativeInputViewTests.swift
@@ -172,6 +172,26 @@ final class AIChatNativeInputViewTests: XCTestCase {
         XCTAssertEqual(mockDelegate.didRemoveContextChipCount, 1)
     }
 
+    // MARK: - Append Text Tests
+
+    func testAppendTextToEmptyField() {
+        sut.appendText("Summarize this page")
+
+        XCTAssertEqual(sut.text, "Summarize this page")
+        XCTAssertEqual(mockDelegate.didChangeTextCalls.last, "Summarize this page")
+    }
+
+    func testAppendTextToExistingText() {
+        sut.text = "Hello"
+
+        sut.appendText("Summarize this page")
+
+        XCTAssertEqual(sut.text, "Hello Summarize this page")
+        XCTAssertEqual(mockDelegate.didChangeTextCalls.last, "Hello Summarize this page")
+    }
+
+    // MARK: - Context Chip Duplicate Tests
+
     func testShowContextChipTwiceDoesNotDuplicate() {
         // Given
         let chipView1 = UIView()

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualInputViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualInputViewController.swift
@@ -113,6 +113,10 @@ final class AIChatContextualInputViewController: UIViewController {
         nativeInputViewController.setText(text)
     }
 
+    func appendText(_ text: String) {
+        nativeInputViewController.appendText(text)
+    }
+
     func showContextChip(_ chipView: UIView) {
         nativeInputViewController.showContextChip(chipView)
         updateQuickActions()

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -455,7 +455,7 @@ extension AIChatContextualSheetViewController: AIChatContextualInputViewControll
             delegate?.aiChatContextualSheetViewControllerDidRequestAttachPage(self)
         }
         if !action.prompt.isEmpty {
-            contextualInputViewController.setText(action.prompt)
+            contextualInputViewController.appendText(action.prompt)
         }
     }
 

--- a/iOS/DuckDuckGo/AIChat/NativeInput/AIChatNativeInputViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/NativeInput/AIChatNativeInputViewController.swift
@@ -69,6 +69,10 @@ final class AIChatNativeInputViewController: UIViewController {
         nativeInputView.setText(text)
     }
 
+    func appendText(_ text: String) {
+        nativeInputView.appendText(text)
+    }
+
     // MARK: - Initialization
 
     init(voiceSearchHelper: VoiceSearchHelperProtocol) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213114670765282

  ### Description
  The "Summarize This Page" quick action now appends its prompt to the end of any existing text in the input field instead of overwriting it. Adds `appendText` through the input view chain and includes unit tests.

  ### Testing Steps
  1. Open the app with contextual AI chat enabled
  2. Open the AI chat contextual sheet
  3. Type some text in the input field (e.g., "Hello")
  4. Tap the "Summarize This Page" quick action
  5. Verify the prompt is appended to the existing text with a space separator (e.g., "Hello Summarize This Page")
  6. Clear the input field
  7. Tap the "Summarize This Page" quick action again
  8. Verify the prompt is set directly without a leading space

  ### Impact and Risks
  **Low** — Minor behavior change to a quick action button. No core functionality affected.

  #### What could go wrong?
  - Users who expected the overwrite behavior may be surprised, but appending is more user-friendly.

  ---
  ###### Internal references:
  [Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering
  Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated UX behavior change limited to prompt text setting; minimal risk beyond potential minor UI/regression in text formatting.
> 
> **Overview**
> Updates the contextual Duck.ai *“Summarize this page”* quick action so its prompt **appends to any existing input text** (space-separated) instead of overwriting it.
> 
> Introduces `appendText` on `AIChatNativeInputView` and threads it through the native/contextual input view-controller chain, and adds unit tests covering append behavior (empty vs non-empty) while keeping delegate text-change notifications consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b2a4dd7f9e852ed1e4ea78c7cf31994de1c4b80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->