### PR TITLE
[iOS][Onboarding] Fix an issue where Fire button animation is shown when trackers blocked dialog is shown

### DIFF
--- a/iOS/DuckDuckGo/DaxDialogs.swift
+++ b/iOS/DuckDuckGo/DaxDialogs.swift
@@ -314,8 +314,12 @@ final class DaxDialogs: NewTabDialogSpecProvider, ContextualOnboardingLogic, Con
     }
     
     var shouldShowFireButtonPulse: Bool {
-        // Show fire the user hasn't seen the fire education dialog or the fire button has not animated before.
-        nonDDGBrowsingMessageSeen && canShowFireButtonAnimationIfDialogIsVisible && (!settings.fireMessageExperimentShown && settings.fireButtonPulseDateShown == nil) && isEnabled
+        // Fire button can pulse when user has seen at least one browsing dialog AND either:
+        // 1. Fire dialog is currently displayed, OR
+        // 2. User navigates away, hasn't seen fire dialog yet, pulse hasn't been shown and no non-fire dialog is currently showing
+        let fireEducationNotSeenYet = !settings.fireMessageExperimentShown && settings.fireButtonPulseDateShown == nil
+
+        return isEnabled && nonDDGBrowsingMessageSeen && canShowFireButtonAnimationIfDialogIsVisible && (isShowingFireDialog || fireEducationNotSeenYet)
     }
 
     var shouldShowPrivacyButtonPulse: Bool {

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1318,6 +1318,7 @@ class TabViewController: UIViewController {
     private var didGoBackForward: Bool = false {
         didSet {
             if didGoBackForward {
+                contextualOnboardingLogic.setDaxDialogDismiss()
                 contextualOnboardingPresenter.dismissContextualOnboardingIfNeeded(from: self)
             }
         }

--- a/iOS/DuckDuckGoTests/DaxDialogTests.swift
+++ b/iOS/DuckDuckGoTests/DaxDialogTests.swift
@@ -1141,11 +1141,11 @@ final class DaxDialog: XCTestCase {
         // GIVEN
         let settings = MockDaxDialogsSettings()
         settings.browsingWithTrackersShown = true
-        settings.fireMessageExperimentShown = false
+        settings.fireMessageExperimentShown = true  // In production, this is set when fire dialog is shown
         settings.fireButtonPulseDateShown = nil
         let sut = makeSUT(settings: settings)
 
-        // Simulate fire dialog being visible
+        // Simulate fire dialog being visible (in production, setFireEducationMessageSeen() sets both)
         sut.setLastShownDialog(type: .fire)
 
         // WHEN


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213309864500264?focus=true
Tech Design URL:
CC:

### Description

Fixes a bug where the fire button pulse animation would incorrectly trigger when locking and unlocking the phone while an onboarding dialog (trackers blocked dialog) was visible.

**Problem**
During the contextual onboarding, when:
  1. A trackers blocked dialog is displayed on screen.
  2. The user locks and unlocks their phone.
The fire button would incorrectly start its pulse animation, even though the user was still viewing the tracker dialog.

**Solution**
Added a new computed property `canShowFireButtonAnimationIfDialogIsVisible` in `DaxDialogs.swift` that gates the fire button pulse animation based on the currently visible dialog:
- No dialog visible → Allow fire button pulse according to existing logic.
- Fire dialog visible → Allow fire button pulse (dialog and animation can go together).
- Other dialog visible → Block fire button pulse (prevents the bug).

This property is integrated into the shouldShowFireButtonPulse logic to prevent animations from triggering during inappropriate device lifecycle events.

### Testing Steps
1. Complete the linear onboarding.
2. Once the contextual onboarding starts, navigate to a site. E.g bbc.co.uk
3. Wait for trackers blocked dialog to appear and Privacy shield to show highlilght animation.
4. Lock and unlock the device.
5. Fire button animation should not happen.

### Impact and Risks
Low: Minor bug fix to existing onboarding animation behavior.

### Quality Considerations
Added unit tests to validate the behaviour

### Notes to Reviewer
While investigating the root cause of this bug, I discovered a potential issue in `BrowserChromeManager.swift:66`.

The KVO observation is created with options: `.new` only, but the callback check for the old observation value `guard observation.newValue != observation.oldValue else { return }`. I could not find anything official but `oldValue` seems to be nil when `.old` is not included in the options, which would cause the guard to never return early. 

This could contribute to unnecessary layout operations. The options should likely be [.old, .new] to ensure proper comparison behavior. This is a separate issue from the fire button animation fix but wanted to flag it.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk behavior change limited to contextual onboarding UI animation gating and associated state reset; main risk is unintended suppression of the Fire pulse in edge dialog-state cases.
> 
> **Overview**
> Prevents the Fire button pulse animation from triggering while a *non-Fire* contextual onboarding dialog is currently visible (e.g., trackers-blocked dialog after lock/unlock), by gating `shouldShowFireButtonPulse` on the last shown dialog type.
> 
> Also resets contextual onboarding dialog state on back/forward navigation (`TabViewController.didGoBackForward`) and adds unit tests covering Fire pulse visibility when Fire, non-Fire, or no dialog is present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d5eeda3c9af162ac172cac4986f8b85845f2b1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->