### PR TITLE
Disable flaky test

### DIFF
--- a/SharedPackages/WebExtensions/Tests/WebExtensionsTests/WebExtensionFeatureFlagHandlerTests.swift
+++ b/SharedPackages/WebExtensions/Tests/WebExtensionsTests/WebExtensionFeatureFlagHandlerTests.swift
@@ -404,6 +404,7 @@ final class WebExtensionFeatureFlagHandlerTests: XCTestCase {
     }
 
     func testWhenWebExtensionsFlagToggledEnabledDisabledEnabledThenOnlyLastEnableRuns() async throws {
+        throw XCTSkip("Flaky test - disabled")
         var enabledCallCount = 0
         let enabledExpectation = expectation(description: "onFeatureFlagEnabled called once")
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200848783441532/task/1213583345544824
Tech Design URL:
CC:

### Description
Disable flaky test

### Testing Steps
Ensure tests are green.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes test execution by skipping a flaky case; no production code paths are modified.
> 
> **Overview**
> **Disables a flaky unit test** in `WebExtensionFeatureFlagHandlerTests` by adding an `XCTSkip` to `testWhenWebExtensionsFlagToggledEnabledDisabledEnabledThenOnlyLastEnableRuns`, preventing intermittent CI failures while leaving the test logic in place for future re-enable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02d6d1ce75451d3a237132ba9f70d418e05e66a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->