### PR TITLE
[iOS] Disable unified_toggle_input E2E test

### DIFF
--- a/.github/workflows/ios_end_to_end.yml
+++ b/.github/workflows/ios_end_to_end.yml
@@ -136,10 +136,6 @@ jobs:
           - test-tag: device_info
             exclude-tags: ipad
             device-model: iPhone-16
-          - test-tag: unified_toggle_input
-            exclude-tags: ipad
-            device-model: iPhone-16
-            device-name: iPhone
           # iPad tests - only tests tagged with 'ipad', exclude iPhone specific tests
           - test-tag: device_info
             exclude-tags: iphone


### PR DESCRIPTION
## Summary
- Removes the `unified_toggle_input` Maestro E2E test from the CI matrix
- The test is [failing on main](https://github.com/duckduckgo/apple-browsers/actions/runs/22838517960/job/66240732441) with assertion `"Search" is visible` after expanding the input bar
- Disabling until the underlying UI issue is investigated and fixed

## Test plan
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes the GitHub Actions E2E test matrix by disabling one failing scenario, with no production code impact.
> 
> **Overview**
> Disables the `unified_toggle_input` Maestro end-to-end run by removing it from the iOS GitHub Actions workflow matrix, so this test no longer executes in CI while other iPhone/iPad tagged suites continue to run unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ace8c367be7ae0e2a7dc81e3b58c119dc38c595c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->