### PR TITLE
[iOS] Fix single tab burn button having small hit area

### DIFF
--- a/iOS/LocalPackages/DuckUI/Sources/DuckUI/Button.swift
+++ b/iOS/LocalPackages/DuckUI/Sources/DuckUI/Button.swift
@@ -145,7 +145,7 @@ public struct SecondaryDestructiveButtonStyle: ButtonStyle {
                     .stroke(borderColor, lineWidth: 1)
             )
             .cornerRadius(Consts.cornerRadius)
-            .contentShape(Rectangle())
+            .contentShape(RoundedRectangle(cornerRadius: Consts.cornerRadius))
     }
 }
 

--- a/iOS/LocalPackages/DuckUI/Sources/DuckUI/Button.swift
+++ b/iOS/LocalPackages/DuckUI/Sources/DuckUI/Button.swift
@@ -145,6 +145,7 @@ public struct SecondaryDestructiveButtonStyle: ButtonStyle {
                     .stroke(borderColor, lineWidth: 1)
             )
             .cornerRadius(Consts.cornerRadius)
+            .contentShape(Rectangle())
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211767540372501/task/1213763183945862?focus=true

### Description
This PR fixes an issue where buttons using the `SecondaryDestructiveButtonStyle` were having a small hit area. Like the burn single tab button.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Tap on the fire button
2. Try tapping on the "Delete this tab" button's edges and verify the taps are registered.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts the tappable area for `SecondaryDestructiveButtonStyle` without altering business logic or data handling.
> 
> **Overview**
> Fixes an issue where `SecondaryDestructiveButtonStyle` buttons could have a smaller-than-expected hit area (e.g., the “Delete this tab” action in the fire confirmation flow).
> 
> The style now sets an explicit `contentShape` matching its rounded rectangle, making taps register across the full visible button bounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80871b7d4dfd09008c2a4a0fe79b303bf38e86ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->