### PR TITLE
remove swift compiler version checks

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "965b6a29db693c707cbc46e819afec68ef37b5e0",
-        "version" : "13.32.0"
+        "revision" : "13976e04d81eefac5a9c718d886ce99460a9123b",
+        "version" : "13.29.0"
       }
     },
     {

--- a/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
@@ -206,7 +206,6 @@ final class AIChatTabChatHeaderView: UIView {
 
     private func makeIconButton(image: DesignSystemImage, accessibilityLabel: String, action: Selector) -> UIButton {
         let button: UIButton
-#if compiler(>=6.2)
         if #available(iOS 26, *) {
             var config = UIButton.Configuration.glass()
             config.image = image
@@ -215,9 +214,6 @@ final class AIChatTabChatHeaderView: UIView {
         } else {
             button = makeIconButtonLegacy(image: image)
         }
-#else
-        button = makeIconButtonLegacy(image: image)
-#endif
         button.translatesAutoresizingMaskIntoConstraints = false
         button.tintColor = UIColor(designSystemColor: .icons)
         button.accessibilityLabel = accessibilityLabel
@@ -234,9 +230,7 @@ final class AIChatTabChatHeaderView: UIView {
     }
 
     private func updateButtonShadows() {
-#if compiler(>=6.2)
         if #available(iOS 26, *) { return }
-#endif
         let isDark = traitCollection.userInterfaceStyle == .dark
         for button in [settingsButton, newChatButton] {
             if isDark {

--- a/iOS/DuckDuckGo/BrowserChromeButton.swift
+++ b/iOS/DuckDuckGo/BrowserChromeButton.swift
@@ -245,11 +245,9 @@ extension BrowserChromeButton {
 
         let barItem = UIBarButtonItem(customView: button)
 
-#if compiler(>=6.2)
         if #available(iOS 26.0, *) {
             barItem.hidesSharedBackground = true
         }
-#endif
 
         barItem.title = title
 

--- a/iOS/DuckDuckGo/DownloadsList.swift
+++ b/iOS/DuckDuckGo/DownloadsList.swift
@@ -54,15 +54,11 @@ struct DownloadsList: View {
         if viewModel.sections.isEmpty {
             emptyState
         } else {
-#if compiler(>=6.2)
             if #available(iOS 26, *) {
                 listWithBottomToolbarLiquidGlass
             } else {
                 listWithBottomToolbar
             }
-#else
-            listWithBottomToolbar
-#endif // compiler(>=6.2)
         }
     }
     
@@ -80,7 +76,6 @@ struct DownloadsList: View {
         .edgesIgnoringSafeArea(.bottom)
     }
 
-#if compiler(>=6.2)
     @available(iOS 26, *)
     private var listWithBottomToolbarLiquidGlass: some View {
         listWithBackground.toolbar {
@@ -97,7 +92,6 @@ struct DownloadsList: View {
             }
         }
     }
-#endif // compiler(>=6.2)
 
     @ViewBuilder
     private var listWithBottomToolbar: some View {

--- a/iOS/DuckDuckGo/MainView.swift
+++ b/iOS/DuckDuckGo/MainView.swift
@@ -352,16 +352,12 @@ extension MainViewFactory {
         let toolbar = coordinator.toolbar!
         let navigationBarCollectionView = coordinator.navigationBarCollectionView!
 
-        #if compiler(>=6.2)
         if #available(iOS 26, *), isPad {
             let guide = superview.layoutGuide(for: .margins(cornerAdaptation: .vertical))
             coordinator.constraints.navigationBarContainerTop = container.topAnchor.constraint(equalTo: guide.topAnchor)
         } else {
             coordinator.constraints.navigationBarContainerTop = container.constrainView(superview.safeAreaLayoutGuide, by: .top)
         }
-        #else
-        coordinator.constraints.navigationBarContainerTop = container.constrainView(superview.safeAreaLayoutGuide, by: .top)
-        #endif
         coordinator.constraints.navigationBarContainerBottom = container.constrainView(toolbar, by: .bottom, to: .top)
         coordinator.constraints.navigationBarContainerHeight = container.constrainAttribute(.height, to: coordinator.omniBar.barView.expectedHeight, relatedBy: .equal)
 
@@ -380,16 +376,12 @@ extension MainViewFactory {
     private func constrainTabBarContainer() {
         let tabBarContainer = coordinator.tabBarContainer!
 
-        #if compiler(>=6.2)
         if #available(iOS 26, *), isPad {
             let guide = superview.layoutGuide(for: .margins(cornerAdaptation: .vertical))
             coordinator.constraints.tabBarContainerTop = tabBarContainer.topAnchor.constraint(equalTo: guide.topAnchor)
         } else {
             coordinator.constraints.tabBarContainerTop = tabBarContainer.constrainView(superview.safeAreaLayoutGuide, by: .top)
         }
-        #else
-        coordinator.constraints.tabBarContainerTop = tabBarContainer.constrainView(superview.safeAreaLayoutGuide, by: .top)
-        #endif
 
         NSLayoutConstraint.activate([
             tabBarContainer.constrainView(superview, by: .leading),

--- a/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
+++ b/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
@@ -253,14 +253,12 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
             isBottomBarHidden = true
         }
 
-        #if compiler(>=6.2)
         if #available(iOS 26, *) {
             newItems.forEach {
                 $0.sharesBackground = false
                 $0.hidesSharedBackground = true
             }
         }
-        #endif
 
         bottomBarItems = newItems
     }
@@ -274,12 +272,10 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
         button.frame = CGRect(x: 0, y: 0, width: 34, height: 44)
 
         let barItem = UIBarButtonItem(customView: button)
-#if compiler(>=6.2)
         if #available(iOS 26.0, *) {
             barItem.sharesBackground = false
             barItem.hidesSharedBackground = true
         }
-#endif
 
         return barItem
     }

--- a/iOS/DuckDuckGo/TabSwitcherViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController.swift
@@ -949,11 +949,9 @@ extension TabSwitcherViewController {
         refreshDisplayModeButton()
         
         titleBarView.tintColor = theme.barTintColor
-        #if compiler(>=6.2)
         if #available(iOS 26.0, *) {
             titleBarView.backItem?.rightBarButtonItem?.hidesSharedBackground = true
         }
-        #endif
 
         toolbar.barTintColor = theme.barBackgroundColor
         toolbar.tintColor = UIColor(singleUseColor: .toolbarButton)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputTopHeaderView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputTopHeaderView.swift
@@ -42,7 +42,6 @@ final class UnifiedInputTopHeaderView: UIView {
     private var titleTrailingToContainerConstraint: NSLayoutConstraint!
 
     private lazy var dismissButton: UIButton = {
-        #if compiler(>=6.2)
         if #available(iOS 26, *) {
             var config = UIButton.Configuration.glass()
             config.image = UIImage(systemName: "xmark")
@@ -51,7 +50,6 @@ final class UnifiedInputTopHeaderView: UIView {
             button.translatesAutoresizingMaskIntoConstraints = false
             return button
         }
-        #endif
         return makePreiOS26DismissButton()
     }()
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -701,7 +701,6 @@ private extension UnifiedToggleInputView {
 extension UnifiedToggleInputView {
 
     private func makeDismissButton() -> UIButton {
-        #if compiler(>=6.2)
         if #available(iOS 26, *) {
             var config = UIButton.Configuration.glass()
             config.image = UIImage(systemName: "xmark")
@@ -711,7 +710,6 @@ extension UnifiedToggleInputView {
             button.addTarget(self, action: #selector(handleDismissTap), for: .primaryActionTriggered)
             return button
         }
-        #endif
         let button = UIButton(type: .system)
         button.translatesAutoresizingMaskIntoConstraints = false
         let image = UIImage(systemName: "xmark")?


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1213720446115474?focus=true
Tech Design URL:
CC: @aataraxiaa @Bunn 

### Description
Removes Swift compiler level checks now that we're using Xcode 26+ everywhere.

### Testing Steps

1. Smoke test affected areas:
* AI Chat
* Input Toggle 
* Tab Switcher
* Main Browsing view
* Downloads list

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly build-time cleanup, but it also changes the pinned `content-scope-scripts` version (a core privacy dependency), which could affect runtime content blocking behavior if the downgrade is unintended.
> 
> **Overview**
> Removes `#if compiler(>=6.2)` guards across several UI components so iOS 26-specific code paths are controlled solely via `#available(iOS 26, *)` (e.g., glass button configurations and iOS 26 toolbar background behavior).
> 
> Updates SwiftPM `Package.resolved` to pin `content-scope-scripts` to `13.29.0` (from `13.32.0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7168bc764b2d5269330312f56aef314944154e3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->