### PR TITLE
[macOS] don't show onboarding on pop-up windows

### DIFF
--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -600,6 +600,8 @@ final class BrowserTabViewController: NSViewController {
             return
         }
 
+        guard !isInPopUpWindow else { return }
+
         guard let tab = tabViewModel?.tab else { return }
 
         // if showLastDialog is true it asks the onboardingDialogTypeProvider for the lastDialog if the last dialog was shown on this tab
@@ -1382,11 +1384,12 @@ extension BrowserTabViewController: TabDelegate {
         subscribeToPinnedTabs()
         hideWebViewSnapshotIfNeeded()
 
-        // When a windows become key it will reload the last contextual onboarding dialog if needed
+        // When a window becomes key it will reload the last contextual onboarding dialog if needed
         // This helps keep dialogs consistent when moving between Windows
         //  - If the dialog was dismissed it will not reload when leaving and coming back to the Window
         //  - It tells presentContextualOnboarding that should show the lastDialog if possible
-        if !wasContextualOnboardingDialogDismissed && onboardingDialogTypeProvider.state != .onboardingCompleted {
+        //  - Skip for pop-up windows; contextual onboarding is excluded there
+        if !isInPopUpWindow && !wasContextualOnboardingDialogDismissed && onboardingDialogTypeProvider.state != .onboardingCompleted {
             presentContextualOnboarding(showLastDialog: true)
         }
     }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL:  https://app.asana.com/1/137249556945/task/1213263289281919
Tech Design URL:
CC:

### Description Don’t show contextual onboarding on pop-up windows

### Testing Steps
1. Start with a fresh install or go to Debug -> Reset Data -> Reset contextual onboarding
2. Open a new tab you should see the onboarding dialog
3. Go to pinterest and click login
4. Click login with google and a pop-up window should appear
5. Check the contextual dialog is not shown on the pop-up window.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation


#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI behavior change gated on `isInPopUpWindow`, with minimal impact outside contextual onboarding presentation.
> 
> **Overview**
> Prevents contextual onboarding dialogs (and associated highlight animations) from appearing in pop-up windows by early-returning in `presentContextualOnboarding` and when reloading the last dialog on `windowDidBecomeKey`.
> 
> Also updates inline comments to clarify the pop-up exclusion behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98d5f07380ddce8b8202236b54635d57b7a5cab7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->