### PR TITLE
Remove memoryPressureReporting feature flag

### DIFF
--- a/macOS/DuckDuckGo/AppHealth/MemoryPressureReporter.swift
+++ b/macOS/DuckDuckGo/AppHealth/MemoryPressureReporter.swift
@@ -16,11 +16,9 @@
 //  limitations under the License.
 //
 
-import Combine
 import Foundation
 import os.log
 import PixelKit
-import PrivacyConfig
 
 extension Notification.Name {
     static let memoryPressureCritical = Notification.Name("com.duckduckgo.macos.memoryPressure.critical")
@@ -54,7 +52,6 @@ enum MemoryPressurePixel: PixelKitEvent {
 ///
 final class MemoryPressureReporter {
 
-    private let featureFlagger: FeatureFlagger
     private let pixelFiring: PixelFiring?
     private let memoryUsageMonitor: MemoryUsageMonitoring
     private let windowContext: () -> WindowContext?
@@ -64,10 +61,8 @@ final class MemoryPressureReporter {
     private let logger: Logger?
     private let notificationCenter: NotificationCenter
     private var memoryPressureSource: DispatchSourceMemoryPressure?
-    private var cancellables: Set<AnyCancellable> = []
 
-    init(featureFlagger: FeatureFlagger,
-         pixelFiring: PixelFiring?,
+    init(pixelFiring: PixelFiring?,
          memoryUsageMonitor: MemoryUsageMonitoring,
          windowContext: @autoclosure @escaping () -> WindowContext?,
          isSyncEnabled: @escaping () -> Bool?,
@@ -75,7 +70,6 @@ final class MemoryPressureReporter {
          launchDate: Date = Date(),
          logger: Logger? = nil,
          notificationCenter: NotificationCenter = .default) {
-        self.featureFlagger = featureFlagger
         self.pixelFiring = pixelFiring
         self.memoryUsageMonitor = memoryUsageMonitor
         self.windowContext = windowContext
@@ -84,33 +78,15 @@ final class MemoryPressureReporter {
         self.launchDate = launchDate
         self.logger = logger
         self.notificationCenter = notificationCenter
-        subscribeToFeatureFlagUpdates()
+        startMonitoring()
     }
 
     deinit {
         stopMonitoring()
     }
 
-    private func subscribeToFeatureFlagUpdates() {
-        featureFlagger.updatesPublisher
-            .compactMap { [weak featureFlagger] in
-                featureFlagger?.isFeatureOn(.memoryPressureReporting)
-            }
-            .prepend(featureFlagger.isFeatureOn(.memoryPressureReporting))
-            .removeDuplicates()
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] isEnabled in
-                if isEnabled {
-                    self?.startMonitoring()
-                } else {
-                    self?.stopMonitoring()
-                }
-            }
-            .store(in: &cancellables)
-    }
-
-    func startMonitoring() {
-        guard memoryPressureSource == nil, featureFlagger.isFeatureOn(.memoryPressureReporting) else { return }
+    private func startMonitoring() {
+        guard memoryPressureSource == nil else { return }
 
         let source = DispatchSource.makeMemoryPressureSource(eventMask: .critical, queue: .main)
 
@@ -127,7 +103,7 @@ final class MemoryPressureReporter {
         logger?.warning("Memory pressure reporter started")
     }
 
-    func stopMonitoring() {
+    private func stopMonitoring() {
         memoryPressureSource?.cancel()
         memoryPressureSource = nil
         logger?.warning("Memory pressure reporter stopped")

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1117,7 +1117,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         webExtensionManagerHolder.appDelegate = self
 
         memoryPressureReporter = MemoryPressureReporter(
-            featureFlagger: featureFlagger,
             pixelFiring: PixelKit.shared,
             memoryUsageMonitor: memoryUsageMonitor,
             windowContext: WindowContext(windowControllersManager: windowControllersManager),

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -224,9 +224,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1201899738287924/task/1212437820560561?focus=true
     case memoryUsageMonitor
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212783502979551?focus=true
-    case memoryPressureReporting
-
     /// Memory Usage Reporting
     /// https://app.asana.com/1/137249556945/project/72649045549333/task/1212762049862432?focus=true
     case memoryUsageReporting
@@ -297,7 +294,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .autofillPasswordSearchPrioritizeDomain,
                 .warnBeforeQuit,
                 .wideEventPostEndpoint,
-                .memoryPressureReporting,
                 .crashCollectionDisableKeysSorting,
                 .crashCollectionLimitCallStackTreeDepth,
                 .memoryUsageReporting,
@@ -381,7 +377,6 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .warnBeforeQuit,
                 .dataImportWideEventMeasurement,
                 .memoryUsageMonitor,
-                .memoryPressureReporting,
                 .memoryUsageReporting,
                 .aiChatSync,
                 .heuristicAction,
@@ -536,8 +531,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             return .remoteReleasable(.subfeature(DataImportSubfeature.dataImportWideEventMeasurement))
         case .memoryUsageMonitor:
             return .disabled
-        case .memoryPressureReporting:
-            return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.memoryPressureReporting))
         case .memoryUsageReporting:
             return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.memoryUsageReporting))
         case .aiChatSync:

--- a/macOS/UnitTests/AppHealth/MemoryPressureReporterTests.swift
+++ b/macOS/UnitTests/AppHealth/MemoryPressureReporterTests.swift
@@ -16,8 +16,6 @@
 //  limitations under the License.
 //
 
-import Combine
-import PrivacyConfig
 import PixelKit
 import PixelKitTestingUtilities
 import XCTest
@@ -26,7 +24,6 @@ import XCTest
 final class MemoryPressureReporterTests: XCTestCase {
 
     private var sut: MemoryPressureReporter!
-    private var mockFeatureFlagger: MockFeatureFlagger!
     private var mockPixelFiring: PixelKitMock!
     private var mockMemoryUsageMonitor: MockPressureMemoryMonitor!
     private var mockAllocationStats: MockPressureAllocationStatsProvider!
@@ -34,7 +31,6 @@ final class MemoryPressureReporterTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockFeatureFlagger = MockFeatureFlagger()
         mockPixelFiring = PixelKitMock()
         mockMemoryUsageMonitor = MockPressureMemoryMonitor()
         mockAllocationStats = MockPressureAllocationStatsProvider()
@@ -43,7 +39,6 @@ final class MemoryPressureReporterTests: XCTestCase {
 
     override func tearDown() {
         sut = nil
-        mockFeatureFlagger = nil
         mockPixelFiring = nil
         mockMemoryUsageMonitor = nil
         mockAllocationStats = nil
@@ -55,7 +50,6 @@ final class MemoryPressureReporterTests: XCTestCase {
 
     private func makeSUT() -> MemoryPressureReporter {
         MemoryPressureReporter(
-            featureFlagger: mockFeatureFlagger,
             pixelFiring: mockPixelFiring,
             memoryUsageMonitor: mockMemoryUsageMonitor,
             windowContext: nil,
@@ -152,7 +146,6 @@ final class MemoryPressureReporterTests: XCTestCase {
     func testWhenCriticalEventProcessed_ThenPostsCriticalNotificationAndFiresCriticalPixel() {
         // Given
         mockMemoryUsageMonitor.currentPhysFootprintMB = 1024
-        mockFeatureFlagger.enabledFeatureFlags = [.memoryPressureReporting]
         sut = makeSUT()
 
         let notificationExpectation = expectation(forNotification: .memoryPressureCritical, object: nil, notificationCenter: notificationCenter) { notification in
@@ -173,7 +166,6 @@ final class MemoryPressureReporterTests: XCTestCase {
     func testWhenCriticalEventProcessed_ThenPixelIncludesContextParameters() {
         // Given
         mockMemoryUsageMonitor.currentPhysFootprintMB = 5000
-        mockFeatureFlagger.enabledFeatureFlags = [.memoryPressureReporting]
         sut = makeSUT()
 
         // When
@@ -192,7 +184,6 @@ final class MemoryPressureReporterTests: XCTestCase {
     @MainActor
     func testWhenNormalEventProcessed_ThenDoesNotPostNotificationsOrFirePixels() {
         // Given
-        mockFeatureFlagger.enabledFeatureFlags = [.memoryPressureReporting]
         sut = makeSUT()
 
         let criticalNotificationExpectation = expectation(forNotification: .memoryPressureCritical, object: nil, notificationCenter: notificationCenter, handler: nil)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201621708115095/task/1212783502979551?focus=true

### Description

Remove the `memoryPressureReporting` feature flag, leaving memory pressure reporting always enabled.

- Remove `FeatureFlagger` dependency from `MemoryPressureReporter` — monitoring now starts unconditionally on init.
- Remove `.memoryPressureReporting` case from `FeatureFlag` enum and all associated references.
- Clean up tests to remove feature flag setup.

### Testing Steps

1. Build and run the app.
2. Open Debug menu and trigger "Simulate Memory Pressure Critical" — verify it fires the pixel as before.
3. Run `MemoryPressureReporterTests` — all tests should pass.

### Impact and Risks

**Low** — Removes a feature flag for an already remotely-enabled feature. No behavior change for users.

#### What could go wrong?

Memory pressure monitoring could theoretically fail to start if the `init` flow changes, but this is unlikely given the straightforward initialization.

### Quality Considerations

- No edge cases — the feature was already enabled remotely with default value `true`.
- No performance impact — same monitoring logic, just without the feature flag check overhead.
- No privacy/security implications.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)