### PR TITLE
Remove network.server entitlement from VPN App Store Debug build

### DIFF
--- a/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppStoreDebug.entitlements
+++ b/macOS/DuckDuckGoVPN/DuckDuckGoVPNAppStoreDebug.entitlements
@@ -2,30 +2,28 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.system-extension.install</key>
-	<true/>
-	<key>com.apple.security.network.client</key>
-	<true/>
-	<key>com.apple.security.network.server</key>
-	<true/>
 	<key>com.apple.developer.networking.networkextension</key>
 	<array>
 		<string>app-proxy-provider</string>
 		<string>packet-tunnel-provider</string>
 	</array>
+	<key>com.apple.developer.system-extension.install</key>
+	<true/>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>$(NETP_APP_GROUP)</string>
-		<string>$(SUBSCRIPTION_APP_GROUP)</string>
-	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>$(IPC_APP_GROUP)</string>
 		<string>$(SUBSCRIPTION_APP_GROUP)</string>
 		<string>$(NETP_APP_GROUP)</string>
 		<string>$(APP_CONFIGURATION_APP_GROUP)</string>
+	</array>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(NETP_APP_GROUP)</string>
+		<string>$(SUBSCRIPTION_APP_GROUP)</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1213643578957445?focus=true

### Description

Removes "Allow incoming connections" entitlement from VPN menu app (App Store only).

### Testing Steps

1. Test the VPN (App Store only)
2. Test uninstalling which uses Unix Domain Sockets, to see if that's affected.

### Impact and Risks

Impact is high in the sense we want to avoid users losing trust in the VPN, but we haven't had many reports of this.
Risks is medium - it should be fine to do this change.

#### What could go wrong?

Not sure - but if something goes wrong we'll need to revert this and hot-fix.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes app entitlements for the App Store debug VPN build, which can affect networking behavior and IPC assumptions at runtime. While small and isolated to a build configuration, misconfiguration could break connectivity or uninstall flows.
> 
> **Overview**
> Removes the `com.apple.security.network.server` (“Allow incoming connections”) entitlement from the VPN App Store *Debug* menu app entitlements (`DuckDuckGoVPNAppStoreDebug.entitlements`).
> 
> Reorders a few existing entitlement entries and ensures `keychain-access-groups` remains present alongside `com.apple.security.network.client` and the network extension capabilities.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99be15efc79c0b484f61b9dbbdcfdac59270ff0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->