### PR TITLE
Improve Menu header Items size and style on iOS 26

### DIFF
--- a/iOS/DuckDuckGo/BrowsingMenu/SheetPresentationMenu/BrowsingMenuSheetView.swift
+++ b/iOS/DuckDuckGo/BrowsingMenu/SheetPresentationMenu/BrowsingMenuSheetView.swift
@@ -33,7 +33,7 @@ struct BrowsingMenuSheetView: View {
     enum Metrics {
         static let headerButtonVerticalPadding: CGFloat = {
             if #available(iOS 26, *) {
-                return 22
+                return 16
             } else {
                 return 12
             }
@@ -435,10 +435,10 @@ private struct BrowsingMenuHeaderView: View {
             }
         }
         .frame(width: MenuHeaderConstant.faviconSize, height: MenuHeaderConstant.faviconSize)
-        .menuHeaderEntryShape()
+        .faviconShape()
         .padding(MenuHeaderConstant.faviconPadding)
         .background(Color.rowBackgroundColor)
-        .menuHeaderEntryShape()
+        .faviconShape()
     }
 
     @ViewBuilder
@@ -463,6 +463,7 @@ private struct BrowsingMenuHeaderView: View {
 
 private enum MenuHeaderConstant {
     static let cornerRadius: CGFloat = 10
+    static let iOS26CornerRadius: CGFloat = 24
     static let faviconSize: CGFloat = 32
     static let faviconPadding: CGFloat = 8
     static let contentSpacing: CGFloat = 12
@@ -473,10 +474,23 @@ private enum MenuHeaderConstant {
 private extension View {
     @ViewBuilder
     func menuHeaderEntryShape() -> some View {
+        if #available(iOS 26, *) {
+            self
+                .clipShape(RoundedRectangle(cornerRadius: MenuHeaderConstant.iOS26CornerRadius, style: .continuous))
+                .contentShape(RoundedRectangle(cornerRadius: MenuHeaderConstant.iOS26CornerRadius, style: .continuous))
+        } else {
+            self
+                .clipShape(RoundedRectangle(cornerRadius: MenuHeaderConstant.cornerRadius, style: .continuous))
+                .contentShape(RoundedRectangle(cornerRadius: MenuHeaderConstant.cornerRadius, style: .continuous))
+        }
+    }
+
+    @ViewBuilder
+    func faviconShape() -> some View {
         if #available(iOS 17, *) {
             self
-                .clipShape(ButtonBorderShape.automatic)
-                .contentShape(ButtonBorderShape.automatic)
+                .clipShape(ButtonBorderShape.roundedRectangle)
+                .contentShape(ButtonBorderShape.roundedRectangle)
         } else {
             self
                 .clipShape(RoundedRectangle(cornerRadius: MenuHeaderConstant.cornerRadius, style: .continuous))


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1213309864500262
Tech Design URL:
CC:

### Description

Applies a custom radius and padding to new menu header.

### Testing Steps
1. Open Menu on iOS 26
2. Check the radius is consistent with other menu items, and inner spacing for items looks good.
3. Check favicon is a rounded rectangle.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
4. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely visual SwiftUI tweaks (padding/clip shapes) scoped to the browsing menu header; low risk beyond potential layout regressions on specific iOS versions.
> 
> **Overview**
> Improves the `BrowsingMenuSheetView` header layout on iOS 26 by reducing header button vertical padding and introducing a larger iOS-26-specific corner radius for header items.
> 
> Updates the website header favicon styling by switching from `ButtonBorderShape.automatic` to an explicit rounded-rectangle shape (`faviconShape()`), separating favicon clipping from the general `menuHeaderEntryShape()` behavior for more consistent visuals across iOS versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a294c03881aebb62890966563bdeadbeb9cb60b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->