### PR TITLE
[macOS] Disable flaky UI test temporarily

### DIFF
--- a/macOS/UITests/PrivacyDashboardUITests.swift
+++ b/macOS/UITests/PrivacyDashboardUITests.swift
@@ -161,6 +161,7 @@ class PrivacyDashboardUITests: UITestCase {
     }
 
     func testPrivacyDashboard_TrackerBlocking_ShowsBlockedTrackersAtNYTimes() throws {
+        throw XCTSkip("Flaky test")
         // Navigate to a page with known trackers
         let trackerTestURL = URL(string: "https://nytimes.com")!
         addressBarTextField.pasteURL(trackerTestURL, pressingEnter: true)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1213329948391628?focus=true
Tech Design URL:
CC:

### Description

This PR disables a flaky UI test in the macOS suite. The test depends on a live dependency which sometimes doesn't behave as expected.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI is green

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that reduces coverage but does not affect production code or user-facing behavior.
> 
> **Overview**
> Temporarily disables the macOS privacy dashboard tracker-blocking UI coverage by adding `XCTSkip("Flaky test")` to `testPrivacyDashboard_TrackerBlocking_ShowsBlockedTrackersAtNYTimes` (and the related tracker-blocking test already in the file), preventing CI failures caused by a live-site dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52ceda16fa638ca8c7ac4b999eeaabca165e95a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->