### PR TITLE
Fix flaky tests on RMF Image Loader

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/RemoteMessagingImageLoaderTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/RemoteMessagingImageLoaderTests.swift
@@ -21,7 +21,7 @@ import XCTest
 
 final class RemoteMessagingImageLoaderTests: XCTestCase {
 
-    private let testCache = URLCache(memoryCapacity: 1024, diskCapacity: 0)
+    private let testCache = URLCache(memoryCapacity: 1024 * 1024, diskCapacity: 0)
 
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213163440487848
Tech Design URL:
CC: @amddg44 

### Description
This PR fixes a flaky test on the RMF Image Loader. The flakiness is due to storage state bleeding from one test case to another.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. CI should stay 🟢 and not flaky

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that isolates URL caching state; no production logic is modified.
> 
> **Overview**
> Fixes flakiness in `RemoteMessagingImageLoaderTests` by replacing use of `URLCache.shared` and per-test caches with a single dedicated `testCache` that is cleared in `setUp`, preventing cached responses from leaking between test cases.
> 
> Updates the `cachedImage` tests to use this shared per-suite cache instance when storing and retrieving `CachedURLResponse` entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4e07dc6785013463e162b8bec40b589c50ee756. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->