### PR TITLE
Report performance metrics also on failed runs

### DIFF
--- a/.github/workflows/macos_performance_tests.yml
+++ b/.github/workflows/macos_performance_tests.yml
@@ -200,6 +200,7 @@ jobs:
         | tee ui-tests.log
 
     - name: Build Performance Report
+      if: always()
       working-directory: macOS
       run: |
         XCRESULT_PATH=$(find DerivedData/Logs/Test -name "*.xcresult" | head -1)
@@ -233,11 +234,19 @@ jobs:
       if: always()
       working-directory: macOS
       run: |
-        echo "Generated insert-statements-memory.sql:"
-        cat insert-statements-memory.sql
+        if [ -f insert-statements-memory.sql ]; then
+          echo "Generated insert-statements-memory.sql:"
+          cat insert-statements-memory.sql
+        else
+          echo "No insert-statements-memory.sql found"
+        fi
 
-        echo "Generated insert-statements-startup-metrics.sql:"
-        cat insert-statements-startup-metrics.sql
+        if [ -f insert-statements-startup-metrics.sql ]; then
+          echo "Generated insert-statements-startup-metrics.sql:"
+          cat insert-statements-startup-metrics.sql
+        else
+          echo "No insert-statements-startup-metrics.sql found"
+        fi
 
     - name: Upload memory metrics
       if: always()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1213609003162396?focus=true

### Description
This change updates macOS performance tests workflow to attempt uploading test results
also on failed runs.

### Testing Steps
Verify that [this performance tests run](https://github.com/duckduckgo/apple-browsers/actions/runs/22893793763) uploaded results to ClickHouse.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that adjust CI step/job conditions; main risk is additional/noisy failures if expected `*.xcresult` or SQL artifacts are missing on failed runs.
> 
> **Overview**
> Ensures macOS performance metrics are still generated and uploaded even when the performance test step fails by running the report build, SQL debug output, and artifact uploads under `if: always()`.
> 
> Also makes the ClickHouse reporting job run regardless of the `performance-tests` job result, and hardens the debug step to handle missing SQL files gracefully.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecadb86c5bb5b28f136894eb088dd98dc1f62923. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->