### PR TITLE
Add per-key migration tracking and bulk putChats for native storage

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageHandler.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageHandler.swift
@@ -83,6 +83,10 @@ public final class DuckAiNativeStorageHandler: DuckAiNativeStorageHandling {
         try dataStore.putChat(chatId: chatId, data: data)
     }
 
+    public func putChats(_ chats: [(chatId: String, data: Data)]) throws {
+        try dataStore.putChats(chats)
+    }
+
     public func getAllChats() throws -> [DuckAiChatRecord] {
         try dataStore.getAllChats()
     }
@@ -119,15 +123,29 @@ public final class DuckAiNativeStorageHandler: DuckAiNativeStorageHandling {
 
     // MARK: - Migration
 
-    public func isMigrationDone() throws -> Bool {
-        return try settingsStore.value(for: \.migrationDone) ?? false
+    public func isMigrationDone(for key: String) throws -> Bool {
+        let flags = try loadMigrationFlags()
+        return flags[key] ?? false
     }
 
-    public func markMigrationDone() throws {
-        try settingsStore.set(true, for: \.migrationDone)
+    public func markMigrationDone(for key: String) throws {
+        var flags = try loadMigrationFlags()
+        flags[key] = true
+        let data = try JSONSerialization.data(withJSONObject: flags, options: [])
+        try settingsStore.set(data, for: \.migrationDone)
     }
 
     // MARK: - Private helpers
+
+    private func loadMigrationFlags() throws -> [String: Bool] {
+        guard let data = try settingsStore.value(for: \.migrationDone) else {
+            return [:]
+        }
+        guard let dict = try JSONSerialization.jsonObject(with: data) as? [String: Bool] else {
+            return [:]
+        }
+        return dict
+    }
 
     private func loadSettingsBlob() throws -> [String: Any] {
         guard let data = try settingsStore.value(for: \.settings) else {

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageHandling.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageHandling.swift
@@ -33,6 +33,7 @@ public protocol DuckAiNativeStorageHandling {
     // MARK: - Chats
 
     func putChat(chatId: String, data: Data) throws
+    func putChats(_ chats: [(chatId: String, data: Data)]) throws
     func getAllChats() throws -> [DuckAiChatRecord]
     func deleteChat(chatId: String) throws
     func deleteAllChats() throws
@@ -47,6 +48,6 @@ public protocol DuckAiNativeStorageHandling {
 
     // MARK: - Migration
 
-    func isMigrationDone() throws -> Bool
-    func markMigrationDone() throws
+    func isMigrationDone(for key: String) throws -> Bool
+    func markMigrationDone(for key: String) throws
 }

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageKeys.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageKeys.swift
@@ -27,6 +27,6 @@ public enum DuckAiNativeStorageKeyNames: String, StorageKeyDescribing {
 public struct DuckAiNativeStorageSettings: StoringKeys {
     public init() {}
 
-    public let migrationDone = StorageKey<Bool>(DuckAiNativeStorageKeyNames.migrationDone)
+    public let migrationDone = StorageKey<Data>(DuckAiNativeStorageKeyNames.migrationDone)
     public let settings = StorageKey<Data>(DuckAiNativeStorageKeyNames.settings)
 }

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageUserScript.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageUserScript.swift
@@ -69,6 +69,7 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
 
         // Chats
         case .putChat: return putChat
+        case .putChats: return putChats
         case .getAllChats: return getAllChats
         case .deleteChat: return deleteChat
         case .deleteAllChats: return deleteAllChats
@@ -222,6 +223,34 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
             Logger.aiChat.debug("DuckAiNativeStorage: putChat '\(chatId)' succeeded (\(jsonData.count) bytes)")
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: putChat failed for \(chatId): \(error.localizedDescription)")
+        }
+        return nil
+    }
+
+    private func putChats(params: Any, message: UserScriptMessage) async -> Encodable? {
+        Logger.aiChat.debug("DuckAiNativeStorage: ← putChats called")
+        guard let dict = params as? [String: Any],
+              let chatsArray = dict["chats"] as? [[String: Any]] else {
+            Logger.aiChat.error("DuckAiNativeStorage: putChats — invalid params")
+            return nil
+        }
+        var chatTuples: [(chatId: String, data: Data)] = []
+        for chatDict in chatsArray {
+            guard let chatId = chatDict["chatId"] as? String,
+                  let data = chatDict["data"] as? [String: Any],
+                  let jsonData = try? JSONSerialization.data(withJSONObject: data) else {
+                Logger.aiChat.error("DuckAiNativeStorage: putChats — skipping invalid chat entry")
+                continue
+            }
+            chatTuples.append((chatId: chatId, data: jsonData))
+        }
+        do {
+            try await performStorageOperation {
+                try self.handler.putChats(chatTuples)
+            }
+            Logger.aiChat.debug("DuckAiNativeStorage: putChats succeeded (\(chatTuples.count) chats)")
+        } catch {
+            Logger.aiChat.error("DuckAiNativeStorage: putChats failed: \(error.localizedDescription)")
         }
         return nil
     }
@@ -383,11 +412,16 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
 
     private func isMigrationDone(params: Any, message: UserScriptMessage) async -> Encodable? {
         Logger.aiChat.debug("DuckAiNativeStorage: ← isMigrationDone called")
+        guard let dict = params as? [String: Any],
+              let key = dict["key"] as? String else {
+            Logger.aiChat.error("DuckAiNativeStorage: isMigrationDone — invalid params (missing key)")
+            return MigrationDoneResponse(value: false)
+        }
         do {
             let done = try await performStorageOperation {
-                try self.handler.isMigrationDone()
+                try self.handler.isMigrationDone(for: key)
             }
-            Logger.aiChat.debug("DuckAiNativeStorage: isMigrationDone → \(done)")
+            Logger.aiChat.debug("DuckAiNativeStorage: isMigrationDone('\(key)') → \(done)")
             return MigrationDoneResponse(value: done)
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: isMigrationDone failed: \(error.localizedDescription)")
@@ -397,11 +431,16 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
 
     private func markMigrationDone(params: Any, message: UserScriptMessage) async -> Encodable? {
         Logger.aiChat.debug("DuckAiNativeStorage: ← markMigrationDone called")
+        guard let dict = params as? [String: Any],
+              let key = dict["key"] as? String else {
+            Logger.aiChat.error("DuckAiNativeStorage: markMigrationDone — invalid params (missing key)")
+            return nil
+        }
         do {
             try await performStorageOperation {
-                try self.handler.markMigrationDone()
+                try self.handler.markMigrationDone(for: key)
             }
-            Logger.aiChat.debug("DuckAiNativeStorage: markMigrationDone succeeded")
+            Logger.aiChat.debug("DuckAiNativeStorage: markMigrationDone('\(key)') succeeded")
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: markMigrationDone failed: \(error.localizedDescription)")
         }

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageUserScriptMessages.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageUserScriptMessages.swift
@@ -29,6 +29,7 @@ public enum DuckAiNativeStorageUserScriptMessages: String, CaseIterable {
 
     // Chats
     case putChat
+    case putChats
     case getAllChats
     case deleteChat
     case deleteAllChats

--- a/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeStorageHandlerTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeStorageHandlerTests.swift
@@ -161,16 +161,24 @@ final class DuckAiNativeStorageHandlerTests: XCTestCase {
 
     // MARK: - Migration
 
-    func testWhenMigrationNotDoneThenReturnsFalse() throws {
-        let result = try handler.isMigrationDone()
+    func testWhenMigrationNotDoneForKeyThenReturnsFalse() throws {
+        let result = try handler.isMigrationDone(for: "chats")
         XCTAssertFalse(result)
     }
 
-    func testWhenMarkMigrationDoneThenReturnsTrue() throws {
-        try handler.markMigrationDone()
+    func testWhenMarkMigrationDoneForKeyThenReturnsTrueForThatKey() throws {
+        try handler.markMigrationDone(for: "chats")
 
-        let result = try handler.isMigrationDone()
-        XCTAssertTrue(result)
+        XCTAssertTrue(try handler.isMigrationDone(for: "chats"))
+        XCTAssertFalse(try handler.isMigrationDone(for: "files"))
+    }
+
+    func testWhenMarkMigrationDoneForMultipleKeysThenEachTrackedIndependently() throws {
+        try handler.markMigrationDone(for: "chats")
+        try handler.markMigrationDone(for: "files")
+
+        XCTAssertTrue(try handler.isMigrationDone(for: "chats"))
+        XCTAssertTrue(try handler.isMigrationDone(for: "files"))
     }
 
     // MARK: - Chat delegation
@@ -182,6 +190,19 @@ final class DuckAiNativeStorageHandlerTests: XCTestCase {
         XCTAssertEqual(mockDataStore.putChatCallCount, 1)
         XCTAssertEqual(mockDataStore.lastPutChatId, "chat-1")
         XCTAssertEqual(mockDataStore.lastPutChatData, data)
+    }
+
+    func testWhenPutChatsThenDelegatesToDataStore() throws {
+        let chats: [(chatId: String, data: Data)] = [
+            (chatId: "chat-1", data: Data("test1".utf8)),
+            (chatId: "chat-2", data: Data("test2".utf8))
+        ]
+        try handler.putChats(chats)
+
+        XCTAssertEqual(mockDataStore.putChatsCallCount, 1)
+        XCTAssertEqual(mockDataStore.lastPutChats?.count, 2)
+        XCTAssertEqual(mockDataStore.lastPutChats?[0].chatId, "chat-1")
+        XCTAssertEqual(mockDataStore.lastPutChats?[1].chatId, "chat-2")
     }
 
     func testWhenDeleteChatThenDelegatesToDataStore() throws {
@@ -222,6 +243,9 @@ private final class MockDuckAiNativeDataStore: DuckAiNativeDataStoring {
     var lastPutChatId: String?
     var lastPutChatData: Data?
 
+    var putChatsCallCount = 0
+    var lastPutChats: [(chatId: String, data: Data)]?
+
     var getAllChatsCallCount = 0
     var stubbedChats: [DuckAiChatRecord] = []
 
@@ -250,6 +274,11 @@ private final class MockDuckAiNativeDataStore: DuckAiNativeDataStoring {
         putChatCallCount += 1
         lastPutChatId = chatId
         lastPutChatData = data
+    }
+
+    func putChats(_ chats: [(chatId: String, data: Data)]) throws {
+        putChatsCallCount += 1
+        lastPutChats = chats
     }
 
     func getAllChats() throws -> [DuckAiChatRecord] {

--- a/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeStorageUserScriptTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeStorageUserScriptTests.swift
@@ -61,6 +61,7 @@ private final class MockDuckAiNativeStorageHandler: DuckAiNativeStorageHandling 
     func deleteAllSettings() throws {}
     func replaceAllSettings(_ settings: [String: Any]) throws {}
     func putChat(chatId: String, data: Data) throws {}
+    func putChats(_ chats: [(chatId: String, data: Data)]) throws {}
     func getAllChats() throws -> [DuckAiChatRecord] { [] }
     func deleteChat(chatId: String) throws {}
     func deleteAllChats() throws {}
@@ -69,6 +70,6 @@ private final class MockDuckAiNativeStorageHandler: DuckAiNativeStorageHandling 
     func listFiles() throws -> [DuckAiFileMetadata] { [] }
     func deleteFile(uuid: String) throws {}
     func deleteAllFiles() throws {}
-    func isMigrationDone() throws -> Bool { false }
-    func markMigrationDone() throws {}
+    func isMigrationDone(for key: String) throws -> Bool { false }
+    func markMigrationDone(for key: String) throws {}
 }

--- a/SharedPackages/BrowserServicesKit/Sources/DuckAiDataStore/DuckAiNativeDataStore.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DuckAiDataStore/DuckAiNativeDataStore.swift
@@ -103,6 +103,19 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
         }
     }
 
+    public func putChats(_ chats: [(chatId: String, data: Data)]) throws {
+        do {
+            try dbQueue.write { db in
+                for chat in chats {
+                    let record = ChatRecord(chatId: chat.chatId, data: chat.data)
+                    try record.save(db)
+                }
+            }
+        } catch {
+            throw DuckAiNativeDataStoreError.databaseError(error)
+        }
+    }
+
     public func getAllChats() throws -> [DuckAiChatRecord] {
         do {
             return try dbQueue.read { db in

--- a/SharedPackages/BrowserServicesKit/Sources/DuckAiDataStore/DuckAiNativeDataStoring.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DuckAiDataStore/DuckAiNativeDataStoring.swift
@@ -23,6 +23,7 @@ public protocol DuckAiNativeDataStoring {
     // MARK: - Chats
 
     func putChat(chatId: String, data: Data) throws
+    func putChats(_ chats: [(chatId: String, data: Data)]) throws
     func getAllChats() throws -> [DuckAiChatRecord]
     func deleteChat(chatId: String) throws
     func deleteAllChats() throws

--- a/SharedPackages/BrowserServicesKit/Tests/DuckAiDataStoreTests/DuckAiNativeDataStoreChatsTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DuckAiDataStoreTests/DuckAiNativeDataStoreChatsTests.swift
@@ -66,6 +66,44 @@ final class DuckAiNativeDataStoreChatsTests: XCTestCase {
         XCTAssertEqual(chats.first, DuckAiChatRecord(chatId: chatId, data: updatedData))
     }
 
+    func testWhenPutChatsThenGetAllChatsReturnsAll() throws {
+        let chats: [(chatId: String, data: Data)] = [
+            (chatId: "chat-1", data: Data("data1".utf8)),
+            (chatId: "chat-2", data: Data("data2".utf8)),
+            (chatId: "chat-3", data: Data("data3".utf8))
+        ]
+
+        try sut.putChats(chats)
+
+        let result = try sut.getAllChats()
+        XCTAssertEqual(result.count, 3)
+        XCTAssertEqual(result.map(\.chatId).sorted(), ["chat-1", "chat-2", "chat-3"])
+    }
+
+    func testWhenPutChatsWithExistingIdsThenTheyAreUpdated() throws {
+        try sut.putChat(chatId: "chat-1", data: Data("old".utf8))
+
+        let chats: [(chatId: String, data: Data)] = [
+            (chatId: "chat-1", data: Data("new".utf8)),
+            (chatId: "chat-2", data: Data("data2".utf8))
+        ]
+        try sut.putChats(chats)
+
+        let result = try sut.getAllChats()
+        XCTAssertEqual(result.count, 2)
+        let chat1 = result.first { $0.chatId == "chat-1" }
+        XCTAssertEqual(chat1?.data, Data("new".utf8))
+    }
+
+    func testWhenPutChatsWithEmptyArrayThenNothingChanges() throws {
+        try sut.putChat(chatId: "chat-1", data: Data("data".utf8))
+
+        try sut.putChats([])
+
+        let result = try sut.getAllChats()
+        XCTAssertEqual(result.count, 1)
+    }
+
     func testWhenDeleteChatThenItIsRemoved() throws {
         let chatId = "chat-1"
         let data = Data("hello".utf8)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201188456623839/task/1213798746286978?focus=true
Tech Design URL:
CC:

### Description
Adds native-side support for the frontend-driven chat/file migration (Approach 1). Migration tracking is now per-key (`isMigrationDone("chats")` / `markMigrationDone("files")`) so chats and files can be migrated independently. A new bulk `putChats` endpoint writes all chats in a single GRDB transaction for efficient Phase 1 migration.

### Testing Steps
1. Verify `isMigrationDone({key: "chats"})` returns false initially, and `markMigrationDone({key: "chats"})` sets only the "chats" flag without affecting "files".
2. Call `putChats({chats: [{chatId: "1", data: {...}}, {chatId: "2", data: {...}}]})` and verify all chats are persisted via `getAllChats`.
3. Run AIChat unit tests: `xcodebuild test -scheme AIChat-Package -destination "platform=iOS Simulator,..." -only-testing AIChatTests/DuckAiNativeStorageHandlerTests -only-testing AIChatTests/DuckAiNativeStorageUserScriptTests`

### Impact and Risks
Low — additive changes to existing native storage bridge; no existing behavior is altered for production users since the feature is behind the `duckAiNativeStorage` feature flag.

#### What could go wrong?
If the frontend sends the old parameterless `isMigrationDone()` call before updating, it would get a false response (safe default).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new bulk chat write path and changes the persisted `migrationDone` value from a single `Bool` to JSON `Data`, which could affect migration/backwards-compatibility if older callers or stored values are present.
> 
> **Overview**
> Adds a bulk `putChats` native-storage API (and user script message) to persist multiple chats in one operation, with `DuckAiNativeDataStore.putChats` writing them in a single GRDB transaction.
> 
> Updates migration tracking from a single global flag to **per-key** flags (`isMigrationDone(for:)` / `markMigrationDone(for:)`) by storing a `[String: Bool]` map serialized as `Data` under the existing `migrationDone` storage key. Tests are expanded to cover bulk chat writes and independent migration flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c61b3582b5171f849a9951d317e1ebe8f2234b5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->