### PR TITLE
[iOS] Hide bubble tail from onboarding dialogs

### DIFF
--- a/SharedPackages/Onboarding/Sources/Onboarding/Rebranding/Shared/OnboardingBubbleView.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Rebranding/Shared/OnboardingBubbleView.swift
@@ -70,7 +70,7 @@ public extension OnboardingBubbleView {
 
     #if os(iOS)
     static func withStepProgressIndicator(
-        tailPosition: TailPosition,
+        tailPosition: TailPosition? = nil,
         currentStep: Int,
         totalSteps: Int,
         isVisible: Bool = true,
@@ -99,7 +99,7 @@ public extension OnboardingBubbleView {
 private struct LinearBubbleWrapper<Content: View>: View {
     @Environment(\.onboardingTheme) private var onboardingTheme
 
-    let tailPosition: OnboardingBubbleView<Content>.TailPosition
+    let tailPosition: OnboardingBubbleView<Content>.TailPosition?
     let content: () -> Content
 
     var body: some View {
@@ -107,8 +107,8 @@ private struct LinearBubbleWrapper<Content: View>: View {
         OnboardingBubbleView(
             tailPosition: tailPosition,
             contentInsets: metrics.contentInsets,
-            arrowLength: metrics.arrowLength,
-            arrowWidth: metrics.arrowWidth,
+            arrowLength: tailPosition != nil ? metrics.arrowLength : nil,
+            arrowWidth: tailPosition != nil ? metrics.arrowWidth : nil,
             content: content
         )
     }

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
@@ -337,17 +337,9 @@ extension OnboardingRebranding {
             stepInfo: ViewState.Intro.StepInfo,
             @ViewBuilder content: @escaping () -> Content
         ) -> some View {
-            let tailPosition: OnboardingBubbleView<Content>.TailPosition = switch configuration.tailDirection {
-            case .leading:
-                .bottom(offset: configuration.tailOffset, direction: .leading)
-            case .trailing:
-                .bottom(offset: configuration.tailOffset, direction: .trailing)
-            }
-
             // Always use withStepProgressIndicator to maintain consistent view identity
             // Use isVisible to control whether the counter is shown
             OnboardingBubbleView.withStepProgressIndicator(
-                tailPosition: tailPosition,
                 currentStep: stepInfo.currentStep,
                 totalSteps: stepInfo.totalSteps,
                 isVisible: configuration.showsStepCounter


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205842942115003/task/1213535203310590

### Description

Makes `TailPosition` optional (defaulting to `nil`) in `withStepProgressIndicator` helper method and removes tail position computation from `RebrandedOnboardingView.makeBubbleView`, so linear onboarding speech bubbles no longer show a tail/arrow.

Fixes `LinearBubbleWrapper` to not override arrow dimensions with theme metrics when `tailPosition` is `nil`, ensuring the tail is fully hidden.

### Testing Steps

1. Run the app on an iPhone simulator
2. Go through the linear onboarding flow and verify speech bubbles have no tail/arrow
3. Verify contextual onboarding bubbles still display correctly (they use `withDismissButton` which is unaffected)
4. Verify the step progress indicator still renders correctly on speech bubbles

### Impact and Risks

Low: Minor visual change to onboarding speech bubbles.

#### What could go wrong?

Bubble layout could shift slightly due to removed arrow space, but `TailConfig(position: nil)` sets arrow dimensions to zero which is already handled by `BubbleView`.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change to onboarding bubble rendering; main risk is minor layout/padding shifts due to removing arrow space.
> 
> **Overview**
> Linear onboarding dialog bubbles no longer show a tail/arrow by default: `OnboardingBubbleView.withStepProgressIndicator` now accepts an optional `tailPosition` (default `nil`), and `RebrandedOnboardingView.makeBubbleView` stops computing/passing a tail position.
> 
> `LinearBubbleWrapper` is updated to only apply theme arrow dimensions when a tail is present, ensuring `tailPosition == nil` fully hides the arrow while keeping the step progress indicator behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b4ace47bd7f194097e9f4e070e0a931b2037027. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->