### PR TITLE
Fix issue with arrow for autocompletion not working

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -600,7 +600,7 @@ extension OmniBarEditingStateViewController: SuggestionTrayManagerDelegate {
     }
 
     func suggestionTrayManager(_ manager: SuggestionTrayManager, shouldUpdateTextTo text: String) {
-        switchBarHandler.updateCurrentText(text)
+        switchBarVC.textEntryViewController.setQueryText(text)
     }
 
     func suggestionTrayManager(_ manager: SuggestionTrayManager, requestsEditFavorite favorite: BookmarkEntity) {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -521,6 +521,14 @@ class SwitchBarTextEntryView: UIView {
         canExpandOnSelectionChange = true
     }
 
+    func setQueryText(_ text: String) {
+        textView.text = text
+        updatePlaceholderVisibility()
+        updateButtonState()
+        updateTextViewHeight()
+        handler.updateCurrentText(text)
+    }
+
     private func disableAutoCorrectionAndSpellChecking() {
         textView.autocorrectionType = .no
         textView.spellCheckingType = .no

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryViewController.swift
@@ -177,6 +177,10 @@ class SwitchBarTextEntryViewController: UIViewController {
         textEntryView.selectAllText()
     }
 
+    func setQueryText(_ text: String) {
+        textEntryView.setQueryText(text)
+    }
+
     private struct Metrics {
         static let containerCornerRadius: CGFloat = 16
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210947754188321/task/1213279492021247?focus=true
Tech Design URL:
CC:

### Description

- Fix autocomplete arrow not updating the text field in the Duck.ai toggle omnibar variant
- The root cause: `currentTextPublisher` subscription guard (`isFirstResponder && hasBeenInteractedWith`) blocks all publisher-driven text updates while the user is typing, including intentional programmatic replacements from autocomplete arrow taps (which was a fix for #3130 
- Add `setQueryText(_:)` to `SwitchBarTextEntryView` that directly sets `textView.text`, bypassing the publisher guard — matching the existing pattern used by the Clear button
- Route the `SuggestionTrayManagerDelegate.shouldUpdateTextTo` call through `setQueryText` instead of `updateCurrentText`

### Testing Steps

**Prerequisites:** Feature flag `.fadeOutOnToggle` ON, use iPhone

#### A. Autocomplete arrow fix

1. Open address bar with Duck.ai toggle ON → type "hel" → tap the arrow next to search suggestion → **Text field shows selected suggestion (XYZ)**
2. After step 1, press Enter → **Searches “XYZ", not "hel"**
3. Type "w" → tap arrow for, let’s say "weather" → tap arrow for "wikipedia" → **Text updates each time**
4. Tap arrow for a URL suggestion → **URL appears in the field**
5. Tap arrow for a bookmark suggestion → **Bookmark title appears in the field**
6. Repeat steps 1-2 on Homepage (NTP) and on SERP
7. Turn Duck.ai toggle OFF → repeat steps 1-2 → **Standard omnibar still works correctly**

#### B. Typing with iOS autocomplete (regression check for #3130)

1. Duck.ai mode → type slowly "unfortunately" → **iOS shows suggestions, text types normally**
2. Duck.ai mode → type quickly "unfortunately" → **Suggestions are NOT automatically accepted**
3. Type text → tap Clear → immediately start typing → **New text appears, not "swallowed"**
4. Repeat quickly: type → Clear → type → Clear → **Text always appears correctly**
5. Duck.ai (empty) → type a letter → **iOS suggestion bar appears** → Clear → type again → **Suggestion bar reappears**

### Impact and Risks

**Impact Level: Low**

#### What could go wrong?

- The publisher guard protecting against stale text overwrites during typing is not modified — regression risk is minimal
- `setQueryText` follows the same pattern as the existing Clear button (direct `textView.text` assignment + handler sync), so the approach is battle-tested

### Quality Considerations

- The fix is scoped to the Duck.ai toggle variant only; the standard omnibar code path is untouched
- No new state or flags introduced — the fix adds a simple passthrough method

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to suggestion-driven text updates; low risk aside from potential UI state/height sync edge cases when programmatically setting text.
> 
> **Overview**
> Fixes autocomplete “arrow/plus” text replacement in the Duck.ai switch-bar omnibar by bypassing the `currentTextPublisher` typing guard when applying a suggestion.
> 
> Adds `setQueryText(_:)` on `SwitchBarTextEntryView`/`SwitchBarTextEntryViewController` to directly set the `UITextView` text, refresh UI state/height, and then sync `SwitchBarHandling`; `SuggestionTrayManagerDelegate.shouldUpdateTextTo` now uses this path instead of `updateCurrentText`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd4436e20dbdedf2f18ab9d6501d629b58d18915. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->