### PR TITLE
Show escape hatch for all users with feature flag on

### DIFF
--- a/iOS/DuckDuckGo/AppLifecycle/IdleReturnEligibilityManager.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/IdleReturnEligibilityManager.swift
@@ -24,6 +24,7 @@ import PrivacyConfig
 
 protocol IdleReturnEligibilityManaging {
     func isEligibleForNTPAfterIdle() -> Bool
+    func isEscapeHatchEligible() -> Bool
     func effectiveAfterInactivityOption() -> AfterInactivityOption
     func idleThresholdSeconds() -> Int
 }
@@ -65,12 +66,18 @@ final class IdleReturnEligibilityManager: IdleReturnEligibilityManaging {
         self.isStillOnboarding = isStillOnboarding
     }
 
-    /// Gates NTP-after-idle on linear onboarding completion and contextual
-    /// onboarding not actively showing NTP dialogs.
-    func isEligibleForNTPAfterIdle() -> Bool {
+    /// Gates escape hatch visibility on feature flag and onboarding completion,
+    /// regardless of the after-inactivity setting.
+    func isEscapeHatchEligible() -> Bool {
         tutorialSettings.hasSeenOnboarding
             && !isStillOnboarding()
             && featureFlagger.isFeatureOn(.showNTPAfterIdleReturn)
+    }
+
+    /// Gates NTP-after-idle on linear onboarding completion, contextual
+    /// onboarding not actively showing NTP dialogs, and the `.newTab` setting.
+    func isEligibleForNTPAfterIdle() -> Bool {
+        isEscapeHatchEligible()
             && effectiveAfterInactivityOption() == .newTab
     }
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1359,7 +1359,7 @@ class MainViewController: UIViewController {
 
     // TODO: - Adjust this to support cross-mode hatches
     private func buildEscapeHatch(sourceTabViewController: TabViewController? = nil) -> EscapeHatchModel? {
-        guard idleReturnEligibilityManager.isEligibleForNTPAfterIdle() else {
+        guard idleReturnEligibilityManager.isEscapeHatchEligible() else {
             return nil
         }
         let currentTab = tabManager.currentTabsModel.currentTab
@@ -3626,7 +3626,7 @@ extension MainViewController: OmniBarDelegate {
     }
 
     func escapeHatchForEditingState() -> EscapeHatchModel? {
-        guard idleReturnEligibilityManager.isEligibleForNTPAfterIdle(),
+        guard idleReturnEligibilityManager.isEscapeHatchEligible(),
               tabManager.currentTabsModel.currentTab?.link == nil else {
             return nil
         }

--- a/iOS/DuckDuckGoTests/IdleReturnEligibilityManagerTests.swift
+++ b/iOS/DuckDuckGoTests/IdleReturnEligibilityManagerTests.swift
@@ -105,6 +105,40 @@ struct IdleReturnEligibilityManagerTests {
         #expect(manager.isEligibleForNTPAfterIdle())
     }
 
+    // MARK: - isEscapeHatchEligible
+
+    @Test("When feature flag on and onboarding done then isEscapeHatchEligible returns true")
+    func whenFeatureOnAndOnboardingDoneThenEscapeHatchEligibleReturnsTrue() {
+        let manager = makeManager(featureOn: true, hasSeenOnboarding: true, isStillOnboarding: false)
+        #expect(manager.isEscapeHatchEligible())
+    }
+
+    @Test("When feature flag off then isEscapeHatchEligible returns false")
+    func whenFeatureOffThenEscapeHatchEligibleReturnsFalse() {
+        let manager = makeManager(featureOn: false)
+        #expect(!manager.isEscapeHatchEligible())
+    }
+
+    @Test("When onboarding not seen then isEscapeHatchEligible returns false")
+    func whenOnboardingNotSeenThenEscapeHatchEligibleReturnsFalse() {
+        let manager = makeManager(featureOn: true, hasSeenOnboarding: false)
+        #expect(!manager.isEscapeHatchEligible())
+    }
+
+    @Test("When contextual onboarding active then isEscapeHatchEligible returns false")
+    func whenContextualOnboardingActiveThenEscapeHatchEligibleReturnsFalse() {
+        let manager = makeManager(featureOn: true, isStillOnboarding: true)
+        #expect(!manager.isEscapeHatchEligible())
+    }
+
+    @Test("When effective option is Last Used Tab then isEscapeHatchEligible still returns true")
+    func whenLastUsedTabThenEscapeHatchEligibleStillReturnsTrue() {
+        let manager = makeManager(featureOn: true, effectiveOption: .lastUsedTab)
+        #expect(manager.isEscapeHatchEligible())
+    }
+
+    // MARK: - effectiveAfterInactivityOption
+
     @Test("effectiveAfterInactivityOption returns value from resolver")
     func effectiveAfterInactivityOptionReturnsValueFromResolver() {
         let managerNewTab = makeManager(effectiveOption: .newTab)

--- a/iOS/DuckDuckGoTests/IdleReturnEvaluatorTests.swift
+++ b/iOS/DuckDuckGoTests/IdleReturnEvaluatorTests.swift
@@ -25,11 +25,16 @@ import PrivacyConfig
 
 final class MockIdleReturnEligibilityManager: IdleReturnEligibilityManaging {
     var isEligibleForNTPAfterIdleResult = true
+    var isEscapeHatchEligibleResult = true
     var effectiveAfterInactivityOptionResult: AfterInactivityOption = .newTab
     var idleThresholdSecondsResult = 300
 
     func isEligibleForNTPAfterIdle() -> Bool {
         isEligibleForNTPAfterIdleResult
+    }
+
+    func isEscapeHatchEligible() -> Bool {
+        isEscapeHatchEligibleResult
     }
 
     func effectiveAfterInactivityOption() -> AfterInactivityOption {

--- a/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
+++ b/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
@@ -40,6 +40,7 @@ import AIChatTestingUtilities
 
 private final class MockIdleReturnEligibilityManagerForMainVC: IdleReturnEligibilityManaging {
     func isEligibleForNTPAfterIdle() -> Bool { false }
+    func isEscapeHatchEligible() -> Bool { false }
     func effectiveAfterInactivityOption() -> AfterInactivityOption { .lastUsedTab }
     func idleThresholdSeconds() -> Int { 60 }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1213770081873452?focus=true

### Description
Show the escape hatch ("Return to..." card) for all users who have the showNTPAfterIdleReturn feature flag enabled, regardless of their after-inactivity setting (New Tab vs Last Used Tab).

### Testing Steps
1. Enable the showNTPAfterIdleReturn feature flag via the debug menu.
2. Go to Settings > General and set "After Inactivity" to Last Used Tab.
3. Browse to any website, then open a new tab.
4. Verify the "Return to..." escape hatch card is visible on the NTP.
5. Tap the omnibar on the NTP and verify the escape hatch appears in the editing state.
6. Background the app, wait for the idle threshold to pass, then return to the app.
7. Verify the app stays on the last used tab (not redirected to NTP), idle redirect should respect the "Last Used Tab" setting.
8. Change the setting to New Tab and repeat steps 3-5; escape hatch should still appear.
9. Background the app, wait for the idle threshold, then return.
10. Verify the app does redirect to the NTP with the escape hatch card visible.
11. Disable the feature flag and open a new tab, escape hatch should not appear.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Users with "Last Used Tab" who have the feature flag on will now see the escape hatch card on manually opened NTPs. This is the intended behavior.
The NTP-after-idle redirect is unchanged, users with "Last Used Tab" will still return to their last tab after idle, not the NTP. The escape hatch only appears when they manually open a new tab.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only gatekeeping for the NTP escape hatch UI while keeping idle-redirect behavior tied to the `.newTab` setting; impact is limited to feature-flagged users and covered by added tests.
> 
> **Overview**
> Decouples escape hatch (“Return to…” card) visibility from NTP-after-idle redirect eligibility.
> 
> `IdleReturnEligibilityManager` introduces `isEscapeHatchEligible()` (feature flag + onboarding completion only) and updates `isEligibleForNTPAfterIdle()` to additionally require the `.newTab` after-inactivity setting. `MainViewController` now uses `isEscapeHatchEligible()` to show the escape hatch on manually opened NTPs and in omnibar editing state even when “After Inactivity” is set to “Last Used Tab”.
> 
> Tests are updated with new mocks/protocol conformance and expanded coverage for the new eligibility rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85cb38c17bb034aa3eab504feb2c4a49605139d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->