### PR TITLE
[iOS] Use a smaller sheet on iOS 15 for the fire button confirmation

### DIFF
--- a/iOS/DuckDuckGo/Fire/FireConfirmationPresenter.swift
+++ b/iOS/DuckDuckGo/Fire/FireConfirmationPresenter.swift
@@ -213,7 +213,7 @@ struct FireConfirmationPresenter {
             sheet.prefersEdgeAttachedInCompactHeight = true
             sheet.widthFollowsPreferredContentSizeWhenEdgeAttached = true
         } else {
-            sheet.detents = [.large()]
+            sheet.detents = [.medium()]
         }
         sheet.prefersGrabberVisible = false
         if #unavailable(iOS 26) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211767540372501/task/1213800951335157?focus=true

### Description
Fix the scoped fire confirmation sheet occupying the full screen on iOS 15 by using `.medium()` detent instead of `.large()`

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Run on an iOS 15 simulator or device
2. Tap the fire button to trigger the scoped fire confirmation modal
3. Verify the sheet appears at roughly half screen height, not full screen
4. Confirm the animation, title, subtitle, and action buttons are visible and functional
5. Repeat on iOS 16+ and verify there is no regression — sheet should still size to content


### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
- The `.medium()` detent is a fixed half-height, so if the content ever grows taller than half the screen on a smaller iOS 15 device, it could be clipped. This is unlikely given the current view content (Lottie animation, title, subtitle, 1–2 buttons).


### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only behavior change limited to iOS <16 sheet sizing; potential risk is content being clipped on smaller screens due to the fixed `.medium()` detent.
> 
> **Overview**
> Adjusts the Fire confirmation sheet presentation on iOS 15 by switching the fallback detent from `.large()` to `.medium()` when `UISheetPresentationController` custom detents aren’t available (iOS <16).
> 
> iOS 16+ behavior remains unchanged, still using a custom detent sized to the SwiftUI content with a max-height cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d15dc8ad6627f126094f10c9ec469caef91934b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->