### PR TITLE
Fix `makePhysicalKeyPressCheck` crash on non-key events

### DIFF
--- a/macOS/DuckDuckGo/Application/WarnBeforeQuitManager.swift
+++ b/macOS/DuckDuckGo/Application/WarnBeforeQuitManager.swift
@@ -599,6 +599,7 @@ final class WarnBeforeQuitManager: ApplicationTerminationDecider {
     /// update `combinedSessionState` but **not** `hidSystemState`, so this distinguishes
     /// real keyboard input from simulated shortcuts.
     static func makePhysicalKeyPressCheck(for event: NSEvent) -> () -> Bool {
+        guard event.type == .keyDown else { return { false } }
         let keyCode = event.keyCode
         let modifierMask = event.keyEquivalent?.modifierMask ?? []
         return {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213264224088432

### Description

Resolves an issue where restart-to-update stopped working.

### Testing Steps

Check the CMD+Q protection works fine.
Check [that restarting to update works well](https://app.asana.com/1/137249556945/task/1212917247399758).

### Impact and Risks

Impact is high - this fixes what'd turn into an incident if released.
Risk is low - should be fairly safe.

#### What could go wrong?

I could've gotten something wrong in my updated logic

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that only adds an event-type guard to avoid invalid key-state reads; minimal behavior impact beyond preventing the crash.
> 
> **Overview**
> Prevents a crash in the “warn before quit” flow by adding a defensive guard in `WarnBeforeQuitManager.makePhysicalKeyPressCheck(for:)` so it returns a closure that always `false` when the triggering `NSEvent` isn’t `.keyDown`, instead of reading key-code state from an incompatible event type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92b6b0f4d1f923a7cf1ffe754402e7325097fadf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->