### PR TITLE
Startup Metrics: Enable Feature Flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -176,6 +176,10 @@ public enum MacOSBrowserConfigSubfeature: String, PrivacySubfeature {
 
     /// Enable Look Up (three-finger click) while keeping link preview disabled
     case webViewLookUpAction
+
+    /// Startup Metrics Reporting
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213380840527060
+    case startupMetrics
 }
 
 public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -307,7 +307,8 @@ extension FeatureFlag: FeatureFlagDescribing {
                 .aiChatSidebarResizable,
                 .aiChatSidebarFloating,
                 .nextStepsListWidget,
-                .webViewLookUpAction:
+                .webViewLookUpAction,
+                .startupMetrics:
             true
         default:
             false
@@ -567,7 +568,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .aiChatSidebarFloating:
             return .internalOnly()
         case .startupMetrics:
-            return .internalOnly()
+            return .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.startupMetrics))
         case .privateProcessName:
             return .disabled
         case .webViewLookUpAction:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213453755898854?focus=true
Tech Design URL:
CC:

### Description
This PR enables the `startupMetrics` Feature Flag, so that we start collecting metrics

### Testing Steps
1. Launch the browser

- [ ] Verify you see `👾[Standard-Fired] m_mac_startup_performance_metrics ` in the console

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The Feature Flag incorrectly remain disabled

### Quality Considerations
None

### Notes to Reviewer
Thank you!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables startup performance metrics reporting by default and makes the flag remotely controllable, which can impact telemetry volume and data collection behavior. Change is small and isolated to feature-flag configuration but affects a privacy/metrics-sensitive area.
> 
> **Overview**
> **Enables Startup Metrics reporting.** Adds `startupMetrics` as a `MacOSBrowserConfigSubfeature` and updates the macOS `FeatureFlag` definition so `startupMetrics` is **on by default**.
> 
> Also changes `startupMetrics` from `internalOnly()` to a **remote-releasable** privacy-config subfeature, allowing rollout/control via remote configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c12ae2ac511129a318026adb53b5c219cc5d93c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->