### PR TITLE
Disable dark reader by default for internal users

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "d41a30161ea0c5107dff4574c461fd021bc531a5",
-        "version" : "13.21.0"
+        "revision" : "307fe6d8a17d12539c44ba98b2d703c38cfe45de",
+        "version" : "13.27.0"
       }
     },
     {

--- a/macOS/DuckDuckGo/Common/Utilities/UserDefaultsKeys.swift
+++ b/macOS/DuckDuckGo/Common/Utilities/UserDefaultsKeys.swift
@@ -84,7 +84,7 @@ enum UserDefaultsKeys: String, StorageKeyDescribing {
 
     // MARK: - DarkReader
 
-    case forceDarkModeOnWebsitesEnabled = "forceDarkModeOnWebsitesEnabled"
+    case forceDarkModeOnWebsites = "forceDarkModeOnWebsites"
 
     // MARK: - Add more app-wide keys here as they are migrated from UserDefaultsWrapper
 

--- a/macOS/DuckDuckGo/DarkReader/DarkReaderFeatureSettings.swift
+++ b/macOS/DuckDuckGo/DarkReader/DarkReaderFeatureSettings.swift
@@ -41,7 +41,7 @@ protocol DarkReaderFeatureSettings: DarkReaderExcludedDomainsProviding {
 }
 
 struct DarkReaderSettings: StoringKeys {
-    let forceDarkModeOnWebsitesEnabled = StorageKey<Bool>(.forceDarkModeOnWebsitesEnabled)
+    let forceDarkModeOnWebsitesEnabled = StorageKey<Bool>(.forceDarkModeOnWebsites)
 }
 
 final class AppDarkReaderFeatureSettings: DarkReaderFeatureSettings {

--- a/macOS/UnitTests/DarkReader/DarkReaderFeatureSettingsTests.swift
+++ b/macOS/UnitTests/DarkReader/DarkReaderFeatureSettingsTests.swift
@@ -106,7 +106,7 @@ final class DarkReaderFeatureSettingsTests: XCTestCase {
 
     func testIsForceDarkModeEnabled_WhenFlagOffAndStoredTrue_ReturnsFalse() throws {
         mockFeatureFlagger.enabledFeatureFlags = []
-        try mockStore.set(true, forKey: UserDefaultsKeys.forceDarkModeOnWebsitesEnabled.rawValue)
+        try mockStore.set(true, forKey: UserDefaultsKeys.forceDarkModeOnWebsites.rawValue)
         sut = makeSUT()
 
         XCTAssertFalse(sut.isForceDarkModeEnabled)
@@ -145,7 +145,7 @@ final class DarkReaderFeatureSettingsTests: XCTestCase {
         sut = makeSUT()
 
         sut.setForceDarkModeEnabled(true)
-        XCTAssertNil(try mockStore.object(forKey: UserDefaultsKeys.forceDarkModeOnWebsitesEnabled.rawValue))
+        XCTAssertNil(try mockStore.object(forKey: UserDefaultsKeys.forceDarkModeOnWebsites.rawValue))
     }
 
     @available(macOS 15.4, *)
@@ -154,10 +154,10 @@ final class DarkReaderFeatureSettingsTests: XCTestCase {
         sut = makeSUT()
 
         sut.setForceDarkModeEnabled(true)
-        XCTAssertTrue(try mockStore.object(forKey: UserDefaultsKeys.forceDarkModeOnWebsitesEnabled.rawValue) as? Bool ?? false)
+        XCTAssertTrue(try mockStore.object(forKey: UserDefaultsKeys.forceDarkModeOnWebsites.rawValue) as? Bool ?? false)
 
         sut.setForceDarkModeEnabled(false)
-        XCTAssertFalse(try mockStore.object(forKey: UserDefaultsKeys.forceDarkModeOnWebsitesEnabled.rawValue) as? Bool ?? true)
+        XCTAssertFalse(try mockStore.object(forKey: UserDefaultsKeys.forceDarkModeOnWebsites.rawValue) as? Bool ?? true)
     }
 
     @available(macOS 15.4, *)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1213585989425974?focus=true

### Description
This change updates Dark Reader settings storage so that it's disabled by default for internal users.

### Testing Steps
1. Clear app data via `macOS/clean-app.sh debug`
2. Launch the app, skip onboarding if needed and enable internal user state.
3. Go to Appearance Settings and verify that "Force dark mode on websites" is disabled by default.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

### Notes to the Reviewer
This change is mostly a revert of #3901 

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the persisted UserDefaults key and removes the internal-user auto-enable path, which can reset existing user preferences and alter pixel-firing behavior. Functionality impact is limited to Dark Reader enablement state and related metrics.
> 
> **Overview**
> **Dark Reader is no longer auto-enabled for internal users** when no prior setting exists; `isForceDarkModeEnabled` now strictly reflects the stored value (defaulting to `false`).
> 
> The stored preference key is renamed from `forceDarkModeOnWebsitesEnabled` to `forceDarkModeOnWebsites`, and unit tests are updated to drop internal-user default/pixel expectations and to validate the new key usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d005a5583b3941bb1ed02772f8579d929761499d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->