### PR TITLE
Enable linear onboarding (v4) for internal users on macOS

### DIFF
--- a/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
@@ -105,7 +105,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
 
     var configuration: OnboardingConfiguration {
         let systemSettings: SystemSettings
-        let order = "v3"
+        let order = applicationBuildType.isDebugBuild || applicationBuildType.isReviewBuild ? "v4" : "v3"
         let platform = OnboardingPlatform(name: "macos")
         if applicationBuildType.isAppStoreBuild {
             let rows = [

--- a/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
@@ -223,6 +223,42 @@ class OnboardingManagerTests: XCTestCase {
         XCTAssertEqual(managerWithFlagsOn.configuration, expectedConfig)
     }
 
+    func testReturnsExpectedOnboardingConfig_WhenDebugBuild_OrderIsV4() {
+        // Given
+        applicationBuildType.isDebugBuild = true
+        let debugManager = OnboardingActionsManager(
+            navigationDelegate: navigationDelegate,
+            dockCustomization: dockCustomization,
+            defaultBrowserProvider: defaultBrowserProvider,
+            appearancePreferences: appearancePreferences,
+            startupPreferences: startupPreferences,
+            dataImportProvider: importProvider,
+            featureFlagger: MockFeatureFlagger(),
+            applicationBuildType: applicationBuildType
+        )
+
+        // Then
+        XCTAssertEqual(debugManager.configuration.order, "v4")
+    }
+
+    func testReturnsExpectedOnboardingConfig_WhenReviewBuild_OrderIsV4() {
+        // Given
+        applicationBuildType.isReviewBuild = true
+        let reviewManager = OnboardingActionsManager(
+            navigationDelegate: navigationDelegate,
+            dockCustomization: dockCustomization,
+            defaultBrowserProvider: defaultBrowserProvider,
+            appearancePreferences: appearancePreferences,
+            startupPreferences: startupPreferences,
+            dataImportProvider: importProvider,
+            featureFlagger: MockFeatureFlagger(),
+            applicationBuildType: applicationBuildType
+        )
+
+        // Then
+        XCTAssertEqual(reviewManager.configuration.order, "v4")
+    }
+
     func testOnOnboardingStarted_UserInteractionIsPrevented() {
         // Given
         navigationDelegate.preventUserInteraction = false


### PR DESCRIPTION
## Summary
- Sets onboarding `order` to `"v4"` for debug and review builds so internal users get the new linear onboarding flow
- Production builds continue to use `"v3"`
- Adds unit tests for both debug and review build type scenarios

## Test plan
- [ ] Verify debug builds return `order: "v4"` in the onboarding init config
- [ ] Verify review builds return `order: "v4"` in the onboarding init config
- [ ] Verify production/App Store builds still return `order: "v3"`
- [ ] Run `OnboardingManagerTests` to confirm all tests pass

https://claude.ai/code/session_011dMqL7egu8W5HKE65rC5Vy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small config tweak gated to debug/review builds plus unit test coverage; production/App Store builds continue using the existing `v3` order.
> 
> **Overview**
> **Enables the new linear onboarding flow (`order: "v4"`) for internal macOS builds.** `OnboardingActionsManager.configuration` now selects `"v4"` when `applicationBuildType` is *debug* or *review*, while keeping `"v3"` for other build types.
> 
> Adds unit tests to assert the `order` is `"v4"` for debug and review build scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ed551d32a39428ca628e0f8a1cd36ab11240fc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->