### PR TITLE
Force mobile User-Agent for AI Chat tabs on iPad

### DIFF
--- a/iOS/DuckDuckGo/Tab.swift
+++ b/iOS/DuckDuckGo/Tab.swift
@@ -69,7 +69,19 @@ public class Tab: NSObject, NSCoding {
             notifyObservers()
         }
     }
-    
+
+    /// Whether to present a desktop identity in the User-Agent string.
+    ///
+    /// AI Chat tabs always identify as mobile (iPad) regardless of the tab's
+    /// desktop-mode setting. This matches the behaviour of the old dedicated
+    /// AIChat WebView, which hardcoded `isDesktop: false`, and ensures that
+    /// server-side UA classification reports `ddg_ios` instead of
+    /// `ddg_mac_desktop` for iPad users in desktop mode.
+    var isDesktopForUserAgent: Bool {
+        if isAITab { return false }
+        return isDesktop
+    }
+
     var link: Link? {
         didSet {
             notifyObservers()

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -2455,7 +2455,7 @@ extension TabViewController: WKNavigationDelegate {
         }
 
         if allowPolicy != WKNavigationActionPolicy.cancel && navigationAction.isTargetingMainFrame() {
-            userAgentManager.update(webView: webView, isDesktop: tabModel.isDesktop, url: url)
+            userAgentManager.update(webView: webView, isDesktop: tabModel.isDesktopForUserAgent, url: url)
         }
 
         if !privacyConfigurationManager.privacyConfig.isProtected(domain: url.host) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201141132935289/1213684434983576/f
Tech Design URL: N/A
CC: N/A

### Description
- AI Chat tabs now always identify as mobile (iPad) regardless of the tab's desktop-mode setting, ensuring server-side UA classification reports `ddg_ios` instead of `ddg_mac_desktop` for iPad users in desktop mode
- Adds `isDesktopForUserAgent` computed property on `Tab` that returns `false` for AI Chat tabs and delegates to `isDesktop` for all others

### Testing Steps
1. Open the app on an iPad simulator in desktop mode
2. Open an AI Chat tab
3. Verify the User-Agent string reports as mobile/iPad, not desktop Mac

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- Minimal risk — only affects AI Chat tabs; all other tabs continue to use the existing `isDesktop` value unchanged

### Quality Considerations
- Edge case: non-AI tabs in desktop mode are unaffected by the change
- Matches the previous dedicated AIChat WebView behaviour that hardcoded `isDesktop: false`

Made with [Cursor](https://cursor.com)