### PR TITLE
Use remotely releasable feature flag for webExtensions

### DIFF
--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -479,7 +479,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .autofillPartialFormSaves:
             return .remoteReleasable(.subfeature(AutofillSubfeature.partialFormSaves))
         case .webExtensions:
-            return .internalOnly()
+            return .remoteReleasable(.feature(.webExtensions))
         case .embeddedExtension:
             return .remoteReleasable(.subfeature(WebExtensionsSubfeature.embeddedExtension))
         case .syncSeamlessAccountSwitching:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203936086921904/task/1213455467693018?focus=true

### Description

### Testing Steps
- Verify that feature flag value is based on privacy config
- Ensure that for the current macOS override value (https://github.com/duckduckgo/privacy-configuration/blob/c254a046fd2e09b17c2c3c8e031010b7c78a1b5d/overrides/macos-override.json#L2229) the behaviour for enabling the web extension functionality only to internal users is retained 


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Low, configuration change.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `webExtensions` gate from internal-only to remote-config driven, so a privacy-config mistake could unintentionally enable/disable web extensions for broader users.
> 
> **Overview**
> Switches the `FeatureFlag.webExtensions` source from `.internalOnly()` to `.remoteReleasable(.feature(.webExtensions))`, making web extension enablement controlled by remote privacy configuration rather than being hard-limited to internal users.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76184ad345a1264afd6cc626b808e60fe70e8c2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->