### PR TITLE
Disable left side icon on iPad toggle

### DIFF
--- a/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
@@ -66,6 +66,7 @@ final class DefaultOmniBarSearchView: UIView {
     }
 
     private let mainStackView = UIStackView()
+    private var mainStackLeadingConstraint: NSLayoutConstraint?
 
     init() {
         super.init(frame: .zero)
@@ -131,8 +132,11 @@ final class DefaultOmniBarSearchView: UIView {
         modeToggleContainer.translatesAutoresizingMaskIntoConstraints = false
         modeToggleView.translatesAutoresizingMaskIntoConstraints = false
 
+        let leadingConstraint = mainStackView.leadingAnchor.constraint(equalTo: leadingAnchor)
+        mainStackLeadingConstraint = leadingConstraint
+
         NSLayoutConstraint.activate([
-            mainStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            leadingConstraint,
             mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
             mainStackView.topAnchor.constraint(equalTo: topAnchor),
             mainStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
@@ -220,5 +224,10 @@ final class DefaultOmniBarSearchView: UIView {
         customIconView.contentMode = .center
         customIconView.isHidden = true
         customIconView.image = nil
+    }
+
+    func setLeftIconAreaHidden(_ hidden: Bool) {
+        leftIconContainerPlaceholder.isHidden = hidden
+        mainStackLeadingConstraint?.constant = hidden ? 16 : 0
     }
 }

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -1085,6 +1085,10 @@ extension DefaultOmniBarView {
         }
     }
 
+    func setLeftIconHiddenForModeToggle(_ hidden: Bool) {
+        searchAreaView.setLeftIconAreaHidden(hidden)
+    }
+
     private func applyExpansionConstraints() {
         if isSearchAreaExpanded {
             searchStackBottomEqualConstraint?.isActive = false

--- a/iOS/DuckDuckGo/OmniBarView.swift
+++ b/iOS/DuckDuckGo/OmniBarView.swift
@@ -108,6 +108,7 @@ protocol ExpandableOmniBarView: OmniBarView {
     func updateTextFieldPlaceholderVisibility(hasText: Bool)
     func updateAIChatSendButton(hasText: Bool)
     func updateLeftIconForMode(_ mode: TextEntryMode)
+    func setLeftIconHiddenForModeToggle(_ hidden: Bool)
 }
 
 protocol OmniBarStatusUpdateable: AnyObject {

--- a/iOS/DuckDuckGo/OmniBarViewController.swift
+++ b/iOS/DuckDuckGo/OmniBarViewController.swift
@@ -705,6 +705,7 @@ class OmniBarViewController: UIViewController, OmniBar {
             expandable.setSearchAreaExpanded(shouldExpand, animated: false)
 
             expandable.updateLeftIconForMode(shouldShowModeToggle ? selectedTextEntryMode : .search)
+            expandable.setLeftIconHiddenForModeToggle(shouldShowModeToggle && isAddressBarSelected)
         }
 
         if dependencies.aiChatAddressBarExperience.isIPadAIToggleExperienceEnabled == false {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211654189969294/task/1213532506662096?focus=true

### Description
When the iPad AI toggle feature flag is enabled and the address bar is selected, the left icon (search loupe / dismiss arrow) is now hidden in both search and duck.ai modes. The text field expands into the reclaimed space with 16pt leading padding to keep it clear of the rounded container edge.

### Testing Steps
  1. On iPad with the iPadAIToggle feature flag enabled, tap the address bar and verify the left icon disappears and the text field extends to the
  left with padding.
  2. Tap away to deselect the address bar and verify the left icon reappears in its normal position.
  3. Toggle between search and duck.ai modes while editing — confirm the left icon stays hidden in both modes.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Icon being displayed when it shouldn't 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout change limited to the iPad AI mode-toggle editing state; main risk is unintended spacing/constraint behavior (e.g., 16pt inset) affecting alignment in edge cases.
> 
> **Overview**
> When the iPad AI mode toggle is shown while the address bar is selected, the omnibar now **hides the entire left icon area** (loupe/dismiss) and reclaims that space for the text field.
> 
> This adds a stored leading constraint on the search view’s main stack so the layout can shift to a **16pt leading inset** when the left icon area is hidden, wires the behavior through `ExpandableOmniBarView` (`setLeftIconHiddenForModeToggle`), and applies it from `OmniBarViewController` alongside existing mode-toggle/expansion updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f1abbb29e8a89a65a4d44b83e760a4853104f47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->