### PR TITLE
[iOS] Add unified_toggle_input tests to nightly e2e CI (iPhone only)

### DIFF
--- a/.github/workflows/ios_end_to_end.yml
+++ b/.github/workflows/ios_end_to_end.yml
@@ -135,7 +135,11 @@ jobs:
             device-model: iPhone-16
           - test-tag: device_info
             exclude-tags: ipad
-            device-model: iPhone-16 
+            device-model: iPhone-16
+          - test-tag: unified_toggle_input
+            exclude-tags: ipad
+            device-model: iPhone-16
+            device-name: iPhone
           # iPad tests - only tests tagged with 'ipad', exclude iPhone specific tests
           - test-tag: device_info
             exclude-tags: iphone


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1213536460091785?focus=true
Tech Design URL:
CC:

### Description

Adds `unified_toggle_input` as an iPhone-only matrix entry in the nightly e2e CI workflow. The `test_ai_chat_tab_header` test was failing when run on iPad because the unified toggle input feature is not available on iPad. No iPad entry is added; the `iphone` tag on the tests provides a secondary guard.

### Testing Steps
1. Merge this PR
2. On the next nightly run, confirm the `unified_toggle_input` matrix job runs on iPhone-16 and passes
3. Confirm no `unified_toggle_input` job runs on iPad

### Impact and Risks

**None** — CI workflow change only, no app code affected.

#### What could go wrong?
- The new job adds slightly to nightly run time (one extra Maestro Cloud job)

### Quality Considerations

N/A — CI-only change.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the GitHub Actions E2E workflow matrix and only add one additional iPhone-only Maestro Cloud job, with no app/runtime logic changes.
> 
> **Overview**
> Adds `unified_toggle_input` to the nightly iOS end-to-end CI matrix in `.github/workflows/ios_end_to_end.yml`, running it on `iPhone-16` (and explicitly excluding iPad-tagged tests).
> 
> This effectively introduces one new iPhone-only Maestro Cloud run and avoids scheduling an iPad variant for that tag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 347fe82c88f7a6ea2860a7a89126c5056ea068dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->