### PR TITLE
[macOS] Skip flaky testWhenFourHoursElapsed_ThenFiresStartupAnd1hAnd2hAnd4hPixels

### DIFF
--- a/macOS/UnitTests/AppHealth/MemoryUsageIntervalReporterTests.swift
+++ b/macOS/UnitTests/AppHealth/MemoryUsageIntervalReporterTests.swift
@@ -126,7 +126,8 @@ final class MemoryUsageIntervalReporterTests: XCTestCase {
         XCTAssertTrue(triggers.contains("1h"))
     }
 
-    func testWhenFourHoursElapsed_ThenFiresStartupAnd1hAnd2hAnd4hPixels() async {
+    func testWhenFourHoursElapsed_ThenFiresStartupAnd1hAnd2hAnd4hPixels() async throws {
+        throw XCTSkip("Flaky test")
         // Given
         mockMemoryUsageMonitor.currentPhysFootprintMB = 512
         mockFeatureFlagger.enabledFeatureFlags = [.memoryUsageReporting]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213242685157468
Tech Design URL:
CC:

### Description
Skip flaky testWhenFourHoursElapsed_ThenFiresStartupAnd1hAnd2hAnd4hPixels

### Testing Steps
Check CI is green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only affects unit test execution by skipping a known flaky test; no production code changes.
> 
> **Overview**
> Marks `testWhenFourHoursElapsed_ThenFiresStartupAnd1hAnd2hAnd4hPixels` as skipped by converting it to `async throws` and immediately `throw XCTSkip("Flaky test")`, effectively disabling the flaky 4-hour interval assertion in `MemoryUsageIntervalReporterTests`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7b3d132e6874690e1116ea2467469d82aef3295. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->