### PR TITLE
Gate variant DMG artifact upload to dry-run only

### DIFF
--- a/.github/workflows/macos_create_variant.yml
+++ b/.github/workflows/macos_create_variant.yml
@@ -261,7 +261,7 @@ jobs:
 
         echo "variant-name=${name}" >> "$GITHUB_OUTPUT"
 
-    - name: Upload variant DMG
+    - name: Upload variant DMG as artifact
       if: ${{ env.DRY_RUN == 'true' }}
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1213760441565821?focus=true

### Description

The artifact upload was running unconditionally on every release, instead of looking at the `dryRun` flag.

### Testing Steps

Production-like test — run with just variant values (throwaway name as it's used for the URL), no dry-run, no dmg-url. Verify:                                                                           
- Artifact upload skipped                                                                                                                                       
- S3 upload runs  

### Impact and Risks

Impact is high.  Fixes an issue that's uploading all variants as artifacts to GH.
Risk is medium.  This touches our release workflow.

#### What could go wrong?

NA

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes release workflow control flow; a mis-specified `DRY_RUN` condition could skip expected artifact uploads or run them unexpectedly.
> 
> **Overview**
> Prevents the macOS variant workflow from uploading the generated DMG as a GitHub Actions artifact on normal runs by gating the `actions/upload-artifact` step behind `DRY_RUN == 'true'`.
> 
> S3 publishing behavior is unchanged: non-dry-run runs still upload to S3 (when no custom `DMG_URL` is provided).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 361afddff2e86cb7949c4d44e399b7321b4494e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->