### PR TITLE
Fix: Onboarding UI Lockdown Delay

### DIFF
--- a/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -129,17 +129,17 @@ final class MainWindowController: NSWindowController {
 
     private func setupWindow(_ window: NSWindow) {
         window.delegate = self
-        startOboardingIfNeeded()
+        startOnboardingIfNeeded()
     }
 
-    private func startOboardingIfNeeded() {
+    private func startOnboardingIfNeeded() {
         guard shouldShowOnboarding, let selectedTab = mainViewController.tabCollectionViewModel.selectedTabViewModel?.tab else {
             return
         }
 
-        /// During Onboarding, several UI elements get disabled. In order to prevent flickering, we'll disable them right after kicking off Onboarding.
-        /// Locking up UI via `OnboardingUserScript.setInit` has a noticeable delay, where elements may flash.
-        ///
+        // During Onboarding, several UI elements get disabled. In order to prevent flickering, we'll disable them right after kicking off Onboarding.
+        // Locking up UI via `OnboardingUserScript.setInit` has a noticeable delay, where elements may flash.
+        //
         selectedTab.startOnboarding()
         userInteraction(prevented: true)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1213101166699788?focus=true
Tech Design URL:
CC:

### Description
Multiple UI elements get locked up during Onboarding. 
In this PR we're changing the spot where this UI lockdown happens, to avoid UI elements flashing.

### Testing Steps
1. `Reset Data > Reset Onboarding`
2. Relaunch the browser

- [ ] Verify the More Options / Fire elements appear disabled as soon as you launch
- [ ] Verify that the UI gets unlocked after completing Onboarding

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing should go wrong!

### Quality Considerations
None

### Notes to Reviewer
Thank you!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
