### PR TITLE
PIR: Disable firing engagement pixels due to issue with hang times

### DIFF
--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
@@ -297,7 +297,12 @@ extension DataBrokerProtectionIOSManager: DBPIOSInterface.AppLifecycleEventsDele
 
     func fireMonitoringPixels() async {
         let isAuthenticated = await authenticationManager.isUserAuthenticated
-        tryToFireEngagementPixels(isAuthenticated: isAuthenticated)
+        
+        /*
+         Engagement pixels disabled for now as checking for the profile on the main thread was causing an increase in hang rates
+         */
+        // tryToFireEngagementPixels(isAuthenticated: isAuthenticated)
+
         tryToFireWeeklyPixels(isAuthenticated: isAuthenticated)
 
         // Stats pixels only fire for authenticated users (they relate to opt-outs)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1197815745158596/task/1213637115806341?focus=true
Tech Design URL:
CC:

### Description
As title, also see release process exception: https://app.asana.com/1/137249556945/project/547792610048271/task/1213637113319609?focus=true

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Smoke test other PIR stats pixels are still fired correctly
2. Test performance/hang times when app is active, it should be improved

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Disables a subset of PIR monitoring pixels and changes the AI Chat contextual webview’s user agent behavior, which could affect analytics coverage and web compatibility if misconfigured.
> 
> **Overview**
> **Improves PIR app-active performance** by disabling (commenting out) engagement pixel firing in `DataBrokerProtectionIOSManager.fireMonitoringPixels()` due to observed hang-rate impact, while keeping weekly/stats pixels intact.
> 
> **Updates AI Chat contextual webview identification** by injecting a `UserAgentManaging` dependency into `AIChatContextualWebViewController` and setting `WKWebView.customUserAgent` from it; adds new unit tests to verify both injected and default user-agent behavior.
> 
> **Localizes x-safari-https redirect prompts** by switching the strings in `UserText` to `NSLocalizedString` and adding translations across multiple `Localizable.strings` locales.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e740be675e1630d6a3b25d136d43f3dbf2432d17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->