### PR TITLE
[iOS] re add select all and deselect all tab switcher menu items

### DIFF
--- a/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
@@ -297,9 +297,9 @@ extension TabSwitcherViewController {
         let canAddBookmarks = selectedTabsContainsWebPages
         let canCloseOther = !selectedTabs.isEmpty && otherTabCount > 0
         let canBookmarkAll = selectedTabs.isEmpty && self.tabsModel.tabs.contains(where: { $0.link != nil })
-        let canShowDeselectAll = interfaceMode.isLarge && selectedTabs.count == tabsModel.count
-        let canShowSelectAll = interfaceMode.isLarge && selectedTabs.count < tabsModel.count
-        let canClose = interfaceMode.isLarge && selectedTabs.count > 0
+        let canShowDeselectAll = selectedTabs.count == tabsModel.count
+        let canShowSelectAll = selectedTabs.count < tabsModel.count
+        let canClose = selectedTabs.count > 0
 
         let items = [
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1213689241792672?focus=true
Tech Design URL:
CC:

### Description
Seems that the select all and deselect all menu options during the iOS 26 liquid glass changes.

I have a follow up task for adding unit and UI tests.

### Testing Steps
1. Open a few tabs, go to tab switcher, tap on menu button, select tabs.  Tap on menu button again and select all.
2. Open menu again should now show deselect all.  Do this.
3. Open menu again, select some of the items and open the menu, should show "select all" again.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Menu items shown in wrong state?

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small UI-logic change that only affects when multi-select menu items are shown; potential impact is limited to incorrect menu state in the tab switcher.
> 
> **Overview**
> Restores the tab switcher multi-select menu’s **Select All** / **Deselect All** / **Close** actions by removing the `interfaceMode.isLarge` gating so these items appear based solely on selection count (all selected / partially selected / any selected), regardless of layout size.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9e722c450b0f54023924a9e316c25a40ea4750b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->