### PR TITLE
[macOS] Fix flaky FreemiumDBP promotion coordinator test

### DIFF
--- a/macOS/UnitTests/Freemium/DBP/FreemiumDBPPromotionViewCoordinatorTests.swift
+++ b/macOS/UnitTests/Freemium/DBP/FreemiumDBPPromotionViewCoordinatorTests.swift
@@ -389,6 +389,7 @@ final class FreemiumDBPPromotionViewCoordinatorTests: XCTestCase {
         XCTAssertFalse(sut.isHomePagePromotionVisible)
     }
 
+    @MainActor
     func testViewModelRefreshes_whenContextualOnboardingCompletes() async throws {
         // Given
         mockUserStateManager.didDismissHomePagePromotion = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1213446946192552?focus=true
Tech Design URL:
CC:

### Description

Adds `@MainActor` to `testViewModelRefreshes_whenContextualOnboardingCompletes`, making it consistent with all other async tests in `FreemiumDBPPromotionViewCoordinatorTests`. Without this annotation, `sut` is created off the main actor, causing Combine's non-thread-safe `@Published` internals to race with GCD-dispatched events — resulting in lost signals and a 5-second timeout.

### Testing Steps
1. Green CI

### Impact and Risks

**None** — test-only change, one annotation added.

#### What could go wrong?
Nothing — this is purely a test execution context fix with no production code changes.

### Quality Considerations

N/A

### Notes to Reviewer

The previous fix (#3648) bumped the timeout from 1s → 5s, which didn't address the root cause. The issue is that `@Published` / Combine subscriptions are not thread-safe; all similar async tests in this file already have `@MainActor` to ensure everything runs on main. This was the only one missing it.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a `@MainActor` annotation to a single unit test to stabilize Combine/@Published timing; no production code changes.
> 
> **Overview**
> Fixes a flaky async unit test in `FreemiumDBPPromotionViewCoordinatorTests` by adding `@MainActor` to `testViewModelRefreshes_whenContextualOnboardingCompletes()` so the SUT and its Combine subscriptions run on the main actor.
> 
> This reduces race conditions that could drop `@Published` updates and cause timeouts during contextual onboarding completion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00a49bb72c9746d8a2122e49fc6556960d949704. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->