### PR TITLE
Prevent hotfix release from running concurrently with internal bump

### DIFF
--- a/.github/workflows/ios_hotfix.yml
+++ b/.github/workflows/ios_hotfix.yml
@@ -7,6 +7,10 @@ defaults:
 on:
   workflow_dispatch:
 
+concurrency:
+  group: 'ios-release'
+  cancel-in-progress: false
+
 jobs:
 
   create_release_branch:

--- a/.github/workflows/macos_hotfix.yml
+++ b/.github/workflows/macos_hotfix.yml
@@ -7,6 +7,10 @@ defaults:
 on:
   workflow_dispatch:
 
+concurrency:
+  group: 'macos-release'
+  cancel-in-progress: false
+
 jobs:
 
   create_release_branch:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1213426597880664/f
Tech Design URL: N/A
CC:

### Description

Add concurrency groups to the iOS and macOS hotfix workflows (`ios_hotfix.yml`, `macos_hotfix.yml`) to prevent starting a hotfix release while an internal release bump is in progress.

This fixes a race condition where both workflows could run simultaneously and pick the same build number — as happened when a hotfix release started during an ongoing internal bump, resulting in duplicate build 636.

The hotfix workflow will now be queued (not cancelled) until the internal bump completes, since both share the same `ios-release` / `macos-release` concurrency group with `cancel-in-progress: false`.

### Testing Steps

N/A — CI workflow change, correctness is evident from the YAML.

### Impact and Risks

**None** — internal CI tooling only; no impact on the app or users.

#### What could go wrong?

If a hotfix release is triggered while an internal bump is running, the hotfix workflow will be queued until the bump finishes (up to ~1 hour). The bump can be manually cancelled to expedite the hotfix if needed.

### Quality Considerations

- No edge cases beyond the queuing delay described above.
- No performance, privacy, or security implications.

### Notes to Reviewer

N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)