### PR TITLE
Fix issue with AI Chat suggestions

### DIFF
--- a/macOS/DuckDuckGo/Suggestions/ViewModel/SuggestionContainerViewModel.swift
+++ b/macOS/DuckDuckGo/Suggestions/ViewModel/SuggestionContainerViewModel.swift
@@ -53,7 +53,7 @@ final class SuggestionContainerViewModel {
     private let searchPreferences: SearchPreferences
     private let themeManager: ThemeManaging
     private let featureFlagger: FeatureFlagger
-    private let isAIFeaturesEnabled: Bool
+    private let aiChatPreferencesStorage: AIChatPreferencesStorage
     private var suggestionResultCancellable: AnyCancellable?
     private var cachedRowContents: [SuggestionRowContent]?
 
@@ -70,7 +70,7 @@ final class SuggestionContainerViewModel {
         self.searchPreferences = searchPreferences
         self.themeManager = themeManager
         self.featureFlagger = featureFlagger
-        self.isAIFeaturesEnabled = aiChatPreferencesStorage.isAIFeaturesEnabled
+        self.aiChatPreferencesStorage = aiChatPreferencesStorage
         subscribeToSuggestionResult()
     }
 
@@ -243,7 +243,7 @@ final class SuggestionContainerViewModel {
 
     private var shouldShowAIChatCellBase: Bool {
         guard featureFlagger.isFeatureOn(.aiChatOmnibarToggle) else { return false }
-        guard isAIFeaturesEnabled else { return false }
+        guard aiChatPreferencesStorage.isAIFeaturesEnabled else { return false }
         guard let userStringValue, !userStringValue.isEmpty else { return false }
         return true
     }

--- a/macOS/UnitTests/Suggestions/ViewModel/SuggestionContainerViewModelTests.swift
+++ b/macOS/UnitTests/Suggestions/ViewModel/SuggestionContainerViewModelTests.swift
@@ -545,6 +545,76 @@ final class SuggestionContainerViewModelTests: XCTestCase {
         XCTAssertEqual(suggestionContainerViewModel.rowContent(at: 0), .searchCell)
     }
 
+    @MainActor
+    func testWhenAIFeaturesDisabledAfterInit_ThenAIChatCellIsHidden() {
+        // Setup with AI chat toggle enabled and AI features initially enabled
+        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle, .aiChatOmnibarCluster]
+        let aiChatStorage = MockAIChatPreferencesStorage()
+        aiChatStorage.isAIFeaturesEnabled = true
+
+        suggestionContainerViewModel = SuggestionContainerViewModel(
+            isHomePage: false,
+            isBurner: false,
+            suggestionContainer: suggestionContainer,
+            searchPreferences: SearchPreferences(
+                persistor: searchPreferencesPersistorMock,
+                windowControllersManager: WindowControllersManagerMock()
+            ),
+            themeManager: MockThemeManager(),
+            featureFlagger: featureFlagger,
+            aiChatPreferencesStorage: aiChatStorage
+        )
+
+        suggestionContainerViewModel.setUserStringValue("test query", userAppendedStringToTheEnd: false)
+        suggestionLoadingMock.completion?(SuggestionResult.noTopHitsResult, nil)
+
+        // AI chat cell should initially be visible
+        XCTAssertTrue(suggestionContainerViewModel.shouldShowAIChatCell, "AI chat cell should appear when AI features enabled")
+
+        // Disable AI features after init (simulates user toggling the setting)
+        aiChatStorage.isAIFeaturesEnabled = false
+
+        // AI chat cell should now be hidden
+        XCTAssertFalse(suggestionContainerViewModel.shouldShowAIChatCell, "AI chat cell should be hidden after AI features disabled")
+
+        // Only search cell should remain in the header
+        XCTAssertTrue(suggestionContainerViewModel.shouldShowSearchCell, "Search cell should still appear")
+    }
+
+    @MainActor
+    func testWhenAIFeaturesDisabledAfterInit_ThenAIChatCellFooterIsHidden() {
+        // Setup with AI chat toggle enabled but cluster OFF (AI chat always in footer)
+        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle]
+        let aiChatStorage = MockAIChatPreferencesStorage()
+        aiChatStorage.isAIFeaturesEnabled = true
+
+        suggestionContainerViewModel = SuggestionContainerViewModel(
+            isHomePage: false,
+            isBurner: false,
+            suggestionContainer: suggestionContainer,
+            searchPreferences: SearchPreferences(
+                persistor: searchPreferencesPersistorMock,
+                windowControllersManager: WindowControllersManagerMock()
+            ),
+            themeManager: MockThemeManager(),
+            featureFlagger: featureFlagger,
+            aiChatPreferencesStorage: aiChatStorage
+        )
+
+        suggestionContainerViewModel.setUserStringValue("test query", userAppendedStringToTheEnd: false)
+        suggestionLoadingMock.completion?(SuggestionResult.noTopHitsResult, nil)
+
+        // AI chat cell should initially appear in the footer
+        let lastRowIndex = suggestionContainerViewModel.numberOfRows - 1
+        XCTAssertEqual(suggestionContainerViewModel.rowContent(at: lastRowIndex), .aiChatCell, "AI chat cell should appear in footer")
+
+        // Disable AI features after init
+        aiChatStorage.isAIFeaturesEnabled = false
+
+        // Footer should no longer contain AI chat cell
+        XCTAssertEqual(suggestionContainerViewModel.numberOfFooterRows, 0, "Footer should have no rows when AI features disabled")
+    }
+
 }
 
 extension SuggestionContainerViewModel {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1213614646214944?focus=true
Tech Design URL:
CC:

### Description
SuggestionContainerViewModel captured isAIFeaturesEnabled as a snapshot at init time, so toggling Duck.ai off in Settings    had no effect on already-open windows. Fixed by storing the AIChatPreferencesStorage reference and reading  isAIFeaturesEnabled dynamically when evaluating whether to show the AI chat suggestion cell.

### Testing Steps
  1. Open a browser window and type something in the address bar — confirm the Duck.ai suggestion row appears.
  2. Go to Settings → Duck.ai and disable AI features, then type in the address bar again — confirm the Duck.ai suggestion
  row is gone.
  3. Re-enable AI features in Settings and type again — confirm the Duck.ai suggestion row reappears.


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI-visibility logic change plus tests; main risk is minor regressions in when the AI chat row appears/disappears.
> 
> **Overview**
> Fixes stale AI Chat suggestion visibility by removing the init-time `isAIFeaturesEnabled` snapshot in `SuggestionContainerViewModel` and instead consulting `AIChatPreferencesStorage.isAIFeaturesEnabled` each time `shouldShowAIChatCell*` is evaluated.
> 
> Adds unit tests asserting that disabling AI features after view model initialization immediately hides the AI chat row in both header and footer layouts (cluster on/off).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c9cbbeeff90ef5629eb72e8815c5d07ded2f738. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->