### PR TITLE
[iOS] fix layout issues on iPad iOS26

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1969,11 +1969,11 @@ class MainViewController: UIViewController {
         forceNavigationBarPositioningOnPadOS26()
     }
 
-    var forceNavigationBarPositioningDebouncer = Debouncer()
+    private var forceNavigationBarPositioningDebouncer = Debouncer()
     private func forceNavigationBarPositioningOnPadOS26() {
         guard #available(iOS 26, *), isPad else { return }
-        forceNavigationBarPositioningDebouncer.debounce(for: 0.1) {
-            self.viewCoordinator.navigationBarContainer.superview?.setNeedsUpdateConstraints()
+        forceNavigationBarPositioningDebouncer.debounce(for: 0.1) { [weak self] in
+            self?.viewCoordinator.navigationBarContainer.superview?.setNeedsUpdateConstraints()
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206584483643184/task/1213689440144379?focus=true
Tech Design URL:
CC:

### Description
Prevent the iPad buttons from overlaying the app's top bar (which makes using the app difficult.

### Testing Steps
1. Launch the app on an iPad
2. Use full screen and windowed mode
3. Check different orientations
4. Cold launch in different orientations

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Layout could be further broken.

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, limited to iPad + iOS 26 layout behavior by forcing a delayed constraint update on the navigation bar container. Main risk is unintended layout regressions during rotation/size changes on iPadOS 26.
> 
> **Overview**
> Prevents iPadOS 26 layout issues where top-bar buttons can overlap the app chrome by forcing a constraint refresh on the navigation bar container.
> 
> Replaces the one-off `setNeedsUpdateConstraints()` call with a reusable `forceNavigationBarPositioningOnPadOS26()` helper (debounced) and invokes it after `viewDidAppear` and after rotation/size transitions to stabilize navigation bar positioning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb389d8527420ff4f83f27c94427f93e2ce6c092. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->