### PR TITLE
macOS: Wait until web extensions are loaded before restoring app state

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1231,9 +1231,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         guard AppVersion.runType.requiresEnvironment else { return }
-        defer {
-            didFinishLaunching = true
-        }
 
         let profilerToken = startupProfiler.measureSequence(initialStep: .appDidFinishLaunchingBeforeRestoration)
 
@@ -1278,6 +1275,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task {
             await setupWebExtensions()
             restoreStateIfNeeded(profilerToken)
+            didFinishLaunching = true
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1213609004439434?focus=true

### Description
This change adjusts app launch to await web extensions load before state restoration happens.
It helps Dark Reader extension to correctly load its config and render restored websites by either
applying dark mode or skipping processing.

### Testing Steps
1. Run [this review build](https://github.com/duckduckgo/apple-browsers/actions/runs/22879627792).
2. Log in to Asana.
3. Enable state restoration, dark mode, and force dark mode on websites.
4. With a focused Asana tab, close the browser and relaunch.
5. Verify that after restart the dark mode is not applied on Asana (it doesn't look awful, but the same as vanilla Asana website).

### Impact and Risks
Medium: It will slow down app startup where extensions are loaded (macOS 15.4 and above). On my machine, for a release build it's a 100-150ms extra for time to interactive (with 3 tabs open and state restoration enabled).

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes app launch sequencing by making state restoration wait on async web-extension loading, which could impact startup timing and restoration ordering. The refactor also moves `didFinishLaunching` and profiler steps into new async/main-actor paths that could affect lifecycle-dependent behavior if misordered.
> 
> **Overview**
> **Delays state restoration until web extensions are ready.** App launch now runs `setupWebExtensions()` in an async `Task` and *awaits* extension loading/sync before calling state restoration, improving correctness for restored tabs that depend on extension configuration (e.g., Dark Reader).
> 
> **Refactors launch flow for clearer sequencing.** State restoration and post-launch work are split into `restoreStateIfNeeded` and `performPostLaunchTasks`, and profiler token handling is made optional/safe (`?.stop()`), with `didFinishLaunching` set only after the async sequence completes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf1bfdf73d4c97ac0e5bab5f7548f545c8e6cf34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->