### PR TITLE
Onboarding: Disables Import Passwords

### DIFF
--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -1763,7 +1763,8 @@ extension AppDelegate: NSMenuItemValidation {
             #selector(AppDelegate.openFile(_:)),
             #selector(AppDelegate.openLocation(_:)),
             #selector(AppDelegate.openPreferences),
-            #selector(AppDelegate.showManageBookmarks(_:)):
+            #selector(AppDelegate.showManageBookmarks(_:)),
+            #selector(AppDelegate.openImportBrowserDataWindow(_:)):
             return isUserInteractionAllowed
 
         // Reopen Last Removed Tab


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1213267087436547?focus=true
Tech Design URL:
CC:

### Description
This PR disables the `Import Bookmarks and Passwords` action during Onboarding.

### Testing Steps
1. `Reset Data > Reset Onboarding`
2. Relaunch the browser

- [ ] Verify `File > Import Bookmarks and Passwords` is disabled
- [ ] Verify that once you complete the Onboarding flow, the `Import Bookmarks (...)` action gets enabled

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The `Import Bookmarks and Passwords` action could get incorrectly disabled

### Quality Considerations
None

### Notes to Reviewer
Thank you!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to menu-item validation logic; main risk is incorrectly enabling/disabling the import action.
> 
> **Overview**
> Disables the `File > Import Bookmarks and Passwords` menu item during onboarding by adding `openImportBrowserDataWindow(_:)` to `AppDelegate.validateMenuItem`, gating it behind `isUserInteractionAllowed` (i.e., onboarding completion).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e7ee8777f200c3599bda639a85e3a4237477e6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->