### PR TITLE
[iOS ]Implement orange border for Omnibar in fire mode

### DIFF
--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalletes/DefaultColorPalette.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalletes/DefaultColorPalette.swift
@@ -96,7 +96,6 @@ struct DefaultColorPalette: ColorPaletteDefinition {
     // Fire Tabs
     private static let fireModeAccent = DynamicColor(lightColor: RebrandingColor.Mandarin.mandarin50, darkColor: RebrandingColor.Mandarin.mandarin40)
     private static let fireModeAccentTertiary = DynamicColor(lightColor: RebrandingColor.Mandarin.mandarin70, darkColor: RebrandingColor.Mandarin.mandarin60)
-    private static let fireModeBackground = DynamicColor(lightColor: x3D3D3D, darkColor: surfaceCanvas.darkColor)
 
     // Highlight
     private static let highlightDecoration = DynamicColor(lightColor: .tint(0.24), darkColor: xF9F9F9.opacity(0.12))
@@ -278,7 +277,6 @@ struct DefaultColorPalette: ColorPaletteDefinition {
             return DynamicColor(lightColor: x1F1F1F.opacity(0.918), darkColor: .tint(0.905))
         case .fireModeAccent: return fireModeAccent
         case .fireModeAccentTertiary: return fireModeAccentTertiary
-        case .fireModeBackground: return fireModeBackground
         }
     }
 }

--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
@@ -50,7 +50,6 @@ public enum SingleUseColor {
     // Fire Mode
     case fireModeAccent
     case fireModeAccentTertiary
-    case fireModeBackground
 }
 
 // MARK: - Onboarding Rebranding 2026

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -145,10 +145,6 @@ class SwitchBarTextEntryView: UIView {
     }
 
     private func setupView() {
-        if handler.isFireTab {
-            overrideUserInterfaceStyle = .dark
-        }
-        
         let fontMetrics = UIFontMetrics(forTextStyle: .body)
         let textFont = fontMetrics.scaledFont(for: UIFont.systemFont(ofSize: Constants.fontSize))
         textView.font = textFont

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryViewController.swift
@@ -35,6 +35,7 @@ class SwitchBarTextEntryViewController: UIViewController {
     private let textEntryView: SwitchBarTextEntryView
     private let handler: SwitchBarHandling
     private let containerView = CompositeShadowView()
+    private let activeOutlineView = UIView()
 
     private(set) lazy var buttonsContainerView: UIView = {
         handler.isUsingFadeOutAnimation ? SwitchBarTextEntryButtonsContainerView() : UIView()
@@ -96,9 +97,11 @@ class SwitchBarTextEntryViewController: UIViewController {
 
         view.addSubview(containerView)
 
+        containerView.addSubview(activeOutlineView)
         containerView.addSubview(textEntryView)
         containerView.addSubview(buttonsContainerView)
 
+        activeOutlineView.translatesAutoresizingMaskIntoConstraints = false
         containerView.translatesAutoresizingMaskIntoConstraints = false
         textEntryView.translatesAutoresizingMaskIntoConstraints = false
         buttonsContainerView.translatesAutoresizingMaskIntoConstraints = false
@@ -112,10 +115,26 @@ class SwitchBarTextEntryViewController: UIViewController {
         textEntryView.layer.cornerRadius = Metrics.containerCornerRadius
         textEntryView.layer.masksToBounds = true
         
-        containerView.backgroundColor = handler.isFireTab ?
-        UIColor(singleUseColor: .fireModeBackground) :
-        UIColor(designSystemColor: .urlBar)
+        containerView.backgroundColor = UIColor(designSystemColor: .urlBar)
         containerView.applyActiveShadow()
+
+        activeOutlineView.isUserInteractionEnabled = false
+        activeOutlineView.layer.borderWidth = Metrics.activeBorderWidth
+        activeOutlineView.layer.cornerRadius = Metrics.activeBorderRadius
+        activeOutlineView.layer.cornerCurve = .continuous
+        activeOutlineView.backgroundColor = .clear
+
+        updateFireModeAppearance()
+    }
+
+    private func updateFireModeAppearance() {
+        if handler.isFireTab {
+            activeOutlineView.layer.borderColor = UIColor(singleUseColor: .fireModeAccent).cgColor
+            activeOutlineView.alpha = 1
+        } else {
+            activeOutlineView.layer.borderColor = UIColor(designSystemColor: .accent).cgColor
+            activeOutlineView.alpha = 0
+        }
     }
 
     private func setupConstraints() {
@@ -123,6 +142,11 @@ class SwitchBarTextEntryViewController: UIViewController {
         buttonsContainerView.setContentHuggingPriority(.defaultHigh, for: .vertical)
 
         NSLayoutConstraint.activate([
+            activeOutlineView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: -Metrics.activeBorderWidth),
+            activeOutlineView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: Metrics.activeBorderWidth),
+            activeOutlineView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: -Metrics.activeBorderWidth),
+            activeOutlineView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: Metrics.activeBorderWidth),
+
             containerView.topAnchor.constraint(equalTo: view.topAnchor),
             containerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             containerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
@@ -185,5 +209,7 @@ class SwitchBarTextEntryViewController: UIViewController {
 
     private struct Metrics {
         static let containerCornerRadius: CGFloat = 16
+        static let activeBorderWidth: CGFloat = 2
+        static let activeBorderRadius: CGFloat = 18
     }
 }

--- a/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
@@ -103,7 +103,6 @@ final class DefaultOmniBarSearchView: UIView {
         textField.tintColor = fireMode
         ? UIColor(singleUseColor: .fireModeAccent)
         : UIColor(designSystemColor: .accent)
-        self.overrideUserInterfaceStyle = fireMode ? .dark : .unspecified
     }
 
     private func setUpSubviews() {

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -325,7 +325,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
     private let searchAreaAlignmentView = UIView()
     private let searchAreaStackView = UIStackView()
 
-    /// Currently unused - should be removed if unlikely to return
+    /// Used for fire mode
     private let activeOutlineView = UIView()
 
     private let stackView = UIStackView()
@@ -594,11 +594,11 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
 
     private func updateFireModeAppearance() {
         if fireMode {
-            searchAreaContainerView.backgroundColor = UIColor(singleUseColor: .fireModeBackground)
             activeOutlineView.layer.borderColor = UIColor(singleUseColor: .fireModeAccent).cgColor
+            activeOutlineView.alpha = 1
         } else {
-            searchAreaContainerView.backgroundColor = UIColor(designSystemColor: .urlBar)
             activeOutlineView.layer.borderColor = UIColor(designSystemColor: .accent).cgColor
+            activeOutlineView.alpha = 0
         }
         progressView?.updateFireModeAppearance(fireMode: fireMode)
     }
@@ -678,10 +678,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
     }
 
     private func setUpInitialState() {
-        // This active outline view needs to be removed in the future.  There is
-        //  some indecision about whether want it or not just now when comparing with
-        //  macOS, the arguments being we should have parity vs it's not need.  So leaving
-        //  it in disabled for now.
+        // Disabled by default, enabled in fire tabs
         activeOutlineView.layer.cornerRadius = Metrics.cornerRadius
         activeOutlineView.alpha = 0
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213735037291312?focus=true

### Description
This PR changes the appearance of the omnibar in fire mode from a forced dark appearance to having an orange border.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Verify fire tabs have an orange border in focused and unfocused states (Check normal and AI chat tabs)
2. Verify normal tabs do not have a border in focused and unfocused states (Check normal and AI chat tabs)

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
