### PR TITLE
[iOS][Onboarding Rebranding] Fix background covered by bottom Address Bar

### DIFF
--- a/SharedPackages/Onboarding/Sources/Onboarding/Rebranding/Shared/Styles/RebrandedOnboardingStyles+Background.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Rebranding/Shared/Styles/RebrandedOnboardingStyles+Background.swift
@@ -98,7 +98,7 @@ extension OnboardingRebranding.OnboardingStyles {
 
         #if os(iOS)
         private static let maxHeightMetricsBuilder = MetricBuilder<CGFloat?>(default: nil).iPad(200).iPhone(landscape: 200)
-        // iPhone excludes .bottom to prevent background from being covered by keyboard when address bar is at bottom position
+        // iPhone excludes .bottom to prevent background from being covered by the address bar when it is positioned at the bottom
         private static let ignoreSafeAreaEdgesBuilder = MetricBuilder<Edge.Set>(default: [.horizontal]).iPad([.bottom, .horizontal])
         #endif
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213334696655103
Tech Design URL:
CC:

### Description

Fixes an iOS visual bug where the onboarding background was being covered by the address bar when positioned at the bottom on iPhone. The background now correctly respects the safe area for iPhone devices while maintaining the existing behavior on iPad.

### Testing Steps
1. Fresh install
2. During linear onboarding select bottom address bar
3. Ensure that the background for Dax dialogs in new tab page is not covered and follows the keyboard.
4. On iPad, verify the background behavior remains unchanged (still ignores bottom safe area).

Alternative way to test it:
1. On iPhone, go to Settings → Appearance → Address Bar Position
2. Switch to "Bottom” position.
3. Reset Contextual Dax dialogs in Debug Menu -> Onboarding.
4. Verify the background gradient is fully visible and not covered by the address bar.
5. Switch address bar back to "Top” position.
6. Verify background still displays correctly.

### Impact and Risks
 Low: Minor visual fix for onboarding UI on iPhone

#### What could go wrong?
- The background could potentially appear incorrectly on different device sizes or orientations

### Quality Considerations
- Edge cases: Tested with both top and bottom address bar positions
- Device compatibility: Uses responsive metrics via MetricBuilder to handle iPhone vs iPad differences

### Notes to Reviewer
Still a partial issue on iPhone SE. When the keyboard comes up the background is covered but it works fine on other devices.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts `ignoresSafeArea` behavior based on device class; potential regressions are limited to background layout on specific iPhone sizes/orientations.
> 
> **Overview**
> Prevents contextual onboarding background illustrations from being obscured by the iPhone bottom address bar by no longer ignoring the `.bottom` safe area on iPhone.
> 
> Introduces a responsive `ignoresSafeAreaEdges` setting (via `MetricBuilder`) so iPad keeps the previous behavior of ignoring `.bottom` while iPhone defaults to only ignoring `.horizontal`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62e6cf50481cbe708d4d26b5260be487062157ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->