### PR TITLE
Improve flaky test

### DIFF
--- a/iOS/DuckDuckGoTests/AIChat/AIChatHistoryManagerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatHistoryManagerTests.swift
@@ -52,7 +52,7 @@ final class AIChatHistoryManagerTests: XCTestCase {
 
     // MARK: - Text Subscription Tests
 
-    func testSubscribeToTextChanges_FetchesSuggestionsOnTextChange() {
+    func testSubscribeToTextChanges_FetchesSuggestionsOnTextChange() async {
         let textSubject = PassthroughSubject<String, Never>()
         sut.subscribeToTextChanges(textSubject)
 
@@ -66,14 +66,14 @@ final class AIChatHistoryManagerTests: XCTestCase {
         let predicate = NSPredicate { _, _ in
             self.mockSuggestionsReader.fetchSuggestionsCallCount == 1
         }
-        let expectation = expectation(for: predicate, evaluatedWith: nil)
-        wait(for: [expectation], timeout: 5.0)
+        let exp = expectation(for: predicate, evaluatedWith: nil)
+        await fulfillment(of: [exp], timeout: 5.0)
 
         XCTAssertEqual(mockSuggestionsReader.fetchSuggestionsCallCount, 1)
         XCTAssertEqual(mockSuggestionsReader.lastQuery, "test query")
     }
 
-    func testSubscribeToTextChanges_EmptyQueryFetchesRecentChats() {
+    func testSubscribeToTextChanges_EmptyQueryFetchesRecentChats() async {
         let textSubject = PassthroughSubject<String, Never>()
         sut.subscribeToTextChanges(textSubject)
 
@@ -82,8 +82,8 @@ final class AIChatHistoryManagerTests: XCTestCase {
         let predicate = NSPredicate { _, _ in
             self.mockSuggestionsReader.fetchSuggestionsCallCount == 1
         }
-        let expectation = expectation(for: predicate, evaluatedWith: nil)
-        wait(for: [expectation], timeout: 5.0)
+        let exp = expectation(for: predicate, evaluatedWith: nil)
+        await fulfillment(of: [exp], timeout: 5.0)
 
         XCTAssertNil(mockSuggestionsReader.lastQuery)
     }
@@ -220,7 +220,7 @@ final class AIChatHistoryManagerTests: XCTestCase {
         XCTAssertEqual(tableView?.alwaysBounceVertical, true)
     }
 
-    func testInstallInContainerView_FetchesSuggestionsImmediately() {
+    func testInstallInContainerView_FetchesSuggestionsImmediately() async {
         let containerView = UIView()
         let parentVC = UIViewController()
 
@@ -229,8 +229,8 @@ final class AIChatHistoryManagerTests: XCTestCase {
         let predicate = NSPredicate { _, _ in
             self.mockSuggestionsReader.fetchSuggestionsCallCount == 1
         }
-        let expectation = expectation(for: predicate, evaluatedWith: nil)
-        wait(for: [expectation], timeout: 5.0)
+        let exp = expectation(for: predicate, evaluatedWith: nil)
+        await fulfillment(of: [exp], timeout: 5.0)
 
         XCTAssertEqual(mockSuggestionsReader.fetchSuggestionsCallCount, 1)
         XCTAssertNil(mockSuggestionsReader.lastQuery)


### PR DESCRIPTION

Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1213655231817515?focus=true
Tech Design URL:
CC:

### Description
Improve flaky test

### Testing Steps
1. CI is green

### Impact and Risks
None: Internal tooling, documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to unit tests and only adjust how expectations are awaited to reduce timing-related flakiness.
> 
> **Overview**
> **Stabilizes `AIChatHistoryManagerTests` by migrating a few expectation-based assertions to Swift concurrency.** The affected tests (`subscribeToTextChanges` and initial install fetch) are now `async` and use `await fulfillment(of:timeout:)` instead of blocking `wait(for:timeout:)`, reducing race/timing issues in CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ee24522ae91e9a31ec412a8c63e2fa08d7bd48a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->