### PR TITLE
Onboarding: New UI Tests

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -271,6 +271,8 @@ final class AddressBarViewController: NSViewController {
         setupAddressBarPlaceHolder()
         addressBarTextField.setAccessibilityIdentifier("AddressBarViewController.addressBarTextField")
 
+        passiveTextField.setAccessibilityIdentifier("AddressBarViewController.passiveTextField")
+
         passiveTextField.isSelectable = !isInPopUpWindow
         /// Passive Address Bar text field is centered by the constraints
         /// Left alignment is used to prevent jumping of the text field in overflow mode when the buttons width changes

--- a/macOS/UITests/Common/XCUIApplicationExtension.swift
+++ b/macOS/UITests/Common/XCUIApplicationExtension.swift
@@ -37,6 +37,8 @@ extension XCUIApplication {
     enum AccessibilityIdentifiers {
         static let okButton = "OKButton"
         static let addressBarTextField = "AddressBarViewController.addressBarTextField"
+        static let addressBarPassiveTextField = "AddressBarViewController.passiveTextField"
+        static let aiChatButton = "AddressBarButtonsViewController.aiChatButton"
         static let bookmarksPanelShortcutButton = "NavigationBarViewController.bookmarkListButton"
         static let manageBookmarksMenuItem = "MainMenu.manageBookmarksMenuItem"
         static let resetBookmarksMenuItem = "MainMenu.resetBookmarks"

--- a/macOS/UITests/OnboardingUITests.swift
+++ b/macOS/UITests/OnboardingUITests.swift
@@ -121,6 +121,19 @@ final class OnboardingUITests: UITestCase {
         XCTAssertTrue(ddgLogo.waitForExistence(timeout: UITests.Timeouts.elementExistence) || tooltip.waitForExistence(timeout: UITests.Timeouts.elementExistence))
     }
 
+    func testDuckAIIsUnavailableDuringOnboarding() throws {
+        let button = app.windows.buttons[XCUIApplication.AccessibilityIdentifiers.aiChatButton]
+
+        XCTAssertFalse(button.exists, "AIChat Button should NOT be visible during onboarding")
+    }
+
+    func testPassiveAddressBarShowsWelcomeMessage() throws {
+        let passiveTextField = app.staticTexts[XCUIApplication.AccessibilityIdentifiers.addressBarPassiveTextField]
+
+        XCTAssertTrue(passiveTextField.waitForExistence(timeout: UITests.Timeouts.elementExistence), "(Passive) AddressBar TextField should be visible")
+        XCTAssertEqual(passiveTextField.value as? String, "Welcome")
+    }
+
     func resetApplicationData() throws {
         let commands = [
             "/usr/bin/defaults delete com.duckduckgo.macos.browser.review",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213116428053488?focus=true
Tech Design URL:
CC:

### Description
In this PR we're adding new Onboarding UI Tests

### Testing Steps
- [ ] Verify the `OnboardingUITests` suite is green
- [ ] Verify [this CI run is green](https://github.com/duckduckgo/apple-browsers/actions/runs/21869169197)

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing

### Quality Considerations
None

### Notes to Reviewer
Thank you!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-test and accessibility-identifier changes only; no production behavior changes beyond exposing identifiers for automation.
> 
> **Overview**
> Adds an accessibility identifier to the passive address bar text field so UI tests can reliably query it.
> 
> Extends the onboarding UI test suite with checks that the AI Chat button is not shown during onboarding and that the passive address bar displays a "Welcome" message, centralizing new identifiers in `XCUIApplication.AccessibilityIdentifiers`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 476d08ccc8ec89da043f01fc286c753a8a29181b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->