### PR TITLE
Fix issue with omnibar after opening duck.ai

### DIFF
--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -838,6 +838,8 @@ extension DefaultOmniBarView {
         aiChatLeftButton.alpha = 0.0
         NSLayoutConstraint.deactivate(aiChatModeConstraints)
 
+        searchAreaView.textField.isHidden = false
+
         if !isSearchAreaExpanded {
             searchAreaView.textField.alpha = 1.0
             searchAreaView.revealButtons()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1213379559282948?focus=true

### Description
Fix issue with omnibar after opening duck.ai

### Testing Steps
1. Open a website
2. Open duck.ai
3. Go to tab switcher, go back to the website
4. Check if the omnibar is being displayed correctly 

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Not display the address bar after switching

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line UI state fix limited to omnibar visibility; low risk of side effects beyond AI Chat mode transitions.
> 
> **Overview**
> Fixes an omnibar state bug when exiting Duck.ai by explicitly un-hiding `searchAreaView.textField` in `hideAIChatOmnibar()`, ensuring the address/search field reappears when returning to regular browsing (e.g., after tab switching).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12599a2caa5a0fa6ef09ceb3661933ff131bf699. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->