### PR TITLE
[macOS] Change testing method to fix flaky tests MemoryUsageIntervalReporterTests

### DIFF
--- a/macOS/DuckDuckGo/AppHealth/MemoryUsageIntervalReporter.swift
+++ b/macOS/DuckDuckGo/AppHealth/MemoryUsageIntervalReporter.swift
@@ -210,11 +210,22 @@ final class MemoryUsageIntervalReporter {
 
 extension MemoryUsageIntervalReporter {
 
-    /// For testing: sets up monitoring state without starting the background task.
+    /// For testing: cancels any Combine-driven monitoring and sets up state manually.
+    ///
+    /// This cancels the feature-flag subscription and any background task so that
+    /// only explicit `checkIntervalsNow()` calls fire pixels — avoiding races between
+    /// the Combine-driven path and the test's manual control flow.
     ///
     /// - Parameter startTime: The simulated session start time.
     func startMonitoringForTesting(startTime: Date = Date()) {
-        lock.withLock { self.startTime = startTime }
+        featureFlagCancellable?.cancel()
+        featureFlagCancellable = nil
+        monitoringTask?.cancel()
+        monitoringTask = nil
+        lock.withLock {
+            self.startTime = startTime
+            self.firedTriggers.removeAll()
+        }
     }
 
     /// For testing and debug menu: triggers an immediate interval check.

--- a/macOS/UnitTests/AppHealth/MemoryUsageIntervalReporterTests.swift
+++ b/macOS/UnitTests/AppHealth/MemoryUsageIntervalReporterTests.swift
@@ -23,6 +23,7 @@ import PrivacyConfig
 import XCTest
 @testable import DuckDuckGo_Privacy_Browser
 
+@MainActor
 final class MemoryUsageIntervalReporterTests: XCTestCase {
 
     private var sut: MemoryUsageIntervalReporter!
@@ -221,7 +222,6 @@ final class MemoryUsageIntervalReporterTests: XCTestCase {
 
     // MARK: - Feature Flag Lifecycle (Production Combine Path)
 
-    @MainActor
     func testWhenFeatureFlagEnabledViaPublisher_ThenStartsMonitoringAndFiresStartup() async throws {
         // Given
         mockMemoryUsageMonitor.currentPhysFootprintMB = 1024
@@ -238,7 +238,6 @@ final class MemoryUsageIntervalReporterTests: XCTestCase {
         XCTAssertTrue(startupFired, "Startup pixel should fire when feature flag is enabled via publisher")
     }
 
-    @MainActor
     func testWhenFeatureFlagToggledOffThenOn_ThenSessionResetsAndStartupFiresAgain() async throws {
         // Given - start with flag ON
         mockMemoryUsageMonitor.currentPhysFootprintMB = 512


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213237225303094
Tech Design URL:
CC:

### Description
`startMonitoringForTesting` now cancels the Combine subscription and any background task before setting the test state, ensuring only the test's explicit checkIntervalsNow() calls fire pixels -- no concurrent writer from the Combine path. Hopefully this will fix the flakiness.

### Testing Steps
Check that tests are green

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing.

### Quality Considerations
Nothing.

### Notes to Reviewer
Nothing.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test-only setup and unit-test actor annotations, with no functional impact on production monitoring logic beyond improved test isolation.
> 
> **Overview**
> Improves test determinism for `MemoryUsageIntervalReporter` by updating `startMonitoringForTesting` to **cancel the feature-flag Combine subscription and any running monitoring task**, then reset `startTime` and `firedTriggers` under lock so only explicit `checkIntervalsNow()` calls can fire pixels.
> 
> Marks `MemoryUsageIntervalReporterTests` as `@MainActor` at the class level (removing per-test annotations) to reduce concurrency flakiness when exercising the production Combine-driven feature-flag path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b653aaa1b3494269df8e7b531e719c124b0acca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->