### PR TITLE
Fix Duck.ai address bar button ignoring show/hide preference

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -1292,10 +1292,10 @@ final class AddressBarButtonsViewController: NSViewController {
         aiChatButton.isHidden = !shouldShowAIChatButton()
         updateAIChatDividerVisibility()
 
-        // Check if the current tab is in the onboarding state and hide the AI chat button if it is
-        guard let tabViewModel else { return }
-        let isOnboarding = [.onboarding].contains(tabViewModel.tab.content)
-        aiChatButton.isHidden = isOnboarding
+        // Hide the AI chat button during onboarding
+        if let tabViewModel, tabViewModel.tab.content == .onboarding {
+            aiChatButton.isHidden = true
+        }
     }
 
     private var isAskAIChatButtonExpanded: Bool = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1213399366089205?focus=true

### Description

An onboarding check unconditionally overwrote the preference-based visibility, forcing the button visible on every non-onboarding tab. Only hide the button during onboarding instead of overwriting visibility.

### Testing Steps

1. Run the app
2. Go to Settings > AI Features > Duck.ai Shortcuts > Enable / Disable "Show Duck.ai shortcut in the address bar"

Make sure the setting is honored.

### Impact and Risks

Medium.  We really want all DuckAI settings honored.
Risk is low - the change is trivial and easy to validate.

#### What could go wrong?

NA

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI visibility logic change with a straightforward condition and no security or data-handling impact.
> 
> **Overview**
> Adjusts `updateAIChatButtonVisibility()` so the onboarding check only *adds an extra hide condition* when the current tab is `.onboarding`, instead of early-returning and potentially overriding preference-driven visibility on other tabs.
> 
> This ensures the Duck.ai address bar shortcut consistently honors `aiChatMenuConfig.shouldDisplayAddressBarShortcut`, while still hiding during onboarding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2f06453769036ea1fbdad5892853c43ef2aa504. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->