### PR TITLE
[iOS] Onboarding rebrand - UI review changes

### DIFF
--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalletes/DefaultColorPalette.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalletes/DefaultColorPalette.swift
@@ -313,17 +313,17 @@ private extension DefaultColorPalette {
         case .buttonsPrimaryText:
             return DynamicColor(lightColor: RebrandingColor.GrayScale.white, darkColor: RebrandingColor.Pollen.pollen100)
         case .buttonsSecondaryDefault:
-            return DynamicColor(lightColor: RebrandingColor.GrayScale.gray10, darkColor: RebrandingColor.GrayScale.gray80)
+            return DynamicColor(lightColor: RebrandingColor.GrayScale.black.opacity(0.06), darkColor: RebrandingColor.GrayScale.white.opacity(0.12))
         case .buttonsSecondaryPressed:
-            return DynamicColor(lightColor: RebrandingColor.GrayScale.gray20, darkColor: RebrandingColor.GrayScale.gray90)
+            return DynamicColor(lightColor: RebrandingColor.GrayScale.black.opacity(0.12), darkColor: RebrandingColor.GrayScale.white.opacity(0.24))
         case .buttonsSecondaryText:
             return DynamicColor(lightColor: RebrandingColor.Eggshell.eggshell90, darkColor: RebrandingColor.Eggshell.eggshell10)
         case .controlsFillPrimary:
             return DynamicColor(lightColor: RebrandingColor.GrayScale.black.opacity(0.06), darkColor: RebrandingColor.GrayScale.white.opacity(0.12))
         case .decorationPrimary:
-            return DynamicColor(lightColor: Color(0x242323).opacity(0.09), darkColor: Color(0xFFFFFF).opacity(0.06))
+            return DynamicColor(lightColor: RebrandingColor.Eggshell.eggshell90.opacity(0.09), darkColor: RebrandingColor.GrayScale.white.opacity(0.06))
         case .decorationSecondary:
-            return DynamicColor(lightColor: Color(0x242323).opacity(0.16), darkColor: Color(0xFFFFFF).opacity(0.09))
+            return DynamicColor(lightColor: RebrandingColor.Eggshell.eggshell90.opacity(0.16), darkColor: RebrandingColor.GrayScale.white.opacity(0.09))
         case .backgroundAccent:
             return DynamicColor(lightColor: Color(0x7295F6).opacity(0.20), darkColor: Color(0x8FABF9).opacity(0.20))
         }

--- a/iOS/DuckDuckGo-iOS.xcodeproj/xcshareddata/xcschemes/iOS Browser Alpha.xcscheme
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/xcshareddata/xcschemes/iOS Browser Alpha.xcscheme
@@ -51,6 +51,16 @@
             ReferencedContainer = "container:DuckDuckGo-iOS.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-ff.onboardingRebranding true"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-isOnboardingCompleted false"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Alpha Debug"

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/Components/AddToDock/RebrandedAddToDockPromoView.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/Components/AddToDock/RebrandedAddToDockPromoView.swift
@@ -27,7 +27,7 @@ extension OnboardingRebranding.OnboardingView {
 
         private enum Design {
             static let borderWidth: CGFloat = 321
-            static let borderHeight: CGFloat = 128
+            static let borderHeight: CGFloat = 127
             static let videoWidth: CGFloat = 300
             static let videoHeight: CGFloat = 120
             static let borderHorizontalPadding: CGFloat = -6

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/Components/AddressBarPositionPicker/RebrandedOnboardingAddressBarPositionPicker.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/Components/AddressBarPositionPicker/RebrandedOnboardingAddressBarPositionPicker.swift
@@ -142,7 +142,7 @@ extension OnboardingRebranding.OnboardingView.OnboardingAddressBarPositionPicker
                     .resizable()
                     .background(
                         Circle()
-                            .fill(Color.white)
+                            .fill(checkboxFillerColor)
                             .frame(width: AddressBarPositionPickerMetrics.Radio.checkSize, height: AddressBarPositionPickerMetrics.Radio.checkSize)
                     )
                     .foregroundStyle(AddressBarPositionPickerMetrics.accentColor)
@@ -157,6 +157,10 @@ extension OnboardingRebranding.OnboardingView.OnboardingAddressBarPositionPicker
 
         private var checkboxStrokeColor: Color {
             colorScheme == .light ? AddressBarPositionPickerMetrics.borderLightColor : AddressBarPositionPickerMetrics.borderDarkColor
+        }
+
+        private var checkboxFillerColor: Color {
+            colorScheme == .light ? .white : Color(baseColor: .gray90)
         }
 
         private var foregroundColor: Color {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1213687308596187?focus=true
https://app.asana.com/1/137249556945/project/1205842942115003/task/1213687308596192
https://app.asana.com/1/137249556945/project/1205842942115003/task/1213687308596199

### Description

Small UI adjustments to the Rebranded onboarding

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only changes to onboarding SwiftUI components and rebranding color mappings, plus disabled-by-default Xcode launch arguments for local testing.
> 
> **Overview**
> Makes small UI review adjustments for the rebranded onboarding experience.
> 
> Updates the rebranding `DefaultColorPalette` mappings for secondary button and decoration colors (using opacity-based black/white and eggshell/white tokens), tweaks the Add-to-Dock promo border height by 1pt, and changes the address bar position picker’s selected radio indicator to use a light/dark-aware fill.
> 
> Adds disabled-by-default launch arguments to the `iOS Browser Alpha` Xcode scheme for toggling `-ff.onboardingRebranding` and resetting `-isOnboardingCompleted` during development.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 965c869862b0c088501aa1e9a739ea0ff5997283. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->