### PR TITLE
[macOS] Add new parameters to memory context

### DIFF
--- a/macOS/DuckDuckGo/AppHealth/MemoryAllocationStatsExporter.swift
+++ b/macOS/DuckDuckGo/AppHealth/MemoryAllocationStatsExporter.swift
@@ -39,9 +39,15 @@ enum MemoryAllocationStatsError: Error {
     case errorSavingSnapshot
 }
 
+/// Provides the current total used bytes from malloc zones.
+/// Conform to this protocol to mock allocation stats in tests.
+protocol MemoryAllocationStatsProviding {
+    func currentTotalUsedBytes() -> UInt64?
+}
+
 /// Exports the`MemoryAllocationStatsSnapshot` as calculated in a given time.
 ///
-final class MemoryAllocationStatsExporter {
+final class MemoryAllocationStatsExporter: MemoryAllocationStatsProviding {
 
     /// Exports a fresh MemoryAllocationStats to the specified URL
     ///
@@ -60,9 +66,15 @@ final class MemoryAllocationStatsExporter {
         try exportSnapshot(targetURL: targetURL)
         return targetURL
     }
+
+    /// Returns the current total used bytes across all malloc zones.
+    /// Returns `nil` if the stats cannot be read (e.g. zone access failure).
+    func currentTotalUsedBytes() -> UInt64? {
+        try? buildStatsSnapshot().totalUsedBytes
+    }
 }
 
-private extension MemoryAllocationStatsExporter {
+extension MemoryAllocationStatsExporter {
 
     func buildStatsSnapshot() throws -> MemoryAllocationStatsSnapshot {
         var zonesAddresses: UnsafeMutablePointer<vm_address_t>?

--- a/macOS/DuckDuckGo/AppHealth/MemoryPressureReporter.swift
+++ b/macOS/DuckDuckGo/AppHealth/MemoryPressureReporter.swift
@@ -59,6 +59,8 @@ final class MemoryPressureReporter {
     private let memoryUsageMonitor: MemoryUsageMonitoring
     private let windowContext: () -> WindowContext?
     private let isSyncEnabled: () -> Bool?
+    private let allocationStatsProvider: MemoryAllocationStatsProviding
+    private let launchDate: Date
     private let logger: Logger?
     private let notificationCenter: NotificationCenter
     private var memoryPressureSource: DispatchSourceMemoryPressure?
@@ -69,6 +71,8 @@ final class MemoryPressureReporter {
          memoryUsageMonitor: MemoryUsageMonitoring,
          windowContext: @autoclosure @escaping () -> WindowContext?,
          isSyncEnabled: @escaping () -> Bool?,
+         allocationStatsProvider: MemoryAllocationStatsProviding = MemoryAllocationStatsExporter(),
+         launchDate: Date = Date(),
          logger: Logger? = nil,
          notificationCenter: NotificationCenter = .default) {
         self.featureFlagger = featureFlagger
@@ -76,6 +80,8 @@ final class MemoryPressureReporter {
         self.memoryUsageMonitor = memoryUsageMonitor
         self.windowContext = windowContext
         self.isSyncEnabled = isSyncEnabled
+        self.allocationStatsProvider = allocationStatsProvider
+        self.launchDate = launchDate
         self.logger = logger
         self.notificationCenter = notificationCenter
         subscribeToFeatureFlagUpdates()
@@ -140,7 +146,9 @@ final class MemoryPressureReporter {
             let context = MemoryReportingContext.collect(
                 memoryUsageMonitor: memoryUsageMonitor,
                 windowContext: windowContext(),
-                isSyncEnabled: isSyncEnabled()
+                isSyncEnabled: isSyncEnabled(),
+                usedAllocationBytes: allocationStatsProvider.currentTotalUsedBytes(),
+                launchDate: launchDate
             )
             pixelFiring?.fire(MemoryPressurePixel.memoryPressureCritical(context: context), frequency: .dailyAndStandard)
         }

--- a/macOS/DuckDuckGo/AppHealth/MemoryReportingBuckets.swift
+++ b/macOS/DuckDuckGo/AppHealth/MemoryReportingBuckets.swift
@@ -67,9 +67,9 @@ enum MemoryReportingBuckets {
         }
     }
 
-    /// Tab count buckets.
+    /// Standard (unpinned) tab count buckets.
     /// Maps a count to: 0, 1, 2, 4, 7, 11, 21, or 51.
-    static func bucketTabCount(_ count: Int) -> Int {
+    static func bucketStandardTabCount(_ count: Int) -> Int {
         switch count {
         case ..<1:
             return 0
@@ -87,6 +87,54 @@ enum MemoryReportingBuckets {
             return 21
         default:
             return 51
+        }
+    }
+
+    /// Pinned tab count buckets.
+    /// Maps a count to: 0, 1, 2, 4, 7, 11, or 15.
+    static func bucketPinnedTabCount(_ count: Int) -> Int {
+        switch count {
+        case ..<1:
+            return 0
+        case 1:
+            return 1
+        case 2..<4:
+            return 2
+        case 4..<7:
+            return 4
+        case 7..<11:
+            return 7
+        case 11..<15:
+            return 11
+        default:
+            return 15
+        }
+    }
+
+    /// Used allocation buckets in megabytes.
+    /// Maps a value to: 0, 64, 128, 256, 512, 1024, 2048, 4096, 8192, or 16384.
+    static func bucketUsedAllocationMB(_ value: Double) -> Int {
+        switch Int(value) {
+        case ..<64:
+            return 0
+        case 64..<128:
+            return 64
+        case 128..<256:
+            return 128
+        case 256..<512:
+            return 256
+        case 512..<1024:
+            return 512
+        case 1024..<2048:
+            return 1024
+        case 2048..<4096:
+            return 2048
+        case 4096..<8192:
+            return 4096
+        case 8192..<16384:
+            return 8192
+        default:
+            return 16384
         }
     }
 

--- a/macOS/DuckDuckGo/AppHealth/MemoryReportingContext.swift
+++ b/macOS/DuckDuckGo/AppHealth/MemoryReportingContext.swift
@@ -20,7 +20,8 @@ import Foundation
 
 /// A snapshot of current windows and tabs in use
 struct WindowContext {
-    let tabs: Int
+    let standardTabs: Int
+    let pinnedTabs: Int
     let windows: Int
 }
 
@@ -38,8 +39,11 @@ struct MemoryReportingContext {
     /// Bucketed number of open windows (0, 1, 2, 4, 7, 11, 21), or `nil` if unavailable.
     let windows: Int?
 
-    /// Bucketed total tab count across all windows (0, 1, 2, 4, 7, 11, 21, 51), or `nil` if unavailable.
-    let tabs: Int?
+    /// Bucketed standard (unpinned) tab count across all windows (0, 1, 2, 4, 7, 11, 21, 51), or `nil` if unavailable.
+    let standardTabs: Int?
+
+    /// Bucketed pinned tab count across all windows (0, 1, 2, 4, 7, 11, 15), or `nil` if unavailable.
+    let pinnedTabs: Int?
 
     /// Architecture of the current build ("ARM" or "Intel").
     let architecture: String
@@ -47,15 +51,24 @@ struct MemoryReportingContext {
     /// Whether Sync is currently enabled (user is logged in and active), or `nil` if unavailable.
     let syncEnabled: Bool?
 
+    /// Bucketed total used allocation in MB (0, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384), or `nil` if unavailable.
+    let usedAllocationMB: Int?
+
+    /// Minutes elapsed since app launch (raw value, not bucketed).
+    let uptimeMinutes: Int
+
     /// Returns context parameters as a dictionary suitable for pixel firing.
     /// Parameters with `nil` values are sent as `"unknown"`.
     var parameters: [String: String] {
         [
             "browser_memory_mb": String(browserMemoryMB),
             "windows": windows.map(String.init) ?? "unknown",
-            "tabs": tabs.map(String.init) ?? "unknown",
+            "standard_tabs": standardTabs.map(String.init) ?? "unknown",
+            "pinned_tabs": pinnedTabs.map(String.init) ?? "unknown",
             "architecture": architecture,
-            "sync_enabled": syncEnabled.map(String.init) ?? "unknown"
+            "sync_enabled": syncEnabled.map(String.init) ?? "unknown",
+            "used_allocation": usedAllocationMB.map(String.init) ?? "unknown",
+            "uptime": String(uptimeMinutes)
         ]
     }
 
@@ -67,23 +80,35 @@ struct MemoryReportingContext {
     ///     window and tab counts will be sent as `"unknown"`.
     ///   - isSyncEnabled: Whether sync is currently enabled. Pass `nil` if unavailable;
     ///     sync status will be sent as `"unknown"`.
+    ///   - usedAllocationBytes: Total used bytes from malloc zones. Pass `nil` if unavailable.
+    ///   - launchDate: The date the app was launched, used to compute uptime in minutes.
     @MainActor
     static func collect(
         memoryUsageMonitor: MemoryUsageMonitoring,
         windowContext: WindowContext?,
-        isSyncEnabled: Bool?
+        isSyncEnabled: Bool?,
+        usedAllocationBytes: UInt64?,
+        launchDate: Date
     ) -> MemoryReportingContext {
         let report = memoryUsageMonitor.getCurrentMemoryUsage()
         let browserMemoryMB = MemoryReportingBuckets.bucketMemoryMB(report.physFootprintMB)
         let windows = windowContext.map(\.windows).map(MemoryReportingBuckets.bucketWindowCount)
-        let tabs = windowContext.map(\.tabs).map(MemoryReportingBuckets.bucketTabCount)
+        let standardTabs = windowContext.map(\.standardTabs).map(MemoryReportingBuckets.bucketStandardTabCount)
+        let pinnedTabs = windowContext.map(\.pinnedTabs).map(MemoryReportingBuckets.bucketPinnedTabCount)
+        let usedAllocationMB = usedAllocationBytes.map { bytes in
+            MemoryReportingBuckets.bucketUsedAllocationMB(Double(bytes) / 1_048_576.0)
+        }
+        let uptimeMinutes = Int(Date().timeIntervalSince(launchDate) / 60.0)
 
         return MemoryReportingContext(
             browserMemoryMB: browserMemoryMB,
             windows: windows,
-            tabs: tabs,
+            standardTabs: standardTabs,
+            pinnedTabs: pinnedTabs,
             architecture: MemoryReportingBuckets.currentArchitecture,
-            syncEnabled: isSyncEnabled
+            syncEnabled: isSyncEnabled,
+            usedAllocationMB: usedAllocationMB,
+            uptimeMinutes: uptimeMinutes
         )
     }
 }

--- a/macOS/DuckDuckGo/AppHealth/MemoryUsageIntervalPixel.swift
+++ b/macOS/DuckDuckGo/AppHealth/MemoryUsageIntervalPixel.swift
@@ -22,7 +22,8 @@ import Foundation
 /// Interval memory usage pixel that fires at startup and scheduled intervals with context parameters.
 ///
 /// Each trigger (startup, 1h, 2h, 4h, 8h, 24h) fires at most once per app session.
-/// Context parameters include bucketed memory usage, window count, tab count, and architecture.
+/// Context parameters include bucketed memory usage, window count, standard/pinned tab counts,
+/// architecture, allocation usage, and uptime.
 ///
 enum MemoryUsageIntervalPixel: PixelKitEvent {
 
@@ -51,7 +52,7 @@ enum MemoryUsageIntervalPixel: PixelKitEvent {
     }
 
     var name: String {
-        "m_mac_memory_usage"
+        "m_mac_memory_usage_interval"
     }
 
     var parameters: [String: String]? {

--- a/macOS/DuckDuckGo/AppHealth/MemoryUsageIntervalReporter.swift
+++ b/macOS/DuckDuckGo/AppHealth/MemoryUsageIntervalReporter.swift
@@ -28,8 +28,8 @@ import PrivacyConfig
 /// `.memoryUsageReporting` feature flag is enabled and ends when the flag is disabled.
 /// Disabling and re-enabling the flag starts a fresh session.
 ///
-/// Context parameters (memory, windows, tabs, architecture, sync) are collected at the
-/// moment of firing each pixel, on the `MainActor`.
+/// Context parameters (memory, windows, standard/pinned tabs, architecture, sync,
+/// allocation, uptime) are collected at the moment of firing each pixel, on the `MainActor`.
 ///
 final class MemoryUsageIntervalReporter {
 
@@ -43,6 +43,8 @@ final class MemoryUsageIntervalReporter {
     private let pixelFiring: PixelFiring?
     private let windowContext: () -> WindowContext?
     private let isSyncEnabled: () -> Bool?
+    private let allocationStatsProvider: MemoryAllocationStatsProviding
+    private let launchDate: Date
     private let logger: Logger?
     private let checkInterval: TimeInterval
 
@@ -68,8 +70,10 @@ final class MemoryUsageIntervalReporter {
     ///   - memoryUsageMonitor: Provides memory usage readings via `getCurrentMemoryUsage()`.
     ///   - featureFlagger: Feature flag provider to check if reporting is enabled.
     ///   - pixelFiring: The pixel firing service for sending analytics.
-    ///   - windowContext: Closure that provides information about opened tabs and windows
+    ///   - windowContext: Closure that provides information about opened tabs and windows.
     ///   - isSyncEnabled: Closure that provides a boolean if Sync is enabled.
+    ///   - allocationStatsProvider: Provides the current total used bytes from malloc zones.
+    ///   - launchDate: The date the app was launched, used to compute uptime.
     ///   - checkInterval: The interval between checks. Defaults to 60 seconds.
     ///   - logger: Optional logger for debugging.
     init(
@@ -78,6 +82,8 @@ final class MemoryUsageIntervalReporter {
         pixelFiring: PixelFiring?,
         windowContext: @autoclosure @escaping () -> WindowContext?,
         isSyncEnabled: @escaping () -> Bool?,
+        allocationStatsProvider: MemoryAllocationStatsProviding = MemoryAllocationStatsExporter(),
+        launchDate: Date = Date(),
         checkInterval: TimeInterval = MemoryUsageIntervalReporter.defaultCheckInterval,
         logger: Logger? = nil
     ) {
@@ -86,6 +92,8 @@ final class MemoryUsageIntervalReporter {
         self.pixelFiring = pixelFiring
         self.windowContext = windowContext
         self.isSyncEnabled = isSyncEnabled
+        self.allocationStatsProvider = allocationStatsProvider
+        self.launchDate = launchDate
         self.checkInterval = checkInterval
         self.logger = logger
         subscribeToFeatureFlagUpdates()
@@ -177,11 +185,14 @@ final class MemoryUsageIntervalReporter {
             guard shouldFire else { continue }
 
             // Collect context on MainActor and fire
-            let context = await MainActor.run { [memoryUsageMonitor, windowContext, isSyncEnabled] in
+            let allocationBytes = allocationStatsProvider.currentTotalUsedBytes()
+            let context = await MainActor.run { [memoryUsageMonitor, windowContext, isSyncEnabled, launchDate] in
                 MemoryReportingContext.collect(
                     memoryUsageMonitor: memoryUsageMonitor,
                     windowContext: windowContext(),
-                    isSyncEnabled: isSyncEnabled()
+                    isSyncEnabled: isSyncEnabled(),
+                    usedAllocationBytes: allocationBytes,
+                    launchDate: launchDate
                 )
             }
 
@@ -244,11 +255,14 @@ extension MemoryUsageIntervalReporter {
     /// checks, deduplication, and feature-flag checks. This is intentional to allow
     /// developers to validate pixel content without enabling the flag or waiting for intervals.
     func fireTriggerNow(_ trigger: MemoryUsageIntervalPixel.Trigger) async {
-        let context = await MainActor.run { [memoryUsageMonitor, windowContext, isSyncEnabled] in
+        let allocationBytes = allocationStatsProvider.currentTotalUsedBytes()
+        let context = await MainActor.run { [memoryUsageMonitor, windowContext, isSyncEnabled, launchDate] in
             MemoryReportingContext.collect(
                 memoryUsageMonitor: memoryUsageMonitor,
                 windowContext: windowContext(),
-                isSyncEnabled: isSyncEnabled()
+                isSyncEnabled: isSyncEnabled(),
+                usedAllocationBytes: allocationBytes,
+                launchDate: launchDate
             )
         }
 

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -389,6 +389,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// which is unavailable before `super.init()`. Initialized immediately after `super.init()`.
     var memoryUsageIntervalReporter: MemoryUsageIntervalReporter?
 
+    /// The date this app instance was launched, used for computing uptime in memory pixels.
+    private let appLaunchDate = Date()
+
     @MainActor
     // swiftlint:disable cyclomatic_complexity
     override init() {
@@ -1065,7 +1068,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             pixelFiring: PixelKit.shared,
             memoryUsageMonitor: memoryUsageMonitor,
             windowContext: WindowContext(
-                tabs: windowControllersManager.allTabCollectionViewModels.reduce(0) { $0 + $1.allTabsCount },
+                standardTabs: windowControllersManager.allTabCollectionViewModels.reduce(0) { $0 + $1.tabCollection.tabs.count },
+                pinnedTabs: windowControllersManager.pinnedTabsManagerProvider.currentPinnedTabManagers.reduce(0) { $0 + $1.tabCollection.tabs.count },
                 windows: windowControllersManager.mainWindowControllers.count
             ),
             isSyncEnabled: { [weak self] in
@@ -1073,6 +1077,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
                 return syncService.authState == .active
             },
+            launchDate: appLaunchDate,
             logger: .memory
         )
 
@@ -1081,7 +1086,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             featureFlagger: featureFlagger,
             pixelFiring: PixelKit.shared,
             windowContext: WindowContext(
-                tabs: windowControllersManager.allTabCollectionViewModels.reduce(0) { $0 + $1.allTabsCount },
+                standardTabs: windowControllersManager.allTabCollectionViewModels.reduce(0) { $0 + $1.tabCollection.tabs.count },
+                pinnedTabs: windowControllersManager.pinnedTabsManagerProvider.currentPinnedTabManagers.reduce(0) { $0 + $1.tabCollection.tabs.count },
                 windows: windowControllersManager.mainWindowControllers.count
             ),
             isSyncEnabled: { [weak self] in
@@ -1089,6 +1095,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
                 return syncService.authState == .active
             },
+            launchDate: appLaunchDate,
             logger: .memory
         )
 

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -683,7 +683,7 @@ extension AppDelegate {
     @objc func fireIntervalPixelNow(_ sender: Any?) {
         let alert = NSAlert()
         alert.messageText = "Fire Interval Pixel"
-        alert.informativeText = "Select a trigger to fire. The reporter will collect current context and fire the m_mac_memory_usage pixel."
+        alert.informativeText = "Select a trigger to fire. The reporter will collect current context and fire the m_mac_memory_usage_interval pixel."
         alert.alertStyle = .informational
 
         let popup = NSPopUpButton(frame: NSRect(x: 0, y: 0, width: 200, height: 24), pullsDown: false)

--- a/macOS/PixelDefinitions/pixels/definitions/memory_pressure_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/memory_pressure_pixels.json5
@@ -20,10 +20,16 @@
                 "description": "Number of open browser windows, bucketed. 'unknown' if unavailable."
             },
             {
-                "key": "tabs",
+                "key": "standard_tabs",
                 "type": "string",
                 "enum": ["0", "1", "2", "4", "7", "11", "21", "51", "unknown"],
-                "description": "Total number of tabs across all windows, bucketed. 'unknown' if unavailable."
+                "description": "Number of standard (unpinned) tabs across all windows, bucketed. 'unknown' if unavailable."
+            },
+            {
+                "key": "pinned_tabs",
+                "type": "string",
+                "enum": ["0", "1", "2", "4", "7", "11", "15", "unknown"],
+                "description": "Number of pinned tabs across all windows, bucketed. 'unknown' if unavailable."
             },
             {
                 "key": "architecture",
@@ -36,6 +42,17 @@
                 "type": "string",
                 "enum": ["true", "false", "unknown"],
                 "description": "Whether Sync is currently enabled. 'unknown' if unavailable."
+            },
+            {
+                "key": "used_allocation",
+                "type": "string",
+                "enum": ["0", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "16384", "unknown"],
+                "description": "Total used allocation from malloc zones in MB, bucketed. 'unknown' if unavailable."
+            },
+            {
+                "key": "uptime",
+                "type": "integer",
+                "description": "Minutes elapsed since app launch (raw value, not bucketed)"
             }
         ]
     }

--- a/macOS/PixelDefinitions/pixels/definitions/memory_usage_interval_pixel.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/memory_usage_interval_pixel.json5
@@ -1,7 +1,7 @@
 // Memory usage interval pixel
 // Fires at startup and scheduled intervals to report memory usage with context
 {
-    "m_mac_memory_usage": {
+    "m_mac_memory_usage_interval": {
         "description": "Fires at startup and scheduled intervals to report browser memory usage with context parameters",
         "owners": ["jotaemepereira"],
         "triggers": ["startup", "scheduled"],
@@ -28,10 +28,16 @@
                 "description": "Number of open browser windows, bucketed. 'unknown' if unavailable."
             },
             {
-                "key": "tabs",
+                "key": "standard_tabs",
                 "type": "string",
                 "enum": ["0", "1", "2", "4", "7", "11", "21", "51", "unknown"],
-                "description": "Total number of tabs across all windows, bucketed. 'unknown' if unavailable."
+                "description": "Number of standard (unpinned) tabs across all windows, bucketed. 'unknown' if unavailable."
+            },
+            {
+                "key": "pinned_tabs",
+                "type": "string",
+                "enum": ["0", "1", "2", "4", "7", "11", "15", "unknown"],
+                "description": "Number of pinned tabs across all windows, bucketed. 'unknown' if unavailable."
             },
             {
                 "key": "architecture",
@@ -44,6 +50,17 @@
                 "type": "string",
                 "enum": ["true", "false", "unknown"],
                 "description": "Whether Sync is currently enabled. 'unknown' if unavailable."
+            },
+            {
+                "key": "used_allocation",
+                "type": "string",
+                "enum": ["0", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "16384", "unknown"],
+                "description": "Total used allocation from malloc zones in MB, bucketed. 'unknown' if unavailable."
+            },
+            {
+                "key": "uptime",
+                "type": "integer",
+                "description": "Minutes elapsed since app launch (raw value, not bucketed)"
             }
         ]
     }

--- a/macOS/UnitTests/AppHealth/MemoryPressureReporterTests.swift
+++ b/macOS/UnitTests/AppHealth/MemoryPressureReporterTests.swift
@@ -29,6 +29,7 @@ final class MemoryPressureReporterTests: XCTestCase {
     private var mockFeatureFlagger: MockFeatureFlagger!
     private var mockPixelFiring: PixelKitMock!
     private var mockMemoryUsageMonitor: MockPressureMemoryMonitor!
+    private var mockAllocationStats: MockPressureAllocationStatsProvider!
     private var notificationCenter: NotificationCenter!
 
     override func setUp() {
@@ -36,6 +37,7 @@ final class MemoryPressureReporterTests: XCTestCase {
         mockFeatureFlagger = MockFeatureFlagger()
         mockPixelFiring = PixelKitMock()
         mockMemoryUsageMonitor = MockPressureMemoryMonitor()
+        mockAllocationStats = MockPressureAllocationStatsProvider()
         notificationCenter = NotificationCenter()
     }
 
@@ -44,6 +46,7 @@ final class MemoryPressureReporterTests: XCTestCase {
         mockFeatureFlagger = nil
         mockPixelFiring = nil
         mockMemoryUsageMonitor = nil
+        mockAllocationStats = nil
         notificationCenter = nil
         super.tearDown()
     }
@@ -57,6 +60,7 @@ final class MemoryPressureReporterTests: XCTestCase {
             memoryUsageMonitor: mockMemoryUsageMonitor,
             windowContext: nil,
             isSyncEnabled: { nil },
+            allocationStatsProvider: mockAllocationStats,
             notificationCenter: notificationCenter
         )
     }
@@ -68,9 +72,12 @@ final class MemoryPressureReporterTests: XCTestCase {
         let context = MemoryReportingContext(
             browserMemoryMB: 1024,
             windows: nil,
-            tabs: nil,
+            standardTabs: nil,
+            pinnedTabs: nil,
             architecture: "ARM",
-            syncEnabled: nil
+            syncEnabled: nil,
+            usedAllocationMB: nil,
+            uptimeMinutes: 0
         )
 
         // When
@@ -85,9 +92,12 @@ final class MemoryPressureReporterTests: XCTestCase {
         let context = MemoryReportingContext(
             browserMemoryMB: 2048,
             windows: 4,
-            tabs: 21,
+            standardTabs: 21,
+            pinnedTabs: 4,
             architecture: "ARM",
-            syncEnabled: true
+            syncEnabled: true,
+            usedAllocationMB: 512,
+            uptimeMinutes: 120
         )
 
         // When
@@ -98,9 +108,12 @@ final class MemoryPressureReporterTests: XCTestCase {
         XCTAssertNotNil(params)
         XCTAssertEqual(params?["browser_memory_mb"], "2048")
         XCTAssertEqual(params?["windows"], "4")
-        XCTAssertEqual(params?["tabs"], "21")
+        XCTAssertEqual(params?["standard_tabs"], "21")
+        XCTAssertEqual(params?["pinned_tabs"], "4")
         XCTAssertEqual(params?["architecture"], "ARM")
         XCTAssertEqual(params?["sync_enabled"], "true")
+        XCTAssertEqual(params?["used_allocation"], "512")
+        XCTAssertEqual(params?["uptime"], "120")
     }
 
     func testMemoryPressurePixelReturnsUnknownForNilDependencies() {
@@ -108,9 +121,12 @@ final class MemoryPressureReporterTests: XCTestCase {
         let context = MemoryReportingContext(
             browserMemoryMB: 512,
             windows: nil,
-            tabs: nil,
+            standardTabs: nil,
+            pinnedTabs: nil,
             architecture: "Intel",
-            syncEnabled: nil
+            syncEnabled: nil,
+            usedAllocationMB: nil,
+            uptimeMinutes: 5
         )
 
         // When
@@ -119,8 +135,10 @@ final class MemoryPressureReporterTests: XCTestCase {
         // Then
         let params = pixel.parameters
         XCTAssertEqual(params?["windows"], "unknown")
-        XCTAssertEqual(params?["tabs"], "unknown")
+        XCTAssertEqual(params?["standard_tabs"], "unknown")
+        XCTAssertEqual(params?["pinned_tabs"], "unknown")
         XCTAssertEqual(params?["sync_enabled"], "unknown")
+        XCTAssertEqual(params?["used_allocation"], "unknown")
     }
 
     // MARK: - Notification + Pixel tests
@@ -160,7 +178,8 @@ final class MemoryPressureReporterTests: XCTestCase {
         let params = mockPixelFiring.actualFireCalls.first?.pixel.parameters
         XCTAssertEqual(params?["browser_memory_mb"], "4096") // 5000MB buckets to 4096
         XCTAssertEqual(params?["windows"], "unknown")
-        XCTAssertEqual(params?["tabs"], "unknown")
+        XCTAssertEqual(params?["standard_tabs"], "unknown")
+        XCTAssertEqual(params?["pinned_tabs"], "unknown")
         XCTAssertNotNil(params?["architecture"])
         XCTAssertEqual(params?["sync_enabled"], "unknown")
     }
@@ -183,7 +202,7 @@ final class MemoryPressureReporterTests: XCTestCase {
     }
 }
 
-// MARK: - Mock
+// MARK: - Mocks
 
 private class MockPressureMemoryMonitor: MemoryUsageMonitoring {
     var currentResidentMB: Double = 0
@@ -196,5 +215,13 @@ private class MockPressureMemoryMonitor: MemoryUsageMonitoring {
             residentBytes: residentBytes,
             physFootprintBytes: physFootprintBytes
         )
+    }
+}
+
+private class MockPressureAllocationStatsProvider: MemoryAllocationStatsProviding {
+    var totalUsedBytes: UInt64?
+
+    func currentTotalUsedBytes() -> UInt64? {
+        totalUsedBytes
     }
 }

--- a/macOS/UnitTests/AppHealth/MemoryReportingBucketsTests.swift
+++ b/macOS/UnitTests/AppHealth/MemoryReportingBucketsTests.swift
@@ -71,30 +71,86 @@ final class MemoryReportingBucketsTests: XCTestCase {
         XCTAssertEqual(MemoryReportingBuckets.bucketWindowCount(100), 21)
     }
 
-    // MARK: - Tab Count Bucketing
+    // MARK: - Standard Tab Count Bucketing
 
-    func testBucketTabCount_AtBoundaries() {
-        XCTAssertEqual(MemoryReportingBuckets.bucketTabCount(0), 0)
-        XCTAssertEqual(MemoryReportingBuckets.bucketTabCount(1), 1)
-        XCTAssertEqual(MemoryReportingBuckets.bucketTabCount(2), 2)
-        XCTAssertEqual(MemoryReportingBuckets.bucketTabCount(4), 4)
-        XCTAssertEqual(MemoryReportingBuckets.bucketTabCount(7), 7)
-        XCTAssertEqual(MemoryReportingBuckets.bucketTabCount(11), 11)
-        XCTAssertEqual(MemoryReportingBuckets.bucketTabCount(21), 21)
-        XCTAssertEqual(MemoryReportingBuckets.bucketTabCount(51), 51)
+    func testBucketStandardTabCount_AtBoundaries() {
+        XCTAssertEqual(MemoryReportingBuckets.bucketStandardTabCount(0), 0)
+        XCTAssertEqual(MemoryReportingBuckets.bucketStandardTabCount(1), 1)
+        XCTAssertEqual(MemoryReportingBuckets.bucketStandardTabCount(2), 2)
+        XCTAssertEqual(MemoryReportingBuckets.bucketStandardTabCount(4), 4)
+        XCTAssertEqual(MemoryReportingBuckets.bucketStandardTabCount(7), 7)
+        XCTAssertEqual(MemoryReportingBuckets.bucketStandardTabCount(11), 11)
+        XCTAssertEqual(MemoryReportingBuckets.bucketStandardTabCount(21), 21)
+        XCTAssertEqual(MemoryReportingBuckets.bucketStandardTabCount(51), 51)
     }
 
-    func testBucketTabCount_WithinRanges() {
-        XCTAssertEqual(MemoryReportingBuckets.bucketTabCount(3), 2)
-        XCTAssertEqual(MemoryReportingBuckets.bucketTabCount(5), 4)
-        XCTAssertEqual(MemoryReportingBuckets.bucketTabCount(6), 4)
-        XCTAssertEqual(MemoryReportingBuckets.bucketTabCount(9), 7)
-        XCTAssertEqual(MemoryReportingBuckets.bucketTabCount(10), 7)
-        XCTAssertEqual(MemoryReportingBuckets.bucketTabCount(15), 11)
-        XCTAssertEqual(MemoryReportingBuckets.bucketTabCount(30), 21)
-        XCTAssertEqual(MemoryReportingBuckets.bucketTabCount(50), 21)
-        XCTAssertEqual(MemoryReportingBuckets.bucketTabCount(100), 51)
-        XCTAssertEqual(MemoryReportingBuckets.bucketTabCount(500), 51)
+    func testBucketStandardTabCount_WithinRanges() {
+        XCTAssertEqual(MemoryReportingBuckets.bucketStandardTabCount(3), 2)
+        XCTAssertEqual(MemoryReportingBuckets.bucketStandardTabCount(5), 4)
+        XCTAssertEqual(MemoryReportingBuckets.bucketStandardTabCount(6), 4)
+        XCTAssertEqual(MemoryReportingBuckets.bucketStandardTabCount(9), 7)
+        XCTAssertEqual(MemoryReportingBuckets.bucketStandardTabCount(10), 7)
+        XCTAssertEqual(MemoryReportingBuckets.bucketStandardTabCount(15), 11)
+        XCTAssertEqual(MemoryReportingBuckets.bucketStandardTabCount(30), 21)
+        XCTAssertEqual(MemoryReportingBuckets.bucketStandardTabCount(50), 21)
+        XCTAssertEqual(MemoryReportingBuckets.bucketStandardTabCount(100), 51)
+        XCTAssertEqual(MemoryReportingBuckets.bucketStandardTabCount(500), 51)
+    }
+
+    // MARK: - Pinned Tab Count Bucketing
+
+    func testBucketPinnedTabCount_AtBoundaries() {
+        XCTAssertEqual(MemoryReportingBuckets.bucketPinnedTabCount(0), 0)
+        XCTAssertEqual(MemoryReportingBuckets.bucketPinnedTabCount(1), 1)
+        XCTAssertEqual(MemoryReportingBuckets.bucketPinnedTabCount(2), 2)
+        XCTAssertEqual(MemoryReportingBuckets.bucketPinnedTabCount(4), 4)
+        XCTAssertEqual(MemoryReportingBuckets.bucketPinnedTabCount(7), 7)
+        XCTAssertEqual(MemoryReportingBuckets.bucketPinnedTabCount(11), 11)
+        XCTAssertEqual(MemoryReportingBuckets.bucketPinnedTabCount(15), 15)
+    }
+
+    func testBucketPinnedTabCount_WithinRanges() {
+        XCTAssertEqual(MemoryReportingBuckets.bucketPinnedTabCount(3), 2)
+        XCTAssertEqual(MemoryReportingBuckets.bucketPinnedTabCount(5), 4)
+        XCTAssertEqual(MemoryReportingBuckets.bucketPinnedTabCount(6), 4)
+        XCTAssertEqual(MemoryReportingBuckets.bucketPinnedTabCount(9), 7)
+        XCTAssertEqual(MemoryReportingBuckets.bucketPinnedTabCount(10), 7)
+        XCTAssertEqual(MemoryReportingBuckets.bucketPinnedTabCount(12), 11)
+        XCTAssertEqual(MemoryReportingBuckets.bucketPinnedTabCount(14), 11)
+        XCTAssertEqual(MemoryReportingBuckets.bucketPinnedTabCount(20), 15)
+        XCTAssertEqual(MemoryReportingBuckets.bucketPinnedTabCount(100), 15)
+    }
+
+    // MARK: - Used Allocation Bucketing
+
+    func testBucketUsedAllocationMB_BelowFirstBucket() {
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(0), 0)
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(32), 0)
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(63.9), 0)
+    }
+
+    func testBucketUsedAllocationMB_AtBoundaries() {
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(64), 64)
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(128), 128)
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(256), 256)
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(512), 512)
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(1024), 1024)
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(2048), 2048)
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(4096), 4096)
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(8192), 8192)
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(16384), 16384)
+    }
+
+    func testBucketUsedAllocationMB_WithinRanges() {
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(100), 64)
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(200), 128)
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(400), 256)
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(800), 512)
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(1500), 1024)
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(3000), 2048)
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(6000), 4096)
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(12000), 8192)
+        XCTAssertEqual(MemoryReportingBuckets.bucketUsedAllocationMB(32000), 16384)
     }
 
     // MARK: - Architecture

--- a/macOS/UnitTests/AppHealth/MemoryUsageIntervalPixelTests.swift
+++ b/macOS/UnitTests/AppHealth/MemoryUsageIntervalPixelTests.swift
@@ -27,27 +27,33 @@ final class MemoryUsageIntervalPixelTests: XCTestCase {
         let context = MemoryReportingContext(
             browserMemoryMB: 1024,
             windows: 2,
-            tabs: 7,
+            standardTabs: 7,
+            pinnedTabs: 2,
             architecture: "ARM",
-            syncEnabled: false
+            syncEnabled: false,
+            usedAllocationMB: 256,
+            uptimeMinutes: 5
         )
         let pixel = MemoryUsageIntervalPixel.memoryUsage(trigger: .startup, context: context)
 
-        XCTAssertEqual(pixel.name, "m_mac_memory_usage")
+        XCTAssertEqual(pixel.name, "m_mac_memory_usage_interval")
     }
 
     func testPixelNameIsSameForAllTriggers() {
         let context = MemoryReportingContext(
             browserMemoryMB: 512,
             windows: 1,
-            tabs: 4,
+            standardTabs: 4,
+            pinnedTabs: 1,
             architecture: "Intel",
-            syncEnabled: true
+            syncEnabled: true,
+            usedAllocationMB: 128,
+            uptimeMinutes: 10
         )
 
         for trigger in MemoryUsageIntervalPixel.Trigger.allCases {
             let pixel = MemoryUsageIntervalPixel.memoryUsage(trigger: trigger, context: context)
-            XCTAssertEqual(pixel.name, "m_mac_memory_usage", "Name should be the same for trigger \(trigger)")
+            XCTAssertEqual(pixel.name, "m_mac_memory_usage_interval", "Name should be the same for trigger \(trigger)")
         }
     }
 
@@ -57,9 +63,12 @@ final class MemoryUsageIntervalPixelTests: XCTestCase {
         let context = MemoryReportingContext(
             browserMemoryMB: 2048,
             windows: 4,
-            tabs: 11,
+            standardTabs: 11,
+            pinnedTabs: 4,
             architecture: "ARM",
-            syncEnabled: true
+            syncEnabled: true,
+            usedAllocationMB: 512,
+            uptimeMinutes: 240
         )
         let pixel = MemoryUsageIntervalPixel.memoryUsage(trigger: .h4, context: context)
 
@@ -68,18 +77,24 @@ final class MemoryUsageIntervalPixelTests: XCTestCase {
         XCTAssertEqual(params?["trigger"], "4h")
         XCTAssertEqual(params?["browser_memory_mb"], "2048")
         XCTAssertEqual(params?["windows"], "4")
-        XCTAssertEqual(params?["tabs"], "11")
+        XCTAssertEqual(params?["standard_tabs"], "11")
+        XCTAssertEqual(params?["pinned_tabs"], "4")
         XCTAssertEqual(params?["architecture"], "ARM")
         XCTAssertEqual(params?["sync_enabled"], "true")
+        XCTAssertEqual(params?["used_allocation"], "512")
+        XCTAssertEqual(params?["uptime"], "240")
     }
 
     func testParametersForStartupTrigger() {
         let context = MemoryReportingContext(
             browserMemoryMB: 0,
             windows: 1,
-            tabs: 1,
+            standardTabs: 1,
+            pinnedTabs: 0,
             architecture: "Intel",
-            syncEnabled: false
+            syncEnabled: false,
+            usedAllocationMB: 64,
+            uptimeMinutes: 0
         )
         let pixel = MemoryUsageIntervalPixel.memoryUsage(trigger: .startup, context: context)
 
@@ -87,9 +102,12 @@ final class MemoryUsageIntervalPixelTests: XCTestCase {
         XCTAssertEqual(params?["trigger"], "startup")
         XCTAssertEqual(params?["browser_memory_mb"], "0")
         XCTAssertEqual(params?["windows"], "1")
-        XCTAssertEqual(params?["tabs"], "1")
+        XCTAssertEqual(params?["standard_tabs"], "1")
+        XCTAssertEqual(params?["pinned_tabs"], "0")
         XCTAssertEqual(params?["architecture"], "Intel")
         XCTAssertEqual(params?["sync_enabled"], "false")
+        XCTAssertEqual(params?["used_allocation"], "64")
+        XCTAssertEqual(params?["uptime"], "0")
     }
 
     func testAllTriggerRawValues() {
@@ -124,32 +142,41 @@ final class MemoryUsageIntervalPixelTests: XCTestCase {
         let context = MemoryReportingContext(
             browserMemoryMB: 512,
             windows: 2,
-            tabs: 4,
+            standardTabs: 4,
+            pinnedTabs: 1,
             architecture: "ARM",
-            syncEnabled: true
+            syncEnabled: true,
+            usedAllocationMB: 128,
+            uptimeMinutes: 30
         )
         let params = context.parameters
 
-        XCTAssertEqual(params.count, 5)
+        XCTAssertEqual(params.count, 8)
         XCTAssertNotNil(params["browser_memory_mb"])
         XCTAssertNotNil(params["windows"])
-        XCTAssertNotNil(params["tabs"])
+        XCTAssertNotNil(params["standard_tabs"])
+        XCTAssertNotNil(params["pinned_tabs"])
         XCTAssertNotNil(params["architecture"])
         XCTAssertNotNil(params["sync_enabled"])
+        XCTAssertNotNil(params["used_allocation"])
+        XCTAssertNotNil(params["uptime"])
     }
 
     func testPixelParametersCount() {
         let context = MemoryReportingContext(
             browserMemoryMB: 1024,
             windows: 1,
-            tabs: 2,
+            standardTabs: 2,
+            pinnedTabs: 0,
             architecture: "ARM",
-            syncEnabled: false
+            syncEnabled: false,
+            usedAllocationMB: 256,
+            uptimeMinutes: 60
         )
         let pixel = MemoryUsageIntervalPixel.memoryUsage(trigger: .h1, context: context)
 
-        // 5 context params + 1 trigger = 6 total
-        XCTAssertEqual(pixel.parameters?.count, 6)
+        // 8 context params + 1 trigger = 9 total
+        XCTAssertEqual(pixel.parameters?.count, 9)
     }
 
     // MARK: - Unknown Fallback
@@ -158,30 +185,39 @@ final class MemoryUsageIntervalPixelTests: XCTestCase {
         let context = MemoryReportingContext(
             browserMemoryMB: 512,
             windows: nil,
-            tabs: nil,
+            standardTabs: nil,
+            pinnedTabs: nil,
             architecture: "ARM",
-            syncEnabled: nil
+            syncEnabled: nil,
+            usedAllocationMB: nil,
+            uptimeMinutes: 5
         )
         let params = context.parameters
 
         XCTAssertEqual(params["browser_memory_mb"], "512")
         XCTAssertEqual(params["windows"], "unknown")
-        XCTAssertEqual(params["tabs"], "unknown")
+        XCTAssertEqual(params["standard_tabs"], "unknown")
+        XCTAssertEqual(params["pinned_tabs"], "unknown")
         XCTAssertEqual(params["architecture"], "ARM")
         XCTAssertEqual(params["sync_enabled"], "unknown")
+        XCTAssertEqual(params["used_allocation"], "unknown")
+        XCTAssertEqual(params["uptime"], "5")
     }
 
     func testWhenDependenciesAreNil_ThenParameterCountIsUnchanged() {
         let context = MemoryReportingContext(
             browserMemoryMB: 1024,
             windows: nil,
-            tabs: nil,
+            standardTabs: nil,
+            pinnedTabs: nil,
             architecture: "Intel",
-            syncEnabled: nil
+            syncEnabled: nil,
+            usedAllocationMB: nil,
+            uptimeMinutes: 0
         )
         let pixel = MemoryUsageIntervalPixel.memoryUsage(trigger: .startup, context: context)
 
         // All keys are still present even when values are "unknown"
-        XCTAssertEqual(pixel.parameters?.count, 6)
+        XCTAssertEqual(pixel.parameters?.count, 9)
     }
 }

--- a/macOS/UnitTests/AppHealth/MemoryUsageIntervalReporterTests.swift
+++ b/macOS/UnitTests/AppHealth/MemoryUsageIntervalReporterTests.swift
@@ -30,12 +30,14 @@ final class MemoryUsageIntervalReporterTests: XCTestCase {
     private var mockMemoryUsageMonitor: MockIntervalMemoryMonitor!
     private var mockFeatureFlagger: MockFeatureFlagger!
     private var mockPixelFiring: PixelKitMock!
+    private var mockAllocationStats: MockIntervalAllocationStatsProvider!
 
     override func setUp() {
         super.setUp()
         mockMemoryUsageMonitor = MockIntervalMemoryMonitor()
         mockFeatureFlagger = MockFeatureFlagger()
         mockPixelFiring = PixelKitMock()
+        mockAllocationStats = MockIntervalAllocationStatsProvider()
     }
 
     override func tearDown() {
@@ -43,6 +45,7 @@ final class MemoryUsageIntervalReporterTests: XCTestCase {
         mockMemoryUsageMonitor = nil
         mockFeatureFlagger = nil
         mockPixelFiring = nil
+        mockAllocationStats = nil
         super.tearDown()
     }
 
@@ -55,6 +58,7 @@ final class MemoryUsageIntervalReporterTests: XCTestCase {
             pixelFiring: mockPixelFiring,
             windowContext: nil,
             isSyncEnabled: { nil },
+            allocationStatsProvider: mockAllocationStats,
             checkInterval: checkInterval
         )
     }
@@ -74,7 +78,7 @@ final class MemoryUsageIntervalReporterTests: XCTestCase {
         // Then
         XCTAssertEqual(mockPixelFiring.actualFireCalls.count, 1)
         let call = mockPixelFiring.actualFireCalls[0]
-        XCTAssertEqual(call.pixel.name, "m_mac_memory_usage")
+        XCTAssertEqual(call.pixel.name, "m_mac_memory_usage_interval")
         XCTAssertEqual(call.pixel.parameters?["trigger"], "startup")
         XCTAssertEqual(call.frequency, .standard)
     }
@@ -82,6 +86,7 @@ final class MemoryUsageIntervalReporterTests: XCTestCase {
     func testWhenStarted_ThenStartupPixelIncludesContextParameters() async {
         // Given
         mockMemoryUsageMonitor.currentPhysFootprintMB = 2500
+        mockAllocationStats.totalUsedBytes = 300 * 1_048_576 // 300 MB -> bucket 256
         mockFeatureFlagger.enabledFeatureFlags = [.memoryUsageReporting]
         sut = makeSUT()
         sut.startMonitoringForTesting()
@@ -94,9 +99,12 @@ final class MemoryUsageIntervalReporterTests: XCTestCase {
         XCTAssertEqual(params?["trigger"], "startup")
         XCTAssertEqual(params?["browser_memory_mb"], "2048")
         XCTAssertEqual(params?["windows"], "unknown")
-        XCTAssertEqual(params?["tabs"], "unknown")
+        XCTAssertEqual(params?["standard_tabs"], "unknown")
+        XCTAssertEqual(params?["pinned_tabs"], "unknown")
         XCTAssertEqual(params?["sync_enabled"], "unknown")
         XCTAssertNotNil(params?["architecture"])
+        XCTAssertEqual(params?["used_allocation"], "256")
+        XCTAssertNotNil(params?["uptime"])
     }
 
     // MARK: - Interval Triggering
@@ -325,12 +333,12 @@ final class MemoryUsageIntervalReporterTests: XCTestCase {
 
         // Then
         for call in mockPixelFiring.actualFireCalls {
-            XCTAssertEqual(call.pixel.name, "m_mac_memory_usage")
+            XCTAssertEqual(call.pixel.name, "m_mac_memory_usage_interval")
         }
     }
 }
 
-// MARK: - Mock
+// MARK: - Mocks
 
 private class MockIntervalMemoryMonitor: MemoryUsageMonitoring {
     var currentResidentMB: Double = 0
@@ -343,5 +351,13 @@ private class MockIntervalMemoryMonitor: MemoryUsageMonitoring {
             residentBytes: residentBytes,
             physFootprintBytes: physFootprintBytes
         )
+    }
+}
+
+private class MockIntervalAllocationStatsProvider: MemoryAllocationStatsProviding {
+    var totalUsedBytes: UInt64?
+
+    func currentTotalUsedBytes() -> UInt64? {
+        totalUsedBytes
     }
 }


### PR DESCRIPTION
Task/Issue URL:https://app.asana.com/1/137249556945/task/1213216561787567
Tech Design URL:
CC:

### Description

Enrich memory usage pixels with additional context parameters and rename the interval pixel to avoid substring collisions.

**New context parameters** added to both `MemoryUsageIntervalPixel` and `MemoryPressurePixel`:
- **`standard_tabs`** / **`pinned_tabs`** — Replace the previous `tabs` parameter. Standard tabs use buckets (0, 1, 2, 4, 7, 11, 21, 51) and pinned tabs use (0, 1, 2, 4, 7, 11, 15).
- **`used_allocation`** — Total used bytes from malloc zones, bucketed in MB (0, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384).
- **`uptime`** — Raw minutes elapsed since app launch.

**Pixel rename**: `m_mac_memory_usage` → `m_mac_memory_usage_interval` to avoid substring collisions with threshold pixels like `m_mac_memory_usage_less_512` (a `hasPixelWithoutQuery` for the old name would match both).

### Testing Steps
1. Build the macOS browser and launch it.
2. Open the **Debug** menu → **Fire Interval Pixel** and select any trigger (e.g. "startup"). Verify in the debug console or pixel logs that the pixel fires with name `m_mac_memory_usage_interval` and includes all context parameters: `trigger`, `browser_memory_mb`, `windows`, `standard_tabs`, `pinned_tabs`, `architecture`, `sync_enabled`, `used_allocation`, `uptime`.
3. Open several windows and tabs (including pinned tabs), then fire the pixel again. Verify that `standard_tabs`, `pinned_tabs`, and `windows` reflect the current state (bucketed).
4. Wait >1 hour (or adjust `checkInterval` locally) and confirm the `1h` trigger fires with an `uptime` value matching elapsed minutes.
5. Run unit tests for `MemoryReportingBucketsTests`, `MemoryUsageIntervalPixelTests`, `MemoryUsageIntervalReporterTests`, and `MemoryPressureReporterTests` — all should pass.

### Impact and Risks
**Low** — Only affects analytics pixels; no user-facing UI or functionality changes.

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
- The `tabs` parameter no longer exists — it's been split into `standard_tabs` and `pinned_tabs`. Dashboards consuming the old `tabs` field will need migration.
- The pixel rename from `m_mac_memory_usage` to `m_mac_memory_usage_interval` does not require privacy triage since it's the same data under a disambiguated name.
- JSON5 pixel definition files have been updated to document all new parameters and their enum values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Analytics-only, but renaming the pixel and changing parameters (`tabs` → `standard_tabs`/`pinned_tabs`) can break downstream dashboards/queries. Reading malloc-zone statistics adds a new runtime dependency that could fail or be mildly expensive under pressure conditions.
> 
> **Overview**
> Enriches macOS memory analytics by expanding `MemoryReportingContext` to include **separate standard vs pinned tab buckets**, **malloc-zone used allocation (bucketed MB)**, and **app uptime (minutes)**, and wires these new fields into both critical memory-pressure and interval memory-usage reporters.
> 
> Renames the interval pixel from `m_mac_memory_usage` to `m_mac_memory_usage_interval` (and updates debug menu copy + JSON5 pixel definitions) to avoid substring collisions, and adds a `MemoryAllocationStatsProviding` abstraction so allocation stats can be injected/mocked in unit tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f66cc1a6d80bd22001fca641eea4519505c4ce87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->