### PR TITLE
[iOS] Update .aiChatSync feature flag to remoteReleasable

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -662,7 +662,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .aiChatAutoAttachContextByDefault:
             return .remoteReleasable(.subfeature(AIChatSubfeature.autoAttachContextByDefault))
         case .aiChatSync:
-            return .disabled
+            return .remoteReleasable(.subfeature(SyncSubfeature.aiChatSync))
         case .aiChatSuggestions:
             return .remoteReleasable(.feature(.duckAiChatHistory))
         case .showWhatsNewPromptOnDemand:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201462886803403/task/1213367393178365?focus=true
Tech Design URL:
CC:

### Description
Updates .aiChatSync feature flag to .remoteReleasable 

### Testing Steps
1. Update Config URL to https://duckduckgo.github.io/privacy-configuration/pr-4597/v4/ios-config.json and confirm .aiChatSync is now enabled

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single feature-flag source change; behavior only changes when remote config enables the flag.
> 
> **Overview**
> Switches the `.aiChatSync` feature flag from `.disabled` to **remote-config controlled** (`.remoteReleasable(.subfeature(SyncSubfeature.aiChatSync))`), allowing it to be turned on/off via the privacy configuration without an app update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 464d4bfb0aeac84f0f0dec46d3121b7e54897511. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->