### PR TITLE
Revert "Remove legacy popup subfeature flags"

### DIFF
--- a/SharedPackages/BrowserServicesKit/Package.resolved
+++ b/SharedPackages/BrowserServicesKit/Package.resolved
@@ -55,6 +55,15 @@
       }
     },
     {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
+        "version" : "1.5.1"
+      }
+    },
+    {
       "identity" : "swift-clocks",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks.git",
@@ -77,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "ffca28be3c9c6a86a579949d23f68818a4b9b5d8",
-        "version" : "3.8.0"
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -606,6 +606,16 @@ public enum PopupBlockingSubfeature: String, PrivacySubfeature {
     }
 
     case createWebViewGatingFailsafe
+
+    /// Use extended user-initiated popup timeout (extends from 1s to 6s)
+    case extendedUserInitiatedPopupTimeout
+
+    /// Suppress empty or about: URL popups after permission approval
+    case suppressEmptyPopUpsOnApproval
+
+    /// Allow popups for current page after permission approval (until next navigation)
+    case allowPopupsForCurrentPage
+
 }
 
 public enum WebExtensionsSubfeature: String, PrivacySubfeature {

--- a/macOS/DuckDuckGo/Permissions/View/PermissionContextMenu.swift
+++ b/macOS/DuckDuckGo/Permissions/View/PermissionContextMenu.swift
@@ -155,7 +155,7 @@ final class PermissionContextMenu: NSMenu {
             }
 
             // Check if we should group empty/about URLs
-            let shouldGroupEmptyUrls = featureFlagger.isFeatureOn(.popupBlocking)
+            let shouldGroupEmptyUrls = featureFlagger.isFeatureOn(.popupBlocking) && featureFlagger.isFeatureOn(.suppressEmptyPopUpsOnApproval)
             let isEmptyUrl = query.url?.isEmpty ?? true || query.url?.navigationalScheme == .about
 
             if shouldGroupEmptyUrls && isEmptyUrl {
@@ -180,7 +180,7 @@ final class PermissionContextMenu: NSMenu {
 
             // Add temporary "Allow for this page" option for pop-ups
             if permission == .popups,
-               featureFlagger.isFeatureOn(.popupBlocking) {
+               featureFlagger.isFeatureOn(.popupBlocking) && featureFlagger.isFeatureOn(.allowPopupsForCurrentPage) {
                 addItem(.allowPopups(queries: emptyUrlPopupQueries, target: self, isChecked: hasTemporaryPopupAllowance && persistedValue == .ask))
             }
 

--- a/macOS/DuckDuckGo/Permissions/ViewModel/PermissionCenterViewModel.swift
+++ b/macOS/DuckDuckGo/Permissions/ViewModel/PermissionCenterViewModel.swift
@@ -172,7 +172,7 @@ final class PermissionCenterViewModel: ObservableObject {
 
     /// Whether "Only allow pop-ups for this visit" option should be shown (based on feature flags)
     var showAllowPopupsForThisVisitOption: Bool {
-        featureFlagger.isFeatureOn(.popupBlocking)
+        featureFlagger.isFeatureOn(.popupBlocking) && featureFlagger.isFeatureOn(.allowPopupsForCurrentPage)
     }
 
     // MARK: - Initialization

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PopupHandlingTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PopupHandlingTabExtension.swift
@@ -106,7 +106,8 @@ final class PopupHandlingTabExtension {
             .filter { event in
                 switch event {
                 case .mouseDown, .keyDown, .middleMouseDown:
-                    guard featureFlagger.isFeatureOn(.popupBlocking) else {
+                    guard featureFlagger.isFeatureOn(.popupBlocking),
+                          featureFlagger.isFeatureOn(.extendedUserInitiatedPopupTimeout) else {
                         return false
                     }
                     Logger.navigation.debug("PopupHandlingTabExtension.interactionEventsPublisher.filter: event: \(String(describing: event))")
@@ -233,7 +234,7 @@ final class PopupHandlingTabExtension {
         // Disable opening empty or `about:` URLs as the opened pop-ups would be non-functional
         // when opened asynchronously after the user has granted the permission.
         if !isCalledSynchronously,
-           featureFlagger.isFeatureOn(.popupBlocking),
+           featureFlagger.isFeatureOn(.popupBlocking), featureFlagger.isFeatureOn(.suppressEmptyPopUpsOnApproval),
            url?.isEmpty ?? true || url?.navigationalScheme == .about {
             Logger.navigation.info("handleCreateWebViewRequest: suppressing pop-up for `\(url?.absoluteString ??? "<nil>")`")
             self.popupsTemporarilyAllowedForCurrentPage = true
@@ -288,7 +289,9 @@ final class PopupHandlingTabExtension {
 
     /// Determines if a popup should be allowed bypassing the permission request:
     /// - If the navigation action is user-initiated (clicked link, etc.), allow the popup
-    /// - If the pop-ups are temporarily allowed for the current page with the "Only allow pop-ups for this visit" option selected
+    /// - If the pop-ups temporarily allowed for the current page with the "Only allow pop-ups for this visit" option selected:
+    ///   - Either for empty/about: URLs specifically with `suppressEmptyPopUpsOnApproval` feature flag enabled
+    ///   - OR for all URLs when `allowPopupsForCurrentPage` feature flag is enabled
     /// - If the initiating domain is allowlisted in the popupBlockingConfig
     /// - Otherwise, do not allow the popup
     /// ---
@@ -309,9 +312,16 @@ final class PopupHandlingTabExtension {
             }
         }
 
-        // Check if pop-ups temporarily allowed for the current page with the "Only allow pop-ups for this visit" option selected.
+        let url = navigationAction.request.url ?? .empty
+        // Check if pop-ups temporarily allowed for the current page with the "Only allow pop-ups for this visit" option selected:
+        // Either for empty/about: URLs specifically with `suppressEmptyPopUpsOnApproval` feature flag enabled,
+        // OR for all URLs when `allowPopupsForCurrentPage` feature flag is enabled
         if featureFlagger.isFeatureOn(.popupBlocking),
-           popupsTemporarilyAllowedForCurrentPage {
+           popupsTemporarilyAllowedForCurrentPage
+            && (
+                (featureFlagger.isFeatureOn(.suppressEmptyPopUpsOnApproval) && (url.isEmpty || url.navigationalScheme == .about))
+                || featureFlagger.isFeatureOn(.allowPopupsForCurrentPage)
+            ) {
             return .popupsTemporarilyAllowedForCurrentPage
         }
 
@@ -336,6 +346,7 @@ final class PopupHandlingTabExtension {
 
         // Check if enhanced popup blocking is enabled and configured properly
         guard featureFlagger.isFeatureOn(.popupBlocking),
+              featureFlagger.isFeatureOn(.extendedUserInitiatedPopupTimeout),
               threshold > 0 else {
             assert(threshold > 0, "userInitiatedPopupThreshold in macos-config must be positive")
             // Fall back to WebKit's basic user-initiated check (1s. user interaction timeout) if feature is disabled or misconfigured
@@ -435,7 +446,7 @@ extension PopupHandlingTabExtension: NavigationResponder {
         }()
 
         // Last interaction event that triggered the link activation (regular click, ⌘-click, middle-click, key press, etc.)
-        let userInteractionEvent = if featureFlagger.isFeatureOn(.popupBlocking) {
+        let userInteractionEvent = if featureFlagger.isFeatureOn(.popupBlocking), featureFlagger.isFeatureOn(.extendedUserInitiatedPopupTimeout) {
             lastUserInteractionEvent
         } else {
             NSApp.currentEvent

--- a/macOS/IntegrationTests/Tab/WindowOpenSecurityTests.swift
+++ b/macOS/IntegrationTests/Tab/WindowOpenSecurityTests.swift
@@ -99,7 +99,8 @@ final class WindowOpenSecurityTests: XCTestCase {
 
         let featureFlagger = MockFeatureFlagger()
         featureFlagger.featuresStub = [
-            FeatureFlag.popupBlocking.rawValue: true
+            FeatureFlag.popupBlocking.rawValue: true,
+            FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue: true
         ]
 
         tab = Tab(content: .none,

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -196,6 +196,18 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212017698257925?focus=true
     case popupBlocking
 
+    /// Use extended user-initiated popup timeout (extends from 1s to 6s)
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212001891093823?focus=true
+    case extendedUserInitiatedPopupTimeout
+
+    /// Suppress empty or about: URL popups after permission approval
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212017701300907?focus=true
+    case suppressEmptyPopUpsOnApproval
+
+    /// Allow all popups for current page after permission approval (until next navigation)
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212017701300913?focus=true
+    case allowPopupsForCurrentPage
+
     /// Web Notifications API polyfill - allows websites to show notifications via native macOS Notification Center
     /// https://app.asana.com/1/137249556945/project/414235014887631/task/1211395954816928?focus=true
     case webNotifications
@@ -291,6 +303,9 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .syncIdentities,
                 .dataImportNewSafariFilePicker,
                 .blurryAddressBarTahoeFix,
+                .allowPopupsForCurrentPage,
+                .extendedUserInitiatedPopupTimeout,
+                .suppressEmptyPopUpsOnApproval,
                 .dataImportWideEventMeasurement,
                 .firstTimeQuitSurvey,
                 .aiChatOmnibarOnboarding,
@@ -373,6 +388,9 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .blackFridayCampaign,
                 .allowProTierPurchase,
                 .popupBlocking,
+                .extendedUserInitiatedPopupTimeout,
+                .suppressEmptyPopUpsOnApproval,
+                .allowPopupsForCurrentPage,
                 .webNotifications,
                 .newPermissionView,
                 .firstTimeQuitSurvey,
@@ -520,6 +538,12 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(PrivacyProSubfeature.allowProTierPurchase))
         case .popupBlocking:
             return .remoteReleasable(.feature(.popupBlocking))
+        case .extendedUserInitiatedPopupTimeout:
+            return .remoteReleasable(.subfeature(PopupBlockingSubfeature.extendedUserInitiatedPopupTimeout))
+        case .suppressEmptyPopUpsOnApproval:
+            return .remoteReleasable(.subfeature(PopupBlockingSubfeature.suppressEmptyPopUpsOnApproval))
+        case .allowPopupsForCurrentPage:
+            return .remoteReleasable(.subfeature(PopupBlockingSubfeature.allowPopupsForCurrentPage))
         case .webNotifications:
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.webNotifications))
         case .newPermissionView:

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlagCategory.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlagCategory.swift
@@ -86,7 +86,10 @@ extension FeatureFlag: FeatureFlagCategorization {
                 .blackFridayCampaign,
                 .allowProTierPurchase:
             return .subscription
-        case .popupBlocking:
+        case .popupBlocking,
+                .extendedUserInitiatedPopupTimeout,
+                .suppressEmptyPopUpsOnApproval,
+                .allowPopupsForCurrentPage:
             return .popupBlocking
         case .webNotifications:
             return .webNotifications

--- a/macOS/UITests/NewPermissionViewTests.swift
+++ b/macOS/UITests/NewPermissionViewTests.swift
@@ -741,6 +741,9 @@ final class NewPermissionViewPopupTests: UITestCase {
             featureFlags: [
                 "newPermissionView": true,
                 "popupBlocking": true,
+                "extendedUserInitiatedPopupTimeout": true,
+                "suppressEmptyPopUpsOnApproval": true,
+                "allowPopupsForCurrentPage": true
             ]
         )
 

--- a/macOS/UITests/PopupHandlingUITests.swift
+++ b/macOS/UITests/PopupHandlingUITests.swift
@@ -52,6 +52,9 @@ final class PopupHandlingUITests: UITestCase {
             featureFlags: [
                 "newPermissionView": false, // Disabled until UI tests can handle the new permission view
                 "popupBlocking": true,
+                "extendedUserInitiatedPopupTimeout": true,
+                "suppressEmptyPopUpsOnApproval": true,
+                "allowPopupsForCurrentPage": true
             ]
         )
 

--- a/macOS/UnitTests/TabExtensionsTests/PopupHandlingTabExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/PopupHandlingTabExtensionTests.swift
@@ -123,6 +123,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testWhenUserInteractionPublisherEnabled_ThenMouseDownUpdatesLastInteractionTime() {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue] = true
         mockPopupBlockingConfig.userInitiatedPopupThreshold = 6.0
 
         let interactionTime: TimeInterval = 1000.0
@@ -162,6 +163,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testWhenUserInteractionPublisherEnabled_ThenKeyDownUpdatesLastInteractionTime() {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue] = true
         mockPopupBlockingConfig.userInitiatedPopupThreshold = 6.0
 
         let interactionTime: TimeInterval = 1000.0
@@ -201,6 +203,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testWhenUserInteractionPublisherEnabled_ThenMiddleMouseDownUpdatesLastInteractionTime() {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue] = true
         mockPopupBlockingConfig.userInitiatedPopupThreshold = 6.0
 
         let interactionTime: TimeInterval = 1000.0
@@ -239,7 +242,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     @MainActor
     func testWhenUserInteractionPublisherEnabled_ThenScrollWheelDoesNotUpdateLastInteractionTime() {
         // GIVEN
-        mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue] = true
         mockPopupBlockingConfig.userInitiatedPopupThreshold = 6.0
         popupHandlingExtension = createExtension()
 
@@ -278,7 +281,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     @MainActor
     func testWhenUserInteractionPublisherDisabled_ThenInteractionsDoNotUpdateLastInteractionTime() {
         // GIVEN
-        mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = false
+        mockFeatureFlagger.featuresStub[FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue] = false
         popupHandlingExtension = createExtension()
 
         // Set current mach absolute time
@@ -352,6 +355,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testWhenNoUserInteractionRecorded_ThenShouldRequirePermission() {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue] = true
         mockPopupBlockingConfig.userInitiatedPopupThreshold = 6.0
         popupHandlingExtension = createExtension()
 
@@ -370,9 +374,29 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     }
 
     @MainActor
+    func testWhenOnlyPopupBlockingEnabled_ThenFallsBackToWebKitUserInitiated() {
+        // GIVEN - Only popupBlocking on, extendedUserInitiatedPopupTimeout off
+        mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue] = false
+        popupHandlingExtension = createExtension()
+
+        // WHEN - navigationAction.isUserInitiated = true/false
+        let userInitiatedAction = WKNavigationAction.mock(url: URL(string: "https://popup.com")!, webView: self.webView, isUserInitiated: true)
+        let nonUserInitiatedAction = WKNavigationAction.mock(url: URL(string: "https://popup.com")!, webView: self.webView, isUserInitiated: false)
+
+        // THEN - Should use WebKit's isUserInitiated
+        let userInitiatedBypassReason = popupHandlingExtension.shouldAllowPopupBypassingPermissionRequest(for: userInitiatedAction, windowFeatures: windowFeatures)
+        XCTAssertEqual(userInitiatedBypassReason, .userInitiated(.webKitUserInitiated), "Expected userInitiated with webKitUserInitiated")
+
+        let nonUserInitiatedBypassReason = popupHandlingExtension.shouldAllowPopupBypassingPermissionRequest(for: nonUserInitiatedAction, windowFeatures: windowFeatures)
+        XCTAssertNil(nonUserInitiatedBypassReason, "Non-user-initiated should require permission")
+    }
+
+    @MainActor
     func testWhenBothFeaturesDisabled_ThenFallsBackToWebKitUserInitiated() {
         // GIVEN - Both features off
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = false
+        mockFeatureFlagger.featuresStub[FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue] = false
         popupHandlingExtension = createExtension()
 
         // WHEN - navigationAction.isUserInitiated = true/false
@@ -391,6 +415,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testWhenRecentUserInteraction_AndExtendedTimeoutEnabled_ThenShouldAllowPopupWithoutPermission() {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue] = true
         mockPopupBlockingConfig.userInitiatedPopupThreshold = 6.0
         popupHandlingExtension = createExtension()
 
@@ -431,6 +456,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testWhenOldUserInteraction_AndExtendedTimeoutEnabled_ThenShouldRequirePermission() {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue] = true
         mockPopupBlockingConfig.userInitiatedPopupThreshold = 6.0
         popupHandlingExtension = createExtension()
 
@@ -469,6 +495,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testWhenPopupApprovedAndSuppressEmptyUrlsEnabled_ThenEmptyUrlIsBlocked() {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.suppressEmptyPopUpsOnApproval.rawValue] = true
         popupHandlingExtension = createExtension()
 
         let queryAddedExpectation = expectation(description: "Permission query added")
@@ -503,12 +530,49 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
         wait(for: [permissionGrantedExpectation], timeout: 0.1)
     }
 
+    @MainActor
+    func testWhenPopupApprovedAndSuppressEmptyUrlsDisabled_ThenEmptyUrlIsAllowed() {
+        // GIVEN
+        mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.suppressEmptyPopUpsOnApproval.rawValue] = false
+        popupHandlingExtension = createExtension()
+
+        let queryAddedExpectation = expectation(description: "Permission query added")
+        let popupCreatedExpectation = expectation(description: "Popup created")
+
+        // Subscribe to permission query changes
+        mockPermissionModel.$authorizationQuery
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink { query in
+                queryAddedExpectation.fulfill()
+                // Grant permission when query is added (async to simulate real behavior)
+                self.mockPermissionModel.allow(query)
+            }
+            .store(in: &cancellables)
+
+        createChildTab = { _, _, _ in
+            popupCreatedExpectation.fulfill()
+            return nil
+        }
+
+        let navigationAction = WKNavigationAction.mock(url: .empty, webView: webView, isUserInitiated: false)
+
+        // WHEN
+        _ = popupHandlingExtension.createWebView(from: webView, with: configuration, for: navigationAction, windowFeatures: windowFeatures)
+
+        // THEN - Wait for query to be added, granted, and popup created
+        wait(for: [queryAddedExpectation, popupCreatedExpectation], timeout: 5.0)
+    }
+
     // MARK: - Allow Popups for Current Page Tests
 
     @MainActor
     func testWhenEmptyUrlPopupApproved_AndAllowPopupsForCurrentPageEnabled_ThenSubsequentEmptyUrlsAllowed() {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.suppressEmptyPopUpsOnApproval.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.allowPopupsForCurrentPage.rawValue] = true
         popupHandlingExtension = createExtension()
 
         let queryAddedExpectation = expectation(description: "Permission query added")
@@ -558,6 +622,8 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testWhenEmptyUrlPopupApproved_AndAllowPopupsForCurrentPageEnabled_ThenSubsequentAboutUrlsAllowed() {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.suppressEmptyPopUpsOnApproval.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.allowPopupsForCurrentPage.rawValue] = true
         popupHandlingExtension = createExtension()
 
         let queryAddedExpectation = expectation(description: "Permission query added")
@@ -607,6 +673,8 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testWhenEmptyUrlPopupApproved_AndAllowPopupsForCurrentPageEnabled_ThenCrossOriginPopupsAllowed() {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.suppressEmptyPopUpsOnApproval.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.allowPopupsForCurrentPage.rawValue] = true
         popupHandlingExtension = createExtension()
 
         let queryAddedExpectation = expectation(description: "Permission query added")
@@ -656,6 +724,8 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testWhenNavigationCommits_AndAllowPopupsForCurrentPageEnabled_ThenPopupAllowanceCleared() {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.suppressEmptyPopUpsOnApproval.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.allowPopupsForCurrentPage.rawValue] = true
         popupHandlingExtension = createExtension()
 
         let queryAddedExpectation = expectation(description: "Permission query added")
@@ -712,9 +782,11 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     }
 
     @MainActor
-    func testWhenTemporaryPopupAllowanceIsSet_ThenCrossOriginPopupsAreAllowed() {
+    func testWhenAllowPopupsForCurrentPageDisabled_ThenCrossOriginPopupsStillRequirePermission() {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.suppressEmptyPopUpsOnApproval.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.allowPopupsForCurrentPage.rawValue] = false
         popupHandlingExtension = createExtension()
 
         let queryAddedExpectation = expectation(description: "Permission query added")
@@ -749,14 +821,14 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
         // Wait for permission callback to complete (inverted expectation ensures tab wasn't created)
         wait(for: [permissionCallbackExpectation], timeout: 0.1)
 
-        // THEN - Empty/about URLs and cross-origin popups are temporarily allowed for the page
+        // THEN - Empty/about URLs still allowed, but cross-origin requires permission when feature disabled
         let emptyAction = WKNavigationAction.mock(url: .empty, webView: webView, isUserInitiated: false)
         let emptyBypassReason = popupHandlingExtension.shouldAllowPopupBypassingPermissionRequest(for: emptyAction, windowFeatures: windowFeatures)
         XCTAssertEqual(emptyBypassReason, .popupsTemporarilyAllowedForCurrentPage, "Expected popupsTemporarilyAllowedForCurrentPage for empty URL")
 
         let crossOriginAction = WKNavigationAction.mock(url: URL(string: "https://other-domain.com")!, webView: self.webView, isUserInitiated: false)
         let crossOriginBypassReason = popupHandlingExtension.shouldAllowPopupBypassingPermissionRequest(for: crossOriginAction, windowFeatures: windowFeatures)
-        XCTAssertEqual(crossOriginBypassReason, .popupsTemporarilyAllowedForCurrentPage, "Expected popupsTemporarilyAllowedForCurrentPage for cross-origin")
+        XCTAssertNil(crossOriginBypassReason, "Cross-origin popup should require permission when feature is disabled")
     }
 
     // MARK: - Multiple Consecutive Popup Tests
@@ -765,6 +837,8 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testWhenMultiplePopupsReceived_AndAllowForCurrentPageEnabled_ThenAllSubsequentPopupsAllowed() {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.suppressEmptyPopUpsOnApproval.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.allowPopupsForCurrentPage.rawValue] = true
         popupHandlingExtension = createExtension()
 
         let queryAddedExpectation = expectation(description: "Permission query added")
@@ -811,6 +885,8 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testWhenAboutBlankPopupApproved_ThenSuppressedAndSubsequentAllowed() {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.suppressEmptyPopUpsOnApproval.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.allowPopupsForCurrentPage.rawValue] = true
         popupHandlingExtension = createExtension()
 
         let queryAddedExpectation = expectation(description: "Permission query added")
@@ -850,9 +926,10 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     // MARK: - Temporary Allowance API Tests
 
     @MainActor
-    func testWhenTemporaryAllowanceSet_ThenTemporaryAllowanceWorksForAllPopupURLs() {
-        // GIVEN
-        mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+    func testWhenSuppressFeatureDisabled_ThenTemporaryAllowanceDoesNotWork() {
+        // GIVEN - suppressEmptyPopUpsOnApproval is OFF
+        mockFeatureFlagger.featuresStub[FeatureFlag.suppressEmptyPopUpsOnApproval.rawValue] = false
+        mockFeatureFlagger.featuresStub[FeatureFlag.allowPopupsForCurrentPage.rawValue] = true
         popupHandlingExtension = createExtension()
 
         // Manually set temporary allowance
@@ -863,18 +940,18 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
         let emptyAction = WKNavigationAction.mock(url: .empty, webView: webView, isUserInitiated: false)
         let regularAction = WKNavigationAction.mock(url: URL(string: "https://popup.com")!, webView: self.webView, isUserInitiated: false)
 
-        // THEN - Temporary allowance should work for both empty and regular URLs
+        // THEN - Temporary allowance should NOT work because suppressEmptyPopUpsOnApproval is OFF
         let emptyBypassReason = popupHandlingExtension.shouldAllowPopupBypassingPermissionRequest(for: emptyAction, windowFeatures: windowFeatures)
-        XCTAssertEqual(emptyBypassReason, .popupsTemporarilyAllowedForCurrentPage, "Expected popupsTemporarilyAllowedForCurrentPage for empty URL")
+        XCTAssertNil(emptyBypassReason, "Empty URL should require permission when suppress feature is off")
 
         let regularBypassReason = popupHandlingExtension.shouldAllowPopupBypassingPermissionRequest(for: regularAction, windowFeatures: windowFeatures)
-        XCTAssertEqual(regularBypassReason, .popupsTemporarilyAllowedForCurrentPage, "Expected popupsTemporarilyAllowedForCurrentPage for regular URL")
+        XCTAssertNil(regularBypassReason, "Regular URL should require permission when suppress feature is off")
     }
 
     @MainActor
     func testSetAndClearPopupAllowanceForCurrentPage() {
         // GIVEN
-        mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.allowPopupsForCurrentPage.rawValue] = true
         popupHandlingExtension = createExtension()
 
         XCTAssertFalse(popupHandlingExtension.popupsTemporarilyAllowedForCurrentPage, "Should start without allowance")
@@ -893,9 +970,9 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     }
 
     @MainActor
-    func testWhenTemporaryAllowanceSet_ThenWebKitUserInitiatedActionUsesTemporaryAllowanceBypassReason() {
+    func testWhenTemporaryAllowanceSet_ThenUserInitiatedStillWorks() {
         // GIVEN
-        mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.allowPopupsForCurrentPage.rawValue] = true
         popupHandlingExtension = createExtension()
         popupHandlingExtension.setPopupAllowanceForCurrentPage()
 
@@ -904,7 +981,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
 
         // THEN - Should still be allowed
         let userInitiatedBypassReason = popupHandlingExtension.shouldAllowPopupBypassingPermissionRequest(for: userInitiatedAction, windowFeatures: windowFeatures)
-        XCTAssertEqual(userInitiatedBypassReason, .popupsTemporarilyAllowedForCurrentPage, "Expected temporary allowance bypass reason")
+        XCTAssertEqual(userInitiatedBypassReason, .userInitiated(.webKitUserInitiated), "Expected userInitiated with webKitUserInitiated")
     }
 
     // MARK: - Edge Cases
@@ -913,6 +990,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testWhenTimeoutExactlyAtBoundary_ThenRequiresPermission() {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue] = true
         mockPopupBlockingConfig.userInitiatedPopupThreshold = 6.0
         popupHandlingExtension = createExtension()
 
@@ -944,7 +1022,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     @MainActor
     func testWhenAllowanceSetManually_AndNavigationOccurs_ThenAllowanceCleared() {
         // GIVEN
-        mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.allowPopupsForCurrentPage.rawValue] = true
         popupHandlingExtension = createExtension()
 
         popupHandlingExtension.setPopupAllowanceForCurrentPage()
@@ -956,6 +1034,37 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
 
         // THEN
         XCTAssertFalse(popupHandlingExtension.popupsTemporarilyAllowedForCurrentPage, "Allowance should be cleared on navigation")
+    }
+
+    @MainActor
+    func testWhenSuppressFeatureDisabled_ThenAboutBlankNotSuppressed() {
+        // GIVEN
+        mockFeatureFlagger.featuresStub[FeatureFlag.suppressEmptyPopUpsOnApproval.rawValue] = false
+        popupHandlingExtension = createExtension()
+
+        let queryAddedExpectation = expectation(description: "Permission query added")
+        let popupCreatedExpectation = expectation(description: "Popup created")
+
+        mockPermissionModel.$authorizationQuery
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink { query in
+                queryAddedExpectation.fulfill()
+                self.mockPermissionModel.allow(query)
+            }
+            .store(in: &cancellables)
+
+        createChildTab = { _, _, _ in
+            popupCreatedExpectation.fulfill()
+            return nil
+        }
+
+        // WHEN - about:blank popup
+        let aboutBlankAction = WKNavigationAction.mock(url: URL(string: "about:blank")!, webView: self.webView, isUserInitiated: false)
+        _ = popupHandlingExtension.createWebView(from: webView, with: configuration, for: aboutBlankAction, windowFeatures: windowFeatures)
+
+        // THEN - Should be created (not suppressed)
+        wait(for: [queryAddedExpectation, popupCreatedExpectation], timeout: 5.0)
     }
 
     // MARK: - Persisted Permission Tests
@@ -1058,6 +1167,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testWhenLinkOpenedInCurrentTab_ThenLastUserInteractionEventNotConsumed() async {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue] = true
         mockPopupBlockingConfig.userInitiatedPopupThreshold = 6.0
         popupHandlingExtension = createExtension()
 
@@ -1102,6 +1212,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testWhenLinkOpenedInNewTab_ThenLastUserInteractionEventConsumed() async {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue] = true
         mockPopupBlockingConfig.userInitiatedPopupThreshold = 6.0
         popupHandlingExtension = createExtension()
 
@@ -1150,6 +1261,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testWhenLinkMiddleClickedInNewTab_ThenLastUserInteractionEventConsumed() async {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue] = true
         mockPopupBlockingConfig.userInitiatedPopupThreshold = 6.0
         popupHandlingExtension = createExtension()
 
@@ -1197,7 +1309,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     @MainActor
     func testWhenPinnedTabNavigatesToAnotherDomain_ThenOpensInNewTab() async {
         // GIVEN - Tab is pinned
-        mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue] = true
         popupHandlingExtension = createExtension(isTabPinned: true)
 
         // WHEN - Navigate to different domain
@@ -1400,6 +1512,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testOnNewWindowCallback_ClearedAfterUse() async {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue] = true
         popupHandlingExtension = createExtension()
 
         let interactionTime: TimeInterval = 1000.0
@@ -1446,6 +1559,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testOnNewWindowCallback_OnlyMatchesCorrectURL() async {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue] = true
         popupHandlingExtension = createExtension()
 
         let interactionTime: TimeInterval = 1000.0
@@ -1492,6 +1606,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testOnNewWindowCallback_WithSwitchToNewTabDisabled() async {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue] = true
         popupHandlingExtension = createExtension(switchToNewTabWhenOpened: false)
 
         let interactionTime: TimeInterval = 1000.0
@@ -1533,6 +1648,7 @@ final class PopupHandlingTabExtensionTests: XCTestCase {
     func testOnNewWindowCallback_MiddleClickWithSwitchToNewTabDisabled() async {
         // GIVEN
         mockFeatureFlagger.featuresStub[FeatureFlag.popupBlocking.rawValue] = true
+        mockFeatureFlagger.featuresStub[FeatureFlag.extendedUserInitiatedPopupTimeout.rawValue] = true
         popupHandlingExtension = createExtension(switchToNewTabWhenOpened: false)
 
         let interactionTime: TimeInterval = 1000.0


### PR DESCRIPTION
Reverts duckduckgo/apple-browsers#3697
PIR E2E tests started failing on main this morning, and this was the first failure, so seeing if reverting helps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes popup permission handling and UI gating by splitting `popupBlocking` into multiple subfeature flags (some default-on), which can alter when popups are allowed/suppressed. Also updates crypto dependencies (`swift-crypto` bump and adds `swift-asn1`), which could impact build/runtime behavior indirectly.
> 
> **Overview**
> Restores *granular popup-blocking subfeature flags* by adding `extendedUserInitiatedPopupTimeout`, `suppressEmptyPopUpsOnApproval`, and `allowPopupsForCurrentPage` to both PrivacyConfig and the macOS `FeatureFlag` system, including default values and remote-releasable mappings.
> 
> Updates popup permission UX/logic to be gated by these new flags: the extended user-interaction timeout tracking only runs when enabled; empty/`about:` popups are only grouped/suppressed when `suppressEmptyPopUpsOnApproval` is on; and the “Allow pop-ups for this page/visit” option and bypass behavior now require `allowPopupsForCurrentPage`. Test suites are updated to enable the new flags and add coverage for the new gating/fallback paths.
> 
> Separately, bumps `swift-crypto` to `3.15.1` and adds `swift-asn1` to `BrowserServicesKit`’s resolved dependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64a17ded9acd8c83b3f0a4681f928fcb0e43eec8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->