### PR TITLE
ContextMenu: Race Condition Workaround

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/ContextMenuManager.swift
@@ -291,8 +291,12 @@ extension ContextMenuManager: WebViewContextMenuDelegate {
             return
         }
 
-        onWillShowContextMenu = { [weak self] in
-            self?.refreshMenuItemsAndResetScriptState(menu: menu)
+        onWillShowContextMenu = { [weak self, weak menu] in
+            guard let self, let menu else {
+                return
+            }
+
+            self.refreshMenuItemsAndResetScriptState(menu: menu)
         }
     }
 

--- a/macOS/LocalPackages/AppKitExtensions/Sources/AppKitExtensions/NSMenuExtension.swift
+++ b/macOS/LocalPackages/AppKitExtensions/Sources/AppKitExtensions/NSMenuExtension.swift
@@ -72,10 +72,10 @@ public extension NSMenu {
     /// This API removes / re-adds all items, effectively forcing a relayout cycle
     ///
     func forceRelayout() {
-        let items = items
+        let currentItems = items
         removeAllItems()
 
-        for item in items {
+        for item in currentItems {
             addItem(item)
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1213420540590804
Tech Design URL:
CC:

### Description
The first time users click on a website, `WebViewContextMenuDelegate` methods may run **BEFORE** the `ContextMenuUserScriptDelegate` callback runs.

This leaves us in a state where both, `linkURL` and `selectedText` may not get initialized.

In this PR we're implementing a deferred initialization **workaround**.

### Testing Steps
1. Launch the browser
2. Open any website
3. Right click over any link

- [ ] Verify the contextual menu looks as expected
- [ ] Please smoke test all of the actions. 
- [ ] [Verify this CI Run is Green please!](https://github.com/duckduckgo/apple-browsers/actions/runs/22367553030)

Note that the **second time** you right click, the flow differs, so we'd need to validate both states (deferred init, and synchronic)

### Screenshots

Before / Broken State | Now
-|-
<img width="263" height="224" src="https://github.com/user-attachments/assets/16d4705d-9814-47f1-9d3b-5ab8c6644273" /> | <img width="266" height="317" src="https://github.com/user-attachments/assets/f51eccc8-3eee-43c0-b4f5-ab5ed473ce59" />


### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Contextual Menu(s) may be broken

### Quality Considerations
This is a workaround, suggestions welcomed

### Notes to Reviewer
Thanks in advance!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the timing/state machine of context menu construction and adds a relayout hack; mistakes here could leave menus unmodified or visually incorrect in some right-click flows.
> 
> **Overview**
> Fixes a first-use race where WebKit’s `willOpenContextMenu` can run before the user-script provides `selectedText`/`linkURL`, by **deferring menu item customization** until `ContextMenuUserScriptDelegate.willShowContextMenu` arrives.
> 
> `ContextMenuManager` now tracks `receivedScriptInitialization` and stores an `onWillShowContextMenu` callback to run the menu-item handler pass later, resets this state on menu close, and forces an `NSMenu` relayout after late modifications via a new `NSMenu.forceRelayout()` helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05b2460e9999e7dd926e518b3697a115d15753f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->