### PR TITLE
[iOS] Add Fire Mode feature flag

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -337,6 +337,9 @@ public enum FeatureFlag: String {
 
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212980785692854?focus=true
     case supportsSyncChatsDeletion
+
+    /// https://app.asana.com/1/137249556945/task/1213314048601761
+    case fireMode
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -466,7 +469,8 @@ extension FeatureFlag: FeatureFlagDescribing {
              .onboardingRebranding,
              .webExtensions,
              .autofillOnboardingExperiment,
-             .supportsSyncChatsDeletion:
+             .supportsSyncChatsDeletion,
+             .fireMode:
             return true
         case .showSettingsCompleteSetupSection:
             if #available(iOS 18.2, *) {
@@ -718,6 +722,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(AutofillSubfeature.onboardingExperiment))
         case .supportsSyncChatsDeletion:
             return .remoteReleasable(.subfeature(AIChatSubfeature.supportsSyncChatsDeletion))
+        case .fireMode:
+            return .disabled
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213299211223748

### Description
Adds a new feature flag that will be used in future PRs implementing fireMode.

### Testing Steps
1. Open the debug screen and ensure the new flag `fireMode` is added and is overridable.

### Impact and Risks
None. 

#### What could go wrong?
N/A

### Quality Considerations
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new, disabled-by-default feature flag with no behavior changes beyond exposing an overridable toggle.
> 
> **Overview**
> Adds a new `FeatureFlag.fireMode` entry and wires it into the feature-flag system so it can be toggled via local overrides/debug tooling.
> 
> `fireMode` is *off by default* and currently marked as `.disabled` for its source (i.e., not remotely configurable yet).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aed840f06213b498d24841252c860d960854f3cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->