### PR TITLE
allow dragging files from Downloads Manager to WebView

### DIFF
--- a/macOS/DuckDuckGo/Bookmarks/Model/BookmarkDragDropManager.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Model/BookmarkDragDropManager.swift
@@ -60,7 +60,8 @@ final class BookmarkDragDropManager {
                 return .copy
             }
 
-            if let string = info.draggingPasteboard.string(forType: .string),
+            let pasteboard = info.draggingPasteboard
+            if let string = pasteboard.string(forType: .string) ?? pasteboard.string(forType: .URL) ?? pasteboard.string(forType: .fileURL),
                 URL(trimmedAddressBarString: string.trimmingWhitespace()) != nil {
                 return .copy
             }
@@ -190,7 +191,7 @@ final class BookmarkDragDropManager {
             if let webViewItem = item.draggedWebViewValues() {
                 url = webViewItem.url
                 title = webViewItem.title ?? self.title(forTabWith: webViewItem.url, in: window) ?? titleFromUrlDroppingSchemeIfNeeded(url)
-            } else if let draggedString = item.string(forType: .string),
+            } else if let draggedString = item.string(forType: .string) ?? item.string(forType: .URL) ?? item.string(forType: .fileURL),
                       let draggedURL = URL(trimmedAddressBarString: draggedString.trimmingWhitespace()) {
                 url = draggedURL
                 title = self.title(forTabWith: draggedURL, in: window) ?? titleFromUrlDroppingSchemeIfNeeded(url)

--- a/macOS/DuckDuckGo/FileDownload/View/DownloadsViewController.swift
+++ b/macOS/DuckDuckGo/FileDownload/View/DownloadsViewController.swift
@@ -424,7 +424,7 @@ final class DownloadsViewController: NSViewController {
 
     private func setupDragAndDrop() {
         tableView.registerForDraggedTypes([.fileURL])
-        tableView.setDraggingSourceOperationMask(NSDragOperation.none, forLocal: true)
+        tableView.setDraggingSourceOperationMask(NSDragOperation.copy, forLocal: true)
         tableView.setDraggingSourceOperationMask(NSDragOperation.move, forLocal: false)
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1213655357850137?focus=true

### Description
- Set dragging source mask to `.copy` for local drag operations from Downloads Manager
- Allow dragging files to Bookmarks Bar by checking `URL` and `fileURL` pasteboard types

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Download a file (https://www.thinkbroadband.com/download)
2. Open Download Manager, drag the file to Desktop or other folder in Finder, validate the file is moved from Downloads but kept in the Download Manager
3. Open drop page https://www.dragdrop.com/test/
4. Drag the file from the Download Manager to the upload area on the page, validate the file is uploaded
5. Download a html page using ⌥+Click on a link
6. Drag the downloaded html page from the Download Manager to the Bookmarks Bar, validate bookmark is created; 
7. Dragging to the Tab Bar should open the page in a new tab

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
8. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
- Local drag operations from the Download Manager can break
- Invalid item types could be added to the bookmarks bar

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI drag-and-drop behavior changes limited to Downloads and bookmark drop validation/creation; potential issues would be incorrect drag operation or accepting unintended pasteboard strings.
> 
> **Overview**
> Allows local drag operations from the Downloads Manager table to be treated as `copy` (instead of `none`), enabling dragging downloaded files into Finder/WebViews.
> 
> Expands bookmark bar drop handling to also read pasteboard `.URL` and `.fileURL` string values (in both drop validation and bookmark creation), so file/URL drags can create bookmarks when they parse as a valid URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47365f02cf7618e2a2190af431aecc3932c794c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->