### PR TITLE
Disable memory tests in macOS code freeze workflow

### DIFF
--- a/.github/workflows/macos_code_freeze.yml
+++ b/.github/workflows/macos_code_freeze.yml
@@ -83,16 +83,6 @@ jobs:
       branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
     secrets: inherit
 
-  memory_tests:
-
-    name: Memory Tests
-
-    needs: create_release_branch
-    uses: ./.github/workflows/macos_memory_usage_tests.yml
-    with:
-      branch: ${{ needs.create_release_branch.outputs.release_branch_name }}
-    secrets: inherit
-
   increment_build_number:
 
     name: Increment Build Number


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213294137982092

### Description
Memory tests never worked on code freeze so this change is disabling it until we resolve
the artifact name clash with UI tests.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that removes a test job; main risk is reduced release-gating coverage during code freeze.
> 
> **Overview**
> Disables memory usage testing during the macOS code-freeze pipeline by removing the `memory_tests` reusable-workflow job (which previously ran on the newly created release branch).
> 
> The workflow now proceeds from `ui_tests` directly to `increment_build_number`, reducing CI coverage for code-freeze runs but avoiding the failing/unused memory-test step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f73a5a8c984050a0490280c7927bbbfd1454d54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->