### PR TITLE
Tab: Enabling Spinner for Duck Search

### DIFF
--- a/macOS/DuckDuckGo/TabBar/Tools/LoadingIndicatorPolicy.swift
+++ b/macOS/DuckDuckGo/TabBar/Tools/LoadingIndicatorPolicy.swift
@@ -31,7 +31,7 @@ struct DefaultLoadingIndicatorPolicy: LoadingIndicatorPolicy {
             return false
         }
 
-        return !url.isDuckDuckGoSearch && !url.isDuckPlayer && url.navigationalScheme?.isHypertextScheme == true
+        return url.navigationalScheme?.isHypertextScheme == true
     }
 
     func shouldCrossfadeFavicon(newFavicon: NSImage?, oldFavicon: NSImage?, displaysPlaceholder: Bool) -> Bool {

--- a/macOS/UnitTests/TabBar/Tools/LoadingIndicatorPolicyTests.swift
+++ b/macOS/UnitTests/TabBar/Tools/LoadingIndicatorPolicyTests.swift
@@ -71,16 +71,6 @@ final class LoadingIndicatorPolicyTests: XCTestCase {
         }
     }
 
-    func testLoadingIndicatorIsNotShownForDuckSearchEvenIfOtherConditionsAreMet(isLoading: Bool, error: NSError?) async throws {
-        let sampleParameters: [(isLoading: Bool, error: NSError?)] = [(true, nil), (true, NSError.testingError), (false, nil), (false, NSError.testingError)]
-
-        for (isLoading, error) in sampleParameters {
-            let searchURL = URL.makeSearchUrl(from: "yosemite")
-            let result = policy.shouldShowLoadingIndicator(isLoading: isLoading, url: searchURL, error: error)
-            XCTAssertFalse(result)
-        }
-    }
-
     // MARK: - Favicon Crossfade Tests
 
     func testFaviconCrossfadesWhenPlaceholderIsDisplayedAndNewFaviconIsAvailable() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1213725464781605?focus=true
Tech Design URL:
CC:

### Description
This PR updates the logic that triggers the Tab Spinner, so that searches in DDG are no longer excluded

### Testing Steps
1. Open duckduckGo.com
2. Look up for any term

- [ ] Verify the Spinner shows up, while the query runs

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing really!

### Quality Considerations
None

### Notes to Reviewer
Thank you!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI logic change that broadens when the tab loading spinner appears; main risk is minor UX regressions (spinner showing on more pages than intended).
> 
> **Overview**
> Updates `DefaultLoadingIndicatorPolicy.shouldShowLoadingIndicator` to show the tab loading spinner for *all* hypertext (`http`/`https`) URLs, removing the previous exclusions for DuckDuckGo Search (and related special-case URLs).
> 
> Adjusts unit tests by deleting the DuckDuckGo Search “spinner should not show” test to match the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36c95f1526f64c2a97b67a368f163852bec726e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->