### PR TITLE
Launch Sequence: Relocates State Restoration Step

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1238,9 +1238,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         startupSync()
 
-        if [.normal, .uiTests].contains(AppVersion.runType) {
+        // Important: The following snippet will be removed once the flag `.startupMetrics` ships
+        if featureFlagger.isFeatureOn(.startupMetrics) == false, [.normal, .uiTests].contains(AppVersion.runType) {
             stateRestorationManager.applicationDidFinishLaunching()
         }
+
         let urlEventHandlerResult = urlEventHandler.applicationDidFinishLaunching()
 
         setUpAutoClearHandler()
@@ -1349,6 +1351,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         userChurnScheduler.start()
 
         memoryUsageMonitor.enableIfNeeded(featureFlagger: featureFlagger)
+
+        // Important: State Restoration be exluded from didFinishLaunching performance measurement
+        if featureFlagger.isFeatureOn(.startupMetrics), [.normal, .uiTests].contains(AppVersion.runType) {
+            stateRestorationManager.applicationDidFinishLaunching()
+        }
 
         PixelKit.fire(GeneralPixel.launch, doNotEnforcePrefix: true)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213367269708407?focus=true
Tech Design URL:
CC:

### Description
In this PR we're relocating the **State Restoration** process, so that it's executed at the very end of `applicationDidFinishLaunching.

Please do note that, for safety, this change is gated behind a feature flag.

### Testing Steps
1. Open `Settings > General`
2. Ensure `Reopen all windows from last session` is selected
3. Open several websites in multiple tabs / windows
4. Close the browser

- [ ] Verify that after relaunching, the browser's state is restored

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
State Restoration could fail under unknown conditions

### Quality Considerations
None

### Notes to Reviewer
Thank you!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the timing of state restoration during app startup, which can affect window/tab restore behavior and startup ordering; gated behind a feature flag to limit exposure.
> 
> **Overview**
> Moves session **state restoration** later in `applicationDidFinishLaunching`, so it can be excluded from startup performance measurement when the `.startupMetrics` feature flag is enabled.
> 
> This change is **feature-flagged**: when `.startupMetrics` is *off*, restoration runs in its previous earlier location; when *on*, it runs near the end of launch (after background tasks and monitors are started, and just before firing the `launch` pixel).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b04f929a1b6060d23fd0dfd533f747601de4ef2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->