### PR TITLE
Update onboarding to v4 with content-scope-scripts polish

### DIFF
--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -63,7 +63,7 @@ let package = Package(
         .package(url: "https://github.com/1024jp/GzipSwift.git", exact: "6.0.1"),
         .package(url: "https://github.com/vapor/jwt-kit.git", exact: "4.13.5"),
         .package(url: "https://github.com/pointfreeco/swift-clocks.git", exact: "1.0.6"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", exact: "13.27.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", branch: "pr-releases/randerson/onboarding-v4-polish"),
         .package(path: "../URLPredictor"),
     ],
     targets: [

--- a/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
@@ -105,7 +105,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
 
     var configuration: OnboardingConfiguration {
         let systemSettings: SystemSettings
-        let order = "v3"
+        let order = "v4"
         let platform = OnboardingPlatform(name: "macos")
         if applicationBuildType.isAppStoreBuild {
             systemSettings = SystemSettings(rows: ["import"])


### PR DESCRIPTION
### Description

This PR updates the onboarding experience to v4 and switches the content-scope-scripts dependency to a branch containing onboarding v4 polish improvements.

**Changes:**
- Updated `OnboardingActionsManager` to use onboarding configuration version "v4" instead of "v3"
- Updated content-scope-scripts dependency from exact version `13.27.0` to the `pr-releases/randerson/onboarding-v4-polish` branch to incorporate the latest polish updates

### Testing Steps

1. Launch the macOS application and trigger the onboarding flow
2. Verify that the onboarding UI displays correctly with v4 styling and behavior
3. Confirm that all onboarding steps complete without errors

### Impact and Risks

**Impact:** Medium - Updates the onboarding experience that users see on first launch or when onboarding is re-triggered.

**What could go wrong:**
- Onboarding UI could fail to render if content-scope-scripts branch has breaking changes
- Onboarding flow could break if v4 configuration is incompatible with current system settings

**Mitigation:** The branch is specifically for onboarding v4 polish, suggesting it's a tested release candidate. Existing onboarding logic remains intact.

### Quality Considerations

- This change depends on an external branch rather than a stable release version. Once the polish is finalized, this should be updated to a stable version tag.
- No new tests required as this is a configuration update to existing onboarding infrastructure.

### Notes to Reviewer

Please verify that the `pr-releases/randerson/onboarding-v4-polish` branch is stable and ready for integration. Consider whether this should be pinned to a specific commit or tag once the polish work is complete.

https://claude.ai/code/session_01PpFjq4PZwQquKUFLJiAqVp