### PR TITLE
iOS: Fix subscription flow nav bar centering and Settings modal top a…

### DIFF
--- a/iOS/DuckDuckGo/MainViewController+Segues.swift
+++ b/iOS/DuckDuckGo/MainViewController+Segues.swift
@@ -483,6 +483,12 @@ extension MainViewController {
                 let navController = SettingsUINavigationController(rootViewController: settingsController)
                 navController.navigationBar.tintColor = UIColor(designSystemColor: .textPrimary)
                 settingsController.modalPresentationStyle = UIModalPresentationStyle.automatic
+                // Opaque nav bar and matching view background so sheet top gap (if any) is visually continuous with the bar
+                let surfaceColor = UIColor(designSystemColor: .surface)
+                navController.view.backgroundColor = surfaceColor
+                navController.navigationBar.isTranslucent = false
+                navController.navigationBar.barTintColor = surfaceColor
+                navController.navigationBar.backgroundColor = surfaceColor
 
                 // Apply custom configuration (e.g. pre-navigate to specific screens before presentation)
                 configure?(settingsViewModel, settingsController)

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionContainerView.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionContainerView.swift
@@ -48,7 +48,7 @@ struct SubscriptionContainerView: View {
     }
 
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             switch currentViewType {
             case .subscribe:
                 SubscriptionFlowView(viewModel: flowViewModel,
@@ -66,5 +66,7 @@ struct SubscriptionContainerView: View {
                                       featureFlagger: featureFlagger)
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .navigationBarTitleDisplayMode(.inline)
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1213616949470391?focus=true

### Description  Fixes the subscription flow / Settings modal layout issues (see task)

### Testing Steps
1. Turn allowProTierPurchase on
2. Navigate to https://duckduckgo.com/subscriptions/plans?origin=funnel_appsettings_ios&tier=pro&environment=staging 
3. Check the header of the modal looks centred and correct (no visible line above the header; bar and background should be continuous)


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: UI-only tweaks to navigation bar styling and SwiftUI layout, with no changes to business logic, networking, or data handling.
> 
> **Overview**
> Improves modal presentation polish in two places.
> 
> The Settings sheet now forces an *opaque* navigation bar and matches the nav controller/view background to the `.surface` color to avoid a visible gap/line at the top of the sheet.
> 
> The subscription flow container removes default `VStack` spacing, expands to fill available space, and forces an `.inline` navigation bar title display mode to keep the header centered/consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c12d5e4460c5f7834480820cca1f846d6216b6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->