### PR TITLE
[macOS] Add blur background to Duck.ai button in fire windows

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "13976e04d81eefac5a9c718d886ce99460a9123b",
-        "version" : "13.29.0"
+        "revision" : "965b6a29db693c707cbc46e819afec68ef37b5e0",
+        "version" : "13.32.0"
       }
     },
     {

--- a/macOS/DuckDuckGo/Preferences/Model/AppearancePreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AppearancePreferences.swift
@@ -262,6 +262,9 @@ final class AppearancePreferences: ObservableObject {
 
     @Published var themeAppearance: ThemeAppearance {
         didSet {
+            guard oldValue != themeAppearance else {
+                return
+            }
             persistor.themeAppearance = themeAppearance.rawValue
             updateUserInterfaceStyle()
         }
@@ -269,6 +272,9 @@ final class AppearancePreferences: ObservableObject {
 
     @Published var themeName: ThemeName {
         didSet {
+            guard oldValue != themeName else {
+                return
+            }
             persistor.themeName = themeName.rawValue
         }
     }

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -179,9 +179,14 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
     @IBOutlet weak var leftSideStackLeadingConstraint: NSLayoutConstraint!
     @IBOutlet weak var rightSideStackView: NSStackView!
     private var duckAIChromeControlContainer: ColorView?
+    private var duckAIChromeBlurView: NSVisualEffectView?
     private var duckAIChromeTitleButton: MouseOverButton?
     private var duckAIChromeSidebarButton: MouseOverButton?
     private var duckAIChromeDivider: ColorView?
+
+    private var isFireWindow: Bool {
+        tabCollectionViewModel.isBurner
+    }
 
     private var isChromeSidebarFeatureEnabled: Bool {
         featureFlagger.isFeatureOn(.aiChatChromeSidebar)
@@ -585,6 +590,7 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
             sidebarButton.isHidden = true
             divider.isHidden = true
             container.isHidden = true
+            updateDuckAIChromeVibrancyBackground()
             return
         }
 
@@ -602,14 +608,16 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
         if !duckAIHidden && !sidebarHidden {
             titleButton.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
             sidebarButton.layer?.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
-            container.backgroundColor = theme.colorsProvider.buttonMouseOverColor
+            container.backgroundColor = isFireWindow ? .clear : theme.colorsProvider.buttonMouseOverColor
         } else if !duckAIHidden {
             titleButton.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMinYCorner, .layerMaxXMaxYCorner]
-            container.backgroundColor = theme.colorsProvider.buttonMouseOverColor
+            container.backgroundColor = isFireWindow ? .clear : theme.colorsProvider.buttonMouseOverColor
         } else if !sidebarHidden {
             sidebarButton.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMinYCorner, .layerMaxXMaxYCorner]
             container.backgroundColor = .clear
         }
+
+        updateDuckAIChromeVibrancyBackground()
     }
 
     func refreshDuckAIChromeButtonsVisibility() {
@@ -629,10 +637,12 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
         guard let duckAIChromeControlContainer, let duckAIChromeTitleButton, let duckAIChromeSidebarButton else { return }
 
         let colorsProvider = theme.colorsProvider
-        duckAIChromeControlContainer.backgroundColor = colorsProvider.buttonMouseOverColor
+        duckAIChromeControlContainer.backgroundColor = isFireWindow ? .clear : colorsProvider.buttonMouseOverColor
         duckAIChromeControlContainer.cornerRadius = theme.toolbarButtonsCornerRadius
         duckAIChromeControlContainer.borderColor = nil
         duckAIChromeControlContainer.borderWidth = 0
+
+        updateDuckAIChromeVibrancyBackground()
 
         let titleFont = NSFont.systemFont(ofSize: 13)
         duckAIChromeTitleButton.attributedTitle = NSAttributedString(string: UserText.aiChatTitle, attributes: [
@@ -681,7 +691,49 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
             colorsProvider.separatorActiveColor : colorsProvider.separatorColor
     }
 
+    private func updateDuckAIChromeVibrancyBackground() {
+        guard let duckAIChromeControlContainer else { return }
+
+        if isFireWindow {
+            if duckAIChromeBlurView == nil {
+                let vibrancyView = NSVisualEffectView()
+                vibrancyView.translatesAutoresizingMaskIntoConstraints = false
+                vibrancyView.material = .hudWindow
+                vibrancyView.blendingMode = .withinWindow
+                vibrancyView.state = .active
+                vibrancyView.wantsLayer = true
+                vibrancyView.layer?.cornerRadius = theme.toolbarButtonsCornerRadius
+                vibrancyView.layer?.masksToBounds = true
+
+                duckAIChromeControlContainer.addSubview(vibrancyView, positioned: .below, relativeTo: duckAIChromeControlContainer.subviews.first)
+
+                NSLayoutConstraint.activate([
+                    vibrancyView.leadingAnchor.constraint(equalTo: duckAIChromeControlContainer.leadingAnchor),
+                    vibrancyView.trailingAnchor.constraint(equalTo: duckAIChromeControlContainer.trailingAnchor),
+                    vibrancyView.topAnchor.constraint(equalTo: duckAIChromeControlContainer.topAnchor),
+                    vibrancyView.bottomAnchor.constraint(equalTo: duckAIChromeControlContainer.bottomAnchor)
+                ])
+                duckAIChromeBlurView = vibrancyView
+            }
+
+            let shadow = NSShadow()
+            shadow.shadowColor = NSColor.black.withAlphaComponent(0.12)
+            shadow.shadowOffset = CGSize(width: 0, height: -0.5)
+            shadow.shadowBlurRadius = 1.5
+            duckAIChromeControlContainer.shadow = shadow
+            duckAIChromeControlContainer.wantsLayer = true
+            duckAIChromeControlContainer.layer?.masksToBounds = false
+        } else {
+            duckAIChromeBlurView?.removeFromSuperview()
+            duckAIChromeBlurView = nil
+            duckAIChromeControlContainer.shadow = nil
+        }
+    }
+
     private func removeDuckAIChromeSegmentedControl() {
+        duckAIChromeBlurView?.removeFromSuperview()
+        duckAIChromeBlurView = nil
+
         guard let duckAIChromeControlContainer else { return }
         rightSideStackView.removeArrangedSubview(duckAIChromeControlContainer)
         duckAIChromeControlContainer.removeFromSuperview()

--- a/macOS/DuckDuckGo/VisualRefresh/ThemeManager.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/ThemeManager.swift
@@ -70,6 +70,7 @@ final class ThemeManager: ObservableObject, ThemeManaging {
     private func subscribeToThemeNameChanges(appearancePreferences: AppearancePreferences) {
         appearancePreferences.$themeName
             .dropFirst()
+            .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] themeName in
                 self?.switchToTheme(named: themeName)
@@ -80,6 +81,7 @@ final class ThemeManager: ObservableObject, ThemeManaging {
     private func subscribeToSystemAppearance() {
         appearancePreferences.$themeAppearance
             .dropFirst()
+            .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] appearance in
                 self?.appearance = appearance


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211654189969294/task/1213690992894525?focus=true

### Description

The Duck.ai split button in the tab bar had poor contrast in fire (burner) windows — the button blended into the dark fire gradient background, making it hard to read.

Added an `NSVisualEffectView` with `.hudWindow` material behind the Duck.ai split button container, visible only in fire windows. The blur view is placed in the view hierarchy between the fire gradient image and the button, using `.withinWindow` blending to create a frosted glass effect that improves contrast. In normal windows, the blur view is hidden and the button renders as before.

Also fixed an issue where switching themes or accent colors would cause redundant theme change notifications, which could reset the blur view state. Added `removeDuplicates()` in ThemeManager and early-return guards in AppearancePreferences to prevent this.

### Testing Steps

1. Open a Fire Window (File → New Fire Window)
2. Verify the Duck.ai split button in the upper-right tab bar area has a visible frosted blur background that contrasts against the fire gradient
3. Open a normal (non-fire) window and verify the Duck.ai button looks unchanged
4. In Settings → Appearance, switch between Light and Dark themes — verify the blur looks correct in both modes in a fire window
5. In Settings → Appearance, change the accent color (e.g. to Green) — verify the blur remains visible and doesn't disappear
6. Switch themes and accent colors multiple times in quick succession — verify no visual glitches

### Impact and Risks

Low — changes are scoped to the Duck.ai split button styling in fire windows only. Normal window appearance is unaffected. The theme deduplication fix is a safe guard against redundant updates.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily UI styling changes, but it also adjusts theme change propagation/deduping and bumps `content-scope-scripts`, which could affect runtime behavior if regressions slip in.
> 
> **Overview**
> Improves contrast for the Duck.ai split control in *Fire/Burner windows* by adding a `.hudWindow` `NSVisualEffectView` blur (plus subtle shadow) behind the segmented control, while keeping the existing solid background behavior in normal windows.
> 
> Reduces redundant theme updates by short-circuiting unchanged `AppearancePreferences` assignments and adding `removeDuplicates()` to `ThemeManager`’s Combine subscriptions, helping prevent unnecessary UI refreshes.
> 
> Updates SwiftPM dependency `content-scope-scripts` from `13.29.0` to `13.32.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7234d35070d072cddfb41af6367a902a54cde7e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->