### PR TITLE
Fix hover feature not found error on iOS

### DIFF
--- a/iOS/DuckDuckGo/HoverUserScript.swift
+++ b/iOS/DuckDuckGo/HoverUserScript.swift
@@ -1,0 +1,73 @@
+//
+//  HoverUserScript.swift
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import WebKit
+import UserScript
+
+protocol HoverUserScriptDelegate: AnyObject {
+
+    @MainActor
+    func hoverUserScript(_ script: HoverUserScript, didChange url: URL?)
+
+}
+
+/// Receives `hoverChanged` notifications from the C-S-S `hover` feature
+/// running in the isolated content world, keeping the WebKit message handler
+/// out of the page's JavaScript context.
+final class HoverUserScript: NSObject, Subfeature {
+
+    let messageOriginPolicy: MessageOriginPolicy = .all
+    let featureName: String = "hover"
+
+    weak var broker: UserScriptMessageBroker?
+    weak var delegate: HoverUserScriptDelegate?
+
+    private(set) var lastURL: URL?
+
+    enum MessageNames: String, CaseIterable {
+        case hoverChanged
+    }
+
+    func handler(forMethodNamed methodName: String) -> Subfeature.Handler? {
+        switch MessageNames(rawValue: methodName) {
+        case .hoverChanged:
+            return { [weak self] in try await self?.hoverChanged(params: $0, original: $1) }
+        default:
+            return nil
+        }
+    }
+
+    @MainActor
+    private func hoverChanged(params: Any, original: WKScriptMessage) async throws -> Encodable? {
+        guard let dict = params as? [String: Any] else { return nil }
+
+        let url: URL?
+        if let href = dict["href"] as? String {
+            url = URL(string: href)
+        } else {
+            url = nil
+        }
+
+        if url != lastURL {
+            lastURL = url
+            delegate?.hoverUserScript(self, didChange: url)
+        }
+
+        return nil
+    }
+}

--- a/iOS/DuckDuckGo/UserScripts.swift
+++ b/iOS/DuckDuckGo/UserScripts.swift
@@ -60,6 +60,7 @@ final class UserScripts: UserScriptsProvider {
     private(set) var fullScreenVideoScript = FullScreenVideoUserScript()
     private(set) var printingSubfeature = PrintingSubfeature()
     private(set) var debugScript = DebugUserScript()
+    private(set) var hoverUserScript = HoverUserScript()
 
     private let isAutoconsentExtensionAvailable: Bool
 
@@ -121,6 +122,7 @@ final class UserScripts: UserScriptsProvider {
         contentScopeUserScriptIsolated.registerSubfeature(delegate: aiChatUserScript)
         contentScopeUserScriptIsolated.registerSubfeature(delegate: subscriptionUserScript)
         contentScopeUserScriptIsolated.registerSubfeature(delegate: serpSettingsUserScript)
+        contentScopeUserScriptIsolated.registerSubfeature(delegate: hoverUserScript)
         contentScopeUserScript.registerSubfeature(delegate: printingSubfeature)
         contentScopeUserScript.registerSubfeature(delegate: pageContextUserScript)
 


### PR DESCRIPTION
Fixes #3849. The hover feature was registered on macOS but not on iOS, causing "feature named 'hover' was not found" errors to flood external error monitoring tools. This change adds the HoverUserScript to iOS and registers it with the contentScopeUserScriptIsolated to match the macOS behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds a new isolated `HoverUserScript` and wires it into existing user script registration, with no changes to navigation, auth, or data persistence.
> 
> **Overview**
> Fixes iOS “feature named `hover` was not found” errors by adding a new `HoverUserScript` subfeature and registering it with `contentScopeUserScriptIsolated`.
> 
> The new script handles `hoverChanged` messages, parses the hovered link `href` into a `URL`, and notifies a delegate only when the hovered URL changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc4f346a2a900217c4b627ad261e663bdc8b2894. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->