### PR TITLE
[iOS] perform focusing of the omnibar in did appear rather than will appear

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -159,17 +159,16 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
             installChatHistoryList()
         }
 
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
         switchBarVC.focusTextField()
         if automaticallySelectsTextOnAppear {
             DispatchQueue.main.async {
                 self.switchBarVC.textEntryViewController.selectAllText()
             }
         }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
 
         DailyPixel.fireDailyAndCount(pixel: .aiChatInternalSwitchBarDisplayed)
         DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarShown)

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -2573,8 +2573,8 @@ extension TabViewController: WKNavigationDelegate {
             return
         }
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(keyboardWillHide),
-                                               name: UIResponder.keyboardWillHideNotification,
+                                               selector: #selector(keyboardDidHide),
+                                               name: UIResponder.keyboardDidHideNotification,
                                                object: nil)
     }
 
@@ -2585,7 +2585,7 @@ extension TabViewController: WKNavigationDelegate {
 
         NotificationCenter.default.removeObserver(
             self,
-            name: UIResponder.keyboardWillHideNotification,
+            name: UIResponder.keyboardDidHideNotification,
             object: nil
         )
     }
@@ -2611,7 +2611,7 @@ extension TabViewController: WKNavigationDelegate {
         ActionMessageView.present(message: UserText.autofillSettingsReportNotWorkingSentConfirmation)
     }
 
-    @objc private func keyboardWillHide(_ notification: Notification) {
+    @objc private func keyboardDidHide(_ notification: Notification) {
         if !fillCreditCardsPromptIsPresenting && isTabCurrentlyPresented() {
             autofillUserScript?.cancelAllPendingReplies()
             cleanupInputAccessoryView()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1213601987646073?focus=true
Tech Design URL:
CC:

### Description
Move removing of input accessories from will hide to did hide in order to not affect the keyboard lifecycle.

### Testing Steps

On a physical device (can't get Siri Intelligence to work on Simulator)
1. Enable Siri Intelligence
2. Add some credit cards in autofill
3. Go to fill.dev
4. Tap the credit card or CCV field
5. Dismiss the in-app sheet
6. Tap the field again so that the input accessor shows the credit cards
7. Tap omnibar to get into focussed state
8. The keyboard will remove the input accessory and then change shape again to add Siri Intelligence
9. Ensure the omnibar / switch bar are position correctly relative to the top of the keyboard.

Showing input accessory for credit cards:

<img width="300"  alt="Screenshot 2026-03-11 at 15 18 44" src="https://github.com/user-attachments/assets/e234d90b-cc8d-42e4-baa0-43eae884c72b" />

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
11. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Some side effect related to auto fill or keyboard management.

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
