### PR TITLE
[htang][Claude]Add wideEvent-starter Claude skill

### DIFF
--- a/.claude/skills/wideEvent-starter/SKILL.md
+++ b/.claude/skills/wideEvent-starter/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: wideEvent-starter
+description: End-to-end wide event creation for apple-browsers — from wide event definition (JSON5 or JSON format) to Swift data class and tests. Use this skill whenever the user wants to define a new wide event, create a wide event definition, create a wide event data class, add a wide event to PixelDefinitions, or provides an Asana link to a wide event task. Also trigger when the user mentions "wide event", "wide event definition", "wide event data class", or wants to add a definition to pixels/definitions/ or wide_events/definitions/ for a wide event, even if they don't explicitly say "definition".
+---
+
+# Wide Event Starter Skill
+
+This skill is instructions and reference material — not an agent itself. Subagents don't have access to MCP servers (like Asana), so the main conversation must handle MCP calls first, then pass the results to a subagent.
+
+**When this skill triggers, follow this sequence:**
+
+1. **Main conversation: Gather context** — Do the MCP calls and user questions yourself (Steps 1–2 below). Subagents can't access MCP servers.
+2. **Spawn subagent: Do the work** — Once you have the wide event format and the user's preferences, spawn a subagent briefed with:
+   - The user's request (what wide event they need, platform, format preference)
+   - The wide event format (the full text fetched from Asana or pasted by the user)
+   - Any Asana task details (if the user provided a task link, fetch it and include the task description)
+   - The skill path: `~/.claude/skills/wideEvent-starter/`
+   - Instructions to read the relevant guide and follow Actions 1–2 below
+
+The subagent writes definitions, creates Swift classes, runs tests, and reports back. If it needs more user input, it returns to the main conversation.
+
+Wide event definitions (both JSON5 and JSON formats) are validated and used to generate a JSON Schema that the backend checks incoming events against. If the definition is wrong or incomplete, the backend will **drop the event** — so correctness matters.
+
+Two actions, usable in sequence or independently:
+
+| Action | What it does | Reference |
+|--------|-------------|-----------|
+| **Wide Event Definition** | Create the JSON5 or JSON definition file | `references/definition/` |
+| **Data Class & Tests** | Create the Swift WideEventData class + XCTestCase | `references/data-class/` |
+
+**Full flow:** Wide Event Definition → Data Class & Tests (+ SwiftLint) → Git Commit. At each transition, ask what the user wants next.
+
+**Partial flow:** Figure out what exists and what the user is asking for, then run the relevant action.
+
+---
+
+## Before Spawning the Subagent (main conversation)
+
+### Step 1 — Fetch the Wide Event Format
+
+Run once per session, before writing the first definition. If the format has already been resolved in this conversation, reuse what's in context.
+
+**Canonical format task ID:** `1211144309209145` ([Wide event format](https://app.asana.com/1/137249556945/project/1212203965891161/task/1211144309209145))
+
+1. **Fetch from Asana:**
+   - Use the Asana MCP `get_task` tool to fetch the canonical format task (ID above) with `opt_fields: "notes,name"`.
+   - The task description (`notes` field) contains the full format. Read it carefully and in full.
+   - Parse the field tables. For each field, extract: field name, data type, allowed values/enums, and description.
+   - **Important:** The Asana task covers all platforms. Exclude parameters that only exist on non-Apple platforms (e.g., `app.dev_mode` is Android-only, `feature.data.ext.error.inner_exceptions` is Windows-only). Only include fields relevant to Apple (iOS/macOS).
+
+2. **Use the format** as the working reference. Use **only** what it says — do not assume or invent fields, types, or values not in the format.
+
+**If Asana MCP is unavailable:** Inform the user and ask them to paste the current wide event format directly. Wait for their response before writing any definition.
+
+**If the format seems incomplete or ambiguous:** Ask the user rather than guessing.
+
+### Step 2 — Choose Definition Format
+
+Ask the user:
+
+> Which format would you like?
+> **(a)** JSON5 under `pixels/definitions/` (legacy flat-parameter format)
+> **(b)** JSON under `wide_events/definitions/` (new nested-object format)
+
+Skip if the user already indicated a preference (mentioned "wide_events" / "new format" / "JSON" → use JSON; mentioned "pixels" / provided existing JSON5 → use JSON5).
+
+### Step 3 — Spawn Subagent and Create the Definition
+
+Spawn a subagent with the wide event format text, user preferences, and any Asana task details. The subagent reads the corresponding guide:
+
+- **(a) JSON5** → `references/definition/json5-guide.md`
+- **(b) JSON** → `references/definition/json-guide.md`
+
+Each guide has the format-specific schema, output template, platform differences, dictionary cross-referencing, and validation commands.
+
+---
+
+## Action 2: Data Class & Tests
+
+See `references/data-class/guide.md` for the WideEventData protocol, class structure, and metadata setup. See `references/data-class/test-guide.md` for test class boilerplate, test categories, and how to run tests. See `examples/` for complete Swift files.
+
+Prompt the user before creating. After creation, spawn a **subagent** to run tests and iteratively fix failures.
+
+---
+
+## Git Commit
+
+1. Present summary of all created/modified files
+2. Ask: "Would you like me to `git add` and commit?" → wait for approval
+3. After commit, ask: "Ready to push?" → wait for approval
+
+Never push without explicit go-ahead.

--- a/.claude/skills/wideEvent-starter/SKILL.md
+++ b/.claude/skills/wideEvent-starter/SKILL.md
@@ -9,11 +9,10 @@ This skill is instructions and reference material — not an agent itself. Subag
 
 **When this skill triggers, follow this sequence:**
 
-1. **Main conversation: Gather context** — Do the MCP calls and user questions yourself (Steps 1–2 below). Subagents can't access MCP servers.
-2. **Spawn subagent: Do the work** — Once you have the wide event format and the user's preferences, spawn a subagent briefed with:
-   - The user's request (what wide event they need, platform, format preference)
-   - The wide event format (the full text fetched from Asana or pasted by the user)
-   - Any Asana task details (if the user provided a task link, fetch it and include the task description)
+1. **Main conversation: Gather context** — Do the MCP calls and user questions yourself (Steps 1–3 below). Subagents can't access MCP servers.
+2. **Spawn subagent: Do the work** — Once you have all the context, spawn a subagent briefed with:
+   - The Asana task details (the proposed wide event description, parameters, owners, etc.)
+   - The user's format preference (JSON5 or JSON)
    - The skill path: `~/.claude/skills/wideEvent-starter/`
    - Instructions to read the relevant guide and follow Actions 1–2 below
 
@@ -36,25 +35,25 @@ Two actions, usable in sequence or independently:
 
 ## Before Spawning the Subagent (main conversation)
 
-### Step 1 — Fetch the Wide Event Format
+### Step 1 — Get the Proposed Wide Event Task
 
-Run once per session, before writing the first definition. If the format has already been resolved in this conversation, reuse what's in context.
+Ask the user for the Asana task link for the proposed wide event, if they haven't already provided one:
 
-**Canonical format task ID:** `1211144309209145` ([Wide event format](https://app.asana.com/1/137249556945/project/1212203965891161/task/1211144309209145))
+> Could you share the Asana task link for this wide event?
 
-1. **Fetch from Asana:**
-   - Use the Asana MCP `get_task` tool to fetch the canonical format task (ID above) with `opt_fields: "notes,name"`.
-   - The task description (`notes` field) contains the full format. Read it carefully and in full.
-   - Parse the field tables. For each field, extract: field name, data type, allowed values/enums, and description.
-   - **Important:** The Asana task covers all platforms. Exclude parameters that only exist on non-Apple platforms (e.g., `app.dev_mode` is Android-only, `feature.data.ext.error.inner_exceptions` is Windows-only). Only include fields relevant to Apple (iOS/macOS).
+Skip if the user already provided a link (e.g., `https://app.asana.com/1/137249556945/task/1212683300907458`).
 
-2. **Use the format** as the working reference. Use **only** what it says — do not assume or invent fields, types, or values not in the format.
+### Step 2 — Fetch the Task from Asana
 
-**If Asana MCP is unavailable:** Inform the user and ask them to paste the current wide event format directly. Wait for their response before writing any definition.
+1. **Extract the task ID** from the URL (the numeric ID after `/task/`, stripping any query params like `?focus=true`).
+2. **Fetch from Asana:** Use the Asana MCP `get_task` tool with `opt_fields: "notes"`.
+3. **Read the task description** (`notes` field) carefully and in full. It contains the proposed wide event details: description, parameters, owners, expected statuses, etc.
 
-**If the format seems incomplete or ambiguous:** Ask the user rather than guessing.
+**If Asana MCP is unavailable:** Ask the user to paste the task description directly.
 
-### Step 2 — Choose Definition Format
+**If the task description seems incomplete or ambiguous:** Ask the user for clarification rather than guessing.
+
+### Step 3 — Choose Definition Format
 
 Ask the user:
 
@@ -64,9 +63,9 @@ Ask the user:
 
 Skip if the user already indicated a preference (mentioned "wide_events" / "new format" / "JSON" → use JSON; mentioned "pixels" / provided existing JSON5 → use JSON5).
 
-### Step 3 — Spawn Subagent and Create the Definition
+### Step 4 — Spawn Subagent and Create the Definition
 
-Spawn a subagent with the wide event format text, user preferences, and any Asana task details. The subagent reads the corresponding guide:
+Spawn a subagent with the Asana task details, user's format preference, and platform choice. The subagent reads the corresponding guide:
 
 - **(a) JSON5** → `references/definition/json5-guide.md`
 - **(b) JSON** → `references/definition/json-guide.md`

--- a/.claude/skills/wideEvent-starter/SKILL.md
+++ b/.claude/skills/wideEvent-starter/SKILL.md
@@ -13,7 +13,7 @@ This skill is instructions and reference material — not an agent itself. Subag
 2. **Spawn subagent: Do the work** — Once you have all the context, spawn a subagent briefed with:
    - The Asana task details (the proposed wide event description, parameters, owners, etc.)
    - The user's format preference (JSON5 or JSON)
-   - The skill path: `~/.claude/skills/wideEvent-starter/`
+   - The skill path: `.claude/skills/wideEvent-starter/` (relative to repo root)
    - Instructions to read the relevant guide and follow Actions 1–2 below
 
 The subagent writes definitions, creates Swift classes, runs tests, and reports back. If it needs more user input, it returns to the main conversation.

--- a/.claude/skills/wideEvent-starter/references/data-class/examples/AuthV2TokenRefreshWideEventData.swift
+++ b/.claude/skills/wideEvent-starter/references/data-class/examples/AuthV2TokenRefreshWideEventData.swift
@@ -1,0 +1,168 @@
+//
+//  AuthV2TokenRefreshWideEventData.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Common
+import Networking
+import PixelKit
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+public class AuthV2TokenRefreshWideEventData: WideEventData {
+    public static let metadata = WideEventMetadata(
+        pixelName: "auth_v2_token_refresh",
+        featureName: "authv2-token-refresh",
+        mobileMetaType: "ios-authv2-token-refresh",
+        desktopMetaType: "macos-authv2-token-refresh",
+        version: "1.0.1"
+    )
+
+    public var globalData: WideEventGlobalData
+    public var contextData: WideEventContextData
+    public var appData: WideEventAppData
+
+    public var refreshTokenDuration: WideEvent.MeasuredInterval?
+    public var fetchJWKSDuration: WideEvent.MeasuredInterval?
+
+    public var failingStep: FailingStep?
+    public var errorData: WideEventErrorData?
+
+    public init(failingStep: FailingStep? = nil,
+                errorData: WideEventErrorData? = nil,
+                contextData: WideEventContextData = WideEventContextData(),
+                appData: WideEventAppData = WideEventAppData(),
+                globalData: WideEventGlobalData = WideEventGlobalData()) {
+        self.failingStep = failingStep
+        self.errorData = errorData
+        self.contextData = contextData
+        self.appData = appData
+        self.globalData = globalData
+    }
+}
+
+extension AuthV2TokenRefreshWideEventData {
+
+    public enum FailingStep: String, Codable, CaseIterable {
+        case tokenRead = "token_read"
+        case refreshAccessToken = "refresh_access_token"
+        case fetchingJWKS = "fetch_jwks"
+        case verifyingAccessToken = "verify_access_token"
+        case verifyingRefreshToken = "verify_refresh_token"
+        case tokenWrite = "token_write"
+    }
+
+    public enum StatusReason: String {
+        case partialData = "partial_data"
+    }
+
+    public func jsonParameters() -> [String: Encodable] {
+        let bucket: DurationBucket = .bucketed(Self.bucket)
+
+        return Dictionary(compacting: [
+            (WideEventParameter.AuthV2RefreshFeature.failingStep, failingStep?.rawValue),
+            (WideEventParameter.AuthV2RefreshFeature.refreshTokenLatency, refreshTokenDuration?.intValue(bucket)),
+            (WideEventParameter.AuthV2RefreshFeature.fetchJWKSLatency, fetchJWKSDuration?.intValue(bucket)),
+        ])
+    }
+
+    private static func bucket(_ ms: Int) -> Int {
+        switch ms {
+        case 0..<1000: return 1000
+        case 1000..<5000: return 5000
+        case 5000..<10000: return 10000
+        case 10000..<30000: return 30000
+        case 30000..<60000: return 60000
+        case 60000..<300000: return 300000
+        default: return 600000
+        }
+    }
+
+}
+
+extension AuthV2TokenRefreshWideEventData {
+
+    public static func authV2RefreshEventMapping(wideEvent: WideEventManaging, isFeatureEnabled: @escaping () -> Bool) -> EventMapping<OAuthClientRefreshEvent> {
+        return .init { event, _, _, _ in
+            guard isFeatureEnabled() else {
+                return
+            }
+
+            switch event {
+            case .tokenRefreshStarted(let refreshID):
+                let globalData = WideEventGlobalData(id: refreshID)
+                let data = AuthV2TokenRefreshWideEventData(globalData: globalData)
+                data.failingStep = .tokenRead
+                wideEvent.startFlow(data)
+            case .tokenRefreshRefreshingAccessToken(refreshID: let refreshID):
+                wideEvent.updateFlow(globalID: refreshID) { (event: inout AuthV2TokenRefreshWideEventData) in
+                    event.refreshTokenDuration = .startingNow()
+                    event.failingStep = .refreshAccessToken
+                }
+            case .tokenRefreshRefreshedAccessToken(refreshID: let refreshID):
+                wideEvent.updateFlow(globalID: refreshID) { (event: inout AuthV2TokenRefreshWideEventData) in
+                    event.refreshTokenDuration?.complete()
+                }
+            case .tokenRefreshFetchingJWKS(refreshID: let refreshID):
+                wideEvent.updateFlow(globalID: refreshID) { (event: inout AuthV2TokenRefreshWideEventData) in
+                    event.fetchJWKSDuration = .startingNow()
+                    event.failingStep = .fetchingJWKS
+                }
+            case .tokenRefreshFetchedJWKS(refreshID: let refreshID):
+                wideEvent.updateFlow(globalID: refreshID) { (event: inout AuthV2TokenRefreshWideEventData) in
+                    event.fetchJWKSDuration?.complete()
+                }
+            case .tokenRefreshVerifyingAccessToken(refreshID: let refreshID):
+                wideEvent.updateFlow(globalID: refreshID) { (event: inout AuthV2TokenRefreshWideEventData) in
+                    event.failingStep = .verifyingAccessToken
+                }
+            case .tokenRefreshVerifyingRefreshToken(refreshID: let refreshID):
+                wideEvent.updateFlow(globalID: refreshID) { (event: inout AuthV2TokenRefreshWideEventData) in
+                    event.failingStep = .verifyingRefreshToken
+                }
+            case .tokenRefreshSavingTokens(refreshID: let refreshID):
+                wideEvent.updateFlow(globalID: refreshID) { (event: inout AuthV2TokenRefreshWideEventData) in
+                    event.failingStep = .tokenWrite
+                }
+            case .tokenRefreshSucceeded(let refreshID):
+                if let data = wideEvent.getFlowData(AuthV2TokenRefreshWideEventData.self, globalID: refreshID) {
+                    data.failingStep = nil
+                    wideEvent.completeFlow(data, status: .success(reason: nil), onComplete: { _, _ in })
+                }
+            case .tokenRefreshFailed(let refreshID, let error):
+                if let data = wideEvent.getFlowData(AuthV2TokenRefreshWideEventData.self, globalID: refreshID) {
+                    data.errorData = WideEventErrorData(error: error)
+                    wideEvent.updateFlow(data)
+                    wideEvent.completeFlow(data, status: .failure, onComplete: { _, _ in })
+                }
+            }
+        }
+    }
+
+}
+
+extension WideEventParameter {
+
+    public enum AuthV2RefreshFeature {
+        static let failingStep = "feature.data.ext.failing_step"
+        static let refreshTokenLatency = "feature.data.ext.refresh_token_latency_ms_bucketed"
+        static let fetchJWKSLatency = "feature.data.ext.fetch_jwks_latency_ms_bucketed"
+    }
+
+}

--- a/.claude/skills/wideEvent-starter/references/data-class/examples/AuthV2WideEventTests.swift
+++ b/.claude/skills/wideEvent-starter/references/data-class/examples/AuthV2WideEventTests.swift
@@ -1,0 +1,211 @@
+//
+//  AuthV2WideEventTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import PixelKit
+@testable import Subscription
+
+final class AuthV2WideEventTests: XCTestCase {
+
+    // MARK: - AuthV2TokenRefreshWideEventData Tests
+
+    func testPixelParameters_withMinimalData() {
+        // Given
+        let contextData = WideEventContextData(name: "test-context")
+        let eventData = AuthV2TokenRefreshWideEventData(
+            contextData: contextData
+        )
+
+        // When
+        let parameters = eventData.pixelParameters()
+
+        // Then
+        XCTAssertNil(parameters["feature.data.ext.failing_step"])
+        XCTAssertNil(parameters["feature.data.ext.application_state"])
+        XCTAssertNil(parameters["feature.data.ext.refresh_token_latency_ms_bucketed"])
+        XCTAssertNil(parameters["feature.data.ext.fetch_jwks_latency_ms_bucketed"])
+    }
+
+    func testPixelParameters_withFailingStep() {
+        // Given
+        let contextData = WideEventContextData(name: "test-context")
+        let eventData = AuthV2TokenRefreshWideEventData(
+            failingStep: .refreshAccessToken,
+            contextData: contextData
+        )
+
+        // When
+        let parameters = eventData.pixelParameters()
+
+        // Then
+        XCTAssertEqual(parameters["feature.data.ext.failing_step"], "refresh_access_token")
+    }
+
+    func testPixelParameters_withAllFailingSteps() {
+        let contextData = WideEventContextData(name: "test-context")
+
+        for failingStep in AuthV2TokenRefreshWideEventData.FailingStep.allCases {
+            // Given
+            let eventData = AuthV2TokenRefreshWideEventData(
+                failingStep: failingStep,
+                contextData: contextData
+            )
+
+            // When
+            let parameters = eventData.pixelParameters()
+
+            // Then
+            XCTAssertEqual(parameters["feature.data.ext.failing_step"], failingStep.rawValue)
+        }
+    }
+
+    func testPixelParameters_withRefreshTokenDuration_bucketing() {
+        let contextData = WideEventContextData(name: "test-context")
+        let baseDate = Date()
+
+        // Test each bucket threshold
+        let testCases: [(milliseconds: Int, expectedBucket: String)] = [
+            (500, "1000"),          // 0-1000ms → 1000
+            (999, "1000"),          // 0-1000ms → 1000
+            (1000, "5000"),         // 1000-5000ms → 5000
+            (3000, "5000"),         // 1000-5000ms → 5000
+            (5000, "10000"),        // 5000-10000ms → 10000
+            (7500, "10000"),        // 5000-10000ms → 10000
+            (10000, "30000"),       // 10000-30000ms → 30000
+            (20000, "30000"),       // 10000-30000ms → 30000
+            (30000, "60000"),       // 30000-60000ms → 60000
+            (45000, "60000"),       // 30000-60000ms → 60000
+            (60000, "300000"),      // 60000-300000ms → 300000
+            (150000, "300000"),     // 60000-300000ms → 300000
+            (300000, "600000"),     // 300000+ms → 600000
+            (500000, "600000")      // 300000+ms → 600000
+        ]
+
+        for (milliseconds, expectedBucket) in testCases {
+            // Given
+            let eventData = AuthV2TokenRefreshWideEventData(contextData: contextData)
+            let endDate = baseDate.addingTimeInterval(TimeInterval(milliseconds) / 1000.0)
+            eventData.refreshTokenDuration = WideEvent.MeasuredInterval(start: baseDate, end: endDate)
+
+            // When
+            let parameters = eventData.pixelParameters()
+
+            // Then
+            XCTAssertEqual(
+                parameters["feature.data.ext.refresh_token_latency_ms_bucketed"],
+                expectedBucket,
+                "Expected bucket \(expectedBucket) for \(milliseconds)ms"
+            )
+        }
+    }
+
+    func testPixelParameters_withFetchJWKSDuration_bucketing() {
+        let contextData = WideEventContextData(name: "test-context")
+        let baseDate = Date()
+
+        // Test a few key buckets for fetchJWKSDuration
+        let testCases: [(milliseconds: Int, expectedBucket: String)] = [
+            (100, "1000"),          // 0-1000ms → 1000
+            (2000, "5000"),         // 1000-5000ms → 5000
+            (8000, "10000"),        // 5000-10000ms → 10000
+            (25000, "30000")        // 10000-30000ms → 30000
+        ]
+
+        for (milliseconds, expectedBucket) in testCases {
+            // Given
+            let eventData = AuthV2TokenRefreshWideEventData(contextData: contextData)
+            let endDate = baseDate.addingTimeInterval(TimeInterval(milliseconds) / 1000.0)
+            eventData.fetchJWKSDuration = WideEvent.MeasuredInterval(start: baseDate, end: endDate)
+
+            // When
+            let parameters = eventData.pixelParameters()
+
+            // Then
+            XCTAssertEqual(
+                parameters["feature.data.ext.fetch_jwks_latency_ms_bucketed"],
+                expectedBucket,
+                "Expected bucket \(expectedBucket) for \(milliseconds)ms"
+            )
+        }
+    }
+
+    func testPixelParameters_withIncompleteInterval() {
+        let contextData = WideEventContextData(name: "test-context")
+        let baseDate = Date()
+
+        let eventData = AuthV2TokenRefreshWideEventData(contextData: contextData)
+        eventData.refreshTokenDuration = WideEvent.MeasuredInterval(start: baseDate, end: nil)
+        var parameters = eventData.pixelParameters()
+        XCTAssertNil(parameters["feature.data.ext.refresh_token_latency_ms_bucketed"])
+
+        // Test with only end date
+        eventData.refreshTokenDuration = WideEvent.MeasuredInterval(start: nil, end: baseDate)
+        parameters = eventData.pixelParameters()
+        XCTAssertNil(parameters["feature.data.ext.refresh_token_latency_ms_bucketed"])
+
+        // Test with no dates
+        eventData.refreshTokenDuration = WideEvent.MeasuredInterval(start: nil, end: nil)
+        parameters = eventData.pixelParameters()
+        XCTAssertNil(parameters["feature.data.ext.refresh_token_latency_ms_bucketed"])
+    }
+
+    func testPixelParameters_withAllParametersSet() {
+        // Given
+        let contextData = WideEventContextData(name: "test-context")
+        let baseDate = Date()
+        let eventData = AuthV2TokenRefreshWideEventData(
+            failingStep: .verifyingAccessToken,
+            contextData: contextData
+        )
+
+        eventData.refreshTokenDuration = WideEvent.MeasuredInterval(
+            start: baseDate,
+            end: baseDate.addingTimeInterval(2.5) // 2500ms → bucket 5000
+        )
+
+        eventData.fetchJWKSDuration = WideEvent.MeasuredInterval(
+            start: baseDate,
+            end: baseDate.addingTimeInterval(0.5) // 500ms → bucket 1000
+        )
+
+        // When
+        let parameters = eventData.pixelParameters()
+
+        // Then
+        XCTAssertEqual(parameters["feature.data.ext.failing_step"], "verify_access_token")
+        XCTAssertEqual(parameters["feature.data.ext.refresh_token_latency_ms_bucketed"], "5000")
+        XCTAssertEqual(parameters["feature.data.ext.fetch_jwks_latency_ms_bucketed"], "1000")
+    }
+
+    func testPixelParameters_withNegativeInterval() {
+        // Given - end date before start date
+        let contextData = WideEventContextData(name: "test-context")
+        let baseDate = Date()
+        let eventData = AuthV2TokenRefreshWideEventData(contextData: contextData)
+        eventData.refreshTokenDuration = WideEvent.MeasuredInterval(
+            start: baseDate,
+            end: baseDate.addingTimeInterval(-5.0) // Negative interval
+        )
+
+        // When
+        let parameters = eventData.pixelParameters()
+
+        // Then - should be bucketed to 1000 (max(0, negative) = 0, which falls in 0-1000 range)
+        XCTAssertEqual(parameters["feature.data.ext.refresh_token_latency_ms_bucketed"], "1000")
+    }
+}

--- a/.claude/skills/wideEvent-starter/references/data-class/guide.md
+++ b/.claude/skills/wideEvent-starter/references/data-class/guide.md
@@ -1,0 +1,122 @@
+# Data Class Guide
+
+For a complete example, see `examples/` in this directory.
+
+## Protocol Requirements
+
+The data class conforms to `WideEventData` (from `SharedPackages/BrowserServicesKit/Sources/PixelKit/WideEvent/WideEventData.swift`).
+
+```swift
+public protocol WideEventData: Codable, WideEventParameterProviding {
+    static var metadata: WideEventMetadata { get }
+    var contextData: WideEventContextData { get set }
+    var globalData: WideEventGlobalData { get set }
+    var appData: WideEventAppData { get set }
+    var errorData: WideEventErrorData? { get set }
+    func completionDecision(for trigger: WideEventCompletionTrigger) async -> WideEventCompletionDecision
+}
+
+// From WideEventParameterProviding:
+func jsonParameters() -> [String: Encodable]
+```
+
+## File Location
+
+Ask the user if unclear. Common locations:
+- `SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/<Feature>/`
+- `SharedPackages/BrowserServicesKit/Sources/Subscription/WideEvents/`
+- `SharedPackages/<FeaturePackage>/Sources/<Module>/`
+
+## Class Structure
+
+The class has four distinct sections:
+
+### 1. Main Class Body
+
+```swift
+import Foundation
+import PixelKit
+
+public class <Feature>WideEventData: WideEventData {
+    public static let metadata = WideEventMetadata(
+        pixelName: "<pixel_suffix>",            // suffix only — "subscription_purchase" not "m_ios_wide_subscription_purchase"
+        featureName: "<feature-name>",           // hyphens, e.g., "subscription-purchase"
+        mobileMetaType: "ios-<feature-name>",    // meta.type enum for iOS
+        desktopMetaType: "macos-<feature-name>", // meta.type enum for macOS
+        version: "1.0.0"
+    )
+
+    // Required protocol properties
+    public var globalData: WideEventGlobalData
+    public var contextData: WideEventContextData
+    public var appData: WideEventAppData
+    public var errorData: WideEventErrorData?
+
+    // Feature-specific properties
+    // ...
+
+    // CodingKeys (if non-Codable properties like closures exist)
+    // init(...)
+    // completionDecision(for:)
+}
+```
+
+### 2. Enums Extension
+
+```swift
+extension <Feature>WideEventData {
+    public enum SomeEnum: String, Codable, CaseIterable {
+        case optionA = "option_a"  // rawValue MUST match JSON5 enum value
+    }
+}
+```
+
+### 3. jsonParameters + Helpers Extension
+
+```swift
+extension <Feature>WideEventData {
+    public func jsonParameters() -> [String: Encodable] {
+        Dictionary(compacting: [
+            (WideEventParameter.<Feature>Feature.someKey, someProperty.rawValue),
+            (WideEventParameter.<Feature>Feature.latency, someDuration?.intValue(bucket)),
+        ])
+    }
+}
+```
+
+### 4. WideEventParameter Extension
+
+```swift
+extension WideEventParameter {
+    public enum <Feature>Feature {
+        static let someKey = "feature.data.ext.some_key"
+    }
+}
+```
+
+## Key Patterns
+
+| Pattern | What | When |
+|---------|------|------|
+| `WideEvent.MeasuredInterval` | Timing/latency properties | Any duration field |
+| `DurationBucket.bucketed()` | Bucket latency values | Latency params with bucketed enums |
+| `Dictionary(compacting:)` | Exclude nil from params | Always in `jsonParameters()` |
+| `WideEventErrorData(error:)` | Wrap NSError for reporting | Error handling |
+| `markAsFailed(at:error:)` | Convenience for fail + error | Features with failing steps |
+| `CodingKeys` enum | Exclude non-Codable props | Closures or non-Codable properties |
+
+## Metadata pixelName
+
+The `pixelName` is the suffix only. The framework prepends `m_ios_wide_` or `m_mac_wide_` automatically.
+- Pixel `m_ios_wide_subscription_purchase` → `pixelName: "subscription_purchase"`
+
+## SwiftLint
+
+After creating the data class and test files, run SwiftLint to fix formatting:
+
+```bash
+swiftlint --fix <data_class_path>
+swiftlint --fix <test_class_path>
+```
+
+Skip if swiftlint is not installed.

--- a/.claude/skills/wideEvent-starter/references/data-class/test-guide.md
+++ b/.claude/skills/wideEvent-starter/references/data-class/test-guide.md
@@ -1,0 +1,177 @@
+# Test Class & Runner Guide
+
+For a complete example, see `examples/` in this directory.
+
+---
+
+## File Location
+
+Mirror the source file location under `Tests/`:
+- `SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/<Feature>/`
+- `SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/`
+- `SharedPackages/<Package>/Tests/<PackageTests>/`
+
+## Setup Boilerplate
+
+Every wide event test class uses the same setup:
+
+```swift
+import XCTest
+import PixelKit
+@testable import <Module>
+
+final class <Feature>WideEventTests: XCTestCase {
+
+    private var wideEvent: WideEvent!
+    private var firedPixels: [(name: String, parameters: [String: String])] = []
+    private var testDefaults: UserDefaults!
+    private var testSuiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        testSuiteName = "\(type(of: self))-\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: testSuiteName) ?? .standard
+        setupMockPixelKit()
+        wideEvent = WideEvent(
+            useMockRequests: true,
+            storage: WideEventUserDefaultsStorage(userDefaults: testDefaults),
+            featureFlagProvider: MockWideEventFeatureFlagProvider(isPostEndpointEnabled: true)
+        )
+        firedPixels.removeAll()
+    }
+
+    override func tearDown() {
+        testDefaults?.removePersistentDomain(forName: testSuiteName)
+        PixelKit.tearDown()
+        super.tearDown()
+    }
+
+    private func setupMockPixelKit() {
+        let mockFireRequest: PixelKit.FireRequest = { pixelName, headers, parameters, allowedQueryReservedCharacters, callBackOnMainThread, onComplete in
+            self.firedPixels.append((name: pixelName, parameters: parameters))
+            DispatchQueue.main.async {
+                onComplete(true, nil)
+            }
+        }
+
+        PixelKit.setUp(
+            dryRun: false,
+            appVersion: "1.0.0",
+            source: "test",
+            defaultHeaders: [:],
+            dateGenerator: Date.init,
+            defaults: testDefaults,
+            fireRequest: mockFireRequest
+        )
+    }
+}
+```
+
+Include `MockWideEventFeatureFlagProvider` at bottom of file (or reuse if it exists):
+```swift
+struct MockWideEventFeatureFlagProvider: WideEventFeatureFlagProviding {
+    let isPostEndpointEnabled: Bool
+    func isEnabled(_ flag: WideEventFeatureFlag) -> Bool {
+        switch flag {
+        case .postEndpoint: return isPostEndpointEnabled
+        }
+    }
+}
+```
+
+## Test Categories
+
+### Happy Path (Successful Flow)
+- Start flow → set durations → complete with `.success`
+- Verify `feature.status == "SUCCESS"`
+- Verify all custom `feature.data.ext.*` keys
+- Verify standard params present: `app.name`, `app.version`, `global.platform`, `global.type`, `global.sample_rate`
+
+### Failure / Error Flow
+- Start flow → trigger error → `markAsFailed()` → complete with `.failure`
+- Verify error domain, code, underlying domain/code
+- Verify `feature.data.ext.failing_step` if applicable
+
+### Cancelled Flow
+- Complete with `.cancelled`
+- Verify no error data, optional fields excluded when nil
+
+### Edge Cases
+- **Duration bucketing**: verify bucketed values (e.g., 2.5s → 5000 bucket)
+- **Optional fields excluded**: nil properties don't appear as keys
+- **Enum variants**: test each case produces correct rawValue
+- **Flow cleanup**: `getAllFlowData().count == 0` after completion
+
+### Completion Decision Tests (if custom logic)
+- Test each branch of `completionDecision(for:)`
+- Use `async` test methods
+
+## Key Assertions
+
+```swift
+// Pixel was fired
+XCTAssert(firedPixels.count >= 1 && firedPixels.count <= 2)
+
+// Custom parameters
+let params = firedPixels[0].parameters
+XCTAssertEqual(params["feature.data.ext.some_key"], "expected_value")
+
+// Standard parameters present
+XCTAssertNotNil(params["app.name"])
+XCTAssertEqual(params["global.type"], "app")
+
+// Optional excluded when nil
+XCTAssertNil(params["feature.data.ext.optional_field"])
+```
+
+---
+
+## Running Tests
+
+### BrowserServicesKit tests
+```bash
+cd <repo_root>/SharedPackages/BrowserServicesKit
+swift test --filter <TestClassName>
+```
+
+### Other packages
+```bash
+cd <repo_root>/SharedPackages/<PackageName>
+swift test --filter <TestClassName>
+```
+
+### App-level tests (if needed)
+```bash
+xcodebuild test \
+  -project <project_path> \
+  -scheme <scheme_name> \
+  -only-testing:<TestTarget>/<TestClassName> \
+  -destination 'platform=iOS Simulator,name=iPhone 16'
+```
+
+## Iterative Fix Loop
+
+1. Run the tests
+2. If pass → done
+3. If fail:
+   - Read the failure output
+   - Identify root cause
+   - Fix the data class or test class
+   - Re-run
+4. Repeat until all pass
+
+## Common Failures
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| Wrong bucketed value | Bucket function range mismatch | Check `bucket()` switch cases |
+| Parameter key not found | Typo in `WideEventParameter` key | Compare with JSON5 definition |
+| Module not found | Wrong `@testable import` | Check package/module name |
+| Unexpected duration | Date arithmetic off | Check `MeasuredInterval` start/end |
+| Pixel not captured | Mock PixelKit not set up | Verify `setupMockPixelKit()` |
+
+## What NOT to Fix
+
+- Don't change assertions to make them pass — fix the data class instead
+- Don't remove failing tests — fix the underlying issue
+- If a test reveals a real data class bug, fix the data class

--- a/.claude/skills/wideEvent-starter/references/definition/examples/json-auth-v2-token-refresh.json
+++ b/.claude/skills/wideEvent-starter/references/definition/examples/json-auth-v2-token-refresh.json
@@ -1,0 +1,69 @@
+{
+    "ios-authv2-token-refresh": {
+        "description": "Sent when AuthV2 has completed a token refresh",
+        "owners": ["samsymons"],
+        "meta": {
+            "type": "ios-authv2-token-refresh",
+            "version": "0.1"
+        },
+        "feature": {
+            "name": "authv2-token-refresh",
+            "status": ["SUCCESS", "FAILURE", "UNKNOWN"],
+            "data": {
+                "ext": {
+                    "status_reason": {
+                        "type": "string",
+                        "description": "The reason provided when the status is UNKNOWN",
+                        "enum": ["partial_data"]
+                    },
+                    "application_state": "foregroundBackgroundState",
+                    "refresh_trigger": {
+                        "type": "string",
+                        "description": "The reason for the refresh.",
+                        "enum": ["backend", "client", "token_adoption"]
+                    },
+                    "failing_step": {
+                        "type": "string",
+                        "description": "The step that the event failed on, if relevant.",
+                        "enum": [
+                            "token_read",
+                            "refresh_access_token",
+                            "fetch_jwks",
+                            "verify_access_token",
+                            "verify_refresh_token",
+                            "token_write"
+                        ]
+                    },
+                    "refresh_token_latency_ms_bucketed": {
+                        "type": "integer",
+                        "description": "The latency value of the token refresh call.",
+                        "enum": [1000, 5000, 10000, 30000, 60000, 300000, 600000]
+                    },
+                    "fetch_jwks_latency_ms_bucketed": {
+                        "type": "integer",
+                        "description": "The latency value of the JWKS call.",
+                        "enum": [1000, 5000, 10000, 30000, 60000, 300000, 600000]
+                    }
+                },
+                "error": {
+                    "domain": {
+                        "type": "string",
+                        "description": "The top level error domain"
+                    },
+                    "code": {
+                        "type": "integer",
+                        "description": "The top level error code"
+                    },
+                    "underlying_domain": {
+                        "type": "string",
+                        "description": "The underlying error domain"
+                    },
+                    "underlying_code": {
+                        "type": "integer",
+                        "description": "The underlying error code"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/.claude/skills/wideEvent-starter/references/definition/examples/json5-auth-v2-token-refresh.json5
+++ b/.claude/skills/wideEvent-starter/references/definition/examples/json5-auth-v2-token-refresh.json5
@@ -1,0 +1,73 @@
+// Defined in https://app.asana.com/1/137249556945/task/1210959493759232
+{
+    "m_ios_wide_auth_v2_token_refresh": {
+        "description": "Wide event sent after an AuthV2 token refresh",
+        "owners": ["samsymons"],
+        "triggers": ["other"],
+        "suffixes": ["daily_standard"],
+        "parameters": [
+            "appVersion",
+            "wideEventAppName",
+            "wideEventAppVersion",
+            "wideEventPlatform",
+            "wideEventType",
+            "wideEventFormFactor",
+            "wideEventSampleRate",
+            "wideEventIsFirstDailyOccurrence",
+            "wideEventFeatureStatus",
+            "wideEventErrorDomain",
+            "wideEventErrorCode",
+            "wideEventUnderlyingErrorDomain",
+            "wideEventUnderlyingErrorCode",
+            "wideEventMetaVersion",
+            {
+                "key": "meta.type",
+                "type": "string",
+                "description": "Wide event type identifier",
+                "enum": ["ios-authv2-token-refresh"]
+            },
+            {
+                "key": "feature.name",
+                "type": "string",
+                "description": "Feature identifier for this wide event",
+                "enum": ["authv2-token-refresh"]
+            },
+            {
+                "key": "feature.data.ext.status_reason",
+                "type": "string",
+                "description": "Reason string for the current status, when applicable - currently applied to UNKNOWN status events",
+                "enum": ["partial_data"]
+            },
+            {
+                "key": "feature.data.ext.application_state",
+                "type": "string",
+                "description": "String representing whether the app is in the background or the foreground at the end of the token refresh",
+                "enum": ["background", "foreground"]
+            },
+            {
+                "key": "feature.data.ext.refresh_trigger",
+                "type": "string",
+                "description": "String representing what caused the token refresh to begin",
+                "enum": ["backend", "client", "token_adoption"]
+            },
+            {
+                "key": "feature.data.ext.failing_step",
+                "type": "string",
+                "description": "The step at which the flow failed, when applicable",
+                "enum": ["token_read", "refresh_access_token", "fetch_jwks", "verify_access_token", "verify_refresh_token", "token_write"]
+            },
+            {
+                "key": "feature.data.ext.refresh_token_latency_ms_bucketed",
+                "type": "integer",
+                "description": "Bucketed latency for token refresh step (ms)",
+                "enum": [1000, 5000, 10000, 30000, 60000, 300000, 600000]
+            },
+            {
+                "key": "feature.data.ext.fetch_jwks_latency_ms_bucketed",
+                "type": "integer",
+                "description": "Bucketed latency for the JWKS fetch step (ms)",
+                "enum": [1000, 5000, 10000, 30000, 60000, 300000, 600000]
+            }
+        ]
+    }
+}

--- a/.claude/skills/wideEvent-starter/references/definition/json-guide.md
+++ b/.claude/skills/wideEvent-starter/references/definition/json-guide.md
@@ -1,0 +1,195 @@
+# JSON Wide Event Definition Guide (wide_events/)
+
+This guide covers the **new JSON nested-object format** stored under `wide_events/definitions/`.
+
+For complete example, see `examples/json-auth-v2-token-refresh.json`.
+
+---
+
+## Directory & File Naming
+
+```
+<platform>/PixelDefinitions/wide_events/
+├── base_event.json          # Common fields inherited by all wide events
+├── props_dictionary.json    # Reusable property definitions (referenced by string)
+└── definitions/             # Your definition files go here
+    └── <feature-name>.json5
+```
+
+- **iOS**: `iOS/PixelDefinitions/wide_events/definitions/`
+- **macOS**: `macOS/PixelDefinitions/wide_events/definitions/`
+
+**File name:** `<feature-name>.json5` (e.g., `auth-v2.json5`)
+
+**Definition key:** The `meta.type` value — `<platform_prefix>-<feature-name>` (e.g., `ios-authv2-token-refresh`).
+
+macOS may not have `base_event.json` or `props_dictionary.json` yet. If missing, create them by adapting the iOS versions (see Platform Differences below).
+
+---
+
+## base_event.json
+
+Defines the common fields every wide event inherits. You do **not** repeat these in your definition — they're merged automatically.
+
+| Section | Fields | Notes |
+|---------|--------|-------|
+| `app` | `name`, `version`, `form_factor` | iOS includes `form_factor`; macOS omits it |
+| `global` | `platform`, `type`, `sample_rate`, `is_first_daily_occurrence` | `platform` enum differs per platform |
+| `feature` | `name`, `status` | You override these in your definition |
+| `context` | `name` | Optional context identifier |
+| `meta` | `version` | Base version (single integer); combined with your two-octet version |
+
+---
+
+## props_dictionary.json
+
+Reusable property definitions. Reference them by using the dictionary key as a **string value** in your definition instead of an inline object.
+
+Example — if `props_dictionary.json` contains:
+```json
+{
+    "foregroundBackgroundState": {
+        "type": "string",
+        "description": "Whether the app is in the foreground or background",
+        "enum": ["foreground", "background"]
+    }
+}
+```
+
+Then in your definition:
+```json
+"application_state": "foregroundBackgroundState"
+```
+
+The schema generator expands the string into the full property definition.
+
+Before writing, read the platform's dictionary:
+- iOS: `iOS/PixelDefinitions/wide_events/props_dictionary.json`
+- macOS: `macOS/PixelDefinitions/wide_events/props_dictionary.json` (create if missing)
+
+Check:
+- Reusable props referenced by string value exist in the dictionary
+- Custom params don't duplicate dictionary entries
+- Type consistency
+
+---
+
+## Output Template
+
+Always use this skeleton when generating a definition. Fill in the `{{placeholders}}`.
+
+```json
+{
+    "{{platform_prefix}}-{{feature-name}}": {
+        "description": "{{one-line description}}",
+        "owners": ["{{github-username}}"],
+        "meta": {
+            "type": "{{platform_prefix}}-{{feature-name}}",
+            "version": "{{major}}.{{minor}}"
+        },
+        "feature": {
+            "name": "{{feature-name}}",
+            "status": [{{status_values}}],
+            "data": {
+                "ext": {
+                    // Custom parameters as nested objects or dictionary refs
+                },
+                "error": {
+                    // Include if feature can fail — see Error Fields below
+                }
+            }
+        }
+    }
+}
+```
+
+Where:
+- `{{platform_prefix}}` — `ios` or `macos`
+- `{{feature-name}}` — hyphenated (e.g., `authv2-token-refresh`)
+- `{{major}}.{{minor}}` — two-octet version (e.g., `0.1`); combined with base_event version automatically
+- `{{status_values}}` — subset of `"SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"` that this event uses
+
+### Status values
+Include only the statuses your event actually uses:
+- **SUCCESS** — unit of work completed successfully
+- **FAILURE** — include error fields when this status is used
+- **CANCELLED** — user deliberately exited the flow
+- **UNKNOWN** — sent before knowing final state; typically includes `status_reason`
+
+### Error fields
+
+Include under `feature.data.error` when the event can have `FAILURE` status:
+
+```json
+"error": {
+    "domain": {
+        "type": "string",
+        "description": "The top level error domain"
+    },
+    "code": {
+        "type": "integer",
+        "description": "The top level error code"
+    },
+    "underlying_domain": {
+        "type": "string",
+        "description": "The underlying error domain"
+    },
+    "underlying_code": {
+        "type": "integer",
+        "description": "The underlying error code"
+    }
+}
+```
+
+---
+
+## Custom Parameters (feature.data.ext)
+
+Parameters go inside `feature.data.ext` as nested objects. See `parameter-formats.md` for the full syntax reference with examples for each type (string enum, integer bucketed, boolean, free-form string, dictionary reference).
+
+General rules:
+- For `string` params, always try to add an `enum` — ask the user if values aren't clear
+- Use `examples` instead of `enum` when values are too numerous
+- Bucket latency/duration values: `[1000, 5000, 10000, 30000, 60000, 300000, 600000]`
+- Error descriptions must be static, developer-defined strings — never exception messages
+
+---
+
+## Platform Differences
+
+| Aspect | iOS | macOS |
+|--------|-----|-------|
+| Definition key prefix | `ios-` | `macos-` |
+| `base_event.json` `global.platform` enum | `["iOS"]` | `["macOS"]` |
+| `base_event.json` `app.form_factor` | Included (`phone`, `tablet`) | Omitted |
+| `base_event.json` `app.name` enum | `["DuckDuckGo", "DuckDuckGo-Alpha", "DuckDuckGo-Experimental"]` | Platform-specific app names |
+| Directory | `iOS/PixelDefinitions/wide_events/` | `macOS/PixelDefinitions/wide_events/` |
+
+When creating for **both platforms**, create one definition file per platform with the appropriate key prefix.
+
+---
+
+## Validation & Lint
+
+The validation script validates definitions and auto-generates schemas. Run it for the platform you're targeting:
+
+```bash
+# From the platform directory (iOS/ or macOS/)
+cd <repo_root>/<platform_dir>
+npm install
+
+# Validate definitions (both pixels/ and wide_events/) and generate schemas
+npm run validate-pixel-defs
+
+# Format/lint fix
+npm run pixel-lint.fix
+```
+
+To validate wide event debug logs from the iOS Simulator (requires a booted simulator with the app installed):
+```bash
+cd <repo_root>/<platform_dir> && ./scripts/validate_wide_events.sh
+```
+
+This script runs `npm run validate-pixel-defs` first, then validates runtime logs at `Library/Caches/wide-event-validation-log.jsonl` against the generated schemas.
+
+If validation fails: read the error, fix the definition, re-run until passing.

--- a/.claude/skills/wideEvent-starter/references/definition/json5-guide.md
+++ b/.claude/skills/wideEvent-starter/references/definition/json5-guide.md
@@ -1,0 +1,184 @@
+# JSON5 Wide Event Definition Guide (pixels/)
+
+This guide covers the **legacy JSON5 flat-parameter format** stored under `pixels/definitions/`.
+
+For complete example, see `examples/json5-auth-v2-token-refresh.json5`.
+
+---
+
+## Directory & File Naming
+
+```
+<platform>/PixelDefinitions/pixels/
+├── params_dictionary.json5    # Shared parameter definitions (referenced by string)
+├── suffixes_dictionary.json5  # Suffix definitions
+└── definitions/               # Your definition files go here
+    └── <feature_name>_wide_event.json5
+```
+
+- **iOS**: `iOS/PixelDefinitions/pixels/definitions/`
+- **macOS**: `macOS/PixelDefinitions/pixels/definitions/`
+
+**File name:** `<feature_name>_wide_event.json5` (e.g., `auth_v2_token_refresh_wide_event.json5`)
+
+**Definition key (pixel name):**
+- iOS: `m_ios_wide_<feature_name>`
+- macOS: `m_mac_wide_<feature_name>`
+
+Use the name from the Asana task if one is explicitly provided.
+
+---
+
+## params_dictionary.json5
+
+Shared parameter definitions. Reference them by using the dictionary key as a **string** in the `parameters` array instead of a full object.
+
+Example — if `params_dictionary.json5` defines `"appVersion"`, then in your definition:
+```json5
+"parameters": [
+    "appVersion",   // ← string reference, expanded by the system
+    { "key": "feature.data.ext.my_param", ... }  // ← inline custom param
+]
+```
+
+Before writing, read the platform's dictionary:
+- iOS: `iOS/PixelDefinitions/pixels/params_dictionary.json5`
+- macOS: `macOS/PixelDefinitions/pixels/params_dictionary.json5`
+
+Check:
+- All referenced default param names exist in the dictionary
+- Custom params don't duplicate dictionary entries (reference by key if they do)
+- Type consistency (`string` vs `integer`)
+
+---
+
+## Output Template
+
+Always use this skeleton when generating a definition. Fill in the `{{placeholders}}` — do not rearrange the structure.
+
+```json5
+// Defined in {{ASANA_TASK_URL}}
+{
+    "m_{{platform}}_wide_{{feature_name}}": {
+        "description": "{{one-line description of when this event fires}}",
+        "owners": [{{owners}}],
+        "triggers": [{{triggers}}],
+        "suffixes": [{{suffixes}}],
+        "parameters": [
+            // === Platform defaults (from wide event format + params_dictionary.json5) ===
+            {{platform_default_params}}
+            // === Custom parameters ===
+            {
+                "key": "meta.type",
+                "type": "string",
+                "description": "Wide event type identifier",
+                "enum": ["{{platform_lowercase}}-{{feature-name-hyphens}}"]
+            },
+            {
+                "key": "feature.name",
+                "type": "string",
+                "description": "Feature identifier for this wide event",
+                "enum": ["{{feature-name-hyphens}}"]
+            },
+            // ... feature.data.ext.* params ...
+        ]
+    }
+}
+```
+
+Where:
+- `{{platform}}` — `ios` or `mac`
+- `{{platform_lowercase}}` — `ios` or `macos` (used in `meta.type`)
+- `{{feature-name-hyphens}}` — feature name with hyphens (e.g., `authv2-token-refresh`)
+- `{{platform_default_params}}` — derived from the wide event format (fetched from Asana) + `params_dictionary.json5`. To determine which and in what order:
+  1. Read the required/optional fields from the wide event format
+  2. Cross-reference with `params_dictionary.json5` to find matching key names
+  3. Check existing definitions in `examples/` for conventional ordering
+  4. iOS includes `wideEventFormFactor`; macOS does not. Not all defaults are needed for every event — compare with existing definitions.
+
+### Status values
+Include only the statuses your event actually uses:
+- **SUCCESS** — unit of work completed successfully
+- **FAILURE** — include error parameters when this status is used
+- **CANCELLED** — user deliberately exited the flow
+- **UNKNOWN** — sent before knowing final state; typically includes `status_reason`
+
+### Error parameters
+
+Include as flat parameter objects when the event can have `FAILURE` status:
+
+```json5
+{
+    "key": "feature.data.error.domain",
+    "type": "string",
+    "description": "The top level error domain"
+},
+{
+    "key": "feature.data.error.code",
+    "type": "integer",
+    "description": "The top level error code"
+},
+{
+    "key": "feature.data.error.underlying_domain",
+    "type": "string",
+    "description": "The underlying error domain"
+},
+{
+    "key": "feature.data.error.underlying_code",
+    "type": "integer",
+    "description": "The underlying error code"
+}
+```
+
+---
+
+## Custom Parameters (feature.data.ext.*)
+
+See `parameter-formats.md` for the full syntax reference with examples for each type (string enum, integer bucketed, boolean, free-form string, dynamic keyPattern).
+
+General rules:
+- For `string` params, always try to add an `enum` — ask the user if values aren't clear
+- Use `keyPattern` (regex) for dynamic keys; escape dots: `feature\\.data\\.ext\\.`
+- Use `examples` instead of `enum` when values are too numerous
+- Bucket latency/duration values: `[1000, 5000, 10000, 30000, 60000, 300000, 600000]`
+- Error descriptions must be static, developer-defined strings — never exception messages
+
+---
+
+## Platform Differences
+
+| Aspect | iOS | macOS |
+|--------|-----|-------|
+| Pixel name prefix | `m_ios_wide_` | `m_mac_wide_` |
+| `meta.type` enum prefix | `ios-` | `macos-` |
+| `wideEventFormFactor` | Included | Omitted |
+| Directory | `iOS/PixelDefinitions/pixels/definitions/` | `macOS/PixelDefinitions/pixels/definitions/` |
+
+When creating for **both platforms**, create one file in each directory with the appropriate definition key prefix.
+
+---
+
+## Validation & Lint
+
+The validation script validates definitions and auto-generates schemas. Run it for the platform you're targeting:
+
+```bash
+# From the platform directory (iOS/ or macOS/)
+cd <repo_root>/<platform_dir>
+npm install
+
+# Validate definitions (both pixels/ and wide_events/) and generate schemas
+npm run validate-pixel-defs
+
+# Format/lint fix
+npm run pixel-lint.fix
+```
+
+To validate wide event debug logs from the iOS Simulator (requires a booted simulator with the app installed):
+```bash
+cd <repo_root>/<platform_dir> && ./scripts/validate_wide_events.sh
+```
+
+This script runs `npm run validate-pixel-defs` first, then validates runtime logs at `Library/Caches/wide-event-validation-log.jsonl` against the generated schemas.
+
+If validation fails: read the error, fix the definition, re-run until passing.

--- a/.claude/skills/wideEvent-starter/references/definition/json5-guide.md
+++ b/.claude/skills/wideEvent-starter/references/definition/json5-guide.md
@@ -65,7 +65,7 @@ Always use this skeleton when generating a definition. Fill in the `{{placeholde
         "triggers": [{{triggers}}],
         "suffixes": [{{suffixes}}],
         "parameters": [
-            // === Platform defaults (from wide event format + params_dictionary.json5) ===
+            // === Platform defaults (from the user's proposed wide event + params_dictionary.json5) ===
             {{platform_default_params}}
             // === Custom parameters ===
             {
@@ -90,10 +90,10 @@ Where:
 - `{{platform}}` — `ios` or `mac`
 - `{{platform_lowercase}}` — `ios` or `macos` (used in `meta.type`)
 - `{{feature-name-hyphens}}` — feature name with hyphens (e.g., `authv2-token-refresh`)
-- `{{platform_default_params}}` — derived from the wide event format (fetched from Asana) + `params_dictionary.json5`. To determine which and in what order:
-  1. Read the required/optional fields from the wide event format
+- `{{platform_default_params}}` — derived from the user's proposed wide event task + `params_dictionary.json5`. To determine which and in what order:
+  1. Read the parameters listed in the user's Asana task description
   2. Cross-reference with `params_dictionary.json5` to find matching key names
-  3. Check existing definitions in `examples/` for conventional ordering
+  3. Check `examples/` for conventional ordering
   4. iOS includes `wideEventFormFactor`; macOS does not. Not all defaults are needed for every event — compare with existing definitions.
 
 ### Status values

--- a/.claude/skills/wideEvent-starter/references/definition/parameter-formats.md
+++ b/.claude/skills/wideEvent-starter/references/definition/parameter-formats.md
@@ -1,0 +1,111 @@
+# Parameter Formats
+
+Reference for custom parameter syntax in both definition formats. Both formats support the same parameter types but use different syntax.
+
+---
+
+## String with enum
+
+**JSON5 (pixels/):**
+```json5
+{
+    "key": "feature.data.ext.refresh_trigger",
+    "type": "string",
+    "description": "What caused the token refresh to begin",
+    "enum": ["backend", "client", "token_adoption"]
+}
+```
+
+**JSON (wide_events/):**
+```json
+"refresh_trigger": {
+    "type": "string",
+    "description": "What caused the token refresh to begin",
+    "enum": ["backend", "client", "token_adoption"]
+}
+```
+
+## Integer with bucketed enum
+
+Standard latency/duration buckets: `[1000, 5000, 10000, 30000, 60000, 300000, 600000]`
+
+**JSON5 (pixels/):**
+```json5
+{
+    "key": "feature.data.ext.refresh_token_latency_ms_bucketed",
+    "type": "integer",
+    "description": "Bucketed latency for token refresh step (ms)",
+    "enum": [1000, 5000, 10000, 30000, 60000, 300000, 600000]
+}
+```
+
+**JSON (wide_events/):**
+```json
+"refresh_token_latency_ms_bucketed": {
+    "type": "integer",
+    "description": "Bucketed latency for token refresh step (ms)",
+    "enum": [1000, 5000, 10000, 30000, 60000, 300000, 600000]
+}
+```
+
+## Boolean
+
+**JSON5 (pixels/):**
+```json5
+{
+    "key": "feature.data.ext.free_trial_eligible",
+    "type": "boolean",
+    "description": "Whether a free trial was available"
+}
+```
+
+**JSON (wide_events/):**
+```json
+"free_trial_eligible": {
+    "type": "boolean",
+    "description": "Whether a free trial was available"
+}
+```
+
+## Free-form string (use sparingly — prefer enums)
+
+**JSON5 (pixels/):**
+```json5
+{
+    "key": "feature.data.ext.subscription_identifier",
+    "type": "string",
+    "description": "Subscription product identifier",
+    "examples": ["ddg.privacy.pro.monthly.renews.us", "ddg.privacy.pro.yearly.renews.us"]
+}
+```
+
+**JSON (wide_events/):**
+```json
+"subscription_identifier": {
+    "type": "string",
+    "description": "Subscription product identifier"
+}
+```
+
+## Dynamic key with keyPattern (JSON5 only)
+
+Used when the key name itself is variable. Escape dots in the regex pattern.
+
+```json5
+{
+    "keyPattern": "feature\\.data\\.ext\\.(bookmarks|passwords)_status",
+    "type": "string",
+    "description": "Status of each type",
+    "enum": ["SUCCESS", "FAILURE", "CANCELLED", "UNKNOWN"]
+}
+```
+
+## Dictionary reference (JSON only)
+
+Reference a reusable property from `props_dictionary.json` by using its key as a string value instead of an inline object.
+
+```json
+"application_state": "foregroundBackgroundState"
+```
+
+The schema generator expands the string into the full property definition from the dictionary.


### PR DESCRIPTION
## Summary
- Adds a Claude Code skill for end-to-end wide event creation in the apple-browsers repo
- Supports both JSON5 (pixels/definitions/) and JSON (wide_events/definitions/) definition formats
- Includes guides for Swift WideEventData class + XCTestCase creation
- Uses auth-v2 token refresh as the consistent example across all references

## Skill Structure
```
.claude/skills/wideEvent-starter/
├── SKILL.md                              — Entry point: MCP fetch → format choice → spawn subagent
└── references/
    ├── definition/                       — Action 1: Wide Event Definition
    │   ├── json5-guide.md                — JSON5 pixels/ format + template
    │   ├── json-guide.md                 — JSON wide_events/ format + template
    │   ├── parameter-formats.md          — Shared parameter syntax (both formats)
    │   └── examples/
    │       ├── json5-auth-v2-token-refresh.json5
    │       └── json-auth-v2-token-refresh.json
    └── data-class/                       — Action 2: Data Class & Tests
        ├── guide.md                      — WideEventData protocol + class structure
        ├── test-guide.md                 — Test class boilerplate + runner
        └── examples/
            ├── AuthV2TokenRefreshWideEventData.swift
            └── AuthV2WideEventTests.swift
```

## How it works
1. Skill triggers when user mentions "wide event", "wide event definition", or "wide event data class"
2. Main conversation fetches the wide event format from Asana (MCP call — subagents can't do MCP)
3. Asks user which format (JSON5 or JSON)
4. Spawns a subagent with the format context to create the definition and/or data class

## Test plan
- [ ] Trigger skill by saying "I need to create a new wide event for X"
- [ ] Verify it fetches the wide event format from Asana
- [ ] Verify it asks which format (JSON5 or JSON)
- [ ] Verify subagent creates a definition following the correct guide
- [ ] Verify data class action creates Swift class + tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds only Claude skill documentation/reference materials (guides + examples) without changing production app code. Risk is limited to developer workflow/consistency issues if the guidance is incorrect.
> 
> **Overview**
> Introduces a new Claude Code skill, `wideEvent-starter`, that standardizes the end-to-end workflow for creating *wide events* in the apple-browsers repo, including an MCP-driven step to fetch the canonical format from Asana and a handoff to a subagent.
> 
> Adds reference docs for both definition formats—**legacy JSON5** under `pixels/definitions/` and **nested JSON** under `wide_events/definitions/`—including templates, platform notes, validation commands, and a shared parameter-format reference.
> 
> Includes complete example artifacts (AuthV2 token refresh) for a wide event definition in both formats, plus a sample `WideEventData` Swift class and corresponding XCTest cases (including latency bucketing assertions) to serve as copy/paste starting points.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83f7396b78b1dd035f1c467c5aa3bb7ae5d7b778. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->