### PR TITLE
Prevent Dax dialogs to appear above Duck.ai during contextual onboarding

### DIFF
--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1891,8 +1891,9 @@ extension TabViewController: WKNavigationDelegate {
             return
         }
               
-        /// Never show onboarding Dax on Youtube or DuckPlayer, unless DuckPlayer is disabled
+        /// Never show onboarding Dax on Duck.ai, Youtube or DuckPlayer (unless DuckPlayer is disabled)
         guard let url = link?.url,
+              !url.isDuckAIURL,
               !url.isDuckPlayer,
               !(url.isYoutube && duckPlayerNavigationHandler.duckPlayer.settings.mode != .disabled) else {
             scheduleTrackerNetworksAnimation(collapsing: true)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213259649400340
Tech Design URL:
CC:

### Description

Dax dialogs are appearing on top of Duck.ai page during the onboarding flow making the experience very confusing. As it is an internal page we should not show any dax dialogs for internal pages. The fix does not prevent showing dialogs when necessary.

### Video

https://github.com/user-attachments/assets/aee3f2d4-e20a-4482-ab12-cb10a5838a7c

### Testing Steps
1. Reset context dialog in the Debug Menu -> Onboarding
2. Open Duck.ai page
3. Ensure no dax dialogs are shown for Duck.ai

### Impact and Risks
Low risk, we already prevent dax dialogs for internal pages such DuckPlayer.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small conditional change in onboarding UI presentation logic with a narrowly scoped URL check; low risk of side effects outside Dax dialog display timing.
> 
> **Overview**
> Prevents contextual onboarding Dax dialogs from being shown when the current tab is displaying Duck.ai by extending the existing exclusion guard in `TabViewController.showDaxDialogOrStartTrackerNetworksAnimationIfNeeded()`.
> 
> When a Duck.ai URL is detected, the code now skips dialog presentation and falls back to scheduling the tracker networks animation (matching the existing behavior for YouTube/DuckPlayer).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e302168249e58347238af3d788098220faca074. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->