### PR TITLE
Add window to handle passwords on status bar

### DIFF
--- a/macOS/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
+++ b/macOS/DuckDuckGo/SecureVault/View/PasswordManagementViewController.swift
@@ -417,16 +417,19 @@ final class PasswordManagementViewController: NSViewController {
 
     @IBAction func openImportBrowserDataWindow(_ sender: Any?) {
         self.dismiss()
+        ensureMainWindowExists()
         DataImportFlowLauncher(pinningManager: pinningManager).launchDataImport(isDataTypePickerExpanded: true)
     }
 
     @IBAction func openExportLogins(_ sender: Any) {
         self.dismiss()
+        ensureMainWindowExists()
         NSApp.sendAction(#selector(AppDelegate.openExportLogins(_:)), to: nil, from: sender)
     }
 
     @IBAction func onImportClicked(_ sender: NSButton) {
         self.dismiss()
+        ensureMainWindowExists()
         DataImportFlowLauncher(pinningManager: pinningManager).launchDataImport(isDataTypePickerExpanded: true)
     }
 
@@ -442,11 +445,26 @@ final class PasswordManagementViewController: NSViewController {
         guard let autofillDeleteAllPasswordsExecutor = builder.buildExecutor() else { return }
         let presenter = builder.buildPresenter()
 
+        let needsWindow = Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.window == nil
+        if needsWindow {
+            self.dismiss()
+            ensureMainWindowExists()
+        }
+
         presenter.show(actionExecutor: autofillDeleteAllPasswordsExecutor) {
             self.refreshData {
                 self.select(category: .logins)
             }
             PixelKit.fire(GeneralPixel.autofillManagementDeleteAllLogins)
+        }
+    }
+
+    /// Opens a new browser window if no main window is currently available.
+    /// This is needed when actions are triggered from the status bar popover
+    /// without any browser window being open.
+    private func ensureMainWindowExists() {
+        if Application.appDelegate.windowControllersManager.lastKeyMainWindowController?.window == nil {
+            Application.appDelegate.windowControllersManager.openNewWindow()
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213687289747723?focus=true
Tech Design URL:
CC:

### Description
Adds an ensureMainWindowExists() helper that opens a new browser window before performing the password menu actions if none is available

### Testing Steps
  1. Close all browser windows so only the passwords status bar icon remains. Click it, open the "More" menu, and select "Import Passwords…" — a  browser window should open and the import flow should appear.
  2. Repeat with "Export Logins" — a browser window should open, authentication should prompt, and the save panel should appear.
  3. Repeat with "Delete All Passwords…" — a browser window should open and the confirmation alert should appear as a sheet.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small UI flow change that only opens a new main window when password actions are triggered without an existing browser window; main potential risk is unexpected window creation timing around modal/sheet presentation.
> 
> **Overview**
> Ensures password-management actions invoked from the status bar popover work when no browser window is open by adding `ensureMainWindowExists()` to open a new main window on demand.
> 
> Calls this helper before launching import/export flows, and adjusts **Delete All Passwords** to first create a window (and dismiss the popover) so the confirmation UI can be presented as a proper sheet.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfd143e963f263e5fa303810a91caf675ab0ed9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->