### PR TITLE
Startup Profiler: Adjusts Time to Interactive Reporting

### DIFF
--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -372,14 +372,13 @@ final class MainViewController: NSViewController {
     }
 
     override func viewDidAppear() {
+        startupProfiler.measureOnce(.timeToInteractive, startStep: .appDelegateInit)
         initPreloader()
 
         mainView.setMouseAboveWebViewTrackingAreaEnabled(true)
         registerForBookmarkBarPromptNotifications()
 
         adjustFirstResponder(force: true)
-
-        startupProfiler.measureOnce(.timeToInteractive, startStep: .appDelegateInit)
     }
 
     var bookmarkBarPromptObserver: Any?


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/inbox/1211150618028591/item/1213547513099556/story/1213311263334728?focus=true
Tech Design URL:
CC:

### Description
This PR adjusts the spot in which `.timeToInteractive` is reported

### Testing Steps
- [ ] Verify the changes make sense please!

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing really, relocating a metric tracking

### Quality Considerations
None

### Notes to Reviewer
Thank you!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk functional impact; changes only the ordering of a startup profiling metric, which may shift reported `timeToInteractive` values but shouldn’t affect app behavior.
> 
> **Overview**
> Adjusts startup profiling by moving `startupProfiler.measureOnce(.timeToInteractive, startStep: .appDelegateInit)` to the start of `MainViewController.viewDidAppear()` (before `initPreloader()` and other UI setup), so the *time-to-interactive* metric is captured earlier in the window’s appearance lifecycle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b7db75420367939b047c979e1a3b98e9331506b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->