### PR TITLE
[macOS] Fix Promo Queue UI tests when remote message is visible

### DIFF
--- a/macOS/UITests/PromoQueueUITests.swift
+++ b/macOS/UITests/PromoQueueUITests.swift
@@ -26,7 +26,7 @@ final class PromoQueueUITests: UITestCase {
         app = XCUIApplication.setUp(featureFlags: ["promoQueue": true])
         app.enforceSingleWindow()
         app.resetPromoState()
-        app.dismissNextSteps()
+        app.dismissExternalPromos()
     }
 
     override func tearDown() {
@@ -157,15 +157,42 @@ private extension XCUIApplication {
         promoQueueMenu.menuItems[Identifiers.advanceSimulatedDate1Day].clickAfterExistenceTestSucceeds()
     }
 
-    /// Dismisses Next Steps (external promo) and advances date to remove its cooldown,
+    /// Dismisses Remote Message and/or Next Steps promos, if visible, and advances date to remove global cooldown
     /// so test promos can be reliably triggered for each scenario.
-    func dismissNextSteps() {
-        guard nextSteps.exists else { return }
+    func dismissExternalPromos() {
+        let nextStepsDismissed = dismissNextSteps()
+        let remoteMessagesDismissed = dismissRemoteMessages()
+        if remoteMessagesDismissed || nextStepsDismissed {
+            advanceSimulatedDateByDay()
+        }
+    }
+
+    /// Dismisses Remote Messages (external promos) to avoid suppressing other promos for test scenarios.
+    /// Returns whether remote messages were dismissed.
+    func dismissRemoteMessages() -> Bool {
+        guard tabBarRemoteMessageCloseButton.exists || ntpRemoteMessageCloseButton.exists else {
+            return false
+        }
+        if tabBarRemoteMessageCloseButton.exists {
+            tabBarRemoteMessageCloseButton.click()
+        }
+        if ntpRemoteMessageCloseButton.exists {
+            ntpRemoteMessageCloseButton.click()
+        }
+        return true
+    }
+
+    /// Dismisses Next Steps (external promo) to avoid suppressing other promos for test scenarios.
+    /// Returns whether Next Steps were dismissed.
+    func dismissNextSteps() -> Bool {
+        guard nextSteps.exists else {
+            return false
+        }
         debugMenu
             .menuItems[Utilities.AccessibilityIdentifiers.NewTabPage.newTabPageDebugMenu]
             .menuItems[Utilities.AccessibilityIdentifiers.NewTabPage.shiftMaxDaysMenuItem]
             .clickAfterExistenceTestSucceeds()
-        advanceSimulatedDateByDay()
+        return true
     }
 
     var alertA: XCUIElement {
@@ -208,5 +235,17 @@ private extension XCUIElement {
 
     var nextSteps: XCUIElement {
         webViews.firstMatch.staticTexts["Next Steps"]
+    }
+
+    var tabBarRemoteMessageCloseButton: XCUIElement {
+        tabGroups.matching(identifier: "Tabs").images["Close"]
+    }
+
+    /// Button to dismiss a remote message
+    ///
+    /// This is not an ideal element identifier (it could match any "Dismiss" button in the webview)
+    /// but we have limited options to check for the presence of a remote message due to its dynamic content.
+    var ntpRemoteMessageCloseButton: XCUIElement {
+        webViews.firstMatch.buttons["Dismiss"].firstMatch
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1213693125618016?focus=true

### Description

Promo Queue UI tests currently fail on macOS 14 because of a remote message that then suppresses other promos (including the promos used in the tests).

This PR ensures any remote messages are dismissed and the global cooldown has passed before continuing with the tests.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Confirm UI tests pass on all macOS versions: https://github.com/duckduckgo/apple-browsers/actions/runs/23199144735

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

* Element matcher for New Tab Page remote message could match with any "Dismiss" button in the webview. The XCUIElement uses the first match (remote message should be first on the page) and takes other actions first (e.g. removing Next Steps) to reduce likelihood of selecting the wrong element.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

The UI tests currently only exercise the test promos, not any real promos. I considered updating the test setup to exclude other promos entirely (e.g. Next Steps, Remote Messages) so they don't interfere. However, a better approach will be to shift to using real promos (not test promos) in these UI tests as we migrate more promos to the promo queue and can cover the queueing scenarios with real promo UI.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to macOS UI test setup to dismiss external promos and adjust simulated time, with no production code impact.
> 
> **Overview**
> Updates `PromoQueueUITests` setup to **dismiss both Remote Message and Next Steps external promos** before running scenarios, preventing them from suppressing test promos.
> 
> Adds UI test helpers to detect/close remote messages in the tab bar or NTP webview and only advances the simulated date by a day when an external promo was actually dismissed (to clear the global cooldown).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74e5086c8f7fdcd38a2d87c1d9106e1f10161489. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->