### PR TITLE
Fix attach file button in Duck.ai floating sidebar

### DIFF
--- a/macOS/DuckDuckGo/AIChat/Sidebar/AIChatViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/Sidebar/AIChatViewController.swift
@@ -468,6 +468,8 @@ final class AIChatViewController: NSViewController {
         }
 
         if isChatFloating {
+            // Use a standalone panel instead of a sheet to prevent the open dialog
+            // from repositioning the narrow floating sidebar when centering itself.
             openPanel.begin(completionHandler: handler)
         } else {
             openPanel.beginSheetModal(for: window, completionHandler: handler)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204912272578138/1213728797172054/f

### Description

The attach file button in the Duck.ai sidebar stopped working when the sidebar was detached into a floating window. The root cause was that open panel dialogs from the sidebar's internal web view were routed through a notification to `BrowserTabViewController`, which gated handling on `isKeyWindow` — always `false` when the floating window is active.

The fix intercepts `.openPanel` dialogs directly in `AIChatViewController` and presents them on `view.window`, which naturally resolves to the correct window in both docked and floating modes. When floating, the panel is shown as a standalone dialog (`begin(completionHandler:)`) instead of a sheet to avoid pushing the narrow floating window off-screen.

### Testing Steps

1. Open the Duck.ai sidebar on any tab
2. Select a model that supports image uploads
3. Click the attach file button — verify the file picker appears as a sheet on the browser window
4. Detach the sidebar into a floating window
5. Click the attach file button — verify the file picker appears as a standalone dialog
6. Select a file and confirm it attaches correctly
7. Re-attach the sidebar back to the browser
8. Click the attach file button again — verify it still works

### Impact and Risks

Low — the change only affects how `.openPanel` dialogs are presented in the AI chat sidebar. Other dialog types continue to flow through the existing notification path. The `Tab` already handles cleanup of `userInteractionDialog` state via completion handlers.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes how `.openPanel` user-interaction dialogs are presented for the AI Chat sidebar, with other dialog types still flowing through the existing notification path.
> 
> **Overview**
> Fixes file-attach/open-panel dialogs in the Duck.ai sidebar when the sidebar is detached into a floating window.
> 
> `AIChatViewController` now intercepts `.openPanel` `userInteractionDialog`s and presents an `NSOpenPanel` on the sidebar’s own `view.window`, using a standalone modal in floating mode (vs a sheet when docked) to avoid repositioning the narrow floating window; other dialog types continue to be forwarded via the existing notification.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 289a1a04ee34897fb467119f7e16350239e6d80a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->