### PR TITLE
[iOS Release] Prevent duplicate AI Chat Sync daily pixels during concurrent FE JS messaging

### DIFF
--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -401,7 +401,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
 
         do {
             let payload = try await syncHandler.getScopedToken()
-            DailyPixel.fire(pixel: .syncAiChatActiveDaily)
+            fireSyncAiChatActiveDailyIfNeeded()
             return AIChatPayloadResponse(payload: payload)
         } catch {
             let reason: String
@@ -420,7 +420,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
                 reason = "internal error"
             }
 
-            DailyPixel.fireDailyAndCount(pixel: .aiChatSyncScopedSyncTokenError, withAdditionalParameters: ["reason": reason])
+            fireSyncDailyAndCountPixel(.aiChatSyncScopedSyncTokenError, withAdditionalParameters: ["reason": reason])
             return AIChatErrorResponse(reason: reason)
         }
     }
@@ -435,13 +435,17 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
         }
 
         guard let dict = params as? [String: Any], let data = dict["data"] as? String else {
-            DailyPixel.fireDailyAndCount(pixel: .aiChatSyncEncryptionError, withAdditionalParameters: ["reason": "invalid parameters"])
+            Task { @MainActor [weak self] in
+                self?.fireSyncDailyAndCountPixel(.aiChatSyncEncryptionError, withAdditionalParameters: ["reason": "invalid parameters"])
+            }
             return AIChatErrorResponse(reason: "invalid parameters")
         }
 
         do {
             let payload = try syncHandler.encrypt(data)
-            DailyPixel.fire(pixel: .syncAiChatActiveDaily)
+            Task { @MainActor [weak self] in
+                self?.fireSyncAiChatActiveDailyIfNeeded()
+            }
             return AIChatPayloadResponse(payload: payload)
         } catch {
             let reason: String
@@ -451,7 +455,9 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
             default:
                 reason = "internal error"
             }
-            DailyPixel.fireDailyAndCount(pixel: .aiChatSyncEncryptionError, withAdditionalParameters: ["reason": reason])
+            Task { @MainActor [weak self] in
+                self?.fireSyncDailyAndCountPixel(.aiChatSyncEncryptionError, withAdditionalParameters: ["reason": reason])
+            }
             return AIChatErrorResponse(reason: reason)
         }
     }
@@ -466,17 +472,23 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
         }
 
         guard let dict = params as? [String: Any], let data = dict["data"] as? String else {
-            DailyPixel.fireDailyAndCount(pixel: .aiChatSyncDecryptionError, withAdditionalParameters: ["reason": "invalid parameters"])
+            Task { @MainActor [weak self] in
+                self?.fireSyncDailyAndCountPixel(.aiChatSyncDecryptionError, withAdditionalParameters: ["reason": "invalid parameters"])
+            }
             return AIChatErrorResponse(reason: "invalid parameters")
         }
 
         do {
             let payload = try syncHandler.decrypt(data)
-            DailyPixel.fire(pixel: .syncAiChatActiveDaily)
+            Task { @MainActor [weak self] in
+                self?.fireSyncAiChatActiveDailyIfNeeded()
+            }
             return AIChatPayloadResponse(payload: payload)
         } catch {
             let reason = error.localizedDescription
-            DailyPixel.fireDailyAndCount(pixel: .aiChatSyncDecryptionError, withAdditionalParameters: ["reason": reason])
+            Task { @MainActor [weak self] in
+                self?.fireSyncDailyAndCountPixel(.aiChatSyncDecryptionError, withAdditionalParameters: ["reason": reason])
+            }
             return AIChatErrorResponse(reason: "internal error")
         }
     }
@@ -492,12 +504,25 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     func setAIChatHistoryEnabled(params: Any, message: UserScriptMessage) -> Encodable? {
         guard let dict = params as? [String: Any],
               let enabled = dict["enabled"] as? Bool else {
-            DailyPixel.fireDailyAndCount(pixel: .aiChatSyncHistoryEnabledError, withAdditionalParameters: ["reason": "invalid parameters"])
+            Task { @MainActor [weak self] in
+                self?.fireSyncDailyAndCountPixel(.aiChatSyncHistoryEnabledError, withAdditionalParameters: ["reason": "invalid parameters"])
+            }
             return AIChatErrorResponse(reason: "invalid parameters")
         }
 
         syncHandler.setAIChatHistoryEnabled(enabled)
         return nil
+    }
+
+    @MainActor
+    private func fireSyncAiChatActiveDailyIfNeeded() {
+        DailyPixel.fire(pixel: .syncAiChatActiveDaily)
+    }
+
+    @MainActor
+    private func fireSyncDailyAndCountPixel(_ pixel: Pixel.Event,
+                                            withAdditionalParameters params: [String: String]) {
+        DailyPixel.fireDailyAndCount(pixel: pixel, withAdditionalParameters: params)
     }
 }
 // swiftlint:enable inclusive_language


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201462886803403/task/1213359570944484?focus=true
Tech Design URL:
CC: @jaceklyp 

### Description
Prevent duplicate daily pixels when FE-triggered JS messages are handled concurrently

### Testing Steps
For ease of testing: to delete the stored daily-pixel key for syncAiChatActiveDaily run this in LLDB: `expr -l Swift -- DailyPixel.storage.removeObject(forKey: Pixel.Event.syncAiChatActiveDaily.name)`
1. Ensure AIChat Sync is enabled and open a new chat window
2. Confirm pixel sync_ai_chat_active_daily is only fired once

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to analytics pixel firing and thread/actor dispatching; no user data flow or sync logic is modified.
> 
> **Overview**
> Prevents duplicate AI Chat Sync *daily* pixel fires when multiple frontend JS messages are handled concurrently by moving pixel firing onto the `@MainActor` and funneling calls through new helper methods.
> 
> Sync-related handlers (`getScopedSyncAuthToken`, `encryptWithSyncMasterKey`, `decryptWithSyncMasterKey`, `setAIChatHistoryEnabled`) now fire success/error pixels via `fireSyncAiChatActiveDailyIfNeeded()` / `fireSyncDailyAndCountPixel(...)`, with non-async code paths dispatching pixel calls using `Task { @MainActor ... }`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16004396760b12f9536ee98b51cbb840e31f7457. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->