### PR TITLE
Rename `embeddedExtension` subfeature to `embedded`

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -628,7 +628,7 @@ public enum PopupBlockingSubfeature: String, PrivacySubfeature {
 public enum WebExtensionsSubfeature: String, PrivacySubfeature {
     public var parent: PrivacyFeature { .webExtensions }
 
-    case embeddedExtension
+    case embeddedExtension = "embedded"
 }
 
 public enum ForceDarkModeOnWebsitesSubfeature: String, PrivacySubfeature {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203936086921904/task/1213568429047051
Tech Design URL:
CC:

### Description
Rename `embeddedExtension` subfeature to `embedded`

### Testing Steps
Confirm tests are green.


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `rawValue` used to look up the WebExtensions embedded subfeature in privacy configuration, which could alter feature-flag behavior if config data still uses the old key.
> 
> **Overview**
> **Renames the WebExtensions embedded subfeature key** by mapping `WebExtensionsSubfeature.embeddedExtension` to the string `"embedded"` instead of the default `"embeddedExtension"`.
> 
> This aligns privacy-config lookups with the updated subfeature identifier without changing call sites (the enum case name remains the same).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc15c89d72de0f7da09d3a74b5fe615b897d53ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->