### PR TITLE
[iOS] Fix auto clear end to end test

### DIFF
--- a/.maestro/release_tests/autoclear.yaml
+++ b/.maestro/release_tests/autoclear.yaml
@@ -16,6 +16,8 @@ tags:
         "autoclear-ui-test": true
         isRunningUITests: true
         ff.browsingMenuSheetEnabledByDefault: "true"
+        ff.burnSingleTab: "true"
+        ff.enhancedDataClearingSettings: "true"
 
 # Enable autoclear
 
@@ -30,8 +32,8 @@ tags:
 - assertVisible: "Data Clearing"
 - tapOn: "Data Clearing"
 - assertVisible: "Off"
-- assertVisible: "Automatically Clear Data"
-- tapOn: "Automatically Clear Data"
+- assertVisible: "Automatically Delete Data"
+- tapOn: "Automatically Delete Data"
 - assertVisible: 
     id: "AutoclearEnabledToggle"
 - tapOn: 

--- a/iOS/DuckDuckGo/AutoClearSettingsView.swift
+++ b/iOS/DuckDuckGo/AutoClearSettingsView.swift
@@ -52,7 +52,8 @@ struct AutoClearSettingsView: View {
     private var autoClearToggleSection: some View {
         Section {
             SettingsCellView(label: UserText.settingsAutomaticallyDeleteData,
-                             accessory: .toggle(isOn: viewModel.autoClearEnabledBinding))
+                             accessory: .toggle(isOn: viewModel.autoClearEnabledBinding),
+                             accessoryAccessibilityIdentifier: Constants.toggleAccessibilityIdentifier)
         } footer: {
             Text(UserText.settingsAutoClearToggleFooter)
                 .foregroundColor(Color(designSystemColor: .textSecondary))
@@ -138,5 +139,11 @@ private struct TimingOptionRow: View {
         .listRowBackground(Color(designSystemColor: .surface))
         .accessibilityLabel(label)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+private extension AutoClearSettingsView {
+    enum Constants {
+        static let toggleAccessibilityIdentifier = "AutoclearEnabledToggle"
     }
 }

--- a/iOS/DuckDuckGo/SettingsCell.swift
+++ b/iOS/DuckDuckGo/SettingsCell.swift
@@ -53,6 +53,7 @@ struct SettingsCellView: View, Identifiable {
     var action: () -> Void = {}
     var enabled: Bool = true
     var accessory: Accessory
+    var accessoryAccessibilityIdentifier: String
     var statusIndicator: StatusIndicatorView?
     var disclosureIndicator: Bool
     var webLinkIndicator: Bool
@@ -76,13 +77,14 @@ struct SettingsCellView: View, Identifiable {
     ///   - webLinkIndicator: Adds a link indicator on the right
     ///   - isButton: Disables the tap actions on the cell if true
     ///   - optionalBadgeText: If non nil displays badges next to the item for feature discovery with the specified text
-    init(label: String, subtitle: String? = nil, image: Image? = nil, action: @escaping () -> Void = {}, accessory: Accessory = .none, enabled: Bool = true, statusIndicator: StatusIndicatorView? = nil, disclosureIndicator: Bool = false, webLinkIndicator: Bool = false, isButton: Bool = false, isGreyedOut: Bool = false, optionalBadgeText: String? = nil, shouldShowWinBackOffer: Bool = false) {
+    init(label: String, subtitle: String? = nil, image: Image? = nil, action: @escaping () -> Void = {}, accessory: Accessory = .none, accessoryAccessibilityIdentifier: String = "", enabled: Bool = true, statusIndicator: StatusIndicatorView? = nil, disclosureIndicator: Bool = false, webLinkIndicator: Bool = false, isButton: Bool = false, isGreyedOut: Bool = false, optionalBadgeText: String? = nil, shouldShowWinBackOffer: Bool = false) {
         self.label = label
         self.subtitle = subtitle
         self.image = image
         self.action = action
         self.enabled = enabled
         self.accessory = accessory
+        self.accessoryAccessibilityIdentifier = accessoryAccessibilityIdentifier
         self.statusIndicator = statusIndicator
         self.disclosureIndicator = disclosureIndicator
         self.webLinkIndicator = webLinkIndicator
@@ -110,6 +112,7 @@ struct SettingsCellView: View, Identifiable {
         self.isButton = isButton
         self.isGreyedOut = false
         self.shouldShowWinBackOffer = false
+        self.accessoryAccessibilityIdentifier = ""
     }
 
     var body: some View {
@@ -215,6 +218,7 @@ struct SettingsCellView: View, Identifiable {
             Toggle("", isOn: isOn)
                 .toggleStyle(SwitchToggleStyle(tint: Color(designSystemColor: .accent)))
                 .fixedSize()
+                .accessibilityIdentifier(accessoryAccessibilityIdentifier)
         case .image(let image):
             if isGreyedOut {
                 image


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1213323110665331?focus=true

### Description
This PR fixes the auto-clear end-to-end test by force-enabling the new auto-clear settings UI and adjusting the test accordingly.

### Testing Steps
No testing needed. Ensure CI passes.

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to internal UI-test wiring and an accessibility identifier on a toggle, with minimal impact on app behavior.
> 
> **Overview**
> Fixes the Auto Clear Maestro E2E by force-enabling the new data-clearing UI via feature flags and updating the flow to tap "Automatically Delete Data" before toggling.
> 
> Adds an accessibility identifier to `SettingsCellView` toggle accessories and wires the Auto Clear toggle to use `AutoclearEnabledToggle`, making UI tests target the switch reliably.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ad3c29af383b0687e4cdb0f8ee4c2313cedf294. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->