### PR TITLE
Fix default search engine shown in PDF context menu instead of DuckDuckGo

### DIFF
--- a/macOS/DuckDuckGo/MainWindow/MainView.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainView.swift
@@ -195,7 +195,7 @@ final class MainView: NSView {
 
         // Find the "Search with %@" item and replace %@ with DuckDuckGo
         for item in menu.items {
-            guard !item.isSeparatorItem else { break }
+            guard !item.isSeparatorItem else { continue }
             if item.title.contains(providerDisplayName) {
                 item.title = item.title.replacingOccurrences(of: providerDisplayName, with: "DuckDuckGo")
                 break


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1213659555956031/task/1213651992403047?focus=true
Tech Design URL: N/A
CC: N/A

### Description
- Fix default search engine shown in PDF context menu instead of DuckDuckGo

### Testing Steps
1. Open Safari Settings -> Search
2. Set Google as the default search engine
3. Open a PDF in DuckDuckGo browser
4. Select some text in the PDF
5. Right-click the selected text
6. Validate there is `Search with DuckDuckGo` item, not `Search with Google`
7. Click the item and validate it opens a DuckDuckGo SERP

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- The rename logic could stop matching if WebKit changes the PDF context menu structure or wording
- Another context menu item could match unexpectedly if Apple changes the menu labels

### Quality Considerations
- Edge case covered: separator items before the search item no longer stop the scan early
- No meaningful performance impact
- No analytics, documentation, privacy, or security changes

### Notes to Reviewer
- Small one-line fix in the existing PDF context menu rename logic

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk one-line control-flow change in PDF context menu item renaming; could only affect matching behavior if WebKit menu structure changes unexpectedly.
> 
> **Overview**
> Ensures the PDF context menu relabeling from the system default provider to DuckDuckGo doesn’t stop early when encountering a separator item.
> 
> The scan now *skips* separator items (`continue`) instead of *terminating* the loop (`break`), improving reliability of finding and rewriting the "Search with %@" menu entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb0c9384fc041d2f326efd37b75c5979a46d0275. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->