### PR TITLE
Update select_xcode_version.sh to use sudo-less xcode-selection

### DIFF
--- a/.github/actions/select-xcode-version/select_xcode_version.sh
+++ b/.github/actions/select-xcode-version/select_xcode_version.sh
@@ -30,7 +30,10 @@ select_xcode_version() {
     fi
     
     echo "Selecting Xcode version $XCODE_VERSION"
-    sudo xcode-select -s "$XCODE_PATH"
+    # sudo xcode-select -s "$XCODE_PATH"
+
+    # Sudo-less xcode-selection
+    echo "DEVELOPER_DIR=$XCODE_PATH" >> "$GITHUB_ENV"
 }
 
 main() {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: N/A
Tech Design URL: N/A
CC: N/A

### Description

Proposing sudo-less xcode-selection for CI environment. Requiring sudo permission may limit automation and impact global settings of the Github runner, especially self-hosted runner

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Adding a step to verify xcodebuild -version after xcode-selection steps
2. Adding a step to verify selected xcode folder

```
runs:
  using: composite
  steps:
    - id: xcode-diagnostics
      shell: bash
      run: |
        set -e
        echo "DEVELOPER_DIR=$DEVELOPER_DIR"
        xcode-select -p          # checking the folder of the selected xcode
        xcodebuild -version   # checking the version of the selected xcodebuild
```
<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

1. Xcode selection step is required for every CI job and runner since sudo-less selection does not have the global scope

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how CI selects the active Xcode toolchain; if some steps depend on `xcode-select` being set globally, builds/tests could run against the wrong Xcode version.
> 
> **Overview**
> Updates the `select-xcode-version` GitHub Action to avoid `sudo xcode-select` and instead select the requested Xcode by exporting `DEVELOPER_DIR` into the workflow environment.
> 
> This keeps the existing version resolution and validation logic, but changes the mechanism used by downstream build steps to pick up the selected Xcode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06d9e69902a596534abb22c9a4b9f2dadad4c4bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->