### PR TITLE
Add feature flag for Force Dark Mode and use privacy feature

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -89,6 +89,7 @@ public enum PrivacyFeature: String {
     case combinedPermissionView
     case pageContext
     case webExtensions
+    case forceDarkModeOnWebsites
 }
 
 /// An abstraction to be implemented by any "subfeature" of a given `PrivacyConfiguration` feature.

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -338,6 +338,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213380159275565?focus=true
     case embeddedExtension
 
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213278892205657?focus=true
+    case forceDarkModeOnWebsites
+
     /// https://app.asana.com/1/137249556945/project/72649045549333/task/1208707884599795?focus=true
     case autofillOnboardingExperiment
 
@@ -480,6 +483,7 @@ extension FeatureFlag: FeatureFlagDescribing {
              .onboardingRebranding,
              .webExtensions,
              .embeddedExtension,
+             .forceDarkModeOnWebsites,
              .autofillOnboardingExperiment,
              .supportsSyncChatsDeletion,
              .fireMode,
@@ -735,6 +739,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .internalOnly()
         case .embeddedExtension:
             return .remoteReleasable(.subfeature(WebExtensionsSubfeature.embeddedExtension))
+        case .forceDarkModeOnWebsites:
+            return .remoteReleasable(.feature(.forceDarkModeOnWebsites))
         case .autofillOnboardingExperiment:
             return .remoteReleasable(.subfeature(AutofillSubfeature.onboardingExperiment))
         case .supportsSyncChatsDeletion:


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1213324981784929?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1213319542423231?focus=true
CC:

### Description

Add a local feature flag. Resolve against top level feature added in https://github.com/duckduckgo/privacy-configuration/pull/4567

### Testing Steps
1. N/A - not functional yet.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new feature flag wired to privacy-configuration; behavior is unchanged unless the flag is enabled remotely or via local override.
> 
> **Overview**
> Introduces a new privacy-configuration top-level feature `forceDarkModeOnWebsites` and exposes it in iOS as a new `FeatureFlag.forceDarkModeOnWebsites`.
> 
> The flag is included in the local override allowlist and is resolved via `.remoteReleasable(.feature(.forceDarkModeOnWebsites))`, enabling remote rollout control for the upcoming Force Dark Mode functionality.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb3aa1a0164b101fcd0da575f854bbc3707baba0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->