### PR TITLE
[iOS] Fix Duck Player settings alignment on iPad

### DIFF
--- a/iOS/DuckDuckGo/SettingsDuckPlayerView.swift
+++ b/iOS/DuckDuckGo/SettingsDuckPlayerView.swift
@@ -66,6 +66,7 @@ struct SettingsDuckPlayerView: View {
                     .daxBodyRegular()
                     .accentColor(Color.init(designSystemColor: .accent))
                 }
+                .frame(maxWidth: .infinity)
                 .listRowBackground(Color.clear)
             }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1213618877927508?focus=true

### Description
This PR fixes a UI issue on iPad where the Duck Player settings screen looked misaligned.

### Screenshots
| Before | After |
|--------|--------|
|<img width="2064" height="2752" alt="Simulator Screenshot - iPad Pro 13-inch (M5) - 2026-03-16 at 05 28 37" src="https://github.com/user-attachments/assets/af77b60f-673f-4ade-95af-4b21e041e620" />|<img width="2064" height="2752" alt="Simulator Screenshot - iPad Pro 13-inch (M5) - 2026-03-16 at 05 43 12" src="https://github.com/user-attachments/assets/a9c15511-8b7c-4485-a8c4-24788f3aa739" />| 

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
Verify duck player settings view is properly aligned on iPad and iPhone

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only SwiftUI layout tweak that expands the Duck Player settings header container to full width; no logic, data, or security behavior changes.
> 
> **Overview**
> Fixes misalignment in the Duck Player settings screen on iPad by forcing the top informational `VStack` (hero image/title/learn-more link) to take the full available width via `.frame(maxWidth: .infinity)` within the `List` row.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33698c139f1276caf4455f221c8e9b1fb192a8bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->