### PR TITLE
Add pre-update check script for DarkReader

### DIFF
--- a/scripts/darkreader/pre-update-check.sh
+++ b/scripts/darkreader/pre-update-check.sh
@@ -54,8 +54,7 @@ else
 fi
 
 # Find manifest in extracted bundle (may be in a subdirectory)
-CURRENT_MANIFEST="$(find "$CURRENT_DIR" -name manifest.json -maxdepth 2 | head -1)"
-CURRENT_BG_JS="$(find "$CURRENT_DIR" -path "*/background/index.js" -maxdepth 3 | head -1)"
+CURRENT_MANIFEST="$(find "$CURRENT_DIR" -maxdepth 2 -name manifest.json | head -1)"
 
 if [[ -z "$CURRENT_MANIFEST" ]]; then
     echo "Error: manifest.json not found in current bundle" >&2
@@ -78,13 +77,13 @@ fail() { echo "  FAIL: $1"; ((FAIL++)) || true; }
 # Clone and build new version
 # ---------------------------------------------------------------------------
 echo "==> Cloning darkreader@${TAG}..."
-git clone --depth 1 --branch "$TAG" https://github.com/darkreader/darkreader.git "$WORK_DIR/darkreader" 2>/dev/null
+git clone --depth 1 --branch "$TAG" https://github.com/darkreader/darkreader.git "$WORK_DIR/darkreader"
 
 echo "==> Installing dependencies..."
-(cd "$WORK_DIR/darkreader" && npm install --silent 2>/dev/null)
+(cd "$WORK_DIR/darkreader" && npm install --silent)
 
 echo "==> Building Chrome MV3 extension..."
-(cd "$WORK_DIR/darkreader" && npm run build -- --chrome-mv3 2>/dev/null)
+(cd "$WORK_DIR/darkreader" && npm run build -- --chrome-mv3)
 
 BUILD_ZIP="$WORK_DIR/darkreader/build/release/darkreader-chrome-mv3.zip"
 if [[ ! -f "$BUILD_ZIP" ]]; then
@@ -96,8 +95,8 @@ NEW_DIR="$WORK_DIR/new"
 mkdir -p "$NEW_DIR"
 unzip -q "$BUILD_ZIP" -d "$NEW_DIR"
 
-NEW_MANIFEST="$(find "$NEW_DIR" -name manifest.json -maxdepth 2 | head -1)"
-NEW_BG_JS="$(find "$NEW_DIR" -path "*/background/index.js" -maxdepth 3 | head -1)"
+NEW_MANIFEST="$(find "$NEW_DIR" -maxdepth 2 -name manifest.json | head -1)"
+NEW_BG_JS="$(find "$NEW_DIR" -maxdepth 3 -path "*/background/index.js" | head -1)"
 
 echo ""
 
@@ -111,10 +110,12 @@ CURRENT_LICENSE="$BUNDLE_DIR/DarkReader-LICENSE.txt"
 
 if [[ ! -f "$NEW_LICENSE" ]]; then
     fail "LICENSE file not found in upstream repo"
+elif [[ ! -f "$CURRENT_LICENSE" ]]; then
+    fail "Current bundled license file not found: $CURRENT_LICENSE"
 elif ! diff -q "$CURRENT_LICENSE" "$NEW_LICENSE" > /dev/null 2>&1; then
-    fail "License has changed — review diff below and escalate for legal review"
+    fail "License has changed — review diff below and escalate for review"
     echo ""
-    diff --unified "$CURRENT_LICENSE" "$NEW_LICENSE" || true
+    diff -u "$CURRENT_LICENSE" "$NEW_LICENSE" || true
 else
     pass "License unchanged"
 fi
@@ -228,7 +229,8 @@ extract_sites() {
 import sys
 with open(sys.argv[1]) as f:
     content = f.read()
-sections = content.split('=' * 32)
+import re
+sections = re.split(r'={10,}', content)
 for section in sections:
     lines = section.strip().split('\n')
     if lines and lines[0].strip():
@@ -239,8 +241,8 @@ for section in sections:
     done | sort -u
 }
 
-CURRENT_CONFIG_DIR="$(find "$CURRENT_DIR" -type d -name config -maxdepth 3 | head -1)"
-NEW_CONFIG_DIR="$(find "$NEW_DIR" -type d -name config -maxdepth 3 | head -1)"
+CURRENT_CONFIG_DIR="$(find "$CURRENT_DIR" -maxdepth 3 -type d -name config | head -1)"
+NEW_CONFIG_DIR="$(find "$NEW_DIR" -maxdepth 3 -type d -name config | head -1)"
 
 if [[ -n "$CURRENT_CONFIG_DIR" && -n "$NEW_CONFIG_DIR" ]]; then
     CURRENT_SITES="$(extract_sites "$CURRENT_CONFIG_DIR")"


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1213557646144002?focus=true
Tech Design URL:
CC:

### Description

Add a script that helps in DarkReader [extension update process](https://app.asana.com/1/137249556945/task/1213523897737033?focus=true). Runs the most important comparisons and validates patches are applied. Also lists changes to upstream sites config to aid in exception updates.

### Testing Steps
1. Run the script with latest DR extension version validate the output.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a standalone internal maintenance script and does not change app/runtime behavior. Main risk is false positives/negatives in the scripted checks impacting the update workflow.
> 
> **Overview**
> Adds `scripts/darkreader/pre-update-check.sh` to run *pre-flight checks* before updating the bundled DarkReader extension.
> 
> The script fetches a target DarkReader tag (or latest), builds the upstream Chrome MV3 zip, then compares it against the currently bundled `darkreader.zip` to **flag license changes**, **permission deltas**, **patch-target string mismatches in `background/index.js`**, basic MV3 manifest structure, and **site-fix/dark-site list additions/removals**; it exits non-zero on failed checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bcd302e0d3217c11c29e41a279f5d51ebba2f71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->