### PR TITLE
Fix Favicons CoreData crash in EncryptedValueTransformer

### DIFF
--- a/macOS/DuckDuckGo/Common/FileSystem/EncryptedValueTransformer.swift
+++ b/macOS/DuckDuckGo/Common/FileSystem/EncryptedValueTransformer.swift
@@ -66,7 +66,9 @@ final class EncryptedValueTransformer<T: NSSecureCoding & NSObject>: ValueTransf
             return data
         }
 
-        return try? NSKeyedUnarchiver.unarchivedObject(ofClass: T.self, from: decryptedData as Data)
+        return try? NSKeyedUnarchiver.unarchivedObject(ofClass: T.self, from: decryptedData as Data,
+                                                       requiresSecureCoding: true,
+                                                       decodingFailurePolicy: .setErrorAndReturn)
     }
 
     // The transformer name is calculated based on the generic class parameter.

--- a/macOS/LocalPackages/Utilities/Sources/Utilities/CoreData/EncryptedValueTransformer.swift
+++ b/macOS/LocalPackages/Utilities/Sources/Utilities/CoreData/EncryptedValueTransformer.swift
@@ -65,7 +65,9 @@ public final class EncryptedValueTransformer<T: NSSecureCoding & NSObject>: Valu
             return data
         }
 
-        return try? NSKeyedUnarchiver.unarchivedObject(ofClass: T.self, from: decryptedData as Data)
+        return try? NSKeyedUnarchiver.unarchivedObject(ofClass: T.self, from: decryptedData as Data,
+                                                       requiresSecureCoding: true,
+                                                       decodingFailurePolicy: .setErrorAndReturn)
     }
 
     // The transformer name is calculated based on the generic class parameter.

--- a/macOS/LocalPackages/Utilities/Sources/Utilities/CoreData/NSKeyedUnarchiver+DecodingFailurePolicy.swift
+++ b/macOS/LocalPackages/Utilities/Sources/Utilities/CoreData/NSKeyedUnarchiver+DecodingFailurePolicy.swift
@@ -1,0 +1,42 @@
+//
+//  NSKeyedUnarchiver+DecodingFailurePolicy.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension NSKeyedUnarchiver {
+
+    /// Unarchives an object with explicit `decodingFailurePolicy` and `requiresSecureCoding` parameters.
+    ///
+    /// Use `.setErrorAndReturn` for `decodingFailurePolicy` to prevent ObjC `NSException`s from
+    /// being raised. Swift's `try?` does not catch ObjC exceptions, so the standard
+    /// `unarchivedObject(ofClass:from:)` class method can crash if the unarchiver encounters invalid data.
+    public static func unarchivedObject<T: NSObject & NSSecureCoding>(
+        ofClass cls: T.Type,
+        from data: Data,
+        requiresSecureCoding: Bool,
+        decodingFailurePolicy: NSCoder.DecodingFailurePolicy
+    ) throws -> T? {
+        let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+        unarchiver.decodingFailurePolicy = decodingFailurePolicy
+        unarchiver.requiresSecureCoding = requiresSecureCoding
+        let object = unarchiver.decodeObject(of: cls, forKey: NSKeyedArchiveRootObjectKey)
+        unarchiver.finishDecoding()
+        return object
+    }
+
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1213720653611128

### Description

Fixes a startup crash (`SIGABRT`) on the Favicons `NSManagedObjectContext` private queue, introduced in 1.181.0 by the Xcode 26.2 upgrade.

`EncryptedValueTransformer.reverseTransformedValue(_:)` used `try? NSKeyedUnarchiver.unarchivedObject(ofClass:from:)` to decode encrypted CoreData attributes. Swift's `try?` only catches Swift errors — it does **not** catch ObjC `NSException`s. With the macOS 26 SDK, `NSKeyedUnarchiver` can raise ObjC exceptions that bypass Swift error handling, causing the uncaught exception to propagate out of the CoreData `context.perform` block and crash the app.

The fix replaces the class-method call with an instance-based `NSKeyedUnarchiver` using `decodingFailurePolicy = .setErrorAndReturn`, which prevents ObjC exceptions entirely — on failure it returns `nil` instead of crashing.

### Testing Steps

1. Build and run the app
2. Verify favicons load correctly on NTP and in the address bar
3. Verify no crash on startup
4. Run `EncryptedValueTransformerTests` — both tests pass

### Impact and Risks

**Medium**: This fixes a crash on startup for affected users. The change is minimal and behavior-preserving — on success, the result is identical; on failure, we now get `nil` instead of a crash.

#### What could go wrong?

The new `NSKeyedUnarchiver` instance-based approach should behave identically to the class method for valid data. The only difference is graceful `nil` return on corrupted/incompatible data instead of an ObjC exception crash.

### Quality Considerations

- The fix applies to both copies of `EncryptedValueTransformer` (Utilities package and app-level)
- `requiresSecureCoding = true` is set to maintain the same security guarantees as the original class method
- Existing `EncryptedValueTransformerTests` pass (roundtrip encoding/decoding)

### Notes to Reviewer

No Favicon code, CoreData model, or Persistence code changed between 1.180.0 and 1.181.0. The crash was caused indirectly by the Xcode 26.2 upgrade (commit `154f531413`) linking against a newer SDK with stricter `NSKeyedUnarchiver` behavior.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Core Data value decoding during app startup; while behavior should be identical for valid data, incorrect configuration could cause values to decode as `nil` instead of failing loudly.
> 
> **Overview**
> Prevents startup/Core Data crashes when decrypting and unarchiving encrypted attributes by switching `EncryptedValueTransformer.reverseTransformedValue` to an unarchiver path that sets `requiresSecureCoding: true` and `decodingFailurePolicy: .setErrorAndReturn`.
> 
> Adds a small `NSKeyedUnarchiver` extension in Utilities to expose this safer unarchiving API, and applies it in both the app-level and Utilities copies of `EncryptedValueTransformer`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a752a85c9f0388d0d5df58a38fefaae9ce50e94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->