### PR TITLE
Fix missing extension manager during initialization

### DIFF
--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -272,10 +272,12 @@ final class MainCoordinator {
         guard webExtensionManager == nil else {
             // Already initialized, just reload extensions and re-register tabs
             webExtensionLoadTask?.cancel()
-            webExtensionLoadTask = Task { @MainActor in
-                await webExtensionManager?.loadInstalledExtensions()
-                await syncEmbeddedExtensions()
-                webExtensionEventsCoordinator?.registerExistingTabsAndWindow()
+            webExtensionLoadTask = Task { @MainActor [weak self] in
+                await self?.webExtensionManager?.loadInstalledExtensions()
+                guard !Task.isCancelled else { return }
+                await self?.syncEmbeddedExtensions()
+                guard !Task.isCancelled else { return }
+                self?.webExtensionEventsCoordinator?.registerExistingTabsAndWindow()
             }
             return
         }
@@ -299,10 +301,12 @@ final class MainCoordinator {
         controller.setWebExtensionManager(webExtensionManager)
 
         // Load extensions asynchronously - the controller is already attached to tabs
-        webExtensionLoadTask = Task { @MainActor in
+        webExtensionLoadTask = Task { @MainActor [weak self] in
             await webExtensionManager.loadInstalledExtensions()
-            await syncEmbeddedExtensions()
-            webExtensionEventsCoordinator?.registerExistingTabsAndWindow()
+            guard !Task.isCancelled else { return }
+            await self?.syncEmbeddedExtensions()
+            guard !Task.isCancelled else { return }
+            self?.webExtensionEventsCoordinator?.registerExistingTabsAndWindow()
         }
     }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1213420787051416?focus=true
Tech Design URL:
CC:

### Description

Fix missing `webExtensionManager` instance during tabs creation.

### Testing Steps
1. Create tabs, make sure webExtensions and embeddedExtensions feature flag is enabled.
2. Close and relaunch the app.
3. Make sure all tabs have the `webExtensionController` assigned.

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Web extension manager is recreated during runtime and feature flag changes.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches web extension startup and feature-flag reinit flows; async task cancellation/order changes could cause missed registrations or incomplete extension loads in edge cases.
> 
> **Overview**
> Fixes web extension initialization timing by making `initializeWebExtensions()` synchronous for wiring up `webExtensionManager`/coordinator to `TabManager` and `MainViewController`, while moving extension loading + embedded-extension sync into a cancellable background `Task`.
> 
> Adds logic to handle re-initialization/feature-flag toggles by cancelling any in-flight load task, reloading installed extensions, re-syncing embedded extensions, and re-registering existing tabs/window; `clearWebExtensionReferences()` now also cancels the task.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c86255a7fddcbda59b22ed44f183948ced9b077b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->