### PR TITLE
[iOS] allows a single end to end test to be run or will default to all

### DIFF
--- a/.github/workflows/ios_end_to_end.yml
+++ b/.github/workflows/ios_end_to_end.yml
@@ -208,9 +208,6 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 60
 
-    env:
-      RUNS_ON: macos-26 # keep this in sync with runs-on above
-
     steps:
 
     - name: Check out the code
@@ -239,7 +236,7 @@ jobs:
   notify-failure:
     name: Notify on failure
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') && github.ref_name == 'main' }}
-    needs: [build-end-to-end-tests, end-to-end-tests, end-to-end-single-flow]
+    needs: [build-end-to-end-tests, end-to-end-tests]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1213740953994578?focus=true
Tech Design URL:
CC:

### Description
Allows a single end to end test to run by name or defaults to all tests as before.

### Testing Steps
Needs to be merged to be tested.

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Could break end to end testing

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI job gating and introduces a new execution path; misconfiguration could skip expected test runs or miss failure notifications (the notify job doesn’t depend on the new single-flow job).
> 
> **Overview**
> Adds a manual `workflow_dispatch` input (`test-flow`) to optionally run a *single* Maestro flow under `.maestro/`, defaulting to the existing full-suite behavior when empty.
> 
> Gates the existing matrix `end-to-end-tests` job behind `inputs.test-flow == ''` and introduces `end-to-end-single-flow` to download the built app artifact and run `mobile-dev-inc/action-maestro-cloud` against the specified flow with a shorter timeout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d71d75433bc955cb5e2d8f3db901c5255e267f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->