### PR TITLE
Fix assigning accessibility label to grid/list switch

### DIFF
--- a/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
+++ b/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
@@ -181,6 +181,7 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
         if let button = tabSwitcherStyleButton.customView as? BrowserChromeButton {
             button.setImage(tabsStyle.image)
         }
+        tabSwitcherStyleButton.accessibilityLabel = tabsStyle.accessibilityLabel
 
         // Configure edit button with menu
         if let button = editButton.customView as? BrowserChromeButton {
@@ -201,7 +202,6 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
         // Configure accessibility labels
         self.fireButton.accessibilityLabel = "Close all tabs and clear data"
         self.fireButton.accessibilityIdentifier = "Browser.Toolbar.Button.Fire"
-        self.tabSwitcherStyleButton.accessibilityLabel = "Toggle between grid and list view"
         self.duckChatButton.accessibilityLabel = UserText.duckAiFeatureName
         self.plusButton.accessibilityLabel = UserText.keyCommandNewTab
         self.doneButton.accessibilityLabel = UserText.navigationTitleDone


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1213478882664272?focus=true
Tech Design URL:
CC:

### Description

As in title.

### Testing Steps
1. Make sure E2E tabswitcher test pass now (https://github.com/duckduckgo/apple-browsers/actions/runs/22577144798)

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
None: Reverted to previous state 

#### What could go wrong?
Tested proper values are set with Accessibility Inspector

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, UI-only accessibility label change that just moves where the `tabSwitcherStyleButton` label is assigned. Main risk is limited to incorrect/absent VoiceOver text if `configureButtonActions` isn’t called in some paths.
> 
> **Overview**
> Fixes the grid/list tab switcher style button’s accessibility text by setting `tabSwitcherStyleButton.accessibilityLabel` dynamically from the current `tabsStyle` in `configureButtonActions`.
> 
> Removes the previously hardcoded label assignment from `configureButtons`, so the label now reflects the active style rather than a static “toggle” description.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92d1e8174ffafb18c3b8621c4918070ed4487c1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->