### PR TITLE
Dismiss duck.ai contextual sheet when tapping on other controls

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -581,6 +581,8 @@ class MainViewController: UIViewController {
         applyCustomizationState()
 
         mobileCustomization.delegate = self
+
+        installContextualSheetDismissGesture()
     }
 
     private func configureStartupPresentation() {
@@ -3384,6 +3386,19 @@ extension MainViewController: OmniBarDelegate {
         themeColorManager.updateThemeColor()
     }
 
+    private func installContextualSheetDismissGesture() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissContextualSheetOnBackgroundTap))
+        tap.cancelsTouchesInView = false
+        tap.delaysTouchesBegan = false
+        tap.delaysTouchesEnded = false
+        tap.delegate = self
+        viewCoordinator.navigationBarContainer.addGestureRecognizer(tap)
+    }
+
+    @objc private func dismissContextualSheetOnBackgroundTap() {
+        currentTab?.aiChatContextualSheetCoordinator.dismissSheet()
+    }
+
     func dismissContextualSheetIfNeeded(completion: @escaping () -> Void) {
         guard let currentTab,
               currentTab.aiChatContextualSheetCoordinator.isSheetPresented,
@@ -4227,6 +4242,15 @@ extension MainViewController: TabSwitcherButtonDelegate {
                 await self.segueToTabSwitcher()
             }
         }
+    }
+}
+
+// MARK: - UIGestureRecognizerDelegate
+
+extension MainViewController: UIGestureRecognizerDelegate {
+
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
     }
 }
 

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -380,6 +380,7 @@ extension MainViewController: TabsBarDelegate {
             return
         }
 
+        currentTab?.aiChatContextualSheetCoordinator.dismissSheet()
         dismissOmniBar()
 
         // Tabs bar is iPad only and this is to work around on a problem iOS 26 which will be fixed later with Xcode 26.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1213721050321592?focus=true

### Description
Dismiss duck.ai contextual sheet when tapping on other controls

### Testing Steps
  1. On iPad, open a web page, tap the duck.ai chip to present the contextual sheet at medium detent, then tap various address bar buttons (back,  forward, refresh, privacy icon, bookmarks, menu, fire, settings) — the sheet should dismiss each time.
  2. With the contextual sheet open, tap a different tab in the tab bar — the sheet should dismiss and the tab should switch.
  3. Verify the sheet still opens, drags, expands to large detent, and dismisses via swipe-down normally.
  4. Try the same on iPhone

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The shouldRecognizeSimultaneouslyWith: true delegate could theoretically interfere with other gesture recognizers on the navigation bar container, though the passthrough configuration (cancelsTouchesInView = false) makes this unlikely.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change adding a non-canceling tap recognizer and an explicit dismissal call; main risk is unintended interaction with other gesture recognizers in `navigationBarContainer`.
> 
> **Overview**
> Ensures the duck.ai contextual sheet is dismissed when the user interacts with other browser controls.
> 
> `MainViewController` now installs a background tap gesture on `navigationBarContainer` (with simultaneous recognition enabled) that dismisses the current tab’s contextual sheet without blocking the underlying control tap. Tab selection from the iPad tabs bar also explicitly dismisses the contextual sheet before switching tabs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21ca353ef705a99822fa450ad30a1b5559fbccd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->