### PR TITLE
[iOS] Fix tab selection border not updating after tab deletion in tab switcher

### DIFF
--- a/iOS/DuckDuckGo/TabSwitcherPageViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherPageViewController.swift
@@ -263,6 +263,15 @@ class TabSwitcherPageViewController: UIViewController {
         collectionView.reloadData()
         updateEmptyStateVisibility()
     }
+
+    func refreshCurrentTabIndicators() {
+        for cell in collectionView.visibleCells {
+            guard let tabCell = cell as? TabViewCell,
+                  let tab = tabCell.tab else { continue }
+            tabCell.isCurrent = isCurrent(tab: tab)
+            tabCell.updateCurrentTabBorder()
+        }
+    }
     
     func scrollToInitialTab() {
         guard let index = tabsModel.currentIndex,
@@ -301,6 +310,8 @@ class TabSwitcherPageViewController: UIViewController {
             pageDelegate.isProcessingUpdates = true
             pageDelegate.page(self, willDeleteTabs: tabsToClose, allDeleted: allTabsDeleted)
             collectionView.deleteItems(at: indexPaths)
+            currentSelection = tabsModel.currentIndex
+            refreshCurrentTabIndicators()
         } completion: { _ in
             pageDelegate.isProcessingUpdates = false
             pageDelegate.pageDidDeleteTabs(self, allDeleted: allTabsDeleted)

--- a/iOS/DuckDuckGo/TabSwitcherPageViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherPageViewController.swift
@@ -265,6 +265,7 @@ class TabSwitcherPageViewController: UIViewController {
     }
 
     func refreshCurrentTabIndicators() {
+        guard currentSelection != nil else { return }
         for cell in collectionView.visibleCells {
             guard let tabCell = cell as? TabViewCell,
                   let tab = tabCell.tab else { continue }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1213984882269206?focus=true

### Description
Fix the current-tab selection border not updating immediately when a tab is deleted in the tab switcher. This is a regression caused by the two-page tab switcher refactor (#4289)

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->

1. Open the tab switcher with multiple tabs in normal mode
2. Close the currently selected (bordered) tab — verify the border immediately appears on the next tab without delay
3. Repeat in fire mode with multiple fire tabs — verify same instant border update
4. Delete the last remaining normal tab — verify the tab switcher dismisses cleanly and a new empty tab is created
5. Delete all fire tabs one by one — verify the empty state appears correctly
6. In multi-select mode, select and delete multiple tabs — verify the border updates correctly after deletion

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts selection state and refreshes visible cell borders after deletions; limited to tab switcher presentation logic.
> 
> **Overview**
> Ensures the current-tab selection border updates immediately after tab deletion in `TabSwitcherPageViewController`.
> 
> This adds `refreshCurrentTabIndicators()` to recompute `isCurrent` for visible `TabViewCell`s and explicitly calls it (after resetting `currentSelection` from `tabsModel.currentIndex`) within `deleteTabsAtIndexPaths` batch updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8386335882ee735203c07f57b60c9ea1559f083c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->