### PR TITLE
Add maxSupportedOS parameter to daily OS version pixel

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "6f987af8900400107f133c9ce9ed050b96523910",
-        "version" : "13.2.0"
+        "revision" : "ac7d2b45a396c008942630ff16bd5e426880880c",
+        "version" : "12.38.0"
       }
     },
     {

--- a/macOS/DuckDuckGo/Common/OSVersion/SupportedOsChecker.swift
+++ b/macOS/DuckDuckGo/Common/OSVersion/SupportedOsChecker.swift
@@ -63,12 +63,12 @@ protocol SupportedOSChecking {
     ///
     var osUpgradeCapability: OSUpgradeCapability { get }
 
-    /// The maximum supported macOS major version for the current hardware as a string, for use as a pixel parameter.
+    /// The maximum supported macOS major version for the current hardware as a string.
     ///
     /// Returns the major version number (e.g. `"15"`) when the hardware model is in the lookup table,
     /// or `"latest"` when the model is unknown or not in the table.
     ///
-    var maxSupportedOSVersionPixelValue: String { get }
+    var maxSupportedOSVersion: String { get }
 }
 
 extension SupportedOSChecking {
@@ -256,7 +256,7 @@ extension SupportedOSChecker: SupportedOSChecking {
         return maxVersion > currentVersion ? .capable : .incapable
     }
 
-    var maxSupportedOSVersionPixelValue: String {
+    var maxSupportedOSVersion: String {
         guard let model = hardwareModel,
               let maxVersion = maxSupportedVersionByModel[model] else {
             return "latest"

--- a/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
+++ b/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
@@ -331,7 +331,7 @@ final class StatisticsLoader {
                           frequency: .legacyDailyNoSuffix,
                           withAdditionalParameters: [
                             PixelKit.Parameters.osUpgradeCapability: checker.osUpgradeCapability.pixelValue,
-                            PixelKit.Parameters.maxSupportedOSVersion: checker.maxSupportedOSVersionPixelValue,
+                            PixelKit.Parameters.maxSupportedOSVersion: checker.maxSupportedOSVersion,
                           ])
         }
     }

--- a/macOS/UnitTests/Common/OSVersion/SupportedOSCheckerTests.swift
+++ b/macOS/UnitTests/Common/OSVersion/SupportedOSCheckerTests.swift
@@ -299,7 +299,7 @@ final class SupportedOSCheckerTests: XCTestCase {
             maxSupportedVersionByModelOverride: ["iMac19,1": 15])
 
         // Then
-        XCTAssertEqual(checker.maxSupportedOSVersionPixelValue, "15")
+        XCTAssertEqual(checker.maxSupportedOSVersion, "15")
     }
 
     func testWhenModelNotInLookupTableThenMaxSupportedOSVersionPixelValueReturnsLatest() {
@@ -312,7 +312,7 @@ final class SupportedOSCheckerTests: XCTestCase {
             maxSupportedVersionByModelOverride: [:])
 
         // Then
-        XCTAssertEqual(checker.maxSupportedOSVersionPixelValue, "latest")
+        XCTAssertEqual(checker.maxSupportedOSVersion, "latest")
     }
 
     func testWhenNoHardwareModelThenMaxSupportedOSVersionPixelValueReturnsLatest() {
@@ -325,7 +325,7 @@ final class SupportedOSCheckerTests: XCTestCase {
             maxSupportedVersionByModelOverride: [:])
 
         // Then
-        XCTAssertEqual(checker.maxSupportedOSVersionPixelValue, "latest")
+        XCTAssertEqual(checker.maxSupportedOSVersion, "latest")
     }
 
     func testWhenModelMapsToOlderOSThenMaxSupportedOSVersionPixelValueReturnsCorrectValue() {
@@ -338,6 +338,6 @@ final class SupportedOSCheckerTests: XCTestCase {
             maxSupportedVersionByModelOverride: ["MacBookAir7,1": 12])
 
         // Then
-        XCTAssertEqual(checker.maxSupportedOSVersionPixelValue, "12")
+        XCTAssertEqual(checker.maxSupportedOSVersion, "12")
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -142,7 +141,6 @@
       "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@babel/types": "^7.28.5",
@@ -160,7 +158,6 @@
       "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.27.2",
         "@babel/helper-validator-option": "^7.27.1",
@@ -178,7 +175,6 @@
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -189,7 +185,6 @@
       "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.27.1",
         "@babel/types": "^7.27.1"
@@ -204,7 +199,6 @@
       "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -223,7 +217,6 @@
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -244,7 +237,6 @@
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -255,7 +247,6 @@
       "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/template": "^7.27.2",
         "@babel/types": "^7.28.4"
@@ -270,7 +261,6 @@
       "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.28.5"
       },
@@ -287,7 +277,6 @@
       "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/parser": "^7.27.2",
@@ -303,7 +292,6 @@
       "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -323,7 +311,6 @@
       "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.28.5"
@@ -642,7 +629,6 @@
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -830,6 +816,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -961,7 +948,6 @@
       "integrity": "sha512-OPz5aBThlyLFgxyhdwf/s2+8ab3OvT7AdTNvKHBwpXomIYeXqpUUuT8LrdtxZSsWJ4R4CU1un4XGh5Ez3nlTpw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
@@ -1120,8 +1106,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "CC-BY-4.0",
-      "peer": true
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1352,8 +1337,7 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.262.tgz",
       "integrity": "sha512-NlAsMteRHek05jRUxUR0a5jpjYq9ykk6+kO0yRaMi5moe7u0fVIOeQ3Y30A8dIiWFBNUoQGi1ljb1i5VtS9WQQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -1440,6 +1424,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1822,7 +1807,6 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2195,7 +2179,6 @@
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -2290,7 +2273,6 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -2418,8 +2400,7 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -2733,6 +2714,7 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -2787,7 +2769,6 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -3148,7 +3129,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -3243,8 +3223,7 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206580121312550/task/1213324754662740?focus=true

### Description

Add maxSupportedOS parameter to daily OS version pixel

### Testing Steps

1. Open Console.app start streaming and filter by "any:os-version-counter"
2. Run the app, load any site
3. Once you get the pixel ensure you see the `maxSupportedOS` pixel parameter (possibly showing "latest" if you're on a newer system).

```
👾[Legacy Daily No Suffix-Fired] m_mac_daily-os-version-counter ["appVersion": "1.178.0", "can_update": "yes", "maxSupportedOs": "latest", "osMajorVersion": "26", "pixelSource": "browser-dmg"]
```

### Impact and Risks

Low impact - we just want to know if users can upgrade to a newer OS version.
Risk is also low - just adding a parameter to an existing pixel.

#### What could go wrong?

NA

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new analytics parameter and simple lookup-based computation; low risk aside from potential schema/telemetry expectations if the new field name/value format is incorrect.
> 
> **Overview**
> Adds a new `maxSupportedOS` parameter to the macOS daily OS version counter pixel, reporting the hardware’s maximum supported macOS major version (or `latest` when unknown).
> 
> This extends `SupportedOSChecker` with `maxSupportedOSVersion`, updates the pixel firing path to include it, updates the pixel definition schema, and adds unit tests covering known/unknown hardware-model cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b92664fa2d7a1424bbc708f4d74c2ee7c164c67c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->