### PR TITLE
Memory Tests Fix: Ensure there's at least one Window

### DIFF
--- a/macOS/PerformanceTests/Extensions/UITests+Helpers.swift
+++ b/macOS/PerformanceTests/Extensions/UITests+Helpers.swift
@@ -30,7 +30,10 @@ extension UITests {
         let application = XCUIApplication.setUp()
 
         /// Ensure there's at least one window open
-        if application.windows.count == 0 {
+        let firstWindow = application.windows.firstMatch
+        let windowAppeared = firstWindow.waitForExistence(timeout: 0.5)
+
+        if !windowAppeared {
             application.openNewWindow()
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1213635911008881
Tech Design URL:
CC:

### Description
In this PR we're fixing a glitch that caused the Memory Tests to fail.

### Testing Steps
- [ ] Verify [this CI workflow is green](https://github.com/duckduckgo/apple-browsers/actions/runs/23014141998)

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing, internal tooling PR

### Quality Considerations
None

### Notes to Reviewer
Thank you!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adds a small precondition check to reduce UI-test flakiness, with minimal impact beyond performance test setup.
> 
> **Overview**
> Fixes flaky macOS performance/memory UI tests by ensuring a window exists before configuring preferences in `UITests.setupInitialState`.
> 
> If no window appears shortly after launch, the helper now opens a new window before toggling session restoration and quitting, preventing setup from running against a windowless app state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9f6ec48e0ab00bd9bf5aac3df191c93c7d07326. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->