### PR TITLE
[macOS] Fire shared onboarding pixels in contextual onboarding

### DIFF
--- a/SharedPackages/Onboarding/Sources/Onboarding/ContextualDaxDialogs/OnboardingSuggestionsViewModel.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/ContextualDaxDialogs/OnboardingSuggestionsViewModel.swift
@@ -26,13 +26,16 @@ public protocol OnboardingNavigationDelegate: AnyObject {
 public struct OnboardingSearchSuggestionsViewModel {
     let suggestedSearchesProvider: OnboardingSuggestionsItemsProviding
     public weak var delegate: OnboardingNavigationDelegate?
+    let onSuggestionPressed: (() -> Void)?
 
     public init(
         suggestedSearchesProvider: OnboardingSuggestionsItemsProviding,
-        delegate: OnboardingNavigationDelegate? = nil
+        delegate: OnboardingNavigationDelegate? = nil,
+        onSuggestionPressed: (() -> Void)? = nil
     ) {
         self.suggestedSearchesProvider = suggestedSearchesProvider
         self.delegate = delegate
+        self.onSuggestionPressed = onSuggestionPressed
     }
 
     public var itemsList: [ContextualOnboardingListItem] {
@@ -41,21 +44,25 @@ public struct OnboardingSearchSuggestionsViewModel {
 
     public func listItemPressed(_ item: ContextualOnboardingListItem) {
         delegate?.searchFromOnboarding(for: item.title)
+        onSuggestionPressed?()
     }
 }
 
 public struct OnboardingSiteSuggestionsViewModel {
     let suggestedSitesProvider: OnboardingSuggestionsItemsProviding
     public weak var delegate: OnboardingNavigationDelegate?
+    let onSuggestionPressed: (() -> Void)?
 
     public init(
         title: String,
         suggestedSitesProvider: OnboardingSuggestionsItemsProviding,
-        delegate: OnboardingNavigationDelegate? = nil
-) {
+        delegate: OnboardingNavigationDelegate? = nil,
+        onSuggestionPressed: (() -> Void)? = nil
+    ) {
         self.title = title
         self.suggestedSitesProvider = suggestedSitesProvider
         self.delegate = delegate
+        self.onSuggestionPressed = onSuggestionPressed
     }
 
     public let title: String
@@ -67,5 +74,6 @@ public struct OnboardingSiteSuggestionsViewModel {
     public func listItemPressed(_ item: ContextualOnboardingListItem) {
         guard let url = URL(string: item.title) else { return }
         delegate?.navigateFromOnboarding(to: url)
+        onSuggestionPressed?()
     }
 }

--- a/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
@@ -96,7 +96,7 @@ final public class OnboardingSharedPixelHandler: OnboardingSharedPixelHandling {
 
 }
 
-public enum OnboardingSharedPixelEvent: PixelKitEvent {
+public enum OnboardingSharedPixelEvent: PixelKitEvent, Equatable {
     // Linear onboarding events
     case welcome(EngagementEvent)
     case setDefault(EngagementEvent)
@@ -114,7 +114,7 @@ public enum OnboardingSharedPixelEvent: PixelKitEvent {
     case fireButton(EngagementEvent)
     case end(EngagementEvent)
 
-    public enum EngagementEvent {
+    public enum EngagementEvent: Equatable {
         public enum Value: String {
             case engage
             case dismiss
@@ -124,7 +124,7 @@ public enum OnboardingSharedPixelEvent: PixelKitEvent {
         case clicked(Value)
     }
 
-    public enum SearchExperienceEvent {
+    public enum SearchExperienceEvent: Equatable {
         public enum Value: String {
             case searchOnly = "search_only"
             case searchPlusDuckAI = "search_plus_duckai"
@@ -134,7 +134,7 @@ public enum OnboardingSharedPixelEvent: PixelKitEvent {
         case clicked(Value)
     }
 
-    public enum SuggestedOrCustomEvent {
+    public enum SuggestedOrCustomEvent: Equatable {
         public enum Value: String {
             case suggested
             case custom
@@ -145,7 +145,7 @@ public enum OnboardingSharedPixelEvent: PixelKitEvent {
         case clicked(Value)
     }
 
-    public enum CustomizeEvent {
+    public enum CustomizeEvent: Equatable {
         public enum Value: String {
             case bookmarksBar = "bookmarks_bar"
             case restoreSession = "restore_session"

--- a/SharedPackages/Onboarding/Sources/OnboardingTests/OnboardingSuggestionsViewModelsTests.swift
+++ b/SharedPackages/Onboarding/Sources/OnboardingTests/OnboardingSuggestionsViewModelsTests.swift
@@ -24,12 +24,14 @@ final class OnboardingSuggestionsViewModelsTests: XCTestCase {
     var navigationDelegate: CapturingOnboardingNavigationDelegate!
     var searchSuggestionsVM: OnboardingSearchSuggestionsViewModel!
     var siteSuggestionsVM: OnboardingSiteSuggestionsViewModel!
+    var onSuggestionPressedCalled: Bool = false
 
     override func setUp() {
         suggestionsProvider = MockOnboardingSuggestionsProvider()
         navigationDelegate = CapturingOnboardingNavigationDelegate()
-        searchSuggestionsVM = OnboardingSearchSuggestionsViewModel(suggestedSearchesProvider: suggestionsProvider, delegate: navigationDelegate)
-        siteSuggestionsVM = OnboardingSiteSuggestionsViewModel(title: "", suggestedSitesProvider: suggestionsProvider, delegate: navigationDelegate)
+        let onSuggestionPressed = { self.onSuggestionPressedCalled = true }
+        searchSuggestionsVM = OnboardingSearchSuggestionsViewModel(suggestedSearchesProvider: suggestionsProvider, delegate: navigationDelegate, onSuggestionPressed: onSuggestionPressed)
+        siteSuggestionsVM = OnboardingSiteSuggestionsViewModel(title: "", suggestedSitesProvider: suggestionsProvider, delegate: navigationDelegate, onSuggestionPressed: onSuggestionPressed)
     }
 
     override func tearDown() {
@@ -37,6 +39,7 @@ final class OnboardingSuggestionsViewModelsTests: XCTestCase {
         navigationDelegate = nil
         searchSuggestionsVM = nil
         siteSuggestionsVM = nil
+        onSuggestionPressedCalled = false
     }
 
     func testSearchSuggestionsViewModelReturnsExpectedSuggestionsList() {
@@ -51,7 +54,7 @@ final class OnboardingSuggestionsViewModelsTests: XCTestCase {
         XCTAssertEqual(searchSuggestionsVM.itemsList, expectedSearchList)
     }
 
-    func testSearchSuggestionsViewModelOnListItemPressed_AsksDelegateToSearchForQuery() {
+    func testSearchSuggestionsViewModelOnListItemPressed_AsksDelegateToSearchForQuery_AndCallsOnSuggestionPressed() {
         // GIVEN
         let item1 = ContextualOnboardingListItem.search(title: "search something")
         let item2 = ContextualOnboardingListItem.surprise(title: "search something else", visibleTitle: "Surprise Me!")
@@ -63,6 +66,7 @@ final class OnboardingSuggestionsViewModelsTests: XCTestCase {
 
         // THEN
         XCTAssertEqual(navigationDelegate.suggestedSearchQuery, randomItem.title)
+        XCTAssertTrue(onSuggestionPressedCalled)
     }
 
     func testSiteSuggestionsViewModelReturnsExpectedSuggestionsList() {
@@ -77,7 +81,7 @@ final class OnboardingSuggestionsViewModelsTests: XCTestCase {
         XCTAssertEqual(siteSuggestionsVM.itemsList, expectedSiteList)
     }
 
-    func testSiteSuggestionsViewModelOnListItemPressed_AsksDelegateToNavigateToURL() {
+    func testSiteSuggestionsViewModelOnListItemPressed_AsksDelegateToNavigateToURL_AndCallsOnSuggestionPressed() {
         // GIVEN
         let item1 = ContextualOnboardingListItem.site(title: "somesite.com")
         let item2 = ContextualOnboardingListItem.surprise(title: "someothersite.com", visibleTitle: "Surprise Me!")
@@ -90,6 +94,7 @@ final class OnboardingSuggestionsViewModelsTests: XCTestCase {
         // THEN
         XCTAssertNotNil(navigationDelegate.urlToNavigateTo)
         XCTAssertEqual(navigationDelegate.urlToNavigateTo, URL(string: randomItem.title))
+        XCTAssertTrue(onSuggestionPressedCalled)
     }
 }
 

--- a/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/ContextualDaxDialogsFactory.swift
+++ b/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/ContextualDaxDialogsFactory.swift
@@ -74,7 +74,11 @@ struct DefaultContextualDaxDialogViewFactory: ContextualDaxDialogsFactory {
     private func searchDoneDialog(shouldFollowUp: Bool, delegate: OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onSuggestionPressed: @escaping () -> Void) -> some View {
         let suggestedSitesProvider = OnboardingSuggestedSitesProvider(surpriseItemTitle: OnboardingSuggestedSitesProvider.surpriseItemTitle)
         let viewModel = OnboardingSiteSuggestionsViewModel(title: "", suggestedSitesProvider: suggestedSitesProvider, delegate: delegate, onSuggestionPressed: onSuggestionPressed)
-        let gotIt = shouldFollowUp ? onGotItPressed : onDismiss
+        let onDismissGotIt = {
+            onboardingPixelReporter.measureGotItPressed(dialogType: .searchDone(shouldFollowUp: shouldFollowUp))
+            onDismiss()
+        }
+        let gotIt = shouldFollowUp ? onGotItPressed : onDismissGotIt
         return OnboardingFirstSearchDoneDialog(shouldFollowUp: shouldFollowUp, viewModel: viewModel, gotItAction: gotIt, onManualDismiss: onManualDismiss)
     }
 
@@ -85,7 +89,11 @@ struct DefaultContextualDaxDialogViewFactory: ContextualDaxDialogsFactory {
     }
 
     private func trackersDialog(message: NSAttributedString, shouldFollowUp: Bool, onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void) -> some View {
-        let gotIt = shouldFollowUp ? onGotItPressed : onDismiss
+        let onDismissGotIt = {
+            onboardingPixelReporter.measureGotItPressed(dialogType: .trackers(message: message, shouldFollowUp: shouldFollowUp))
+            onDismiss()
+        }
+        let gotIt = shouldFollowUp ? onGotItPressed : onDismissGotIt
         let viewModel = OnboardingFireButtonDialogViewModel(onboardingPixelReporter: onboardingPixelReporter, fireCoordinator: fireCoordinator, onDismiss: onDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: onFireButtonPressed)
         return OnboardingTrackersDoneDialog(shouldFollowUp: true, message: message, blockedTrackersCTAAction: gotIt, viewModel: viewModel, onManualDismiss: onManualDismiss)
     }

--- a/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/ContextualDaxDialogsFactory.swift
+++ b/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/ContextualDaxDialogsFactory.swift
@@ -21,7 +21,7 @@ import SwiftUI
 import Onboarding
 
 protocol ContextualDaxDialogsFactory {
-    func makeView(for type: ContextualDialogType, delegate: OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void) -> AnyView
+    func makeView(for type: ContextualDialogType, delegate: OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void, onSuggestionPressed: @escaping () -> Void) -> AnyView
 }
 
 struct DefaultContextualDaxDialogViewFactory: ContextualDaxDialogsFactory {
@@ -33,23 +33,24 @@ struct DefaultContextualDaxDialogViewFactory: ContextualDaxDialogsFactory {
         self.fireCoordinator = fireCoordinator
     }
 
-    func makeView(for type: ContextualDialogType, delegate: any OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void) -> AnyView {
+    func makeView(for type: ContextualDialogType, delegate: any OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void, onSuggestionPressed: @escaping () -> Void) -> AnyView {
         let dialogView: AnyView
         switch type {
         case .tryASearch:
-            dialogView = AnyView(tryASearchDialog(delegate: delegate, onDismiss: onDismiss))
+            dialogView = AnyView(tryASearchDialog(delegate: delegate, onDismiss: onDismiss, onManualDismiss: onManualDismiss, onSuggestionPressed: onSuggestionPressed))
         case .searchDone(shouldFollowUp: let shouldFollowUp):
-            dialogView = AnyView(searchDoneDialog(shouldFollowUp: shouldFollowUp, delegate: delegate, onDismiss: onDismiss, onGotItPressed: onGotItPressed))
+            dialogView = AnyView(searchDoneDialog(shouldFollowUp: shouldFollowUp, delegate: delegate, onDismiss: onDismiss, onManualDismiss: onManualDismiss, onGotItPressed: onGotItPressed, onSuggestionPressed: onSuggestionPressed))
         case .tryASite:
-            dialogView = AnyView(tryASiteDialog(delegate: delegate, onDismiss: onDismiss))
+            dialogView = AnyView(tryASiteDialog(delegate: delegate, onDismiss: onDismiss, onManualDismiss: onManualDismiss, onSuggestionPressed: onSuggestionPressed))
         case .trackers(message: let message, shouldFollowUp: let shouldFollowUp):
-            dialogView = AnyView(trackersDialog(message: message, shouldFollowUp: shouldFollowUp, onDismiss: onDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: onFireButtonPressed))
+            dialogView = AnyView(trackersDialog(message: message, shouldFollowUp: shouldFollowUp, onDismiss: onDismiss, onManualDismiss: onManualDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: onFireButtonPressed))
         case .tryFireButton:
-            dialogView = AnyView(tryFireButtonDialog(onDismiss: onDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: onFireButtonPressed))
+            dialogView = AnyView(tryFireButtonDialog(onDismiss: onDismiss, onManualDismiss: onManualDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: onFireButtonPressed))
         case .highFive:
-            dialogView = AnyView(highFiveDialog(onDismiss: onDismiss, onGotItPressed: onGotItPressed))
+            dialogView = AnyView(highFiveDialog(onDismiss: onDismiss, onManualDismiss: onManualDismiss, onGotItPressed: onGotItPressed))
             onboardingPixelReporter.measureLastDialogShown()
         }
+        onboardingPixelReporter.measureDialogShown(dialogType: type)
         let adjustedView = {
             HStack {
                 Spacer()
@@ -64,42 +65,42 @@ struct DefaultContextualDaxDialogViewFactory: ContextualDaxDialogsFactory {
         return AnyView(viewWithBackground)
     }
 
-    private func tryASearchDialog(delegate: OnboardingNavigationDelegate, onDismiss: @escaping () -> Void) -> some View {
+    private func tryASearchDialog(delegate: OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onSuggestionPressed: @escaping () -> Void) -> some View {
         let suggestedSearchedProvider = OnboardingSuggestedSearchesProvider()
-        let viewModel = OnboardingSearchSuggestionsViewModel(suggestedSearchesProvider: suggestedSearchedProvider, delegate: delegate)
-        return OnboardingTrySearchDialog(viewModel: viewModel, onManualDismiss: onDismiss)
+        let viewModel = OnboardingSearchSuggestionsViewModel(suggestedSearchesProvider: suggestedSearchedProvider, delegate: delegate, onSuggestionPressed: onSuggestionPressed)
+        return OnboardingTrySearchDialog(viewModel: viewModel, onManualDismiss: onManualDismiss)
     }
 
-    private func searchDoneDialog(shouldFollowUp: Bool, delegate: OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void) -> some View {
+    private func searchDoneDialog(shouldFollowUp: Bool, delegate: OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onSuggestionPressed: @escaping () -> Void) -> some View {
         let suggestedSitesProvider = OnboardingSuggestedSitesProvider(surpriseItemTitle: OnboardingSuggestedSitesProvider.surpriseItemTitle)
-        let viewModel = OnboardingSiteSuggestionsViewModel(title: "", suggestedSitesProvider: suggestedSitesProvider, delegate: delegate)
+        let viewModel = OnboardingSiteSuggestionsViewModel(title: "", suggestedSitesProvider: suggestedSitesProvider, delegate: delegate, onSuggestionPressed: onSuggestionPressed)
         let gotIt = shouldFollowUp ? onGotItPressed : onDismiss
-        return OnboardingFirstSearchDoneDialog(shouldFollowUp: shouldFollowUp, viewModel: viewModel, gotItAction: gotIt, onManualDismiss: onDismiss)
+        return OnboardingFirstSearchDoneDialog(shouldFollowUp: shouldFollowUp, viewModel: viewModel, gotItAction: gotIt, onManualDismiss: onManualDismiss)
     }
 
-    private func tryASiteDialog(delegate: OnboardingNavigationDelegate, onDismiss: @escaping () -> Void) -> some View {
+    private func tryASiteDialog(delegate: OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onSuggestionPressed: @escaping () -> Void) -> some View {
         let suggestedSitesProvider = OnboardingSuggestedSitesProvider(surpriseItemTitle: OnboardingSuggestedSitesProvider.surpriseItemTitle)
-        let viewModel = OnboardingSiteSuggestionsViewModel(title: "", suggestedSitesProvider: suggestedSitesProvider, delegate: delegate)
-        return OnboardingTryVisitingASiteDialog(viewModel: viewModel, onManualDismiss: onDismiss)
+        let viewModel = OnboardingSiteSuggestionsViewModel(title: "", suggestedSitesProvider: suggestedSitesProvider, delegate: delegate, onSuggestionPressed: onSuggestionPressed)
+        return OnboardingTryVisitingASiteDialog(viewModel: viewModel, onManualDismiss: onManualDismiss)
     }
 
-    private func trackersDialog(message: NSAttributedString, shouldFollowUp: Bool, onDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void) -> some View {
+    private func trackersDialog(message: NSAttributedString, shouldFollowUp: Bool, onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void) -> some View {
         let gotIt = shouldFollowUp ? onGotItPressed : onDismiss
         let viewModel = OnboardingFireButtonDialogViewModel(onboardingPixelReporter: onboardingPixelReporter, fireCoordinator: fireCoordinator, onDismiss: onDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: onFireButtonPressed)
-        return OnboardingTrackersDoneDialog(shouldFollowUp: true, message: message, blockedTrackersCTAAction: gotIt, viewModel: viewModel, onManualDismiss: onDismiss)
+        return OnboardingTrackersDoneDialog(shouldFollowUp: true, message: message, blockedTrackersCTAAction: gotIt, viewModel: viewModel, onManualDismiss: onManualDismiss)
     }
 
-    private func tryFireButtonDialog(onDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void) -> some View {
+    private func tryFireButtonDialog(onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void) -> some View {
         let viewModel = OnboardingFireButtonDialogViewModel(onboardingPixelReporter: onboardingPixelReporter, fireCoordinator: fireCoordinator, onDismiss: onDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: onFireButtonPressed)
-        return OnboardingFireDialog(viewModel: viewModel, onManualDismiss: onDismiss)
+        return OnboardingFireDialog(viewModel: viewModel, onManualDismiss: onManualDismiss)
     }
 
-    private func highFiveDialog(onDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void) -> some View {
+    private func highFiveDialog(onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void) -> some View {
         let action = {
             onDismiss()
             onGotItPressed()
         }
-        return OnboardingFinalDialog(highFiveAction: action, onManualDismiss: onDismiss)
+        return OnboardingFinalDialog(highFiveAction: action, onManualDismiss: onManualDismiss)
     }
 }
 

--- a/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/OnboardingPixelReporter.swift
+++ b/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/OnboardingPixelReporter.swift
@@ -31,7 +31,11 @@ protocol OnboardingAddressBarReporting: AnyObject {
 protocol OnboardingDialogsReporting: AnyObject {
     func measureLastDialogShown()
     func measureFireButtonTryIt()
+    func measureSuggestionPressed()
+    func measureDialogShown(dialogType: ContextualDialogType)
     func measureDialogDismissed(dialogType: ContextualDialogType)
+    func measureDialogManuallyDismissed(dialogType: ContextualDialogType)
+    func measureGotItPressed(dialogType: ContextualDialogType)
 }
 
 protocol OnboardingFireReporting: AnyObject {
@@ -43,14 +47,21 @@ final class OnboardingPixelReporter {
     private weak var onboardingStateProvider: (ContextualOnboardingDialogTypeProviding & ContextualOnboardingStateUpdater)?
     private let fire: (PixelKitEvent, PixelKit.Frequency) -> Void
     private let userDefaults: UserDefaults
+    private let sharedPixelHandler: OnboardingSharedPixelHandling
 
     init(onboardingStateProvider: ContextualOnboardingDialogTypeProviding & ContextualOnboardingStateUpdater
  = Application.appDelegate.onboardingContextualDialogsManager,
          userDefaults: UserDefaults = UserDefaults.standard,
-         fireAction: @escaping (PixelKitEvent, PixelKit.Frequency) -> Void = { event, frequency in PixelKit.fire(event, frequency: frequency) }) {
+         fireAction: @escaping (PixelKitEvent, PixelKit.Frequency) -> Void = { event, frequency in PixelKit.fire(event, frequency: frequency) },
+         onboardingSharedPixelHandler: OnboardingSharedPixelHandling = OnboardingSharedPixelHandler(
+            platform: .macOS,
+            installType: DefaultReinstallUserDetection(keyValueStore: Application.appDelegate.keyValueStore).isReinstallingUser ? .reinstall : .newInstall,
+            installDate: AppDelegate.firstLaunchDate
+         )) {
         self.onboardingStateProvider = onboardingStateProvider
         self.fire = fireAction
         self.userDefaults = userDefaults
+        self.sharedPixelHandler = onboardingSharedPixelHandler
     }
 }
 
@@ -64,9 +75,11 @@ extension OnboardingPixelReporter: OnboardingAddressBarReporting {
     func measureAddressBarTypedIn() {
         if onboardingStateProvider?.lastDialog == .tryASearch {
             fire(ContextualOnboardingPixel.onboardingSearchCustom, .uniqueByName)
+            sharedPixelHandler.fire(.search(.clicked(.custom)))
         }
         if onboardingStateProvider?.lastDialog == .tryASite {
             fire(ContextualOnboardingPixel.onboardingVisitSiteCustom, .uniqueByName)
+            sharedPixelHandler.fire(.visitSite(.clicked(.custom)))
         }
     }
 
@@ -107,11 +120,76 @@ extension OnboardingPixelReporter: OnboardingDialogsReporting {
         }
     }
 
+    func measureDialogManuallyDismissed(dialogType: ContextualDialogType) {
+        switch dialogType {
+        case .tryASearch:
+            sharedPixelHandler.fire(.search(.clicked(.dismiss)))
+        case .searchDone:
+            sharedPixelHandler.fire(.searchResults(.clicked(.dismiss)))
+        case .tryASite:
+            sharedPixelHandler.fire(.visitSite(.clicked(.dismiss)))
+        case .trackers:
+            sharedPixelHandler.fire(.trackersBlocked(.clicked(.dismiss)))
+        case .tryFireButton:
+            sharedPixelHandler.fire(.fireButton(.clicked(.dismiss)))
+        case .highFive:
+            sharedPixelHandler.fire(.end(.clicked(.dismiss)))
+        }
+    }
+
     func measureLastDialogShown() {
         fire(ContextualOnboardingPixel.onboardingFinished, .uniqueByName)
     }
 
     func measureFireButtonTryIt() {
         fire(ContextualOnboardingPixel.onboardingFireButtonTryItPressed, .uniqueByName)
+        sharedPixelHandler.fire(.fireButton(.clicked(.engage)))
+    }
+
+    func measureDialogShown(dialogType: ContextualDialogType) {
+        switch dialogType {
+        case .tryASearch:
+            sharedPixelHandler.fire(.search(.shown))
+        case .searchDone:
+            sharedPixelHandler.fire(.searchResults(.shown))
+        case .tryASite:
+            sharedPixelHandler.fire(.visitSite(.shown))
+        case .trackers:
+            sharedPixelHandler.fire(.trackersBlocked(.shown))
+        case .tryFireButton:
+            sharedPixelHandler.fire(.fireButton(.shown))
+        case .highFive:
+            sharedPixelHandler.fire(.end(.shown))
+        }
+    }
+
+    func measureGotItPressed(dialogType: ContextualDialogType) {
+        switch dialogType {
+        case .searchDone(let shouldFollowUp):
+            sharedPixelHandler.fire(.searchResults(.clicked(.engage)))
+            if shouldFollowUp {
+                sharedPixelHandler.fire(.visitSite(.shown))
+            }
+        case .trackers(_, let shouldFollowUp):
+            sharedPixelHandler.fire(.trackersBlocked(.clicked(.engage)))
+            if shouldFollowUp {
+                sharedPixelHandler.fire(.fireButton(.shown))
+            }
+        case .highFive:
+            sharedPixelHandler.fire(.end(.clicked(.engage)))
+        case .tryASearch,
+                .tryASite,
+                .tryFireButton:
+            break
+        }
+    }
+
+    func measureSuggestionPressed() {
+        if onboardingStateProvider?.lastDialog == .tryASearch {
+            sharedPixelHandler.fire(.search(.clicked(.suggested)))
+        }
+        if onboardingStateProvider?.lastDialog == .tryASite {
+            sharedPixelHandler.fire(.visitSite(.clicked(.suggested)))
+        }
     }
 }

--- a/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/Rebranding/ContextualDaxDialogsProvider.swift
+++ b/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/Rebranding/ContextualDaxDialogsProvider.swift
@@ -64,7 +64,7 @@ final class ContextualDaxDialogsProvider: ContextualDaxDialogsFactory {
         }
     }
 
-    func makeView(for type: ContextualDialogType, delegate: any OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void) -> AnyView {
-        factory.makeView(for: type, delegate: delegate, onDismiss: onDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: onFireButtonPressed)
+    func makeView(for type: ContextualDialogType, delegate: any OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void, onSuggestionPressed: @escaping () -> Void) -> AnyView {
+        factory.makeView(for: type, delegate: delegate, onDismiss: onDismiss, onManualDismiss: onManualDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: onFireButtonPressed, onSuggestionPressed: onSuggestionPressed)
     }
 }

--- a/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/Rebranding/RebrandedContextualDaxDialogsFactory.swift
+++ b/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/Rebranding/RebrandedContextualDaxDialogsFactory.swift
@@ -29,23 +29,24 @@ struct RebrandedContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
         self.fireCoordinator = fireCoordinator
     }
 
-    func makeView(for type: ContextualDialogType, delegate: any OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void) -> AnyView {
+    func makeView(for type: ContextualDialogType, delegate: any OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void, onSuggestionPressed: @escaping () -> Void) -> AnyView {
         let dialogView: AnyView
         switch type {
         case .tryASearch:
-            dialogView = AnyView(tryASearchDialog(delegate: delegate, onDismiss: onDismiss))
+            dialogView = AnyView(tryASearchDialog(delegate: delegate, onDismiss: onDismiss, onManualDismiss: onManualDismiss, onSuggestionPressed: onSuggestionPressed))
         case .searchDone(shouldFollowUp: let shouldFollowUp):
-            dialogView = AnyView(searchDoneDialog(shouldFollowUp: shouldFollowUp, delegate: delegate, onDismiss: onDismiss, onGotItPressed: onGotItPressed))
+            dialogView = AnyView(searchDoneDialog(shouldFollowUp: shouldFollowUp, delegate: delegate, onDismiss: onDismiss, onManualDismiss: onManualDismiss, onGotItPressed: onGotItPressed, onSuggestionPressed: onSuggestionPressed))
         case .tryASite:
-            dialogView = AnyView(tryASiteDialog(delegate: delegate, onDismiss: onDismiss))
+            dialogView = AnyView(tryASiteDialog(delegate: delegate, onDismiss: onDismiss, onManualDismiss: onManualDismiss, onSuggestionPressed: onSuggestionPressed))
         case .trackers(message: let message, shouldFollowUp: let shouldFollowUp):
-            dialogView = AnyView(trackersDialog(message: message, shouldFollowUp: shouldFollowUp, onDismiss: onDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: onFireButtonPressed))
+            dialogView = AnyView(trackersDialog(message: message, shouldFollowUp: shouldFollowUp, onDismiss: onDismiss, onManualDismiss: onManualDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: onFireButtonPressed))
         case .tryFireButton:
-            dialogView = AnyView(tryFireButtonDialog(onDismiss: onDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: onFireButtonPressed))
+            dialogView = AnyView(tryFireButtonDialog(onDismiss: onDismiss, onManualDismiss: onManualDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: onFireButtonPressed))
         case .highFive:
-            dialogView = AnyView(highFiveDialog(onDismiss: onDismiss, onGotItPressed: onGotItPressed))
+            dialogView = AnyView(highFiveDialog(onDismiss: onDismiss, onManualDismiss: onManualDismiss, onGotItPressed: onGotItPressed))
             onboardingPixelReporter.measureLastDialogShown()
         }
+        onboardingPixelReporter.measureDialogShown(dialogType: type)
 
         let adjustedView = HStack {
             Spacer()
@@ -80,41 +81,41 @@ struct RebrandedContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
 
     // MARK: - Private Dialog Builders
 
-    private func tryASearchDialog(delegate: OnboardingNavigationDelegate, onDismiss: @escaping () -> Void) -> some View {
+    private func tryASearchDialog(delegate: OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onSuggestionPressed: @escaping () -> Void) -> some View {
         let suggestedSearchesProvider = OnboardingSuggestedSearchesProvider()
-        let viewModel = OnboardingSearchSuggestionsViewModel(suggestedSearchesProvider: suggestedSearchesProvider, delegate: delegate)
-        return OnboardingRebranding.OnboardingTrySearchDialog(viewModel: viewModel, onManualDismiss: onDismiss)
+        let viewModel = OnboardingSearchSuggestionsViewModel(suggestedSearchesProvider: suggestedSearchesProvider, delegate: delegate, onSuggestionPressed: onSuggestionPressed)
+        return OnboardingRebranding.OnboardingTrySearchDialog(viewModel: viewModel, onManualDismiss: onManualDismiss)
     }
 
-    private func searchDoneDialog(shouldFollowUp: Bool, delegate: OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void) -> some View {
+    private func searchDoneDialog(shouldFollowUp: Bool, delegate: OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onSuggestionPressed: @escaping () -> Void) -> some View {
         let suggestedSitesProvider = OnboardingSuggestedSitesProvider(surpriseItemTitle: OnboardingSuggestedSitesProvider.surpriseItemTitle)
-        let viewModel = OnboardingSiteSuggestionsViewModel(title: "", suggestedSitesProvider: suggestedSitesProvider, delegate: delegate)
+        let viewModel = OnboardingSiteSuggestionsViewModel(title: "", suggestedSitesProvider: suggestedSitesProvider, delegate: delegate, onSuggestionPressed: onSuggestionPressed)
         let gotIt = shouldFollowUp ? onGotItPressed : onDismiss
-        return OnboardingRebranding.OnboardingSearchDoneDialog(shouldFollowUp: shouldFollowUp, viewModel: viewModel, gotItAction: gotIt, onManualDismiss: onDismiss)
+        return OnboardingRebranding.OnboardingSearchDoneDialog(shouldFollowUp: shouldFollowUp, viewModel: viewModel, gotItAction: gotIt, onManualDismiss: onManualDismiss)
     }
 
-    private func tryASiteDialog(delegate: OnboardingNavigationDelegate, onDismiss: @escaping () -> Void) -> some View {
+    private func tryASiteDialog(delegate: OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onSuggestionPressed: @escaping () -> Void) -> some View {
         let suggestedSitesProvider = OnboardingSuggestedSitesProvider(surpriseItemTitle: OnboardingSuggestedSitesProvider.surpriseItemTitle)
-        let viewModel = OnboardingSiteSuggestionsViewModel(title: "", suggestedSitesProvider: suggestedSitesProvider, delegate: delegate)
-        return OnboardingRebranding.OnboardingTrySiteDialog(viewModel: viewModel, onManualDismiss: onDismiss)
+        let viewModel = OnboardingSiteSuggestionsViewModel(title: "", suggestedSitesProvider: suggestedSitesProvider, delegate: delegate, onSuggestionPressed: onSuggestionPressed)
+        return OnboardingRebranding.OnboardingTrySiteDialog(viewModel: viewModel, onManualDismiss: onManualDismiss)
     }
 
-    private func trackersDialog(message: NSAttributedString, shouldFollowUp: Bool, onDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void) -> some View {
+    private func trackersDialog(message: NSAttributedString, shouldFollowUp: Bool, onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void) -> some View {
         let gotIt = shouldFollowUp ? onGotItPressed : onDismiss
         let viewModel = OnboardingFireButtonDialogViewModel(onboardingPixelReporter: onboardingPixelReporter, fireCoordinator: fireCoordinator, onDismiss: onDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: onFireButtonPressed)
-        return OnboardingRebranding.OnboardingTrackersBlockedDialog(shouldFollowUp: true, message: message, blockedTrackersCTAAction: gotIt, viewModel: viewModel, onManualDismiss: onDismiss)
+        return OnboardingRebranding.OnboardingTrackersBlockedDialog(shouldFollowUp: true, message: message, blockedTrackersCTAAction: gotIt, viewModel: viewModel, onManualDismiss: onManualDismiss)
     }
 
-    private func tryFireButtonDialog(onDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void) -> some View {
+    private func tryFireButtonDialog(onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void) -> some View {
         let viewModel = OnboardingFireButtonDialogViewModel(onboardingPixelReporter: onboardingPixelReporter, fireCoordinator: fireCoordinator, onDismiss: onDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: onFireButtonPressed)
-        return OnboardingRebranding.OnboardingFireDialog(viewModel: viewModel, onManualDismiss: onDismiss)
+        return OnboardingRebranding.OnboardingFireDialog(viewModel: viewModel, onManualDismiss: onManualDismiss)
     }
 
-    private func highFiveDialog(onDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void) -> some View {
+    private func highFiveDialog(onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void) -> some View {
         let action = {
             onDismiss()
             onGotItPressed()
         }
-        return OnboardingRebranding.OnboardingEndOfJourneyDialog(highFiveAction: action, onManualDismiss: onDismiss)
+        return OnboardingRebranding.OnboardingEndOfJourneyDialog(highFiveAction: action, onManualDismiss: onManualDismiss)
     }
 }

--- a/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/Rebranding/RebrandedContextualDaxDialogsFactory.swift
+++ b/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/Rebranding/RebrandedContextualDaxDialogsFactory.swift
@@ -90,7 +90,11 @@ struct RebrandedContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
     private func searchDoneDialog(shouldFollowUp: Bool, delegate: OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onSuggestionPressed: @escaping () -> Void) -> some View {
         let suggestedSitesProvider = OnboardingSuggestedSitesProvider(surpriseItemTitle: OnboardingSuggestedSitesProvider.surpriseItemTitle)
         let viewModel = OnboardingSiteSuggestionsViewModel(title: "", suggestedSitesProvider: suggestedSitesProvider, delegate: delegate, onSuggestionPressed: onSuggestionPressed)
-        let gotIt = shouldFollowUp ? onGotItPressed : onDismiss
+        let onDismissGotIt = {
+            onboardingPixelReporter.measureGotItPressed(dialogType: .searchDone(shouldFollowUp: shouldFollowUp))
+            onDismiss()
+        }
+        let gotIt = shouldFollowUp ? onGotItPressed : onDismissGotIt
         return OnboardingRebranding.OnboardingSearchDoneDialog(shouldFollowUp: shouldFollowUp, viewModel: viewModel, gotItAction: gotIt, onManualDismiss: onManualDismiss)
     }
 
@@ -101,7 +105,11 @@ struct RebrandedContextualDaxDialogsFactory: ContextualDaxDialogsFactory {
     }
 
     private func trackersDialog(message: NSAttributedString, shouldFollowUp: Bool, onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void) -> some View {
-        let gotIt = shouldFollowUp ? onGotItPressed : onDismiss
+        let onDismissGotIt = {
+            onboardingPixelReporter.measureGotItPressed(dialogType: .trackers(message: message, shouldFollowUp: shouldFollowUp))
+            onDismiss()
+        }
+        let gotIt = shouldFollowUp ? onGotItPressed : onDismissGotIt
         let viewModel = OnboardingFireButtonDialogViewModel(onboardingPixelReporter: onboardingPixelReporter, fireCoordinator: fireCoordinator, onDismiss: onDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: onFireButtonPressed)
         return OnboardingRebranding.OnboardingTrackersBlockedDialog(shouldFollowUp: true, message: message, blockedTrackersCTAAction: gotIt, viewModel: viewModel, onManualDismiss: onManualDismiss)
     }

--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -669,48 +669,18 @@ final class BrowserTabViewController: NSViewController {
         // once a dialog is presented we reset the is dismissed flag
         self.wasContextualOnboardingDialogDismissed = false
 
-        let onDismissAction: () -> Void = { [weak self] in
-            guard let self else { return }
-            // we mark the flag for dialog dismissed
-            wasContextualOnboardingDialogDismissed = true
-            delegate?.dismissViewHighlight()
-            self.removeChild(in: self.containerStackView, webViewContainer: webViewContainer)
-            if let lastDialog = onboardingDialogTypeProvider.lastDialog {
-                self.onboardingPixelReporter.measureDialogDismissed(dialogType: lastDialog)
-            }
-        }
-
-        let onManualDismissAction = { [weak self] in
-            guard let self else { return }
-            if let lastDialog = onboardingDialogTypeProvider.lastDialog {
-                onboardingPixelReporter.measureDialogManuallyDismissed(dialogType: lastDialog)
-            }
-            onDismissAction()
-        }
-
-        let onGotItPressed = { [weak self] in
-            guard let self else { return }
-
-            onboardingDialogTypeProvider.gotItPressed()
-            onboardingPixelReporter.measureGotItPressed(dialogType: dialogType)
-
-            let currentState = onboardingDialogTypeProvider.lastDialog
-
-            // Reset highlight animations
-            delegate?.dismissViewHighlight()
-
-            // Process state
-            if case .tryFireButton = currentState {
-                delegate?.highlightFireButton()
-            }
-        }
-
         let daxView = onboardingDialogFactory.makeView(
             for: dialogType,
             delegate: tab,
-            onDismiss: onDismissAction,
-            onManualDismiss: onManualDismissAction,
-            onGotItPressed: onGotItPressed,
+            onDismiss: { [weak self] in
+                self?.handleContextualOnboardingOnDismiss()
+            },
+            onManualDismiss: { [weak self] in
+                self?.handleContextualOnboardingOnManualDismiss()
+            },
+            onGotItPressed: { [weak self] in
+                self?.handleContextualOnboardingOnGotItPressed(dialogType: dialogType)
+            },
             onFireButtonPressed: { [weak delegate] in
                 delegate?.dismissViewHighlight()
             },
@@ -733,6 +703,32 @@ final class BrowserTabViewController: NSViewController {
             delegate?.highlightFireButton()
         } else if case .trackers = dialogType {
             delegate?.highlightPrivacyShield()
+        }
+    }
+
+    private func handleContextualOnboardingOnDismiss() {
+        wasContextualOnboardingDialogDismissed = true
+        delegate?.dismissViewHighlight()
+        removeChild(in: containerStackView, webViewContainer: webViewContainer)
+        if let lastDialog = onboardingDialogTypeProvider.lastDialog {
+            onboardingPixelReporter.measureDialogDismissed(dialogType: lastDialog)
+        }
+    }
+
+    private func handleContextualOnboardingOnManualDismiss() {
+        if let lastDialog = onboardingDialogTypeProvider.lastDialog {
+            onboardingPixelReporter.measureDialogManuallyDismissed(dialogType: lastDialog)
+        }
+        handleContextualOnboardingOnDismiss()
+    }
+
+    private func handleContextualOnboardingOnGotItPressed(dialogType: ContextualDialogType) {
+        onboardingDialogTypeProvider.gotItPressed()
+        onboardingPixelReporter.measureGotItPressed(dialogType: dialogType)
+        let currentState = onboardingDialogTypeProvider.lastDialog
+        delegate?.dismissViewHighlight()
+        if case .tryFireButton = currentState {
+            delegate?.highlightFireButton()
         }
     }
 

--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -680,10 +680,19 @@ final class BrowserTabViewController: NSViewController {
             }
         }
 
+        let onManualDismissAction = { [weak self] in
+            guard let self else { return }
+            if let lastDialog = onboardingDialogTypeProvider.lastDialog {
+                onboardingPixelReporter.measureDialogManuallyDismissed(dialogType: lastDialog)
+            }
+            onDismissAction()
+        }
+
         let onGotItPressed = { [weak self] in
             guard let self else { return }
 
             onboardingDialogTypeProvider.gotItPressed()
+            onboardingPixelReporter.measureGotItPressed(dialogType: dialogType)
 
             let currentState = onboardingDialogTypeProvider.lastDialog
 
@@ -700,9 +709,13 @@ final class BrowserTabViewController: NSViewController {
             for: dialogType,
             delegate: tab,
             onDismiss: onDismissAction,
+            onManualDismiss: onManualDismissAction,
             onGotItPressed: onGotItPressed,
             onFireButtonPressed: { [weak delegate] in
                 delegate?.dismissViewHighlight()
+            },
+            onSuggestionPressed: { [weak onboardingPixelReporter] in
+                onboardingPixelReporter?.measureSuggestionPressed()
             })
         let hostingController = NSHostingController(rootView: AnyView(daxView))
         insertChild(hostingController, in: containerStackView, at: 0)

--- a/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
+++ b/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
@@ -560,17 +560,19 @@ class CapturingDialogFactory: ContextualDaxDialogsFactory {
     private var onGotItPressed: (() -> Void)?
     private var onFireButtonPressed: (() -> Void)?
     private var onManualDismissPressed: (() -> Void)?
+    private var onSuggestionPressed: (() -> Void)?
 
     init(expectation: XCTestExpectation) {
         self.expectation = expectation
     }
 
-    func makeView(for type: ContextualDialogType, delegate: OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void) -> AnyView {
+    func makeView(for type: ContextualDialogType, delegate: OnboardingNavigationDelegate, onDismiss: @escaping () -> Void, onManualDismiss: @escaping () -> Void, onGotItPressed: @escaping () -> Void, onFireButtonPressed: @escaping () -> Void, onSuggestionPressed: @escaping () -> Void) -> AnyView {
         capturedType = type
         capturedDelegate = delegate
         self.onGotItPressed = onGotItPressed
         self.onFireButtonPressed = onFireButtonPressed
-        self.onManualDismissPressed = onDismiss
+        self.onManualDismissPressed = onManualDismiss
+        self.onSuggestionPressed = onSuggestionPressed
         expectation.fulfill()
         return AnyView(OnboardingFinalDialog(highFiveAction: {}, onManualDismiss: {}))
     }
@@ -585,6 +587,10 @@ class CapturingDialogFactory: ContextualDaxDialogsFactory {
 
     func performOnManualDismiss() {
         onManualDismissPressed?()
+    }
+
+    func performOnSuggestionPressed() {
+        onSuggestionPressed?()
     }
 
 }
@@ -619,7 +625,11 @@ private class CapturingOnboardingPixelReporter: OnboardingPixelReporting {
     var measureFireButtonTryItCalled = false
     var measureLastDialogShownCalled = false
     var measureSiteVisitedCalled = false
+    var measureSuggestionPressedCalled = false
     var dismissedDialog: ContextualDialogType?
+    var manuallyDismissedDialog: ContextualDialogType?
+    var shownDialog: ContextualDialogType?
+    var gotItPressedDialog: ContextualDialogType?
 
     func measureFireButtonSkipped() {
         measureFireButtonSkippedCalled = true
@@ -651,6 +661,22 @@ private class CapturingOnboardingPixelReporter: OnboardingPixelReporting {
 
     func measureDialogDismissed(dialogType: ContextualDialogType) {
         dismissedDialog = dialogType
+    }
+
+    func measureDialogManuallyDismissed(dialogType: ContextualDialogType) {
+        manuallyDismissedDialog = dialogType
+    }
+
+    func measureSuggestionPressed() {
+        measureSuggestionPressedCalled = true
+    }
+
+    func measureDialogShown(dialogType: ContextualDialogType) {
+        shownDialog = dialogType
+    }
+
+    func measureGotItPressed(dialogType: ContextualDialogType) {
+        gotItPressedDialog = dialogType
     }
 }
  private class DockCustomizerMock: DockCustomization {

--- a/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
+++ b/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
@@ -517,6 +517,57 @@ final class BrowserTabViewControllerOnboardingTests: XCTestCase {
         XCTAssertTrue(delegate.didCallDismissViewHighlight)
     }
 
+    func testWhenDialogSuggestionPressed_ThenPixelReporterMeasuresSuggestionPressed() throws {
+        // GIVEN
+        dialogProvider.dialog = .tryASearch
+        let url = URL.duckDuckGo
+        let delegate = BrowserTabViewControllerDelegateSpy()
+        viewController.delegate = delegate
+        tab.navigateFromOnboarding(to: url)
+        wait(for: [expectation], timeout: 3.0)
+        XCTAssertFalse(pixelReporter.measureSuggestionPressedCalled)
+
+        // WHEN
+        factory.performOnSuggestionPressed()
+
+        // THEN
+        XCTAssertTrue(pixelReporter.measureSuggestionPressedCalled)
+    }
+
+    func testWhenDialogManuallyDismissed_ThenPixelReporterMeasuresManuallyDismissed() throws {
+        // GIVEN
+        dialogProvider.dialog = .tryASearch
+        let url = URL.duckDuckGo
+        let delegate = BrowserTabViewControllerDelegateSpy()
+        viewController.delegate = delegate
+        tab.navigateFromOnboarding(to: url)
+        wait(for: [expectation], timeout: 3.0)
+        XCTAssertNil(pixelReporter.manuallyDismissedDialog)
+
+        // WHEN
+        factory.performOnManualDismiss()
+
+        // THEN
+        XCTAssertEqual(pixelReporter.manuallyDismissedDialog, .tryASearch)
+    }
+
+    func testWhenDialogGotItPressed_ThenPixelReporterMeasuresGotItPressed() {
+        // GIVEN
+        dialogProvider.dialog = .defaultSearchDone
+        let url = URL.duckDuckGo
+        let delegate = BrowserTabViewControllerDelegateSpy()
+        viewController.delegate = delegate
+        tab.navigateFromOnboarding(to: url)
+        wait(for: [expectation], timeout: 3.0)
+        XCTAssertNil(pixelReporter.gotItPressedDialog)
+
+        // WHEN
+        factory.performOnGotItPressed()
+
+        // THEN
+        XCTAssertEqual(pixelReporter.gotItPressedDialog, .defaultSearchDone)
+    }
+
 }
 
 class MockDialogsProvider: ContextualOnboardingDialogTypeProviding, ContextualOnboardingStateUpdater {

--- a/macOS/UnitTests/Onboarding/ContextualOnboarding/ContextualDaxDialogsFactoryTests.swift
+++ b/macOS/UnitTests/Onboarding/ContextualOnboarding/ContextualDaxDialogsFactoryTests.swift
@@ -66,15 +66,20 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
     func testWhenMakeViewForTryASearchThenOnboardingTrySearchDialogViewCreatedAndOnActionExpectedSearchOccurs() throws {
         // GIVEN
         let dialogType = ContextualDialogType.tryASearch
+        var onSuggestionPressedRun = false
+        let onSuggestionPressed = { onSuggestionPressedRun = true }
         var onDismissRun = false
         let onDismiss = { onDismissRun = true }
+        var onManualDismissRun = false
+        let onManualDismiss = { onManualDismissRun = true }
 
         // WHEN
-        let result = factory.makeView(for: dialogType, delegate: delegate, onDismiss: onDismiss, onGotItPressed: {}, onFireButtonPressed: {})
+        let result = factory.makeView(for: dialogType, delegate: delegate, onDismiss: onDismiss, onManualDismiss: onManualDismiss, onGotItPressed: {}, onFireButtonPressed: {}, onSuggestionPressed: onSuggestionPressed)
 
         // THEN
         let view = try XCTUnwrap(find(OnboardingTrySearchDialog.self, in: result))
         XCTAssertTrue(view.viewModel.delegate === delegate)
+        XCTAssertEqual(reporter.shownDialog, dialogType)
 
         // WHEN
         let query = "some search"
@@ -84,7 +89,9 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         // THEN
         XCTAssertTrue(delegate.didCallSearchFor)
         XCTAssertEqual(delegate.capturedQuery, query)
-        XCTAssertTrue(onDismissRun)
+        XCTAssertTrue(onSuggestionPressedRun)
+        XCTAssertFalse(onDismissRun)
+        XCTAssertTrue(onManualDismissRun)
     }
 
     func testWhenMakeViewForSearchDoneWithShouldFollowUpThenOnboardingsearchDoneViewCreatedAndOnActionNothingOccurs() throws {
@@ -94,14 +101,17 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         let dialogType = ContextualDialogType.searchDone(shouldFollowUp: true)
         let onDismiss = { onDismissRun = true }
         let onGotItPressed = { onGotItPressedRun = true }
+        var onManualDismissRun = false
+        let onManualDismiss = { onManualDismissRun = true }
 
         // WHEN
-        let result = factory.makeView(for: dialogType, delegate: delegate, onDismiss: onDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: {})
+        let result = factory.makeView(for: dialogType, delegate: delegate, onDismiss: onDismiss, onManualDismiss: onManualDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: {}, onSuggestionPressed: {})
 
         // THEN
         let view = try XCTUnwrap(find(OnboardingFirstSearchDoneDialog.self, in: result))
         let subView = find(OnboardingTryVisitingSiteDialogContent.self, in: result)
         XCTAssertNil(subView)
+        XCTAssertEqual(reporter.shownDialog, dialogType)
 
         // WHEN
         view.gotItAction()
@@ -115,7 +125,8 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         view.onManualDismiss()
 
         // THEN
-        XCTAssertTrue(onDismissRun)
+        XCTAssertFalse(onDismissRun)
+        XCTAssertTrue(onManualDismissRun)
     }
 
     func testWhenMakeViewForSearchDoneWithoutShouldFollowUpThenOnboardingsearchDoneViewCreatedAndOnActionOccurs() throws {
@@ -125,14 +136,17 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         let dialogType = ContextualDialogType.searchDone(shouldFollowUp: false)
         let onDismiss = { onDismissRun = true }
         let onGotItPressed = { onGotItPressedRun = true }
+        var onManualDismissRun = false
+        let onManualDismiss = { onManualDismissRun = true }
 
         // WHEN
-        let result = factory.makeView(for: dialogType, delegate: delegate, onDismiss: onDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: {})
+        let result = factory.makeView(for: dialogType, delegate: delegate, onDismiss: onDismiss, onManualDismiss: onManualDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: {}, onSuggestionPressed: {})
 
         // THEN
         let view = try XCTUnwrap(find(OnboardingFirstSearchDoneDialog.self, in: result))
         let subView = find(OnboardingTryVisitingSiteDialogContent.self, in: result)
         XCTAssertNil(subView)
+        XCTAssertEqual(reporter.shownDialog, dialogType)
 
         // WHEN
         view.gotItAction()
@@ -140,20 +154,26 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         // THEN
         XCTAssertTrue(onDismissRun)
         XCTAssertFalse(onGotItPressedRun)
+        XCTAssertFalse(onManualDismissRun)
     }
 
     func testWhenMakeViewForTryASiteThenOnboardingTrySiteDialogViewCreatedAndOnActionExpectedSearchOccurs() throws {
         // GIVEN
         let dialogType = ContextualDialogType.tryASite
+        var onSuggestionPressedRun = false
+        let onSuggestionPressed = { onSuggestionPressedRun = true }
         var onDismissRun = false
         let onDismiss = { onDismissRun = true }
+        var onManualDismissRun = false
+        let onManualDismiss = { onManualDismissRun = true }
 
         // WHEN
-        let result = factory.makeView(for: dialogType, delegate: delegate, onDismiss: onDismiss, onGotItPressed: {}, onFireButtonPressed: {})
+        let result = factory.makeView(for: dialogType, delegate: delegate, onDismiss: onDismiss, onManualDismiss: onManualDismiss, onGotItPressed: {}, onFireButtonPressed: {}, onSuggestionPressed: onSuggestionPressed)
 
         // THEN
         let view = try XCTUnwrap(find(OnboardingTryVisitingASiteDialog.self, in: result))
         XCTAssertTrue(view.viewModel.delegate === delegate)
+        XCTAssertEqual(reporter.shownDialog, dialogType)
 
         // WHEN
         let urlString = "some.site"
@@ -163,7 +183,9 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         // THEN
         XCTAssertTrue(delegate.didNavigateToCalled)
         XCTAssertEqual(delegate.capturedUrlString, urlString)
-        XCTAssertTrue(onDismissRun)
+        XCTAssertTrue(onSuggestionPressedRun)
+        XCTAssertFalse(onDismissRun)
+        XCTAssertTrue(onManualDismissRun)
     }
 
     func testWhenMakeViewForTrackerBlockerWithShouldFollowUpThenTrackerBlockerViewCreatedAndOnActionNothingOccurs() throws {
@@ -174,20 +196,24 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         let dialogType = ContextualDialogType.trackers(message: trackerMessage, shouldFollowUp: true)
         let onDismiss = { onDismissRun = true }
         let onGotItPressed = { onGotItPressedRun = true }
+        var onManualDismissRun = false
+        let onManualDismiss = { onManualDismissRun = true }
 
         // WHEN
-        let result = factory.makeView(for: dialogType, delegate: delegate, onDismiss: onDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: {})
+        let result = factory.makeView(for: dialogType, delegate: delegate, onDismiss: onDismiss, onManualDismiss: onManualDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: {}, onSuggestionPressed: {})
 
         // THEN
         let view = try XCTUnwrap(find(OnboardingTrackersDoneDialog.self, in: result))
         let subView = find(OnboardingFireButtonDialogContent.self, in: result)
         XCTAssertNil(subView)
+        XCTAssertEqual(reporter.shownDialog, dialogType)
 
         // WHEN
         view.blockedTrackersCTAAction()
 
         // THEN
         XCTAssertFalse(onDismissRun)
+        XCTAssertFalse(onManualDismissRun)
         XCTAssertTrue(onGotItPressedRun)
 
         // WHEN
@@ -195,7 +221,8 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         view.onManualDismiss()
 
         // THEN
-        XCTAssertTrue(onDismissRun)
+        XCTAssertFalse(onDismissRun)
+        XCTAssertTrue(onManualDismissRun)
     }
 
     func testWhenMakeViewForTrackerBlockerWithoutShouldFollowUpThenTrackerBlockerViewCreatedAndOnActionOccurs() throws {
@@ -206,20 +233,24 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         let dialogType = ContextualDialogType.trackers(message: trackerMessage, shouldFollowUp: false)
         let onDismiss = { onDismissRun = true }
         let onGotItPressed = { onGotItPressedRun = true }
+        var onManualDismissRun = false
+        let onManualDismiss = { onManualDismissRun = true }
 
         // WHEN
-        let result = factory.makeView(for: dialogType, delegate: delegate, onDismiss: onDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: {})
+        let result = factory.makeView(for: dialogType, delegate: delegate, onDismiss: onDismiss, onManualDismiss: onManualDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: {}, onSuggestionPressed: {})
 
         // THEN
         let view = try XCTUnwrap(find(OnboardingTrackersDoneDialog.self, in: result))
         let subView = find(OnboardingFireButtonDialogContent.self, in: result)
         XCTAssertNil(subView)
+        XCTAssertEqual(reporter.shownDialog, dialogType)
 
         // WHEN
         view.blockedTrackersCTAAction()
 
         // THEN
         XCTAssertTrue(onDismissRun)
+        XCTAssertFalse(onManualDismissRun)
         XCTAssertFalse(onGotItPressedRun)
     }
 
@@ -230,18 +261,22 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         let dialogType = ContextualDialogType.highFive
         let onDismiss = { onDismissRun = true }
         let onGotItPressed = { onGotItPressedRun = true }
+        var onManualDismissRun = false
+        let onManualDismiss = { onManualDismissRun = true }
 
         // WHEN
-        let result = factory.makeView(for: dialogType, delegate: delegate, onDismiss: onDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: {})
+        let result = factory.makeView(for: dialogType, delegate: delegate, onDismiss: onDismiss, onManualDismiss: onManualDismiss, onGotItPressed: onGotItPressed, onFireButtonPressed: {}, onSuggestionPressed: {})
 
         // THEN
         let view = try XCTUnwrap(find(OnboardingFinalDialog.self, in: result))
+        XCTAssertEqual(reporter.shownDialog, dialogType)
 
         // WHEN
         view.highFiveAction()
 
         // THEN
         XCTAssertTrue(onDismissRun)
+        XCTAssertFalse(onManualDismissRun)
         XCTAssertTrue(onGotItPressedRun)
 
         // WHEN
@@ -249,7 +284,8 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         view.onManualDismiss()
 
         // THEN
-        XCTAssertTrue(onDismissRun)
+        XCTAssertFalse(onDismissRun)
+        XCTAssertTrue(onManualDismissRun)
     }
 
     @MainActor
@@ -260,6 +296,8 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         let dialogType = ContextualDialogType.tryFireButton
         let onFireButtonPressed = { onFireButtonRun = true }
         let onDismiss = { onDismissRun = true }
+        var onManualDismissRun = false
+        let onManualDismiss = { onManualDismissRun = true }
 
         let mainViewController = MainViewController(
             tabCollectionViewModel: TabCollectionViewModel(tabCollection: TabCollection(tabs: [])),
@@ -281,10 +319,11 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         }
 
         // WHEN
-        let result = factory.makeView(for: dialogType, delegate: delegate, onDismiss: onDismiss, onGotItPressed: {}, onFireButtonPressed: onFireButtonPressed)
+        let result = factory.makeView(for: dialogType, delegate: delegate, onDismiss: onDismiss, onManualDismiss: onManualDismiss, onGotItPressed: {}, onFireButtonPressed: onFireButtonPressed, onSuggestionPressed: {})
 
         // THEN
         let view = try XCTUnwrap(find(OnboardingFireDialog.self, in: result))
+        XCTAssertEqual(reporter.shownDialog, dialogType)
 
         // WHEN
         window.isVisible = true
@@ -292,13 +331,16 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
 
         // THEN
         XCTAssertTrue(onFireButtonRun)
+        XCTAssertTrue(onDismissRun)
+        XCTAssertFalse(onManualDismissRun)
 
         // WHEN
         onDismissRun = false
         view.onManualDismiss()
 
         // THEN
-        XCTAssertTrue(onDismissRun)
+        XCTAssertFalse(onDismissRun)
+        XCTAssertTrue(onManualDismissRun)
     }
 
     func testWhenMakeViewForTryFireButtonAndSkipButtonIsPressedThenmeasureFireButtonSkippedCalled() throws {
@@ -306,20 +348,23 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         let dialogType = ContextualDialogType.highFive
 
         // WHEN
-        _=factory.makeView(for: dialogType, delegate: delegate, onDismiss: {}, onGotItPressed: {}, onFireButtonPressed: {})
+        _=factory.makeView(for: dialogType, delegate: delegate, onDismiss: {}, onManualDismiss: {}, onGotItPressed: {}, onFireButtonPressed: {}, onSuggestionPressed: {})
 
         // THEN
         XCTAssertTrue(reporter.measureLastDialogShownCalled)
+        XCTAssertEqual(reporter.shownDialog, dialogType)
     }
 
 }
 
 class CapturingOnboardingPixelReporter: OnboardingPixelReporting {
+    
     var measureFireButtonSkippedCalled = false
     var measureFireButtonTryItCalled = false
     var measureLastDialogShownCalled = false
     var measureSiteVisitedCalled = false
     var dismissedDialog: ContextualDialogType?
+    var shownDialog: ContextualDialogType?
 
     func measureFireButtonSkipped() {
         measureFireButtonSkippedCalled = true
@@ -351,6 +396,19 @@ class CapturingOnboardingPixelReporter: OnboardingPixelReporting {
 
     func measureDialogDismissed(dialogType: ContextualDialogType) {
         dismissedDialog = dialogType
+    }
+
+    func measureDialogManuallyDismissed(dialogType: ContextualDialogType) {
+    }
+
+    func measureSuggestionPressed() {
+    }
+
+    func measureDialogShown(dialogType: ContextualDialogType) {
+        shownDialog = dialogType
+    }
+
+    func measureGotItPressed(dialogType: ContextualDialogType) {
     }
 }
 extension CapturingOnboardingNavigationDelegate: OnboardingNavigationDelegate {}

--- a/macOS/UnitTests/Onboarding/ContextualOnboarding/ContextualDaxDialogsFactoryTests.swift
+++ b/macOS/UnitTests/Onboarding/ContextualOnboarding/ContextualDaxDialogsFactoryTests.swift
@@ -154,6 +154,7 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         // THEN
         XCTAssertTrue(onDismissRun)
         XCTAssertFalse(onGotItPressedRun)
+        XCTAssertEqual(reporter.gotItPressedDialog, dialogType)
         XCTAssertFalse(onManualDismissRun)
     }
 
@@ -252,6 +253,7 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
         XCTAssertTrue(onDismissRun)
         XCTAssertFalse(onManualDismissRun)
         XCTAssertFalse(onGotItPressedRun)
+        XCTAssertEqual(reporter.gotItPressedDialog, dialogType)
     }
 
     func testWhenMakeViewForHighFiveThenFinalDialogViewCreatedAndOnActionExpectedSearchOccurs() throws {
@@ -364,6 +366,7 @@ class CapturingOnboardingPixelReporter: OnboardingPixelReporting {
     var measureSiteVisitedCalled = false
     var dismissedDialog: ContextualDialogType?
     var shownDialog: ContextualDialogType?
+    var gotItPressedDialog: ContextualDialogType?
 
     func measureFireButtonSkipped() {
         measureFireButtonSkippedCalled = true
@@ -408,6 +411,7 @@ class CapturingOnboardingPixelReporter: OnboardingPixelReporting {
     }
 
     func measureGotItPressed(dialogType: ContextualDialogType) {
+        gotItPressedDialog = dialogType
     }
 }
 extension CapturingOnboardingNavigationDelegate: OnboardingNavigationDelegate {}

--- a/macOS/UnitTests/Onboarding/ContextualOnboarding/ContextualDaxDialogsFactoryTests.swift
+++ b/macOS/UnitTests/Onboarding/ContextualOnboarding/ContextualDaxDialogsFactoryTests.swift
@@ -358,7 +358,6 @@ final class ContextualDaxDialogsFactoryTests: XCTestCase {
 }
 
 class CapturingOnboardingPixelReporter: OnboardingPixelReporting {
-    
     var measureFireButtonSkippedCalled = false
     var measureFireButtonTryItCalled = false
     var measureLastDialogShownCalled = false

--- a/macOS/UnitTests/Onboarding/ContextualOnboarding/OnboardingPixelReporterTests.swift
+++ b/macOS/UnitTests/Onboarding/ContextualOnboarding/OnboardingPixelReporterTests.swift
@@ -19,6 +19,7 @@
 import XCTest
 import PixelKit
 import Navigation
+import Onboarding
 import PrivacyDashboard
 @testable import DuckDuckGo_Privacy_Browser
 
@@ -29,14 +30,19 @@ final class OnboardingPixelReporterTests: XCTestCase {
     var eventSent: PixelKitEvent?
     var frequency: PixelKit.Frequency?
     var userDefaults: UserDefaults?
+    private var sharedPixelHandler: MockOnboardingSharedPixelHandler!
 
     override func setUpWithError() throws {
         onboardingState = MockContextualOnboardingState()
         userDefaults = UserDefaults(suiteName: "OnboardingPixelReporterTests") ?? UserDefaults.standard
-        reporter = OnboardingPixelReporter(onboardingStateProvider: onboardingState, userDefaults: userDefaults!, fireAction: { [weak self] event, frequency  in
+        sharedPixelHandler = MockOnboardingSharedPixelHandler()
+        reporter = OnboardingPixelReporter(onboardingStateProvider: onboardingState,
+                                           userDefaults: userDefaults!,
+                                           fireAction: { [weak self] event, frequency  in
             self?.eventSent = event
             self?.frequency = frequency
-        })
+        },
+                                           onboardingSharedPixelHandler: sharedPixelHandler)
     }
 
     override func tearDownWithError() throws {
@@ -46,6 +52,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         frequency = nil
         userDefaults?.removePersistentDomain(forName: "OnboardingPixelReporterTests")
         userDefaults = nil
+        sharedPixelHandler = nil
     }
 
     func test_WhenMeasureAddressBarTypedIn_ThenDependingOnTheState_CorrectPixelsAreSent() throws {
@@ -53,26 +60,43 @@ final class OnboardingPixelReporterTests: XCTestCase {
         reporter.measureAddressBarTypedIn()
         XCTAssertEqual(eventSent?.name, ContextualOnboardingPixel.onboardingSearchCustom.name)
         XCTAssertEqual(frequency, .uniqueByName)
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.search(.clicked(.custom))])
 
         eventSent = nil
         frequency = nil
+        sharedPixelHandler.reset()
         onboardingState.lastDialog = .tryASite
         reporter.measureAddressBarTypedIn()
         XCTAssertEqual(eventSent?.name, ContextualOnboardingPixel.onboardingVisitSiteCustom.name)
         XCTAssertEqual(frequency, .uniqueByName)
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.visitSite(.clicked(.custom))])
 
         eventSent = nil
         frequency = nil
+        sharedPixelHandler.reset()
         onboardingState.lastDialog = .highFive
         reporter.measureAddressBarTypedIn()
         XCTAssertNil(eventSent)
         XCTAssertNil(frequency)
+        XCTAssertTrue(sharedPixelHandler.eventsReceived.isEmpty)
+    }
+
+    func test_WhenMeasureSuggestionPressed_ThenDependingOnTheState_CorrectPixelsAreSent() {
+        onboardingState.lastDialog = .tryASearch
+        reporter.measureSuggestionPressed()
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.search(.clicked(.suggested))])
+
+        sharedPixelHandler.reset()
+        onboardingState.lastDialog = .tryASite
+        reporter.measureSuggestionPressed()
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.visitSite(.clicked(.suggested))])
     }
 
     func test_WhenMeasureFireButtonTryIt_ThenOnboardingFireButtonTryItPressedSent() {
         reporter.measureFireButtonTryIt()
         XCTAssertEqual(eventSent?.name, ContextualOnboardingPixel.onboardingFireButtonTryItPressed.name)
         XCTAssertEqual(frequency, .uniqueByName)
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.fireButton(.clicked(.engage))])
     }
 
     func test_WhenMeasureLastDialogShown_ThenOnboardingFinishedSent() {
@@ -93,9 +117,10 @@ final class OnboardingPixelReporterTests: XCTestCase {
         reporter.measureFireButtonPressed()
         XCTAssertNil(eventSent)
         XCTAssertNil(frequency)
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [])
     }
 
-    func test_WhenMeasurePrivacyDashboardOpened_AndOnboardingNotCompleted_ThenOnboardingFireButtonPressedSent() {
+    func test_WhenMeasurePrivacyDashboardOpened_AndOnboardingNotCompleted_ThenOnboardingPrivacyDashboardOpenedSent() {
         onboardingState.state = .ongoing
         reporter.measurePrivacyDashboardOpened()
         XCTAssertEqual(eventSent?.name, ContextualOnboardingPixel.onboardingPrivacyDashboardOpened.name)
@@ -107,6 +132,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         reporter.measurePrivacyDashboardOpened()
         XCTAssertNil(eventSent)
         XCTAssertNil(frequency)
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [])
     }
 
     func test_WhenMeasureSiteVisited_ThenSecondSiteVisitedSentOnlyTheSecondTime() {
@@ -119,6 +145,36 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(frequency, .uniqueByName)
         eventSent = nil
         frequency = nil
+    }
+
+    func test_WhenMeasureTrySearchShown_ThenSearchShownEventSent() throws {
+        reporter.measureDialogShown(dialogType: .tryASearch)
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.search(.shown)])
+    }
+
+    func test_WhenMeasureSearchResultShown_ThenSearchResultShownEventSent() throws {
+        reporter.measureDialogShown(dialogType: .defaultSearchDone)
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.searchResults(.shown)])
+    }
+
+    func test_WhenMeasureTryVisitSiteShown_ThenVisitSiteShownEventSent() throws {
+        reporter.measureDialogShown(dialogType: .tryASite)
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.visitSite(.shown)])
+    }
+
+    func test_WhenMeasureTrackersBlockedShown_ThenTrackersBlockedShownEventSent() throws {
+        reporter.measureDialogShown(dialogType: .defaultTrackers)
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.trackersBlocked(.shown)])
+    }
+
+    func test_WhenMeasureTryFireButtonShown_ThenFireButtonShownEventSent() throws {
+        reporter.measureDialogShown(dialogType: .tryFireButton)
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.fireButton(.shown)])
+    }
+
+    func test_WhenMeasureFinalShown_ThenEndShownEventSent() throws {
+        reporter.measureDialogShown(dialogType: .highFive)
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.end(.shown)])
     }
 
     func test_WhenMeasureTrySearchDismissed_ThenTrySearchDismissedEventSent() throws {
@@ -157,6 +213,36 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(frequency, .uniqueByName)
     }
 
+    func test_WhenMeasureTrySearchManuallyDismissed_ThenTrySearchDismissClickedEventSent() throws {
+        reporter.measureDialogManuallyDismissed(dialogType: .tryASearch)
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.search(.clicked(.dismiss))])
+    }
+
+    func test_WhenMeasureSearchResultManuallyDismissed_ThenSearchResultDismissClickedEventSent() throws {
+        reporter.measureDialogManuallyDismissed(dialogType: .defaultSearchDone)
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.searchResults(.clicked(.dismiss))])
+    }
+
+    func test_WhenMeasureTryVisitSiteManuallyDismissed_ThenTryVisitSiteDismissClickedEventSent() throws {
+        reporter.measureDialogManuallyDismissed(dialogType: .tryASite)
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.visitSite(.clicked(.dismiss))])
+    }
+
+    func test_WhenMeasureTrackersBlockedManuallyDismissed_ThenTrackersBlockedDismissClickedEventSent() throws {
+        reporter.measureDialogManuallyDismissed(dialogType: .defaultTrackers)
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.trackersBlocked(.clicked(.dismiss))])
+    }
+
+    func test_WhenMeasureTryFireButtonManuallyDismissed_ThenTryFireButtonDismissClickedEventSent() throws {
+        reporter.measureDialogManuallyDismissed(dialogType: .tryFireButton)
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.fireButton(.clicked(.dismiss))])
+    }
+
+    func test_WhenMeasureFinalManuallyDismissed_ThenFinalDialogDismissClickedEventSent() throws {
+        reporter.measureDialogManuallyDismissed(dialogType: .highFive)
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.end(.clicked(.dismiss))])
+    }
+
     // Tab Onboarding Pixel test
     @MainActor
     func test_WhenNavigationDidFinish_ThenReporterMeasureSiteVisitedCalled() {
@@ -166,6 +252,35 @@ final class OnboardingPixelReporterTests: XCTestCase {
         tab.navigationDidFinish(Navigation(identity: .expected, responders: .init(), state: .approved, isCurrent: true))
 
         XCTAssertTrue(capturingReporter.measureSiteVisitedCalled)
+    }
+
+    func test_WhenGotItPressed_OnSearchDoneDialog_ThenExpectedPixelsSent() {
+        reporter.measureGotItPressed(dialogType: .searchDone(shouldFollowUp: false))
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.searchResults(.clicked(.engage))])
+
+        sharedPixelHandler.reset()
+        reporter.measureGotItPressed(dialogType: .searchDone(shouldFollowUp: true))
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [
+            .searchResults(.clicked(.engage)),
+            .visitSite(.shown)
+        ])
+    }
+
+    func test_WhenGotItPressed_OnTrackersDialog_ThenExpectedPixelsSent() {
+        reporter.measureGotItPressed(dialogType: .trackers(message: .init(), shouldFollowUp: false))
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.trackersBlocked(.clicked(.engage))])
+
+        sharedPixelHandler.reset()
+        reporter.measureGotItPressed(dialogType: .trackers(message: .init(), shouldFollowUp: true))
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [
+            .trackersBlocked(.clicked(.engage)),
+            .fireButton(.shown)
+        ])
+    }
+
+    func test_WhenGotItPressed_OnFinalDialog_ThenEndClickedEngageEventSent() {
+        reporter.measureGotItPressed(dialogType: .highFive)
+        XCTAssertEqual(sharedPixelHandler.eventsReceived, [.end(.clicked(.engage))])
     }
 
 }
@@ -197,4 +312,16 @@ class MockContextualOnboardingState: ContextualOnboardingStateUpdater, Contextua
 
     func turnOffFeature() {}
 
+}
+
+private class MockOnboardingSharedPixelHandler: OnboardingSharedPixelHandling {
+    var eventsReceived: [OnboardingSharedPixelEvent] = []
+
+    func fire(_ event: OnboardingSharedPixelEvent) {
+        eventsReceived.append(event)
+    }
+
+    func reset() {
+        eventsReceived = []
+    }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1213981990940008?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1213629555566377?focus=true (pixel spec)
CC:

### Description

Updates the contextual onboarding flow (default and rebranded) to fire the new shared pixels related to contextual onboarding:

* New pixels are fired in `OnboardingPixelReporter` (when dialogs are shown or clicked to engage/dismiss), including new protocol methods to measure:
   * When a dialog is shown
   * When a suggestion is selected (from the list) in the "try search" or "visit site" dialogs
   * When a dialog is dismissed manually (as opposed to the current method that is called any time a dialog is dismissed, including automatically)
   * When a "Got it" button is pressed on a dialog
* Calls the new protocol methods where needed to measure each action

Note that all existing onboarding pixels are still fired, in addition to the shared onboarding pixels.

⚠️ Depends on https://github.com/duckduckgo/apple-browsers/pull/4357

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
**Onboarding flow engaging with dialogs:**
1. Build and run the app.
2. Debug -> Feature Flag Overrides -> Other -> disable `onboardingRebranding`
3. Debug -> Reset Data -> Reset Contextual Onboarding
4. Close and reopen the window or relaunch the app.
5. Confirm `m_mac_onboarding_search` is fired with parameters:
   * `e` = `shown`
   * `d` = days since you installed the app (if less than 28) - this should be included with the same value on all subsequent pixels
   * `it` = `new` or `reinstall` (depending on whether it is a new install or reinstall) - this should be included with the same value on all subsequent pixels
6. Click a suggested search or enter a custom search and confirm `m_mac_onboarding_search` is fired with `e` = `clicked` and `value` = `suggested`/`custom` (depending on which search you did)
7. When the next dialog is shown, confirm `m_mac_onboarding_search-results` is fired with `e` = `shown`
8. Click "Got it" and confirm `m_mac_onboarding_search-results` is fired with `e` = `clicked` and `value` = `engage`
9. When the next dialog is shown, confirm `m_mac_onboarding_visit-site` is fired with `e` = `shown`
10. Click a suggested site or enter a custom site URL and confirm `m_mac_onboarding_visit-site` is fired with `e` = `clicked` and `value` = `suggested`/`custom` (depending on which site you visited)
11. When the next dialog is shown, confirm `m_mac_onboarding_trackers-blocked ` is fired with `e` = `shown`
12. Click "Got it" and confirm `m_mac_onboarding_trackers-blocked` is fired with `e` = `clicked` and `value` = `engage`
13. When the next dialog is shown, confirm `m_mac_onboarding_fire-button` is fired with `e` = `shown`
14. Click "Try it" and confirm `m_mac_onboarding_fire-button` is fired with `e` = `clicked` and `value` = `engage`
15. Fire the tab/window/everything.
16. When the next dialog is shown, confirm `m_mac_onboarding_end` is fired with `e` = `shown`
17. Click "High five!" and confirm `m_mac_onboarding_end` with `e` = `clicked` and `value` = `engage`
18. Debug -> Feature Flag Overrides -> Other -> enable `onboardingRebranding`
19. Debug -> Reset Data -> Reset Contextual Onboarding
20. Close and reopen the window or relaunch the app.
21. Repeat steps 5-17 and confirm the same pixels are fired with the rebranded contextual onboarding flow.

**Onboarding flow dismissing dialogs:**
1. Build and run the app.
2. Debug -> Feature Flag Overrides -> Other -> disable `onboardingRebranding`
3. Debug -> Reset Data -> Reset Contextual Onboarding
4. Close and reopen the window or relaunch the app.
5. Confirm `m_mac_onboarding_search` is fired with parameters:
   * `e` = `shown`
   * `d` = days since you installed the app (if less than 28) - this should be included with the same value on all subsequent pixels
   * `it` = `new` or `reinstall` (depending on whether it is a new install or reinstall) - this should be included with the same value on all subsequent pixels
6. Click the "X" to dismiss the dialog and confirm `m_mac_onboarding_search` is fired with `e` = `clicked` and `value` = `dismiss`
7. Open a new tab and when the next dialog is shown, confirm `m_mac_onboarding_visit-site` is fired with `e` = `shown`
10. Click the "X" to dismiss the dialog and confirm `m_mac_onboarding_visit-site` is fired with `e` = `clicked` and `value` = `dismiss`
11. Visit a website and when the next dialog is shown, confirm `m_mac_onboarding_trackers-blocked ` is fired with `e` = `shown`
12. Click the "X" to dismiss the dialog and confirm `m_mac_onboarding_trackers-blocked` is fired with `e` = `clicked` and `value` = `dismiss`
13. Visit another website and when the next dialog is shown, confirm `m_mac_onboarding_fire-button` is fired with `e` = `shown`
14. Click the "X" to dismiss the dialog and confirm `m_mac_onboarding_fire-button` is fired with `e` = `clicked` and `value` = `dismiss`
16. Open a new tab and when the next dialog is shown, confirm `m_mac_onboarding_end` is fired with `e` = `shown`
17. Click the "X" to dismiss the dialog and confirm `m_mac_onboarding_end` with `e` = `clicked` and `value` = `dismiss`
18. Debug -> Feature Flag Overrides -> Other -> enable `onboardingRebranding`
19. Debug -> Reset Data -> Reset Contextual Onboarding
20. Close and reopen the window or relaunch the app.
21. Repeat steps 5-14 and confirm the same pixels are fired with the rebranded contextual onboarding flow.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
19. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
* Unit tests added to confirm expected pixels are fired
* Both default and rebranded dialogs are updated to use these pixels

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
* Privacy: Cross-platform privacy triage complete, pixel definitions and linear onboarding pixels to be added separately

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new contextual onboarding instrumentation and changes dialog callback wiring (shown/engage/dismiss/suggestion) across both legacy and rebranded flows, which could affect onboarding progression/dismiss behavior if miswired. Functional impact is mostly analytics, but it touches core `BrowserTabViewController` dialog handling.
> 
> **Overview**
> **Contextual onboarding now emits shared onboarding pixels** in addition to the existing macOS contextual pixels, covering dialog *shown*, *Got it/engage*, *manual dismiss*, and *suggestion selected* events.
> 
> This threads new callbacks (`onManualDismiss`, `onSuggestionPressed`) through `ContextualDaxDialogsFactory` (legacy + rebranded) and updates `BrowserTabViewController` to distinguish manual dismiss vs general dismiss and to report `Got it`/suggestion actions via `OnboardingPixelReporter`. Tests are expanded/added to validate the new callbacks and shared pixel events, and `OnboardingSharedPixelEvent` is made `Equatable` to support assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a93bacf987d2f3b6485d27430bf94caa1bb6f31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->