### PR TITLE
Remove orphaned swiftlint:enable force_try comment

### DIFF
--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
@@ -262,5 +262,3 @@ struct MockDarkReaderFeatureSettings: DarkReaderFeatureSettings {
     func setForceDarkModeEnabled(_ enabled: Bool) {}
     func themeDidChange() {}
 }
-
-// swiftlint:enable force_try


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1213507740266462?focus=true
Tech Design URL:
CC:

### Description
The merge commit 7d7e99aa10 re-introduced the swiftlint:enable directive from the release branch but the corresponding swiftlint:disable had already been removed in #3695.


### Testing Steps
1. CI is green