### PR TITLE
[macOS] Fix report broken site enabled for history view

### DIFF
--- a/macOS/DuckDuckGo/Menus/MainMenuActions.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenuActions.swift
@@ -279,8 +279,7 @@ extension AppDelegate {
     static func openReportABrowserProblem(_ sender: Any?, category: ProblemCategory? = nil, subcategory: SubCategory? = nil) {
         var window: NSWindow?
 
-        // Check if we can report broken site (same logic as openReportBrokenSite)
-        let canReportBrokenSite = Application.appDelegate.windowControllersManager.selectedTab?.canReload ?? false
+        let canReportBrokenSite = Application.appDelegate.windowControllersManager.selectedTab?.canReportBrokenSite ?? false
 
         let formView = ReportProblemFormFlowView(
             canReportBrokenSite: canReportBrokenSite,
@@ -1916,7 +1915,7 @@ extension AppDelegate: NSMenuItemValidation {
             return areTherePasswords
 
         case #selector(AppDelegate.openReportBrokenSite(_:)):
-            return Application.appDelegate.windowControllersManager.selectedTab?.canReload ?? false
+            return Application.appDelegate.windowControllersManager.selectedTab?.canReportBrokenSite ?? false
 
         default:
             return true

--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -785,6 +785,15 @@ protocol TabDelegate: ContentOverlayUserScriptDelegate {
     @Published private(set) var canGoBack: Bool = false
     @Published private(set) var canReload: Bool = false
 
+    /// Whether the current tab content is a real web page that can be reported as broken.
+    /// `.url` and `.aiChat` tabs are eligible — internal pages such as History and Settings are not.
+    var canReportBrokenSite: Bool {
+        switch content {
+        case .url, .aiChat: return true
+        default: return false
+        }
+    }
+
     @MainActor
     var backHistoryItems: [BackForwardListItem] {
         [BackForwardListItem](webView.backForwardList.backList)

--- a/macOS/UnitTests/Tab/Model/TabTests.swift
+++ b/macOS/UnitTests/Tab/Model/TabTests.swift
@@ -431,6 +431,43 @@ final class TabTests: XCTestCase {
         XCTAssertFalse(tab.webView.configuration.preferences[.mediaSessionEnabled])
     }
 
+    // MARK: - canReportBrokenSite
+
+    @MainActor func testCanReportBrokenSiteIsTrueForURLContent() {
+        tab = Tab(content: .url(.duckDuckGo, source: .ui))
+        XCTAssertTrue(tab.canReportBrokenSite)
+    }
+
+    @MainActor func testCanReportBrokenSiteIsFalseForHistoryContent() {
+        tab = Tab(content: .history(pane: nil))
+        XCTAssertFalse(tab.canReportBrokenSite)
+    }
+
+    @MainActor func testCanReportBrokenSiteIsFalseForSettingsContent() {
+        tab = Tab(content: .settings(pane: nil))
+        XCTAssertFalse(tab.canReportBrokenSite)
+    }
+
+    @MainActor func testCanReportBrokenSiteIsFalseForBookmarksContent() {
+        tab = Tab(content: .bookmarks)
+        XCTAssertFalse(tab.canReportBrokenSite)
+    }
+
+    @MainActor func testCanReportBrokenSiteIsFalseForNewtabContent() {
+        tab = Tab(content: .newtab)
+        XCTAssertFalse(tab.canReportBrokenSite)
+    }
+
+    @MainActor func testCanReportBrokenSiteIsFalseForReleaseNotesContent() {
+        tab = Tab(content: .releaseNotes)
+        XCTAssertFalse(tab.canReportBrokenSite)
+    }
+
+    @MainActor func testCanReportBrokenSiteIsTrueForAIChatContent() {
+        tab = Tab(content: .aiChat(.duckDuckGo))
+        XCTAssertTrue(tab.canReportBrokenSite)
+    }
+
 }
 
 private extension Tab {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1213689727062961?focus=true
Tech Design URL:
CC:

### Description
Disables ‘Report broken site’ for history view.

### Testing Steps
1. Open the History view (via menu or keyboard shortcut). Confirm that Help → Report Broken Site is greyed out in the menu bar and cannot be triggered.
2. Navigate to any regular website (e.g. duckduckgo.com). Confirm Help → Report Broken Site is enabled and opens the report flow normally.
3. Open the Report a Browser Problem dialog while on a real website — confirm the "Report Broken Site" option within the form is available.
4. Repeat step 3 while the History view is the active tab — confirm the "Report Broken Site" option within the form is correctly disabled.
5. Check that Duck.ai can be reported
6. Check that videos playing in Duck Player can be reported


### Impact and Risks
Risk level: Low — Small bug fix; no new behaviour is introduced for the common case (real web pages).

#### What could go wrong?
Nothing specific.

### Quality Considerations
- The fix consolidates the "can report" logic into a single computed property (canReportBrokenSite) on Tab, replacing two separate copies of canReload-based checks that were semantically wrong.
- canReload was a proxy for "is a web page" but it also returns true for internal pages after they finish loading — it was never the right signal here.
- Unit tests cover all key content types: .url, .aiChat (true), .history, .settings, .bookmarks, .newtab, .releaseNotes (false).

### Notes to Reviewer
The core issue was that both the menu item validation and the `canReportBrokenSite` parameter passed into the report form were using `canReload` instead of a content-type check. History tabs can reload, so canReload was true for them, making the report option available when it shouldn't be. The fix introduces a dedicated property that checks content type directly.


—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: swaps a UI enablement check from `canReload` to a dedicated content-type predicate and adds unit tests; behavior changes only for internal tabs like History/Settings.
> 
> **Overview**
> **Fixes incorrect ‘Report Broken Site’ availability on internal pages.** Menu validation and the “Report Broken Site” option inside the “Report a Browser Problem” flow now use a new `Tab.canReportBrokenSite` predicate instead of `canReload`, preventing reporting from tabs like History/Settings.
> 
> Adds unit tests covering eligible (`.url`, `.aiChat`) vs ineligible internal tab types (e.g. History, Settings, Bookmarks, New Tab, Release Notes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff9b73675361c595e81264335d72b8f5ef4049aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->