### PR TITLE
Disables Memory Baseline Comparisons on CI

### DIFF
--- a/.github/workflows/macos_performance_tests.yml
+++ b/.github/workflows/macos_performance_tests.yml
@@ -155,11 +155,6 @@ jobs:
         log stream --debug --info --predicate 'process == "DuckDuckGo Review" OR process == "UI Tests-Runner"' --style syslog > app-console.log 2>&1 &
         echo $! > log_stream.pid
 
-    - name: Override XCTest Baseline HW Specs
-      working-directory: macOS
-      run: |
-        ./scripts/override-test-baseline-specs.sh
-
     - name: Build Performance Tests
       working-directory: macOS
       run: |


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1213668082317065
Tech Design URL:
CC:

### Description
This PR disables Performance Baseline comparisons in our CI workflow. We've been experiencing unstable measurements since last week, with deviations that range from +12% / +20%.

### Testing Steps
- [ ] Verify [this CI job is green please!](https://github.com/duckduckgo/apple-browsers/actions/runs/23164177769)

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing, internal tooling PR

### Quality Considerations
None

### Notes to Reviewer
Thank you!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes the CI workflow by removing a pre-test baseline override step, but it may alter performance/baseline comparison behavior and result stability in the performance job.
> 
> **Overview**
> Disables performance baseline comparisons in CI by removing the `Override XCTest Baseline HW Specs` step from `macos_performance_tests.yml`, so the workflow no longer runs the baseline-spec override script before building/running performance tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b3ec75366bd9acace63aab74dfaabd59c58bfe6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->