### PR TITLE
[iOS] Unified Input: Add Customize Responses button

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/iOS/PublicAPI/AIChatInputBoxHandling.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/iOS/PublicAPI/AIChatInputBoxHandling.swift
@@ -26,6 +26,7 @@ public protocol AIChatInputBoxHandling {
     var didSubmitPrompt: PassthroughSubject<String, Never> { get }
     var didSubmitQuery: PassthroughSubject<String, Never> { get }
     var didPressStopGeneratingButton: PassthroughSubject<Void, Never> { get }
+    var didPressCustomizeResponsesButton: PassthroughSubject<Void, Never> { get }
 
     var persistedModelId: String? { get }
 

--- a/SharedPackages/Infrastructure/DesignResourcesKitIcons/Sources/DesignResourcesKitIcons/DesignSystemImages+Glyphs.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKitIcons/Sources/DesignResourcesKitIcons/DesignSystemImages+Glyphs.swift
@@ -463,6 +463,7 @@ public extension DesignSystemImages {
             public static var news: DesignSystemImage { .init(resource: .news24) }
             public static var note: DesignSystemImage { .init(resource: .note24) }
             public static var openIn: DesignSystemImage { .init(resource: .openIn24) }
+            public static var options: DesignSystemImage { .init(resource: .options24) }
             public static var pageContentAttach: DesignSystemImage { .init(resource: .pageContentAttach24) }
             public static var paste: DesignSystemImage { .init(resource: .paste24) }
             public static var pin: DesignSystemImage { .init(resource: .pin24) }

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
@@ -55,6 +55,7 @@ final class AIChatUserScript: NSObject, Subfeature {
         case openSettingsAction
         case toggleSidebarAction
         case syncStatusChanged(AIChatSyncHandler.SyncStatus)
+        case customizeResponsesAction
 
         var methodName: String {
             switch self {
@@ -72,6 +73,8 @@ final class AIChatUserScript: NSObject, Subfeature {
                 return "submitToggleSidebarAction"
             case .syncStatusChanged:
                 return "submitSyncStatusChanged"
+            case .customizeResponsesAction:
+                return "submitCustomizeResponsesAction"
             }
         }
 
@@ -253,6 +256,10 @@ final class AIChatUserScript: NSObject, Subfeature {
 
         inputBoxHandler?.didPressStopGeneratingButton
             .sink(receiveValue: { [weak self] _ in self?.push(.promptInterruption) })
+            .store(in: &inputBoxCancellables)
+
+        inputBoxHandler?.didPressCustomizeResponsesButton
+            .sink(receiveValue: { [weak self] _ in self?.push(.customizeResponsesAction) })
             .store(in: &inputBoxCancellables)
 
         handler.setAIChatInputBoxHandler(inputBoxHandler)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentsStripView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentsStripView.swift
@@ -91,11 +91,13 @@ final class UnifiedToggleInputAttachmentsStripView: UIView {
         translatesAutoresizingMaskIntoConstraints = false
         clipsToBounds = false
         addSubview(stackView)
+        let bottomConstraint = stackView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        bottomConstraint.priority = .defaultHigh
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.topPadding),
             stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.horizontalPadding),
             stackView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -Constants.horizontalPadding),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            bottomConstraint,
         ])
     }
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -81,6 +81,7 @@ final class UnifiedToggleInputCoordinator: AIChatInputBoxHandling {
     let didSubmitPrompt = PassthroughSubject<String, Never>()
     let didSubmitQuery = PassthroughSubject<String, Never>()
     let didPressStopGeneratingButton = PassthroughSubject<Void, Never>()
+    let didPressCustomizeResponsesButton = PassthroughSubject<Void, Never>()
 
     var aiChatStatusPublisher: Published<AIChatStatusValue>.Publisher { $aiChatStatus }
     var aiChatInputBoxVisibilityPublisher: Published<AIChatInputBoxVisibility>.Publisher { $aiChatInputBoxVisibility }
@@ -205,6 +206,8 @@ final class UnifiedToggleInputCoordinator: AIChatInputBoxHandling {
         viewController.delegate = self
         subscribeToGeneratingState()
         subscribeToStopGeneratingTap()
+        subscribeToCustomizeResponsesTap()
+        viewController.isCustomizeResponsesButtonHidden = true
 
         if let cachedLabel = preferences.selectedModelShortName {
             viewController.modelName = cachedLabel
@@ -260,6 +263,7 @@ final class UnifiedToggleInputCoordinator: AIChatInputBoxHandling {
 
         viewController.apply(renderState.viewConfig, animated: false)
         viewController.deactivateInput()
+        viewController.isCustomizeResponsesButtonHidden = false
         intentSubject.send(.showCollapsed)
     }
 
@@ -271,6 +275,7 @@ final class UnifiedToggleInputCoordinator: AIChatInputBoxHandling {
         let renderState = computeRenderState()
 
         viewController.apply(renderState.viewConfig, animated: false)
+        viewController.isCustomizeResponsesButtonHidden = false
         fetchModels()
 
         if let prefilledText, !prefilledText.isEmpty {
@@ -301,6 +306,7 @@ final class UnifiedToggleInputCoordinator: AIChatInputBoxHandling {
         let renderState = computeRenderState()
         viewController.apply(renderState.viewConfig, animated: false)
         viewController.deactivateInput()
+        viewController.isCustomizeResponsesButtonHidden = true
         contentViewController.setHeaderDisplayMode(renderState.headerDisplayMode)
         intentSubject.send(.hide)
     }
@@ -318,6 +324,7 @@ final class UnifiedToggleInputCoordinator: AIChatInputBoxHandling {
 
         let renderState = computeRenderState()
         viewController.apply(renderState.viewConfig, animated: false)
+        viewController.isCustomizeResponsesButtonHidden = true
         fetchModels()
 
         if let text = prefilledText, !text.isEmpty {
@@ -751,6 +758,16 @@ final class UnifiedToggleInputCoordinator: AIChatInputBoxHandling {
         viewController.handler.stopGeneratingButtonTappedPublisher
             .sink { [weak self] in
                 self?.didPressStopGeneratingButton.send()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func subscribeToCustomizeResponsesTap() {
+        viewController.handler.customizeResponsesButtonTappedPublisher
+            .sink { [weak self] in
+                guard let self else { return }
+                self.didPressCustomizeResponsesButton.send()
+                self.showCollapsed()
             }
             .store(in: &cancellables)
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
@@ -104,6 +104,11 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
         stopGeneratingButtonTappedSubject.eraseToAnyPublisher()
     }
 
+    private let customizeResponsesButtonTappedSubject = PassthroughSubject<Void, Never>()
+    var customizeResponsesButtonTappedPublisher: AnyPublisher<Void, Never> {
+        customizeResponsesButtonTappedSubject.eraseToAnyPublisher()
+    }
+
     // MARK: - Initialization
 
     init(isVoiceSearchEnabled: Bool, isToggleEnabled: Bool = true) {
@@ -152,6 +157,10 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
 
     func stopGeneratingButtonTapped() {
         stopGeneratingButtonTappedSubject.send()
+    }
+
+    func customizeResponsesButtonTapped() {
+        customizeResponsesButtonTappedSubject.send()
     }
 
     func updateBarPosition(isTop: Bool) {}

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
@@ -40,6 +40,7 @@ final class UnifiedToggleInputToolbarView: UIView {
 
     // MARK: - Callbacks
 
+    var onCustomizeResponsesTapped: (() -> Void)?
     var onAttachTapped: (() -> Void)?
     var onModelPickerTapped: (() -> Void)?
     var onSubmitTapped: (() -> Void)?
@@ -81,7 +82,18 @@ final class UnifiedToggleInputToolbarView: UIView {
         set { imageButton.isHidden = newValue }
     }
 
+    var isCustomizeResponsesButtonHidden: Bool {
+        get { customizeResponsesButton.isHidden }
+        set { customizeResponsesButton.isHidden = newValue }
+    }
+
     // MARK: - UI Components
+
+    private lazy var customizeResponsesButton: UIButton = makeToolButton(
+        image: DesignSystemImages.Glyphs.Size24.options,
+        accessibilityLabel: UserText.aiChatToolbarCustomizeResponsesButtonAccessibilityLabel,
+        action: #selector(customizeResponsesTapped)
+    )
 
     private lazy var imageButton: UIButton = makeToolButton(
         image: DesignSystemImages.Glyphs.Size24.attach,
@@ -170,7 +182,11 @@ final class UnifiedToggleInputToolbarView: UIView {
     // MARK: - Setup
 
     private func setupUI() {
-        imageButton.translatesAutoresizingMaskIntoConstraints = false
+        let leftGroup = UIStackView(arrangedSubviews: [customizeResponsesButton, imageButton])
+        leftGroup.axis = .horizontal
+        leftGroup.spacing = 0
+        leftGroup.alignment = .center
+        leftGroup.translatesAutoresizingMaskIntoConstraints = false
 
         let spacer = UIView()
         spacer.translatesAutoresizingMaskIntoConstraints = false
@@ -182,7 +198,7 @@ final class UnifiedToggleInputToolbarView: UIView {
         rightGroup.alignment = .center
         rightGroup.translatesAutoresizingMaskIntoConstraints = false
 
-        let outerStack = UIStackView(arrangedSubviews: [imageButton, spacer, rightGroup])
+        let outerStack = UIStackView(arrangedSubviews: [leftGroup, spacer, rightGroup])
         outerStack.axis = .horizontal
         outerStack.alignment = .center
         outerStack.translatesAutoresizingMaskIntoConstraints = false
@@ -237,6 +253,7 @@ final class UnifiedToggleInputToolbarView: UIView {
         }
     }
 
+    @objc private func customizeResponsesTapped() { onCustomizeResponsesTapped?() }
     @objc private func attachTapped() { onAttachTapped?() }
     @objc private func modelPickerTapped() { onModelPickerTapped?() }
     @objc private func submitTapped() { onSubmitTapped?() }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -123,6 +123,11 @@ final class UnifiedToggleInputView: UIView {
         set { toolsToolbar.isModelChipHidden = newValue }
     }
 
+    var isCustomizeResponsesButtonHidden: Bool {
+        get { toolsToolbar.isCustomizeResponsesButtonHidden }
+        set { toolsToolbar.isCustomizeResponsesButtonHidden = newValue }
+    }
+
     /// Called inside animation blocks when a hierarchy-wide layout pass is needed
     /// so that sibling views (e.g. the content container) animate in sync.
     /// The owning view controller sets this.
@@ -562,6 +567,9 @@ private extension UnifiedToggleInputView {
         }
         toolsToolbar.onStopGeneratingTapped = { [weak self] in
             self?.handler.stopGeneratingButtonTapped()
+        }
+        toolsToolbar.onCustomizeResponsesTapped = { [weak self] in
+            self?.handler.customizeResponsesButtonTapped()
         }
         toolsToolbar.onAttachTapped = { [weak self] in
             self?.onAttachTapped?()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -144,6 +144,11 @@ final class UnifiedToggleInputViewController: UIViewController {
         set { inputBarView.isImageButtonHidden = newValue }
     }
 
+    var isCustomizeResponsesButtonHidden: Bool {
+        get { inputBarView.isCustomizeResponsesButtonHidden }
+        set { inputBarView.isCustomizeResponsesButtonHidden = newValue }
+    }
+
     var isAttachmentsFull: Bool {
         inputBarView.isAttachmentsFull
     }

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -1981,6 +1981,7 @@ public struct UserText {
 
     // MARK: - AI Chat
     public static let aiChatToolbarSearchButtonAccessibilityLabel = NotLocalizedString("aichat.toolbar.search.button.accessibility.label", value: "Search web", comment: "Accessibility label for the search/globe button in the Duck.ai native input toolbar")
+    public static let aiChatToolbarCustomizeResponsesButtonAccessibilityLabel = NotLocalizedString("aichat.toolbar.customizeResponses.button.accessibility.label", value: "Customize Responses", comment: "Accessibility label for the customize responses button in the Duck.ai native input toolbar")
     public static let aiChatToolbarAttachButtonAccessibilityLabel = NotLocalizedString("aichat.toolbar.attach.button.accessibility.label", value: "Attach image", comment: "Accessibility label for the image/attach button in the Duck.ai native input toolbar")
     public static let aiChatToolbarSubmitButtonAccessibilityLabel = NotLocalizedString("aichat.toolbar.submit.button.accessibility.label", value: "Submit", comment: "Accessibility label for the submit button in the Duck.ai native input toolbar")
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -762,6 +762,51 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
+    // MARK: - Customize Responses Button
+
+    func test_customizeResponsesTap_forwardsPublisher() {
+        let exp = expectation(description: "didPressCustomizeResponsesButton fires")
+        sut.didPressCustomizeResponsesButton
+            .sink { exp.fulfill() }
+            .store(in: &cancellables)
+
+        sut.viewController.handler.customizeResponsesButtonTapped()
+        waitForExpectations(timeout: 1)
+    }
+
+    func test_customizeResponsesTap_collapsesInput() {
+        sut.showExpanded()
+        XCTAssertEqual(sut.displayState, .aiTab(.expanded))
+
+        sut.viewController.handler.customizeResponsesButtonTapped()
+        XCTAssertEqual(sut.displayState, .aiTab(.collapsed))
+    }
+
+    func test_customizeResponsesButton_hiddenInitially() {
+        XCTAssertTrue(sut.viewController.isCustomizeResponsesButtonHidden)
+    }
+
+    func test_customizeResponsesButton_visibleOnAITab() {
+        sut.showCollapsed()
+        XCTAssertFalse(sut.viewController.isCustomizeResponsesButtonHidden)
+
+        sut.showExpanded()
+        XCTAssertFalse(sut.viewController.isCustomizeResponsesButtonHidden)
+    }
+
+    func test_customizeResponsesButton_hiddenWhenHidden() {
+        sut.showCollapsed()
+        XCTAssertFalse(sut.viewController.isCustomizeResponsesButtonHidden)
+
+        sut.hide()
+        XCTAssertTrue(sut.viewController.isCustomizeResponsesButtonHidden)
+    }
+
+    func test_customizeResponsesButton_hiddenInOmnibar() {
+        sut.activateFromOmnibar()
+        XCTAssertTrue(sut.viewController.isCustomizeResponsesButtonHidden)
+    }
+
     // MARK: - Model Selection: persistedModelId
 
     func test_persistedModelId_returnsPreferencesValue() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1213684376655870
Tech Design URL:
CC:

### Description

Adds a **Customize Responses** button (Options-24 icon) to the unified input toolbar. The button is the leftmost item in the toolbar button group, alongside the attach button.

- Sends `submitCustomizeResponsesAction` frontend message when tapped
- Only visible on AI chat tabs — hidden during omnibar/search transitions
- Tapping collapses the input and dismisses the keyboard
- Fixes a pre-existing auto-layout constraint warning in the attachments strip view when collapsing with height=0

### Prerequisites

1. Enable the **unifiedToggleInput** feature flag in Settings → Internal → Feature Flags
2. Set the AI Chat URL to `https://euw-serp-dev-testing8.duck.ai/` 

### Testing Steps

1. Navigate to an AI chat tab and expand the input
2. Verify the Options (sliders) button appears leftmost in the toolbar
4. Tap the Options button — the Customize Responses frontend modal should open, and the input should collapse
5. Use search-to-chat transition (type in omnibar, switch to AI chat mode) — verify the Options button is NOT visible during the transition
6. Navigate back to a chat tab — verify the Options button is visible again

### Impact and Risks

Low: Adds a new button to the AI chat toolbar. No changes to existing functionality.

#### What could go wrong?

- Button visibility could leak into omnibar mode — mitigated by explicit hide/show at each state transition, with tests covering all display states

### Quality Considerations

- 6 new unit tests covering: publisher forwarding, input collapse on tap, initial hidden state, visibility on AI tab, hidden when hidden, hidden in omnibar
- No performance impact — single button addition with standard UIKit patterns

### Notes to Reviewer

- The `submitCustomizeResponsesAction` frontend message is new — frontend support is still in progress
- The attachments strip constraint fix (lowering bottom constraint priority) is a pre-existing issue from the image attachment PR, included here for convenience

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)