### PR TITLE
Startup Metrics: New Feature Flag

### DIFF
--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -300,7 +300,8 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/task/1213316822018797
     case aiChatSidebarResizable
 
-    /// https://app.asana.com/1/137249556945/inbox/1211150618028591/item/1212357178932004/story/1213311263334728?focus=true
+    /// Startup Metrics Feature Flag
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213380840527060
     case startupMetrics
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/inbox/1211150618028591/item/1212357178932004/story/1213311263334728?focus=true
Tech Design URL:
CC:

### Description
This PR adds a new Feature Flag for the Startup Metrics project

### Testing Steps
- [ ] Verify the changes make sense
- [ ] Verify the CI is green please!

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing really, as this PR affects no executable path

### Quality Considerations
None

### Notes to Reviewer
Thank you!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new feature flag entry and wiring without changing runtime behavior unless the flag is explicitly checked elsewhere.
> 
> **Overview**
> Adds a new `FeatureFlag.startupMetrics` case for the Startup Metrics project.
> 
> Wires the flag into the feature-flag infrastructure by allowing local overrides and marking its source as **internal-only** (default remains off).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed92e621a79772191a9ef90c342ce85f0bbeb4f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->