### PR TITLE
[iOS] Set DDG custom user agent on contextual mode web view

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1700,6 +1700,7 @@
 		C13EBC4F2EE9CCE700CE5A4B /* AIChatContextualModeFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13EBC4E2EE9CCE700CE5A4B /* AIChatContextualModeFeature.swift */; };
 		C13EBC512EE9CD2F00CE5A4B /* AIChatContextualModeFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13EBC502EE9CD2F00CE5A4B /* AIChatContextualModeFeatureTests.swift */; };
 		C13EBC532EF62A0000CE5A4B /* AIChatContextualSheetCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13EBC522EF62A0000CE5A4B /* AIChatContextualSheetCoordinatorTests.swift */; };
+		C590E41C21CD46E99C4A5B2E /* AIChatContextualWebViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7971E90992B46FABF42A908 /* AIChatContextualWebViewControllerTests.swift */; };
 		C13EEA1E2D64CFCA001D5DC3 /* DataImportViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13EEA1D2D64CFCA001D5DC3 /* DataImportViewModelTests.swift */; };
 		C13EEA202D64E59A001D5DC3 /* ZipContentSelectionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13EEA1F2D64E59A001D5DC3 /* ZipContentSelectionViewModelTests.swift */; };
 		C13EEA222D64F6DB001D5DC3 /* DataImportSummaryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13EEA212D64F6DB001D5DC3 /* DataImportSummaryViewModelTests.swift */; };
@@ -4193,6 +4194,7 @@
 		C13EBC4E2EE9CCE700CE5A4B /* AIChatContextualModeFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualModeFeature.swift; sourceTree = "<group>"; };
 		C13EBC502EE9CD2F00CE5A4B /* AIChatContextualModeFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualModeFeatureTests.swift; sourceTree = "<group>"; };
 		C13EBC522EF62A0000CE5A4B /* AIChatContextualSheetCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualSheetCoordinatorTests.swift; sourceTree = "<group>"; };
+		E7971E90992B46FABF42A908 /* AIChatContextualWebViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualWebViewControllerTests.swift; sourceTree = "<group>"; };
 		C13EEA1D2D64CFCA001D5DC3 /* DataImportViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataImportViewModelTests.swift; sourceTree = "<group>"; };
 		C13EEA1F2D64E59A001D5DC3 /* ZipContentSelectionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipContentSelectionViewModelTests.swift; sourceTree = "<group>"; };
 		C13EEA212D64F6DB001D5DC3 /* DataImportSummaryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataImportSummaryViewModelTests.swift; sourceTree = "<group>"; };
@@ -5425,6 +5427,7 @@
 				C16670E32EE7301300C6105C /* SubscriptionAIChatStateHandlerTests.swift */,
 				C13EBC502EE9CD2F00CE5A4B /* AIChatContextualModeFeatureTests.swift */,
 				C13EBC522EF62A0000CE5A4B /* AIChatContextualSheetCoordinatorTests.swift */,
+				E7971E90992B46FABF42A908 /* AIChatContextualWebViewControllerTests.swift */,
 				C1AITEST2F2E000400E35AD5 /* AIChatPageContextHandlerTests.swift */,
 				3124186C2F48C9FE0023B9DE /* IPadModeToggleTextModelTests.swift */,
 			);
@@ -12899,6 +12902,7 @@
 				F194FAFB1F14E622009B4DF8 /* UIFontExtensionTests.swift in Sources */,
 				C13EBC512EE9CD2F00CE5A4B /* AIChatContextualModeFeatureTests.swift in Sources */,
 				C13EBC532EF62A0000CE5A4B /* AIChatContextualSheetCoordinatorTests.swift in Sources */,
+				C590E41C21CD46E99C4A5B2E /* AIChatContextualWebViewControllerTests.swift in Sources */,
 				BBFF18B12C76448100C48D7D /* QuerySubmittedTests.swift in Sources */,
 				9FFDA8392DFA8DC2007923F7 /* VideoPlayerCoordinatorTests.swift in Sources */,
 				CB18A3662E2790C700BE9D8D /* UserAgentConfigurationTests.swift in Sources */,

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
@@ -50,6 +50,7 @@ final class AIChatContextualWebViewController: UIViewController {
     private var downloadHandler: DownloadHandling
     private let pixelHandler: AIChatContextualModePixelFiring
     private let debugSettings: AIChatDebugSettingsHandling
+    private let userAgentManager: UserAgentManaging
 
     private(set) var aiChatContentHandler: AIChatContentHandling
 
@@ -87,6 +88,7 @@ final class AIChatContextualWebViewController: UIViewController {
         let webView = WKWebView(frame: .zero, configuration: createWebViewConfiguration())
         webView.isOpaque = false
         webView.backgroundColor = .systemBackground
+        webView.customUserAgent = userAgentManager.userAgent(isDesktop: false, url: aiChatSettings.aiChatURL)
         webView.navigationDelegate = self
         webView.translatesAutoresizingMaskIntoConstraints = false
         if #available(iOS 16.4, *) {
@@ -127,7 +129,8 @@ final class AIChatContextualWebViewController: UIViewController {
          downloadHandler: DownloadHandling,
          getPageContext: ((PageContextRequestReason) -> AIChatPageContextData?)?,
          pixelHandler: AIChatContextualModePixelFiring,
-         debugSettings: AIChatDebugSettingsHandling = AIChatDebugSettings()) {
+         debugSettings: AIChatDebugSettingsHandling = AIChatDebugSettings(),
+         userAgentManager: UserAgentManaging = DefaultUserAgentManager.shared) {
         self.aiChatSettings = aiChatSettings
         self.privacyConfigurationManager = privacyConfigurationManager
         self.contentBlockingAssetsPublisher = contentBlockingAssetsPublisher
@@ -136,6 +139,7 @@ final class AIChatContextualWebViewController: UIViewController {
         self.downloadHandler = downloadHandler
         self.pixelHandler = pixelHandler
         self.debugSettings = debugSettings
+        self.userAgentManager = userAgentManager
 
         let productSurfaceTelemetry = PixelProductSurfaceTelemetry(featureFlagger: featureFlagger, dailyPixelFiring: DailyPixel.self)
         self.aiChatContentHandler = AIChatContentHandler(

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualWebViewControllerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualWebViewControllerTests.swift
@@ -1,0 +1,153 @@
+//
+//  AIChatContextualWebViewControllerTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import AIChat
+import BrowserServicesKit
+import BrowserServicesKitTestsUtils
+import Combine
+import WebKit
+@testable import Core
+@testable import DuckDuckGo
+
+final class AIChatContextualWebViewControllerTests: XCTestCase {
+
+    // MARK: - Tests
+
+    @MainActor
+    func testWebViewUsesCustomUserAgent() {
+        let expectedURL = URL(string: "https://duck.ai/chat")!
+        let stubUserAgent = StubUserAgentManager(stubbedUserAgent: "ddg_ios/7.100.0 (com.duckduckgo; iOS 17.0)")
+
+        let sut = AIChatContextualWebViewController(
+            aiChatSettings: MockAIChatSettingsProvider(aiChatURL: expectedURL),
+            privacyConfigurationManager: MockPrivacyConfigurationManager(),
+            contentBlockingAssetsPublisher: Empty().eraseToAnyPublisher(),
+            featureDiscovery: MockFeatureDiscovery(),
+            featureFlagger: MockFeatureFlagger(),
+            downloadHandler: StubDownloadHandler(),
+            getPageContext: nil,
+            pixelHandler: StubContextualModePixelHandler(),
+            userAgentManager: stubUserAgent
+        )
+
+        sut.loadViewIfNeeded()
+
+        let webView = sut.view.firstSubview(ofType: WKWebView.self)
+        XCTAssertNotNil(webView)
+        XCTAssertEqual(webView?.customUserAgent, "ddg_ios/7.100.0 (com.duckduckgo; iOS 17.0)")
+        XCTAssertEqual(stubUserAgent.capturedURL, expectedURL)
+        XCTAssertEqual(stubUserAgent.capturedIsDesktop, false)
+    }
+
+    @MainActor
+    func testWebViewUsesDefaultUserAgentManagerWhenNoneProvided() {
+        let sut = AIChatContextualWebViewController(
+            aiChatSettings: MockAIChatSettingsProvider(),
+            privacyConfigurationManager: MockPrivacyConfigurationManager(),
+            contentBlockingAssetsPublisher: Empty().eraseToAnyPublisher(),
+            featureDiscovery: MockFeatureDiscovery(),
+            featureFlagger: MockFeatureFlagger(),
+            downloadHandler: StubDownloadHandler(),
+            getPageContext: nil,
+            pixelHandler: StubContextualModePixelHandler()
+        )
+
+        sut.loadViewIfNeeded()
+
+        let webView = sut.view.firstSubview(ofType: WKWebView.self)
+        XCTAssertNotNil(webView)
+        XCTAssertNotNil(webView?.customUserAgent)
+        XCTAssertFalse(webView?.customUserAgent?.isEmpty ?? true)
+    }
+}
+
+// MARK: - Helpers
+
+private extension UIView {
+    func firstSubview<T: UIView>(ofType type: T.Type) -> T? {
+        for subview in subviews {
+            if let match = subview as? T {
+                return match
+            }
+            if let match = subview.firstSubview(ofType: type) {
+                return match
+            }
+        }
+        return nil
+    }
+}
+
+// MARK: - Stubs
+
+private final class StubUserAgentManager: UserAgentManaging {
+    let stubbedUserAgent: String
+    var capturedURL: URL?
+    var capturedIsDesktop: Bool?
+
+    init(stubbedUserAgent: String) {
+        self.stubbedUserAgent = stubbedUserAgent
+    }
+
+    func extractAndSetDefaultUserAgent() async throws -> String { stubbedUserAgent }
+    func setDefaultUserAgent(_ userAgent: String) {}
+    func userAgent(isDesktop: Bool) -> String { stubbedUserAgent }
+
+    func userAgent(isDesktop: Bool, url: URL?) -> String {
+        capturedIsDesktop = isDesktop
+        capturedURL = url
+        return stubbedUserAgent
+    }
+
+    func update(request: inout URLRequest, isDesktop: Bool) {}
+    func update(webView: WKWebView, isDesktop: Bool, url: URL?) {}
+}
+
+private final class StubDownloadHandler: NSObject, DownloadHandling {
+    var onDownloadComplete: DownloadCompletionHandler?
+
+    func download(_ download: WKDownload, decideDestinationUsing response: URLResponse, suggestedFilename: String) async -> URL? {
+        return nil
+    }
+}
+
+private final class StubContextualModePixelHandler: AIChatContextualModePixelFiring {
+    func fireSheetOpened() {}
+    func fireSheetDismissed() {}
+    func fireSessionRestored() {}
+    func fireExpandButtonTapped() {}
+    func fireNewChatButtonTapped() {}
+    func fireQuickActionSummarizeSelected() {}
+    func firePageContextPlaceholderShown() {}
+    func firePageContextPlaceholderTapped() {}
+    func firePageContextAutoAttached() {}
+    func firePageContextUpdatedOnNavigation(url: String) {}
+    func firePageContextManuallyAttachedNative() {}
+    func firePageContextManuallyAttachedFrontend() {}
+    func firePageContextRemovedNative() {}
+    func firePageContextRemovedFrontend() {}
+    func firePageContextCollectionEmpty() {}
+    func firePageContextCollectionUnavailable() {}
+    func firePromptSubmittedWithContext() {}
+    func firePromptSubmittedWithoutContext() {}
+    func beginManualAttach() {}
+    func endManualAttach() {}
+    var isManualAttachInProgress: Bool { false }
+    func reset() {}
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1213568909605911

## Description

The contextual AI chat web view was missing the DDG custom user agent that full mode includes. Network requests from contextual mode were being sent with Safari's default user agent instead of the `ddg_ios/...` identifier.

## Steps to test this PR

1. Open a page in the browser
2. Trigger contextual AI chat (e.g. select text → Ask Duck AI)
3. Submit a prompt
4. Verify network requests include the DDG custom user agent (e.g. via proxy or web inspector)

## What changed

- Added `UserAgentManaging` dependency to `AIChatContextualWebViewController`
- Set `webView.customUserAgent` in the web view's lazy initializer, matching the pattern used by `AIChatWebViewController` in full mode
- Default parameter (`DefaultUserAgentManager.shared`) means no changes needed at existing call sites
- Added unit tests verifying the user agent is applied correctly

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1203764234894239/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/184709971311439/f)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311439/f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `WKWebView` user agent for contextual AI chat, which can affect server-side behavior and request handling for duck.ai. Scope is small and covered by a new unit test, but regressions would surface as chat loading/compat issues.
> 
> **Overview**
> **Contextual AI Chat now uses the DuckDuckGo custom user agent.** `AIChatContextualWebViewController` injects a `UserAgentManaging` dependency (defaulting to `DefaultUserAgentManager.shared`) and sets `webView.customUserAgent` when constructing the `WKWebView`.
> 
> Adds `AIChatContextualWebViewControllerTests` and Xcode project wiring to verify the custom UA is applied (including URL/isDesktop inputs) and that a non-empty default UA is used when no manager is provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbc39c2da56daa238354d28ba06edcccd36415c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->