### PR TITLE
Add missing translations for Duck.ai contextual attach content

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Resources/Localizable.xcstrings
+++ b/SharedPackages/AIChat/Sources/AIChat/Resources/Localizable.xcstrings
@@ -510,10 +510,34 @@
       "comment" : "Title for the attach placeholder chip in Duck.ai contextual sheet",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "bg" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прикачи съдържанието на страницата"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Připojit obsah stránky"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vedhæft sideindhold"
+          }
+        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Seiteninhalt anhängen"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Επισύναψη περιεχομένου σελίδας"
           }
         },
         "en" : {
@@ -528,16 +552,64 @@
             "value" : "Adjuntar contenido de la página"
           }
         },
+        "et" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lisa lehe sisu"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liitä sivun sisältö"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Joindre le contenu de la page"
           }
         },
+        "hr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Priloži sadržaj stranice"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oldal tartalmának csatolása"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Allega il contenuto della pagina"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ページの内容を添付"
+          }
+        },
+        "lt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pridėkite puslapio turinį"
+          }
+        },
+        "lv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pievienot lapas saturu"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Legg ved sideinnhold"
           }
         },
         "nl" : {
@@ -558,10 +630,40 @@
             "value" : "Anexar contexto da página"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atașează conținutul paginii"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Добавить содержимое страницы"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pripoj obsah stránky"
+          }
+        },
+        "sl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Priloži vsebino strani"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bifoga sidans innehåll"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sayfa İçeriğini Ekle"
           }
         }
       }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1213610071888929
Tech Design URL:
CC:

### Description

Import missing translations for the `duckai.contextual.attach.content` key ("Attach Page Content") in the Duck.ai contextual sheet. 21 locales were falling back to English despite translations being available from Smartling.

### Testing Steps

N/A

### Impact and Risks

None — translation-only change.

#### What could go wrong?

A translated string could be incorrect, but these come directly from Smartling.

### Quality Considerations

Strings imported from the official Smartling translation export.

### Notes to Reviewer

Only the `Localizable.xcstrings` file in the AIChat package was modified. All other changes from the bulk import were reverted.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)