### PR TITLE
[macOS] Fix flaky PromoService unit test

### DIFF
--- a/macOS/UnitTests/Promotions/PromoServiceTests.swift
+++ b/macOS/UnitTests/Promotions/PromoServiceTests.swift
@@ -412,16 +412,22 @@ final class PromoServiceTests: XCTestCase {
         let promoB = PromoTestHelpers.makePromo(id: "promo-b", coexistingPromoIDs: ["promo-a"], delegate: delegateB)
         let promoC = PromoTestHelpers.makePromo(id: "promo-c", coexistingPromoIDs: [], delegate: delegateC)
         let promoService = makeService(promos: [promoA, promoB, promoC])
+        let showAExpectation = XCTestExpectation(description: "A is shown")
         let showBExpectation = XCTestExpectation(description: "B is shown")
-        let hideExpectation = XCTestExpectation(description: "all hidden")
+        let showCExpectation = XCTestExpectation(description: "C is shown")
+        showCExpectation.isInverted = true // We do not expect C to be shown
+        let previousCRecord = PromoHistoryRecord(id: promoC.id)
         promoService.visiblePromosPublisher
             .dropFirst()
             .sink { promos in
-                if promos.contains(where: { $0.id == "promo-b" }) && !promos.contains(where: { $0.id == "promo-c" }) {
+                if promos.contains(where: { $0.id == promoA.id }) {
+                    showAExpectation.fulfill()
+                }
+                if promos.contains(where: { $0.id == promoB.id }) {
                     showBExpectation.fulfill()
                 }
-                if promos.isEmpty {
-                    hideExpectation.fulfill()
+                if promos.contains(where: { $0.id == promoC.id }) {
+                    showCExpectation.fulfill()
                 }
             }
             .store(in: &cancellables)
@@ -429,13 +435,12 @@ final class PromoServiceTests: XCTestCase {
         // When: show A and B (they coexist), C is blocked when evaluated
         promoService.applicationDidBecomeActive()
         triggerSubject.send(.appLaunched)
-        await fulfillment(of: [showBExpectation], timeout: timeout)
-        delegateA.completeShow(with: .actioned)
-        delegateB.completeShow(with: .actioned)
-        await fulfillment(of: [hideExpectation], timeout: timeout)
+        await fulfillment(of: [showAExpectation, showBExpectation], timeout: timeout)
+        await fulfillment(of: [showCExpectation], timeout: 0.5) // Short timeout for inverted expectation
 
         // Then: C was never shown
-        XCTAssertEqual(delegateC.hideCallCount, 0)
+        let currentCRecord = historyStore.record(for: promoC.id)
+        XCTAssertEqual(previousCRecord, currentCRecord)
     }
 
     func testWhenAppInitiatedPromoDismissedRecently_ThenGlobalCooldownBlocksNextAppPromo() async {

--- a/macOS/UnitTests/Promotions/PromoServiceTests.swift
+++ b/macOS/UnitTests/Promotions/PromoServiceTests.swift
@@ -72,28 +72,22 @@ final class PromoServiceTests: XCTestCase {
         // Given: Two medium promos
         let delegate1 = MockPromoDelegate(isEligible: true)
         let delegate2 = MockPromoDelegate(isEligible: true)
-        delegate2.setShowResult(.actioned)
         let promo1 = PromoTestHelpers.makePromo(id: "promo-1", delegate: delegate1)
         let promo2 = PromoTestHelpers.makePromo(id: "promo-2", delegate: delegate2)
         let promoService = makeService(promos: [promo1, promo2])
 
-        let shownExpectation = XCTestExpectation(description: "primary promo shown")
-        let resultExpectation = XCTestExpectation(description: "primary promo result recorded")
+        let promo1ShownExpectation = XCTestExpectation(description: "promo 1 shown")
+        let promo2ShownExpectation = XCTestExpectation(description: "promo 2 shown")
+        promo2ShownExpectation.isInverted = true // We do not expect promo 2 to be shown
+        let previousPromo2Record = PromoHistoryRecord(id: promo2.id)
         promoService.visiblePromosPublisher
             .dropFirst()
             .sink { promos in
-                if promos.contains(where: { $0.id == "promo-2" }) {
-                    XCTFail("Second promo should not be shown")
-                } else if promos.contains(where: { $0.id == "promo-1" }) {
-                    shownExpectation.fulfill()
+                if promos.contains(where: { $0.id == promo1.id }) {
+                    promo1ShownExpectation.fulfill()
                 }
-            }
-            .store(in: &cancellables)
-        promoService.historyPublisher(for: "promo-1")
-            .compactMap { $0 }
-            .sink { record in
-                if record.actioned, record.timesDismissed == 1 {
-                    resultExpectation.fulfill()
+                if promos.contains(where: { $0.id == promo2.id }) {
+                    promo2ShownExpectation.fulfill()
                 }
             }
             .store(in: &cancellables)
@@ -101,17 +95,12 @@ final class PromoServiceTests: XCTestCase {
         // When: Trigger is sent
         promoService.applicationDidBecomeActive()
         triggerSubject.send(.appLaunched)
-        await fulfillment(of: [shownExpectation], timeout: timeout)
-        delegate1.completeShow(with: .actioned)
-        await fulfillment(of: [resultExpectation], timeout: timeout)
+        await fulfillment(of: [promo1ShownExpectation], timeout: timeout)
+        await fulfillment(of: [promo2ShownExpectation], timeout: 0.5) // Short timeout for inverted expectation
 
-        // Then: Promo history records contain expected history
-        let record1 = historyStore.record(for: "promo-1")
-        let record2 = historyStore.record(for: "promo-2")
-        XCTAssertEqual(record1.timesDismissed, 1)
-        XCTAssertTrue(record1.actioned)
-        XCTAssertEqual(record2.timesDismissed, 0)
-        XCTAssertFalse(record2.actioned)
+        // Then: promo 2 was never shown
+        let currentPromo2Record = historyStore.record(for: promo2.id)
+        XCTAssertEqual(previousPromo2Record, currentPromo2Record)
     }
 
     func testWhenTwoMediumPromosHaveMutualCoexistingIds_ThenBothCanBeVisible() async {
@@ -321,27 +310,22 @@ final class PromoServiceTests: XCTestCase {
         let delegate1 = MockPromoDelegate(isEligible: true)
         let delegate2 = MockPromoDelegate(isEligible: true)
         delegate2.setShowResult(.actioned)
-        let promo1 = PromoTestHelpers.makePromo(id: "global", context: .global, delegate: delegate1)
-        let promo2 = PromoTestHelpers.makePromo(id: "ntp", context: .newTabPage, delegate: delegate2)
-        let promoService = makeService(promos: [promo1, promo2])
+        let globalPromo = PromoTestHelpers.makePromo(id: "global", context: .global, delegate: delegate1)
+        let ntpPromo = PromoTestHelpers.makePromo(id: "ntp", context: .newTabPage, delegate: delegate2)
+        let promoService = makeService(promos: [globalPromo, ntpPromo])
 
-        let shownExpectation = XCTestExpectation(description: "global promo is shown")
-        let resultExpectation = XCTestExpectation(description: "global promo result recorded")
+        let globalShownExpectation = XCTestExpectation(description: "global promo is shown")
+        let ntpShownExpectation = XCTestExpectation(description: "ntp promo is shown")
+        ntpShownExpectation.isInverted = true // We do not expect ntp promo to be shown
+        let previousNTPRecord = PromoHistoryRecord(id: ntpPromo.id)
         promoService.visiblePromosPublisher
             .dropFirst()
             .sink { promos in
-                if promos.contains(where: { $0.context == .newTabPage }) {
-                    XCTFail("New tab page context should be blocked by global context promo")
-                } else if promos.contains(where: { $0.id == "global" }) {
-                    shownExpectation.fulfill()
+                if promos.contains(where: { $0.id == globalPromo.id }) {
+                    globalShownExpectation.fulfill()
                 }
-            }
-            .store(in: &cancellables)
-        promoService.historyPublisher(for: "global")
-            .compactMap { $0 }
-            .sink { record in
-                if record.actioned, record.timesDismissed == 1 {
-                    resultExpectation.fulfill()
+                if promos.contains(where: { $0.id == ntpPromo.id }) {
+                    ntpShownExpectation.fulfill()
                 }
             }
             .store(in: &cancellables)
@@ -350,17 +334,12 @@ final class PromoServiceTests: XCTestCase {
         promoService.applicationDidBecomeActive()
         triggerSubject.send(.appLaunched)
         triggerSubject.send(.newTabPageAppeared)
-        await fulfillment(of: [shownExpectation], timeout: timeout)
-        delegate1.completeShow(with: .actioned)
-        await fulfillment(of: [resultExpectation], timeout: timeout)
+        await fulfillment(of: [globalShownExpectation], timeout: timeout)
+        await fulfillment(of: [ntpShownExpectation], timeout: 0.5) // Short timeout for inverted expectation
 
-        // Then: Promo history records contain expected history
-        let record1 = historyStore.record(for: "global")
-        let record2 = historyStore.record(for: "ntp")
-        XCTAssertEqual(record1.timesDismissed, 1)
-        XCTAssertTrue(record1.actioned)
-        XCTAssertEqual(record2.timesDismissed, 0)
-        XCTAssertFalse(record2.actioned)
+        // Then: NTP promo was never shown
+        let currentNTPRecord = historyStore.record(for: ntpPromo.id)
+        XCTAssertEqual(previousNTPRecord, currentNTPRecord)
     }
 
     func testWhenTwoSameContextPromosHaveMutualCoexistingIds_ThenBothCanBeVisible() async {

--- a/macOS/UnitTests/Promotions/PromoServiceTests.swift
+++ b/macOS/UnitTests/Promotions/PromoServiceTests.swift
@@ -79,7 +79,6 @@ final class PromoServiceTests: XCTestCase {
         let promo1ShownExpectation = XCTestExpectation(description: "promo 1 shown")
         let promo2ShownExpectation = XCTestExpectation(description: "promo 2 shown")
         promo2ShownExpectation.isInverted = true // We do not expect promo 2 to be shown
-        let previousPromo2Record = PromoHistoryRecord(id: promo2.id)
         promoService.visiblePromosPublisher
             .dropFirst()
             .sink { promos in
@@ -97,10 +96,6 @@ final class PromoServiceTests: XCTestCase {
         triggerSubject.send(.appLaunched)
         await fulfillment(of: [promo1ShownExpectation], timeout: timeout)
         await fulfillment(of: [promo2ShownExpectation], timeout: 0.5) // Short timeout for inverted expectation
-
-        // Then: promo 2 was never shown
-        let currentPromo2Record = historyStore.record(for: promo2.id)
-        XCTAssertEqual(previousPromo2Record, currentPromo2Record)
     }
 
     func testWhenTwoMediumPromosHaveMutualCoexistingIds_ThenBothCanBeVisible() async {
@@ -309,7 +304,6 @@ final class PromoServiceTests: XCTestCase {
         // Given: Global context promo and other context promo
         let delegate1 = MockPromoDelegate(isEligible: true)
         let delegate2 = MockPromoDelegate(isEligible: true)
-        delegate2.setShowResult(.actioned)
         let globalPromo = PromoTestHelpers.makePromo(id: "global", context: .global, delegate: delegate1)
         let ntpPromo = PromoTestHelpers.makePromo(id: "ntp", context: .newTabPage, delegate: delegate2)
         let promoService = makeService(promos: [globalPromo, ntpPromo])
@@ -317,7 +311,6 @@ final class PromoServiceTests: XCTestCase {
         let globalShownExpectation = XCTestExpectation(description: "global promo is shown")
         let ntpShownExpectation = XCTestExpectation(description: "ntp promo is shown")
         ntpShownExpectation.isInverted = true // We do not expect ntp promo to be shown
-        let previousNTPRecord = PromoHistoryRecord(id: ntpPromo.id)
         promoService.visiblePromosPublisher
             .dropFirst()
             .sink { promos in
@@ -336,10 +329,6 @@ final class PromoServiceTests: XCTestCase {
         triggerSubject.send(.newTabPageAppeared)
         await fulfillment(of: [globalShownExpectation], timeout: timeout)
         await fulfillment(of: [ntpShownExpectation], timeout: 0.5) // Short timeout for inverted expectation
-
-        // Then: NTP promo was never shown
-        let currentNTPRecord = historyStore.record(for: ntpPromo.id)
-        XCTAssertEqual(previousNTPRecord, currentNTPRecord)
     }
 
     func testWhenTwoSameContextPromosHaveMutualCoexistingIds_ThenBothCanBeVisible() async {
@@ -395,7 +384,6 @@ final class PromoServiceTests: XCTestCase {
         let showBExpectation = XCTestExpectation(description: "B is shown")
         let showCExpectation = XCTestExpectation(description: "C is shown")
         showCExpectation.isInverted = true // We do not expect C to be shown
-        let previousCRecord = PromoHistoryRecord(id: promoC.id)
         promoService.visiblePromosPublisher
             .dropFirst()
             .sink { promos in
@@ -416,10 +404,6 @@ final class PromoServiceTests: XCTestCase {
         triggerSubject.send(.appLaunched)
         await fulfillment(of: [showAExpectation, showBExpectation], timeout: timeout)
         await fulfillment(of: [showCExpectation], timeout: 0.5) // Short timeout for inverted expectation
-
-        // Then: C was never shown
-        let currentCRecord = historyStore.record(for: promoC.id)
-        XCTAssertEqual(previousCRecord, currentCRecord)
     }
 
     func testWhenAppInitiatedPromoDismissedRecently_ThenGlobalCooldownBlocksNextAppPromo() async {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1213988317404111?focus=true
Tech Design URL:
CC:

### Description

Addresses flakiness in PromoService unit tests with scenarios where a promo is not shown. These tests had a couple flaws:
* The flaky test in the task expected multiple promos to be shown but didn't explicitly await both promos' visibility
* All updated tests had expectations/assertions around the promo history (with flakiness around fulfilling those history expectations), even though they only need to test whether promos are shown

These tests are updated with more explicit expectations matching the scenarios under test:
* All expected promos are shown
* Suppressed promo is not shown (inverted expectation)

The inverted expectations add a little extra time to the test run (0.5s per inverted expectation) but are simpler, more explicit checks for the expected scenario.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Confirm PR checks pass

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
* Flakiness could persist on CI. Tests now await all required conditions (and no extraneous conditions) and each passed 1,000 runs locally.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust expectations and timing; low risk to production but could still miss regressions if the new assertions are insufficient.
> 
> **Overview**
> Refactors a few flaky `PromoServiceTests` cases where a promo should be *suppressed* (second medium promo, non-global context blocked by global promo, and non-coexisting promo C blocked by visible promo B).
> 
> The tests now **wait explicitly for expected promos to appear** and use **inverted expectations with short timeouts** to assert that blocked promos are never shown, removing the prior dependency on completing `show()` and validating promo history records for these scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b84e37cd233c9c51c493c3b18478a4a5386b0b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->