### PR TITLE
Only process MetricKit payloads related to crashes

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Crashes/CrashCollection.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Crashes/CrashCollection.swift
@@ -92,7 +92,7 @@ public final class CrashCollection {
                 }
 
             // Only process crash diagnostics
-            let processedData = process(payloads.filter({ $0.crashDiagnostics?.isEmpty != true }))
+            let processedData = process(payloads.filter({ $0.crashDiagnostics?.isEmpty == false }))
 
             didFindCrashReports(pixelParameters, processedData) {
                 Task {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1213399298322183?focus=true

### Description
This change updates CrashCollection callback to only be called when MetricKit payloads contain
actual crash reports. It will skip disk write exception reports and other reports that don't cause crashes.

### Testing Steps
Test that regular MetricKit crash reporting still works:
1. Launch the macOS Browser app
2. Detach debugger
3. Remove internal user state
4. Crash the app
5. Relaunch the app and verify that you've seen the crash report dialog.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrows processing to crash-related MetricKit payloads, with minimal logic change and no auth/data-model impact.
> 
> **Overview**
> Updates `CrashCollection` to **only process and upload MetricKit payloads that include non-empty `crashDiagnostics`**, skipping diagnostics like disk-write/cpu/hang reports.
> 
> This prevents `didFindCrashReports` and subsequent crash uploads from being triggered by non-crash diagnostic payloads while keeping pixel parameter generation based on crash diagnostics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b9663bf79ce95f94a9ccbc2a92fc9a9afc2d869. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->