### PR TITLE
Remove fadeOutOnToggle flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -369,9 +369,6 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Controls showing the Hide AI section in Settings -> AI Features
     case showHideAiGeneratedImages
 
-    /// Controls different input sizes and fade out animation for toggle.
-    case fadeOutOnToggle
-
     /// Signals that the iOS app should display duck.ai chats in "contextual mode" when opened from specific entry points
     case contextualDuckAIMode
 

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -218,9 +218,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213313932650457
     case iPadAIToggle
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212197756955039
-    case fadeOutOnToggle
-
     /// macOS: https://app.asana.com/1/137249556945/project/1211834678943996/task/1212015252281641
     /// iOS: https://app.asana.com/1/137249556945/project/1211834678943996/task/1212015250423471
     case attributedMetrics
@@ -443,7 +440,6 @@ extension FeatureFlag: FeatureFlagDescribing {
              .fullDuckAIMode,
              .iPadDuckaiOnTab,
              .iPadAIToggle,
-             .fadeOutOnToggle,
              .attributedMetrics,
              .storeSerpSettings,
              .showHideAIGeneratedImagesSection,
@@ -655,8 +651,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(AIChatSubfeature.iPadDuckaiOnTab))
         case .iPadAIToggle:
             return .internalOnly()
-        case .fadeOutOnToggle:
-            return .remoteReleasable(.subfeature(AIChatSubfeature.fadeOutOnToggle))
         case .attributedMetrics:
             return .remoteReleasable(.feature(.attributedMetrics))
         case .onboardingSearchExperience:

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
@@ -23,7 +23,6 @@ import Persistence
 import Core
 import UIKit
 import AIChat
-import PrivacyConfig
 import enum Common.DevicePlatform
 
 // MARK: - TextEntryMode Enum
@@ -84,7 +83,6 @@ final class SwitchBarHandler: SwitchBarHandling {
     private let aiChatSettings: AIChatSettingsProvider
     private let funnelState: SwitchBarFunnelProviding
     private var sessionStateMetrics: SessionStateMetricsProviding
-    private let featureFlagger: FeatureFlagger
 
     // MARK: - Published Properties
     @Published private(set) var currentText: String = ""
@@ -104,7 +102,7 @@ final class SwitchBarHandler: SwitchBarHandling {
     }
 
     var isUsingFadeOutAnimation: Bool {
-        featureFlagger.isFeatureOn(.fadeOutOnToggle) && devicePlatform.isIphone
+        devicePlatform.isIphone
     }
 
     var isVoiceSearchEnabled: Bool {
@@ -158,14 +156,12 @@ final class SwitchBarHandler: SwitchBarHandling {
          aiChatSettings: AIChatSettingsProvider,
          funnelState: SwitchBarFunnelProviding = SwitchBarFunnel(storage: UserDefaults.standard),
          sessionStateMetrics: SessionStateMetricsProviding,
-         featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
          devicePlatform: DevicePlatformProviding.Type = DevicePlatform.self) {
         self.voiceSearchHelper = voiceSearchHelper
         self.storage = storage
         self.aiChatSettings = aiChatSettings
         self.funnelState = funnelState
         self.sessionStateMetrics = sessionStateMetrics
-        self.featureFlagger = featureFlagger
         self.devicePlatform = devicePlatform
 
         // Set up app lifecycle observers to reset session flags

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -561,10 +561,9 @@ extension SwitchBarTextEntryView: UITextViewDelegate {
         handler.updateCurrentText(textView.text ?? "")
         handler.markUserInteraction()
 
-        // Only reload input views when fadeOutOnToggle is OFF to preserve legacy behavior.
-        // When ON, reloadInputViews() on every keystroke causes the publisher to deliver
+        // On iPad, reload input views on each keystroke (old behavior, without fade-out animation)
+        // On iPhone, skip reloadInputViews() as it causes the publisher to deliver
         // stale text values that interfere with iOS autocomplete.
-        // When deleting .fadeOutOnToggle flag, delete textView.reloadInputViews() here as this fixes
         // https://app.asana.com/1/137249556945/inbox/1210947754150827/item/1212750684390654/story/1212749500239461?focus=true
         if !handler.isUsingFadeOutAnimation {
             textView.reloadInputViews()

--- a/iOS/DuckDuckGoTests/SwitchBar/SwitchBarHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/SwitchBar/SwitchBarHandlerTests.swift
@@ -29,6 +29,10 @@ final class SwitchBarHandlerTests: XCTestCase {
         static let toggleState = "SwitchBarHandler.toggleState"
     }
 
+    private final class MockDevicePlatform: DevicePlatformProviding {
+        static var isIphone: Bool = true
+    }
+
     private var sut: SwitchBarHandler!
     private var mockVoiceSearchHelper: MockVoiceSearchHelper!
     private var mockStorage: MockKeyValueStore!
@@ -36,6 +40,7 @@ final class SwitchBarHandlerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        MockDevicePlatform.isIphone = true
         mockVoiceSearchHelper = MockVoiceSearchHelper()
         mockStorage = MockKeyValueStore()
         cancellables = Set<AnyCancellable>()
@@ -50,15 +55,18 @@ final class SwitchBarHandlerTests: XCTestCase {
         super.tearDown()
     }
 
-    private func createSUT() {
+    private func createSUT(devicePlatform: DevicePlatformProviding.Type = MockDevicePlatform.self) {
         sut = SwitchBarHandler(
             voiceSearchHelper: mockVoiceSearchHelper,
             storage: mockStorage, aiChatSettings: MockAIChatSettingsProvider(),
-            sessionStateMetrics: SessionStateMetrics(storage: mockStorage)
+            sessionStateMetrics: SessionStateMetrics(storage: mockStorage),
+            devicePlatform: devicePlatform
         )
     }
 
-    func testVoiceButtonNotVisible_WhenNoTextAndTopBar() {
+    func testVoiceButtonNotVisible_WhenIPadAndNoTextAndTopBar() {
+        MockDevicePlatform.isIphone = false
+        createSUT()
         sut.updateBarPosition(isTop: true)
         mockVoiceSearchHelper.isVoiceSearchEnabled = true
         sut.clearText()
@@ -418,33 +426,20 @@ final class SwitchBarHandlerTests: XCTestCase {
     }
      */
 
-    // MARK: - Voice Button with .fadeOutOnToggle Tests
+    // MARK: - Voice Button Tests (iPhone uses fade-out animation)
 
-    private func createSUTWithFadeOutEnabled() {
-        let mockFeatureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.fadeOutOnToggle])
-        sut = SwitchBarHandler(
-            voiceSearchHelper: mockVoiceSearchHelper,
-            storage: mockStorage,
-            aiChatSettings: MockAIChatSettingsProvider(),
-            sessionStateMetrics: SessionStateMetrics(storage: mockStorage),
-            featureFlagger: mockFeatureFlagger
-        )
-    }
-
-    func testVoiceButtonVisible_WhenFadeOutEnabledAndTopBarAndNoText() {
-        // Given: FadeOut enabled, top bar position, voice search enabled, no text
-        createSUTWithFadeOutEnabled()
+    func testVoiceButtonVisible_WhenIPhoneAndTopBarAndNoText() {
+        // Given: iPhone, top bar position, voice search enabled, no text
         sut.updateBarPosition(isTop: true)
         mockVoiceSearchHelper.isVoiceSearchEnabled = true
         sut.clearText()
 
-        // Then: Voice button should be visible (new behavior with fadeOut)
+        // Then: Voice button should be visible
         XCTAssertTrue(sut.buttonState.showsVoiceButton)
     }
 
-    func testVoiceButtonNotVisible_WhenFadeOutEnabledAndTopBarAndHasText() {
-        // Given: FadeOut enabled, top bar position, voice search enabled, has text
-        createSUTWithFadeOutEnabled()
+    func testVoiceButtonNotVisible_WhenIPhoneAndTopBarAndHasText() {
+        // Given: iPhone, top bar position, voice search enabled, has text
         sut.updateBarPosition(isTop: true)
         mockVoiceSearchHelper.isVoiceSearchEnabled = true
         sut.updateCurrentText("some text")
@@ -453,9 +448,8 @@ final class SwitchBarHandlerTests: XCTestCase {
         XCTAssertFalse(sut.buttonState.showsVoiceButton)
     }
 
-    func testVoiceButtonVisible_WhenFadeOutEnabledAndBottomBarAndNoText() {
-        // Given: FadeOut enabled, bottom bar position, voice search enabled, no text
-        createSUTWithFadeOutEnabled()
+    func testVoiceButtonVisible_WhenIPhoneAndBottomBarAndNoText() {
+        // Given: iPhone, bottom bar position, voice search enabled, no text
         sut.updateBarPosition(isTop: false)
         mockVoiceSearchHelper.isVoiceSearchEnabled = true
         sut.clearText()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1212197756955039
  Tech Design URL:
  CC:

  ### Description

  Removes the `fadeOutOnToggle` feature flag, graduating the fade-out animation behavior as the permanent implementation on iPhone.

  The flag previously guarded: fade animation when switching Search ↔ AI Chat, microphone button visibility in the text field, expanded text field height in AI
  Chat mode, and autocorrect behavior. All of these behaviors are now unconditionally active on iPhone and remain unchanged on iPad (which never used the fade-out path).

  The only code change is in `SwitchBarHandler.isUsingFadeOutAnimation`:
  ```swift
  // Before
  featureFlagger.isFeatureOn(.fadeOutOnToggle) && devicePlatform.isIphone

  // After
  devicePlatform.isIphone
```

### Testing Steps

Note: enable voice search before testing.

  1. iPhone — top bar
    - Switch Search → AI Chat: verify fade animation (not swipe).
    - In AI Chat with empty field: verify text field is taller (68pt) and microphone is visible inside the field.
    - Type text: verify autocorrect turns on; clear field: verify autocorrect turns off.
  3. iPhone — bottom bar
    - Repeat animation and autocorrect checks above.
  4. iPad
    - Switch Search → AI Chat: verify swipe animation (not fade).
    - Verify text field height is standard (44pt) in AI Chat mode.
    - Verify autocorrect is always on in AI Chat mode.

### Impact and Risks

Low — behavior is unchanged for all users. The flag was already fully rolled out on iPhone; iPad was never affected.

### What could go wrong?

iPad could accidentally get iPhone behavior if the devicePlatform.isIphone check were wrong. This is covered by MockDevicePlatform in the updated unit tests.

### Quality Considerations
  - Unit tests updated: removed createSUTWithFadeOutEnabled() helper and .fadeOutOnToggle references; added MockDevicePlatform to properly test iPhone vs iPadbehavior.

### Notes to Reviewer

  The key invariants to verify: iPad behavior must remain identical to before (swipe animation, standard heights, always-on autocorrect, mic only at bottom bar). iPhone should work as in recent weeks
   Everything in SwitchBarHandler that branches on isUsingFadeOutAnimation remains untouched — only the definition of that property changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily removes a fully-rolled-out flag and simplifies gating to `devicePlatform.isIphone`; behavior changes should be limited to any edge cases in iPhone/iPad platform detection.
> 
> **Overview**
> The PR **removes the `fadeOutOnToggle` feature flag** from both privacy config (`AIChatSubfeature`) and iOS `FeatureFlag`, including its local-override and source wiring.
> 
> In `SwitchBarHandler`, fade-out behavior is now **always enabled on iPhone** (no `FeatureFlagger` dependency), and `SwitchBarTextEntryView` updates its comments/logic to treat iPad as the legacy `reloadInputViews()` path while iPhone avoids it to prevent stale text/autocomplete issues.
> 
> Unit tests are updated to drop flag-based setup and instead use a mock device platform to assert iPhone vs iPad behavior for voice button visibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9fdf8ff7955d2f5a1f417f065457586c314287c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->