### PR TITLE
Extend breakage report with autoplay blocking mode

### DIFF
--- a/iOS/PixelDefinitions/pixels/definitions/broken_site_reporting.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/broken_site_reporting.json5
@@ -204,6 +204,12 @@
                 "description": "Whether force dark mode is enabled. Only sent when value is known."
             },
             {
+                "key": "autoplayBlockingMode",
+                "type": "string",
+                "description": "The user's autoplay blocking setting. Only sent when the feature is enabled.",
+                "enum": ["allowAll", "blockAudio", "blockAll"]
+            },
+            {
                 "key": "isAfterSuppressedXSafariRedirect",
                 "type": "boolean",
                 "description": "Whether the page was loaded after a suppressed x-safari-https redirect. Only sent when true."
@@ -505,6 +511,12 @@
                 "key": "isForceDarkModeEnabled",
                 "type": "boolean",
                 "description": "Whether force dark mode is enabled. Only sent when value is known."
+            },
+            {
+                "key": "autoplayBlockingMode",
+                "type": "string",
+                "description": "The user's autoplay blocking setting. Only sent when the feature is enabled.",
+                "enum": ["allowAll", "blockAudio", "blockAll"]
             },
             {
                 "key": "isAfterSuppressedXSafariRedirect",


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/38424471409662/task/1213608979825187?focus=true
Tech Design URL:
CC:

### Description

Extend the breakage reports (ebpf / protection-toggled-off-breakage-report) with the selected autoplay blocking policy mode (`autoplayBlockingMode`).

### Testing Steps
N/A

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
N/A

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only change to analytics/pixel definitions adding an optional parameter; main risk is downstream ingestion or validation expecting the previous parameter set.
> 
> **Overview**
> Extends broken site reporting pixel definitions (`epbf` and `m_protection-toggled-off-breakage-report`) to include a new optional `autoplayBlockingMode` parameter.
> 
> The new field is a string enum (`allowAll`, `blockAudio`, `blockAll`) and is intended to be sent only when the autoplay feature is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89ba667baf936ea40a022387bf8edaa92bd3052f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->