### PR TITLE
Debt: macOS AI Chat Visibility Logic

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -1308,11 +1308,6 @@ final class AddressBarButtonsViewController: NSViewController {
     private func updateAIChatButtonVisibility() {
         aiChatButton.isHidden = !shouldShowAIChatButton()
         updateAIChatDividerVisibility()
-
-        // Hide the AI chat button during onboarding
-        if let tabViewModel, tabViewModel.tab.content == .onboarding {
-            aiChatButton.isHidden = true
-        }
     }
 
     private var isAskAIChatButtonExpanded: Bool = false
@@ -1355,7 +1350,7 @@ final class AddressBarButtonsViewController: NSViewController {
     }
 
     private func shouldShowAIChatButton() -> Bool {
-        aiChatMenuConfig.shouldDisplayAddressBarShortcut && !shouldSkipShowingAnyAIChatButton()
+        aiChatMenuConfig.shouldDisplayAddressBarShortcut && !shouldSkipShowingAnyAIChatButton() && tabViewModel?.tab.content != .onboarding
     }
 
     private func shouldShowAskAIChatButton() -> Bool {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1213576829042702?focus=true
Tech Design URL:
CC:

### Description
In this (Debt) PR, we're converging all of the logic to update`aiChatButton.isHidden` in a single spot.

### Testing Steps
1. Launch the Browser
2. Open `Settings > AI Features`

- [ ] Verify that toggling `Show Duck.AI shortcut in the Address Bar`

### Testing: Onboarding
1. Launch the browser
2. Click on `Reset Data > Reset Onboarding`
3. Click on `Reset Data > Reset Contextual Onboarding`
4. Relaunch

- [ ] Verify that during Onboarding, the Duck.AI button doesn't show up in the Address bar
- [ ] Verify that once Onboarding is complete, you can toggle the button visibility via `Settings > AI Features > Shock Duck AI in the address bar`

### Testing: UI Tests

- [ ] Verify [this UI Tests CI Run is green](https://github.com/duckduckgo/apple-browsers/actions/runs/22867829868) please

### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
If this PR is faulty, the Duck AI button could display (or hide) when it shouldn't.

### Quality Considerations
None

### Notes to Reviewer
Thanks a lot, in advance!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the address-bar AI Chat button visibility logic, including onboarding suppression, which could cause the shortcut to appear or disappear in the wrong states during onboarding or preference toggling.
> 
> **Overview**
> **Unifies AI Chat shortcut visibility logic in the address bar.**
> 
> The onboarding-specific hiding of the `aiChatButton` was moved from `updateAIChatButtonVisibility()` into `shouldShowAIChatButton()`, making onboarding just another eligibility condition and keeping all `aiChatButton.isHidden` decisions driven by the same helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 886f83534a9142d4b8ee9c80269425d38caddf22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->