### PR TITLE
Subscription add/edit email fixed

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/ScriptRequestValidator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/ScriptRequestValidator.swift
@@ -33,12 +33,12 @@ public protocol ScriptRequestValidator {
     func canPageRequestToken(_ message: WKScriptMessage) async -> Bool
 }
 
-/// Default implementation of `ScriptRequestValidator` that validates token requests based on URL path and host verification.
+/// Default implementation of `ScriptRequestValidator` that validates token requests based on URL path prefix and host verification.
 ///
 /// This validator implements a multi-layer security check to ensure that only authorized subscription pages
 /// can request tokens. The validation process includes:
 /// - Main frame verification (prevents iframe attacks)
-/// - URL path validation against known subscription paths
+/// - URL path prefix validation (must be under `/subscriptions/` or `/identity-theft-restoration`)
 /// - Host matching against expected subscription domain
 /// - Security origin verification to prevent XSS attacks
 ///
@@ -46,10 +46,6 @@ public protocol ScriptRequestValidator {
 public struct DefaultScriptRequestValidator: ScriptRequestValidator {
 
     private let subscriptionManager: any SubscriptionManager
-
-    /// Set of all valid subscription URL paths that are authorized to request tokens.
-    /// Paths are dynamically retrieved from `SubscriptionURL.allSubscriptionPaths()`.
-    private var allValidPaths: Set<String> { SubscriptionURL.allSubscriptionPaths() }
 
     /// Creates a new validator with the specified subscription manager.
     ///
@@ -64,10 +60,9 @@ public struct DefaultScriptRequestValidator: ScriptRequestValidator {
     /// 1. Verifies the request comes from the main frame (not an iframe)
     /// 2. Extracts and validates the requesting page's URL and host
     /// 3. Verifies the URL uses HTTPS scheme (rejects HTTP and other protocols)
-    /// 4. Normalizes the URL path by filtering out empty and "/" components
-    /// 5. Checks if the path matches a known valid subscription path
-    /// 6. Verifies the host matches the expected subscription domain
-    /// 7. Confirms the security origin matches the host (prevents XSS)
+    /// 4. Checks if the path is under `/subscriptions/` or is `/identity-theft-restoration`
+    /// 5. Verifies the host matches the expected subscription domain
+    /// 6. Confirms the security origin matches the host (prevents XSS)
     ///
     /// - Parameter message: The script message containing the token request
     /// - Returns: `true` if all security checks pass and the request is authorized, `false` otherwise
@@ -86,12 +81,14 @@ public struct DefaultScriptRequestValidator: ScriptRequestValidator {
         // Verify the URL uses HTTPS to prevent token exposure over insecure connections
         guard webViewURL.scheme == "https" else { return false }
 
-        // Normalise the path by filtering out empty and "/" components, then joining
-        var path = webViewURL.pathComponents.filter { !$0.isEmpty && $0 != "/" }.joined(separator: "/")
-        path = path.hasPrefix("/") ? String(path.dropFirst()) : path
-
-        // Verify the path is a known valid subscription path
-        guard allValidPaths.contains(path) else { return false }
+        // Verify the path is under /subscriptions/ or is /identity-theft-restoration
+        let subscriptionsPath = subscriptionManager.url(for: .baseURL).path
+        let identityTheftRestorationPath = subscriptionManager.url(for: .identityTheftRestoration).path
+        guard webViewURL.path == subscriptionsPath
+                || webViewURL.path.hasPrefix("\(subscriptionsPath)/")
+                || webViewURL.path == identityTheftRestorationPath else {
+            return false
+        }
 
         // Verify the host matches the expected subscription domain
         let expectedHost = subscriptionManager.url(for: .baseURL).host

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL.swift
@@ -40,6 +40,8 @@ public enum SubscriptionURL: Equatable {
     case identityTheftRestoration
     case plans
     case upgradeToTier(String)
+    case addEmail
+    case addEmailSuccess
 
     public enum StaticURLs {
         public static let defaultBaseSubscriptionURL = URL(string: "https://duckduckgo.com/subscriptions")!
@@ -88,6 +90,10 @@ public enum SubscriptionURL: Equatable {
                 baseURL.appendingPathComponent("plans")
             case .upgradeToTier(let tier):
                 baseURL.appendingPathComponent("plans").appendingParameter(name: "tier", value: tier)
+            case .addEmail:
+                baseURL.appendingPathComponent("add-email")
+            case .addEmailSuccess:
+                baseURL.appendingPathComponent("add-email/success")
             }
         }()
 
@@ -107,39 +113,6 @@ public enum SubscriptionURL: Equatable {
         }
     }
 
-    /// Returns a set of all subscription URL paths for validating get token requests.
-    /// Paths are extracted from the enum cases, excluding external URLs that don't use the base subscription URL.
-    ///
-    /// Note: `.upgradeToTier` is not included separately as it uses the same path as `.plans`,
-    /// differing only by a query parameter (`tier=<value>`). Query parameters are not validated by path matching.
-    public static func allSubscriptionPaths() -> Set<String> {
-        let baseURL = StaticURLs.defaultBaseSubscriptionURL
-        let cases: [SubscriptionURL] = [
-            .baseURL,
-            .purchase,
-            .welcome,
-            .activationFlow,
-            .activationFlowThisDeviceEmailStep,
-            .activationFlowThisDeviceActivateEmailStep,
-            .activationFlowThisDeviceActivateEmailOTPStep,
-            .activationFlowAddEmailStep,
-            .activationFlowLinkViaEmailStep,
-            .activationFlowSuccess,
-            .manageEmail,
-            .identityTheftRestoration,
-            .plans
-        ]
-
-        return Set(cases.compactMap { urlCase -> String? in
-            let url = urlCase.subscriptionURL(environment: .production)
-            // Only include paths that are relative to the base subscription URL
-            guard url.host == baseURL.host else { return nil }
-
-            let path = url.path
-            // Remove leading slash if present
-            return path.hasPrefix("/") ? String(path.dropFirst()) : path
-        })
-    }
 }
 
 extension SubscriptionURL {

--- a/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionManagerMock.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/SubscriptionTestingUtilities/Managers/SubscriptionManagerMock.swift
@@ -74,7 +74,10 @@ public final class SubscriptionManagerMock: SubscriptionManager {
     public var subscriptionURL: SubscriptionURL?
     public func url(for type: SubscriptionURL) -> URL {
         subscriptionURL = type
-        return resultURL
+        if let resultURL {
+            return resultURL
+        }
+        return type.subscriptionURL(environment: currentEnvironment.serviceEnvironment)
     }
 
     public var urlForPurchaseFromRedirect: URL!

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/ScriptRequestValidatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/ScriptRequestValidatorTests.swift
@@ -33,7 +33,7 @@ final class ScriptRequestValidatorTests: XCTestCase {
     override func setUp() {
         super.setUp()
         subscriptionManager = SubscriptionManagerMock()
-        subscriptionManager.resultURL = validBaseURL
+        subscriptionManager.currentEnvironment = .init(serviceEnvironment: .production, purchasePlatform: .appStore)
         validator = DefaultScriptRequestValidator(subscriptionManager: subscriptionManager)
     }
 
@@ -67,21 +67,6 @@ final class ScriptRequestValidatorTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result, "Base URL path should be allowed")
-    }
-
-    func testCanPageRequestToken_AllValidPaths_ReturnTrue() async throws {
-        // Given
-        let validPaths = SubscriptionURL.allSubscriptionPaths()
-
-        // When/Then
-        for path in validPaths {
-            let urlString = path.isEmpty ? "https://duckduckgo.com/subscriptions" : "https://duckduckgo.com/\(path)"
-            let url = URL(string: urlString)!
-            let message = createMockMessage(url: url, isMainFrame: true, securityOriginHost: validHost)
-
-            let result = await validator.canPageRequestToken(message)
-            XCTAssertTrue(result, "Path '\(path)' should be allowed")
-        }
     }
 
     // MARK: - Main Frame Tests
@@ -165,14 +150,38 @@ final class ScriptRequestValidatorTests: XCTestCase {
 
     func testCanPageRequestToken_InvalidPath_ReturnsFalse() async throws {
         // Given
-        let url = URL(string: "https://duckduckgo.com/subscriptions/invalid-path")!
+        let url = URL(string: "https://duckduckgo.com/some-other-path")!
         let message = createMockMessage(url: url, isMainFrame: true, securityOriginHost: validHost)
 
         // When
         let result = await validator.canPageRequestToken(message)
 
         // Then
-        XCTAssertFalse(result, "Invalid paths should be rejected")
+        XCTAssertFalse(result, "Paths outside /subscriptions/ should be rejected")
+    }
+
+    func testCanPageRequestToken_UnknownSubscriptionSubpath_ReturnsTrue() async throws {
+        // Given - any path under /subscriptions/ should be allowed without needing explicit registration
+        let url = URL(string: "https://duckduckgo.com/subscriptions/future-feature")!
+        let message = createMockMessage(url: url, isMainFrame: true, securityOriginHost: validHost)
+
+        // When
+        let result = await validator.canPageRequestToken(message)
+
+        // Then
+        XCTAssertTrue(result, "Any path under /subscriptions/ should be allowed")
+    }
+
+    func testCanPageRequestToken_PathOutsideAllowedPrefixes_ReturnsFalse() async throws {
+        // Given
+        let url = URL(string: "https://duckduckgo.com/settings")!
+        let message = createMockMessage(url: url, isMainFrame: true, securityOriginHost: validHost)
+
+        // When
+        let result = await validator.canPageRequestToken(message)
+
+        // Then
+        XCTAssertFalse(result, "Paths outside allowed prefixes should be rejected")
     }
 
     func testCanPageRequestToken_PathWithTrailingSlash_HandledCorrectly() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
@@ -55,6 +55,8 @@ final class SubscriptionURLTests: XCTestCase {
                                               .manageEmail,
                                               .identityTheftRestoration,
                                               .plans,
+                                              .addEmail,
+                                              .addEmailSuccess,
                                               .upgradeToTier("pro")]
 
         for urlType in allURLTypes {
@@ -78,6 +80,8 @@ final class SubscriptionURLTests: XCTestCase {
                                               .manageEmail,
                                               .identityTheftRestoration,
                                               .plans,
+                                              .addEmail,
+                                              .addEmailSuccess,
                                               .upgradeToTier("pro")]
 
         for urlType in allURLTypes {

--- a/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
+++ b/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
@@ -300,15 +300,12 @@ final class SubscriptionFlowViewModel: ObservableObject {
         !isCurrentURL(matching: .plans) &&
         !isCurrentURL(matching: .welcome) &&
         !isCurrentURL(matching: .activationFlowSuccess) &&
-        !isCurrentURL(matching: subscriptionManager.url(for: .baseURL).appendingPathComponent("add-email/success"))
+        !isCurrentURL(matching: subscriptionManager.url(for: .addEmailSuccess))
     }
 
     private func isCurrentURLMatchingPostPurchaseAddEmailFlow() -> Bool {
-        // Not defined in SubscriptionURL as this flow is only triggered by FE as a part of post purchase flow. Only need for comparison.
-        let baseURL = subscriptionManager.url(for: .baseURL)
-        let addEmailURL = baseURL.appendingPathComponent("add-email")
-        let addEmailSuccessURL = baseURL.appendingPathComponent("add-email/success")
-
+        let addEmailURL = subscriptionManager.url(for: .addEmail)
+        let addEmailSuccessURL = subscriptionManager.url(for: .addEmailSuccess)
         return isCurrentURL(matching: addEmailURL) || isCurrentURL(matching: addEmailSuccessURL)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1213423295137700/comment/1213493909180863?focus=true

### Description

Fix for a subscription bug that stops our user from adding and editing an email to the Subscription.

### Testing Steps
1. Restore a subscription
2. Add another email
3. Edit the email

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subscription token-request validation logic, widening allowed paths to a prefix match; mistakes here could unintentionally permit token access from more pages on the subscription host.
> 
> **Overview**
> Relaxes `DefaultScriptRequestValidator` path checks from an allowlisted set of exact subscription paths to allowing any URL under the base `/subscriptions` path (plus the `/identity-theft-restoration` path), and removes the now-unused `SubscriptionURL.allSubscriptionPaths()` helper.
> 
> Adds explicit `SubscriptionURL` cases for the add-email flow (`.addEmail`, `.addEmailSuccess`) and updates `SubscriptionFlowViewModel` to use these canonical URLs instead of hard-coded path appends. Test utilities and unit tests are updated to reflect the new URL cases and the new prefix-based validation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e691183c6c8bedf11e492417fa3ed0f754e66978. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->