### PR TITLE
[macOS] BookmarkSearchTests: Wait for popover to exist before trying to dismiss it

### DIFF
--- a/macOS/UITests/BookmarkSearchTests.swift
+++ b/macOS/UITests/BookmarkSearchTests.swift
@@ -58,7 +58,6 @@ class BookmarkSearchTests: UITestCase {
 
     func testFilteredResultsInPanel() {
         addThreeBookmarks()
-        closeShowBookmarksBarAlert()
         app.openBookmarksPanel()
         searchInBookmarksPanel(for: "Bookmark #2")
         assertOnlyBookmarkExists(on: app.outlines.firstMatch, bookmarkTitle: "Bookmark #2")
@@ -101,7 +100,7 @@ class BookmarkSearchTests: UITestCase {
 
     private func addBookmarkAndOpenBookmarksPanel(bookmarkPageTitle: String, in folder: String? = nil) {
         addBookmark(pageTitle: bookmarkPageTitle, in: folder)
-        closeShowBookmarksBarAlert()
+        app.dismissBookmarksBarPopover()
         app.openBookmarksPanel()
     }
 
@@ -184,7 +183,7 @@ class BookmarkSearchTests: UITestCase {
         createFolderWithSubFolder()
         openNewTab()
         addBookmark(pageTitle: "Bookmark #1", in: "Folder #2")
-        closeShowBookmarksBarAlert()
+        app.dismissBookmarksBarPopover()
 
         if mode == .panel {
             app.openBookmarksPanel()
@@ -235,7 +234,6 @@ class BookmarkSearchTests: UITestCase {
     private func testDragAndDropToReorder(in mode: BookmarkMode) {
         addThreeBookmarks()
         if mode == .panel {
-            closeShowBookmarksBarAlert()
             app.openBookmarksPanel()
         } else {
             openBookmarksManager()
@@ -318,9 +316,5 @@ class BookmarkSearchTests: UITestCase {
         folderLocationButton.tap()
         folderLocationButton.menuItems["Folder #1"].tap()
         app.buttons["Add Folder"].tap()
-    }
-
-    private func closeShowBookmarksBarAlert() {
-        app.dismissPopover(buttonIdentifier: "Hide")
     }
 }

--- a/macOS/UITests/BookmarkSortTests.swift
+++ b/macOS/UITests/BookmarkSortTests.swift
@@ -51,7 +51,7 @@ class BookmarkSortTests: UITestCase {
 
     func testWhenChangingSortingInThePanelIsReflectedInTheManager() {
         addBookmark(pageTitle: "Bookmark #1")
-        app.dismissPopover(buttonIdentifier: "Hide")
+        app.dismissBookmarksBarPopover()
         app.openBookmarksPanel()
         selectSortByName(mode: .panel)
         app.openBookmarksPanel() // Here we do not open the panel, we close it by tapping the shortcut button again.
@@ -84,7 +84,6 @@ class BookmarkSortTests: UITestCase {
             app.openNewTab()
         }
 
-        closeShowBookmarksBarAlert()
         app.openBookmarksPanel()
         app.verifyBookmarkOrder(expectedOrder: ["Bookmark #2", "Bookmark #3", "Bookmark #1"], mode: .panel)
     }
@@ -95,7 +94,6 @@ class BookmarkSortTests: UITestCase {
             app.openNewTab()
         }
 
-        closeShowBookmarksBarAlert()
         app.openBookmarksManager()
         app.verifyBookmarkOrder(expectedOrder: ["Bookmark #2", "Bookmark #3", "Bookmark #1"], mode: .manager)
     }
@@ -106,7 +104,6 @@ class BookmarkSortTests: UITestCase {
             app.openNewTab()
         }
 
-        closeShowBookmarksBarAlert()
         app.openBookmarksPanel()
         selectSortByName(mode: .panel)
         app.verifyBookmarkOrder(expectedOrder: ["Bookmark #1", "Bookmark #2", "Bookmark #3"], mode: .panel)
@@ -118,7 +115,6 @@ class BookmarkSortTests: UITestCase {
             app.openNewTab()
         }
 
-        closeShowBookmarksBarAlert()
         app.openBookmarksManager()
         selectSortByName(mode: .manager)
         app.verifyBookmarkOrder(expectedOrder: ["Bookmark #1", "Bookmark #2", "Bookmark #3"], mode: .manager)
@@ -130,7 +126,6 @@ class BookmarkSortTests: UITestCase {
             app.openNewTab()
         }
 
-        closeShowBookmarksBarAlert()
         app.openBookmarksPanel()
         selectSortByName(mode: .panel, descending: true)
         app.verifyBookmarkOrder(expectedOrder: ["Bookmark #3", "Bookmark #2", "Bookmark #1"], mode: .panel)
@@ -142,7 +137,6 @@ class BookmarkSortTests: UITestCase {
             app.openNewTab()
         }
 
-        closeShowBookmarksBarAlert()
         app.openBookmarksManager()
         selectSortByName(mode: .manager, descending: true)
         app.verifyBookmarkOrder(expectedOrder: ["Bookmark #3", "Bookmark #2", "Bookmark #1"], mode: .manager)
@@ -218,9 +212,5 @@ class BookmarkSortTests: UITestCase {
                                bookmarkingViaDialog: true,
                                escapingDialog: true,
                                folderName: folder)
-    }
-
-    private func closeShowBookmarksBarAlert() {
-        app.dismissPopover(buttonIdentifier: "Hide")
     }
 }

--- a/macOS/UITests/Common/XCUIApplicationExtension.swift
+++ b/macOS/UITests/Common/XCUIApplicationExtension.swift
@@ -132,22 +132,6 @@ extension XCUIApplication {
         value(forKey: "bundleID") as? String
     }
 
-    /// Dismiss popover with the passed button identifier if exists. If it does not exist it continues the execution without failing.
-    /// - Parameter buttonIdentifier: The button identifier we want to tap from the popover
-    func dismissPopover(buttonIdentifier: String) {
-        let popover = popovers.firstMatch
-        guard popover.wait(for: .keyPath(\.exists, equalTo: true), timeout: UITests.Timeouts.elementExistence) else {
-            return
-        }
-
-        let button = popover.buttons[buttonIdentifier]
-        guard button.exists else {
-            return
-        }
-
-        button.tap()
-    }
-
     /// Enforces single a single window by:
     ///  1. First, closing all windows
     ///  2. Opening a new window


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1213307324185545

### Description

The UI test `BookmarkSearchTests.testEmptyStateWhenSearchingInPanel()` had a flaky failure because the "Show bookmarks bar?" popover was not being dismissed consistently. This was caused by the `dismissPopover(buttonIdentifier:)` method checking for the popover's immediate existence, instead of waiting for it.

We now have a more deterministic helper `dismissBookmarksBarPopover()`. This updates the Bookmark tests to use that helper:

* Uses that helper to dismiss the popover when it's expected to appear.
* Removes the helper in scenarios where it isn't needed (where a new tab is opened before any further interaction, so that popover isn't visible).

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Confirm the [UI tests workflow](https://github.com/duckduckgo/apple-browsers/actions/runs/22108608427) passes.
2. You can also run the `BookmarkSearchTests` and `BookmarkSortTests` locally to confirm they pass, waiting for the popover to appear before dismissing it.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

If we are only using `dismissBookmarksBarPopover()` to dismiss the popover if needed (i.e. it isn't a part of the expected UI for the test, only an interruption that we need to account for), we could update that method to not make an assertion on the button's existence, e.g. like this:

```swift
        guard targetButton.waitForExistence(timeout: UITests.Timeouts.elementExistence) else {
            return
        }
```

I left that method as-is because I'm not sure if we are relying on it (or want to rely on it) in other tests to assert the popover's existence in a specific flow.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor that changes how popovers are dismissed to reduce UI flakiness; no production logic or data handling is affected.
> 
> **Overview**
> Improves reliability of macOS bookmarks UI tests by standardizing dismissal of the “Show bookmarks bar?” UI via `app.dismissBookmarksBarPopover()`, ensuring the target button exists before tapping to avoid overlapping popovers during bookmarks panel/manager flows.
> 
> Cleans up test utilities by removing per-test `closeShowBookmarksBarAlert()` helpers and deleting the generic `XCUIApplication.dismissPopover(buttonIdentifier:)` extension method, updating affected tests accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7536ed78a372d718074f63b0ffd8fdb77a7c1d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->