### PR TITLE
Fix trailing space in Croatia country code blocking subscriptions

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/StoreSubscriptionConfiguration.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/StoreSubscriptionConfiguration.swift
@@ -150,7 +150,7 @@ public enum SubscriptionRegion: CaseIterable {
             return Set(["USA"])
         case .restOfWorld:
             return Set(["CAN", "GBR", "AUT", "DEU", "NLD", "POL", "SWE",
-                        "BEL", "BGR", "HRV ", "CYP", "CZE", "DNK", "EST", "FIN", "FRA", "GRC", "HUN", "IRL", "ITA", "LVA", "LTU", "LUX", "MLT", "PRT",
+                        "BEL", "BGR", "HRV", "CYP", "CZE", "DNK", "EST", "FIN", "FRA", "GRC", "HUN", "IRL", "ITA", "LVA", "LTU", "LUX", "MLT", "PRT",
                         "ROU", "SVK", "SVN", "ESP"])
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209882303470922/task/1213747950233461?focus=true
Tech Design URL: N/A
CC:

### Description

This PR fixes a typo in the `restOfWorld` region country codes where Croatia's ISO 3166-1 Alpha-3 code was listed as `"HRV "` (with a trailing space) instead of `"HRV"`. This trailing space prevented Croatian users from matching the `restOfWorld` region, completely blocking them from purchasing Privacy Pro subscriptions.

When StoreKit provides the country code "HRV" (without space), it fails to match "HRV " in the Set, causing `SubscriptionRegion.matchingRegion(for: "HRV")` to return nil and leaving Croatian users without any available subscription options.

### Testing Steps

1. Verify the change: Confirm that line 153 in `StoreSubscriptionConfiguration.swift` now contains `"HRV"` without a trailing space
2. Check formatting: Ensure all other country codes in the array remain properly formatted
3. Manual testing would require a Croatian Apple ID account to verify subscription availability

### Impact and Risks

**Impact: High** - This bug completely blocked Croatian users from purchasing Privacy Pro subscriptions.

#### What could go wrong?

- If the fix is somehow incorrect, Croatian users would continue to be blocked from subscriptions. However, the fix is straightforward (removing a trailing space) and aligns with the ISO 3166-1 Alpha-3 standard that all other country codes follow.
- No other country codes or functionality are affected by this single-character change.

### Quality Considerations

- The fix ensures Croatia's country code matches the standard ISO 3166-1 Alpha-3 format ("HRV") that StoreKit uses
- All other country codes in the `restOfWorld` array are correctly formatted without trailing spaces
- The `Set<String>` matching logic requires exact string matches, so the trailing space completely prevented the match

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-string change to region mapping logic; main risk is unintended region classification, but the change is a straightforward typo fix.
> 
> **Overview**
> Fixes a typo in `SubscriptionRegion.restOfWorld.countryCodes` where Croatia’s StoreKit ISO alpha-3 code was listed as `"HRV "` (trailing space) instead of `"HRV"`, allowing `matchingRegion(for:)` and subscription product selection to work for Croatian storefronts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e12c8af4282d565e68f863a6fe9baaa652e0b883. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->