### PR TITLE
iOS fix downgrade banner visibility

### DIFF
--- a/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
+++ b/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionSettingsViewModel.swift
@@ -420,8 +420,10 @@ final class SubscriptionSettingsViewModel: ObservableObject {
         state.cancelPendingDowngradeDetails = nil
         state.subscriptionInfo = subscription
 
-        // Check for pending plan first (downgrade scheduled)
-        if let pendingPlan = subscription.firstPendingPlan {
+        // Check for pending plan first (downgrade scheduled) — only show downgrade copy when pending tier differs from current
+        if let pendingPlan = subscription.firstPendingPlan,
+           let currentTier = subscription.tier,
+           pendingPlan.tier != currentTier {
             let effectiveDate = dateFormatter.string(from: pendingPlan.effectiveAt)
             let tierName = pendingPlan.tier.rawValue.capitalized
             state.subscriptionDetails = UserText.pendingDowngradeInfo(tierName: tierName, billingPeriod: pendingPlan.billingPeriod, effectiveDate: effectiveDate)

--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionSettingsViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionSettingsViewModelTests.swift
@@ -586,6 +586,35 @@ final class SubscriptionSettingsViewModelTests: XCTestCase {
         XCTAssertTrue(sut.state.subscriptionDetails.contains("renews") == true)
     }
 
+    func testSubscriptionDetails_WhenPendingPlanSameTierAsCurrent_ShowsRenewalCopyAndNoBanner() async {
+        // Given - Crossgrade: pending plan has same tier as current (e.g. Pro yearly → Pro monthly)
+        // Downgrade copy and banner should not be shown; normal renewal copy only
+        let pendingPlan = DuckDuckGoSubscription.PendingPlan(
+            productId: "ddg-privacy-pro-monthly-renews",
+            billingPeriod: .monthly,
+            effectiveAt: Date(timeIntervalSince1970: 1711557633),
+            status: "pending",
+            tier: .pro
+        )
+        mockSubscriptionManager.resultSubscription = .success(SubscriptionMockFactory.subscription(
+            status: .autoRenewable,
+            tier: .pro,
+            pendingPlans: [pendingPlan]
+        ))
+        mockSubscriptionManager.resultTokenContainer = OAuthTokensFactory.makeValidTokenContainer()
+        sut = makeSUT()
+        
+        // When
+        await waitForSubscriptionUpdate()
+        
+        // Then - Should show normal renewal/expiry copy, not pending downgrade
+        XCTAssertFalse(sut.state.subscriptionDetails.isEmpty)
+        XCTAssertTrue(sut.state.subscriptionDetails.contains("renews"),
+                      "Expected renewal copy, got: \(sut.state.subscriptionDetails)")
+        XCTAssertNil(sut.state.cancelPendingDowngradeDetails,
+                     "Banner should be hidden for same-tier pending plan (crossgrade)")
+    }
+
     func testShouldShowUpgrade_WhenPendingPlanExists_ReturnsFalse() async {
         // Given - Active subscription with pending plan and available upgrades
         let pendingPlan = DuckDuckGoSubscription.PendingPlan(


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1213542861384493?focus=true

### Description Fixes an issue for which pending crossgrades are shown ad downgrade

### Testing Steps
iOS with pro feature flag on

1. Subscribe to plus or pro monthly
2. Crossgrade to yearlly
3. Check no pending downgrade banner is shown and that there are no changes to the expiration date on the footer
4. Try for the opposite crossgrade
5. Try and actual downgrade and test the banner and footer copy are updates

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small conditional change to subscription status messaging that affects only UI copy/banner visibility for pending plan changes; covered by a new unit test, with no security or data-handling impact.
> 
> **Overview**
> Fixes a subscription settings UI bug where **pending crossgrades** (same tier, different billing period) were incorrectly treated as downgrades.
> 
> `SubscriptionSettingsViewModel.updateSubscriptionsStatusMessage` now shows pending-downgrade footer copy and the cancel banner only when the pending plan’s tier differs from the current tier, and adds a test to ensure same-tier pending plans show normal renewal copy with no banner. Release notes copy was also tweaked.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c56adfa3c5f06cb73d8dc2646778ee386b7cf2b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->