### PR TITLE
Prevent corner clipping of iOS 26 sheets

### DIFF
--- a/iOS/DuckDuckGo/Fire/FireConfirmationPresenter.swift
+++ b/iOS/DuckDuckGo/Fire/FireConfirmationPresenter.swift
@@ -212,7 +212,9 @@ struct FireConfirmationPresenter {
             sheet.detents = [.large()]
         }
         sheet.prefersGrabberVisible = false
-        sheet.preferredCornerRadius = Constants.sheetCornerRadius
+        if #unavailable(iOS 26) {
+            sheet.preferredCornerRadius = Constants.sheetCornerRadius
+        }
     }
     
     private func calculateSheetHeight<Content: View>(for hostingController: UIHostingController<Content>,

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2990,7 +2990,9 @@ extension MainViewController: OmniBarDelegate {
             }
             sheet.prefersGrabberVisible = true
             sheet.widthFollowsPreferredContentSizeWhenEdgeAttached = true
-            sheet.preferredCornerRadius = 24
+            if #unavailable(iOS 26) {
+                sheet.preferredCornerRadius = 24
+            }
         }
 
         let isiPad = UIDevice.current.userInterfaceIdiom == .pad


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1213309864500262?focus=true
Tech Design URL:
CC:

### Description

Leaves default corner radius on Burn and Menu sheet when running on iOS 26. This prevents clipping of the bottom corners.

### Testing Steps
1. On iOS 26 open browsing menu and fire confirmation and confirm bottom edges are aligned nicely with the screen.


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, iOS-version-gated UI presentation tweak limited to sheet appearance; minimal behavioral impact outside visual styling.
> 
> **Overview**
> Prevents bottom-corner clipping on iOS 26 by **leaving the system-default sheet corner radius** instead of forcing a custom one.
> 
> This gates `UISheetPresentationController.preferredCornerRadius` behind `#unavailable(iOS 26)` for both the fire confirmation sheet (`FireConfirmationPresenter`) and the browsing menu sheet configuration in `MainViewController`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d2e4d5d74b6a65d0016a42d146d9bd323572e8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->