### PR TITLE
Prevent termination decider chain from running twice

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1530,7 +1530,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let handler = TerminationDeciderHandler(
             deciders: createTerminationDeciders(),
             replyToApplicationShouldTerminate: { [weak self] shouldTerminate in
-                self?.terminationHandler = nil
+                // Keep terminationHandler set after successful completion so the
+                // guard in applicationShouldTerminate blocks any subsequent calls.
+                // During Sparkle updates the system can fire a second terminate
+                // request right after reply:YES. If we cleared the handler, the
+                // decider chain would re-run against already-closed windows and
+                // overwrite the saved state with empty data.
+                if !shouldTerminate {
+                    self?.terminationHandler = nil
+                }
                 NSApp.reply(toApplicationShouldTerminate: shouldTerminate)
             }
         )


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213734485242032?focus=true

### Description

Fixes an issue that causes tabs to be cleared on Update.

### Testing Steps

1. Enable restoration
2. Disable data clearing
3. Run the updates server
4. Try updating many times and ensure tabs are properly restored each time.  (I could make it fail after about 4 attempts before this fix)

### Impact and Risks

NA

#### What could go wrong?

NA

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes app termination flow and adds sandbox entitlement to read the Dock plist; mistakes here could still impact state restoration during updates or introduce sandbox/permissions regressions.
> 
> **Overview**
> Fixes a Sparkle update edge case where macOS can issue a second termination request immediately after a successful `reply:YES`, causing the termination decider chain to re-run and potentially overwrite saved session state with empty data.
> 
> Refactors Dock integration: introduces `DockStateChecking` so dock presence can be queried even when dock modification is disabled, gates Dock customization/notification logic for App Store builds, switches the Dock plist path resolution, and adds the required App Store sandbox entitlement for `/Library/Preferences/com.apple.dock.plist`. Adds `DockCustomizerTests` to cover App Store vs non–App Store behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12a0a177db00fc834b6d8adaca54f2fbaf6eeb9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->