### PR TITLE
Broadcast omnibar mode changes to all NTP windows

### DIFF
--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
@@ -50,9 +50,10 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
         self.actionHandler = actionHandler
         super.init()
 
-        Publishers.Merge(
-            configProvider.isAIChatShortcutEnabledPublisher,
-            configProvider.isAIChatSettingVisiblePublisher
+        Publishers.Merge3(
+            configProvider.isAIChatShortcutEnabledPublisher.map { _ in () }.eraseToAnyPublisher(),
+            configProvider.isAIChatSettingVisiblePublisher.map { _ in () }.eraseToAnyPublisher(),
+            configProvider.modePublisher.map { _ in () }.eraseToAnyPublisher()
         )
         .sink { [weak self] _ in
             Task { @MainActor in


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209121419454298/task/1211647811352894?focus=true
Tech Design URL:
CC:

### Description

The Combine subscription in `NewTabPageOmnibarClient` only merged `isAIChatShortcutEnabledPublisher` and `isAIChatSettingVisiblePublisher`, so mode changes (Search <-> Duck.ai) were never broadcast via `omnibar_onConfigUpdate` to other windows. Only `enableAi`/`showAiSetting` changes triggered the push.

This adds `configProvider.modePublisher` to the merge (using `Merge3` with type erasure to `Void` since the three publishers have different `Output` types) so that mode changes also push `omnibar_onConfigUpdate` to all windows.

**Companion PR:** https://github.com/duckduckgo/content-scope-scripts/pull/2557 — ensures existing tabs ignore subscription-sourced mode changes while new tabs pick up the latest default.

### Testing Steps

1. ~~Update `Package.swift` to use `.package(url: "https://github.com/duckduckgo/content-scope-scripts.git", branch: "pr-releases/randerson/fix-shared-omnibar-tab-state”)`~~
2. Build and run the macOS app
3. Open two windows, each with a New Tab Page
4. In Window A, type a search query (e.g. "test")
5. In Window B, switch to Duck.ai mode
6. Verify Window A stays on Search with the query intact
7. Open a new tab in Window A — it should default to Duck.ai mode
8. Disable Duck.ai in settings — verify all windows reset to Search mode

### Impact and Risks

Low: Only affects NTP omnibar mode propagation across windows.

#### What could go wrong?

Mode changes now trigger `notifyConfigUpdated()` which pushes to all windows. This is the same mechanism already used for `enableAi` and `showAiSetting` changes. The JS side guards against disruptive updates to the current tab.

### Quality Considerations

- The `modePublisher` was already defined in the `NewTabPageOmnibarConfigProviding` protocol and implemented in both the real and mock config providers — it was just not wired into the notification merge.
- Existing unit tests continue to pass since the mock already fires `modeSubject.send()` on `didSet`.

### Notes to Reviewer

One-line functional change: `Publishers.Merge` -> `Publishers.Merge3` with `modePublisher` added. The `.map { _ in () }.eraseToAnyPublisher()` is needed because the three publishers have different output types (`Bool`, `Bool`, `OmnibarMode`).

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small Combine wiring change that broadens when `omnibar_onConfigUpdate` is emitted, with minimal behavioral surface area beyond additional update notifications.
> 
> **Overview**
> Ensures New Tab Page omnibar **mode changes** (e.g., Search ↔ Duck.ai) trigger the same cross-window `omnibar_onConfigUpdate` push as existing AI shortcut/visibility config changes.
> 
> Updates `NewTabPageOmnibarClient` to merge `modePublisher` into the config-change subscription (switching to `Publishers.Merge3` with type-erased `Void` outputs) so all NTP windows receive mode updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dd593837b1068462df37af580ae7c512911c1eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->