### PR TITLE
Lazy-load findInPageViewController in MainViewController

### DIFF
--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -40,7 +40,6 @@ final class MainViewController: NSViewController {
     let browserTabViewController: BrowserTabViewController
     let aiChatMenuConfig: AIChatMenuVisibilityConfigurable
     let aiChatCoordinator: AIChatCoordinating
-
     let aiChatSummarizer: AIChatSummarizer
     let aiChatTranslator: AIChatTranslator
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206580121312550/task/1213748955774064
Tech Design URL:
CC:

### Description

Defers creation of `findInPageViewController` in `MainViewController` by making it a `lazy` property. It is not needed during window creation — it is only accessed when the user triggers Find in Page (Cmd+F).

The lazy initializer creates the VC from its storyboard, sets its delegate, and adds it to the view hierarchy via `addAndLayoutChild`. This removes a storyboard deserialization + view setup from the `MainViewController` startup path.

Based on initial work by @ayoy in `dominik/mainvc-refactoring`.

### Testing Steps

1. Open the app — verify the window loads normally
2. Use Find in Page (Cmd+F) — verify it works correctly
3. Close the window — verify no crashes or leaks

### Impact and Risks

Low: Internal refactor of property initialization timing for a single view controller. No user-facing behavior change.

#### What could go wrong?

- Accessing the lazy var in `deinit` could force unnecessary initialization — **mitigated**: `isLazyVar` guard prevents this, consistent with the existing pattern used in other files.

### Notes to Reviewer

- The `isLazyVar` pattern is already established in this codebase (BrowserTabViewController, NavigationBarViewController, AddressBarTextField, AddressBarButtonsViewController, DBPHomeViewController).

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)