### PR TITLE
Fix issue when starting a new chat

### DIFF
--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualInputViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualInputViewController.swift
@@ -66,8 +66,7 @@ final class AIChatContextualInputViewController: UIViewController {
         return view
     }()
 
-    private var safeAreaBottomConstraint: NSLayoutConstraint?
-    private var keyboardBottomConstraint: NSLayoutConstraint?
+    private var bottomConstraint: NSLayoutConstraint?
 
     // MARK: - Initialization
 
@@ -160,6 +159,8 @@ private extension AIChatContextualInputViewController {
         quickActionsScrollView.addSubview(quickActionsView)
         embedNativeInputViewController()
 
+        bottomConstraint = nativeInputViewController.view.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor)
+
         NSLayoutConstraint.activate([
             quickActionsScrollView.topAnchor.constraint(equalTo: view.topAnchor),
             quickActionsScrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.horizontalPadding),
@@ -176,11 +177,8 @@ private extension AIChatContextualInputViewController {
             nativeInputViewController.view.topAnchor.constraint(greaterThanOrEqualTo: quickActionsView.bottomAnchor, constant: Constants.quickActionsBottomSpacing),
             nativeInputViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.horizontalPadding),
             nativeInputViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Constants.horizontalPadding),
-            nativeInputViewController.view.bottomAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.bottomAnchor),
+            bottomConstraint!,
         ])
-
-        safeAreaBottomConstraint = nativeInputViewController.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
-        safeAreaBottomConstraint?.isActive = true
     }
 
     func embedNativeInputViewController() {
@@ -232,37 +230,23 @@ private extension AIChatContextualInputViewController {
         )
     }
 
-    // Note: UIKeyboardLayoutGuide has known issues on first appearance in sheets.
-    // The layout frame isn't properly initialized until after the view has appeared.
-    // We use a safe area constraint initially, then switch to keyboard layout guide when the keyboard appears.
-    //
-    // Related references:
-    // - https://useyourloaf.com/blog/keyboard-layout-guide/
-    // - https://developer.apple.com/forums/thread/746826
-
     @objc func keyboardWillShow(_ notification: Notification) {
-        if keyboardBottomConstraint == nil {
-            safeAreaBottomConstraint?.isActive = false
-            keyboardBottomConstraint = nativeInputViewController.view.bottomAnchor.constraint(
-                equalTo: view.keyboardLayoutGuide.topAnchor,
-                constant: -Constants.keyboardSpacing
-            )
-            keyboardBottomConstraint?.isActive = true
-        } else {
-            keyboardBottomConstraint?.constant = -Constants.keyboardSpacing
-        }
+        bottomConstraint?.constant = -Constants.keyboardSpacing
     }
 
     @objc func keyboardWillHide(_ notification: Notification) {
-        keyboardBottomConstraint?.constant = 0
+        bottomConstraint?.constant = bottomPaddingForOrientation()
     }
 
     func updateBottomPaddingForOrientation() {
-        guard UIDevice.current.userInterfaceIdiom == .pad else { return }
+        bottomConstraint?.constant = bottomPaddingForOrientation()
+    }
+
+    func bottomPaddingForOrientation() -> CGFloat {
+        guard UIDevice.current.userInterfaceIdiom == .pad else { return 0 }
         let isLandscape = UIDevice.current.orientation.isLandscape ||
             (view.window?.windowScene?.interfaceOrientation.isLandscape ?? false)
-        let padding: CGFloat = isLandscape ? Constants.iPadLandscapeBottomPadding : 0
-        safeAreaBottomConstraint?.constant = -padding
+        return isLandscape ? -Constants.iPadLandscapeBottomPadding : 0
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213684449576753?focus=true
Tech Design URL:
CC:

### Description
Fix issue when starting a new chat on contextual sheet

### Testing Steps
  1. On iPad, open the Duck.ai contextual sheet, type a prompt and submit it so the web view loads, then tap the "New Chat" button — verify the bottom padding of the native input looks correct (no extra gap above the input).
  2. Repeat the above in both portrait and landscape orientations to confirm the iPad landscape bottom padding still applies correctly.
  3. Open the contextual sheet fresh (without prior chat) and verify the initial layout and keyboard behavior are unchanged.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features


#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that simplifies bottom constraint handling for the contextual native input; main risk is unintended spacing/regression across keyboard show/hide and iPad orientations.
> 
> **Overview**
> Fixes incorrect bottom spacing for the contextual native input (notably after tapping *New Chat* on iPad) by **replacing the dual safe-area/keyboard constraint switching** with a single `bottomConstraint` anchored to `keyboardLayoutGuide`.
> 
> Keyboard and orientation handling now adjust this one constraint’s constant (including iPad landscape padding) instead of activating/deactivating separate constraints, reducing state drift that could leave extra gaps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afc2b141c0518cab3a1d3ce12700b3ade04c2f06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->