### PR TITLE
Remove stale BSK and duplicate package refs from xcodeproj files

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -17064,22 +17064,6 @@
 				version = 0.9.20;
 			};
 		};
-		984249C12CED4F430071C7DB /* XCRemoteSwiftPackageReference "OHHTTPStubs" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/AliSoftware/OHHTTPStubs.git";
-			requirement = {
-				kind = exactVersion;
-				version = 9.1.0;
-			};
-		};
-		984249C42CED4F430071C7DB /* XCRemoteSwiftPackageReference "BrowserServicesKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/DuckDuckGo/BrowserServicesKit";
-			requirement = {
-				kind = revision;
-				revision = 6a5642a07acc85af9e1b165066e5b9d9716b7a09;
-			};
-		};
 		9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/airbnb/lottie-spm.git";
@@ -17150,14 +17134,6 @@
 			requirement = {
 				kind = exactVersion;
 				version = 1.5.0;
-			};
-		};
-		F4D7F632298C00C3006C3AE9 /* XCRemoteSwiftPackageReference "ios-js-support" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/duckduckgo/ios-js-support";
-			requirement = {
-				kind = exactVersion;
-				version = 2.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -17460,32 +17436,26 @@
 		};
 		984249C02CED4F430071C7DB /* OHHTTPStubs */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 984249C12CED4F430071C7DB /* XCRemoteSwiftPackageReference "OHHTTPStubs" */;
 			productName = OHHTTPStubs;
 		};
 		984249C22CED4F430071C7DB /* OHHTTPStubsSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 984249C12CED4F430071C7DB /* XCRemoteSwiftPackageReference "OHHTTPStubs" */;
 			productName = OHHTTPStubsSwift;
 		};
 		984249C62CED4F430071C7DB /* ContentBlocking */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 984249C42CED4F430071C7DB /* XCRemoteSwiftPackageReference "BrowserServicesKit" */;
 			productName = ContentBlocking;
 		};
 		984249C72CED4F430071C7DB /* Common */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 984249C42CED4F430071C7DB /* XCRemoteSwiftPackageReference "BrowserServicesKit" */;
 			productName = Common;
 		};
 		984249C82CED4F430071C7DB /* Subscription */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 984249C42CED4F430071C7DB /* XCRemoteSwiftPackageReference "BrowserServicesKit" */;
 			productName = Subscription;
 		};
 		984249C92CED4F430071C7DB /* SubscriptionTestingUtilities */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 984249C42CED4F430071C7DB /* XCRemoteSwiftPackageReference "BrowserServicesKit" */;
 			productName = SubscriptionTestingUtilities;
 		};
 		986CD5342DE8F4FA00AFA98A /* RemoteMessaging */ = {
@@ -17726,7 +17696,6 @@
 		};
 		F4D7F633298C00C3006C3AE9 /* FindInPageIOSJSSupport */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = F4D7F632298C00C3006C3AE9 /* XCRemoteSwiftPackageReference "ios-js-support" */;
 			productName = FindInPageIOSJSSupport;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -19435,46 +19435,6 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		3706FA72293F65D500E42796 /* XCRemoteSwiftPackageReference "BrowserServicesKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
-			requirement = {
-				kind = revision;
-				revision = 4f3695b5b598593ce3c44fe810637e3406206c19;
-			};
-		};
-		3706FDD7293F661700E42796 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/AliSoftware/OHHTTPStubs.git";
-			requirement = {
-				kind = exactVersion;
-				version = 9.1.0;
-			};
-		};
-		37C320BA2F1E80A1008F4604 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/pointfreeco/swift-snapshot-testing";
-			requirement = {
-				kind = exactVersion;
-				version = 1.18.7;
-			};
-		};
-		3FFD51CF7C19ACBDB9687474 /* XCRemoteSwiftPackageReference "BrowserServicesKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
-			requirement = {
-				kind = revision;
-				revision = a968dd3d8d5ff95b6eae65889c1a365174a53a69;
-			};
-		};
-		4311906792B7676CE9535D76 /* XCRemoteSwiftPackageReference "BrowserServicesKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
-			requirement = {
-				kind = revision;
-				revision = c06709ba8a586f6a40190bacaaaaa96b2d55e540;
-			};
-		};
 		4B5235432C7BB14D00AFAF64 /* XCRemoteSwiftPackageReference "wireguard-apple" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duckduckgo/wireguard-apple";
@@ -19547,20 +19507,11 @@
 				version = 0.1.0;
 			};
 		};
-		FAE06B199CA1F209B55B34E9 /* XCRemoteSwiftPackageReference "BrowserServicesKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/duckduckgo/BrowserServicesKit";
-			requirement = {
-				kind = revision;
-				revision = a968dd3d8d5ff95b6eae65889c1a365174a53a69;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		08D4923DC968236E22E373E2 /* Crashes */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = FAE06B199CA1F209B55B34E9 /* XCRemoteSwiftPackageReference "BrowserServicesKit" */;
 			productName = Crashes;
 		};
 		1E54E8E72EB3A33F00EB24CD /* AutoconsentStats */ = {
@@ -19617,7 +19568,6 @@
 		};
 		3706FA71293F65D500E42796 /* BrowserServicesKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3706FA72293F65D500E42796 /* XCRemoteSwiftPackageReference "BrowserServicesKit" */;
 			productName = BrowserServicesKit;
 		};
 		7B11B3092EF304B6005F0687 /* AutomationServer */ = {
@@ -19632,27 +19582,22 @@
 		};
 		3706FA76293F65D500E42796 /* ContentBlocking */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3706FA72293F65D500E42796 /* XCRemoteSwiftPackageReference "BrowserServicesKit" */;
 			productName = ContentBlocking;
 		};
 		3706FA77293F65D500E42796 /* PrivacyDashboard */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3706FA72293F65D500E42796 /* XCRemoteSwiftPackageReference "BrowserServicesKit" */;
 			productName = PrivacyDashboard;
 		};
 		3706FA78293F65D500E42796 /* UserScript */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3706FA72293F65D500E42796 /* XCRemoteSwiftPackageReference "BrowserServicesKit" */;
 			productName = UserScript;
 		};
 		3706FDD6293F661700E42796 /* OHHTTPStubs */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3706FDD7293F661700E42796 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */;
 			productName = OHHTTPStubs;
 		};
 		3706FDD8293F661700E42796 /* OHHTTPStubsSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3706FDD7293F661700E42796 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */;
 			productName = OHHTTPStubsSwift;
 		};
 		371BBC562D00C891008FA0C7 /* NewTabPage */ = {
@@ -19705,7 +19650,6 @@
 		};
 		37C320B92F1E80A1008F4604 /* SnapshotTesting */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 37C320BA2F1E80A1008F4604 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
 			productName = SnapshotTesting;
 		};
 		37C320BB2F1E80A1008F4604 /* AppKitExtensions */ = {
@@ -20156,7 +20100,6 @@
 		};
 		537FC71EA5115A983FAF3170 /* Crashes */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 4311906792B7676CE9535D76 /* XCRemoteSwiftPackageReference "BrowserServicesKit" */;
 			productName = Crashes;
 		};
 		5641734A2CFE168700F4B716 /* PixelExperimentKit */ = {
@@ -20864,7 +20807,6 @@
 		};
 		DC3F73D49B2D44464AFEFCD8 /* Subscription */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3FFD51CF7C19ACBDB9687474 /* XCRemoteSwiftPackageReference "BrowserServicesKit" */;
 			productName = Subscription;
 		};
 		F124E0DC2D6E12190035C7BA /* NetworkingTestingUtils */ = {


### PR DESCRIPTION
Task/Issue URL: n/a
Tech Design URL: n/a
CC:

### Description

BSK moved from its own repo to a local workspace package, but the old `XCRemoteSwiftPackageReference` entries in both xcodeproj files were never removed. There are also duplicate remote refs for OHHTTPStubs, ios-js-support, and swift-snapshot-testing that built up from project merges.

This removes those orphaned/duplicate ref blocks and drops the `package =` binding from their product deps so they become packageless, same as everything else.

What changed:
- iOS: deleted 3 orphaned remote ref blocks, unbound 7 product deps
- macOS: deleted 6 orphaned remote ref blocks, unbound 10 product deps

### Testing Steps

1. Open `DuckDuckGo.xcworkspace` in Xcode
2. Check there are no package resolution errors
3. Build iOS Browser and macOS Browser schemes
4. Run WebViewUnitTests (iOS) — ContentBlocking, Common, Subscription, SubscriptionTestingUtilities, OHHTTPStubs, OHHTTPStubsSwift should still resolve

### Impact and Risks

None. These were orphaned objects outside any `packageReferences` array — they had no effect on builds. The `package =` removal just makes those deps packageless, same as ~300 other deps already are.

#### What could go wrong?

Nothing, really. Package resolution is identical before and after because these refs weren't being used.

### Notes to Reviewer

- No functional change to package resolution
- The old BSK refs point to the archived repo (github.com/DuckDuckGo/BrowserServicesKit, archived Feb 2025)
- The duplicate OHHTTPStubs/ios-js-support/swift-snapshot-testing refs came from Xcode project merges; only the copy in `packageReferences` is kept

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Project-file only changes removing stale/duplicate Swift package reference objects and unbinding some product dependencies; build output should be unchanged but there’s a small risk of Xcode package resolution issues if any dependency was implicitly relying on the deleted IDs.
> 
> **Overview**
> Removes stale/duplicate `XCRemoteSwiftPackageReference` entries from the iOS and macOS `.xcodeproj` files (including old `BrowserServicesKit` refs and extra copies of packages like `OHHTTPStubs`, `ios-js-support`, and `swift-snapshot-testing`).
> 
> Updates affected `XCSwiftPackageProductDependency` items to drop their explicit `package =` bindings so they resolve via the remaining package references, reducing project-merge cruft without changing app code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53a1a9af79726857e3d9974b6564804771a16712. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->