### PR TITLE
[macOS] fix: call _webContentProcessInfo on main thread for Memory Reporter

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -3450,6 +3450,8 @@
 		BB6EE5302F33DB6D009420FA /* MemoryUsageThresholdReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6EE52E2F33DB6D009420FA /* MemoryUsageThresholdReporter.swift */; };
 		BB6EE5322F33DF8F009420FA /* MemoryUsageThresholdReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6EE5312F33DF8F009420FA /* MemoryUsageThresholdReporterTests.swift */; };
 		BB6EE5332F33DF8F009420FA /* MemoryUsageThresholdReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6EE5312F33DF8F009420FA /* MemoryUsageThresholdReporterTests.swift */; };
+		BB44A0022F50000000000001 /* MemoryUsageMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB44A0012F50000000000001 /* MemoryUsageMonitorTests.swift */; };
+		BB44A0032F50000000000001 /* MemoryUsageMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB44A0012F50000000000001 /* MemoryUsageMonitorTests.swift */; };
 		BB72939D2EE709AB00BCC3BB /* ReinstallUserDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB72939C2EE709AB00BCC3BB /* ReinstallUserDetectionTests.swift */; };
 		BB72939E2EE709AB00BCC3BB /* ReinstallUserDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB72939C2EE709AB00BCC3BB /* ReinstallUserDetectionTests.swift */; };
 		BB731F312CDBA6360023D2E4 /* FireWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB731F302CDBA6320023D2E4 /* FireWindowTests.swift */; };
@@ -6158,6 +6160,7 @@
 		BB6EE52B2F33C74F009420FA /* MemoryUsagePixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryUsagePixel.swift; sourceTree = "<group>"; };
 		BB6EE52E2F33DB6D009420FA /* MemoryUsageThresholdReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryUsageThresholdReporter.swift; sourceTree = "<group>"; };
 		BB6EE5312F33DF8F009420FA /* MemoryUsageThresholdReporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryUsageThresholdReporterTests.swift; sourceTree = "<group>"; };
+		BB44A0012F50000000000001 /* MemoryUsageMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryUsageMonitorTests.swift; sourceTree = "<group>"; };
 		BB72939C2EE709AB00BCC3BB /* ReinstallUserDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReinstallUserDetectionTests.swift; sourceTree = "<group>"; };
 		BB731F302CDBA6320023D2E4 /* FireWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireWindowTests.swift; sourceTree = "<group>"; };
 		BB7696C42D6E333300AD8DAB /* DefaultBrowserAndDockPromptPresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserAndDockPromptPresenting.swift; sourceTree = "<group>"; };
@@ -12244,6 +12247,7 @@
 				BB153C542F3A11DF004D9F5E /* MemoryUsageIntervalPixelTests.swift */,
 				BB6EE5312F33DF8F009420FA /* MemoryUsageThresholdReporterTests.swift */,
 				3727A5A92F180136002E10E1 /* MemoryPressureReporterTests.swift */,
+				BB44A0012F50000000000001 /* MemoryUsageMonitorTests.swift */,
 				ED4B8BD82E8C3FB100B9D9E9 /* MacWatchdogDiagnosticProviderTests.swift */,
 				EDF339132E8BFD110062E7C3 /* MockWatchdogDiagnosticProvider.swift */,
 				B5F31F4B2F50E2B90060E5C1 /* PerformanceMetricsReporterTests.swift */,
@@ -15582,6 +15586,7 @@
 				9F3910632B68C35600CB5112 /* DownloadsTabExtensionTests.swift in Sources */,
 				3706FE47293F661700E42796 /* URLExtensionTests.swift in Sources */,
 				BB6EE5322F33DF8F009420FA /* MemoryUsageThresholdReporterTests.swift in Sources */,
+				BB44A0022F50000000000001 /* MemoryUsageMonitorTests.swift in Sources */,
 				6590DB552DB7D59F007D6046 /* DuckPlayerTabExtensionTests.swift in Sources */,
 				9F8D57332BCCCB9A00AEA660 /* UserDefaultsBookmarkFoldersStoreTests.swift in Sources */,
 				F1F861172C1B25D4005DB446 /* SubscriptionUIHandlerMock.swift in Sources */,
@@ -17444,6 +17449,7 @@
 				9FBB0C092CBD39B70006B6A6 /* ViewHighlighterTests.swift in Sources */,
 				56B234BF2A84EFD200F2A1CC /* NavigationBarUrlExtensionsTests.swift in Sources */,
 				BB6EE5332F33DF8F009420FA /* MemoryUsageThresholdReporterTests.swift in Sources */,
+				BB44A0032F50000000000001 /* MemoryUsageMonitorTests.swift in Sources */,
 				56A0542D2C201DA8007D8FAB /* MockContentBlocking.swift in Sources */,
 				56A054442C2252CE007D8FAB /* OnboardingUserScriptTests.swift in Sources */,
 				9FAD623A2BCFDB32007F3A65 /* WebsiteInfoHelpers.swift in Sources */,

--- a/macOS/DuckDuckGo/AppHealth/MemoryUsageMonitor.swift
+++ b/macOS/DuckDuckGo/AppHealth/MemoryUsageMonitor.swift
@@ -254,29 +254,90 @@ final class MemoryUsageMonitor: @unchecked Sendable, MemoryUsageMonitoring {
     ///
     /// Returns `nil` if the private API is unavailable or fails, so callers can
     /// distinguish "0 bytes used" from "unable to measure."
-    private static func getWebContentProcessMemory() -> (totalBytes: UInt64, processCount: Int)? {
-        let selector = Selector(("_webContentProcessInfo"))
-        guard WKProcessPool.responds(to: selector),
-              let processInfoList = WKProcessPool.perform(selector)?
-                .takeUnretainedValue() as? [NSObject] else {
-            return nil
+    ///
+    /// - Parameters:
+    ///   - pidProvider: Override for PID collection. When `nil` (default), uses the real
+    ///     `WKProcessPool._webContentProcessInfo` API. Provided for testing only.
+    ///   - memoryProvider: Override for per-PID resident size lookup. When `nil` (default),
+    ///     uses `proc_pidinfo`. Returns `nil` for a given PID if memory is unreadable
+    ///     (e.g. the process has exited). Provided for testing only.
+    static func getWebContentProcessMemory(
+        pidProvider: (() -> [pid_t]?)? = nil,
+        memoryProvider: ((pid_t) -> UInt64?)? = nil
+    ) -> (totalBytes: UInt64, processCount: Int)? {
+        // _webContentProcessInfo must be called on the main thread. WebKit's
+        // AuxiliaryProcessProxy objects are owned and destroyed on the main thread;
+        // calling this API off the main thread races with WebContent process termination,
+        // causing a use-after-free crash inside AuxiliaryProcessProxy::taskInfo.
+        // We extract the PIDs (plain integers) on the main thread, then query
+        // proc_pidinfo with those values — proc_pidinfo is a syscall with no WebKit
+        // involvement and handles dead processes safely via its return value.
+        //
+        // Callers and their thread context:
+        //   - MemoryUsageThresholdReporter.checkThresholdAndFire — Task.detached(priority: .utility) [background] ← crash path
+        //   - MemoryUsageMonitor internal polling loop            — Task {} [background]
+        //   - MemoryPressureReporter.handleMemoryPressureEvent   — @MainActor [main thread]
+        //   - MemoryUsageIntervalReporter                        — await MainActor.run { } [main thread]
+        //   - MemoryUsageDisplayer.present(in:)                  — @MainActor [main thread]
+        //
+        // DispatchQueue.main.sync from the main thread deadlocks, so we skip the dispatch
+        // when already on the main thread. Thread.isMainThread is the right guard here: all
+        // main-thread callers use @MainActor or await MainActor.run, and Swift's MainActor
+        // is backed by DispatchQueue.main, so Thread.isMainThread is equivalent to holding
+        // the main queue's serial token for these callers. If that backing ever changed, the
+        // guard would need to be revisited.
+        let collectPIDs: () -> [pid_t]?
+        if let pidProvider {
+            collectPIDs = pidProvider
+        } else {
+            let selector = Selector(("_webContentProcessInfo"))
+            guard WKProcessPool.responds(to: selector) else { return nil }
+            // autoreleasepool ensures the objects returned by the private API are kept alive
+            // for the duration of the call. takeUnretainedValue() does not retain, and
+            // _webContentProcessInfo's memory management convention is unknown — if it returns
+            // an autoreleased value, the array and its AuxiliaryProcessProxy-derived elements
+            // could be freed before compactMap finishes without an explicit pool scope.
+            collectPIDs = {
+                autoreleasepool {
+                    guard let processInfoList = WKProcessPool.perform(selector)?
+                        .takeUnretainedValue() as? [NSObject] else { return nil }
+                    let pidSelector = Selector(("pid"))
+                    return processInfoList.compactMap { processInfo in
+                        guard processInfo.responds(to: pidSelector),
+                              let pid = processInfo.value(forKey: "pid") as? pid_t,
+                              pid > 0 else { return nil }
+                        return pid
+                    }
+                }
+            }
         }
+
+        let pids: [pid_t]? = Thread.isMainThread
+            ? collectPIDs()
+            : DispatchQueue.main.sync { collectPIDs() }
+
+        guard let pids else { return nil }
 
         var totalBytes: UInt64 = 0
         var processCount = 0
 
-        let pidSelector = Selector(("pid"))
-        for processInfo in processInfoList {
-            guard processInfo.responds(to: pidSelector),
-                  let pid = processInfo.value(forKey: "pid") as? pid_t,
-                  pid > 0 else { continue }
+        for pid in pids {
+            guard pid > 0 else { continue }
+            let residentSize: UInt64?
+            if let memoryProvider {
+                residentSize = memoryProvider(pid)
+            } else {
+                var taskInfo = proc_taskinfo()
+                let size = Int32(MemoryLayout<proc_taskinfo>.size)
+                let result = proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &taskInfo, size)
+                // A reused PID between collectPIDs() and proc_pidinfo() could attribute another
+                // process's memory to WebContent, slightly inflating the total. The window is
+                // vanishingly small and the over-count is acceptable for telemetry purposes.
+                residentSize = result == size ? taskInfo.pti_resident_size : nil
+            }
 
-            var taskInfo = proc_taskinfo()
-            let size = Int32(MemoryLayout<proc_taskinfo>.size)
-            let result = proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &taskInfo, size)
-
-            if result == size {
-                totalBytes += taskInfo.pti_resident_size
+            if let residentSize {
+                totalBytes += residentSize
                 processCount += 1
             }
         }

--- a/macOS/UnitTests/AppHealth/MemoryUsageMonitorTests.swift
+++ b/macOS/UnitTests/AppHealth/MemoryUsageMonitorTests.swift
@@ -1,0 +1,124 @@
+//
+//  MemoryUsageMonitorTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo_Privacy_Browser
+
+final class MemoryUsageMonitorTests: XCTestCase {
+
+    // MARK: - Thread Safety (regression tests for commit fixing use-after-free crash)
+
+    func testWebContentMemory_pidProviderCalledOnMainThread_whenCalledFromBackground() {
+        // The fix: _webContentProcessInfo must run on the main thread to avoid a
+        // use-after-free crash in WebKit's AuxiliaryProcessProxy. When getWebContentProcessMemory
+        // is called from a background thread it should dispatch the pid collection to main.
+        var calledOnMainThread: Bool?
+        let pidExp = expectation(description: "pidProvider called")
+        let completionExp = expectation(description: "getWebContentProcessMemory returned")
+
+        DispatchQueue.global().async {
+            _ = MemoryUsageMonitor.getWebContentProcessMemory(
+                pidProvider: {
+                    calledOnMainThread = Thread.isMainThread
+                    pidExp.fulfill()
+                    return []
+                }
+            )
+            completionExp.fulfill()
+        }
+
+        wait(for: [pidExp, completionExp], timeout: 2.0, enforceOrder: true)
+        XCTAssertTrue(calledOnMainThread == true, "PID provider must be called on the main thread to avoid use-after-free in WebKit")
+    }
+
+    func testWebContentMemory_doesNotDeadlock_whenCalledFromMainThread() {
+        // Regression: if the code always used DispatchQueue.main.sync it would deadlock
+        // when the caller is already on the main thread. The Thread.isMainThread guard
+        // must skip the sync dispatch in that case.
+        var pidProviderCalled = false
+
+        _ = MemoryUsageMonitor.getWebContentProcessMemory(
+            pidProvider: {
+                pidProviderCalled = true
+                return []
+            }
+        )
+
+        XCTAssertTrue(pidProviderCalled, "PID provider should be called directly without dispatch when already on the main thread")
+    }
+
+    // MARK: - Memory Aggregation
+
+    func testWebContentMemory_sumsResidentMemoryAcrossAllPIDs() {
+        let result = MemoryUsageMonitor.getWebContentProcessMemory(
+            pidProvider: { [100, 200] },
+            memoryProvider: { pid in
+                switch pid {
+                case 100: return 1_000
+                case 200: return 2_000
+                default: return nil
+                }
+            }
+        )
+
+        XCTAssertEqual(result?.totalBytes, 3_000)
+        XCTAssertEqual(result?.processCount, 2)
+    }
+
+    func testWebContentMemory_returnsNil_whenPIDProviderReturnsNil() {
+        let result = MemoryUsageMonitor.getWebContentProcessMemory(
+            pidProvider: { nil }
+        )
+
+        XCTAssertNil(result)
+    }
+
+    func testWebContentMemory_excludesPIDsWhoseMemoryIsUnreadable() {
+        // Simulates a process that terminated between collectPIDs() and proc_pidinfo():
+        // its memoryProvider returns nil and it should not count toward the total.
+        let result = MemoryUsageMonitor.getWebContentProcessMemory(
+            pidProvider: { [100, 200] },
+            memoryProvider: { pid in pid == 200 ? 2_000 : nil }
+        )
+
+        XCTAssertEqual(result?.totalBytes, 2_000)
+        XCTAssertEqual(result?.processCount, 1)
+    }
+
+    func testWebContentMemory_returnsZero_whenPIDProviderReturnsEmptyArray() {
+        let result = MemoryUsageMonitor.getWebContentProcessMemory(
+            pidProvider: { [] },
+            memoryProvider: { _ in nil }
+        )
+
+        XCTAssertEqual(result?.totalBytes, 0)
+        XCTAssertEqual(result?.processCount, 0)
+    }
+
+    func testWebContentMemory_filtersOutNonPositivePIDs() {
+        // The real collectPIDs already enforces pid > 0; this test ensures the aggregation
+        // loop also enforces it so the invariant holds regardless of what pidProvider returns.
+        let result = MemoryUsageMonitor.getWebContentProcessMemory(
+            pidProvider: { [0, -1, 200] },
+            memoryProvider: { _ in 1_000 }
+        )
+
+        XCTAssertEqual(result?.totalBytes, 1_000)
+        XCTAssertEqual(result?.processCount, 1)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1213610116924374?focus=true
Tech Design URL:
CC:

### Description
`getWebContentProcessMemory` was called from background threads (e.g. MemoryUsageThresholdReporter's Task.detached), racing with WebKit destroying `AuxiliaryProcessProxy` objects on the main thread — causing a use-after-free crash in `AuxiliaryProcessProxy::taskInfo`.

Fix: PID collection via `WKProcessPool._webContentProcessInfo` is now always dispatched to the main thread via `DispatchQueue.main.sync`. When the caller is already on the main thread, the dispatch is skipped to avoid deadlock.
proc_pidinfo remains off-main since it's a plain syscall with no WebKit involvement.

Also added: autoreleasepool around the private API call to ensure WebKit objects returned via `takeUnretainedValue()` stay alive for the duration of the PID extraction.

Tests: New `MemoryUsageMonitorTests` covering the thread dispatch behaviour (background → main, main → no deadlock), memory aggregation, PID unavailability, and pid ≤ 0 filtering.


### Testing Steps
1. Run the application, open various tabs
2. Go to Debug -> Memory Usage Reporter -> Fire Interval Pixel Now
3. Check the console and see the `wc_total_memory` parameter has the right bucket (you can compare this with the number with the WC number in the address bar after turning on the `memoryUsageMonitor` feature flag)

<img width="647" height="274" alt="Screenshot 2026-03-11 at 11 12 52 AM" src="https://github.com/user-attachments/assets/0a1cec58-4ea4-4bd1-82f4-f8466e194172” />


### Impact and Risks
Medium: Could disrupt specific features or user flows

#### What could go wrong?
The crash is still happening and we need to turn on the feature flag

### Quality Considerations
Nothing specific.

### Notes to Reviewer
- I’ve run the tests multiple times (using the run repeatedly)
- I’ve also added some code to fetch the WC content memory every 2 seconds to see if it was working.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches AppHealth memory reporting by adding main-thread synchronization around a private WebKit API call; mistakes here could reintroduce deadlocks or miss WebContent memory telemetry. Changes are localized and covered by new unit tests.
> 
> **Overview**
> Fixes a crash in `MemoryUsageMonitor.getWebContentProcessMemory` by **always collecting WebContent PIDs on the main thread** (skipping `DispatchQueue.main.sync` when already on main to avoid deadlock), then performing `proc_pidinfo` lookups off-main.
> 
> Refactors the helper to accept injectable `pidProvider`/`memoryProvider` (test-only) and wraps the private `_webContentProcessInfo` call in an `autoreleasepool` to keep returned objects alive during PID extraction. Adds `MemoryUsageMonitorTests` and wires it into the Xcode project to cover thread-dispatch behavior and aggregation/filtering edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b98645d29d6ca197aad4df55c86efa4c70919232. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->