### PR TITLE
[MacOS] [Data Clearing] Fix Flakey Pixel Retrigger Test

### DIFF
--- a/macOS/UnitTests/Fire/DataClearingPixelsReporterTests.swift
+++ b/macOS/UnitTests/Fire/DataClearingPixelsReporterTests.swift
@@ -82,16 +82,13 @@ final class DataClearingPixelsReporterTests: XCTestCase {
         Self.logger.info("[👀 DIAGNOSTIC] Initial time: \(startTime, format: .fixed(precision: 17))")
         sut.fireRetriggerPixelIfNeeded()
 
-        // When - at 19.99 seconds (near boundary, avoids exact 20.0 floating-point precision issues)
-        currentTime += 19.99
+        // When - at 20 seconds
+        currentTime += 20.0
         let endTime = currentTime!
         let elapsed = endTime - startTime
         Self.logger.info("[👀 DIAGNOSTIC] After increment - currentTime: \(endTime, format: .fixed(precision: 17)), elapsed: \(elapsed, format: .fixed(precision: 17))")
 
         sut.fireRetriggerPixelIfNeeded()
-
-        Self.logger.info("[👀 DIAGNOSTIC] Actual fire calls count: \(self.mockPixelFiring.actualFireCalls.count)")
-        Self.logger.info("[👀 DIAGNOSTIC] Actual fire calls: \(String(describing: self.mockPixelFiring.actualFireCalls))")
 
         // Then
         mockPixelFiring.expectedFireCalls = [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213530925408934?focus=true
Tech Design URL:
CC:

### Description

Fixes a flaky test `testWhenCalledExactlyAt20SecondsThenRetriggerPixelIsFired` that was failing inconsistently in the GitHub non-sandbox CI environment.

#### Root Cause

The test was failing due to floating-point precision issues when testing at exactly the 20-second boundary:

1. **Large base values**: `CACurrentMediaTime()` returns the system uptime in seconds (e.g., `165862.96004058336`), which is a large value
2. **Accumulated precision errors**: When computing `(now - lastFire)` where both are large values differing by exactly 20.0, floating-point arithmetic can produce results like `20.000000000000004` or `19.999999999999996` due to limited precision in binary representation
3. **Exact boundary sensitivity**: The comparison `(now - lastFire) <= 20.0` is sensitive to these tiny precision errors at the exact boundary, causing the test to pass or fail depending on which side of 20.0 the computed result lands

#### Solution

**1. Use fixed float starting point (`0.0`)**
- Changed from `CACurrentMediaTime()` to a fixed `0.0` starting value
- Eliminates precision errors: `(20.0 - 0.0)` is exactly `20.0` in floating-point
- Makes the test deterministic across all environments

**2. Add diagnostic logging**
- Added `Logger` with 17-digit precision to track exact time values
- Helps debug if the issue reoccurs in CI

### Testing Steps

1. Run `testWhenCalledExactlyAt20SecondsThenRetriggerPixelIsFired` locally - should pass consistently
2. Check CI logs for the diagnostic output showing clean `20.0` values
3. Verify all other `DataClearingPixelsReporterTests` still pass

### Impact and Risks

**Low**: Test-only change. No production code modified. Improves test reliability in CI.

#### What could go wrong?

- Test could still fail if there are other environmental issues, but diagnostic logging will help identify them
- The fixed time approach is standard for unit tests and eliminates the precision issues

### Quality Considerations

- The test suite provides comprehensive boundary coverage (10s inside, 20s exact, 21s outside)
- No edge cases introduced - the fixed time approach is more deterministic than using system time
- No performance impact - test-only change
- Diagnostic logging helps monitor the fix effectiveness in CI

### Notes to Reviewer

- The key insight is that floating-point subtraction with small values (20.0 - 0.0) produces exact results, while subtraction of large values (165882.96 - 165862.96) can have precision errors at the exact boundary
- Other similar tests (10s, 21s) worked fine because they weren't at the exact boundary condition
- The diagnostic logs with 17-digit precision will help us see any future precision issues

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)