### PR TITLE
Fix newTabPageShown daily pixel firing once per session

### DIFF
--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageCoordinator.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageCoordinator.swift
@@ -116,7 +116,6 @@ final class NewTabPageCoordinator {
         )
 
         notificationCenter.publisher(for: .newTabPageWebViewDidAppear)
-            .prefix(1)
             .sink { [weak self] _ in
                 self?.newTabPageShownPixelSender.firePixel()
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1213647224149041

### Description

The `newTabPageShown` daily pixel (`m_mac_newtab_shown`) was only firing once per app session instead of once per calendar day. The Combine subscription in `NewTabPageCoordinator` used `.prefix(1)`, which completed the pipeline after the first `.newTabPageWebViewDidAppear` notification. This prevented the pixel from firing again if the app remained open across midnight.

The fix removes `.prefix(1)` since PixelKit's `legacyDaily` frequency already handles once-per-day deduplication via `pixelHasBeenFiredToday`.

### Testing Steps

1. Open a new tab — verify the `m_mac_newtab_shown_d` pixel fires
2. Navigate to a website.
3. Open a new tab — verify that the pixel firing was attempted again (this is what wasn't happening and got fixed here).

### Impact and Risks

**Low** — This is a pixel-only fix with no user-facing behavior change. The pixel was under-reporting; this fix ensures it reports correctly once per day.

#### What could go wrong?

- The pixel could fire on every new tab appearance instead of daily. This is mitigated by PixelKit's built-in `legacyDaily` frequency check which deduplicates per calendar day.

### Quality Considerations

- No performance concern: `firePixel()` is lightweight and PixelKit's daily check is a simple UserDefaults date comparison
- No privacy impact: the pixel already existed, this just fixes its frequency
- Existing unit tests for `NewTabPageShownPixelSender` continue to pass

### Notes to Reviewer

The `.prefix(1)` was redundant with PixelKit's daily deduplication and actively prevented the pixel from firing on subsequent days within a long-running session.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a Combine `.prefix(1)` that prematurely stopped listening for `.newTabPageWebViewDidAppear`, relying on existing PixelKit daily deduplication to prevent over-firing.
> 
> **Overview**
> Ensures the `newTabPageShown` daily pixel can fire again on subsequent days within the same app session by **removing the `.prefix(1)`** from the `.newTabPageWebViewDidAppear` Combine subscription in `NewTabPageCoordinator`.
> 
> The notification listener now stays active for the app lifetime, while PixelKit’s `.legacyDaily` frequency continues to deduplicate the event to once per calendar day.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9f0c0b64620a23cb62f9d9b663d7ebdc3805c8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->