### PR TITLE
fix Omnibar Dax logo bug

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
@@ -76,6 +76,10 @@ final class SuggestionTrayManager: NSObject {
         return !shouldDisplaySuggestionTray && (canDisplayFavorites || hasRemoteMessages)
     }
 
+    var hasFavorites: Bool {
+        suggestionTrayViewController?.hasFavorites ?? false
+    }
+
     var shouldDisplaySuggestionTray: Bool {
         let query = switchBarHandler.currentText
         // No text so don't show suggestins

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -546,8 +546,8 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
         let isHorizontallyCompactLayoutEnabled = requiresHorizontallyCompactLayout(for: view.bounds.size)
         let isShowingChatHistory = aiChatHistoryManager?.hasSuggestions == true
 
-        let hasEscapeHatch = escapeHatchModel != nil
-        let isHomeDaxVisible = !shouldDisplaySuggestionTray && (!shouldDisplayFavoritesOverlay || hasEscapeHatch) && !isHorizontallyCompactLayoutEnabled
+        let hasEscapeHatchWithoutFavorites = escapeHatchModel != nil && !(suggestionTrayManager?.hasFavorites ?? false)
+        let isHomeDaxVisible = !shouldDisplaySuggestionTray && (!shouldDisplayFavoritesOverlay || hasEscapeHatchWithoutFavorites) && !isHorizontallyCompactLayoutEnabled
 
         let isAIDaxVisible: Bool
         if switchBarHandler.isUsingFadeOutAnimation {
@@ -559,6 +559,7 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
         daxLogoManager.updateVisibility(isHomeDaxVisible: isHomeDaxVisible, isAIDaxVisible: isAIDaxVisible)
         daxLogoManager.setEscapeHatchBaseOffset(escapeHatchModel != nil ? Constants.escapeHatchLogoZoneHeight : 0)
     }
+
 }
 
 // MARK: - NavigationActionBarViewAnimationDelegate

--- a/iOS/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/iOS/DuckDuckGo/SuggestionTrayViewController.swift
@@ -266,6 +266,10 @@ class SuggestionTrayViewController: UIViewController {
         favoritesModel.favorites.count > 0
     }
 
+    var hasFavorites: Bool {
+        canDisplayFavorites
+    }
+
     var hasRemoteMessages: Bool {
         return !newTabPageDependencies.homePageMessagesConfiguration.homeMessages.isEmpty
     }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1213542863139367?focus=true

### Description Fix a bug where the logo was shown together with the favourite when escape hatch is visible

### Testing Steps
1. Turn showNTPAfterIdleReturn FF on
2. add a favorite 
3. Visit a site
4. Open a new tab and focus (omnibar view)
5. Check the logo is not shown together with the favourites

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
6. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
What's the impact on users if something goes wrong?
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!--
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that tweaks Dax logo visibility logic based on whether favorites exist; main risk is unintended logo hiding/showing in edge layout states.
> 
> **Overview**
> Fixes a visual overlap in the OmniBar editing state by refining `updateDaxVisibility()` so the home Dax logo is not shown when the favorites overlay is displayed and favorites are present, even if an escape hatch exists.
> 
> Adds a lightweight `hasFavorites` signal from `SuggestionTrayViewController` through `SuggestionTrayManager` to support this conditional visibility check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c1ab9fc414499cddbf84640525008c5b90a1abb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->