### PR TITLE
[macOS] Fix fireproofing for duckduckgo.com and duck.ai subdomains

### DIFF
--- a/macOS/DuckDuckGo/Fireproofing/Model/FireproofDomains.swift
+++ b/macOS/DuckDuckGo/Fireproofing/Model/FireproofDomains.swift
@@ -188,6 +188,14 @@ internal class FireproofDomains: DomainFireproofStatusProviding {
         store.clear()
     }
 
+    /// Returns true if the domain (or its eTLD+1) is duckduckgo.com or duck.ai.
+    /// Handles subdomains and dot-prefixed cookie domains.
+    func isDuckDuckGoDomain(_ domain: String) -> Bool {
+        let normalized = domain.dropping(prefix: ".")
+        let eTLDPlus1 = tld.eTLDplus1(normalized) ?? normalized
+        return eTLDPlus1 == URL.duckduckgoDomain || eTLDPlus1 == URL.duckAiDomain
+    }
+
     func isFireproof(cookieDomain: String) -> Bool {
         let domainWithoutDotPrefix = cookieDomain.dropping(prefix: ".")
         let eTLDPlus1Domain = tld.eTLDplus1(domainWithoutDotPrefix) ?? domainWithoutDotPrefix

--- a/macOS/DuckDuckGo/Tab/Services/WebsiteDataStore.swift
+++ b/macOS/DuckDuckGo/Tab/Services/WebsiteDataStore.swift
@@ -176,9 +176,7 @@ internal class WebCacheManager {
         let allRecords = await websiteDataStore.dataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes())
 
         let removableRecords = allRecords.filter { record in
-            // For Local Storage, only remove records that *exactly match* the display name.
-            // Subdomains or root domains should be excluded.
-            !URL.duckduckgoDomain.contains(record.displayName) && !URL.duckAiDomain.contains(record.displayName) && !fireproofDomains.fireproofDomains.contains(record.displayName)
+            !fireproofDomains.isDuckDuckGoDomain(record.displayName) && !fireproofDomains.isFireproof(fireproofDomain: record.displayName)
         }
         await websiteDataStore.removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypesExceptCookies, for: removableRecords)
         return .success(())
@@ -202,7 +200,7 @@ internal class WebCacheManager {
 
         // Don't clear fireproof domains
         let cookiesToRemove = cookies.filter { cookie in
-            !self.fireproofDomains.isFireproof(cookieDomain: cookie.domain) && ![URL.duckduckgoDomain, URL.duckAiDomain].contains(cookie.domain)
+            !self.fireproofDomains.isDuckDuckGoDomain(cookie.domain) && !self.fireproofDomains.isFireproof(cookieDomain: cookie.domain)
         }
 
         for cookie in cookiesToRemove {

--- a/macOS/UnitTests/Tab/Services/WebsiteDataStoreTests.swift
+++ b/macOS/UnitTests/Tab/Services/WebsiteDataStoreTests.swift
@@ -161,6 +161,49 @@ final class WebCacheManagerTests: XCTestCase {
         XCTAssertEqual(dataStore.records.first?.displayName, "duck.ai")
     }
 
+    @MainActor func testWhenClearedThenDDGSubdomainCookiesAndStorageAreRetained() async {
+        let logins = MockPreservedLogins(domains: [])
+
+        let cookieStore = MockHTTPCookieStore(cookies: [
+            .make(domain: "duckduckgo.com"),
+            .make(domain: ".duckduckgo.com"),
+            .make(domain: "www.duckduckgo.com"),
+            .make(domain: "duck.ai"),
+            .make(domain: ".duck.ai"),
+            .make(domain: "www.duck.ai"),
+            .make(domain: "facebook.com")
+        ])
+
+        let dataStore = MockDataStore()
+        dataStore.cookieStore = cookieStore
+        dataStore.records = [
+            MockDataRecord(recordName: "duckduckgo.com"),
+            MockDataRecord(recordName: "www.duckduckgo.com"),
+            MockDataRecord(recordName: "duck.ai"),
+            MockDataRecord(recordName: "www.duck.ai"),
+            MockDataRecord(recordName: "facebook.com")
+        ]
+
+        let webCacheManager = WebCacheManager(fireproofDomains: logins, websiteDataStore: dataStore)
+        await webCacheManager.clear()
+
+        // All DDG and duck.ai cookies (including subdomains and dot-prefixed) should be retained
+        XCTAssertEqual(cookieStore.cookies.count, 6)
+        XCTAssertTrue(cookieStore.cookies.contains(where: { $0.domain == "duckduckgo.com" }))
+        XCTAssertTrue(cookieStore.cookies.contains(where: { $0.domain == ".duckduckgo.com" }))
+        XCTAssertTrue(cookieStore.cookies.contains(where: { $0.domain == "www.duckduckgo.com" }))
+        XCTAssertTrue(cookieStore.cookies.contains(where: { $0.domain == "duck.ai" }))
+        XCTAssertTrue(cookieStore.cookies.contains(where: { $0.domain == ".duck.ai" }))
+        XCTAssertTrue(cookieStore.cookies.contains(where: { $0.domain == "www.duck.ai" }))
+
+        // All DDG and duck.ai records (including subdomains) should be retained
+        XCTAssertEqual(dataStore.records.count, 4)
+        XCTAssertTrue(dataStore.records.contains(where: { $0.displayName == "duckduckgo.com" }))
+        XCTAssertTrue(dataStore.records.contains(where: { $0.displayName == "www.duckduckgo.com" }))
+        XCTAssertTrue(dataStore.records.contains(where: { $0.displayName == "duck.ai" }))
+        XCTAssertTrue(dataStore.records.contains(where: { $0.displayName == "www.duck.ai" }))
+    }
+
     func testWhenClearedThenCookiesForLoginsAreRetained() {
         let logins = MockPreservedLogins(domains: [
             "example.com"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1213659555956031/task/1213897111409790?focus=true
Tech Design URL:
CC:

### Description

Fixed the Fire button incorrectly deleting local storage, IndexedDB, and cookies for subdomains of duckduckgo.com and duck.ai (e.g. `www.duckduckgo.com`, `.duckduckgo.com`, `www.duck.ai`).

**Local Storage/IndexedDB bug:** `removeLocalStorageAndIndexedDBForNonFireproofDomains()` used inverted `String.contains()` — `"duckduckgo.com".contains(record.displayName)` checks if the constant contains the record as a substring, which fails for subdomains. User-fireproofed domains also used exact array membership instead of eTLD+1 matching.

**Cookie bug:** `removeCookies()` used exact-match array check `[...].contains(cookie.domain)` which missed dot-prefixed domains (`.duckduckgo.com`) and subdomain cookies (`www.duck.ai`).

**Fix:** Added `isDuckDuckGoDomain()` helper on `FireproofDomains` that normalizes domains (strips dot prefix, resolves eTLD+1) before comparing. Used consistently in both clearing paths. Also switched local storage filtering to use `isFireproof(fireproofDomain:)` for proper eTLD+1 matching of user-fireproofed domains.

### Testing Steps

1. Visit duck.ai, start a chat conversation
2. Click the Fire button to clear All data (make sure Duck.ai isn't switched)
3. Visit duck.ai again — verify chat history is preserved
4. Visit duckduckgo.com, adjust settings
5. Fire again — verify duckduckgo.com settings/cookies are preserved

### Impact and Risks

**Medium** — Affects data preservation during Fire for DuckDuckGo domains. Previously subdomain data was incorrectly deleted.

#### What could go wrong?

The eTLD+1 normalization could theoretically over-match, but `isDuckDuckGoDomain()` only checks against two specific hardcoded domains (`duckduckgo.com`, `duck.ai`) so the blast radius is minimal.

### Quality Considerations

- Added `testWhenClearedThenDDGSubdomainCookiesAndStorageAreRetained` covering subdomains and dot-prefixed cookie domains for both duckduckgo.com and duck.ai
- Existing `WebCacheManagerTests` verify the original exact-match behavior still works

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes domain-matching logic in Fire data-clearing paths (cookies, local storage, IndexedDB), so mistakes could either retain unwanted site data or over-delete user data; scope is limited to DuckDuckGo/duck.ai and fireproof domain checks.
> 
> **Overview**
> Fixes Fire-button data clearing so `duckduckgo.com` and `duck.ai` *subdomains* and dot-prefixed cookie domains are preserved, not treated as removable.
> 
> Adds `FireproofDomains.isDuckDuckGoDomain()` (normalizes dot-prefix + eTLD+1) and uses it in `WebCacheManager` when filtering website records and cookies; also switches record filtering to use `isFireproof(fireproofDomain:)` for correct eTLD+1 matching of user-fireproofed domains. Updates unit tests with coverage ensuring DDG/duck.ai subdomain cookies and website data records are retained.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cd77ac55e3d182098e686cfe4abaee4ee50b96f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->