### PR TITLE
[iOS] Enable minimalChromeInLandscape by default

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -658,7 +658,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .aiChatContextualFireButton:
             Config(source: .remoteReleasable(.subfeature(AIChatSubfeature.contextualFireButton)))
         case .minimalChromeInLandscape:
-            Config(defaultValue: .internalOnly, source: .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.minimalChromeInLandscape)))
+            Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.minimalChromeInLandscape)))
         case .aiChatNativeStorage:
             Config(source: .remoteReleasable(.subfeature(AIChatSubfeature.nativeStorage)))
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1213990975086432/f
Tech Design URL:
CC:

### Description
Enables the `minimalChromeInLandscape` feature flag by default, changing it from `.internalOnly` to `.enabled`. In the same time https://github.com/duckduckgo/privacy-configuration/pull/4913 enables this feature for internal users only. Goal is to be able to remove this from privacy config once we are fine with releasing it to all users.

### Testing Steps
1. Verify feature is enabled when internal flag is on (assuming current config was fetched).
2. Disable internal user, verify the feature is not enabled.
3. Use embedded config (set an invalid URL for privacy config), verify the feature is always enabled.

### Impact and Risks
Low

#### What could go wrong?
Privacy configuration with internal setting is not embed in the release - unlikely as this is done while preparing a release.

### Quality Considerations
N/A

### Notes to Reviewer

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Low Risk**
> Low risk: changes only the default value of a single feature flag, mainly affecting landscape UI layout behavior unless overridden by remote config.
> 
> **Overview**
> Enables the `minimalChromeInLandscape` feature flag by default by changing its `FeatureFlag` configuration from `.internalOnly` to `.enabled`.
> 
> This shifts the baseline behavior so the minimal-chrome landscape UI can be active for all users unless a remote privacy configuration overrides it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6afb6bb1f343f747deaf1287d112464d1b59a124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>