### PR TITLE
intercept subscription url

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2137,7 +2137,11 @@ class MainViewController: UIViewController {
             .sink { [weak self] notification in
                 let deepLinkTarget: SettingsViewModel.SettingsDeepLinkSection
                 if let redirectURLComponents = notification.userInfo?[TabURLInterceptorParameter.interceptedURLComponents] as? URLComponents {
-                    deepLinkTarget = .subscriptionFlow(redirectURLComponents: redirectURLComponents)
+                    if redirectURLComponents.path == "/subscriptions/plans" {
+                        deepLinkTarget = .subscriptionPlanChangeFlow(redirectURLComponents: redirectURLComponents)
+                    } else {
+                        deepLinkTarget = .subscriptionFlow(redirectURLComponents: redirectURLComponents)
+                    }
                 } else {
                     deepLinkTarget = .subscriptionFlow()
                 }

--- a/iOS/DuckDuckGo/TabURLInterceptor.swift
+++ b/iOS/DuckDuckGo/TabURLInterceptor.swift
@@ -57,7 +57,8 @@ final class TabURLInterceptorDefault: TabURLInterceptor {
     }
 
     static let interceptedURLs: [InterceptedURLInfo] = [
-        InterceptedURLInfo(id: .subscription, path: "/pro")
+        InterceptedURLInfo(id: .subscription, path: "/subscriptions"),
+        InterceptedURLInfo(id: .subscription, path: "/subscriptions/plans")
     ]
     
     func allowsNavigatingTo(url: URL) -> Bool {
@@ -104,7 +105,7 @@ extension TabURLInterceptorDefault {
                 var userInfo: [AnyHashable: Any]?
 
                 if let components = interceptedURLComponents {
-                    userInfo = [TabURLInterceptorParameter.interceptedURLComponents: interceptedURLComponents as Any]
+                    userInfo = [TabURLInterceptorParameter.interceptedURLComponents: components as Any]
                 }
 
                 NotificationCenter.default.post(

--- a/iOS/DuckDuckGoTests/TabURLInterceptorTests.swift
+++ b/iOS/DuckDuckGoTests/TabURLInterceptorTests.swift
@@ -58,12 +58,12 @@ class TabURLInterceptorDefaultTests: XCTestCase {
     func testNotificationForInterceptedSubscriptionPath() {
         _ = self.expectation(forNotification: .urlInterceptSubscription, object: nil, handler: nil)
 
-        let url = URL(string: "https://duckduckgo.com/pro")!
+        let url = URL(string: "https://duckduckgo.com/subscriptions")!
         let canNavigate = urlInterceptor.allowsNavigatingTo(url: url)
-        
+
         // Fail if no note is posted
         XCTAssertFalse(canNavigate)
-        
+
         waitForExpectations(timeout: 1) { error in
             if let error = error {
                 XCTFail("Notification expectation failed: \(error)")
@@ -78,7 +78,7 @@ class TabURLInterceptorDefaultTests: XCTestCase {
             capturedNotification = notification
             return true
         })
-        let url = try XCTUnwrap(URL(string: "https://duckduckgo.com/pro?origin=test_origin"))
+        let url = try XCTUnwrap(URL(string: "https://duckduckgo.com/subscriptions?origin=test_origin"))
         
         // WHEN
         _ = urlInterceptor.allowsNavigatingTo(url: url)
@@ -97,7 +97,7 @@ class TabURLInterceptorDefaultTests: XCTestCase {
             capturedNotification = notification
             return true
         })
-        let url = try XCTUnwrap(URL(string: "https://duckduckgo.com/pro"))
+        let url = try XCTUnwrap(URL(string: "https://duckduckgo.com/subscriptions"))
 
         // WHEN
         _ = urlInterceptor.allowsNavigatingTo(url: url)
@@ -186,7 +186,7 @@ class TabURLInterceptorDefaultTests: XCTestCase {
         notificationExpectation.isInverted = true
 
         // GIVEN
-        let url = URL(string: "https://duck.co/pro")!
+        let url = URL(string: "https://duck.co/subscriptions")!
         mockInternalUserStoring.isInternalUser = false
 
         // WHEN
@@ -201,7 +201,37 @@ class TabURLInterceptorDefaultTests: XCTestCase {
         let notificationExpectation = expectation(forNotification: .urlInterceptSubscription, object: nil, handler: nil)
 
         // GIVEN
-        let url = URL(string: "https://duck.co/pro")!
+        let url = URL(string: "https://duck.co/subscriptions")!
+        mockInternalUserStoring.isInternalUser = true
+
+        // WHEN
+        let canNavigate = urlInterceptor.allowsNavigatingTo(url: url)
+
+        // THEN
+        XCTAssertFalse(canNavigate)
+        await fulfillment(of: [notificationExpectation], timeout: 0.5)
+    }
+
+    func testNotificationForInterceptedSubscriptionPlansPath() async {
+        let notificationExpectation = expectation(forNotification: .urlInterceptSubscription, object: nil, handler: nil)
+
+        // GIVEN
+        let url = URL(string: "https://duck.co/subscriptions/plans")!
+        mockInternalUserStoring.isInternalUser = true
+
+        // WHEN
+        let canNavigate = urlInterceptor.allowsNavigatingTo(url: url)
+
+        // THEN
+        XCTAssertFalse(canNavigate)
+        await fulfillment(of: [notificationExpectation], timeout: 0.5)
+    }
+
+    func testNotificationForInterceptedSubscriptionUpgradePath() async {
+        let notificationExpectation = expectation(forNotification: .urlInterceptSubscription, object: nil, handler: nil)
+
+        // GIVEN
+        let url = URL(string: "https://duckduckgo.com/subscriptions/plans?tier=pro")!
         mockInternalUserStoring.isInternalUser = true
 
         // WHEN


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1213398556933185?focus=true

### Description Navigating to Subscriptions and plans page should open the subscription / plan change flows

### Testing Steps
1. Go to debug settings -> Feature Flags -> turn “allowProTierpurchase” on
2. Go to debug settings -> Subscription -> on Custom base subscription url edit and use https://eponomareva/duckduckgo.com/subscriptions
1. Go to debug settings -> Configuration URLs -> Remote Message Framework Config -> override with https://jsonkeeper.com/b/SKZBJ
3. Go to debug settings -> Remote Messaging click on Delete All and then Refresh config
4. Open the NTP and a remote message should appear
5. Click on the action and checks it loads the pro purchase page (Note it will go through DUO authentication)

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes to URL interception and settings deep-link routing with unit test coverage; low blast radius aside from potential misrouting of subscription URLs.
> 
> **Overview**
> Updates subscription deep-link interception to match the new `/subscriptions` URL structure and support plan changes.
> 
> `TabURLInterceptor` now intercepts `/subscriptions` and `/subscriptions/plans` (instead of `/pro`) and posts normalized `URLComponents` to preserve attribution query params. `MainViewController` routes intercepted `/subscriptions/plans` links into the *plan change* settings deep link (`.subscriptionPlanChangeFlow`) while other subscription links continue to open the standard purchase flow.
> 
> Tests are updated and expanded to cover the new paths and internal-user `duck.co` interception behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20e9997204cb7ab734f08dbc2352070798405893. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->