### PR TITLE
Prevent SubJobWebRunning from resuming CheckedContinuation multiple times

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/SubJobWebRunner/BrokerProfileOptOutSubJobWebRunner.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/SubJobWebRunner/BrokerProfileOptOutSubJobWebRunner.swift
@@ -147,6 +147,7 @@ public final class BrokerProfileOptOutSubJobWebRunner: SubJobWebRunning, BrokerP
                                          showWebView: showWebView)
                     } catch {
                         failed(with: error)
+                        return
                     }
 
                     if let optOutStep = context.dataBroker.optOutStep() {

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/SubJobWebRunner/BrokerProfileScanSubJobWebRunner.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/SubJobWebRunner/BrokerProfileScanSubJobWebRunner.swift
@@ -114,6 +114,7 @@ public final class BrokerProfileScanSubJobWebRunner: SubJobWebRunning, BrokerPro
                         try await initialize(handler: webViewHandler, isFakeBroker: context.dataBroker.isFakeBroker, showWebView: showWebView)
                     } catch {
                         failed(with: error)
+                        return
                     }
 
                     do {

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/SubJobWebRunner/SubJobWebRunner.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/SubJobWebRunner/SubJobWebRunner.swift
@@ -235,14 +235,20 @@ public extension SubJobWebRunning {
 
     func complete(_ value: ReturnValue) {
         self.firePostLoadingDurationPixel(hasError: false)
-        self.continuation?.resume(returning: value)
+
+        guard let continuation else { return }
+
         self.continuation = nil
+        continuation.resume(returning: value)
     }
 
     func failed(with error: Error) {
         self.firePostLoadingDurationPixel(hasError: true)
-        self.continuation?.resume(throwing: error)
+
+        guard let continuation else { return }
+
         self.continuation = nil
+        continuation.resume(throwing: error)
     }
 
     func initialize(handler: WebViewHandler?,


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1213740700571980?focus=true
Tech Design URL:
CC: @THISISDINOSAUR 

### Description

Tightens the implementation to prevent accidentally resuming CheckedContinuation multiple times.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Smoke test PIR.
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk defensive concurrency change that avoids double-resuming a `CheckedContinuation` during error/cancellation paths. Main behavior change is early-returning after `initialize` failures, which could slightly alter timing of downstream actions but should only affect already-failing runs.
> 
> **Overview**
> Prevents `SubJobWebRunner` from resuming its `CheckedContinuation` more than once by guarding and nil’ing the continuation before calling `resume` in both `complete` and `failed`.
> 
> Adds missing early `return`s after `initialize` errors in both scan and opt-out web runners so execution doesn’t continue after a failure, reducing chances of duplicate completion/failure signaling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2abb3c7cb82e90258fc7637e66d659de26f9a60d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->