### PR TITLE
[macOS] remove tabClosingEventRecreation feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -144,10 +144,6 @@ public enum MacOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/1204006570077678/task/1211448334620171?focus=true
     case blurryAddressBarTahoeFix
 
-    /// Tab closing event recreation feature flag (failsafe for removing private API)
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212206087745586?focus=true
-    case tabClosingEventRecreation
-
     /// Feature Flag for the First Time Quit Survey
     /// https://app.asana.com/1/137249556945/inbox/1203972458584425/item/1212200919350194/story/1212483080081687
     case firstTimeQuitSurvey

--- a/macOS/DuckDuckGo/Application/Application.swift
+++ b/macOS/DuckDuckGo/Application/Application.swift
@@ -19,7 +19,6 @@
 import AppKit
 import Combine
 import Common
-import FeatureFlags
 import Foundation
 import PrivacyConfig
 
@@ -28,7 +27,6 @@ final class Application: NSApplication, WarnBeforeQuitManagerDelegate {
 
     public static var appDelegate: AppDelegate! // swiftlint:disable:this weak_delegate
     private var fireWindowPreferenceCancellable: AnyCancellable?
-    private var featureFlagger: FeatureFlagger { delegateTyped.featureFlagger }
 
     /// Event interceptor hook for WarnBeforeQuitManager
     /// Returns nil to consume event, or the event to pass through
@@ -151,8 +149,7 @@ final class Application: NSApplication, WarnBeforeQuitManagerDelegate {
         }
 
         // Handle the hack to reset the click count to 1 for the next incoming mouse event of the given type.
-        if let expectedEventType = shouldResetClickCountForNextEventOfTypes, expectedEventType.contains(event.type),
-           featureFlagger.isFeatureOn(.tabClosingEventRecreation) {
+        if let expectedEventType = shouldResetClickCountForNextEventOfTypes, expectedEventType.contains(event.type) {
             if event.clickCount > 1 {
                 event = {
                     guard let cg = event.cgEvent?.copy() else { return event }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -233,10 +233,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1148564399326804/task/1211985993948718?focus=true
     case newPermissionView
 
-    /// Tab closing event recreation (failsafe for removing private API)
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212206087745586?focus=true
-    case tabClosingEventRecreation
-
     /// Shows a survey when quitting the app for the first time in a determined period
     /// https://app.asana.com/1/137249556945/project/1204006570077678/task/1212242893241885?focus=true
     case firstTimeQuitSurvey
@@ -328,7 +324,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .extendedUserInitiatedPopupTimeout,
                 .suppressEmptyPopUpsOnApproval,
                 .popupPermissionButtonPersistence,
-                .tabClosingEventRecreation,
                 .dataImportWideEventMeasurement,
                 .firstTimeQuitSurvey,
                 .aiChatOmnibarOnboarding,
@@ -444,7 +439,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .unknownUsernameCategorization,
                 .credentialsImportPromotionForExistingUsers,
                 .scheduledDefaultBrowserAndDockPromptsInactiveUser,
-                .tabClosingEventRecreation,
                 .terminationDeciderSequence,
                 .crashCollectionDisableKeysSorting,
                 .crashCollectionLimitCallStackTreeDepth:
@@ -588,8 +582,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.webNotifications))
         case .newPermissionView:
             return .remoteReleasable(.feature(.combinedPermissionView))
-        case .tabClosingEventRecreation:
-            return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.tabClosingEventRecreation))
         case .firstTimeQuitSurvey:
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.firstTimeQuitSurvey))
         case .terminationDeciderSequence:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1211834678943996/1212206087745586
Tech Design URL: N/A
CC: N/A

### Description
- Remove the retired `tabClosingEventRecreation` feature flag from macOS feature flag definitions and privacy config subfeatures.
- Make click-count recreation behavior in `Application.sendEvent(_:)` unconditional when reset types are present.
- Remove now-unused feature-flag plumbing in `Application` after flag graduation.

### Testing Steps
1. Launch the macOS app.
2. Open multiple tabs with close buttons visible.
3. Rapidly close tabs using repeated close-button clicks and repeated middle-clicks.
4. Confirm tabs continue to close as expected without requiring pauses.
5. Verify no regressions in normal click handling elsewhere in the app window.

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- Event handling could behave differently for rapid multi-click interactions.
- Mitigation: manual verification of repeated close interactions and standard click flows.

### Quality Considerations
- Edge cases: rapid repeated click/middle-click tab closing behavior remains intact.
- Performance: no material impact; conditional flag check removed.
- Monitoring/analytics: no new telemetry changes.
- Documentation: no additional docs needed beyond PR context.
- Privacy/security: no user data handling changes.

### Notes to Reviewer
- This is a flag graduation/removal only; behavior is intentionally preserved as permanent.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized flag cleanup plus a straightforward removal of a runtime gate; main risk is subtle input-event behavior changes during rapid multi-click interactions.
> 
> **Overview**
> Removes the retired `tabClosingEventRecreation` flag from both privacy-config subfeatures and the macOS `FeatureFlag` definitions/mappings.
> 
> Updates `Application.sendEvent(_:)` so the click-count reset hack used for rapid tab-closing runs unconditionally whenever `shouldResetClickCountForNextEventOfTypes` matches, and deletes the now-unused feature-flag plumbing/import in `Application`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 432a8a4e587ee4ce170f70605417e4d7a533cfd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->