### PR TITLE
Allow fireproofing non-etld+1 domains

### DIFF
--- a/macOS/DuckDuckGo/Fireproofing/Model/FireproofDomains.swift
+++ b/macOS/DuckDuckGo/Fireproofing/Model/FireproofDomains.swift
@@ -154,8 +154,8 @@ internal class FireproofDomains: DomainFireproofStatusProviding {
         let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty,
               let url = URL(trimmedAddressBarString: trimmed),
-              url.navigationalScheme?.isHypertextScheme == true,
-              let eTLDPlus1Domain = tld.eTLDplus1(url.host) else { return nil }
+              url.navigationalScheme?.isHypertextScheme == true else { return nil }
+        let eTLDPlus1Domain = tld.eTLDplus1(url.host) ?? url.host
         return eTLDPlus1Domain
     }
 
@@ -190,10 +190,7 @@ internal class FireproofDomains: DomainFireproofStatusProviding {
 
     func isFireproof(cookieDomain: String) -> Bool {
         let domainWithoutDotPrefix = cookieDomain.dropping(prefix: ".")
-        guard let eTLDPlus1Domain = tld.eTLDplus1(domainWithoutDotPrefix) else {
-            // eTLD+1 domain not available, domain is probably invalid
-            return false
-        }
+        let eTLDPlus1Domain = tld.eTLDplus1(domainWithoutDotPrefix) ?? domainWithoutDotPrefix
 
         return container.contains(domain: eTLDPlus1Domain)
     }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1213690788927256?focus=true

### Description
- Allow fireproofing non-eTLD+1 domains (IP addresses, localhost etc.)

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Open 192.168.0.1, right click the tab, fireproof the site, validate the menu item changes to Remove Fireproofing
2. Open `localhost`, open the 🍔 (“More”) menu, fireproof the site, validate the menu item changes to Remove Fireproofing
3. Open Settings -> Data Clearing -> Manage fireproof websites; Validate the newly added domains are there
4. Remove fireproofing from 192.168.0.1
5. Right click the `localhost` tab, remove fireproofing, validate the menu item is now Fireproof This Site

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
6. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Medium

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
- Adding invalid domains to Fireproof sites list
- Incorrectly treating non-fireproof websites as `fireproof`

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes domain normalization/validation for fireproofing to accept hosts that don’t resolve to eTLD+1 (e.g., IPs/localhost), which could allow unexpected or invalid entries and affect when cookies are preserved.
> 
> **Overview**
> Fireproofing now supports non-eTLD+1 hosts by falling back to the raw host/domain when `tld.eTLDplus1` can’t be derived.
> 
> This updates `add`, `remove`, `isFireproof(cookieDomain:)`, `isFireproof(fireproofDomain:)`, and `normalizedHost(fromUserInput:)` so IP addresses, `localhost`, and similar hosts can be added/checked/removed instead of being rejected as invalid.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04eed6e5467228349de142e066ae7b4dd83eceae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->