### PR TITLE
Register SSH key for DuckSans in Smartling workflow

### DIFF
--- a/.github/workflows/smartling.yml
+++ b/.github/workflows/smartling.yml
@@ -99,6 +99,11 @@ jobs:
           fi
           echo "✅ Running on branch: $BRANCH"
 
+      - name: Register SSH keys for private repos
+        uses: webfactory/ssh-agent@v0.9.1
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_DUCKSANS_FONT }}
+
       - name: Check out the code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/904401899170/task/1213689353541416
Tech Design URL:
CC:

### Description

Adds the SSH_PRIVATE_KEY_DUCKSANS_FONT SSH key registration step to the Smartling workflow, matching the pattern used in all other workflows. This fixes SPM package resolution failure during translation export/download caused by the private native-apps-ducksans repo.

### Testing Steps
N/A

### Impact and Risks
None: Internal tooling

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds SSH key setup to allow fetching a private dependency; main risk is workflow failure if the secret is missing or misconfigured.
> 
> **Overview**
> Ensures the `Smartling` GitHub Actions workflow can access private repositories during runs by registering an SSH key (`SSH_PRIVATE_KEY_DUCKSANS_FONT`) via `webfactory/ssh-agent` before `actions/checkout`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28a5575486707c465c013057e4093bf5a78765ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->