### PR TITLE
Remove browsing menu sheet opt in

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -206,9 +206,6 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/481882893211075/task/1212057154681076?focus=true
     case productTelemetrySurfaceUsage
 
-    /// https://app.asana.com/1/137249556945/project/1206226850447395/task/1211661206210892?focus=true
-    case experimentalBrowsingMenu
-
     ///  https://app.asana.com/1/137249556945/project/414709148257752/task/1212395110448661?focus=true
     case appRatingPrompt
 

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -237,9 +237,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211998614203542?focus=true
     case allowProTierPurchase
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211992061067315?focus=true
-    case browsingMenuSheetPresentation
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212835969125260?focus=true
     case browsingMenuSheetEnabledByDefault
 
@@ -349,7 +346,6 @@ extension FeatureFlag: FeatureFlagDescribing {
              .unifiedURLPredictor,
              .migrateKeychainAccessibility,
              .dataImportWideEventMeasurement,
-             .browsingMenuSheetPresentation,
              .appRatingPrompt,
              .autofillPasswordSearchPrioritizeDomain,
              .showWhatsNewPromptOnDemand,
@@ -424,7 +420,6 @@ extension FeatureFlag: FeatureFlagDescribing {
              .standaloneMigration,
              .blackFridayCampaign,
              .allowProTierPurchase,
-             .browsingMenuSheetPresentation,
              .browsingMenuSheetEnabledByDefault,
              .autofillExtensionSettings,
              .canPromoteAutofillExtensionInBrowser,
@@ -636,8 +631,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(AIChatSubfeature.standaloneMigration))
         case .allowProTierPurchase:
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.allowProTierPurchase))
-        case .browsingMenuSheetPresentation:
-            return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.experimentalBrowsingMenu))
         case .browsingMenuSheetEnabledByDefault:
             return .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.browsingMenuSheetEnabledByDefault))
         case .autofillExtensionSettings:

--- a/iOS/DuckDuckGo/BrowsingMenu/SheetPresentationMenu/BrowsingMenuSheetCapability.swift
+++ b/iOS/DuckDuckGo/BrowsingMenu/SheetPresentationMenu/BrowsingMenuSheetCapability.swift
@@ -23,7 +23,6 @@ import Persistence
 import PrivacyConfig
 
 protocol BrowsingMenuSheetCapable {
-    var isExperimentalMenuOptInEnabled: Bool { get }
     var isEnabled: Bool { get }
     var isSettingsOptionVisible: Bool { get }
     var isWebsiteHeaderEnabled: Bool { get }
@@ -49,7 +48,6 @@ enum BrowsingMenuSheetCapability {
 }
 
 struct BrowsingMenuSheetUnavailableCapability: BrowsingMenuSheetCapable {
-    let isExperimentalMenuOptInEnabled: Bool = false
     let isEnabled: Bool = false
     let isSettingsOptionVisible: Bool = false
     let isWebsiteHeaderEnabled: Bool = false
@@ -69,10 +67,6 @@ struct BrowsingMenuSheetDefaultCapability: BrowsingMenuSheetCapable {
         self.keyValueStore = keyValueStore
     }
 
-    var isExperimentalMenuOptInEnabled: Bool {
-        featureFlagger.isFeatureOn(.browsingMenuSheetPresentation)
-    }
-
     var isEnabled: Bool {
         if isEnabledByDefault {
             if featureFlagger.internalUserDecider.isInternalUser {
@@ -80,14 +74,11 @@ struct BrowsingMenuSheetDefaultCapability: BrowsingMenuSheetCapable {
             }
             return true
         }
-        return isExperimentalMenuOptInEnabled && (storedEnabledValue ?? false)
+        return storedEnabledValue ?? false
     }
 
     var isSettingsOptionVisible: Bool {
-        if isEnabledByDefault {
-            return featureFlagger.internalUserDecider.isInternalUser
-        }
-        return isExperimentalMenuOptInEnabled
+        isEnabledByDefault && featureFlagger.internalUserDecider.isInternalUser
     }
 
     var isWebsiteHeaderEnabled: Bool {

--- a/iOS/DuckDuckGoTests/BrowsingMenu/BrowsingMenuSheetCapabilityTests.swift
+++ b/iOS/DuckDuckGoTests/BrowsingMenu/BrowsingMenuSheetCapabilityTests.swift
@@ -44,27 +44,9 @@ final class BrowsingMenuSheetCapabilityTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - isExperimentalMenuOptInEnabled
-
-    func testExperimentalMenuOptInEnabledReturnsTrueWhenBrowsingMenuSheetPresentationFlagIsEnabled() {
-        mockFeatureFlagger.enabledFeatureFlags = [.browsingMenuSheetPresentation]
-
-        let capability = createCapability()
-
-        XCTAssertTrue(capability.isExperimentalMenuOptInEnabled)
-    }
-
-    func testExperimentalMenuOptInEnabledReturnsFalseWhenBrowsingMenuSheetPresentationFlagIsDisabled() {
-        mockFeatureFlagger.enabledFeatureFlags = []
-
-        let capability = createCapability()
-
-        XCTAssertFalse(capability.isExperimentalMenuOptInEnabled)
-    }
-
     // MARK: - isEnabled (when isEnabledByDefault is false)
 
-    func testIsEnabledReturnsFalseWhenExperimentalMenuOptInEnabledIsFalse() {
+    func testIsEnabledReturnsFalseWhenNotEnabledByDefaultAndNoStoredValue() {
         mockFeatureFlagger.enabledFeatureFlags = []
 
         let capability = createCapability()
@@ -72,16 +54,8 @@ final class BrowsingMenuSheetCapabilityTests: XCTestCase {
         XCTAssertFalse(capability.isEnabled)
     }
 
-    func testIsEnabledReturnsFalseWhenExperimentalMenuOptInEnabledIsTrueButNoStoredValue() {
-        mockFeatureFlagger.enabledFeatureFlags = [.browsingMenuSheetPresentation]
-
-        let capability = createCapability()
-
-        XCTAssertFalse(capability.isEnabled)
-    }
-
-    func testIsEnabledReturnsTrueWhenExperimentalMenuOptInEnabledIsTrueAndStoredValueIsTrue() {
-        mockFeatureFlagger.enabledFeatureFlags = [.browsingMenuSheetPresentation]
+    func testIsEnabledReturnsTrueWhenNotEnabledByDefaultAndStoredValueIsTrue() {
+        mockFeatureFlagger.enabledFeatureFlags = []
         try? mockKeyValueStore.set(true, forKey: "com_duckduckgo_experimentalBrowsingMenu_enabled")
 
         let capability = createCapability()
@@ -89,8 +63,8 @@ final class BrowsingMenuSheetCapabilityTests: XCTestCase {
         XCTAssertTrue(capability.isEnabled)
     }
 
-    func testIsEnabledReturnsFalseWhenExperimentalMenuOptInEnabledIsTrueAndStoredValueIsFalse() {
-        mockFeatureFlagger.enabledFeatureFlags = [.browsingMenuSheetPresentation]
+    func testIsEnabledReturnsFalseWhenNotEnabledByDefaultAndStoredValueIsFalse() {
+        mockFeatureFlagger.enabledFeatureFlags = []
         try? mockKeyValueStore.set(false, forKey: "com_duckduckgo_experimentalBrowsingMenu_enabled")
 
         let capability = createCapability()
@@ -150,15 +124,7 @@ final class BrowsingMenuSheetCapabilityTests: XCTestCase {
 
     // MARK: - isSettingsOptionVisible (when isEnabledByDefault is false)
 
-    func testIsSettingsOptionVisibleReturnsTrueWhenExperimentalMenuOptInEnabledIsTrue() {
-        mockFeatureFlagger.enabledFeatureFlags = [.browsingMenuSheetPresentation]
-
-        let capability = createCapability()
-
-        XCTAssertTrue(capability.isSettingsOptionVisible)
-    }
-
-    func testIsSettingsOptionVisibleReturnsFalseWhenExperimentalMenuOptInEnabledIsFalse() {
+    func testIsSettingsOptionVisibleReturnsFalseWhenNotEnabledByDefault() {
         mockFeatureFlagger.enabledFeatureFlags = []
 
         let capability = createCapability()
@@ -208,7 +174,7 @@ final class BrowsingMenuSheetCapabilityTests: XCTestCase {
     }
 
     func testIsWebsiteHeaderEnabledReturnsFalseWhenNotEnabledByDefault() {
-        mockFeatureFlagger.enabledFeatureFlags = [.browsingMenuSheetPresentation]
+        mockFeatureFlagger.enabledFeatureFlags = []
 
         let capability = createCapability()
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1213223157255856
Tech Design URL:
CC:

### Description

Removes the opt-in possibility for non-internal users and removes the associated flag.

### Testing Steps
1. Turn on internal user flag
2. Go to Appearance Settings, verify the opt-in switch is visible and functional (enables/disables new menu)
3. Leave the switch enabled.
4. Disable internal user flag, Disable `browsingMenuSheetEnabledByDefault`
5. Make sure last switch value is respected and new menu is active.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
6. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Switch state is not preserved

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a feature-flag gate and simplifies enablement logic; main risk is behavior change around when the new menu can be toggled and whether stored preference is respected.
> 
> **Overview**
> Removes the remote feature flag/subfeature used to *opt in* to the browsing menu sheet (`experimentalBrowsingMenu` / `browsingMenuSheetPresentation`) and deletes its mapping from `FeatureFlag`.
> 
> Simplifies `BrowsingMenuSheetCapability` so the sheet menu is either **enabled by default** via `browsingMenuSheetEnabledByDefault` (with an internal-only settings toggle) or otherwise controlled solely by the persisted user setting; updates unit tests to match the new enablement and settings-visibility rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddef1517dfb97d58615b3d9ea55aece653e4f5c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->