### PR TITLE
Switch from internalOnly to remoteReleasable for the iOS .webExtensions feature flag

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -723,7 +723,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .onboardingRebranding:
             return .disabled
         case .webExtensions:
-            return .internalOnly()
+            return .remoteReleasable(.feature(.webExtensions))
         case .embeddedExtension:
             return .remoteReleasable(.subfeature(WebExtensionsSubfeature.embeddedExtension))
         case .forceDarkModeOnWebsites:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1163321984198618/task/1213537037615830
Tech Design URL:
CC:

### Description
Switch from internalOnly to remoteReleasable for the iOS .webExtensions feature flag

### Testing Steps
Double check feature flags and privacy configuration.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Internal feature remote releasable setup.


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes rollout control for the `webExtensions` capability from internal-only to remotely configurable, increasing the chance of wider enablement if misconfigured. Risk depends on downstream readiness/security/perf of the feature when toggled on for more users.
> 
> **Overview**
> Switches the `FeatureFlag.webExtensions` source from `internalOnly()` to `remoteReleasable(.feature(.webExtensions))`, allowing the Web Extensions feature to be enabled/disabled via remote Privacy Config rollout controls rather than being limited to internal builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8d11a3598e386e910dcc2c57e455117cc602e87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->