### PR TITLE
Add pixel for willConnectToWindow in Connected state

### DIFF
--- a/iOS/Core/Pixel.swift
+++ b/iOS/Core/Pixel.swift
@@ -28,7 +28,6 @@ public struct PixelParameters {
     public static let duration = "dur"
     static let test = "test"
     public static let appVersion = "appVersion"
-    public static let osVersion = "osVersion"
 
     public static let autocompleteBookmarkCapable = "bc"
     public static let autocompleteIncludedLocalResults = "sb"
@@ -187,6 +186,7 @@ public struct PixelParameters {
 
     public static let appState = "state"
     public static let appEvent = "event"
+    public static let windowChanged = "windowChanged"
 
     public static let didCallWillEnterForeground = "didCallWillEnterForeground"
 

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1601,6 +1601,7 @@ extension Pixel {
 
         // MARK: Lifecycle
         case appDidTransitionToUnexpectedState
+        case sceneWillConnectToWindowCalledInConnectedState
 
         // MARK: Tab interaction state debug pixels
         case tabInteractionStateSourceMissingRootDirectory
@@ -3181,6 +3182,7 @@ extension Pixel.Event {
 
         // MARK: Lifecycle
         case .appDidTransitionToUnexpectedState: return "m_debug_app-did-transition-to-unexpected-state-4"
+        case .sceneWillConnectToWindowCalledInConnectedState: return "m_debug_scene-will-connect-to-window-called-in-connected-state"
 
         case .debugBreakageExperiment: return "m_debug_breakage_experiment_u"
 

--- a/iOS/DuckDuckGo/AppLifecycle/AppStateMachine.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStateMachine.swift
@@ -160,6 +160,10 @@ final class AppStateMachine {
     /// if the app is backgrounded before user authentication (iOS 18.0+).
     private(set) var actionToHandle: AppAction?
 
+    /// Identity of the last window passed via `willConnectToWindow`, used to detect whether
+    /// consecutive scene connections reuse the same window or receive a new one.
+    private var lastConnectedWindowIdentifier: ObjectIdentifier?
+
     private let terminatingStateFactory: TerminatingStateFactory
 
     init(initialState: AppState, terminatingStateFactory: TerminatingStateFactory = DefaultTerminatingStateFactory()) {
@@ -210,6 +214,7 @@ final class AppStateMachine {
     private func respond(to event: AppEvent, in launching: LaunchingHandling) {
         switch event {
         case .willConnectToWindow(let window):
+            storeWindowIdentifier(window)
             let connected = launching.makeConnectedState(window: window, actionToHandle: actionToHandle)
             currentState = .connected(connected)
         default:
@@ -236,6 +241,11 @@ final class AppStateMachine {
             // However, we only transition to Foreground after didBecomeActive, since both events occur in sequence.
             // We may revisit this if any UI glitches appear, as some work could potentially happen earlier in willEnterForeground.
             break
+        case .willConnectToWindow(let window):
+            let windowChanged = lastConnectedWindowIdentifier != ObjectIdentifier(window)
+            storeWindowIdentifier(window)
+            DailyPixel.fireDailyAndCount(pixel: .sceneWillConnectToWindowCalledInConnectedState,
+                                         withAdditionalParameters: [PixelParameters.windowChanged: String(windowChanged)])
         default:
             handleUnexpectedEvent(event, for: .connected(connected))
         }
@@ -253,6 +263,7 @@ final class AppStateMachine {
         case .willResignActive:
             foreground.willLeave()
         case .willConnectToWindow(let window): // Please remove once we stop supporting iOS 16
+            storeWindowIdentifier(window)
             currentState = .connected(foreground.makeConnectedState(window: window, actionToHandle: actionToHandle))
         default:
             handleUnexpectedEvent(event, for: .foreground(foreground))
@@ -273,6 +284,7 @@ final class AppStateMachine {
         case .willEnterForeground:
             background.willLeave()
         case .willConnectToWindow(let window): // Please remove once we stop supporting iOS 16
+            storeWindowIdentifier(window)
             currentState = .connected(background.makeConnectedState(window: window, actionToHandle: actionToHandle))
         default:
             handleUnexpectedEvent(event, for: .background(background))
@@ -289,6 +301,10 @@ final class AppStateMachine {
         if case .willConnectToWindow(let window) = event {
             terminating.alertAndTerminate(window: window)
         }
+    }
+
+    private func storeWindowIdentifier(_ window: UIWindow) {
+        lastConnectedWindowIdentifier = ObjectIdentifier(window)
     }
 
     private func handleUnexpectedEvent(_ event: AppEvent, for state: AppState) {

--- a/iOS/PixelDefinitions/pixels/definitions/startup_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/startup_pixels.json5
@@ -150,8 +150,8 @@
             "appVersion",
             {
                 "key": "windowChanged",
-                "description": "Whether the window pointer changed between consecutive willConnectToWindow calls (true/false)",
-                "type": "string"
+                "description": "Whether the window instance changed between consecutive willConnectToWindow calls",
+                "type": "boolean"
             }
         ]
     }

--- a/iOS/PixelDefinitions/pixels/definitions/startup_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/startup_pixels.json5
@@ -140,5 +140,19 @@
         "triggers": ["startup"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion", "errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
+    },
+    "m_debug_scene-will-connect-to-window-called-in-connected-state": {
+        "description": "Fires when willConnectToWindow is called while already in the Connected state, indicating an unexpected consecutive scene connection. The windowChanged parameter indicates whether the window instance changed between calls.",
+        "owners": ["jaceklyp"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "windowChanged",
+                "description": "Whether the window pointer changed between consecutive willConnectToWindow calls (true/false)",
+                "type": "string"
+            }
+        ]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213911572019891

### Description

Handle `willConnectToWindow` explicitly in the `Connected` state instead of falling through to the unexpected state handler (which was causing spikes in `m_debug_app-did-transition-to-unexpected-state-4`). A new dedicated pixel fires when this occurs, including a `windowChanged` parameter that compares `ObjectIdentifier` values to detect whether the window instance changed between consecutive calls.

Also removes the unused `PixelParameters.osVersion` constant.

### Testing Steps

1. Build and run the app on a device or simulator.
2. Verify the app launches and transitions through states normally without unexpected pixel fires.
3. Confirm the project compiles without errors — the new pixel enum case and parameter are wired up correctly.

### Impact and Risks

Low: Adds a new debug pixel for an edge-case scene lifecycle event. No changes to app behavior or UI. The `willConnectToWindow` in Connected state is now explicitly handled (no-op + pixel) instead of firing the unexpected state pixel.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds debug telemetry and a small state-machine branch for an unexpected lifecycle edge case, without changing user-facing behavior or data flows.
> 
> **Overview**
> Adds explicit handling for `willConnectToWindow` events received while already in the `Connected` app lifecycle state, firing a new daily-count debug pixel (`sceneWillConnectToWindowCalledInConnectedState`) instead of routing through the generic unexpected-state pixel.
> 
> Tracks the last connected `UIWindow` identifier to emit a `windowChanged` parameter on that pixel, and removes the unused `PixelParameters.osVersion` constant while registering the new pixel in `startup_pixels.json5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5b350c9a28905438385d429ef048f080606bb01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->