### PR TITLE
Fix Main Thread Checker warning for web notifications permission

### DIFF
--- a/macOS/DuckDuckGo/Tab/UserScripts/WebNotificationsHandler.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/WebNotificationsHandler.swift
@@ -324,7 +324,7 @@ final class WebNotificationsHandler: NSObject, Subfeature {
 
         // Request permission through PermissionModel (shows UI, handles storage)
         // Fire Windows: permissions cleared on burn via burnPermissions()
-        let grantedInUI: Bool = await withCheckedContinuation { continuation in
+        let grantedInUI: Bool = await withCheckedContinuation(isolation: MainActor.shared) { continuation in
             permissionModel.request([.notification], forDomain: domain, url: url)
                 .sink { isGranted in
                     continuation.resume(returning: isGranted)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201621708115095/task/1213372342124456
Tech Design URL: N/A
CC:

### Description

Fix a Main Thread Checker violation in `WebNotificationsHandler.requestPermission()`. The `permissionModel.request()` call triggers UI (permission popup) but was invoked inside a `withCheckedContinuation` block without main actor isolation, meaning it could run on an arbitrary thread. This adds `isolation: MainActor.shared` to ensure the continuation closure always executes on the main actor.

### Testing Steps

1. Open the project in Xcode with Main Thread Checker enabled (Product → Scheme → Edit Scheme → Diagnostics → Main Thread Checker)
2. Visit https://permission.site and request notifications permission
3. Verify that no Main Thread Checker warnings are displayed in Xcode

### Impact and Risks

Low: Small bug fix improving threading correctness for the web notifications permission flow.

#### What could go wrong?

The permission request closure is now explicitly dispatched on the main actor. Since `permissionModel.request()` already expected to run on the main thread, this change aligns the calling code with the existing expectation. Risk is minimal.

### Quality Considerations

- Edge case: If the continuation was already running on the main thread before, this is a no-op. The fix only matters when the continuation would have been scheduled on a background thread.
- No performance impact — this simply ensures correct thread dispatch.
- No privacy/security implications.

### Notes to Reviewer

One-line change: adds `isolation: MainActor.shared` parameter to `withCheckedContinuation`.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line concurrency/isolation change around a UI permission prompt; behavior should be unchanged aside from guaranteed main-thread execution.
> 
> **Overview**
> Fixes a Main Thread Checker issue in `WebNotificationsHandler` by running the `withCheckedContinuation` block for notification permission requests on `MainActor`, ensuring the UI-triggering `permissionModel.request()` is always invoked on the main thread.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a7e765fa238eb1bb862b4625ab49971f36d6238. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->