### PR TITLE
Fix WireGuardAdapter reasserting race condition

### DIFF
--- a/SharedPackages/VPN/Sources/VPN/WireGuardKit/WireGuardAdapter.swift
+++ b/SharedPackages/VPN/Sources/VPN/WireGuardKit/WireGuardAdapter.swift
@@ -446,12 +446,6 @@ final class WireGuardAdapter: WireGuardAdapterProtocol {
                 self.packetTunnelProvider?.reasserting = true
             }
 
-            defer {
-                if reassert {
-                    self.packetTunnelProvider?.reasserting = false
-                }
-            }
-
             do {
                 let settingsGenerator = try self.makeSettingsGenerator(with: tunnelConfiguration)
                 let settings = settingsGenerator.generateNetworkSettings()
@@ -489,8 +483,14 @@ final class WireGuardAdapter: WireGuardAdapterProtocol {
                     fatalError()
                 }
 
+                if reassert {
+                    self.packetTunnelProvider?.reasserting = false
+                }
                 completionHandler(nil)
             } catch let error as WireGuardAdapterError {
+                if reassert {
+                    self.packetTunnelProvider?.reasserting = false
+                }
                 completionHandler(error)
             } catch {
                 fatalError()


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1213572100606676?focus=true
Tech Design URL:
CC:

### Description

This PR fixes a race condition in the WG adapter. This was causing a flaky test failure, as you can see in https://github.com/duckduckgo/apple-browsers/actions/runs/22839923861.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI is green

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VPN tunnel state signaling (`NEPacketTunnelProvider.reasserting`) during live config updates; incorrect ordering could impact perceived connection state or recovery behavior.
> 
> **Overview**
> Ensures `WireGuardAdapter.update(...)` clears `packetTunnelProvider.reasserting` **before** calling the completion handler, instead of via a `defer` that could run after callbacks.
> 
> This updates both the success and `WireGuardAdapterError` error paths to consistently reset `reasserting`, reducing races in connection-status reporting during runtime configuration updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e72302704912c2ad5f7fc963c015e2d213c82add. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->