### PR TITLE
Attributed metric pixel definitions update

### DIFF
--- a/iOS/PixelDefinitions/pixels/definitions/attributed_metric.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/attributed_metric.json5
@@ -122,7 +122,7 @@
                 "type": "string"
             },
             {
-                "key": "dayAverage",
+                "key": "day_average",
                 "description": "Number of days with data used to compute the average",
                 "type": "string"
             },
@@ -155,7 +155,7 @@
                 "type": "string"
             },
             {
-                "key": "dayAverage",
+                "key": "day_average",
                 "description": "Number of days with data used to compute the average",
                 "type": "string"
             },
@@ -188,7 +188,7 @@
                 "type": "string"
             },
             {
-                "key": "dayAverage",
+                "key": "day_average",
                 "description": "Number of days with data used to compute the average",
                 "type": "string"
             },
@@ -221,7 +221,7 @@
                 "type": "string"
             },
             {
-                "key": "dayAverage",
+                "key": "day_average",
                 "description": "Number of days with data used to compute the average",
                 "type": "string"
             },

--- a/macOS/PixelDefinitions/pixels/definitions/attributed_metric.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/attributed_metric.json5
@@ -122,7 +122,7 @@
                 "type": "string"
             },
             {
-                "key": "dayAverage",
+                "key": "day_average",
                 "description": "Number of days with data used to compute the average",
                 "type": "string"
             },
@@ -155,7 +155,7 @@
                 "type": "string"
             },
             {
-                "key": "dayAverage",
+                "key": "day_average",
                 "description": "Number of days with data used to compute the average",
                 "type": "string"
             },
@@ -188,7 +188,7 @@
                 "type": "string"
             },
             {
-                "key": "dayAverage",
+                "key": "day_average",
                 "description": "Number of days with data used to compute the average",
                 "type": "string"
             },
@@ -221,7 +221,7 @@
                 "type": "string"
             },
             {
-                "key": "dayAverage",
+                "key": "day_average",
                 "description": "Number of days with data used to compute the average",
                 "type": "string"
             },


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205842942115003/task/1213767678350968?focus=true

### Description

Attributed Metric pixels definition update

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renames a pixel parameter key in iOS/macOS attributed metric definitions, which could break analytics ingestion or dashboards still expecting `dayAverage`. Scope is small and limited to pixel metadata, with no runtime code changes.
> 
> **Overview**
> Updates iOS and macOS `attributed_metric.json5` pixel definitions to use a consistent snake_case parameter name by renaming the `dayAverage` parameter to `day_average` for the attributed-metric *average past week* pixels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8f023ad7e1dccdb54f01f1561053a8a4b753645. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->