### PR TITLE
[CI] Retry UI test artifact fetches if they fail

### DIFF
--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -231,12 +231,23 @@ jobs:
     - name: Download and unzip artifact
       env:
         GH_TOKEN: ${{ github.token }}
-      retry:
-        max-attempts: 5
-        when: failure()
       run: |
-        echo "Forcing failure to test retry behavior" && exit 1
-        gh run download "${{ github.run_id }}" --dir .
+        max_attempts=5
+        retry_delay=10
+
+        for attempt in $(seq 1 $max_attempts); do
+          echo "Attempt $attempt of $max_attempts"
+          if gh run download "${{ github.run_id }}" --dir .; then
+            echo "Download successful"
+            exit 0
+          fi
+          if [[ $attempt -lt $max_attempts ]]; then
+            echo "Download failed, retrying in ${retry_delay}s..."
+            sleep $retry_delay
+          fi
+        done
+        echo "All download attempts failed"
+        exit 1
 
     - name: Set cache key hash
       run: |


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1213224645009529
Tech Design URL:
CC:

### Description

This PR attempts to improve UI test reliability to retrying the artifact fetch if it fails.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that [this UI test run](https://github.com/duckduckgo/apple-browsers/actions/runs/21873738659) never had any artifact fetch failures

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change; risk is mainly workflow failures if the `gh run download` behavior/path differs from the previous action or token permissions are insufficient.
> 
> **Overview**
> Improves reliability of the macOS UI tests workflow by replacing the single `actions/download-artifact@v4` step with a scripted `gh run download` that retries up to 5 times with a delay.
> 
> The new step authenticates using `GH_TOKEN` and fails the job only after exhausting all retry attempts, reducing flakiness from transient artifact download failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfd37e2079d2588637c642cab567617f57ac26ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->