### PR TITLE
[macOS] Preload MaliciousSiteProtection datasets on startup

### DIFF
--- a/macOS/DuckDuckGo/MaliciousSiteProtection/MaliciousSiteProtectionManager.swift
+++ b/macOS/DuckDuckGo/MaliciousSiteProtection/MaliciousSiteProtectionManager.swift
@@ -143,6 +143,10 @@ public class MaliciousSiteProtectionManager: MaliciousSiteDetecting {
             return MaliciousSiteProtection.DataManager(fileStore: fileStore, embeddedDataProvider: embeddedDataProvider, fileNameProvider: Self.fileName(for:))
         }()
 
+        Task.detached {
+            await dataManager.preloadData(for: ThreatKind.allCases)
+        }
+
         let supportedThreatsProvider = {
             let isScamProtectionEnabled = featureFlagger.isFeatureOn(.scamSiteProtection)
             return isScamProtectionEnabled ? ThreatKind.allCases : ThreatKind.allCases.filter { $0 != .scam }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206580121312550/task/1213809249616776
Tech Design URL:
CC:

### Description

Preloads MaliciousSiteProtection threat datasets into the in-memory cache during app startup, before any tab navigates. Previously, each tab's first navigation would independently trigger disk reads and JSON decoding for all threat types. Now this happens once, early, on a background thread.

### Testing Steps

1. Build and run the macOS app
2. Profile with Time Profiler — confirm dataset loading happens once during startup preload, not per-tab
3. Navigate to a known phishing test URL and confirm the warning page still appears

### Impact and Risks

**Low** — Uses an existing, tested method on a background thread. Does not block app launch.

#### What could go wrong?

If preload hasn't finished before the first tab evaluates a URL, the existing lazy-load path runs as before — no regression. Actor serialization ensures no data races.

### Quality Considerations

- No new disk I/O or network calls — moves existing work earlier
- Runs off main thread via Task.detached
- DataManager is an actor, so cache access is inherently thread-safe

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)