### PR TITLE
check-dependencies-updates.sh script improvements

### DIFF
--- a/scripts/check-dependencies-updates.sh
+++ b/scripts/check-dependencies-updates.sh
@@ -442,7 +442,7 @@ parse_resolved_files() {
         [[ -z "$file" ]] && continue
 
         local version="2"
-        if head -5 "$file" 2>/dev/null | grep -q '"version"[[:space:]]*:[[:space:]]*1'; then
+        if tail -3 "$file" 2>/dev/null | grep -q '"version"[[:space:]]*:[[:space:]]*1'; then
             version="1"
         fi
         verbose "Parsing $file (format version: $version)"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213576123789981?focus=true

### Description

The check-dependencies-updates.sh script is now ignoring DerivedData folders

### Testing Steps

Run the script

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk shell-script refactor; main risk is altered `find`/parsing behavior potentially missing or misclassifying some dependencies or `Package.resolved` formats.
> 
> **Overview**
> Tightens `scripts/check-dependencies-updates.sh` to **skip build artifact directories** (notably `DerivedData`, plus `.build`/`Packages`) when searching for `Package.swift`, `project.pbxproj`, and `Package.resolved`, reducing noise and runtime.
> 
> Refactors several parsing helpers to be more robust and Bash-native: simplifies GitHub repo/package name extraction, switches semver parsing/comparison to regex + `read`, improves search-root existence detection, and adjusts `Package.resolved` format detection to reliably distinguish v1 vs v2.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7662364d78ddbcd69bde8379bcecdff31ae6290f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->