### PR TITLE
Remove same-site suppression from tracker protection pipeline

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentScopeScript/TrackerProtectionEventMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentScopeScript/TrackerProtectionEventMapper.swift
@@ -75,17 +75,6 @@ public struct TrackerProtectionEventMapper {
         return TrackerBlockingReason(rawValue: tracker.reason ?? "")?.isNonTrackerThirdPartyRequest ?? false
     }
 
-    /// Returns true when request and page share the same eTLD+1.
-    /// Same-site detections (both tracker and non-tracker) are suppressed
-    /// from the privacy dashboard, matching legacy WebKit first-party behavior.
-    public func isSameSiteDetection(_ tracker: TrackerProtectionSubfeature.TrackerDetection) -> Bool {
-        let requestETLDplus1 = tld.eTLDplus1(forStringURL: tracker.url)
-        let pageETLDplus1 = tld.eTLDplus1(forStringURL: tracker.pageUrl)
-
-        guard let requestETLDplus1, let pageETLDplus1 else { return false }
-        return requestETLDplus1 == pageETLDplus1
-    }
-
     public func surrogateHost(from surrogate: TrackerProtectionSubfeature.SurrogateInjection) -> String? {
         return URL(string: surrogate.url)?.host
     }

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentScopeScript/TrackerProtectionEventMapperTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentScopeScript/TrackerProtectionEventMapperTests.swift
@@ -77,52 +77,29 @@ final class TrackerProtectionEventMapperTests: XCTestCase {
         return try! JSONDecoder().decode(TrackerProtectionSubfeature.SurrogateInjection.self, from: data)
     }
 
-    // MARK: - P0-1: Same-site suppression (strict same eTLD+1)
+    // MARK: - P0-1: Same eTLD+1 requests are not auto-suppressed
 
-    func testSameSiteDetection_sameETLDplus1_tracker_returnsTrue() {
+    func testSameETLDplus1BlockedTracker_mapsToBlocked() {
         let tracker = makeTracker(
             url: "https://cdn.example.com/pixel.js",
             blocked: true,
             reason: "default block",
             pageUrl: "https://www.example.com/page"
         )
-        XCTAssertTrue(mapper.isSameSiteDetection(tracker))
+        let request = mapper.detectedRequest(from: tracker)
+        XCTAssertEqual(request.state, .blocked)
     }
 
-    func testSameSiteDetection_sameETLDplus1_thirdPartyRequest_returnsTrue() {
+    func testSameETLDplus1ThirdPartyRequest_mapsToOtherThirdPartyRequest() {
         let tracker = makeTracker(
             url: "https://cdn.example.com/image.png",
             blocked: false,
             reason: "thirdPartyRequest",
             pageUrl: "https://www.example.com"
         )
-        XCTAssertTrue(mapper.isSameSiteDetection(tracker))
-    }
-
-    func testSameSiteDetection_differentETLDplus1_returnsFalse() {
-        let tracker = makeTracker(
-            url: "https://tracker.other.com/pixel.js",
-            pageUrl: "https://www.example.com"
-        )
-        XCTAssertFalse(mapper.isSameSiteDetection(tracker))
-    }
-
-    func testSameSiteDetection_sameHost_returnsTrue() {
-        let tracker = makeTracker(
-            url: "https://example.com/pixel.js",
-            pageUrl: "https://example.com/page"
-        )
-        XCTAssertTrue(mapper.isSameSiteDetection(tracker))
-    }
-
-    func testSameSiteDetection_firstPartyReason_sameETLDplus1_returnsTrue() {
-        let tracker = makeTracker(
-            url: "https://cdn.example.com/script.js",
-            blocked: false,
-            reason: "first party",
-            pageUrl: "https://www.example.com"
-        )
-        XCTAssertTrue(mapper.isSameSiteDetection(tracker))
+        let request = mapper.detectedRequest(from: tracker)
+        XCTAssertEqual(request.state, .allowed(reason: .otherThirdPartyRequest))
+        XCTAssertTrue(TrackerProtectionEventMapper.isThirdPartyRequest(tracker))
     }
 
     // MARK: - P0-2: Affiliated third-party tracker → ownedByFirstParty
@@ -193,9 +170,9 @@ final class TrackerProtectionEventMapperTests: XCTestCase {
         }
     }
 
-    // MARK: - P0-4: Non-tracker same-site suppression
+    // MARK: - P0-4: Non-tracker third-party classification
 
-    func testThirdPartyRequest_sameSite_isSameSiteDetection() {
+    func testThirdPartyRequest_sameSite_routesAsThirdPartyRequest() {
         let tracker = makeTracker(
             url: "https://cdn.example.com/style.css",
             blocked: false,
@@ -206,7 +183,9 @@ final class TrackerProtectionEventMapperTests: XCTestCase {
             category: nil,
             prevalence: nil
         )
-        XCTAssertTrue(mapper.isSameSiteDetection(tracker))
+        let request = mapper.detectedRequest(from: tracker)
+        XCTAssertEqual(request.state, .allowed(reason: .otherThirdPartyRequest))
+        XCTAssertTrue(TrackerProtectionEventMapper.isThirdPartyRequest(tracker))
     }
 
     // MARK: - P0-5: Non-tracker affiliated classification

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -3164,10 +3164,6 @@ extension TabViewController: TrackerProtectionSubfeatureDelegate {
                            didDetectTracker tracker: TrackerProtectionSubfeature.TrackerDetection) {
         guard let url = url else { return }
 
-        if Self.trackerProtectionMapper.isSameSiteDetection(tracker) {
-            return
-        }
-
         let detectedRequest = Self.trackerProtectionMapper.detectedRequest(from: tracker)
 
         if TrackerProtectionEventMapper.isThirdPartyRequest(tracker) {

--- a/macOS/DuckDuckGo/Tab/TabExtensions/ContentBlockingTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/ContentBlockingTabExtension.swift
@@ -173,10 +173,6 @@ extension ContentBlockingTabExtension: TrackerProtectionSubfeatureDelegate {
 
     func trackerProtection(_ subfeature: TrackerProtectionSubfeature,
                            didDetectTracker tracker: TrackerProtectionSubfeature.TrackerDetection) {
-        if trackerProtectionMapper.isSameSiteDetection(tracker) {
-            return
-        }
-
         let detectedRequest = trackerProtectionMapper.detectedRequest(from: tracker)
 
         if TrackerProtectionEventMapper.isThirdPartyRequest(tracker) {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1163321984198618/task/1205994559844411?focus=true
Tech Design URL:
CC:

### Description

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1.
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tracker-protection event routing on iOS and macOS so same eTLD+1 requests are now surfaced instead of dropped, which can affect privacy dashboard counts and related logic that triggers on detected requests.
> 
> **Overview**
> Removes **same-site (same eTLD+1) suppression** from the tracker-protection event pipeline by deleting `TrackerProtectionEventMapper.isSameSiteDetection` and eliminating the early-return checks in both iOS `TabViewController` and macOS `ContentBlockingTabExtension`.
> 
> Updates unit tests to assert that same eTLD+1 events are still mapped and routed (blocked trackers remain `.blocked`; non-tracker `thirdPartyRequest` events map to `.allowed(reason: .otherThirdPartyRequest)` and continue down the third-party-request path).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 846401b23266022ea57915800d9e468de4b313cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->