### PR TITLE
Fix check_automatic_freeze job failing on code freeze workflows

### DIFF
--- a/.github/workflows/ios_code_freeze.yml
+++ b/.github/workflows/ios_code_freeze.yml
@@ -24,6 +24,9 @@ jobs:
     name: Check Automatic Code Freeze
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || vars.IOS_AUTOMATIC_CODE_FREEZE == '1'
+    defaults:
+      run:
+        working-directory: .
     steps:
       - name: Code freeze is enabled
         run: echo "Automatic code freeze is enabled or workflow was triggered manually"

--- a/.github/workflows/macos_code_freeze.yml
+++ b/.github/workflows/macos_code_freeze.yml
@@ -24,6 +24,9 @@ jobs:
     name: Check Automatic Code Freeze
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || vars.MACOS_AUTOMATIC_CODE_FREEZE == '1'
+    defaults:
+      run:
+        working-directory: .
     steps:
       - name: Code freeze is enabled
         run: echo "Automatic code freeze is enabled or workflow was triggered manually"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1213687129776443
Tech Design URL:
CC:

### Description

The `check_automatic_freeze` job in both `macos_code_freeze.yml` and `ios_code_freeze.yml` fails because the workflow-level `defaults.run.working-directory` points to `macOS`/`iOS`, but this job runs on `ubuntu-latest` without checking out the repo — so that directory doesn't exist.

Adds a job-level `defaults.run.working-directory: .` override so the echo step runs from the workspace root.

### Testing Steps
N/A

### Impact and Risks

Low — CI-only change affecting the code freeze gate job.

#### What could go wrong?

Nothing significant. The override only affects the `check_automatic_freeze` job which runs a single echo command.

### Notes to Reviewer

Same fix applied to both `macos_code_freeze.yml` and `ios_code_freeze.yml`.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that only adjusts the working directory for a single echo step in the code-freeze gate job.
> 
> **Overview**
> Fixes iOS and macOS code-freeze workflows by overriding `check_automatic_freeze` job defaults to run in the repo root (`working-directory: .`), avoiding failures from inheriting the workflow-level `iOS`/`macOS` working directory on `ubuntu-latest` before checkout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16ab5582b782674cee8aec488905b11ac06bfdff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->