### PR TITLE
Publish DMG release at the end of macOS code freeze workflow

### DIFF
--- a/.github/workflows/macos_code_freeze.yml
+++ b/.github/workflows/macos_code_freeze.yml
@@ -169,8 +169,6 @@ jobs:
     needs: [ create_release_branch, run_tests, increment_build_number, prepare_release, tag_and_merge, publish_release ]
     if: >
       always() &&
-      needs.create_release_branch.outputs.asana_task_id != '' &&
-      needs.create_release_branch.outputs.release_branch_name != '' &&
       (
         needs.run_tests.result == 'failure' ||
         needs.increment_build_number.result == 'failure' ||


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1213720303163889?focus=true

### Description
This change updates macOS Code Freeze workflow so that it publishes the DMG as the last step,
unifying the behavior between iOS, macOS App Store and macOS DMG.

### Testing Steps
N/A, I'll test it live next Monday (I'm on release rotation), but the changes are straightforward and
largely a copy-paste from the iOS Code Freeze workflow.

### Impact and Risks
Low: may break code freeze in which case I'll fix it.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the macOS release automation pipeline by adding a new publish step and wiring it into failure reporting, which could block or mis-order releases if the new job or its dependencies behave unexpectedly.
> 
> **Overview**
> The macOS code-freeze workflow now runs a new **Publish DMG Release** job (`macos_publish_dmg_release.yml`) after `tag_and_merge`, so DMG publication happens automatically at the end of code freeze.
> 
> Failure reporting was updated to include this new publish step in `needs` and in the `report_failure` condition, so publish failures are surfaced the same way as other release-step failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af4cb0a3fc762be425d4917dfd407eb0ffbaef3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->