### PR TITLE
[iOS] Avoid ATB server timeout test failures

### DIFF
--- a/iOS/IntegrationTests/AtbServerTests.swift
+++ b/iOS/IntegrationTests/AtbServerTests.swift
@@ -34,8 +34,8 @@ class AtbServerTests: XCTestCase {
     var original: Method!
     var new: Method!
     
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    override func setUp() {
+        super.setUp()
         PixelKit.configureExperimentKit(featureFlagger: MockFeatureFlagger())
         store = MockStatisticsStore()
         loader = StatisticsLoader(statisticsStore: store)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1213637414614957?focus=true
Tech Design URL:
CC:

### Description

This PR fixes an issue where the ATB tests can time out when the GHA runner network access has failed.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Run the tests locally and check that they still work as expected in the happy path

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to integration test behavior, replacing hard failures on CI network timeouts with explicit skips.
> 
> **Overview**
> Makes the ATB server integration tests more resilient to CI networking issues by switching from `wait(for:)` to `XCTWaiter.wait` and **skipping** the test when the request times out.
> 
> All affected tests are updated to `throws` so they can `throw XCTSkip(...)` instead of failing when the expectation isn’t fulfilled within 5 seconds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7209419ebad646356e89febf49cd1b0ec611d1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->