### PR TITLE
Skip Warn Before Quit for simulated key events

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1504,7 +1504,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             action: .quit,
             isWarningEnabled: { [tabsPreferences] in
                 tabsPreferences.warnBeforeQuitting
-            }
+            },
+            isPhysicalKeyPress: WarnBeforeQuitManager.makePhysicalKeyPressCheck(for: currentEvent)
         ) else { return nil }
 
         let presenter = WarnBeforeQuitOverlayPresenter(

--- a/macOS/DuckDuckGo/Application/WarnBeforeQuitManager.swift
+++ b/macOS/DuckDuckGo/Application/WarnBeforeQuitManager.swift
@@ -19,6 +19,7 @@
 import AppKit
 import Combine
 import Common
+import CoreGraphics
 import OSLog
 import PixelKit
 import SwiftUI
@@ -103,6 +104,10 @@ final class WarnBeforeQuitManager: ApplicationTerminationDecider {
     /// Checks if modifiers are currently held (injectable for testing)
     private let isModifierHeld: (NSEvent.ModifierFlags) -> Bool
 
+    /// Checks if the triggering key combination is physically pressed on hardware (not simulated).
+    /// When nil, the check is skipped (assumes physical). Pass `makePhysicalKeyPressCheck(for:)` in production.
+    private let isPhysicalKeyPress: (() -> Bool)?
+
     /// Delegate for event interception
     private weak var application: WarnBeforeQuitManagerDelegate?
 
@@ -151,6 +156,7 @@ final class WarnBeforeQuitManager: ApplicationTerminationDecider {
           timerFactory: ((TimeInterval, @escaping @MainActor () -> Void) -> Timer)? = nil,
           animationDelay: TimeInterval = Constants.defaultAnimationDelay,
           isModifierHeld: ((NSEvent.ModifierFlags) -> Bool)? = nil,
+          isPhysicalKeyPress: (() -> Bool)? = nil,
           delegate: WarnBeforeQuitManagerDelegate? = nil) {
         // Validate this is a keyDown event with modifier and valid character
         guard currentEvent.type == .keyDown,
@@ -173,6 +179,7 @@ final class WarnBeforeQuitManager: ApplicationTerminationDecider {
             let currentModifiers = NSEvent.modifierFlags.deviceIndependent
             return currentModifiers.intersection(requiredModifiers) == requiredModifiers
         }
+        self.isPhysicalKeyPress = isPhysicalKeyPress
         // Create state AsyncStream for external observation
         (stateStreamStorage, stateSubject) = AsyncStream<State>.makeStream(of: State.self, bufferingPolicy: .bufferingNewest(3))
     }
@@ -204,6 +211,14 @@ final class WarnBeforeQuitManager: ApplicationTerminationDecider {
         // Don't show confirmation if another decider already delayed termination or feature is disabled
         guard !isAsync, warningEnabled, currentState == .idle else {
             assert(currentState == .idle, "shouldTerminate should only be called when currentState is .idle, but currentState is \(currentState)")
+            return .sync(.next)
+        }
+
+        // Skip warning for simulated key events (e.g., from mouse button remapping tools).
+        // CGEventSource.hidSystemState only reflects physical hardware — programmatic key
+        // injections via CGEventPost won't appear in the HID state.
+        if let isPhysicalKeyPress, !isPhysicalKeyPress() {
+            Logger.general.debug("WarnBeforeQuitManager: Skipping warning — key event is not from physical keyboard")
             return .sync(.next)
         }
 
@@ -574,6 +589,24 @@ final class WarnBeforeQuitManager: ApplicationTerminationDecider {
                 return nil // consume event to prevent beep
             }
             return event // pass through other events
+        }
+    }
+
+    /// Creates a closure that checks whether the key combination from `event` is physically
+    /// pressed on hardware, using `CGEventSource.hidSystemState`.
+    ///
+    /// Programmatic key injections (e.g., mouse button remapping tools posting via `CGEventPost`)
+    /// update `combinedSessionState` but **not** `hidSystemState`, so this distinguishes
+    /// real keyboard input from simulated shortcuts.
+    static func makePhysicalKeyPressCheck(for event: NSEvent) -> () -> Bool {
+        let keyCode = event.keyCode
+        let modifierMask = event.keyEquivalent?.modifierMask ?? []
+        return {
+            let physicalFlags = CGEventSource.flagsState(.hidSystemState)
+            let requiredCGFlags = CGEventFlags(rawValue: UInt64(modifierMask.rawValue))
+            let modifiersPhysicallyHeld = physicalFlags.contains(requiredCGFlags)
+            let keyPhysicallyHeld = CGEventSource.keyState(.hidSystemState, key: CGKeyCode(keyCode))
+            return modifiersPhysicallyHeld && keyPhysicallyHeld
         }
     }
 

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -1073,7 +1073,8 @@ extension MainViewController {
         guard let manager = WarnBeforeQuitManager(
             currentEvent: currentEvent,
             action: .close,
-            isWarningEnabled: { [tabsPreferences] in tabsPreferences.warnBeforeClosingPinnedTabs }
+            isWarningEnabled: { [tabsPreferences] in tabsPreferences.warnBeforeClosingPinnedTabs },
+            isPhysicalKeyPress: WarnBeforeQuitManager.makePhysicalKeyPressCheck(for: currentEvent)
         ) else {
             completion(false)
             return

--- a/macOS/UnitTests/WarnBeforeQuit/WarnBeforeQuitManagerTests.swift
+++ b/macOS/UnitTests/WarnBeforeQuit/WarnBeforeQuitManagerTests.swift
@@ -171,6 +171,117 @@ final class WarnBeforeQuitManagerTests: XCTestCase, Sendable {
         XCTAssertNotNil(manager, "Manager should successfully filter device-dependent flags")
     }
 
+    // MARK: - Simulated Key Event Tests
+
+    func testSimulatedKeyEventSkipsWarningAndProceeds() {
+        // Given - isPhysicalKeyPress returns false (simulated event, e.g. from mouse button remapping)
+        let event = createKeyEvent(type: .keyDown, character: "q", modifierFlags: .command)
+        let manager = WarnBeforeQuitManager(
+            currentEvent: event,
+            action: .quit,
+            isWarningEnabled: { self.isWarningEnabled },
+            isPhysicalKeyPress: { false },
+            delegate: mockDelegate
+        )!
+
+        // When
+        let query = manager.shouldTerminate(isAsync: false)
+
+        // Then - should skip warning and proceed immediately
+        guard case .sync(let decision) = query else {
+            XCTFail("Expected sync decision, got: \(query)")
+            return
+        }
+        XCTAssertEqual(decision, .next)
+    }
+
+    func testPhysicalKeyEventShowsWarning() async throws {
+        // Given - isPhysicalKeyPress returns true (real keyboard press)
+        let event = createKeyEvent(type: .keyDown, character: "q", modifierFlags: .command)
+
+        let totalDuration = WarnBeforeQuitManager.Constants.requiredHoldDuration + WarnBeforeQuitManager.Constants.animationBufferDuration
+        let eventReceiver = makeEventReceiver(events: [
+            (event: nil, timeAdvance: totalDuration + Constants.earlyReleaseTimeAdvance)
+        ])
+
+        mockDelegate.eventReceiver = eventReceiver
+        let manager = try XCTUnwrap(WarnBeforeQuitManager(
+            currentEvent: event,
+            action: .quit,
+            isWarningEnabled: { self.isWarningEnabled },
+            now: { self.now },
+            animationDelay: 0,
+            isPhysicalKeyPress: { true },
+            delegate: mockDelegate
+        ))
+
+        // When
+        let expectations = setupExpectationsForStateChanges(3, manager: manager)
+        let query = manager.shouldTerminate(isAsync: false)
+        await fulfillment(of: expectations, timeout: Constants.expectationTimeout)
+
+        // Then - should show warning (enters keyDown/holding/completed states)
+        guard case .async = query else {
+            XCTFail("Expected async decision for quit action (fires pixel), got: \(query)")
+            return
+        }
+        XCTAssertEqual(collectedStates.first, .keyDown)
+    }
+
+    func testNilPhysicalKeyPressCheckShowsWarning() async throws {
+        // Given - isPhysicalKeyPress is nil (default, no check performed — assumes physical)
+        let event = createKeyEvent(type: .keyDown, character: "q", modifierFlags: .command)
+
+        let totalDuration = WarnBeforeQuitManager.Constants.requiredHoldDuration + WarnBeforeQuitManager.Constants.animationBufferDuration
+        let eventReceiver = makeEventReceiver(events: [
+            (event: nil, timeAdvance: totalDuration + Constants.earlyReleaseTimeAdvance)
+        ])
+
+        mockDelegate.eventReceiver = eventReceiver
+        let manager = try XCTUnwrap(WarnBeforeQuitManager(
+            currentEvent: event,
+            action: .quit,
+            isWarningEnabled: { self.isWarningEnabled },
+            now: { self.now },
+            animationDelay: 0,
+            delegate: mockDelegate
+        ))
+
+        // When
+        let expectations = setupExpectationsForStateChanges(3, manager: manager)
+        let query = manager.shouldTerminate(isAsync: false)
+        await fulfillment(of: expectations, timeout: Constants.expectationTimeout)
+
+        // Then - should show warning (nil means no check, proceeds as normal)
+        guard case .async = query else {
+            XCTFail("Expected async decision for quit action, got: \(query)")
+            return
+        }
+        XCTAssertEqual(collectedStates.first, .keyDown)
+    }
+
+    func testSimulatedKeyEventForCloseSkipsWarningAndProceeds() {
+        // Given - simulated Cmd+W for closing pinned tab
+        let event = createKeyEvent(type: .keyDown, character: "w", modifierFlags: .command)
+        let manager = WarnBeforeQuitManager(
+            currentEvent: event,
+            action: .close,
+            isWarningEnabled: { self.isWarningEnabled },
+            isPhysicalKeyPress: { false },
+            delegate: mockDelegate
+        )!
+
+        // When
+        let query = manager.shouldTerminate(isAsync: false)
+
+        // Then - should skip warning and proceed
+        guard case .sync(let decision) = query else {
+            XCTFail("Expected sync decision, got: \(query)")
+            return
+        }
+        XCTAssertEqual(decision, .next)
+    }
+
     // MARK: - State Stream Tests
 
     func testStateStreamEmitsHoldingAndCompletedStatesWhenHoldDurationReached() async throws {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213235241617189
Tech Design URL:
CC:

### Description
Detect whether Cmd+Q / Cmd+W originates from a physical keyboard press or a programmatic injection (e.g., mouse button remapped to Cmd+Q via tools like BetterTouchTool or Logitech Options).

Uses `CGEventSource.flagsState(.hidSystemState)` and `CGEventSource.keyState(.hidSystemState, key:)` which only reflect physical hardware state — simulated events posted via `CGEventPost` update `combinedSessionState` but **not** `hidSystemState`. When a simulated key event is detected, the hold-to-quit/close warning is skipped and the action proceeds immediately.

### Testing Steps
1. Map a mouse button to Cmd+Q using a remapping tool → app should quit immediately without the "Hold to Quit" overlay
2. Press Cmd+Q on the physical keyboard → "Hold to Quit" overlay should appear as before
3. Map a mouse button to Cmd+W with a pinned tab focused → pinned tab should close without the "Hold to Close" overlay
4. Press Cmd+W on the physical keyboard with a pinned tab focused → "Hold to Close" overlay should appear as before
5. Run `WarnBeforeQuitManagerTests` — all 55 tests pass (includes 4 new tests for simulated vs physical key detection)

### Impact and Risks
Low: Only affects the Warn Before Quit/Close overlay behavior. Core quit and close functionality is unchanged.

#### What could go wrong?
- Some driver-level remapping tools (e.g., Karabiner-Elements) that create virtual HID keyboard devices may still appear as physical hardware to the HID state table — for those users the overlay would still show, which is the existing behavior and not a regression.

### Quality Considerations
- The `isPhysicalKeyPress` closure is injectable (defaults to `nil` = no check) so all 51 existing tests remain untouched and 4 new tests cover the simulated/physical/nil scenarios.
- The check uses only public CoreGraphics APIs (`CGEventSource.flagsState`, `CGEventSource.keyState`).

### Notes to Reviewer
- The `isPhysicalKeyPress` parameter follows the same injectable closure pattern as the existing `isModifierHeld` parameter in `WarnBeforeQuitManager.init`.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is narrowly scoped to whether the warning overlay is shown for quit/pinned-tab close, with a conservative default (nil check behaves as before) and new unit coverage for the new decision branch.
> 
> **Overview**
> Prevents the *Hold to Quit/Close* overlay from appearing when ⌘Q/⌘W is triggered via **simulated** key events (e.g., mouse remapping tools), letting the quit/close proceed immediately.
> 
> `WarnBeforeQuitManager` now accepts an injectable `isPhysicalKeyPress` check and uses CoreGraphics HID state (`CGEventSource.flagsState(.hidSystemState)` / `keyState`) to distinguish physical keyboard shortcuts from injected events; `AppDelegate` and pinned-tab close flow now pass this check in production. Unit tests add coverage for simulated vs physical (and nil/default) behavior for both quit and close actions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f305ffb6ab9c31a33a6403880a570218e2794c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->