### PR TITLE
Tabs: Fixing x animation

### DIFF
--- a/macOS/DuckDuckGo/Common/View/AppKit/MouseOverButton.swift
+++ b/macOS/DuckDuckGo/Common/View/AppKit/MouseOverButton.swift
@@ -42,10 +42,6 @@ internal class MouseOverButton: NSButton, Hoverable {
     @IBInspectable dynamic var backgroundInset: NSPoint = .zero
     @IBInspectable dynamic var mustAnimateOnMouseOver: Bool = false
 
-    private enum Animations {
-        static let duration: TimeInterval = 0.15
-    }
-
     @IBInspectable var mouseOverTintColor: NSColor? {
         didSet {
             updateTintColor()

--- a/macOS/DuckDuckGo/Common/View/AppKit/MouseOverButton.swift
+++ b/macOS/DuckDuckGo/Common/View/AppKit/MouseOverButton.swift
@@ -183,16 +183,8 @@ internal class MouseOverButton: NSButton, Hoverable {
     }
 
     func updateTintColor() {
-        guard mustAnimateOnMouseOver && !isMouseDown else {
-            NSAppearance.withAppAppearance {
-                self.contentTintColor = currentTintColor()
-            }
-            return
-        }
-
-        NSAnimationContext.runAnimationGroup { context in
-            context.duration = Animations.duration
-            self.animator().contentTintColor = currentTintColor()
+        NSAppearance.withAppAppearance {
+            self.contentTintColor = currentTintColor()
         }
     }
 

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -575,6 +575,15 @@ final class TabBarItemCellView: NSView {
     func startSpinnerIfNeeded(isLoading: Bool, error: WKError?, url: URL?) {
         faviconView.startSpinnerIfNeeded(isLoading: isLoading, url: url, error: error)
     }
+
+    func refreshStateIfNeeded(isSelected: Bool, isDragged: Bool, isMouseOver: Bool) {
+        guard displaysTabsAnimations else {
+            return
+        }
+
+        backgroundView.refreshStateIfNeeded(isSelected: isSelected, isDragged: isDragged, isMouseOver: isMouseOver)
+        closeButton.animator().isHidden = isMouseOver && (widthStage.isCloseButtonHidden && NSApp.isCommandPressed)
+    }
 }
 
 extension TabBarItemCellView: ThemeUpdateListening {
@@ -1537,7 +1546,7 @@ extension TabBarViewItem: MouseClickViewDelegate {
         delegate?.tabBarViewItem(self, isMouseOver: isMouseOver)
         self.isMouseOver = isMouseOver
 
-        cell.backgroundView.refreshStateIfNeeded(isSelected: isSelected, isDragged: isDragged, isMouseOver: isMouseOver)
+        cell.refreshStateIfNeeded(isSelected: isSelected, isDragged: isDragged, isMouseOver: isMouseOver)
 
         view.needsLayout = true
         eventMonitor = isMouseOver ? NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -582,7 +582,21 @@ final class TabBarItemCellView: NSView {
         }
 
         backgroundView.refreshStateIfNeeded(isSelected: isSelected, isDragged: isDragged, isMouseOver: isMouseOver)
-        closeButton.animator().isHidden = isMouseOver && (widthStage.isCloseButtonHidden && NSApp.isCommandPressed)
+        refreshCloseButton(isSelected: isSelected, isMouseOver: isMouseOver, animated: true)
+    }
+
+    private func refreshCloseButton(isSelected: Bool, isMouseOver: Bool, animated: Bool) {
+        let isHidden = (!isMouseOver || (widthStage.isCloseButtonHidden && !NSApp.isCommandPressed)) && !isSelected
+        guard closeButton.isHidden != isHidden else {
+            return
+        }
+
+        guard animated else {
+            closeButton.isHidden = isHidden
+            return
+        }
+
+        closeButton.animator().isHidden = isHidden
     }
 }
 
@@ -854,7 +868,7 @@ final class TabBarViewItem: NSCollectionViewItem {
 
             updateSubviews()
 
-            cell.backgroundView.refreshStateIfNeeded(isSelected: isSelected, isDragged: isDragged, isMouseOver: isMouseOver)
+            cell.refreshStateIfNeeded(isSelected: isSelected, isDragged: isDragged, isMouseOver: isMouseOver)
             updateUsedPermissions()
         }
     }

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -576,17 +576,19 @@ final class TabBarItemCellView: NSView {
         faviconView.startSpinnerIfNeeded(isLoading: isLoading, url: url, error: error)
     }
 
-    func refreshStateIfNeeded(isSelected: Bool, isDragged: Bool, isMouseOver: Bool) {
+    func refreshStateIfNeeded(isSelected: Bool, isDragged: Bool, isMouseOver: Bool, isPinned: Bool) {
         guard displaysTabsAnimations else {
             return
         }
 
         backgroundView.refreshStateIfNeeded(isSelected: isSelected, isDragged: isDragged, isMouseOver: isMouseOver)
-        refreshCloseButton(isSelected: isSelected, isMouseOver: isMouseOver, animated: true)
+        refreshCloseButton(isSelected: isSelected, isMouseOver: isMouseOver, isPinned: isPinned, animated: true)
     }
 
-    private func refreshCloseButton(isSelected: Bool, isMouseOver: Bool, animated: Bool) {
-        let isHidden = (!isMouseOver || (widthStage.isCloseButtonHidden && !NSApp.isCommandPressed)) && !isSelected
+    private func refreshCloseButton(isSelected: Bool, isMouseOver: Bool, isPinned: Bool, animated: Bool) {
+        let mustDisplayCloseButton = (isMouseOver && (!widthStage.isCloseButtonHidden || NSApp.isCommandPressed)) || isSelected
+        let isHidden = !mustDisplayCloseButton || isPinned
+
         guard closeButton.isHidden != isHidden else {
             return
         }
@@ -868,7 +870,7 @@ final class TabBarViewItem: NSCollectionViewItem {
 
             updateSubviews()
 
-            cell.refreshStateIfNeeded(isSelected: isSelected, isDragged: isDragged, isMouseOver: isMouseOver)
+            cell.refreshStateIfNeeded(isSelected: isSelected, isDragged: isDragged, isMouseOver: isMouseOver, isPinned: isPinned)
             updateUsedPermissions()
         }
     }
@@ -1560,7 +1562,7 @@ extension TabBarViewItem: MouseClickViewDelegate {
         delegate?.tabBarViewItem(self, isMouseOver: isMouseOver)
         self.isMouseOver = isMouseOver
 
-        cell.refreshStateIfNeeded(isSelected: isSelected, isDragged: isDragged, isMouseOver: isMouseOver)
+        cell.refreshStateIfNeeded(isSelected: isSelected, isDragged: isDragged, isMouseOver: isMouseOver, isPinned: isPinned)
 
         view.needsLayout = true
         eventMonitor = isMouseOver ? NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1213814409705421?focus=true
Tech Design URL:
CC:

### Description
In this PR we're making sure that the Tab's `x` is faded in on mouse over.

### Testing Steps
1. Launch + enable `tabAnimations`
2. Relaunch if needed

- [ ] Verify that, on mouse over, the Tab's `X` is animated with a fade in

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The `x` button could end up in an invalid state

### Quality Considerations
None

### Notes to Reviewer
Thank you!

### Demo

https://github.com/user-attachments/assets/2228e4e3-6e86-4902-9f1a-9650bb88cb9f



---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change: adjusts tab close button show/hide behavior and removes tint-color animation in `MouseOverButton`, with minimal impact outside tab UI state updates.
> 
> **Overview**
> Fixes the tab close (`X`) hover/selection behavior when `tabAnimations` is enabled by centralizing state refresh in `TabBarItemCellView.refreshStateIfNeeded(...)` and animating `closeButton.isHidden` changes.
> 
> Removes the `MouseOverButton` tint-color animation path, making `contentTintColor` updates apply immediately (still within `NSAppearance.withAppAppearance`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 973cbb26cb2aeaefd4457f36cb34c6d19336aee0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->