### PR TITLE
[macOS] Route all AIChat Sync error reporting pixels through a single MainActor helper

### DIFF
--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -395,7 +395,9 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
         }
 
         guard let dict = params as? [String: Any], let data = dict["data"] as? String else {
-            fireSyncDailyAndStandardPixelOnMainActor(AIChatPixel.aiChatSyncEncryptionError(reason: "invalid parameters"))
+            Task { @MainActor [weak self] in
+                self?.fireSyncDailyAndStandardPixel(AIChatPixel.aiChatSyncEncryptionError(reason: "invalid parameters"))
+            }
             return AIChatErrorResponse(reason: "invalid parameters")
         }
 
@@ -413,7 +415,9 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
             default:
                 reason = "internal error"
             }
-            fireSyncDailyAndStandardPixelOnMainActor(AIChatPixel.aiChatSyncEncryptionError(reason: reason))
+            Task { @MainActor [weak self] in
+                self?.fireSyncDailyAndStandardPixel(AIChatPixel.aiChatSyncEncryptionError(reason: reason))
+            }
             return AIChatErrorResponse(reason: reason)
         }
     }
@@ -428,7 +432,9 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
         }
 
         guard let dict = params as? [String: Any], let data = dict["data"] as? String else {
-            fireSyncDailyAndStandardPixelOnMainActor(AIChatPixel.aiChatSyncDecryptionError(reason: "invalid parameters"))
+            Task { @MainActor [weak self] in
+                self?.fireSyncDailyAndStandardPixel(AIChatPixel.aiChatSyncDecryptionError(reason: "invalid parameters"))
+            }
             return AIChatErrorResponse(reason: "invalid parameters")
         }
 
@@ -440,7 +446,9 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
             return AIChatPayloadResponse(payload: payload)
         } catch {
             let reason = error.localizedDescription
-            fireSyncDailyAndStandardPixelOnMainActor(AIChatPixel.aiChatSyncDecryptionError(reason: reason))
+            Task { @MainActor [weak self] in
+                self?.fireSyncDailyAndStandardPixel(AIChatPixel.aiChatSyncDecryptionError(reason: reason))
+            }
             return AIChatErrorResponse(reason: "internal error")
         }
     }
@@ -470,7 +478,9 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     func setAIChatHistoryEnabled(params: Any, message: UserScriptMessage) -> Encodable? {
         guard let dict = params as? [String: Any],
               let enabled = dict["enabled"] as? Bool else {
-            fireSyncDailyAndStandardPixelOnMainActor(AIChatPixel.aiChatSyncHistoryEnabledError(reason: "invalid parameters"))
+            Task { @MainActor [weak self] in
+                self?.fireSyncDailyAndStandardPixel(AIChatPixel.aiChatSyncHistoryEnabledError(reason: "invalid parameters"))
+            }
             return AIChatErrorResponse(reason: "invalid parameters")
         }
 
@@ -499,11 +509,6 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
         pixelFiring?.fire(pixel, frequency: .dailyAndStandard)
     }
 
-    private func fireSyncDailyAndStandardPixelOnMainActor(_ pixel: PixelKitEvent) {
-        Task { @MainActor [weak self] in
-            self?.fireSyncDailyAndStandardPixel(pixel)
-        }
-    }
 }
 // swiftlint:enable inclusive_language
 


### PR DESCRIPTION
Task/Issue URL:
Tech Design URL:
CC:

### Description

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1.
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor limited to analytics pixel firing and actor/thread routing; main functional behavior (sync token/encrypt/decrypt flows and returned errors) is unchanged.
> 
> **Overview**
> Refactors AIChat Sync error reporting in `AIChatUserScriptHandling.swift` to route all `.dailyAndStandard` pixels through a new `@MainActor` helper (`fireSyncDailyAndStandardPixel`).
> 
> Updates `getScopedSyncAuthToken`, `encryptWithSyncMasterKey`, `decryptWithSyncMasterKey`, and `setAIChatHistoryEnabled` to use the helper (wrapping calls in `Task { @MainActor … }` where needed) while keeping the existing error responses and reasons unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c73aa288660b47752b732591f7f4a267d951e1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->