### PR TITLE
[iOS] BrowserKit import summary screen

### DIFF
--- a/iOS/DuckDuckGo/DataImport/DataImportViewModel.swift
+++ b/iOS/DuckDuckGo/DataImport/DataImportViewModel.swift
@@ -41,11 +41,12 @@ final class DataImportViewModel: ObservableObject {
         case promo
         case inBrowserPromo = "in_browser_promo"
         case whatsNew
+        case browserExport = "browser_export"
 
         var documentTypes: [UTType] {
             switch self {
             case .passwords, .settings, .promo, .inBrowserPromo, .whatsNew: return [.zip, .commaSeparatedText]
-            case .bookmarks: return [.zip, .html]
+            case .bookmarks, .browserExport: return [.zip, .html]
             }
         }
     }

--- a/iOS/DuckDuckGo/MainViewController+Segues.swift
+++ b/iOS/DuckDuckGo/MainViewController+Segues.swift
@@ -412,9 +412,7 @@ extension MainViewController {
                                         importScreen: importScreen,
                                         syncService: syncService) { [weak self] source in
             guard let self else { return }
-            dismissPresentedDataImportSummaryIfNeeded {
-                self.segueToSettingsSync(with: source)
-            }
+            self.segueToSettingsSync(with: source)
         } onCompletion: { }
     }
 
@@ -566,24 +564,6 @@ extension MainViewController {
         }
     }
 
-    private func dismissPresentedDataImportSummaryIfNeeded(completion: @escaping () -> Void) {
-        let topMostViewController = topMostPresentedViewController(startingFrom: self)
-        guard topMostViewController is DataImportSummaryViewController else {
-            completion()
-            return
-        }
-
-        topMostViewController.dismiss(animated: true, completion: completion)
-    }
-
-    private func topMostPresentedViewController(startingFrom rootViewController: UIViewController) -> UIViewController {
-        var currentViewController = rootViewController
-        while let presentedViewController = currentViewController.presentedViewController {
-            currentViewController = presentedViewController
-        }
-        return currentViewController
-    }
-    
 }
 
 // Exists to fire a did disappear notification for settings when the controller did disappear

--- a/iOS/DuckDuckGo/MainViewController+Segues.swift
+++ b/iOS/DuckDuckGo/MainViewController+Segues.swift
@@ -396,6 +396,28 @@ extension MainViewController {
         }
     }
 
+    func presentDataImportSummary(_ summary: DataImportSummary,
+                                  importScreen: DataImportViewModel.ImportScreen = .bookmarks) {
+        clearNavigationStack { [weak self] in
+            guard let self else { return }
+
+            let summaryViewController = self.makeDataImportSummaryViewController(summary: summary, importScreen: importScreen)
+            self.present(summaryViewController, animated: true)
+        }
+    }
+
+    private func makeDataImportSummaryViewController(summary: DataImportSummary,
+                                                     importScreen: DataImportViewModel.ImportScreen) -> DataImportSummaryViewController {
+        DataImportSummaryViewController(summary: summary,
+                                        importScreen: importScreen,
+                                        syncService: syncService) { [weak self] source in
+            guard let self else { return }
+            dismissPresentedDataImportSummaryIfNeeded {
+                self.segueToSettingsSync(with: source)
+            }
+        } onCompletion: { }
+    }
+
     func segueToFeedback() {
         Logger.lifecycle.debug(#function)
         hideAllHighlightsIfNeeded()
@@ -542,6 +564,24 @@ extension MainViewController {
         if !daxDialogsManager.shouldShowFireButtonPulse {
             ViewHighlighter.hideAll()
         }
+    }
+
+    private func dismissPresentedDataImportSummaryIfNeeded(completion: @escaping () -> Void) {
+        let topMostViewController = topMostPresentedViewController(startingFrom: self)
+        guard topMostViewController is DataImportSummaryViewController else {
+            completion()
+            return
+        }
+
+        topMostViewController.dismiss(animated: true, completion: completion)
+    }
+
+    private func topMostPresentedViewController(startingFrom rootViewController: UIViewController) -> UIViewController {
+        var currentViewController = rootViewController
+        while let presentedViewController = currentViewController.presentedViewController {
+            currentViewController = presentedViewController
+        }
+        return currentViewController
     }
     
 }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4248,13 +4248,16 @@ extension MainViewController: GestureToolbarButtonDelegate {
 
 extension MainViewController {
 
-    func clearNavigationStack() {
+    func clearNavigationStack(completion: (() -> Void)? = nil) {
         dismissOmniBar()
 
-        if let presented = presentedViewController {
-            presented.dismiss(animated: false) { [weak self] in
-                self?.clearNavigationStack()
-            }
+        guard let presented = presentedViewController else {
+            completion?()
+            return
+        }
+
+        presented.dismiss(animated: false) { [weak self] in
+            self?.clearNavigationStack(completion: completion)
         }
     }
 

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -640,8 +640,8 @@ extension MainCoordinator: UserActivityHandling {
 
     private func handleDataImportResult(_ result: Result<DataImportSummary, Error>) {
         switch result {
-        case .success:
-            Logger.general.debug("Data import success - present summary screen")
+        case .success(let summary):
+            controller.presentDataImportSummary(summary, importScreen: .bookmarks)
         case .failure(let error):
             Logger.general.error("Data import failed: \(error.localizedDescription, privacy: .public)")
         }

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -641,7 +641,7 @@ extension MainCoordinator: UserActivityHandling {
     private func handleDataImportResult(_ result: Result<DataImportSummary, Error>) {
         switch result {
         case .success(let summary):
-            controller.presentDataImportSummary(summary, importScreen: .bookmarks)
+            controller.presentDataImportSummary(summary, importScreen: .browserExport)
         case .failure(let error):
             Logger.general.error("Data import failed: \(error.localizedDescription, privacy: .public)")
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213329852851324?focus=true
Tech Design URL:
CC:

### Description
Presents data import summary screen at end of BrowserKit data import flow

### Testing Steps
** Requires XCode 26.4 for testing. Also ensure you enrol the 26.4 simulator for Face ID first as otherwise the Safari export flow will just get stuck with no auth prompt
1. From Settings > Apps > Safari trigger the data export flow
2. Select DuckDuckGo as destination & complete the export
3. Confirm the success screen is presented when you are taken to DuckDuckGo

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

--
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/navigation change: adds a new data-import screen type and a post-import summary presentation; main behavior change is `clearNavigationStack` now supports an optional completion callback.
> 
> **Overview**
> Presents the data import summary screen at the end of the BrowserKit Safari export/import flow by handling the successful `DataImportUserActivityHandler` result and showing `DataImportSummaryViewController`.
> 
> Adds a new `ImportScreen.browserExport` type (treated like bookmarks for accepted document types) and updates `MainViewController.clearNavigationStack` to accept an optional completion so callers can reliably present UI after dismissing any currently presented controllers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7860302a572a732a8bd8cf085a5aec7fc3496c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->