### PR TITLE
Fix CI unit test failure reporting for SwiftTesting

### DIFF
--- a/scripts/report-failed-unit-test.sh
+++ b/scripts/report-failed-unit-test.sh
@@ -176,9 +176,9 @@ main() {
 
 	# All SwiftTesting test cases have the same class name in JUnit report, so we can omit it from the task name
 	if [[ "${class_name}" == "SwiftTesting" ]]; then
-		task_name="${testcase_name}"
+		local task_name="${testcase_name}"
 	else
-		task_name="${class_name}.${testcase_name}"
+		local task_name="${class_name}.${testcase_name}"
 	fi
 	echo "Processing ${task_name}"
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203301625297703/1213427089036466/f

### Description

SwiftTesting test cases use the `@Test` annotation name in JUnit XML results, which frequently contains spaces. This broke the CI script that reports failed unit tests to Asana because the test name was not URL-encoded in the Asana API search request.

This PR:
- Percent-encodes the test name using `jq` before passing it to the curl request in `find_task_and_occurrences`
- Strips the generic "SwiftTesting" class prefix from task names, since all SwiftTesting test cases share the same class name in JUnit reports

### Testing Steps
Verify by checking [this task](https://app.asana.com/1/137249556945/project/1205237866452338/task/1213430590601417?focus=true).

To test locally:
1. `export ASANA_ACCESS_TOKEN=<your asana token>`
2. Run the following command from the root of the monorepo and verify that 200 is output to the console and a subtask is added to [this Asana task](https://app.asana.com/1/137249556945/project/1205237866452338/task/1213430590601417?focus=true):
```
./scripts/report-failed-unit-test.sh -s 1205419026232032 SwiftTesting "Check URL Item Action Callback Dismisses Modal With Item Action Type" 'Swift testing test failed' https://github.com/duckduckgo/apple-browsers/actions/runs/22385308728/attempts/1
```

Alternatively go the full route:
1. Download `ios-unittests.xml` from [this workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/22384327305/attempts/1). NOTE: it's really a zip :D so you'll need to change its extension to `zip` and unpack it. The proper XML file is around 500kB.
2. `export ASANA_ACCESS_TOKEN=<your asana token>`
3. Run the following command from the root of the monorepo, as seen in the workflow file:
```
  yq < ios-unittests.xml -p xml -o json -r \
    $'[.testsuites.testsuite[].testcase] | flatten | map(select(.failure) | .+@classname + " " + .+@name + " \'" + .failure.+@message + "\' https://github.com/duckduckgo/apple-browsers/actions/runs/22384327305/attempts/1") | .[]' \
    | sort -u -k 1,2 \
    | xargs -L 1 ./scripts/report-failed-unit-test.sh -s 1205419026232032
```

### Impact and Risks
None — internal CI tooling only.

#### What could go wrong?
If `jq` is unavailable on the CI runner, the encoding step would fail. `jq` is already a dependency of this script (used for parsing API responses), so this is not a new requirement.

### Quality Considerations
- Edge case: test names with special characters beyond spaces (e.g., quotes, ampersands) are also handled correctly by `jq`'s `@uri` filter.


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated CI script changes; primary risk is mismatched task lookup/naming, with no impact on production systems.
> 
> **Overview**
> Fixes CI Asana reporting for failed unit tests whose names contain spaces/special characters.
> 
> The Asana search query now URL-encodes the task name before calling `tasks/search`, preventing broken queries for SwiftTesting `@Test` names. Task naming is also adjusted to drop the generic `SwiftTesting` class prefix (use just `testcase_name`), reducing duplicate/incorrect task lookups while keeping non-SwiftTesting cases as `Class.Test`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63537fe4fe7e443e89361accf5b59b88ede9a75e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->