### PR TITLE
fix flaky sunscription tests

### DIFF
--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionSettingsViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionSettingsViewModelTests.swift
@@ -26,6 +26,7 @@ import Networking
 import NetworkingTestingUtils
 import Persistence
 
+@MainActor
 final class SubscriptionSettingsViewModelTests: XCTestCase {
 
     var sut: SubscriptionSettingsViewModel!
@@ -665,7 +666,6 @@ final class SubscriptionSettingsViewModelTests: XCTestCase {
 
         sut.cancelPendingDowngrade()
 
-        await Task.yield()
         XCTAssertTrue(sut.state.isShowingGoogleView)
     }
 
@@ -702,7 +702,6 @@ final class SubscriptionSettingsViewModelTests: XCTestCase {
         XCTAssertNil(sut.state.cancelDowngradeTransactionStatus)
     }
 
-    @MainActor
     func testSetCancelDowngradeError_SetsCancelDowngradeErrorInState() async  {
         sut = makeSUT()
         let error = AppStorePurchaseFlowError.purchaseFailed(NSError(domain: "Test", code: -1))
@@ -712,7 +711,6 @@ final class SubscriptionSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(sut.state.cancelDowngradeError, .purchaseFailed)
     }
 
-    @MainActor
     func testClearCancelDowngradeError_ClearsErrorInState() {
         sut = makeSUT()
         sut.setCancelDowngradeError(AppStorePurchaseFlowError.purchaseFailed(NSError(domain: "Test", code: -1)))


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1213377394303428?focus=true

### Description Fix flaky test

### Testing Steps
1. Test pass in CI

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only concurrency/annotation tweaks; no production logic changes, with minimal risk aside from potentially revealing existing race conditions.
> 
> **Overview**
> Marks `SubscriptionSettingsViewModelTests` as `@MainActor` to ensure all test methods/state assertions run on the main thread.
> 
> Removes an explicit `Task.yield()` from `testCancelPendingDowngrade_WhenGoogleSubscription_ShowsGoogleView` and drops redundant per-test `@MainActor` annotations, reducing async timing flakiness in these subscription settings tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f899c2adeac4d5843ca15fececc2dfc2008379b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->