### PR TITLE
Fix sidebar behavior

### DIFF
--- a/macOS/DuckDuckGo/AIChat/Sidebar/AIChatSidebarHosting.swift
+++ b/macOS/DuckDuckGo/AIChat/Sidebar/AIChatSidebarHosting.swift
@@ -114,6 +114,13 @@ extension BrowserTabViewController: AIChatSidebarHosting {
             selectTab(with: tabID)
         }
 
+        // Keep exactly one AI Chat VC attached to the sidebar container.
+        // Without this, tab switches can leave multiple chat VCs stacked,
+        // and the "already embedded" fast-path can show stale content.
+        children
+            .filter { $0 !== chatViewController && $0.view.superview === sidebarContainer }
+            .forEach { $0.removeCompletely() }
+
         if chatViewController.parent === self,
            chatViewController.view.superview === sidebarContainer {
             return

--- a/macOS/UnitTests/AIChat/AIChatCoordinatorTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatCoordinatorTests.swift
@@ -746,6 +746,36 @@ final class AIChatCoordinatorTests: XCTestCase {
         XCTAssertTrue(coordinator.isSidebarOpen(for: tab2))
     }
 
+    func testSwitchingBetweenTabs_keepsPerTabSidebarContent() {
+        // Given
+        let tabA = "tab-a"
+        let tabB = "tab-b"
+        let prompt = AIChatNativePrompt.queryPrompt("hello", autoSubmit: false)
+
+        // Open chat on tab A and remember its VC.
+        mockSidebarHost.currentTabID = tabA
+        coordinator.toggleSidebar()
+        let tabAViewController = mockSessionStore.sessions[tabA]?.chatViewController
+        XCTAssertNotNil(tabAViewController)
+        XCTAssertTrue(mockSidebarHost.embeddedViewController === tabAViewController)
+
+        // Open chat on tab B and remember its VC.
+        mockSidebarHost.currentTabID = tabB
+        coordinator.revealChat(for: prompt)
+        let tabBViewController = mockSessionStore.sessions[tabB]?.chatViewController
+        XCTAssertNotNil(tabBViewController)
+        XCTAssertTrue(mockSidebarHost.embeddedViewController === tabBViewController)
+        XCTAssertFalse(tabAViewController === tabBViewController)
+
+        // When - switch back to tab A.
+        mockSidebarHost.currentTabID = tabA
+        coordinator.sidebarHostDidSelectTab(with: tabA)
+
+        // Then - sidebar should show tab A's own controller, not tab B's.
+        XCTAssertTrue(mockSidebarHost.embeddedViewController === tabAViewController)
+        XCTAssertFalse(mockSidebarHost.embeddedViewController === tabBViewController)
+    }
+
     // MARK: - Detach / Attach Tests
 
     func testDetachSidebar_movesToFloatingWindow() {
@@ -963,6 +993,7 @@ class MockAIChatSidebarHosting: AIChatSidebarHosting {
     var burnerMode: BurnerMode = .regular
 
     var embeddedViewController: NSViewController?
+    private var embeddedControllersInContainer: [NSViewController] = []
     private(set) var isResizeHandleVisible = false
 
     init() {
@@ -973,6 +1004,12 @@ class MockAIChatSidebarHosting: AIChatSidebarHosting {
     var sidebarContainerScreenFrame: NSRect?
 
     func embedChatViewController(_ vc: NSViewController, for tabID: TabIdentifier?) {
+        embeddedControllersInContainer.removeAll { $0 !== vc }
+        if let existingIndex = embeddedControllersInContainer.firstIndex(where: { $0 === vc }) {
+            embeddedViewController = embeddedControllersInContainer[existingIndex]
+            return
+        }
+        embeddedControllersInContainer.append(vc)
         embeddedViewController = vc
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/949243614371883/task/1213684396055579?focus=true
CC: @Bunn 

### Description
Fix for Duck.ai sidebar persists across tabs on macOS.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Open Tab A and sidebar, type AAA.
2. Open Tab B and sidebar, type BBB.
3. Switch to Tab A and confirm you can see chat history with AAA. 
4. Close chat and reopen and confirm AAA is still visible.
5. Switch to tab B and confirm you can see BBB.
6. Undock/redock chats on both tabs and confirm they have their history preserved.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 94ffbdbe99dbee00231a640e420c27f96c174eab. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->