### PR TITLE
Update skip onboarding screen to match rebranded design

### DIFF
--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingView+SkipOnboardingContent.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingView+SkipOnboardingContent.swift
@@ -52,36 +52,37 @@ extension OnboardingView {
         }
 
         var body: some View {
-            VStack(spacing: 24.0) {
-                AnimatableTypingText(Copy.title, startAnimating: animateTitle, skipAnimation: isSkipped) {
-                    withAnimation {
-                        animateMessage.wrappedValue = true
+            VStack(spacing: 20.0) {
+                VStack(spacing: 28.0) {
+                    AnimatableTypingText(Copy.title, startAnimating: animateTitle, skipAnimation: isSkipped) {
+                        withAnimation {
+                            animateMessage.wrappedValue = true
+                        }
                     }
-                }
-                .foregroundColor(.primary)
-                .font(Font.system(size: 20, weight: .bold))
+                    .foregroundColor(.primary)
+                    .multilineTextAlignment(.center)
+                    .font(Font.system(size: 24, weight: .bold))
 
-                AnimatableTypingText(Copy.message.attributed.withFont(.daxBodyBold(), forText: Self.fireButtonCopy), startAnimating: animateMessage, skipAnimation: isSkipped) {
-                    withAnimation {
-                        showCTA.wrappedValue = true
+                    AnimatableTypingText(Copy.message.attributed.withFont(.daxBodyBold(), forText: Self.fireButtonCopy), startAnimating: animateMessage, skipAnimation: isSkipped) {
+                        withAnimation {
+                            showCTA.wrappedValue = true
+                        }
                     }
+                    .foregroundColor(.primary)
+                    .multilineTextAlignment(.center)
+                    .font(Font.system(size: 18))
                 }
-                .foregroundColor(.primary)
-                .font(Font.system(size: 16))
 
-                VStack {
+                VStack(spacing: 8.0) {
                     Button(action: startBrowsingAction) {
                         Text(Copy.confirmSkipOnboardingCTA)
                     }
                     .buttonStyle(PrimaryButtonStyle())
 
-                    OnboardingBorderedButton(
-                        maxHeight: 50.0,
-                        content: {
-                            Text(Copy.resumeOnboardingCTA)
-                        },
-                        action: resumeOnboardingAction
-                    )
+                    Button(action: resumeOnboardingAction) {
+                        Text(Copy.resumeOnboardingCTA)
+                    }
+                    .buttonStyle(SecondaryFillButtonStyle())
                 }
                 .visibility(showCTA.wrappedValue ? .visible : .invisible)
             }

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+SkipOnboardingContent.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView+SkipOnboardingContent.swift
@@ -22,10 +22,8 @@ import DuckUI
 import Onboarding
 
 private enum SkipOnboardingContentMetrics {
-    static let titleFont = Font.system(size: 20, weight: .bold)
-    static let messageFont = Font.system(size: 16)
-    static let buttonMaxHeight: CGFloat = 50.0
-    static let additionalTopMargin: CGFloat = 0
+    static let textSpacing: CGFloat = 28.0
+    static let buttonSpacing: CGFloat = 8.0
 }
 
 extension OnboardingRebranding.OnboardingView {
@@ -37,73 +35,72 @@ extension OnboardingRebranding.OnboardingView {
 
         @Environment(\.onboardingTheme) private var onboardingTheme
 
-        private var animateTitle: Binding<Bool>
-        private var animateMessage: Binding<Bool>
-        private var showCTA: Binding<Bool>
-        private var isSkipped: Binding<Bool>
         private let startBrowsingAction: () -> Void
         private let resumeOnboardingAction: () -> Void
 
         init(
-            animateTitle: Binding<Bool>,
-            animateMessage: Binding<Bool>,
-            showCTA: Binding<Bool>,
-            isSkipped: Binding<Bool>,
             startBrowsingAction: @escaping () -> Void,
             resumeOnboardingAction: @escaping () -> Void
         ) {
-            self.animateTitle = animateTitle
-            self.animateMessage = animateMessage
-            self.showCTA = showCTA
-            self.isSkipped = isSkipped
             self.startBrowsingAction = startBrowsingAction
             self.resumeOnboardingAction = resumeOnboardingAction
         }
 
         var body: some View {
-            LinearDialogContentContainer(
-                metrics: .init(
-                    outerSpacing: onboardingTheme.linearOnboardingMetrics.contentOuterSpacing,
-                    textSpacing: onboardingTheme.linearOnboardingMetrics.contentOuterSpacing,
-                    contentSpacing: 0,
-                    actionsSpacing: onboardingTheme.linearOnboardingMetrics.actionsSpacing
-                ),
-                message: AnyView(
-                    AnimatableTypingText(Copy.message.attributed.withFont(.daxBodyBold(), forText: Self.fireButtonCopy), startAnimating: animateMessage, skipAnimation: isSkipped) {
-                        withAnimation {
-                            showCTA.wrappedValue = true
-                        }
-                    }
-                    .foregroundColor(.primary)
-                    .font(SkipOnboardingContentMetrics.messageFont)
-                ),
-                title: {
-                    AnimatableTypingText(Copy.title, startAnimating: animateTitle, skipAnimation: isSkipped) {
-                        withAnimation {
-                            animateMessage.wrappedValue = true
-                        }
-                    }
-                    .foregroundColor(.primary)
-                    .font(SkipOnboardingContentMetrics.titleFont)
-                },
-                actions: {
-                    VStack {
-                        Button(action: startBrowsingAction) {
-                            Text(Copy.confirmSkipOnboardingCTA)
-                        }
-                        .buttonStyle(PrimaryButtonStyle())
-
-                        OnboardingBorderedButton(
-                            maxHeight: SkipOnboardingContentMetrics.buttonMaxHeight,
-                            content: {
-                                Text(Copy.resumeOnboardingCTA)
-                            },
-                            action: resumeOnboardingAction
-                        )
-                    }
-                    .visibility(showCTA.wrappedValue ? .visible : .invisible)
+            ZStack(alignment: .top) {
+                VStack(spacing: 0) {
+                    bubbleContent
+                    Spacer()
                 }
-            )
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
+            .padding(.top, onboardingTheme.linearOnboardingMetrics.minTopMargin)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        }
+
+        private var bubbleContent: some View {
+            OnboardingBubbleView(
+                tailPosition: .bottom(offset: onboardingTheme.linearOnboardingMetrics.bubbleTailOffset, direction: .leading),
+                contentInsets: onboardingTheme.linearBubbleMetrics.contentInsets,
+                arrowLength: onboardingTheme.linearBubbleMetrics.arrowLength,
+                arrowWidth: onboardingTheme.linearBubbleMetrics.arrowWidth
+            ) {
+                LinearDialogContentContainer(
+                    metrics: .init(
+                        outerSpacing: onboardingTheme.linearOnboardingMetrics.contentOuterSpacing,
+                        textSpacing: SkipOnboardingContentMetrics.textSpacing,
+                        contentSpacing: 0,
+                        actionsSpacing: onboardingTheme.linearOnboardingMetrics.actionsSpacing
+                    ),
+                    message: AnyView(
+                        Text(AttributedString(Copy.message.attributed.withFont(.daxBodyBold(), forText: Self.fireButtonCopy)))
+                            .foregroundColor(onboardingTheme.colorPalette.textPrimary)
+                            .multilineTextAlignment(.center)
+                            .font(onboardingTheme.typography.body)
+                    ),
+                    title: {
+                        Text(Copy.title)
+                            .foregroundColor(onboardingTheme.colorPalette.textPrimary)
+                            .multilineTextAlignment(.center)
+                            .font(onboardingTheme.typography.title)
+                    },
+                    actions: {
+                        VStack(spacing: SkipOnboardingContentMetrics.buttonSpacing) {
+                            Button(action: startBrowsingAction) {
+                                Text(Copy.confirmSkipOnboardingCTA)
+                            }
+                            .buttonStyle(onboardingTheme.primaryButtonStyle.style)
+
+                            Button(action: resumeOnboardingAction) {
+                                Text(Copy.resumeOnboardingCTA)
+                            }
+                            .buttonStyle(onboardingTheme.secondaryButtonStyle.style)
+                        }
+                    }
+                )
+            }
+            .frame(maxWidth: onboardingTheme.linearOnboardingMetrics.bubbleMaxWidth)
+            .frame(maxWidth: .infinity, alignment: .center)
         }
 
     }

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
@@ -204,10 +204,6 @@ extension OnboardingRebranding {
             let skipOnboardingView: AnyView? = if shouldShowSkipOnboardingButton {
                 AnyView(
                     SkipOnboardingContent(
-                        animateTitle: $model.skipOnboardingState.animateTitle,
-                        animateMessage: $model.skipOnboardingState.animateMessage,
-                        showCTA: $model.skipOnboardingState.showContent,
-                        isSkipped: $model.isSkipped,
                         startBrowsingAction: model.confirmSkipOnboardingAction,
                         resumeOnboardingAction: {
                             animateBrowserComparisonViewState(isResumingOnboarding: true)


### PR DESCRIPTION
## Summary
- Wraps the skip onboarding content in `OnboardingBubbleView` with correct tail position, matching other rebranded screens
- Uses theme-based typography (DuckSans Display Bold 24pt title, DuckSans Product Regular 18pt body), color palette, and pill-shaped button styles from `onboardingTheme`
- Removes typing animations (`AnimatableTypingText`) and related animation bindings in favor of static `Text` views
- Updates the non-rebranded fallback view with matching font sizes and layout spacing

## Test plan
- [ ] Launch app with `-ff.onboardingRebranding true` flag
- [ ] Navigate to onboarding via Settings > All Debug Options > Onboarding
- [ ] Tap "I've been here before" on the intro screen
- [ ] Verify the skip onboarding dialog matches the Figma design (speech bubble, correct fonts, pill buttons, spacing)
- [ ] Verify the bubble tail points correctly toward the Dax logo
- [ ] Verify "Start Browsing" (primary) and "Show Tutorial" (secondary) buttons work correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to onboarding layout and styling with no changes to navigation/actions beyond wiring removal of text animation state.
> 
> **Overview**
> Updates the *Skip Onboarding* UI to match the rebranded design. The rebranded variant now renders inside `OnboardingBubbleView` with theme-driven spacing, typography, colors, and primary/secondary button styles, and drops `AnimatableTypingText`/animation bindings in favor of static `Text`.
> 
> Also aligns the legacy (non-rebranded) skip screen layout by centering text, adjusting title/body font sizes and spacing, and switching the secondary CTA to `SecondaryFillButtonStyle()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89b243931d44755905a403ffc878c2371ea4998f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->