### PR TITLE
Fix flaky AIChat history tests

### DIFF
--- a/iOS/DuckDuckGoTests/AIChat/AIChatHistoryManagerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatHistoryManagerTests.swift
@@ -52,7 +52,7 @@ final class AIChatHistoryManagerTests: XCTestCase {
 
     // MARK: - Text Subscription Tests
 
-    func testSubscribeToTextChanges_FetchesSuggestionsOnTextChange() async {
+    func testSubscribeToTextChanges_FetchesSuggestionsOnTextChange() {
         let textSubject = PassthroughSubject<String, Never>()
         sut.subscribeToTextChanges(textSubject)
 
@@ -63,21 +63,27 @@ final class AIChatHistoryManagerTests: XCTestCase {
 
         textSubject.send("test query")
 
-        // Wait for debounce (150ms) plus processing time
-        try? await Task.sleep(nanoseconds: 200_000_000)
+        let predicate = NSPredicate { _, _ in
+            self.mockSuggestionsReader.fetchSuggestionsCallCount == 1
+        }
+        let expectation = expectation(for: predicate, evaluatedWith: nil)
+        wait(for: [expectation], timeout: 5.0)
 
         XCTAssertEqual(mockSuggestionsReader.fetchSuggestionsCallCount, 1)
         XCTAssertEqual(mockSuggestionsReader.lastQuery, "test query")
     }
 
-    func testSubscribeToTextChanges_EmptyQueryFetchesRecentChats() async {
+    func testSubscribeToTextChanges_EmptyQueryFetchesRecentChats() {
         let textSubject = PassthroughSubject<String, Never>()
         sut.subscribeToTextChanges(textSubject)
 
         textSubject.send("")
 
-        // Wait for debounce
-        try? await Task.sleep(nanoseconds: 200_000_000)
+        let predicate = NSPredicate { _, _ in
+            self.mockSuggestionsReader.fetchSuggestionsCallCount == 1
+        }
+        let expectation = expectation(for: predicate, evaluatedWith: nil)
+        wait(for: [expectation], timeout: 5.0)
 
         XCTAssertNil(mockSuggestionsReader.lastQuery)
     }
@@ -202,17 +208,20 @@ final class AIChatHistoryManagerTests: XCTestCase {
         XCTAssertEqual(parentVC.children.count, 1)
     }
 
-    func testInstallInContainerView_FetchesSuggestionsImmediately() async {
+    func testInstallInContainerView_FetchesSuggestionsImmediately() {
         let containerView = UIView()
         let parentVC = UIViewController()
 
         sut.installInContainerView(containerView, parentViewController: parentVC)
 
-        // Allow async fetch to complete
-        try? await Task.sleep(nanoseconds: 50_000_000)
+        let predicate = NSPredicate { _, _ in
+            self.mockSuggestionsReader.fetchSuggestionsCallCount == 1
+        }
+        let expectation = expectation(for: predicate, evaluatedWith: nil)
+        wait(for: [expectation], timeout: 5.0)
 
         XCTAssertEqual(mockSuggestionsReader.fetchSuggestionsCallCount, 1)
-        XCTAssertNil(mockSuggestionsReader.lastQuery) // Empty query for initial fetch
+        XCTAssertNil(mockSuggestionsReader.lastQuery)
     }
 }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1213533816421180?focus=true
Tech Design URL:
CC:

### Description

This PR fixes some flaky tests by avoiding arbitrary sleep calls and instead using a predicate expectation with a timeout.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI is green

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to test code and only adjust synchronization/waiting strategy. Main risk is masking real hangs by using longer timeouts, but no production logic is touched.
> 
> **Overview**
> **Deflakes `AIChatHistoryManagerTests`** by removing async `Task.sleep`-based waiting and switching to `XCTest` predicate expectations that wait until `fetchSuggestions` is actually invoked.
> 
> The affected tests (`subscribeToTextChanges` cases and initial fetch on `installInContainerView`) are no longer `async` and now deterministically wait (with a timeout) for `mockSuggestionsReader.fetchSuggestionsCallCount` to reach `1` before asserting results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46e26554c693ee4e813bebae0b127cd86427680b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->