### PR TITLE
Fix removing items from appcast2.xml by appcastManager

### DIFF
--- a/macOS/scripts/appcast_manager/appcastManager.swift
+++ b/macOS/scripts/appcast_manager/appcastManager.swift
@@ -816,7 +816,7 @@ func removeVersionFromAppcast(_ version: String, appcastContent: String) -> Stri
         return nil
     }
 
-    return xmlDoc.xmlString(options: [.nodePreserveWhitespace, .nodePreserveAll, .nodePrettyPrint])
+    return xmlDoc.xmlString
 }
 
 func writeAppcastContent(_ content: String, to filePath: URL) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1213757674156505?focus=true
CC: @alessandroboron 

### Description
This change replaces `NSRegularExpression` for removing items from the appcast file with
a more robust `XMLDocument` approach. The regex-based solution would incorrectly remove
multiple items from the appcast file, if there were items for newer versions at the top of the file.

This has manifested recently when running a public release workflow for 1.182.0 version
after a new internal release (1.183.0) was published.

### Testing Steps
Let's test the exact failing scenario from 1.182.0 public release:
1. Install [Sparkle 2.8.1 tools](https://github.com/sparkle-project/Sparkle/releases/tag/2.8.1).
2. Download appcast2_old.xml and release_notes.html from [this task](https://app.asana.com/1/137249556945/project/1201899738287924/task/1213778110802551?focus=true). This is the appcast file that was in place before the faulty 1.182.0 release was run.
3. Edit appcastManager.swift and set `let maximumDeltas = "0"` (instead of 2) – this speeds up appcast generation. Deltas generation logic is untouched by this change.
4. Run appcastManager.swift:
```
macOS/scripts/appcast_manager/appcastManager.swift --release-to-public-channel \
  --version 1.182.0.659 \
  --release-notes-html ~/Downloads/release_notes.html \
  --appcast-path ~/Downloads/appcast2_old.xml
```
5. Verify that the generated appcast2.xml has:
  * 1.183.0 version as the first one, released to internal channel,
  * 1.182.0 version as the second one, released publicly,
  * 1.181.1 as the third version and 1.55.0 as the last version.

### Impact and Risks
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes release automation behavior by altering how `appcast2.xml` is sourced and how items are removed, which could affect publishing if XML parsing/serialization differs from expectations.
> 
> **Overview**
> Fixes `appcastManager.swift` so removing a build from `appcast2.xml` is done via `XMLDocument`/XPath and `detach()` instead of a regex, preventing accidental deletion of multiple `<item>` entries.
> 
> Adds a `--appcast-path` debug flag to use a local appcast file (copying it into the working directory) rather than downloading from the CDN, and threads `Arguments` through the common download path.
> 
> Also logs the full `generate_appcast` command before execution to aid debugging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49a98810f5cb292d6f4c1e448885a80e4856c4df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->