### PR TITLE
Use ForceDarkMode subfeature for incremental rollout

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -614,5 +614,5 @@ public enum WebExtensionsSubfeature: String, PrivacySubfeature {
 public enum ForceDarkModeOnWebsitesSubfeature: String, PrivacySubfeature {
     public var parent: PrivacyFeature { .forceDarkModeOnWebsites }
 
-    case iOSFeatureRollout
+    case featureRollout
 }

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -727,7 +727,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .embeddedExtension:
             return .remoteReleasable(.subfeature(WebExtensionsSubfeature.embeddedExtension))
         case .forceDarkModeOnWebsites:
-            return .remoteReleasable(.subfeature(ForceDarkModeOnWebsitesSubfeature.iOSFeatureRollout))
+            return .remoteReleasable(.subfeature(ForceDarkModeOnWebsitesSubfeature.featureRollout))
         case .autofillOnboardingExperiment:
             return .remoteReleasable(.subfeature(AutofillSubfeature.onboardingExperiment))
         case .supportsSyncChatsDeletion:


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1213433780673823?focus=true
Tech Design URL:
CC: @miasma13 

### Description

Create a subfeature for Force Dark Mode on websites to enable incremental rollout on iOS.

### Testing Steps
1. Override config with https://duckduckgo.github.io/privacy-configuration/pr-4639/v4/ios-config.json and validate the feature is enabled once applied

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Feature is enabled properly

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the remote flag source for `forceDarkModeOnWebsites` from a top-level feature key to a new subfeature key, which can cause the rollout to be incorrectly enabled/disabled if configs aren’t updated in sync.
> 
> **Overview**
> Switches iOS `forceDarkModeOnWebsites` feature gating to use a new privacy-config subfeature (`ForceDarkModeOnWebsitesSubfeature.featureRollout`) to support incremental rollout.
> 
> Adds the new subfeature definition in `PrivacyFeature.swift` and updates `FeatureFlag.source` to reference it instead of the top-level `.feature(.forceDarkModeOnWebsites)` key.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49e35c429b017a6bdf20e62b0ae6e75d70b4e60d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->