### PR TITLE
Fix keyboard issue on contextual view

### DIFF
--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -271,10 +271,13 @@ final class AIChatContextualSheetViewController: UIViewController {
         super.viewWillAppear(animated)
         configureSheetPresentation()
         pixelHandler.fireSheetOpened()
+        addKeyboardObserver()
     }
-    
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        view.endEditing(true)
+        removeKeyboardObserver()
         pixelHandler.fireSheetDismissed()
     }
 
@@ -351,7 +354,6 @@ private extension AIChatContextualSheetViewController {
         removeCurrentChildViewController()
         embedChildViewController(webVC)
         isWebViewVisible = true
-        webVC.setMediumDetent(isCurrentlyMediumDetent)
     }
 
     func showWebViewWithPrompt(_ prompt: String, pageContext: AIChatPageContextData?) {
@@ -688,6 +690,25 @@ private extension AIChatContextualSheetViewController {
         modalPresentationStyle = .pageSheet
     }
 
+    func addKeyboardObserver() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(sheetKeyboardWillShow),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
+    }
+
+    func removeKeyboardObserver() {
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+    }
+
+    @objc func sheetKeyboardWillShow() {
+        if isWebViewVisible && isCurrentlyMediumDetent {
+            expandToLargeDetent()
+        }
+    }
+
     func configureSheetPresentation() {
         guard let sheet = sheetPresentationController else { return }
 
@@ -708,9 +729,7 @@ private extension AIChatContextualSheetViewController {
 extension AIChatContextualSheetViewController: UISheetPresentationControllerDelegate {
 
     func sheetPresentationControllerDidChangeSelectedDetentIdentifier(_ sheetPresentationController: UISheetPresentationController) {
-        let isMediumDetent = sheetPresentationController.selectedDetentIdentifier == .medium
-        isCurrentlyMediumDetent = isMediumDetent
-        webViewController?.setMediumDetent(isMediumDetent)
+        isCurrentlyMediumDetent = sheetPresentationController.selectedDetentIdentifier == .medium
     }
 
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualWebViewController.swift
@@ -74,11 +74,6 @@ final class AIChatContextualWebViewController: UIViewController {
     private var urlObservation: NSKeyValueObservation?
     private var lastContextualChatURL: URL?
 
-    /// Constraint for adjusting WebView bottom when keyboard appears
-    private var webViewBottomConstraint: NSLayoutConstraint?
-    private var isMediumDetent = true
-    private var lastKnownKeyboardFrame: CGRect?
-
     /// URL to load on viewDidLoad instead of the default AI chat URL (for cold restore).
     var initialURL: URL?
 
@@ -174,22 +169,8 @@ final class AIChatContextualWebViewController: UIViewController {
         }
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        setupKeyboardObservers()
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-
-        removeKeyboardObservers()
-        webViewBottomConstraint?.constant = 0
-        lastKnownKeyboardFrame = nil
-    }
-
     deinit {
         urlObservation?.invalidate()
-        removeKeyboardObservers()
     }
 
     // MARK: - Public Methods
@@ -248,28 +229,6 @@ final class AIChatContextualWebViewController: UIViewController {
         webView.load(URLRequest(url: url))
     }
 
-    /// Updates the sheet detent. Keyboard fix only applies in medium detent.
-    func setMediumDetent(_ isMediumDetent: Bool) {
-        let wasInMediumDetent = self.isMediumDetent
-        self.isMediumDetent = isMediumDetent
-
-        if isMediumDetent && !wasInMediumDetent {
-            recalculateKeyboardOverlapIfNeeded()
-        } else if !isMediumDetent && webViewBottomConstraint?.constant != 0 {
-            UIView.animate(withDuration: 0.25) {
-                self.webViewBottomConstraint?.constant = 0
-                self.view.layoutIfNeeded()
-            }
-        }
-    }
-
-    private func recalculateKeyboardOverlapIfNeeded() {
-        guard let keyboardFrame = lastKnownKeyboardFrame else {
-            return
-        }
-        adjustForKeyboard(frame: keyboardFrame, duration: 0.25, options: .curveEaseInOut)
-    }
-
     // MARK: - Private Methods
 
     private func setupUI() {
@@ -278,103 +237,15 @@ final class AIChatContextualWebViewController: UIViewController {
         view.addSubview(webView)
         view.addSubview(loadingView)
 
-        let bottomConstraint = webView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        webViewBottomConstraint = bottomConstraint
-
         NSLayoutConstraint.activate([
             webView.topAnchor.constraint(equalTo: view.topAnchor),
             webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            bottomConstraint,
+            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
 
             loadingView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             loadingView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         ])
-    }
-
-    private func setupKeyboardObservers() {
-        removeKeyboardObservers()
-
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(keyboardWillChangeFrame),
-            name: UIResponder.keyboardWillChangeFrameNotification,
-            object: nil
-        )
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(keyboardWillHide),
-            name: UIResponder.keyboardWillHideNotification,
-            object: nil
-        )
-    }
-
-    private func removeKeyboardObservers() {
-        NotificationCenter.default.removeObserver(
-            self,
-            name: UIResponder.keyboardWillChangeFrameNotification,
-            object: nil
-        )
-        NotificationCenter.default.removeObserver(
-            self,
-            name: UIResponder.keyboardWillHideNotification,
-            object: nil
-        )
-    }
-
-    @objc private func keyboardWillChangeFrame(_ notification: Notification) {
-        guard let userInfo = notification.userInfo,
-              let keyboardFrame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue else {
-            return
-        }
-
-        lastKnownKeyboardFrame = keyboardFrame
-
-        guard isMediumDetent, view.window != nil else {
-            return
-        }
-
-        let duration = (userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue ?? 0
-        let animationCurveRaw = (userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? NSNumber)?.uintValue ?? UIView.AnimationOptions.curveEaseInOut.rawValue
-        let animationCurve = UIView.AnimationOptions(rawValue: animationCurveRaw)
-
-        adjustForKeyboard(frame: keyboardFrame, duration: duration, options: animationCurve)
-    }
-
-    @objc private func keyboardWillHide(_ notification: Notification) {
-        lastKnownKeyboardFrame = nil
-
-        guard view.window != nil else {
-            return
-        }
-
-        let userInfo = notification.userInfo
-        let duration = (userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue ?? 0
-        let animationCurveRaw = (userInfo?[UIResponder.keyboardAnimationCurveUserInfoKey] as? NSNumber)?.uintValue ?? UIView.AnimationOptions.curveEaseInOut.rawValue
-        let animationCurve = UIView.AnimationOptions(rawValue: animationCurveRaw)
-
-        webViewBottomConstraint?.constant = 0
-
-        UIView.animate(withDuration: duration, delay: 0, options: animationCurve) {
-            self.view.layoutIfNeeded()
-        }
-    }
-
-    private func adjustForKeyboard(frame keyboardFrame: CGRect, duration: TimeInterval, options: UIView.AnimationOptions) {
-        let keyboardFrameInView = view.convert(keyboardFrame, from: nil)
-        let keyboardOverlap = max(0, view.bounds.height - keyboardFrameInView.origin.y)
-
-        // Guard against invalid keyboard positions during sheet animation transitions
-        // If keyboard is above the view (negative Y) or overlap exceeds view height, skip adjustment
-        if keyboardFrameInView.origin.y < 0 || keyboardOverlap > view.bounds.height {
-            return
-        }
-
-        webViewBottomConstraint?.constant = -keyboardOverlap
-
-        UIView.animate(withDuration: duration, delay: 0, options: options) {
-            self.view.layoutIfNeeded()
-        }
     }
 
     private func createWebViewConfiguration() -> WKWebViewConfiguration {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211654189969294/task/1213690512620616?focus=true
Tech Design URL:
CC:

### Description
 Fixes a bug where the keyboard would briefly appear then dismiss when tapping the input field in the contextual Duck.ai sheet after closing and reopening it. The root cause was twofold: stale RTI (Remote Text Input) sessions from the dismissed WKWebView, and aggressive web view resizing in medium detent that shrank the view to ~120pt during keyboard animation, causing WebKit to blur the focused input. 

The fix calls  endEditing(true) on dismiss to clean up input sessions, auto-expands the sheet to large detent when the keyboard appears with the web view in  medium detent, and removes the now-unnecessary keyboard constraint adjustment from the web view controller.


### Testing Steps
  1. Open a page, tap the Duck.ai button to open the contextual sheet, submit a prompt, then close the sheet.
  2. Reopen the sheet, tap the input field in the web view — verify the keyboard appears and stays visible.
  3. Verify normal first-use flow still works: open sheet, type in native input, submit prompt, confirm sheet expands to large and shows the response.


### Impact and Risks
Medium: Could disrupt specific features or user flows


#### What could go wrong?
The keyboard may overlap the bottom of the web view content in large detent since the manual constraint adjustment was removed, though WKWebView  should handle this internally via scroll inset adjustments.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sheet/keyboard interaction and removes custom WKWebView keyboard inset handling; could introduce new layout/overlap issues when the keyboard appears, especially around detent transitions.
> 
> **Overview**
> Fixes a contextual Duck.ai sheet keyboard regression by **forcing input cleanup on dismiss** (`view.endEditing(true)`) and **auto-expanding the sheet to `.large` when the keyboard shows while the web view is visible in `.medium` detent**.
> 
> Removes the prior web-view-level keyboard workaround: deletes keyboard observers, bottom constraint resizing, and detent syncing (`setMediumDetent`) from `AIChatContextualWebViewController`, leaving keyboard handling to the sheet + WebKit defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 178082a56737c8781f3dfa73bb554846bd37f835. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->