### PR TITLE
Fix iOS experimental build Xcode version

### DIFF
--- a/.github/workflows/ios_experimental.yml
+++ b/.github/workflows/ios_experimental.yml
@@ -111,8 +111,6 @@ jobs:
     - name: Select Xcode
       if: steps.check-upload.outputs.should_skip != 'true'
       uses: ./.github/actions/select-xcode-version
-      with:
-        xcode-version: "26.2"
 
     - name: Setup Ruby and dependencies
       if: steps.check-upload.outputs.should_skip != 'true'


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1213586440985414?focus=true
Tech Design URL:
CC:

### Description

We previously override the iOS experimental workflow to use Xcode 26.1. Now that we use `macos-26` runners we need to swap back to the latest Xcode. This is done by removing the override, and having the workflow start using the `xcode-version` value.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that the change looks correct

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only change that stops forcing Xcode 26.1 and relies on the repo’s standard Xcode selection, affecting only CI build environment.
> 
> **Overview**
> The iOS experimental GitHub Actions workflow no longer forces `xcode-version: "26.1"` when running the `select-xcode-version` action.
> 
> As a result, the workflow will use the action’s default behavior (e.g., `.xcode-version`), aligning the experimental build with the runner’s intended Xcode setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d6a164522f322880689f0a4caa6d0e7a8819613. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->