### PR TITLE
[macOS] Fire shared onboarding pixels in linear onboarding

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "90bff0962bf29ae21328a549d8ca30b1072dd9d53bf50e4cd116d155cc556f86",
+  "originHash" : "5732e4323d8c33ae56889a069891ba50b81de2b18346cdfb08300759c54aa142",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "56754c6e0fd58a76a78f2241b6e811d08cfbee84",
-        "version" : "13.37.0"
+        "revision" : "71bac704c43c64b70c96569e51836c3281946a3f",
+        "version" : "13.38.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -63,7 +63,7 @@ let package = Package(
         .package(url: "https://github.com/1024jp/GzipSwift.git", exact: "6.0.1"),
         .package(url: "https://github.com/vapor/jwt-kit.git", exact: "4.13.5"),
         .package(url: "https://github.com/pointfreeco/swift-clocks.git", exact: "1.0.6"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", exact: "13.37.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", exact: "13.38.0"),
         .package(path: "../URLPredictor"),
     ],
     targets: [

--- a/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
@@ -175,7 +175,14 @@ public extension OnboardingSharedPixelEvent {
     }
 
     var standardParameters: [PixelKitStandardParameter]? {
-        nil
+        switch self {
+        case .addToDock:
+            // Include pixel source for Add to Dock step, to measure engagement in macOS App Store vs DMG versions.
+            // The DMG step adds the app to the Dock programmatically while the App Store step only shows instructions.
+            return [.pixelSource]
+        default:
+            return nil
+        }
     }
 
     var error: NSError? {

--- a/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
@@ -96,7 +96,7 @@ final public class OnboardingSharedPixelHandler: OnboardingSharedPixelHandling {
 
 }
 
-public enum OnboardingSharedPixelEvent: PixelKitEvent {
+public enum OnboardingSharedPixelEvent: PixelKitEvent, Equatable {
     // Linear onboarding events
     case welcome(EngagementEvent)
     case setDefault(EngagementEvent)
@@ -114,7 +114,7 @@ public enum OnboardingSharedPixelEvent: PixelKitEvent {
     case fireButton(EngagementEvent)
     case end(EngagementEvent)
 
-    public enum EngagementEvent {
+    public enum EngagementEvent: Equatable {
         public enum Value: String {
             case engage
             case dismiss
@@ -124,7 +124,7 @@ public enum OnboardingSharedPixelEvent: PixelKitEvent {
         case clicked(Value)
     }
 
-    public enum SearchExperienceEvent {
+    public enum SearchExperienceEvent: Equatable {
         public enum Value: String {
             case searchOnly = "search_only"
             case searchPlusDuckAI = "search_plus_duckai"
@@ -134,7 +134,7 @@ public enum OnboardingSharedPixelEvent: PixelKitEvent {
         case clicked(Value)
     }
 
-    public enum SuggestedOrCustomEvent {
+    public enum SuggestedOrCustomEvent: Equatable {
         public enum Value: String {
             case suggested
             case custom
@@ -145,7 +145,7 @@ public enum OnboardingSharedPixelEvent: PixelKitEvent {
         case clicked(Value)
     }
 
-    public enum CustomizeEvent {
+    public enum CustomizeEvent: Equatable {
         public enum Value: String {
             case bookmarksBar = "bookmarks_bar"
             case restoreSession = "restore_session"

--- a/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
@@ -51,12 +51,12 @@ final public class OnboardingSharedPixelHandler: OnboardingSharedPixelHandling {
 
     let platform: Platform
     let installType: InstallType?
-    let installDate: Date?
+    let installDateProvider: () -> Date?
     let currentDateProvider: () -> Date
     let pixelFiring: PixelFiring?
 
     var daysSinceInstall: Int? {
-        guard let installDate else { return nil }
+        guard let installDate = installDateProvider() else { return nil }
         return Calendar.current.numberOfDaysBetween(installDate, and: currentDateProvider())
     }
 
@@ -76,12 +76,12 @@ final public class OnboardingSharedPixelHandler: OnboardingSharedPixelHandling {
 
     public init(platform: Platform,
                 installType: InstallType?,
-                installDate: Date?,
+                installDateProvider: @escaping () -> Date?,
                 currentDateProvider: @escaping () -> Date = { Date() },
                 pixelFiring: PixelFiring? = PixelKit.shared) {
         self.platform = platform
         self.installType = installType
-        self.installDate = installDate
+        self.installDateProvider = installDateProvider
         self.currentDateProvider = currentDateProvider
         self.pixelFiring = pixelFiring
     }

--- a/SharedPackages/Onboarding/Sources/OnboardingTests/OnboardingSharedPixelTests.swift
+++ b/SharedPackages/Onboarding/Sources/OnboardingTests/OnboardingSharedPixelTests.swift
@@ -175,6 +175,16 @@ final class OnboardingSharedPixelTests: XCTestCase {
         let event = try XCTUnwrap(pixelFiring.actualFireCalls.first)
         XCTAssertNil(event.additionalParameters?["d"])
     }
+
+    func testAddToDockEventIncludesPixelSourceParameter() throws {
+        let pixelFiring = PixelKitMock()
+        let pixelHandler = makeHandler(pixelFiring: pixelFiring)
+
+        pixelHandler.fire(.addToDock(.clicked(.engage)))
+
+        let event = try XCTUnwrap(pixelFiring.actualFireCalls.first)
+        XCTAssertEqual(event.pixel.standardParameters, [.pixelSource])
+    }
 }
 
 private extension OnboardingSharedPixelTests {

--- a/SharedPackages/Onboarding/Sources/OnboardingTests/OnboardingSharedPixelTests.swift
+++ b/SharedPackages/Onboarding/Sources/OnboardingTests/OnboardingSharedPixelTests.swift
@@ -146,7 +146,7 @@ final class OnboardingSharedPixelTests: XCTestCase {
     func testWhenDaysSinceInstallIsInRangeThenDParameterIsIncluded() throws {
         let pixelFiring = PixelKitMock()
         let currentDate = Date()
-        let pixelHandler = makeHandler(installDate: currentDate.daysAgo(28), currentDateProvider: { currentDate }, pixelFiring: pixelFiring)
+        let pixelHandler = makeHandler(installDateProvider: { currentDate.daysAgo(28) }, currentDateProvider: { currentDate }, pixelFiring: pixelFiring)
 
         pixelHandler.fire(.welcome(.shown))
 
@@ -157,7 +157,7 @@ final class OnboardingSharedPixelTests: XCTestCase {
     func testWhenDaysSinceInstallIsOutOfRangeThenDParameterIsOmitted() throws {
         let pixelFiring = PixelKitMock()
         let currentDate = Date()
-        let pixelHandler = makeHandler(installDate: currentDate.daysAgo(29), currentDateProvider: { currentDate }, pixelFiring: pixelFiring)
+        let pixelHandler = makeHandler(installDateProvider: { currentDate.daysAgo(29) }, currentDateProvider: { currentDate }, pixelFiring: pixelFiring)
 
         pixelHandler.fire(.welcome(.shown))
 
@@ -168,7 +168,7 @@ final class OnboardingSharedPixelTests: XCTestCase {
     func testWhenDaysSinceInstallIsNegativeThenDParameterIsOmitted() throws {
         let pixelFiring = PixelKitMock()
         let currentDate = Date()
-        let pixelHandler = makeHandler(installDate: currentDate.daysAgo(-1), currentDateProvider: { currentDate }, pixelFiring: pixelFiring)
+        let pixelHandler = makeHandler(installDateProvider: { currentDate.daysAgo(-1) }, currentDateProvider: { currentDate }, pixelFiring: pixelFiring)
 
         pixelHandler.fire(.welcome(.shown))
 
@@ -190,12 +190,12 @@ final class OnboardingSharedPixelTests: XCTestCase {
 private extension OnboardingSharedPixelTests {
     func makeHandler(platform: OnboardingSharedPixelHandler.Platform = .macOS,
                      installType: OnboardingSharedPixelHandler.InstallType? = nil,
-                     installDate: Date? = nil,
+                     installDateProvider: @escaping () -> Date? = { nil },
                      currentDateProvider: @escaping () -> Date = { Date() },
                      pixelFiring: PixelFiring? = nil) -> OnboardingSharedPixelHandler {
         OnboardingSharedPixelHandler(platform: platform,
                                      installType: installType,
-                                     installDate: installDate,
+                                     installDateProvider: installDateProvider,
                                      currentDateProvider: currentDateProvider,
                                      pixelFiring: pixelFiring)
     }

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -3877,6 +3877,8 @@
 		CC26B68A2F0D6C2400D380B6 /* NewTabPageNextStepsSingleCardProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC26B6882F0D6C1200D380B6 /* NewTabPageNextStepsSingleCardProvider.swift */; };
 		CC26B68C2F0D716200D380B6 /* NewTabPageNextStepsPersistor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC26B68B2F0D715300D380B6 /* NewTabPageNextStepsPersistor.swift */; };
 		CC26B68D2F0D716200D380B6 /* NewTabPageNextStepsPersistor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC26B68B2F0D715300D380B6 /* NewTabPageNextStepsPersistor.swift */; };
+		CC33F77F2F86642F006536BE /* OnboardingUserScript+Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC33F77E2F866426006536BE /* OnboardingUserScript+Telemetry.swift */; };
+		CC33F7802F86642F006536BE /* OnboardingUserScript+Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC33F77E2F866426006536BE /* OnboardingUserScript+Telemetry.swift */; };
 		CC34456F2E674E7700019518 /* UserScriptErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC34456E2E674E7700019518 /* UserScriptErrorTests.swift */; };
 		CC3445702E674E7700019518 /* UserScriptErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC34456E2E674E7700019518 /* UserScriptErrorTests.swift */; };
 		CC3967ED2F461D6700AE83F2 /* PromoType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42E5F600100000001 /* PromoType.swift */; };
@@ -6528,6 +6530,7 @@
 		CC26B6772F0D28D500D380B6 /* MockNewTabPageNextStepsCardsActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNewTabPageNextStepsCardsActionHandler.swift; sourceTree = "<group>"; };
 		CC26B6882F0D6C1200D380B6 /* NewTabPageNextStepsSingleCardProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageNextStepsSingleCardProvider.swift; sourceTree = "<group>"; };
 		CC26B68B2F0D715300D380B6 /* NewTabPageNextStepsPersistor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageNextStepsPersistor.swift; sourceTree = "<group>"; };
+		CC33F77E2F866426006536BE /* OnboardingUserScript+Telemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingUserScript+Telemetry.swift"; sourceTree = "<group>"; };
 		CC34456E2E674E7700019518 /* UserScriptErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserScriptErrorTests.swift; sourceTree = "<group>"; };
 		CC438E1C2EBCE224008537AD /* DefaultBrowserAndDockPromptUIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserAndDockPromptUIProvider.swift; sourceTree = "<group>"; };
 		CC438E222EBCEB50008537AD /* MockDefaultBrowserAndDockPromptUIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDefaultBrowserAndDockPromptUIProvider.swift; sourceTree = "<group>"; };
@@ -9926,6 +9929,7 @@
 				56A053FB2C19E8F7007D8FAB /* OnboardingActionsManager.swift */,
 				56A054012C1AFA5D007D8FAB /* OnboardingConfiguration.swift */,
 				56A0543D2C215FB3007D8FAB /* OnboardingUserScript.swift */,
+				CC33F77E2F866426006536BE /* OnboardingUserScript+Telemetry.swift */,
 				8443DC6C2CF0C777000B8829 /* Tab+OnboardingNavigationDelegate.swift */,
 			);
 			path = Onboarding;
@@ -14505,6 +14509,7 @@
 				84F1C8DF2C774D4200716446 /* NSTableViewExtension.swift in Sources */,
 				3706FA88293F65D500E42796 /* Logger+Multiple.swift in Sources */,
 				3745DE0C2D53969300024FC8 /* HistoryDebugMenu.swift in Sources */,
+				CC33F77F2F86642F006536BE /* OnboardingUserScript+Telemetry.swift in Sources */,
 				EECA36BC2E869E49005A42EE /* SafariArchiveImporter.swift in Sources */,
 				846FA8DD2ED6CDAC00F263AA /* NewWindowPolicyDecisionMaking.swift in Sources */,
 				3706FA89293F65D500E42796 /* CrashReportPromptPresenter.swift in Sources */,
@@ -16711,6 +16716,7 @@
 				1EC711512D033D200009EB5C /* UserText+NetworkProtection+Shared.swift in Sources */,
 				B61EF3EC266F91E700B4D78F /* WKWebView+Download.swift in Sources */,
 				311B262728E73E0A00FD181A /* TabShadowConfig.swift in Sources */,
+				CC33F7802F86642F006536BE /* OnboardingUserScript+Telemetry.swift in Sources */,
 				BB7B5F982C4ED73800BA4AF8 /* BookmarksSearchAndSortMetrics.swift in Sources */,
 				B6BCC54A2AFDF24B002C5499 /* TaskWithProgress.swift in Sources */,
 				B6DB3AEF278D5C370024C5C4 /* URLSessionExtension.swift in Sources */,

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -928,7 +928,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             contentScopePreferences: contentScopePreferences,
             syncErrorHandler: syncErrorHandler,
             webExtensionAvailability: webExtensionAvailability,
-            dockCustomization: dockCustomization
+            dockCustomization: dockCustomization,
+            reinstallUserDetection: DefaultReinstallUserDetection(keyValueStore: keyValueStore),
+            installDateProvider: { AppDelegate.firstLaunchDate }
         )
         privacyFeatures = AppPrivacyFeatures(
             contentBlocking: contentBlocking,

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -893,7 +893,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 contentScopePreferences: contentScopePreferences,
                 syncErrorHandler: syncErrorHandler,
                 webExtensionAvailability: webExtensionAvailability,
-                dockCustomization: dockCustomization
+                dockCustomization: dockCustomization,
+                reinstallUserDetection: DefaultReinstallUserDetection(keyValueStore: keyValueStore),
+                installDateProvider: { AppDelegate.firstLaunchDate }
             )
             privacyFeatures = AppPrivacyFeatures(contentBlocking: contentBlocking, database: database.db)
             appContentBlocking = contentBlocking

--- a/macOS/DuckDuckGo/ContentBlocker/ContentBlocking.swift
+++ b/macOS/DuckDuckGo/ContentBlocker/ContentBlocking.swift
@@ -91,7 +91,9 @@ final class AppContentBlocking {
         contentScopePreferences: ContentScopePreferences,
         syncErrorHandler: SyncErrorHandling,
         webExtensionAvailability: WebExtensionAvailabilityProviding?,
-        dockCustomization: DockCustomization
+        dockCustomization: DockCustomization,
+        reinstallUserDetection: ReinstallingUserDetecting,
+        installDateProvider: @escaping () -> Date
     ) {
         let buildType = StandardApplicationBuildType()
         // When TEST_PRIVACY_CONFIG_PATH is set, skip cached config to use embedded (test) config
@@ -133,7 +135,9 @@ final class AppContentBlocking {
             contentScopePreferences: contentScopePreferences,
             syncErrorHandler: syncErrorHandler,
             webExtensionAvailability: webExtensionAvailability,
-            dockCustomization: dockCustomization
+            dockCustomization: dockCustomization,
+            reinstallUserDetection: reinstallUserDetection,
+            installDateProvider: installDateProvider
         )
     }
 
@@ -162,7 +166,9 @@ final class AppContentBlocking {
         contentScopePreferences: ContentScopePreferences,
         syncErrorHandler: SyncErrorHandling,
         webExtensionAvailability: WebExtensionAvailabilityProviding?,
-        dockCustomization: DockCustomization
+        dockCustomization: DockCustomization,
+        reinstallUserDetection: ReinstallingUserDetecting,
+        installDateProvider: @escaping () -> Date
     ) {
         self.privacyConfigurationManager = privacyConfigurationManager
         self.tld = tld
@@ -211,7 +217,9 @@ final class AppContentBlocking {
                                                   contentScopePreferences: contentScopePreferences,
                                                   syncErrorHandler: syncErrorHandler,
                                                   webExtensionAvailability: webExtensionAvailability,
-                                                  dockCustomization: dockCustomization)
+                                                  dockCustomization: dockCustomization,
+                                                  reinstallUserDetection: reinstallUserDetection,
+                                                  installDateProvider: installDateProvider)
 
         adClickAttributionRulesProvider = AdClickAttributionRulesProvider(config: adClickAttribution,
                                                                           compiledRulesSource: contentBlockingManager,

--- a/macOS/DuckDuckGo/ContentBlocker/ScriptSourceProviding.swift
+++ b/macOS/DuckDuckGo/ContentBlocker/ScriptSourceProviding.swift
@@ -25,6 +25,7 @@ import History
 import HistoryView
 import NewTabPage
 import TrackerRadarKit
+import Persistence
 import PixelKit
 import PrivacyConfig
 import enum UserScript.UserScriptError
@@ -85,7 +86,9 @@ protocol ScriptSourceProviding {
         },
         syncErrorHandler: Application.appDelegate.syncErrorHandler,
         webExtensionAvailability: Application.appDelegate.webExtensionAvailability,
-        dockCustomization: Application.appDelegate.dockCustomization
+        dockCustomization: Application.appDelegate.dockCustomization,
+        reinstallUserDetection: DefaultReinstallUserDetection(keyValueStore: Application.appDelegate.keyValueStore),
+        installDateProvider: { AppDelegate.firstLaunchDate }
     )
 }
 
@@ -144,7 +147,9 @@ struct ScriptSourceProvider: ScriptSourceProviding {
          syncServiceProvider: @escaping () -> DDGSyncing?,
          syncErrorHandler: SyncErrorHandling,
          webExtensionAvailability: WebExtensionAvailabilityProviding?,
-         dockCustomization: DockCustomization
+         dockCustomization: DockCustomization,
+         reinstallUserDetection: ReinstallingUserDetecting,
+         installDateProvider: @escaping () -> Date
     ) {
 
         self.configStorage = configStorage
@@ -173,7 +178,13 @@ struct ScriptSourceProvider: ScriptSourceProviding {
         self.sessionKey = generateSessionKey()
         self.messageSecret = generateSessionKey()
         self.autofillSourceProvider = buildAutofillSource()
-        self.onboardingActionsManager = buildOnboardingActionsManager(onboardingNavigationDelegate, appearancePreferences, startupPreferences)
+        self.onboardingActionsManager = buildOnboardingActionsManager(
+            onboardingNavigationDelegate,
+            appearancePreferences,
+            startupPreferences,
+            reinstallUserDetection,
+            installDateProvider
+        )
         self.historyViewActionsManager = HistoryViewActionsManager(
             historyCoordinator: historyCoordinator,
             bookmarksHandler: bookmarkManager,
@@ -261,7 +272,13 @@ struct ScriptSourceProvider: ScriptSourceProviding {
         }
     }
 
-    private func buildOnboardingActionsManager(_ navigationDelegate: OnboardingNavigating, _ appearancePreferences: AppearancePreferences, _ startupPreferences: StartupPreferences) -> OnboardingActionsManaging {
+    private func buildOnboardingActionsManager(
+        _ navigationDelegate: OnboardingNavigating,
+        _ appearancePreferences: AppearancePreferences,
+        _ startupPreferences: StartupPreferences,
+        _ reinstallUserDetection: ReinstallingUserDetecting,
+        _ installDateProvider: @escaping () -> Date
+    ) -> OnboardingActionsManaging {
         return OnboardingActionsManager(
             navigationDelegate: navigationDelegate,
             dockCustomization: dockCustomization,
@@ -270,7 +287,9 @@ struct ScriptSourceProvider: ScriptSourceProviding {
             startupPreferences: startupPreferences,
             bookmarkManager: bookmarkManager,
             pinningManager: pinningManager,
-            featureFlagger: featureFlagger
+            featureFlagger: featureFlagger,
+            reinstallUserDetection: reinstallUserDetection,
+            installDateProvider: installDateProvider
         )
     }
 

--- a/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
@@ -83,6 +83,9 @@ protocol OnboardingActionsManaging {
     /// It is called every time the user ends an onboarding step
     func stepCompleted(step _: OnboardingSteps)
 
+    /// It is called every time the user ends an onboarding step with another step to show next
+    func stepShown(step _: OnboardingSteps)
+
     /// It is called in case of error loading the pages
     func reportException(with param: [String: String])
 
@@ -162,6 +165,9 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
 
         return excludedSteps
     }
+
+    private var didRequestDefaultBrowser: Bool = false
+    private var didToggleDuckPlayer: Bool = false
 
     convenience init(
         navigationDelegate: OnboardingNavigating,
@@ -243,10 +249,12 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
 
     func addToDock() {
         dockCustomization.addToDock()
+        onboardingSharedPixelHandler.fire(.addToDock(.clicked(.engage)))
     }
 
     @MainActor
     func importData() async -> Bool {
+        onboardingSharedPixelHandler.fire(.importData(.clicked(.engage)))
         return await withCheckedContinuation { continuation in
             dataImportProvider.showImportWindow(customTitle: UserText.importDataTitleOnboarding, completion: { [weak self] in
                 guard let self else {
@@ -260,6 +268,8 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
 
     func setAsDefault() {
         try? defaultBrowserProvider.presentDefaultBrowserPrompt()
+        onboardingSharedPixelHandler.fire(.setDefault(.clicked(.engage)))
+        didRequestDefaultBrowser = true
     }
 
     func setBookmarkBar(enabled: Bool) {
@@ -292,6 +302,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
     func stepCompleted(step: OnboardingSteps) {
         Logger.general.debug("Onboarding step completed: \("\(step)", privacy: .public)")
         fireStepCompletedPixel(for: step)
+        fireSharedPixelOnStepCompletion(for: step)
     }
 
     private func fireStepCompletedPixel(for step: OnboardingSteps) {
@@ -318,6 +329,72 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         }
     }
 
+    private func fireSharedPixelOnStepCompletion(for step: OnboardingSteps) {
+        let pixel: OnboardingSharedPixelEvent?
+        switch step {
+        case .welcome:
+            // This step is measured as part of the getStarted step, when the button is clicked
+            pixel = nil
+        case .getStarted:
+            pixel = .welcome(.clicked(.engage))
+        case .makeDefaultSingle:
+            if !didRequestDefaultBrowser {
+                pixel = .setDefault(.clicked(.dismiss))
+            } else {
+                // If the user sets the default browser, we measure that click when it happens
+                pixel = nil
+            }
+        case .systemSettings:
+            // Each system settings row is measured separately, when it is completed
+            pixel = nil
+        case .duckPlayerSingle:
+            if !didToggleDuckPlayer {
+                pixel = .duckPlayer(.clicked(.dismiss))
+            } else {
+                // If the user previews Duck Player, we measure that click when it happens
+                pixel = nil
+            }
+        case .customize:
+            let enabled: [OnboardingSharedPixelEvent.CustomizeEvent.Value] = [
+                appearancePreferences.showBookmarksBar ? .bookmarksBar : nil,
+                startupPreferences.restorePreviousSession ? .restoreSession : nil,
+                startupPreferences.homeButtonPosition == .left ? .homeButton : nil
+            ].compactMap { $0 }
+            pixel = .customization(.clicked(enabled))
+        case .addressBarMode:
+            let value: OnboardingSharedPixelEvent.SearchExperienceEvent.Value = aiChatPreferencesStorage.showSearchAndDuckAIToggle ? .searchPlusDuckAI : .searchOnly
+            pixel = .searchExperience(.clicked(value))
+        }
+        if let pixel {
+            onboardingSharedPixelHandler.fire(pixel)
+        }
+    }
+
+    func stepShown(step: OnboardingSteps) {
+        let pixel: OnboardingSharedPixelEvent?
+        switch step {
+        case .welcome:
+            pixel = .welcome(.shown)
+        case .getStarted:
+            // This step is measured as part of the welcome step, since it is shown automatically
+            pixel = nil
+        case .makeDefaultSingle:
+            pixel = .setDefault(.shown)
+        case .systemSettings:
+            // Each system settings row is measured separately, when it is shown
+            pixel = nil
+        case .duckPlayerSingle:
+            pixel = .duckPlayer(.shown)
+        case .customize:
+            pixel = .customization(.shown)
+        case .addressBarMode:
+            pixel = .searchExperience(.shown)
+        }
+        if let pixel {
+            onboardingSharedPixelHandler.fire(pixel)
+        }
+    }
+
     func reportException(with param: [String: String]) {
         let message = param["message"] ?? ""
         let id = param["id"] ?? ""
@@ -326,7 +403,27 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
     }
 
     func reportTelemetryEvent(_ event: OnboardingUserScript.TelemetryEvent) {
-        print("*** Telemetry event reported: \(event)")
+        switch event {
+        case .dockInstructionsShown:
+            onboardingSharedPixelHandler.fire(.addToDock(.clicked(.engage)))
+        case .duckPlayerToggled:
+            didToggleDuckPlayer = true
+            onboardingSharedPixelHandler.fire(.duckPlayer(.clicked(.engage)))
+        case .rowShown(let row):
+            switch row {
+            case .dock, .dockInstructions:
+                onboardingSharedPixelHandler.fire(.addToDock(.shown))
+            case .dataImport:
+                onboardingSharedPixelHandler.fire(.importData(.shown))
+            }
+        case .rowSkipped(let row):
+            switch row {
+            case .dock, .dockInstructions:
+                onboardingSharedPixelHandler.fire(.addToDock(.clicked(.dismiss)))
+            case .dataImport:
+                onboardingSharedPixelHandler.fire(.importData(.clicked(.dismiss)))
+            }
+        }
     }
 
     private func onboardingHasFinished() {

--- a/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
@@ -20,6 +20,7 @@ import AIChat
 import Combine
 import Common
 import Foundation
+import Onboarding
 import os.log
 import PixelKit
 import PrivacyConfig
@@ -107,6 +108,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
     private var aiChatPreferencesStorage: AIChatPreferencesStorage
     private let featureFlagger: FeatureFlagger
     private let applicationBuildType: ApplicationBuildType
+    private let onboardingSharedPixelHandler: OnboardingSharedPixelHandling
     private var cancellables = Set<AnyCancellable>()
 
     @UserDefaultsWrapper(key: .onboardingFinished, defaultValue: false)
@@ -169,7 +171,9 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         startupPreferences: StartupPreferences,
         bookmarkManager: BookmarkManager,
         pinningManager: PinningManager,
-        featureFlagger: FeatureFlagger
+        featureFlagger: FeatureFlagger,
+        reinstallUserDetection: ReinstallingUserDetecting,
+        installDateProvider: () -> Date
     ) {
         self.init(
             navigationDelegate: navigationDelegate,
@@ -179,7 +183,12 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
             startupPreferences: startupPreferences,
             dataImportProvider: BookmarksAndPasswordsImportStatusProvider(bookmarkManager: bookmarkManager, pinningManager: pinningManager),
             aiChatPreferencesStorage: DefaultAIChatPreferencesStorage(),
-            featureFlagger: featureFlagger
+            featureFlagger: featureFlagger,
+            onboardingSharedPixelHandler: OnboardingSharedPixelHandler(
+                platform: .macOS,
+                installType: reinstallUserDetection.isReinstallingUser ? .reinstall : .newInstall,
+                installDate: installDateProvider()
+             )
         )
     }
 
@@ -192,7 +201,8 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         dataImportProvider: DataImportStatusProviding,
         aiChatPreferencesStorage: AIChatPreferencesStorage = DefaultAIChatPreferencesStorage(),
         featureFlagger: FeatureFlagger,
-        applicationBuildType: ApplicationBuildType = StandardApplicationBuildType()
+        applicationBuildType: ApplicationBuildType = StandardApplicationBuildType(),
+        onboardingSharedPixelHandler: OnboardingSharedPixelHandling
     ) {
         self.navigation = navigationDelegate
         self.dockCustomization = dockCustomization
@@ -203,6 +213,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         self.aiChatPreferencesStorage = aiChatPreferencesStorage
         self.featureFlagger = featureFlagger
         self.applicationBuildType = applicationBuildType
+        self.onboardingSharedPixelHandler = onboardingSharedPixelHandler
     }
 
     func onboardingStarted() {

--- a/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
@@ -39,6 +39,12 @@ enum OnboardingExcludedStep: String {
     case addressBarMode
 }
 
+enum OnboardingRow: String, Decodable {
+    case dock
+    case dockInstructions = "dock-instructions"
+    case dataImport = "import"
+}
+
 protocol OnboardingActionsManaging {
     /// Provides the configuration needed to set up the FE onboarding
     var configuration: OnboardingConfiguration { get }
@@ -78,6 +84,9 @@ protocol OnboardingActionsManaging {
 
     /// It is called in case of error loading the pages
     func reportException(with param: [String: String])
+
+    /// Used for any event sent exclusively for telemetry
+    func reportTelemetryEvent(_ event: OnboardingUserScript.TelemetryEvent)
 }
 
 protocol OnboardingNavigating: AnyObject {
@@ -109,12 +118,15 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         let platform = OnboardingPlatform(name: "macos")
         if applicationBuildType.isAppStoreBuild {
             let rows = [
-                featureFlagger.isFeatureOn(.addToDockAppStore) ? "dock-instructions" : nil,
-                "import",
+                featureFlagger.isFeatureOn(.addToDockAppStore) ? OnboardingRow.dockInstructions.rawValue : nil,
+                OnboardingRow.dataImport.rawValue,
             ].compactMap { $0 }
             systemSettings = SystemSettings(rows: rows)
         } else {
-            systemSettings = SystemSettings(rows: ["dock", "import"])
+            systemSettings = SystemSettings(rows: [
+                OnboardingRow.dock.rawValue,
+                OnboardingRow.dataImport.rawValue
+            ])
         }
         let stepDefinitions = StepDefinitions(systemSettings: systemSettings)
         let preferredLocale = Bundle.main.preferredLocalizations.first ?? "en"
@@ -300,6 +312,10 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         let id = param["id"] ?? ""
         PixelKit.fire(GeneralPixel.onboardingExceptionReported(message: message, id: id), frequency: .standard)
         Logger.general.error("Onboarding error: \("\(id): \(message)", privacy: .public)")
+    }
+
+    func reportTelemetryEvent(_ event: OnboardingUserScript.TelemetryEvent) {
+        print("*** Telemetry event reported: \(event)")
     }
 
     private func onboardingHasFinished() {

--- a/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
@@ -179,7 +179,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         pinningManager: PinningManager,
         featureFlagger: FeatureFlagger,
         reinstallUserDetection: ReinstallingUserDetecting,
-        installDateProvider: () -> Date
+        installDateProvider: @escaping () -> Date
     ) {
         self.init(
             navigationDelegate: navigationDelegate,
@@ -193,7 +193,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
             onboardingSharedPixelHandler: OnboardingSharedPixelHandler(
                 platform: .macOS,
                 installType: reinstallUserDetection.isReinstallingUser ? .reinstall : .newInstall,
-                installDate: installDateProvider()
+                installDateProvider: installDateProvider
              )
         )
     }

--- a/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
@@ -224,6 +224,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
 
     func onboardingStarted() {
         navigation.updatePreventUserInteraction(prevent: true)
+        stepShown(step: .welcome)
     }
 
     @MainActor

--- a/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
@@ -452,6 +452,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
 
     private func fireOnboardingFinishedPixels(userSawToggleOnboarding: Bool) {
         PixelKit.fire(GeneralPixel.onboardingFinalStepComplete, frequency: .dailyAndCount)
+        fireSharedPixelForFinalStep(userSawToggleOnboarding)
 
         guard userSawToggleOnboarding else { return }
 
@@ -459,6 +460,14 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
             ? .aiChatOnboardingFinishedToggleOn
             : .aiChatOnboardingFinishedToggleOff
         PixelKit.fire(togglePixel, frequency: .dailyAndCount, includeAppVersionParameter: true)
+    }
+
+    private func fireSharedPixelForFinalStep(_ userSawToggleOnboarding: Bool) {
+        if userSawToggleOnboarding {
+            fireSharedPixelOnStepCompletion(for: .addressBarMode)
+        } else {
+            fireSharedPixelOnStepCompletion(for: .customize)
+        }
     }
 
 }

--- a/macOS/DuckDuckGo/Onboarding/OnboardingUserScript+Telemetry.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingUserScript+Telemetry.swift
@@ -1,5 +1,5 @@
 //
-//  OnboardingUserScript+TelemetryEvent.swift
+//  OnboardingUserScript+Telemetry.swift
 //
 //  Copyright © 2026 DuckDuckGo. All rights reserved.
 //

--- a/macOS/DuckDuckGo/Onboarding/OnboardingUserScript+Telemetry.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingUserScript+Telemetry.swift
@@ -1,0 +1,71 @@
+//
+//  OnboardingUserScript+TelemetryEvent.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension OnboardingUserScript {
+
+    enum TelemetryEvent: Equatable {
+        case rowShown(OnboardingRow)
+        case rowSkipped(OnboardingRow)
+        case dockInstructionsShown
+        case duckPlayerToggled
+    }
+}
+
+extension OnboardingUserScript.TelemetryEvent: Decodable {
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let payload = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .payload)
+        let eventName = try payload.decode(EventName.self, forKey: .name)
+
+        switch eventName {
+        case .rowShown:
+            let row = try Self.decodeOnboardingRow(from: payload)
+            self = .rowShown(row)
+        case .rowSkipped:
+            let row = try Self.decodeOnboardingRow(from: payload)
+            self = .rowSkipped(row)
+        case .dockInstructionsShown:
+            self = .dockInstructionsShown
+        case .duckPlayerToggled:
+            self = .duckPlayerToggled
+        }
+    }
+}
+
+private extension OnboardingUserScript.TelemetryEvent {
+
+    enum CodingKeys: String, CodingKey {
+        case payload = "attributes"
+        case name
+        case value
+    }
+
+    enum EventName: String, Decodable {
+        case rowShown = "row_shown"
+        case rowSkipped = "row_skipped"
+        case dockInstructionsShown = "dock_instructions_shown"
+        case duckPlayerToggled = "duck_player_toggled"
+    }
+
+    private static func decodeOnboardingRow(from container: KeyedDecodingContainer<CodingKeys>) throws -> OnboardingRow {
+        return try container.decode(OnboardingRow.self, forKey: .value)
+    }
+}

--- a/macOS/DuckDuckGo/Onboarding/OnboardingUserScript.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingUserScript.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import Common
 import Foundation
 import PixelKit
 import UserScript
@@ -46,6 +47,7 @@ final class OnboardingUserScript: NSObject, Subfeature {
         case requestSetAsDefault
         case reportInitException
         case reportPageException
+        case telemetryEvent
     }
 
     init(onboardingActionsManager: OnboardingActionsManaging) {
@@ -69,7 +71,8 @@ final class OnboardingUserScript: NSObject, Subfeature {
             .setDuckAiInAddressBar: setDuckAiInAddressBar,
             .stepCompleted: stepCompleted,
             .reportInitException: reportException,
-            .reportPageException: reportException
+            .reportPageException: reportException,
+            .telemetryEvent: reportTelemetryEvent
     ]
 
     @MainActor
@@ -158,6 +161,12 @@ extension OnboardingUserScript {
     private func reportException(params: Any, original: WKScriptMessage) async throws -> Encodable? {
         guard let params = params as? [String: String] else { return nil }
         onboardingActionsManager.reportException(with: params)
+        return nil
+    }
+
+    private func reportTelemetryEvent(params: Any, original: WKScriptMessage) async throws -> Encodable? {
+        guard let event: OnboardingUserScript.TelemetryEvent = DecodableHelper.decode(from: params) else { return nil }
+        onboardingActionsManager.reportTelemetryEvent(event)
         return nil
     }
 

--- a/macOS/DuckDuckGo/Onboarding/OnboardingUserScript.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingUserScript.swift
@@ -155,6 +155,9 @@ extension OnboardingUserScript {
         if let params = params as? [String: String], let stepString = params["id"], let step = OnboardingSteps(rawValue: stepString) {
             onboardingActionsManager.stepCompleted(step: step)
         }
+        if let params = params as? [String: String], let stepString = params["next"], let step = OnboardingSteps(rawValue: stepString) {
+            onboardingActionsManager.stepShown(step: step)
+        }
         return nil
     }
 

--- a/macOS/DuckDuckGo/Tab/Model/UserContentUpdating.swift
+++ b/macOS/DuckDuckGo/Tab/Model/UserContentUpdating.swift
@@ -22,6 +22,7 @@ import Common
 import BrowserServicesKit
 import History
 import NewTabPage
+import Persistence
 import PrivacyConfig
 import UserScript
 import Configuration
@@ -108,7 +109,9 @@ final class UserContentUpdating {
          contentScopePreferences: ContentScopePreferences,
          syncErrorHandler: SyncErrorHandling,
          webExtensionAvailability: WebExtensionAvailabilityProviding?,
-         dockCustomization: DockCustomization
+         dockCustomization: DockCustomization,
+         reinstallUserDetection: ReinstallingUserDetecting,
+         installDateProvider: @escaping () -> Date
     ) {
         func onNotificationWithInitial(_ name: Notification.Name) -> AnyPublisher<Notification, Never> {
             return NotificationCenter.default.publisher(for: name)
@@ -154,7 +157,9 @@ final class UserContentUpdating {
                                                           syncServiceProvider: syncServiceProvider,
                                                           syncErrorHandler: syncErrorHandler,
                                                           webExtensionAvailability: webExtensionAvailability,
-                                                          dockCustomization: dockCustomization)
+                                                          dockCustomization: dockCustomization,
+                                                          reinstallUserDetection: reinstallUserDetection,
+                                                          installDateProvider: installDateProvider)
                 return NewContent(rulesUpdate: rulesUpdate, sourceProvider: sourceProvider, contentScopePreferences: contentScopePreferences)
             }
             return await newContentTask.value

--- a/macOS/DuckDuckGo/Tab/UserScripts/SpecialPagesUserScriptExtension.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/SpecialPagesUserScriptExtension.swift
@@ -63,7 +63,9 @@ extension SpecialPagesUserScript {
             startupPreferences: NSApp.delegateTyped.startupPreferences,
             bookmarkManager: NSApp.delegateTyped.bookmarkManager,
             pinningManager: NSApp.delegateTyped.pinningManager,
-            featureFlagger: NSApp.delegateTyped.featureFlagger
+            featureFlagger: NSApp.delegateTyped.featureFlagger,
+            reinstallUserDetection: DefaultReinstallUserDetection(keyValueStore: NSApp.delegateTyped.keyValueStore),
+            installDateProvider: { AppDelegate.firstLaunchDate }
         )
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/onboarding_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/onboarding_pixels.json5
@@ -1,4 +1,4 @@
-// Onboarding step completion pixels for tracking user progress through the initial onboarding flow
+// Onboarding step completion pixels for measuring progress through the initial onboarding flow.
 {
     "m_mac_onboarding_step-complete-welcome": {
         "description": "Fired when the user completes the Welcome step of the onboarding flow",
@@ -48,5 +48,181 @@
         "triggers": ["other"],
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_onboarding_welcome": {
+        "description": "Fired on the Welcome step of the linear onboarding flow.",
+        "owners": ["rachelmcr"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "onboardingEventType",
+            "onboardingClickedValue",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall"
+        ]
+    },
+    "m_mac_onboarding_set-default": {
+        "description": "Fired on the Set Default Browser step of the linear onboarding flow.",
+        "owners": ["rachelmcr"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "onboardingEventType",
+            "onboardingClickedValue",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall"
+        ]
+    },
+    "m_mac_onboarding_add-to-dock": {
+        "description": "Fired on the Add to Dock row of the System Settings step of the linear onboarding flow.",
+        "owners": ["rachelmcr"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "onboardingEventType",
+            "onboardingClickedValue",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall"
+        ]
+    },
+    "m_mac_onboarding_import-data": {
+        "description": "Fired on the Import row of the System Settings step of the linear onboarding flow.",
+        "owners": ["rachelmcr"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "onboardingEventType",
+            "onboardingClickedValue",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall"
+        ]
+    },
+    "m_mac_onboarding_duck-player": {
+        "description": "Fired on the Duck Player step of the linear onboarding flow.",
+        "owners": ["rachelmcr"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "onboardingEventType",
+            "onboardingClickedValue",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall"
+        ]
+    },
+    "m_mac_onboarding_customization": {
+        "description": "Fired on the Customization step of the linear onboarding flow.",
+        "owners": ["rachelmcr"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "onboardingEventType",
+            {
+                "key": "value",
+                "type": "string",
+                "description": "Comma-separated list of enabled customizations (bookmarks_bar, restore_session, home_button) or dismiss if all customizations were skipped"
+            },
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall"
+        ]
+    },
+    "m_mac_onboarding_search-experience": {
+        "description": "Fired on the Search Experience step of the linear onboarding flow.",
+        "owners": ["rachelmcr"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "onboardingEventType",
+            {
+                "key": "value",
+                "type": "string",
+                "description": "Which search experience option the user selected",
+                "enum": ["search_only", "search_plus_duckai"]
+            },
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall"
+        ]
+    },
+    "m_mac_onboarding_search": {
+        "description": "Fired on the Search step of the contextual onboarding flow.",
+        "owners": ["rachelmcr"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "onboardingEventType",
+            {
+                "key": "value",
+                "type": "string",
+                "description": "Whether the user selected a suggested search, entered a custom search, or dismissed the step",
+                "enum": ["custom", "dismiss", "suggested"]
+            },
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall"
+        ]
+    },
+    "m_mac_onboarding_search-results": {
+        "description": "Fired on the Search Done step of the contextual onboarding flow.",
+        "owners": ["rachelmcr"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "onboardingEventType",
+            "onboardingClickedValue",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall"
+        ]
+    },
+    "m_mac_onboarding_visit-site": {
+        "description": "Fired on the Visit A Site step of the contextual onboarding flow.",
+        "owners": ["rachelmcr"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "onboardingEventType",
+            {
+                "key": "value",
+                "type": "string",
+                "description": "Whether the user selected a suggested site, entered a custom site, or dismissed the step",
+                "enum": ["custom", "dismiss", "suggested"]
+            },
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall"
+        ]
+    },
+    "m_mac_onboarding_trackers-blocked": {
+        "description": "Fired on the Trackers Blocked step of the contextual onboarding flow.",
+        "owners": ["rachelmcr"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "onboardingEventType",
+            "onboardingClickedValue",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall"
+        ]
+    },
+    "m_mac_onboarding_fire-button": {
+        "description": "Fired on the Fire Button step of the contextual onboarding flow.",
+        "owners": ["rachelmcr"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "onboardingEventType",
+            "onboardingClickedValue",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall"
+        ]
+    },
+    "m_mac_onboarding_end": {
+        "description": "Fired on the final step of the contextual onboarding flow.",
+        "owners": ["rachelmcr"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "onboardingEventType",
+            "onboardingClickedValue",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall"
+        ]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/onboarding_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/onboarding_pixels.json5
@@ -53,25 +53,13 @@
         "description": "Fired on the Welcome step of the linear onboarding flow.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
-        "parameters": [
-            "appVersion",
-            "onboardingEventType",
-            "onboardingClickedValue",
-            "onboardingInstallType",
-            "onboardingDaysSinceInstall"
-        ]
+        "parameters": ["appVersion", "onboardingEventType", "onboardingClickedValue", "onboardingInstallType", "onboardingDaysSinceInstall"]
     },
     "m_mac_onboarding_set-default": {
         "description": "Fired on the Set Default Browser step of the linear onboarding flow.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
-        "parameters": [
-            "appVersion",
-            "onboardingEventType",
-            "onboardingClickedValue",
-            "onboardingInstallType",
-            "onboardingDaysSinceInstall"
-        ]
+        "parameters": ["appVersion", "onboardingEventType", "onboardingClickedValue", "onboardingInstallType", "onboardingDaysSinceInstall"]
     },
     "m_mac_onboarding_add-to-dock": {
         "description": "Fired on the Add to Dock row of the System Settings step of the linear onboarding flow.",
@@ -90,25 +78,13 @@
         "description": "Fired on the Import row of the System Settings step of the linear onboarding flow.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
-        "parameters": [
-            "appVersion",
-            "onboardingEventType",
-            "onboardingClickedValue",
-            "onboardingInstallType",
-            "onboardingDaysSinceInstall"
-        ]
+        "parameters": ["appVersion", "onboardingEventType", "onboardingClickedValue", "onboardingInstallType", "onboardingDaysSinceInstall"]
     },
     "m_mac_onboarding_duck-player": {
         "description": "Fired on the Duck Player step of the linear onboarding flow.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
-        "parameters": [
-            "appVersion",
-            "onboardingEventType",
-            "onboardingClickedValue",
-            "onboardingInstallType",
-            "onboardingDaysSinceInstall"
-        ]
+        "parameters": ["appVersion", "onboardingEventType", "onboardingClickedValue", "onboardingInstallType", "onboardingDaysSinceInstall"]
     },
     "m_mac_onboarding_customization": {
         "description": "Fired on the Customization step of the linear onboarding flow.",
@@ -164,13 +140,7 @@
         "description": "Fired on the Search Done step of the contextual onboarding flow.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
-        "parameters": [
-            "appVersion",
-            "onboardingEventType",
-            "onboardingClickedValue",
-            "onboardingInstallType",
-            "onboardingDaysSinceInstall"
-        ]
+        "parameters": ["appVersion", "onboardingEventType", "onboardingClickedValue", "onboardingInstallType", "onboardingDaysSinceInstall"]
     },
     "m_mac_onboarding_visit-site": {
         "description": "Fired on the Visit A Site step of the contextual onboarding flow.",
@@ -193,36 +163,18 @@
         "description": "Fired on the Trackers Blocked step of the contextual onboarding flow.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
-        "parameters": [
-            "appVersion",
-            "onboardingEventType",
-            "onboardingClickedValue",
-            "onboardingInstallType",
-            "onboardingDaysSinceInstall"
-        ]
+        "parameters": ["appVersion", "onboardingEventType", "onboardingClickedValue", "onboardingInstallType", "onboardingDaysSinceInstall"]
     },
     "m_mac_onboarding_fire-button": {
         "description": "Fired on the Fire Button step of the contextual onboarding flow.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
-        "parameters": [
-            "appVersion",
-            "onboardingEventType",
-            "onboardingClickedValue",
-            "onboardingInstallType",
-            "onboardingDaysSinceInstall"
-        ]
+        "parameters": ["appVersion", "onboardingEventType", "onboardingClickedValue", "onboardingInstallType", "onboardingDaysSinceInstall"]
     },
     "m_mac_onboarding_end": {
         "description": "Fired on the final step of the contextual onboarding flow.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
-        "parameters": [
-            "appVersion",
-            "onboardingEventType",
-            "onboardingClickedValue",
-            "onboardingInstallType",
-            "onboardingDaysSinceInstall"
-        ]
+        "parameters": ["appVersion", "onboardingEventType", "onboardingClickedValue", "onboardingInstallType", "onboardingDaysSinceInstall"]
     }
 }

--- a/macOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/macOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -282,5 +282,28 @@
         "type": "string",
         "description": "Location selection for the VPN latency test",
         "enum": ["nearest", "custom"]
+    },
+    "onboardingEventType": {
+        "key": "e",
+        "type": "string",
+        "description": "Event type to classify what happened at each onboarding step",
+        "enum": ["shown", "clicked"]
+    },
+    "onboardingClickedValue": {
+        "key": "value",
+        "type": "string",
+        "description": "Whether the user clicked the primary CTA or skipped/closed the onboarding step",
+        "enum": ["engage", "dismiss"]
+    },
+    "onboardingInstallType": {
+        "key": "it",
+        "type": "string",
+        "description": "Install type to distinguish between first-time installs and reinstalls during onboarding",
+        "enum": ["new", "reinstall"]
+    },
+    "onboardingDaysSinceInstall": {
+        "key": "d",
+        "type": "integer",
+        "description": "Days since install when the value is between 0 and 28 inclusive during onboarding",
     }
 }

--- a/macOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/macOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -304,6 +304,6 @@
     "onboardingDaysSinceInstall": {
         "key": "d",
         "type": "integer",
-        "description": "Days since install when the value is between 0 and 28 inclusive during onboarding",
+        "description": "Days since install when the value is between 0 and 28 inclusive during onboarding"
     }
 }

--- a/macOS/UnitTests/ContentBlocker/ContentBlockingUpdatingTests.swift
+++ b/macOS/UnitTests/ContentBlocker/ContentBlockingUpdatingTests.swift
@@ -94,7 +94,9 @@ final class ContentBlockingUpdatingTests: XCTestCase {
                                        contentScopePreferences: ContentScopePreferences(windowControllersManager: WindowControllersManagerMock()),
                                        syncErrorHandler: SyncErrorHandler(),
                                        webExtensionAvailability: nil,
-                                       dockCustomization: DockCustomizerMock())
+                                       dockCustomization: DockCustomizerMock(),
+                                       reinstallUserDetection: DefaultReinstallUserDetection(keyValueStore: MockKeyValueStore()),
+                                       installDateProvider: { Date() })
         /// Set it to any value to trigger `didSet` that unblocks updates stream
         updating.userScriptDependenciesProvider = nil
     }

--- a/macOS/UnitTests/ContentBlocker/ScriptSourceProviderTests.swift
+++ b/macOS/UnitTests/ContentBlocker/ScriptSourceProviderTests.swift
@@ -101,7 +101,9 @@ final class ScriptSourceProviderTests: XCTestCase {
             syncServiceProvider: { nil },
             syncErrorHandler: SyncErrorHandler(),
             webExtensionAvailability: nil,
-            dockCustomization: DockCustomizerMock()
+            dockCustomization: DockCustomizerMock(),
+            reinstallUserDetection: DefaultReinstallUserDetection(keyValueStore: MockKeyValueStore()),
+            installDateProvider: { Date() }
         )
 
         let cohorts = try XCTUnwrap(sourceProvider.currentCohorts)

--- a/macOS/UnitTests/Onboarding/Mocks/CapturingOnboardingActionsManager.swift
+++ b/macOS/UnitTests/Onboarding/Mocks/CapturingOnboardingActionsManager.swift
@@ -43,6 +43,7 @@ class CapturingOnboardingActionsManager: OnboardingActionsManaging {
     var reportExceptionCalled = false
     var exceptionParams: [String: String] = [:]
     var completedStep: OnboardingSteps?
+    var shownStep: OnboardingSteps?
     var bookmarkBarVisible: Bool?
     var homeButtonVisible: Bool?
     var sessionRestoreEnabled: Bool?
@@ -96,6 +97,10 @@ class CapturingOnboardingActionsManager: OnboardingActionsManaging {
 
     func stepCompleted(step: OnboardingSteps) {
         completedStep = step
+    }
+
+    func stepShown(step: OnboardingSteps) {
+        shownStep = step
     }
 
     func reportException(with param: [String: String]) {

--- a/macOS/UnitTests/Onboarding/Mocks/CapturingOnboardingActionsManager.swift
+++ b/macOS/UnitTests/Onboarding/Mocks/CapturingOnboardingActionsManager.swift
@@ -47,6 +47,7 @@ class CapturingOnboardingActionsManager: OnboardingActionsManaging {
     var homeButtonVisible: Bool?
     var sessionRestoreEnabled: Bool?
     var duckAiInAddressBarEnabled: Bool?
+    var reportedTelemetryEvent: OnboardingUserScript.TelemetryEvent?
 
     func onboardingStarted() {
         onboardingStartedCalled = true
@@ -100,5 +101,9 @@ class CapturingOnboardingActionsManager: OnboardingActionsManaging {
     func reportException(with param: [String: String]) {
         reportExceptionCalled = true
         exceptionParams = param
+    }
+
+    func reportTelemetryEvent(_ event: OnboardingUserScript.TelemetryEvent) {
+        reportedTelemetryEvent = event
     }
 }

--- a/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
@@ -393,6 +393,144 @@ class OnboardingManagerTests: XCTestCase {
         XCTAssertEqual(self.appearancePersistor.homeButtonPosition, .hidden)
     }
 
+    // MARK: Shared pixels
+
+    func testExpectedShownPixelsFired_WhenStepShown() {
+        // When
+        manager.stepShown(step: .welcome)
+        manager.stepShown(step: .getStarted)
+        manager.stepShown(step: .makeDefaultSingle)
+        manager.stepShown(step: .systemSettings)
+        manager.stepShown(step: .duckPlayerSingle)
+        manager.stepShown(step: .customize)
+        manager.stepShown(step: .addressBarMode)
+
+        // Then
+        XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [
+            .welcome(.shown),
+            .setDefault(.shown),
+            .duckPlayer(.shown),
+            .customization(.shown),
+            .searchExperience(.shown)
+        ])
+    }
+
+    func testExpectedShownPixelsFired_WhenRowShownTelemetryEventReported() {
+        // When
+        manager.reportTelemetryEvent(.rowShown(.dock))
+        manager.reportTelemetryEvent(.rowShown(.dockInstructions))
+        manager.reportTelemetryEvent(.rowShown(.dataImport))
+
+        // Then
+        XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [
+            .addToDock(.shown),
+            .addToDock(.shown),
+            .importData(.shown)
+        ])
+    }
+
+    func testExpectedDismissPixelsFired_WhenRowSkippedTelemetryEventReported() {
+        // When
+        manager.reportTelemetryEvent(.rowSkipped(.dock))
+        manager.reportTelemetryEvent(.rowSkipped(.dockInstructions))
+        manager.reportTelemetryEvent(.rowSkipped(.dataImport))
+
+        // Then
+        XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [
+            .addToDock(.clicked(.dismiss)),
+            .addToDock(.clicked(.dismiss)),
+            .importData(.clicked(.dismiss))
+        ])
+    }
+
+    func testOnlySetDefaultEngagePixelFired_WhenDefaultBrowserRequested() {
+        // When
+        manager.setAsDefault()
+
+        // Then
+        XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [.setDefault(.clicked(.engage))])
+
+        // When
+        manager.stepCompleted(step: .makeDefaultSingle)
+
+        // Then
+        XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [.setDefault(.clicked(.engage))])
+    }
+
+    func testSetDefaultDismissPixelFired_WhenDefaultBrowserStepCompleted_AndDefaultBrowserNotRequested() {
+        // When
+        manager.stepCompleted(step: .makeDefaultSingle)
+
+        // Then
+        XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [.setDefault(.clicked(.dismiss))])
+    }
+
+    func testAddToDockEngagePixelFired_WhenAddedToDock() {
+        // When
+        manager.addToDock()
+
+        // Then
+        XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [.addToDock(.clicked(.engage))])
+    }
+
+    func testAddToDockEngagePixelFired_WhenDockInstructionsShownTelemetryEventReported() {
+        // When
+        manager.reportTelemetryEvent(.dockInstructionsShown)
+
+        // Then
+        XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [.addToDock(.clicked(.engage))])
+    }
+
+    func testImportEngagePixelFired_WhenImportRequested() async {
+        // When
+        _ = await manager.importData()
+
+        // Then
+        XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [.importData(.clicked(.engage))])
+    }
+
+    func testOnlyDuckPlayerEngagePixelFired_WhenDuckPlayerToggledTelemetryEventReported() {
+        // When
+        manager.reportTelemetryEvent(.duckPlayerToggled)
+
+        // Then
+        XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [.duckPlayer(.clicked(.engage))])
+
+        // When
+        manager.stepCompleted(step: .duckPlayerSingle)
+
+        // Then
+        XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [.duckPlayer(.clicked(.engage))])
+    }
+
+    func testDuckPlayerDismissPixelFired_WhenDuckPlayerStepCompleted_AndDuckPlayerNotToggled() {
+        // When
+        manager.stepCompleted(step: .duckPlayerSingle)
+
+        // Then
+        XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [.duckPlayer(.clicked(.dismiss))])
+    }
+
+    func testCustomizationClickedPixelFired_WithEnabledSettings_WhenCustomizeStepCompleted() {
+        // When
+        manager.setBookmarkBar(enabled: true)
+        manager.setSessionRestore(enabled: false)
+        manager.setHomeButtonPosition(enabled: true)
+        manager.stepCompleted(step: .customize)
+
+        // Then
+        XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [.customization(.clicked([.bookmarksBar, .homeButton]))])
+    }
+
+    func testSearchExperienceClickedPixelFired_WithAddressBarSetting_WhenAddressBarModeStepCompleted() {
+        // When
+        manager.setDuckAiInAddressBar(enabled: false)
+        manager.stepCompleted(step: .addressBarMode)
+
+        // Then
+        XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [.searchExperience(.clicked(.searchOnly))])
+    }
+
 }
 
 private class MockOnboardingSharedPixelHandler: OnboardingSharedPixelHandling {

--- a/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import Onboarding
 import Persistence
 import PersistenceTestingUtils
 import PrivacyConfig
@@ -40,6 +41,7 @@ class OnboardingManagerTests: XCTestCase {
     var startupPersistor: StartupPreferencesUserDefaultsPersistor!
     var importProvider: CapturingDataImportProvider!
     var applicationBuildType: MockApplicationBuildType!
+    private var onboardingSharedPixelHandler: MockOnboardingSharedPixelHandler!
 
     @MainActor override func setUp() {
         navigationDelegate = CapturingOnboardingNavigation()
@@ -63,6 +65,7 @@ class OnboardingManagerTests: XCTestCase {
         startupPreferences = StartupPreferences(pinningManager: MockPinningManager(), persistor: startupPersistor, appearancePreferences: appearancePreferences)
         importProvider = CapturingDataImportProvider()
         applicationBuildType = MockApplicationBuildType()
+        onboardingSharedPixelHandler = MockOnboardingSharedPixelHandler()
         manager = OnboardingActionsManager(
             navigationDelegate: navigationDelegate,
             dockCustomization: dockCustomization,
@@ -71,7 +74,8 @@ class OnboardingManagerTests: XCTestCase {
             startupPreferences: startupPreferences,
             dataImportProvider: importProvider,
             featureFlagger: MockFeatureFlagger(),
-            applicationBuildType: applicationBuildType
+            applicationBuildType: applicationBuildType,
+            onboardingSharedPixelHandler: onboardingSharedPixelHandler
         )
     }
 
@@ -87,6 +91,7 @@ class OnboardingManagerTests: XCTestCase {
         fireButtonPreferencesPersistor = nil
         importProvider = nil
         applicationBuildType = nil
+        onboardingSharedPixelHandler = nil
     }
 
     func testReturnsExpectedOnboardingConfig_WhenBothFlagsAreOff_ExcludesAddressBarMode() {
@@ -117,7 +122,8 @@ class OnboardingManagerTests: XCTestCase {
             startupPreferences: startupPreferences,
             dataImportProvider: importProvider,
             featureFlagger: MockFeatureFlagger(),
-            applicationBuildType: applicationBuildType
+            applicationBuildType: applicationBuildType,
+            onboardingSharedPixelHandler: onboardingSharedPixelHandler
         )
         let stepDefinitions = StepDefinitions(systemSettings: SystemSettings(rows: ["import"]))
         let expectedConfig = OnboardingConfiguration(
@@ -145,7 +151,8 @@ class OnboardingManagerTests: XCTestCase {
             startupPreferences: startupPreferences,
             dataImportProvider: importProvider,
             featureFlagger: featureFlagger,
-            applicationBuildType: applicationBuildType
+            applicationBuildType: applicationBuildType,
+            onboardingSharedPixelHandler: onboardingSharedPixelHandler
         )
 
         let systemSettings = SystemSettings(rows: ["dock", "import"])
@@ -175,7 +182,8 @@ class OnboardingManagerTests: XCTestCase {
             startupPreferences: startupPreferences,
             dataImportProvider: importProvider,
             featureFlagger: featureFlagger,
-            applicationBuildType: applicationBuildType
+            applicationBuildType: applicationBuildType,
+            onboardingSharedPixelHandler: onboardingSharedPixelHandler
         )
 
         let systemSettings = SystemSettings(rows: ["dock", "import"])
@@ -205,7 +213,8 @@ class OnboardingManagerTests: XCTestCase {
             startupPreferences: startupPreferences,
             dataImportProvider: importProvider,
             featureFlagger: featureFlagger,
-            applicationBuildType: applicationBuildType
+            applicationBuildType: applicationBuildType,
+            onboardingSharedPixelHandler: onboardingSharedPixelHandler
         )
 
         let systemSettings = SystemSettings(rows: ["dock", "import"])
@@ -384,4 +393,16 @@ class OnboardingManagerTests: XCTestCase {
         XCTAssertEqual(self.appearancePersistor.homeButtonPosition, .hidden)
     }
 
+}
+
+private class MockOnboardingSharedPixelHandler: OnboardingSharedPixelHandling {
+    var eventsReceived: [OnboardingSharedPixelEvent] = []
+
+    func fire(_ event: OnboardingSharedPixelEvent) {
+        eventsReceived.append(event)
+    }
+
+    func reset() {
+        eventsReceived = []
+    }
 }

--- a/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
@@ -395,6 +395,14 @@ class OnboardingManagerTests: XCTestCase {
 
     // MARK: Shared pixels
 
+    func testWelcomeShownPixelFired_WhenOnboardingStarted() {
+        // When
+        manager.onboardingStarted()
+
+        // Then
+        XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [.welcome(.shown)])
+    }
+
     func testExpectedShownPixelsFired_WhenStepShown() {
         // When
         manager.stepShown(step: .welcome)

--- a/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
@@ -530,10 +530,53 @@ class OnboardingManagerTests: XCTestCase {
         XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [.customization(.clicked([.bookmarksBar, .homeButton]))])
     }
 
-    func testSearchExperienceClickedPixelFired_WithAddressBarSetting_WhenAddressBarModeStepCompleted() {
+    @MainActor
+    func testCustomizationSharedPixelFired_WhenCustomizeIsFinalStep() {
+        // Given
+        let featureFlagger = MockFeatureFlagger()
+        featureFlagger.enabledFeatureFlags = []
+        let manager = OnboardingActionsManager(
+            navigationDelegate: navigationDelegate,
+            dockCustomization: dockCustomization,
+            defaultBrowserProvider: defaultBrowserProvider,
+            appearancePreferences: appearancePreferences,
+            startupPreferences: startupPreferences,
+            dataImportProvider: importProvider,
+            featureFlagger: featureFlagger,
+            applicationBuildType: applicationBuildType,
+            onboardingSharedPixelHandler: onboardingSharedPixelHandler
+        )
+
+        // When
+        manager.setBookmarkBar(enabled: true)
+        manager.setSessionRestore(enabled: true)
+        manager.setHomeButtonPosition(enabled: true)
+        manager.goToAddressBar()
+
+        // Then
+        XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [.customization(.clicked([.bookmarksBar, .restoreSession, .homeButton]))])
+    }
+
+    @MainActor
+    func testSearchExperienceClickedPixelFired_WithAddressBarSetting_WhenAddressBarModeIsFinalStep() {
+        // Given
+        let featureFlagger = MockFeatureFlagger()
+        featureFlagger.enabledFeatureFlags = [.aiChatOmnibarToggle, .aiChatOmnibarOnboarding]
+        let manager = OnboardingActionsManager(
+            navigationDelegate: navigationDelegate,
+            dockCustomization: dockCustomization,
+            defaultBrowserProvider: defaultBrowserProvider,
+            appearancePreferences: appearancePreferences,
+            startupPreferences: startupPreferences,
+            dataImportProvider: importProvider,
+            featureFlagger: featureFlagger,
+            applicationBuildType: applicationBuildType,
+            onboardingSharedPixelHandler: onboardingSharedPixelHandler
+        )
+
         // When
         manager.setDuckAiInAddressBar(enabled: false)
-        manager.stepCompleted(step: .addressBarMode)
+        manager.goToAddressBar()
 
         // Then
         XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [.searchExperience(.clicked(.searchOnly))])

--- a/macOS/UnitTests/Onboarding/OnboardingUserScriptTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingUserScriptTests.swift
@@ -151,6 +151,17 @@ final class OnboardingUserScriptTests: XCTestCase {
     }
 
     @MainActor
+    func testStepCompleted_CallsStepShown_ForNextStep() async throws {
+        let randomStep = OnboardingSteps.allCases.randomElement()!
+        let params = ["next": randomStep.rawValue]
+        let handler = try XCTUnwrap(script.handler(forMethodNamed: "stepCompleted"))
+
+        let result = try await handler(params, WKScriptMessage.mock())
+        XCTAssertEqual(mockManager.shownStep, randomStep)
+        XCTAssertNil(result)
+    }
+
+    @MainActor
     func testRowShownTelemetryEvent_CallsReportTelemetryEvent_WithExpectedEvent() async throws {
         let rowShown = OnboardingRow.dataImport
         let params = [

--- a/macOS/UnitTests/Onboarding/OnboardingUserScriptTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingUserScriptTests.swift
@@ -150,4 +150,64 @@ final class OnboardingUserScriptTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    @MainActor
+    func testRowShownTelemetryEvent_CallsReportTelemetryEvent_WithExpectedEvent() async throws {
+        let rowShown = OnboardingRow.dataImport
+        let params = [
+            "attributes": [
+                "name": "row_shown",
+                "value": rowShown.rawValue
+            ]
+        ]
+        let handler = try XCTUnwrap(script.handler(forMethodNamed: "telemetryEvent"))
+
+        let result = try await handler(params, WKScriptMessage.mock())
+        XCTAssertEqual(mockManager.reportedTelemetryEvent, .rowShown(rowShown))
+        XCTAssertNil(result)
+    }
+
+    @MainActor
+    func testRowSkippedTelemetryEvent_CallsReportTelemetryEvent_WithExpectedEvent() async throws {
+        let rowSkipped = OnboardingRow.dataImport
+        let params = [
+            "attributes": [
+                "name": "row_skipped",
+                "value": rowSkipped.rawValue
+            ]
+        ]
+        let handler = try XCTUnwrap(script.handler(forMethodNamed: "telemetryEvent"))
+
+        let result = try await handler(params, WKScriptMessage.mock())
+        XCTAssertEqual(mockManager.reportedTelemetryEvent, .rowSkipped(rowSkipped))
+        XCTAssertNil(result)
+    }
+
+    @MainActor
+    func testDockInstructionsShownTelemetryEvent_CallsReportTelemetryEvent_WithExpectedEvent() async throws {
+        let params = [
+            "attributes": [
+                "name": "dock_instructions_shown"
+            ]
+        ]
+        let handler = try XCTUnwrap(script.handler(forMethodNamed: "telemetryEvent"))
+
+        let result = try await handler(params, WKScriptMessage.mock())
+        XCTAssertEqual(mockManager.reportedTelemetryEvent, .dockInstructionsShown)
+        XCTAssertNil(result)
+    }
+
+    @MainActor
+    func testDuckPlayerToggledTelemetryEvent_CallsReportTelemetryEvent_WithExpectedEvent() async throws {
+        let params = [
+            "attributes": [
+                "name": "duck_player_toggled"
+            ]
+        ]
+        let handler = try XCTUnwrap(script.handler(forMethodNamed: "telemetryEvent"))
+
+        let result = try await handler(params, WKScriptMessage.mock())
+        XCTAssertEqual(mockManager.reportedTelemetryEvent, .duckPlayerToggled)
+        XCTAssertNil(result)
+    }
+
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1213900912684658?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1213629555566377?focus=true (pixel spec)
CC:

### Description

Updates the frontend onboarding integration to fire the new shared pixels related to linear onboarding:

* Bumps the C-S-S version to include a new `telemetryEvent` message on certain frontend actions.
* Adds decoding for the `telemetryEvent` message to a `TelemetryEvent` for each expected event we need to measure.
* New pixels are fired in `OnboardingActionsManager` (when steps are shown or clicked to engage/dismiss), including new protocol methods to measure:
   * When an onboarding step is shown
   * When a telemetry event is reported

Note that all existing onboarding pixels are still fired, in addition to the shared onboarding pixels.

⚠️ Depends on https://github.com/duckduckgo/apple-browsers/pull/4357

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
**Onboarding flow engaging with dialogs:**
1. Build and run the app. (You may need to reset package caches to pick up the new C-S-S version.)
2. Debug -> Reset Data -> Reset Onboarding
3. Close and reopen the window or relaunch the app.
4. Confirm `m_mac_onboarding_welcome` is fired with parameters:
   * `e` = `shown`
   * `d` = days since you installed the app (if less than 28) - this should be included with the same value on all subsequent pixels
   * `it` = `new` or `reinstall` (depending on whether it is a new install or reinstall) - this should be included with the same value on all subsequent pixels
5. Click "Let's do it!" and confirm `m_mac_onboarding_welcome` is fired with `e` = `clicked` and `value` = `engage`
6. Confirm `m_mac_onboarding_set-default` is fired with `e` = `shown`
7. Click "Make DuckDuckGo Your Default" and confirm `m_mac_onboarding_set-default` is fired with `e` = `clicked` and `value` = `engage`
8. In system settings dialog, choose either option (to set new default browser or keep current one)
9. Click "Next" and confirm `m_mac_onboarding_add-to-dock` is fired with `e` = `shown`
10. Click "Keep in Dock" and confirm `m_mac_onboarding_add-to-dock` is fired with `e` = `clicked` and `value` = `engage`
11. Confirm `m_mac_onboarding_import-data` is fired with `e` = `shown`
12. Click "Import Now" and confirm `m_mac_onboarding_import-data` is fired with `e` = `clicked` and `value` = `engage`
13. Import data or cancel the import.
14. Click "Next" and confirm `m_mac_onboarding_duck-player` is fired with `e` = `shown`
15. Click "See With/Without Duck Player" and confirm `m_mac_onboarding_duck-player` is fired with `e` = `clicked` and `value` = `engage`
16. Click "Next" and confirm `m_mac_onboarding_customization` is fired with `e` = `shown`
17. Enable all three of the customization options
18. Click "Next" and confirm `m_mac_onboarding_customization` is fired with `e` = `clicked` and `value` = `bookmarks_bar,restore_session,home_button`
19. Confirm `m_mac_onboarding_search-experience` is fired with `e` = `shown`
20. Select the Search Only option
21. Click "Start Browsing" and confirm `m_mac_onboarding_search-experience` is fired with `e` = `clicked` and `value` = `search_only`.

**Onboarding flow dismissing dialogs:**
1. Build and run the app.
2. Debug -> Reset Data -> Reset Onboarding
3. Close and reopen the window or relaunch the app.
4. Confirm `m_mac_onboarding_welcome` is fired with parameters:
   * `e` = `shown`
   * `d` = days since you installed the app (if less than 28) - this should be included with the same value on all subsequent pixels
   * `it` = `new` or `reinstall` (depending on whether it is a new install or reinstall) - this should be included with the same value on all subsequent pixels
5. Click "Let's do it!" and confirm `m_mac_onboarding_welcome` is fired with `e` = `clicked` and `value` = `engage`
6. Confirm `m_mac_onboarding_set-default` is fired with `e` = `shown`
7. Click "Skip" and confirm `m_mac_onboarding_set-default` is fired with `e` = `clicked` and `value` = `dismiss`
8. Confirm `m_mac_onboarding_add-to-dock` is fired with `e` = `shown`
10. Click "Skip" and confirm `m_mac_onboarding_add-to-dock` is fired with `e` = `clicked` and `value` = `dismiss`
11. Confirm `m_mac_onboarding_import-data` is fired with `e` = `shown`
12. Click "Skip" and confirm `m_mac_onboarding_import-data` is fired with `e` = `clicked` and `value` = `dismiss `
14. Click "Next" and confirm `m_mac_onboarding_duck-player` is fired with `e` = `shown`
15. Click "Next" and confirm `m_mac_onboarding_duck-player` is fired with `e` = `clicked` and `value` = `dismiss `
16. Click "Next" and confirm `m_mac_onboarding_customization` is fired with `e` = `shown`
17. Skip all three of the customization options
18. Click "Next" and confirm `m_mac_onboarding_customization` is fired with `e` = `clicked` and `value` = `dismiss `
19. Confirm `m_mac_onboarding_search-experience` is fired with `e` = `shown`
21. Click "Start Browsing" and confirm `m_mac_onboarding_search-experience` is fired with `e` = `clicked` and `value` = `search_plus_duckai`.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
* Unit tests added to confirm expected pixels are fired
* Manually tested engage/dismiss paths, and tested with `aiChatOmnibarOnboarding` disabled, to confirm expected pixels are fired
* Pixel definitions have been validated (via script)

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
Privacy: Cross-platform privacy triage complete, contextual onboarding pixels added separately

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new onboarding telemetry and pixel-firing logic across the macOS onboarding flow, which could impact analytics correctness and event volume if mappings/edge cases are wrong, but does not affect core browsing or privacy behavior.
> 
> **Overview**
> Adds **shared onboarding pixel instrumentation** to macOS linear onboarding, firing `OnboardingSharedPixelEvent`s for step *shown* and *engage/dismiss* actions (including final-step handling) alongside existing onboarding pixels.
> 
> Updates the onboarding JS bridge to accept a new `telemetryEvent` message, decode it into typed `TelemetryEvent`s (row shown/skipped, dock-instructions shown, Duck Player toggled), and forward these into `OnboardingActionsManager` so the corresponding shared pixels are fired.
> 
> Plumbs install context into the shared pixel handler (install type via reinstall detection and install date via provider), updates shared pixel event definitions to support `Equatable`, lazy install-date lookup, and `pixelSource` on the Add-to-Dock event; includes new/updated unit tests and pixel definition/parameter dictionary entries. Also bumps `content-scope-scripts` to `13.38.0` to support the new telemetry message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73bd509e273ffe9947c4a16915d5eb62da7936ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->