### PR TITLE
WatchdogTests: Disables Flaky Test

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Watchdog/WatchdogTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Watchdog/WatchdogTests.swift
@@ -531,6 +531,8 @@ final class WatchdogTests: XCTestCase {
     }
 
     func testCooldownDoesNotAffectRecoveredEvents() async throws {
+        throw XCTSkip("Flaky test: https://app.asana.com/1/137249556945/project/1211150618152277/task/1213707947733499?focus=true")
+
         let store = FiredEventsStore()
         let eventMapper = EventMapping<Watchdog.Event> { event, _, _, onComplete in
             store.append(event)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1213707947733499?focus=true
Tech Design URL:
CC:

### Description
This PR disables a flaky test that's been randomly failing.

### Testing Steps
- [ ] Verify the CI is green please!

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing

### Quality Considerations
None

### Notes to Reviewer
TY!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes a unit test by skipping it, with no production code impact. The main risk is reduced coverage around cooldown behavior for recovered hang events until the flakiness is addressed.
> 
> **Overview**
> Disables the flaky `testCooldownDoesNotAffectRecoveredEvents` in `WatchdogTests` by adding an `XCTSkip` with a tracking link, preventing intermittent CI failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cba6dbdfc05cf030e2e49b22bee44f3066ac71df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->