### PR TITLE
Fix initial right-click context menu messaging timing

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
@@ -50,7 +50,10 @@ final class ContextMenuManager: NSObject {
     }
 
     private var isWebViewSupportedScheme: Bool {
-        guard let linkURL, let scheme = URL(string: linkURL)?.scheme else {
+        guard let linkURL else {
+            return originalItems?[.openLinkInNewWindow] != nil
+        }
+        guard let scheme = URL(string: linkURL)?.scheme else {
             return false
         }
         return WKWebView.handlesURLScheme(scheme)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1213420540590804?focus=true
Tech Design URL:
CC:

### Description

Appears that `willOpenContextMenu` fires before the broker delivers the message on the first right-click on a link in a new window, which means the context window is missing items until the second attempt. Trusting webkit's determination of compatible links solves this.

### Testing Steps
1. Load something like wikipedia with a lot of quick links in a fresh initial window
2. Right-click once and validate that the context menu immediately contains "Open link in new tab/new window/new fire window"

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to context-menu gating logic; risk is limited to potentially showing/hiding link actions incorrectly for some edge-case menus.
> 
> **Overview**
> Fixes a timing issue where link-related context menu entries could be missing on the first right-click in a new window.
> 
> `ContextMenuManager.isWebViewSupportedScheme` now falls back to trusting WebKit’s provided menu items (checking for `.openLinkInNewWindow`) when `linkURL` hasn’t arrived yet, instead of treating the scheme as unsupported and removing/replacing items.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ff52e462bff76b539eb0856014846ce30a123be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->