### PR TITLE
Fix failing pixel validation for Easter egg logo pixels

### DIFF
--- a/iOS/DuckDuckGo/DaxEasterEggLogos/DaxEasterEggFullScreenViewController.swift
+++ b/iOS/DuckDuckGo/DaxEasterEggLogos/DaxEasterEggFullScreenViewController.swift
@@ -200,10 +200,10 @@ class DaxEasterEggFullScreenViewController: UIViewController {
     @objc private func setAsLogoButtonTapped() {
         if isCurrentLogoStored {
             logoStore.clearLogo()
-            Pixel.fire(pixel: .daxEasterEggLogoResetToDefault)
+            DailyPixel.fireDailyAndCount(pixel: .daxEasterEggLogoResetToDefault)
         } else if let urlString = imageURL?.absoluteString {
             logoStore.setLogo(url: urlString)
-            Pixel.fire(pixel: .daxEasterEggLogoSetAsPermanent)
+            DailyPixel.fireDailyAndCount(pixel: .daxEasterEggLogoSetAsPermanent)
         }
         dismiss(animated: true)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1213752126384944

### Description

Change `daxEasterEggLogoResetToDefault` and `daxEasterEggLogoSetAsPermanent` from `Pixel.fire` to `DailyPixel.fireDailyAndCount`. These pixels' definitions declare `first_daily_count` suffixes but were fired as plain pixels, causing live validation failures.

### Testing Steps
N/A

### Impact and Risks

Low — telemetry-only change, no user-facing impact.

#### What could go wrong?

Daily deduplication means we'll see fewer total events than before (expected and desired).

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)