### PR TITLE
Onboarding: Disables Bookmarks Management Menu

### DIFF
--- a/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarMenuFactory.swift
+++ b/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarMenuFactory.swift
@@ -42,7 +42,7 @@ struct BookmarksBarMenuFactory {
         menu.addItem(NSMenuItem(title: UserText.bookmarksManageBookmarks, action: manageBookmarksSelector, target: target))
     }
 
-    private static func makeMenuItem( _ prefs: AppearancePreferences) -> NSMenuItem {
+    static func makeMenuItem( _ prefs: AppearancePreferences) -> NSMenuItem {
         let item = NSMenuItem(title: UserText.showBookmarksBar, action: nil, keyEquivalent: "B")
         item.submenu = NSMenu(items: [
             BlockMenuItem(title: UserText.mainMenuBookmarksShowBookmarksBarAlways, isChecked: prefs.showBookmarksBar && prefs.bookmarksBarAppearance == .alwaysOn) {

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -1177,7 +1177,8 @@ extension MainViewController {
 
         tabBarViewController.fireButton.isEnabled = !prevented
         tabBarViewController.isInteractionPrevented = prevented
-        navigationBarViewController.controlsForUserPrevention.forEach { $0?.isEnabled = !prevented }
+
+        navigationBarViewController.userInteraction(prevented: prevented)
         bookmarksBarViewController.userInteraction(prevented: prevented)
     }
 }

--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -673,11 +673,11 @@ final class MainMenu: NSMenu {
             return
         }
         self.toggleBookmarksBarMenuItem = toggleBookmarksBarMenuItem
-        toggleBookmarksBarMenuItem.target = self
-        toggleBookmarksBarMenuItem.action = #selector(toggleBookmarksBarFromMenu(_:))
+        toggleBookmarksBarMenuItem.action = #selector(MainViewController.toggleBookmarksBarFromMenu)
         toggleBookmarksBarMenuItem.setAccessibilityIdentifier("MainMenu.toggleBookmarksBar")
 
         self.bookmarksMenuToggleBookmarksBarMenuItem = bookmarksMenuToggleBookmarksBarMenuItem
+        bookmarksMenuToggleBookmarksBarMenuItem.action = #selector(MainViewController.toggleBookmarksBarFromMenu)
     }
 
     private func updateHomeButtonMenuItem() {
@@ -694,13 +694,6 @@ final class MainMenu: NSMenu {
             return
         }
         self.showTabsAndBookmarksBarOnFullScreenMenuItem = showTabsAndBookmarksBarOnFullScreenMenuItem
-    }
-
-    @MainActor
-    @objc
-    private func toggleBookmarksBarFromMenu(_ sender: Any) {
-        guard let mainVC = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.mainViewController else { return }
-        mainVC.toggleBookmarksBarFromMenu(sender)
     }
 
     private func updateShortcutMenuItems() {

--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -1666,7 +1666,8 @@ extension MainViewController: NSMenuItemValidation {
         case #selector(MainViewController.bookmarkAllOpenTabs(_:)):
             return tabCollectionViewModel.canBookmarkAllOpenTabs()
         case #selector(MainViewController.openBookmark(_:)),
-             #selector(MainViewController.showManageBookmarks(_:)):
+             #selector(MainViewController.showManageBookmarks(_:)),
+            #selector(MainViewController.toggleBookmarksBarFromMenu(_:)):
             return allowsUserInteraction
 
         // New Tabs

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -142,6 +142,8 @@ final class NavigationBarViewController: NSViewController {
     var isDownloadsPopoverShown: Bool {
         popovers.isDownloadsPopoverShown
     }
+
+    private var allowsUserInteraction: Bool = true
     private var isAutoFillAutosaveMessageVisible: Bool = false
 
     private var urlCancellable: AnyCancellable?
@@ -196,7 +198,7 @@ final class NavigationBarViewController: NSViewController {
         tabCollectionViewModel.isPopup
     }
 
-    var controlsForUserPrevention: [NSControl?] {
+    private var controlsForUserPrevention: [NSControl?] {
         return [homeButton,
                 optionsButton,
                 overflowButton,
@@ -857,6 +859,14 @@ final class NavigationBarViewController: NSViewController {
                                          withDelegate: self)
         } else {
             Logger.passwordManager.error("Received save autofill data call, but there was no data to present")
+        }
+    }
+
+    func userInteraction(prevented: Bool) {
+        allowsUserInteraction = !prevented
+
+        controlsForUserPrevention.forEach { control in
+            control?.isEnabled = !prevented
         }
     }
 
@@ -1907,7 +1917,9 @@ extension NavigationBarViewController: NSMenuDelegate {
     public func menuNeedsUpdate(_ menu: NSMenu) {
         menu.removeAllItems()
 
-        BookmarksBarMenuFactory.addToMenu(menu, prefs: NSApp.delegateTyped.appearancePreferences)
+        let bookmarksMenu = BookmarksBarMenuFactory.makeMenuItem(NSApp.delegateTyped.appearancePreferences)
+        bookmarksMenu.isEnabled = allowsUserInteraction
+        menu.addItem(bookmarksMenu)
 
         menu.addItem(NSMenuItem.separator())
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1213263959692969?focus=true
Tech Design URL:
CC:

### Description
Disables Bookmarks Management during the Onboarding Sequence.

### Testing Steps: Onboarding
1. `Reset Data > Reset Onboarding`
2. Relaunch the browser

- [ ] Verify `View > Bookmarks Bar` is disabled
- [ ] Verify `Bookmarks > Bookmarks Bar` is disabled
- [ ] Verify that pressing `CMD + Shift + B` does nothing

### Testing Steps: Unlocked
1. Complete Onboarding

- [ ] Verify `View > Bookmarks Bar` is enabled 
- [ ] Verify `Bookmarks > Bookmarks Bar` is enabled
- [ ] Verify that pressing `CMD + Shift + B` toggles the Bookmarks Bar

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The Bookmarks Bar Menu could be incorrectly disabled

### Quality Considerations
None

### Notes to Reviewer
Thank you!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch menu action routing and enable/disable logic for a global keyboard shortcut, so regressions could leave the Bookmarks Bar permanently enabled/disabled or unresponsive during onboarding.
> 
> **Overview**
> **Prevents Bookmarks Bar toggling while user interaction is disabled (e.g., during onboarding).** The navigation bar overflow menu now inserts the Bookmarks Bar submenu as a single item and explicitly disables it based on a new `allowsUserInteraction` flag.
> 
> Bookmarks Bar menu handling is refactored so `MainMenu` items target `MainViewController.toggleBookmarksBarFromMenu` directly (removing an intermediate `MainMenu` action), and `MainViewController.userInteraction(prevented:)` now delegates enable/disable behavior to `NavigationBarViewController.userInteraction(prevented:)`. Menu validation (`validateMenuItem`) is updated so the Bookmarks Bar shortcut/action is disabled when interaction is prevented.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bafd6db0d13f0ed5de5b8af547d894a06e38a5d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->