### PR TITLE
[iOS] Fix contextual AI chat sheet double-present crash

### DIFF
--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -185,6 +185,7 @@ final class AIChatContextualSheetCoordinator {
 private extension AIChatContextualSheetCoordinator {
     
     func presentExistingSheet(_ sheetVC: UIViewController, from presentingVC: UIViewController) {
+        guard sheetVC.presentingViewController == nil else { return }
         presentingVC.present(sheetVC, animated: true)
     }
     

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -90,10 +90,12 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
     private final class MockPresentingViewController: UIViewController {
         var presentedVC: UIViewController?
         var presentAnimated: Bool?
+        var presentCallCount = 0
 
         override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
             presentedVC = viewControllerToPresent
             presentAnimated = flag
+            presentCallCount += 1
             completion?()
         }
     }
@@ -420,6 +422,28 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
 
         // Then - no null signal sent (sheet not visible)
         XCTAssertFalse(receivedPush)
+    }
+
+    // MARK: - Double Present Guard Tests
+
+    @MainActor
+    func testPresentSheetSkipsPresentationWhenSheetIsAlreadyPresented() async {
+        // Given
+        let window = UIWindow()
+        let rootVC = UIViewController()
+        window.rootViewController = rootVC
+        window.makeKeyAndVisible()
+
+        await sut.presentSheet(from: rootVC)
+        let sheetVC = sut.sheetViewController!
+        XCTAssertNotNil(sheetVC.presentingViewController)
+
+        // When
+        let secondPresenter = MockPresentingViewController()
+        await sut.presentSheet(from: secondPresenter)
+
+        // Then
+        XCTAssertEqual(secondPresenter.presentCallCount, 0)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
Asana Task: https://app.asana.com/1/137249556945/project/1206488453854252/task/1213531617741826?focus=true

## Summary

- Guard against re-presenting the contextual AI chat sheet when it's already being presented
- Fixes `NSInvalidArgumentException` crash (SIGABRT) in `AIChatContextualSheetCoordinator.presentExistingSheet` — triggered when the user re-opens the sheet while the dismiss animation is still in flight
- Sentry: https://errors.duckduckgo.com/organizations/ddg/issues/719786 (21 events, 17 users)

## Test plan

- [ ] Open contextual AI chat sheet, swipe to dismiss, and immediately re-open — should not crash
- [ ] Normal open/close/reopen flow still works
- [ ] Unit test `testPresentSheetSkipsPresentationWhenSheetIsAlreadyPresented` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a simple presentation guard and a unit test around an edge case; behavior only changes when the sheet is already on-screen, preventing a crash.
> 
> **Overview**
> Prevents a crash when the contextual AI chat sheet is opened again while it is already being presented by adding a guard in `presentExistingSheet` to skip re-presenting an on-screen sheet.
> 
> Adds test coverage for this edge case by tracking presentation call count on a mock presenter and asserting a second `presentSheet` call does not attempt to present again.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb0fbfcb01f11e13e3abeee149375a8f4e90f77c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->