### PR TITLE
Fix address bar focus ring when activating window via URL click

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -924,7 +924,7 @@ final class AddressBarViewController: NSViewController {
         self.clickPoint = nil
         guard let window = self.view.window, event.window === window, window.sheets.isEmpty else { return event }
 
-        if beginDraggingSessionIfNeeded(with: event, in: window) {
+        if window.isKeyWindow, beginDraggingSessionIfNeeded(with: event, in: window) {
             return nil
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1213533651570167?focus=true

### Description

When clicking on the address bar URL text to activate an inactive window, the focus ring wouldn't appear and hover events would stop working. This was caused by `beginDraggingSessionIfNeeded` entering a blocking `nextEvent` loop (for drag detection) before the window had a chance to activate, interfering with the normal window activation and first responder flow.

The fix skips drag detection when the window isn't key. Dragging a URL from an inactive window isn't a realistic user interaction, so there's no functional loss.

### Testing Steps
Verify that [this UI tests workflow](https://github.com/duckduckgo/apple-browsers/actions/runs/22676274775) passes.

1. Open a browser window and navigate to any URL
2. Deactivate the window (click on another app or another browser window)
3. Click precisely on the URL text in the address bar of the inactive window
4. Verify the focus ring (orange border) appears around the address bar
5. Verify hover events work (move mouse over UI elements and confirm hover states)
6. Also verify that dragging the URL from the address bar still works when the window is already active

### Impact and Risks

Low — Minor interaction fix affecting only the address bar focus behavior during window activation.

#### What could go wrong?

Drag-from-address-bar could fail in an edge case where the window is somehow not key but the user expects to drag. This is unlikely since the window must be active for meaningful interaction.

### Quality Considerations

- The fix is a single guard condition added to an existing code path
- No new state or logic introduced
- Drag functionality is preserved for the normal (window-is-active) case

### Notes to Reviewer

N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-condition change to mouse handling that only affects URL drag initiation when the window is not key. Main risk is an edge case where users expect to drag from a non-key window, which is unlikely.
> 
> **Overview**
> Fixes an address bar activation issue by **skipping `beginDraggingSessionIfNeeded` drag-detection when the window is not key**.
> 
> This prevents the drag detection loop from running during initial window activation (e.g., clicking URL text in an inactive window), allowing the normal first-responder/focus-ring and hover behavior to proceed, while preserving drag-from-address-bar when the window is already active.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d13aeadc5cf0af39a39c4929627d01f297530e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->