### PR TITLE
Ensure traffic light alpha KVO runs on main thread

### DIFF
--- a/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -236,6 +236,7 @@ final class MainWindowController: NSWindowController {
         for button in semaphoreButtons {
             button
                 .publisher(for: \.alphaValue)
+                .receive(on: DispatchQueue.main)
                 .sink { [weak button] alphaValue in
                     if let button, alphaValue != .activeViewAlpha {
                         button.alphaValue = .activeViewAlpha


### PR DESCRIPTION
## Summary
- Adds `.receive(on: DispatchQueue.main)` to the KVO publisher observing semaphore button `alphaValue` in `MainWindowController`
- KVO callbacks can fire on whatever thread mutates the observed property. AppKit may change button alpha during background window animations, violating the main-thread contract when the sink sets `alphaValue` back

## Test plan
- [ ] Enable `semaphoreAlwaysVisible` feature flag
- [ ] Verify traffic light buttons remain visible in fullscreen
- [ ] Minimize/close windows rapidly and confirm no crashes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a Combine scheduler hop to ensure AppKit UI updates for traffic light button `alphaValue` occur on the main thread, reducing the chance of threading-related crashes during window animations.
> 
> **Overview**
> Ensures the traffic light (window semaphore) `alphaValue` KVO/Combine pipeline delivers on the main thread before the sink reasserts `.activeViewAlpha`.
> 
> This prevents background-thread KVO callbacks from triggering AppKit UI mutations off the main queue when the `semaphoreAlwaysVisible` feature is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56b53e9b8ef3de51923f822219cd95cb6a4e16be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->