### PR TITLE
[macOS] Fix flaky TabLazyLoaderTests by enforcing @MainActor isolation

### DIFF
--- a/macOS/UnitTests/TabBar/ViewModel/TabLazyLoaderTests.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabLazyLoaderTests.swift
@@ -340,13 +340,14 @@ class TabLazyLoaderTests: XCTestCase {
         XCTAssertEqual(isLazyLoadingPausedEvents, [false, true, false])
     }
 
+    @MainActor
     func waitForLoadingDidFinishEvent<DataSource>(
         _ lazyLoader: TabLazyLoader<DataSource>,
         and otherExpectations: [XCTestExpectation] = [],
         expectedDidFinishValue expectedValue: Bool = true,
         file: StaticString = #file,
         line: UInt = #line,
-        _ block: () async -> Void
+        _ block: () -> Void
     ) async {
 
         let expectation = self.expectation(description: "loadingDidFinish")
@@ -356,7 +357,7 @@ class TabLazyLoaderTests: XCTestCase {
             expectation.fulfill()
         }
 
-        await block()
+        block()
 
         await fulfillment(of: otherExpectations + [expectation], timeout: 2)
         cancellable.cancel()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201037661562251/1212857355346361/f
Tech Design URL:
CC:

### Description

The `waitForLoadingDidFinishEvent` test helper declared its block parameter as `() async -> Void` — a non-`@MainActor`-isolated async closure. When called from a `@MainActor` test via `await block()`, Swift could run the closure on the concurrent executor instead of the main actor. This caused `scheduleLazyLoading()` and its Combine chain to race against the mock's `Task { @MainActor in }` completions on the main actor, leading to flaky test failures in CI.

Changed the block to `@MainActor () -> Void` to explicitly guarantee main actor execution. All callers pass synchronous closures, so this is a safe change.

### Testing Steps

1. Run `TabLazyLoaderTests` — all 12 tests should pass.

### Impact and Risks

None: Test-only change.

#### What could go wrong?

Nothing — only the test helper signature changed.

### Quality Considerations

- All callers were already passing synchronous closures, so changing `() async -> Void` to `() -> Void` is a no-op for them.
- Adding `@MainActor` makes the main-actor requirement explicit at compile time rather than relying on runtime coincidence.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that tightens actor isolation and removes an unnecessary async closure, reducing race conditions in CI.
> 
> **Overview**
> Stabilizes `TabLazyLoaderTests` by updating the `waitForLoadingDidFinishEvent` helper to be `@MainActor`-isolated and to accept a synchronous `() -> Void` block (removing the prior `() async -> Void` + `await`).
> 
> This makes the lazy-loading trigger code run deterministically on the main actor, preventing races between `scheduleLazyLoading()`/Combine callbacks and main-actor `Task` completions used in the mocks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1962284da8e0fa522c290c827556b94df25670e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->