### PR TITLE
Make sure TabSwitcher tap is effective after app relaunch

### DIFF
--- a/.maestro/browser_features/state_restoration.yaml
+++ b/.maestro/browser_features/state_restoration.yaml
@@ -53,7 +53,9 @@ tags:
     arguments:
         isRunningUITests: true
 
-- tapOn: "Tab Switcher"
+- tapOn:
+    text: "Tab Switcher"
+    retryTapIfNoChange: true
 - tapOn:
     point: 20%, 25%
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1213583252059659?focus=true
Tech Design URL:
CC:

### Description

Include a retry in case TabSwitcher tap is not effective after re-launching the app during state restoration tests.
Use [retryTapIfNoChange](https://docs.maestro.dev/reference/commands-available/tapon):

> retries the tap if the UI hierarchy does not change after the initial tap. This is useful for handling early taps before the UI is fully responsive.

### Testing Steps
Make sure [state_restoration test](https://github.com/duckduckgo/apple-browsers/actions/runs/23486497269/job/68343326057) pass.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
--

### Quality Considerations
--

### Notes to Reviewer
--

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adds a retry to reduce flakiness when tapping the Tab Switcher after app relaunch.
> 
> **Overview**
> Improves the `state_restoration.yaml` Maestro UI test by making the post-relaunch tap on `Tab Switcher` use `retryTapIfNoChange: true`, reducing flakiness when the first tap doesn’t register.
> 
> No app/runtime logic changes; this only adjusts test interaction behavior during state restoration verification.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a27d7c0da6ec42f6cc4d495ebb9a870fa03ce7b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->