### PR TITLE
Remove duplicate unit test

### DIFF
--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -446,28 +446,6 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         XCTAssertEqual(secondPresenter.presentCallCount, 0)
     }
 
-    // MARK: - Double Present Guard Tests
-
-    @MainActor
-    func testPresentSheetSkipsPresentationWhenSheetIsAlreadyPresented() async {
-        // Given
-        let window = UIWindow()
-        let rootVC = UIViewController()
-        window.rootViewController = rootVC
-        window.makeKeyAndVisible()
-
-        await sut.presentSheet(from: rootVC)
-        let sheetVC = sut.sheetViewController!
-        XCTAssertNotNil(sheetVC.presentingViewController)
-
-        // When
-        let secondPresenter = MockPresentingViewController()
-        await sut.presentSheet(from: secondPresenter)
-
-        // Then
-        XCTAssertEqual(secondPresenter.presentCallCount, 0)
-    }
-
     // MARK: - Helpers
 
 }


### PR DESCRIPTION
## Summary
- Removes an exact duplicate of `testPresentSheetSkipsPresentationWhenSheetIsAlreadyPresented` in `AIChatContextualSheetCoordinatorTests` (including a duplicate `// MARK:` section header)

## Test plan
- [ ] Verify unit tests still compile and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes a duplicated unit test and section header only; no production code paths change, so risk is limited to minor test coverage/organization effects.
> 
> **Overview**
> Removes an exact duplicate of `testPresentSheetSkipsPresentationWhenSheetIsAlreadyPresented` (and its duplicate `// MARK:` header) from `AIChatContextualSheetCoordinatorTests.swift`, leaving a single copy of the test for the sheet double-presentation guard.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5099d39ff9338bfe927dc1e6d4b27e11709771f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->