### PR TITLE
[iOS][Onboarding Rebranding] Adjust dialog top padding for iPad linear flow

### DIFF
--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/RebrandedOnboardingView.swift
@@ -34,12 +34,6 @@ private enum BubbleBackedDialogMetrics {
     /// iPhone uses 0.0 (relies on padding), iPad uses percentage of screen height
     static let dialogVerticalOffsetPercentage = MetricBuilder<CGFloat>(default: 0.0)
         .iPad(portrait: 0.15, landscape: 0.05)
-
-    /// Whether to use padding-based positioning (iPhone) or offset-based positioning (iPad).
-    @MainActor
-    static let usePaddingBasedPositioning = MetricBuilder<Bool>(default: true)
-        .iPad(false)
-        .build()
 }
 
 /// Animation timing constants for the rebranded onboarding bubble dialogs.
@@ -245,6 +239,11 @@ extension OnboardingRebranding {
             let configuration = bubbleBackedDialogConfiguration(for: state.type)
 
             return GeometryReader { geometry in
+                let defaultTopPadding = onboardingTheme.linearOnboardingMetrics.minTopMargin + configuration.additionalTopMargin
+                // On iPad we reduce the gap between dialog and background illustration by adding extra padding to the dialog by a percentage of screen height based on orientation.
+                let platformSpecificTopPadding = geometry.size.height * BubbleBackedDialogMetrics.dialogVerticalOffsetPercentage.build(v: verticalSizeClass, h: horizontalSizeClass)
+                let topPadding = defaultTopPadding + platformSpecificTopPadding
+
                 ScrollView(.vertical, showsIndicators: false) {
                     VStack(alignment: .center) {
                         bubbleBackedDialogView(state: state, configuration: configuration)
@@ -252,10 +251,9 @@ extension OnboardingRebranding {
                             .frame(maxWidth: onboardingTheme.linearOnboardingMetrics.bubbleMaxWidth, alignment: .center)
                             .frame(maxWidth: .infinity, alignment: .center)
                             .frame(width: geometry.size.width, alignment: .center)
-                            .padding(.top, BubbleBackedDialogMetrics.usePaddingBasedPositioning ? onboardingTheme.linearOnboardingMetrics.minTopMargin + configuration.additionalTopMargin : nil) //iPhone does not use offset and relies on top padding.
+                            .padding(.top, topPadding)
                     }
                     .frame(minHeight: geometry.size.height, alignment: .top)
-                    .offset(y: geometry.size.height * BubbleBackedDialogMetrics.dialogVerticalOffsetPercentage.build(v: verticalSizeClass, h: horizontalSizeClass)) // On iPad we reduce the gap between dialog and background illustration by offsetting the dialog by a percentage of screen height based on orientation.
                     .background {
                         GeometryReader { proxy in
                             Color.clear.preference(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213806153713155
Tech Design URL:
CC:

### Description

Adds device-specific top padding for iPad onboarding dialogs to reduce the gap between the dialog and background illustration. Uses percentage-based padding that scales with screen height (15% in portrait, 5% in landscape), while iPhone behaviour remains unchanged.

**Changes:**
- Added  `dialogVerticalOffsetPercentage` metric
- iPad dialogs now get additional top padding based on screen height percentage
- iPhone continues using existing margin values

### Testing Steps
1. Launch the linear onboarding flow.
2. Verify dialog positioning is unchanged.
4. Repeat on iPad in portrait orientation.
5. Verify dialog has additional top spacing, for portrait/landscape

### Screenshots
https://app.asana.com/1/137249556945/task/1213684346924470/comment/1213806153713170?focus=true

### Impact and Risks
**Low** - Visual positioning enhancement for iPad only. No functional changes to onboarding flow.

#### What could go wrong?
Dialog could appear too high on iPad in certain scenarios. Mitigated by using percentage-based values that scale proportionally with screen size

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only layout adjustment limited to the rebranded linear onboarding dialog positioning on iPad; main risk is misaligned padding on unusual iPad sizes/orientations.
> 
> **Overview**
> Adjusts the rebranded linear onboarding dialog layout to add **iPad-only, orientation-aware** extra top padding, reducing the visual gap to the background illustration.
> 
> Introduces a `MetricBuilder`-driven `dialogVerticalOffsetPercentage` and uses `horizontalSizeClass`/`verticalSizeClass` with `GeometryReader` to compute additional padding (15% portrait, 5% landscape), while keeping iPhone behavior unchanged (0% default).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19b63cdede5d0417bf2b292a35b1fa29989c0bd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->