### PR TITLE
Fix memory leak on SuggestionsReader

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/Suggestions/SuggestionsReader.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/Suggestions/SuggestionsReader.swift
@@ -49,6 +49,7 @@ public final class SuggestionsReader: SuggestionsReading {
     public enum ReaderError: Error, LocalizedError {
         case webViewNotInitialized
         case scriptNotInitialized
+        case operationSuperseded
         case navigationFailed(Error)
 
         public var errorDescription: String? {
@@ -57,6 +58,8 @@ public final class SuggestionsReader: SuggestionsReading {
                 return "WebView not initialized"
             case .scriptNotInitialized:
                 return "UserScript not initialized"
+            case .operationSuperseded:
+                return "Operation superseded"
             case .navigationFailed(let error):
                 return "Navigation failed: \(error.localizedDescription)"
             }
@@ -150,7 +153,7 @@ public final class SuggestionsReader: SuggestionsReading {
             // Fetch suggestions from this domain
             let fetchResult = await withCheckedContinuation { continuation in
                 // Resume any previous continuation to avoid leaking a suspended caller
-                self.fetchContinuation?.resume(returning: .failure(ReaderError.scriptNotInitialized))
+                self.fetchContinuation?.resume(returning: .failure(ReaderError.operationSuperseded))
                 self.fetchContinuation = continuation
                 script.fetchChats(query: query, maxChats: maxChats, since: since)
             }
@@ -330,7 +333,7 @@ public final class SuggestionsReader: SuggestionsReading {
 
         return await withCheckedContinuation { continuation in
             // Resume any previous continuation to avoid leaking a suspended caller
-            self.navigationContinuation?.resume(returning: .failure(ReaderError.webViewNotInitialized))
+            self.navigationContinuation?.resume(returning: .failure(ReaderError.operationSuperseded))
             self.navigationContinuation = continuation
 
             if #available(iOS 15.0, macOS 12.0, *) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1213424531365777?focus=true
Tech Design URL:
CC:

### Description
Fix memory leak on SuggestionsReader

### Testing Steps
1. Smoke test duck.ai chat suggestions on both iOS and macOS
2. On iOS, open new tabs, select the address bar, then deselect the address bar, check that SuggestionsReader is not leaking


### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Regression on duck.ai suggestions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes async continuation lifecycle and WebView script/handler cleanup, which could cause new cancellation-style failures or missed suggestion results if callers assume older operations still complete.
> 
> **Overview**
> Fixes `SuggestionsReader` resource/continuation leaks by **superseding in-flight navigation and fetch operations**: starting a new `navigateToSite`/fetch now resumes any previous `CheckedContinuation` with a new `operationSuperseded` error.
> 
> Strengthens teardown by explicitly removing the `ContentScopeUserScript` handler, clearing all user scripts/message handlers (where supported), and nulling `suggestionsUserScript` references (`webView`/`onChatsReceived`) before releasing the `WKWebView`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efefe06950f98b1c4946bac719b65198274c0f42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->