### PR TITLE
Set duck.ai toggle on if user skips onboarding

### DIFF
--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
@@ -160,6 +160,7 @@ final class OnboardingIntroViewModel: ObservableObject {
 
     func confirmSkipOnboardingAction() {
         pixelReporter.measureConfirmSkipOnboardingCTAAction()
+        onboardingSearchExperienceProvider.storeAIChatSearchInputDuringOnboardingChoice(enable: true)
         contextualDaxDialogs.disableContextualDaxDialogs()
         onCompletingOnboardingIntro?()
     }

--- a/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -505,6 +505,20 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         XCTAssertTrue(pixelReporterMock.didCallMeasureConfirmSkipOnboardingCTAAction)
     }
 
+    func testWhenConfirmSkipOnboardingActionIsCalledThenAIChatSearchInputChoiceIsStoredAsEnabled() {
+        // GIVEN
+        let mockSearchExperienceProvider = MockOnboardingSearchExperienceProvider()
+        let sut = makeSUT(currentOnboardingStep: .introDialog(isReturningUser: true), onboardingSearchExperienceProvider: mockSearchExperienceProvider)
+        XCTAssertFalse(mockSearchExperienceProvider.storeAIChatSearchInputDuringOnboardingChoiceCalled)
+
+        // WHEN
+        sut.confirmSkipOnboardingAction()
+
+        // THEN
+        XCTAssertTrue(mockSearchExperienceProvider.storeAIChatSearchInputDuringOnboardingChoiceCalled)
+        XCTAssertEqual(mockSearchExperienceProvider.lastStoredValue, true)
+    }
+
     func testWhenStartOnboardingActionResumingTrueIsCalledThenPixelReporterMeasureResumeOnboardingCTA() {
         // GIVEN
         onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedIPhoneSteps(isReturningUser: true)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1213539375189611?focus=true

### Description
Set duck.ai toggle on if user skips onboarding

### Testing Steps
  1. Reset onboarding state so onboarding appears as a returning user (with the skip option), then skip onboarding and verify that Settings → AI  Features → Toggle on Address Bar is set to "Search and Duck.ai".
  2. Don't skip the onboarding, select the option without the duck.ai toggle during onboarding, see if it works
  3. Don't skip the onboarding, select the option with the duck.ai toggle during onboarding, see if it works after the onboarding is completed

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Regression on onboarding


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single onboarding skip path now persists an AI chat search-input preference, plus a focused unit test. Main risk is unintended defaulting for returning users who skip onboarding.
> 
> **Overview**
> Confirming *Skip onboarding* now explicitly stores the onboarding search-experience preference with `storeAIChatSearchInputDuringOnboardingChoice(enable: true)`, effectively turning on the duck.ai address-bar option for users who skip the flow.
> 
> Adds a unit test in `OnboardingIntroViewModelTests` to assert the preference is persisted when `confirmSkipOnboardingAction()` is invoked.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe187561c59987a3ae27805565e7537b3f221448. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->