### PR TITLE
Fix voice chat on sidebar

### DIFF
--- a/macOS/DuckDuckGo/AIChat/Sidebar/AIChatViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/Sidebar/AIChatViewController.swift
@@ -94,6 +94,7 @@ final class AIChatViewController: NSViewController {
 
     private lazy var aiTab: Tab = Tab(content: .url(currentAIChatURL, source: .ui), burnerMode: burnerMode, isLoadedInSidebar: true)
 
+    private var permissionAuthorizationPopover: PermissionAuthorizationPopover?
     private var cancellables = Set<AnyCancellable>()
 
     init(currentAIChatURL: URL,
@@ -159,6 +160,7 @@ final class AIChatViewController: NSViewController {
         updateWebViewMask()
         subscribeToURLChanges()
         subscribeToUserInteractionDialogChanges()
+        subscribeToPermissionAuthorizationQueries()
         subscribeToThemeChanges()
     }
 
@@ -427,6 +429,40 @@ final class AIChatViewController: NSViewController {
             .store(in: &cancellables)
     }
 
+    private func subscribeToPermissionAuthorizationQueries() {
+        aiTab.permissions.$authorizationQuery
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] query in
+                guard let self else { return }
+                if let query {
+                    showPermissionAuthorizationPopover(for: query)
+                } else if let popover = permissionAuthorizationPopover, popover.isShown,
+                          !popover.viewController.isAuthorizationInProgress {
+                    popover.close()
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    private func showPermissionAuthorizationPopover(for query: PermissionAuthorizationQuery) {
+        let popover = permissionAuthorizationPopover ?? {
+            let popover = PermissionAuthorizationPopover(featureFlagger: NSApp.delegateTyped.featureFlagger)
+            self.permissionAuthorizationPopover = popover
+            return popover
+        }()
+
+        if popover.isShown {
+            guard popover.viewController.query !== query else { return }
+            if popover.viewController.isAuthorizationInProgress { return }
+            popover.close()
+        }
+
+        popover.viewController.query = query
+        query.wasShownOnce = true
+
+        popover.show(positionedBelow: topBar)
+    }
+
     @objc private func openInNewTabButtonClicked() {
         delegate?.didClickOpenInNewTabButton()
     }
@@ -454,6 +490,8 @@ final class AIChatViewController: NSViewController {
     }
 
     func stopLoading() {
+        permissionAuthorizationPopover?.close()
+
         aiTab.webView.navigationDelegate = nil
         aiTab.webView.uiDelegate = nil
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201392122292466/task/1213507734075423?focus=true
Tech Design URL:
CC:

### Description

Fixes voice chat (microphone permission) not working when AI Chat is opened in the sidebar. The sidebar's `AIChatViewController` was missing the permission authorization flow — it didn't subscribe to `authorizationQuery` changes or show the `PermissionAuthorizationPopover`. This adds the same permission handling that exists in the main tab view, allowing the microphone permission prompt to appear when using voice chat from the sidebar.

### Testing Steps

1. Open AI Chat in the sidebar
2. Click the voice/microphone button to start a voice chat
3. Verify that the microphone permission popover appears positioned below the top bar
4. Grant the permission and verify voice chat works
5. Close the sidebar, reopen it, and try voice chat again — confirm it still works
6. While the permission popover is showing, click "Open in new tab" or close the sidebar — verify the popover is dismissed cleanly
7. Open AI Chat in a regular tab and confirm voice chat still works as before (no regression)

### Impact and Risks

Low impact. The change is scoped to `AIChatViewController` (sidebar only) and adds permission handling that mirrors existing behavior in the main tab. No shared code paths are modified.

#### What could go wrong?

- The permission popover could be positioned incorrectly relative to the sidebar's top bar
- Edge case where rapidly opening/closing the sidebar while the popover is shown could leave stale state, though the `stopLoading()` cleanup should handle this

### Quality Considerations



### Notes to Reviewer

The implementation follows the same pattern used for permission authorization in the main tab view. The key addition is `subscribeToPermissionAuthorizationQueries()` which observes `aiTab.permissions.$authorizationQuery` and shows/hides a `PermissionAuthorizationPopover` accordingly.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds sidebar handling for permission authorization queries (e.g., microphone) and popover lifecycle, which could affect user permission prompts and related UI state if edge cases are missed.
> 
> **Overview**
> Fixes AI Chat sidebar voice/mic permission prompting by wiring the sidebar `AIChatViewController` into the existing permission-authorization flow.
> 
> The sidebar now subscribes to `aiTab.permissions.$authorizationQuery` to show a `PermissionAuthorizationPopover` positioned under the top bar, updates/avoids replacing the popover while authorization is in progress, and ensures the popover is dismissed during teardown via `stopLoading()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 290622344893c9f325fe8608e198e4d39f206640. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->