### PR TITLE
[macOS] Update .aiChatSync feature flag to remoteReleasable

### DIFF
--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -589,7 +589,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .memoryUsageReporting:
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.memoryUsageReporting))
         case .aiChatSync:
-            return .disabled
+            return .remoteReleasable(.subfeature(SyncSubfeature.aiChatSync))
         case .heuristicAction:
             return .remoteReleasable(.subfeature(AutoconsentSubfeature.heuristicAction))
         case .nextStepsListWidget:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201462886803403/task/1213423816111327?focus=true
Tech Design URL:
CC:

### Description
Updates .aiChatSync feature flag to .remoteReleasable

### Testing Steps
1. Update Config URL to https://duckduckgo.github.io/privacy-configuration/pr-4597/v4/macos-config.json and confirm .aiChatSync is now enabled

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features



---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single feature-flag wiring change; risk is limited to unintentionally enabling/disabling AI Chat sync via remote configuration.
> 
> **Overview**
> Updates macOS `FeatureFlag.source` so `aiChatSync` is no longer `.disabled` and instead maps to `.remoteReleasable(.subfeature(SyncSubfeature.aiChatSync))`, allowing the feature to be turned on/off via remote config rather than being permanently off in-app.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40e0fe0581ecd9d2518fc318ecbef341fdd55bef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->