### PR TITLE
Change iPad feature flag to default true

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -212,6 +212,7 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866614122594
     case fullDuckAIMode
 
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213227027157584
     case iPadDuckaiOnTab
 
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212197756955039
@@ -355,7 +356,8 @@ extension FeatureFlag: FeatureFlagDescribing {
              .crashCollectionDisableKeysSorting,
              .freeTrialConversionWideEvent,
              .crashCollectionLimitCallStackTreeDepth,
-             .tabSwitcherTrackerCount:
+             .tabSwitcherTrackerCount,
+             .iPadDuckaiOnTab:
             true
         default:
             false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213226966704518

### Description
Change iPad feature flag to default true

### Testing Steps
1. This was tested before, just flipping the default value.
2. CI is green

### Impact and Risks
None: Internal tooling, documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single feature-flag default flip; risk is limited to unintentionally enabling the iPad Duck AI tab UI for users who rely on the default state.
> 
> **Overview**
> Enables the `iPadDuckaiOnTab` feature flag by default by adding it to the `FeatureFlag.defaultValue == true` allowlist in `FeatureFlag.swift`.
> 
> Also adds an Asana task reference comment for `iPadDuckaiOnTab` alongside the other feature-flag definitions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48c8cbd3835467c44f79578acbe8dcb91b9b5b81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->