### PR TITLE
Fix tab bar collection view crash on macOS Monterey

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarCollectionView.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarCollectionView.swift
@@ -126,7 +126,7 @@ open class TabBarCollectionView: NSCollectionView {
 
     /// Performs an animated update on the collection view.
     /// On macOS 13+ uses `performBatchUpdates` for proper implicit animations.
-    /// On macOS 12 uses `NSAnimationContext` with explicit layout invalidation
+    /// On macOS 12 and earlier uses `NSAnimationContext` with explicit layout invalidation
     /// to avoid a crash caused by data source consistency validation in `performBatchUpdates`.
     private func performAnimatedUpdate(_ updates: @escaping () -> Void, completionHandler: ((Bool) -> Void)? = nil) {
         if #available(macOS 13.0, *) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213211529458060

### Description
On macOS 12, performBatchUpdates apparently validates data source consistency
even when no structural changes (inserts/deletes) are made. Using it for scroll
animations causes a crash when the tab count changes between the last Collection View
sync and the scroll call. This change switches to using NSAnimationContext on macOS 12
with explicit layout invalidation while keeping the old behavior (performBatchUpdates) on macOS 13+.

### Testing Steps
If possible, test with [this build](https://github.com/duckduckgo/apple-browsers/actions/runs/21856765869) on macOS Monterey. Alternatively, adjust `TabBarCollectionView.performAnimatedUpdate` so that it performs macOS 12 branch at all times and run locally.

Smoke test the tab bar by creating multiple tabs and navigate through them - switch, close, add new tabs, open bookmarks folders in current window. There will be no animations but there should also be no crashes.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is scoped to tab bar scroll animations and adds an OS-version-specific fallback to avoid a Monterey crash; main risk is subtle animation/layout behavior differences on macOS 12.
> 
> **Overview**
> Prevents a macOS 12 crash in tab bar scrolling by routing scroll animations through a new `performAnimatedUpdate` helper.
> 
> On macOS 13+ it preserves the prior `performBatchUpdates` behavior, while on macOS 12 and earlier it invalidates layout and uses `NSAnimationContext` to run the animation (and calls completion) without triggering collection view data-source consistency validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4da94de97350ac662a9ad27b03f1c1687f68d88c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->