### PR TITLE
Fix Duck.ai context sheet bottom clipping on iPad landscape

### DIFF
--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualInputViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualInputViewController.swift
@@ -92,6 +92,10 @@ final class AIChatContextualInputViewController: UIViewController {
         configureNativeInput()
         configureQuickActions()
         setupKeyboardObservers()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         updateBottomPaddingForOrientation()
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204167627774280/task/1213568793838187?focus=true
Tech Design URL: 
CC:

### Description
Add bottom padding to the native input area when on iPad in landscape orientation to prevent the submit button and input content from being clipped by the sheet edge.

Feature flag: iPadPageContext

### Testing Steps
  1. On iPad simulato, open a webpage, tap the Duck.ai button to show the context sheet in landscape — verify the "Ask privately" input, "Attach Page Content" chip, and submit button are fully visible with padding at the bottom.
  2. Rotate to portrait and back to landscape — verify the padding adjusts correctly and the layout remains intact in both orientations.
  3. On iPhone, open the same context sheet in portrait — verify the layout is unchanged with no extra bottom padding.


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
Wrong padding

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that tweaks a single bottom constraint based on iPad orientation; potential issues are limited to incorrect padding or layout regressions on rotation.
> 
> **Overview**
> Prevents Duck.ai’s contextual input sheet from clipping the native input area on **iPad landscape** by applying an extra bottom inset.
> 
> Adds `updateBottomPaddingForOrientation()` and hooks it into `viewWillAppear` and `viewWillTransition` to adjust `safeAreaBottomConstraint` (only on iPad) when rotating between portrait and landscape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f193999f897802b8e1f7c0ad0c683e7a8c9df0d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->