### PR TITLE
Update fastlane to 2.232.2 and fastlane plugin to 3.1.8

### DIFF
--- a/iOS/Gemfile
+++ b/iOS/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'fastlane', '2.232.1'
+gem 'fastlane', '2.232.2'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/iOS/Gemfile.lock
+++ b/iOS/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: 3eea3955dcb887f8c4abd8427b77dbf2f1fe90fa
-  tag: 3.1.7
+  revision: 0f4fc06bfd07096fd6b8198d89bb80bf96f8156e
+  tag: 3.1.8
   specs:
-    fastlane-plugin-ddg_apple_automation (3.1.7)
+    fastlane-plugin-ddg_apple_automation (3.1.8)
       asana
       climate_control
       httpparty
@@ -15,7 +15,7 @@ GEM
   specs:
     CFPropertyList (3.0.8)
     abbrev (0.1.2)
-    addressable (2.8.8)
+    addressable (2.8.9)
       public_suffix (>= 2.0.2, < 8.0)
     artifactory (3.0.17)
     asana (2.0.0)
@@ -25,8 +25,8 @@ GEM
       oauth2 (>= 1.4, < 3)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1213.0)
-    aws-sdk-core (3.242.0)
+    aws-partitions (1.1224.0)
+    aws-sdk-core (3.243.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -34,11 +34,11 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.121.0)
+    aws-sdk-kms (1.122.0)
       aws-sdk-core (~> 3, >= 3.241.4)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.213.0)
-      aws-sdk-core (~> 3, >= 3.241.4)
+    aws-sdk-s3 (1.215.0)
+      aws-sdk-core (~> 3, >= 3.243.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.12.1)
@@ -61,7 +61,7 @@ GEM
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.112.0)
-    faraday (1.10.4)
+    faraday (1.10.5)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -86,14 +86,14 @@ GEM
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
+    faraday-retry (1.0.4)
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     faraday_middleware-multi_json (0.0.6)
       faraday_middleware
       multi_json
-    fastimage (2.4.0)
-    fastlane (2.232.1)
+    fastimage (2.4.1)
+    fastlane (2.232.2)
       CFPropertyList (>= 2.3, < 4.0.0)
       abbrev (~> 0.1.2)
       addressable (>= 2.8, < 3.0.0)
@@ -160,7 +160,7 @@ GEM
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-playcustomapp_v1 (0.17.0)
       google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.60.0)
+    google-apis-storage_v1 (0.61.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-cloud-core (1.8.0)
       google-cloud-env (>= 1.0, < 3.a)
@@ -198,7 +198,7 @@ GEM
     httpparty (0.2.0)
       httparty (> 0)
     jmespath (1.6.2)
-    json (2.18.1)
+    json (2.19.1)
     jwt (2.10.2)
       base64
     logger (1.7.0)
@@ -227,14 +227,14 @@ GEM
     os (1.1.4)
     ostruct (0.6.3)
     plist (3.7.2)
-    public_suffix (7.0.2)
-    rack (3.2.4)
+    public_suffix (7.0.5)
+    rack (3.2.5)
     rake (13.3.1)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
-    retriable (3.1.2)
+    retriable (3.4.1)
     rexml (3.4.4)
     rouge (3.28.0)
     ruby2_keywords (0.0.5)
@@ -284,7 +284,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane (= 2.232.1)
+  fastlane (= 2.232.2)
   fastlane-plugin-ddg_apple_automation!
 
 BUNDLED WITH

--- a/iOS/fastlane/Pluginfile
+++ b/iOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '3.1.7'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '3.1.8'

--- a/macOS/Gemfile
+++ b/macOS/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'fastlane', '2.232.1'
+gem 'fastlane', '2.232.2'
 gem 'httparty'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')

--- a/macOS/Gemfile.lock
+++ b/macOS/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: 3eea3955dcb887f8c4abd8427b77dbf2f1fe90fa
-  tag: 3.1.7
+  revision: 0f4fc06bfd07096fd6b8198d89bb80bf96f8156e
+  tag: 3.1.8
   specs:
-    fastlane-plugin-ddg_apple_automation (3.1.7)
+    fastlane-plugin-ddg_apple_automation (3.1.8)
       asana
       climate_control
       httpparty
@@ -15,7 +15,7 @@ GEM
   specs:
     CFPropertyList (3.0.8)
     abbrev (0.1.2)
-    addressable (2.8.8)
+    addressable (2.8.9)
       public_suffix (>= 2.0.2, < 8.0)
     artifactory (3.0.17)
     asana (2.0.0)
@@ -25,8 +25,8 @@ GEM
       oauth2 (>= 1.4, < 3)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1213.0)
-    aws-sdk-core (3.242.0)
+    aws-partitions (1.1224.0)
+    aws-sdk-core (3.243.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -34,11 +34,11 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.121.0)
+    aws-sdk-kms (1.122.0)
       aws-sdk-core (~> 3, >= 3.241.4)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.213.0)
-      aws-sdk-core (~> 3, >= 3.241.4)
+    aws-sdk-s3 (1.215.0)
+      aws-sdk-core (~> 3, >= 3.243.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.12.1)
@@ -61,7 +61,7 @@ GEM
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.112.0)
-    faraday (1.10.4)
+    faraday (1.10.5)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -86,14 +86,14 @@ GEM
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
+    faraday-retry (1.0.4)
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     faraday_middleware-multi_json (0.0.6)
       faraday_middleware
       multi_json
-    fastimage (2.4.0)
-    fastlane (2.232.1)
+    fastimage (2.4.1)
+    fastlane (2.232.2)
       CFPropertyList (>= 2.3, < 4.0.0)
       abbrev (~> 0.1.2)
       addressable (>= 2.8, < 3.0.0)
@@ -160,7 +160,7 @@ GEM
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-playcustomapp_v1 (0.17.0)
       google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.60.0)
+    google-apis-storage_v1 (0.61.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-cloud-core (1.8.0)
       google-cloud-env (>= 1.0, < 3.a)
@@ -198,7 +198,7 @@ GEM
     httpparty (0.2.0)
       httparty (> 0)
     jmespath (1.6.2)
-    json (2.18.1)
+    json (2.19.1)
     jwt (2.10.2)
       base64
     logger (1.7.0)
@@ -227,14 +227,14 @@ GEM
     os (1.1.4)
     ostruct (0.6.3)
     plist (3.7.2)
-    public_suffix (7.0.2)
-    rack (3.2.4)
+    public_suffix (7.0.5)
+    rack (3.2.5)
     rake (13.3.1)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
-    retriable (3.1.2)
+    retriable (3.4.1)
     rexml (3.4.4)
     rouge (3.28.0)
     ruby2_keywords (0.0.5)
@@ -284,7 +284,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane (= 2.232.1)
+  fastlane (= 2.232.2)
   fastlane-plugin-ddg_apple_automation!
   httparty
 

--- a/macOS/fastlane/Pluginfile
+++ b/macOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '3.1.7'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '3.1.8'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1213618792194332?focus=true

### Description
A patch-version bump for fastlane and a bump for the plugin to include
first part of refactoring related to automatic code freeze via https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation/pull/63

### Testing Steps
Verify that CI is green.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency update limited to Fastlane tooling, though it could affect CI/release lanes if the updated Fastlane/plugin changes behavior.
> 
> **Overview**
> Updates iOS and macOS Fastlane tooling by bumping `fastlane` from `2.232.1` to `2.232.2` and `fastlane-plugin-ddg_apple_automation` from `3.1.7` to `3.1.8`.
> 
> Regenerates both `Gemfile.lock` files to reflect the new plugin git revision and related transitive gem updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c807605fc9f3e0faaf018358e71015e9c4d8de92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->