### PR TITLE
Fix: Privacy Dashboard Popover Background

### DIFF
--- a/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardPopover.swift
+++ b/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardPopover.swift
@@ -113,6 +113,6 @@ extension PrivacyDashboardPopover: PrivacyDashboardViewControllerSizeDelegate {
 extension PrivacyDashboardPopover: ThemeUpdateListening {
 
     func applyThemeStyle(theme: ThemeStyleProviding) {
-        backgroundColor = theme.palette.surfaceCanvas
+        backgroundColor = theme.palette.surfaceSecondary
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1213348741034757
Tech Design URL:
CC:

### Description
In this PR we're updating the Privacy Dashboard's Popover Background, so that it matches the embedded HTML's background.

### Testing Steps
1. Launch the browser
2. Click on the Privacy Dashboard button

- [ ] Verify the popover (the top arrow) matches the content's background

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The incorrect color could be rendered

### Quality Considerations
None

### Notes to Reviewer
Thanks in advance!!

### Screenshots

Before | Now
-|-
<img width="413" height="195" alt="Before" src="https://github.com/user-attachments/assets/95154af7-b3f2-4667-a21d-72cab626d596" /> | <img width="414" height="207" alt="Now" src="https://github.com/user-attachments/assets/1d8f8073-439b-4100-b03d-d9d4127c22b9" />


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change: updates the popover background token used during theme application, with minimal chance of affecting behavior beyond appearance.
> 
> **Overview**
> Updates `PrivacyDashboardPopover` theming so the popover background uses `theme.palette.surfaceSecondary` instead of `surfaceCanvas`, aligning the popover (including the arrow) with the embedded dashboard content background.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdf91c7e484426333ba4c1816b2a68af9978bee1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->