### PR TITLE
Exclude bookmark button from trailing width to prevent URL jump on hover

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -556,7 +556,22 @@ final class AddressBarButtonsViewController: NSViewController {
             updateTrackingAreaForHover()
         }
         self.buttonsWidth = buttonsContainer.frame.size.width + 10.0
-        self.trailingButtonsWidth = trailingButtonsContainer.frame.size.width + 14.0
+        self.trailingButtonsWidth = trailingButtonsWidthExcludingBookmark()
+    }
+
+    /// Computes trailing buttons width excluding the bookmark button's contribution.
+    /// This keeps the text field's trailing constraint stable when the bookmark button
+    /// appears/disappears on hover, preventing the URL from shifting.
+    private func trailingButtonsWidthExcludingBookmark() -> CGFloat {
+        var width = trailingButtonsContainer.frame.size.width + 14.0
+        if !bookmarkButton.isHidden && bookmarkButton.frame.width > 0 {
+            width -= bookmarkButton.frame.width
+            let hasOtherVisibleItems = trailingButtonsContainer.arrangedSubviews.contains { !$0.isHidden && $0 !== bookmarkButton }
+            if hasOtherVisibleItems {
+                width -= trailingButtonsContainer.spacing
+            }
+        }
+        return width
     }
 
     func updateTrackingAreaForHover() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1212839308493653
Tech Design URL:
CC:

### Description

When hovering the navigation bar, the bookmark button appears in the trailing buttons stack view. Because `trailingButtonsWidth` is computed from the stack's frame, showing/hiding the bookmark button changes the text field's trailing constraint, causing the URL to visibly shift due to the passive text field's centerX constraint.

This PR excludes the bookmark button's width contribution from the `trailingButtonsWidth` calculation, keeping the text field's trailing constraint stable regardless of bookmark button visibility.

### Testing Steps

1. Set the address bar to display full URL.
2. Navigate to a non-bookmarked URL that’s reasonably long.
3. Shrink the window horizontally so that the URL just fits and there’s extra 30-40px space.
4. Hover over the navigation bar — the bookmark icon should appear without the URL text shifting -> test the same with a production app to see at what width it gets broken.
5. Move the mouse away — the bookmark icon should disappear without the URL shifting
6. Bookmark the URL — the icon should remain permanently visible
7. Navigate to the homepage (new tab) — the bookmark button should be fully hidden (no reserved space)
8. Verify the AI Chat divider still shows/hides correctly relative to the bookmark button

### Impact and Risks

Low: Minor visual fix for URL jumping on hover.

#### What could go wrong?

The trailing buttons width could be computed incorrectly if the bookmark button is the only visible item in the trailing stack (spacing subtraction edge case). This is handled by checking for other visible arranged subviews before subtracting spacing.

### Quality Considerations

- Edge case: bookmark button as the only visible trailing stack item — handled by conditionally subtracting spacing only when other items are visible.

### Notes to Reviewer

The fix is a single new helper method (`trailingButtonsWidthExcludingBookmark()`) called from `viewDidLayout()`. No changes to bookmark visibility logic.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Low Risk**
> Small, localized layout calculation change in `viewDidLayout`; risk is limited to minor UI spacing/constraint regressions around the trailing button stack.
> 
> **Overview**
> Prevents the address bar URL from shifting when the bookmark button appears/disappears on hover by updating how `trailingButtonsWidth` is computed.
> 
> `AddressBarButtonsViewController` now calculates trailing width via a helper that subtracts the bookmark button (and its spacing when applicable) from the trailing stack’s measured width, keeping the text field’s trailing constraint stable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77842ef29f5e6ad06b3e3b91a6ab015081c08c84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY —>