### PR TITLE
[macOS][Bookmarks] Add Daily and Count pixel when user bookmarks all open tabs

### DIFF
--- a/macOS/DuckDuckGo/Bookmarks/ViewModel/BookmarkAllTabsDialogViewModel.swift
+++ b/macOS/DuckDuckGo/Bookmarks/ViewModel/BookmarkAllTabsDialogViewModel.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import Combine
+import PixelKit
 
 @MainActor
 protocol BookmarkAllTabsDialogEditing: BookmarksDialogViewModel {
@@ -37,6 +38,7 @@ final class BookmarkAllTabsDialogViewModel: BookmarkAllTabsDialogEditing {
     private let websites: [WebsiteInfo]
     private let foldersStore: BookmarkFoldersStore
     private let bookmarkManager: BookmarkManager
+    private let pixelFiring: PixelFiring?
 
     private var folderCancellable: AnyCancellable?
 
@@ -62,11 +64,13 @@ final class BookmarkAllTabsDialogViewModel: BookmarkAllTabsDialogEditing {
         websites: [WebsiteInfo],
         foldersStore: BookmarkFoldersStore,
         bookmarkManager: BookmarkManager,
+        pixelFiring: PixelFiring? = PixelKit.shared,
         dateFormatterConfigurationProvider: () -> DateFormatterConfiguration = DateFormatterConfiguration.defaultConfiguration
     ) {
         self.websites = websites
         self.foldersStore = foldersStore
         self.bookmarkManager = bookmarkManager
+        self.pixelFiring = pixelFiring
 
         folders = .init(bookmarkManager.list)
         selectedFolder = foldersStore.lastBookmarkAllTabsFolderIdUsed.flatMap(bookmarkManager.getBookmarkFolder(withId:))
@@ -79,6 +83,8 @@ final class BookmarkAllTabsDialogViewModel: BookmarkAllTabsDialogEditing {
     }
 
     func addOrSave(dismiss: () -> Void) {
+        pixelFiring?.fire(GeneralPixel.bookmarksSaveAllOpenTabs, frequency: .dailyAndCount)
+
         // Save last used folder
         foldersStore.lastBookmarkAllTabsFolderIdUsed = selectedFolder?.id
 

--- a/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -492,6 +492,7 @@ enum GeneralPixel: PixelKitEvent {
     case bookmarksSortByName(origin: String)
     case bookmarksSearchExecuted(origin: String)
     case bookmarksSearchResultClicked(origin: String)
+    case bookmarksSaveAllOpenTabs
 
     case syncSentUnauthenticatedRequest
     case syncMetadataCouldNotLoadDatabase
@@ -1313,6 +1314,7 @@ enum GeneralPixel: PixelKitEvent {
         case .bookmarksSortByName: return "m_mac_sort_bookmarks_by_name"
         case .bookmarksSearchExecuted: return "m_mac_search_bookmarks_executed"
         case .bookmarksSearchResultClicked: return "m_mac_search_result_clicked"
+        case .bookmarksSaveAllOpenTabs: return "m_mac_bookmarks_save-all-open-tabs"
 
             // Broken site prompt
         case .pageRefreshThreeTimesWithin20Seconds: return "m_mac_reload-three-times-within-20-seconds"
@@ -1830,6 +1832,7 @@ enum GeneralPixel: PixelKitEvent {
                 .bookmarksSortByName,
                 .bookmarksSearchExecuted,
                 .bookmarksSearchResultClicked,
+                .bookmarksSaveAllOpenTabs,
                 .syncSentUnauthenticatedRequest,
                 .syncMetadataCouldNotLoadDatabase,
                 .syncBookmarksProviderInitializationFailed,

--- a/macOS/PixelDefinitions/pixels/definitions/bookmarks_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/bookmarks_pixels.json5
@@ -2,7 +2,7 @@
 {
     "m_mac_bookmarks_save-all-open-tabs": {
         "description": "Daily and count pixel fired when user bookmark all open tabs",
-        "owners": ["aboron"],
+        "owners": ["alessandroboron"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource"]

--- a/macOS/PixelDefinitions/pixels/definitions/bookmarks_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/bookmarks_pixels.json5
@@ -1,0 +1,10 @@
+// Bookmarks pixels
+{
+    "m_mac_bookmarks_save-all-open-tabs": {
+        "description": "Daily and count pixel fired when user bookmark all open tabs",
+        "owners": ["aboron"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource"]
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213919943027829?focus=true
Tech Design URL:
CC:

### Description

This PR adds a daily and count pixel to measure when all open tabs are bookmarked

### Testing Steps
1. Launch the macOS app.
2. Open few sites in multiple tabs.
3. Bookmark all open tabs
4. Verify that "m_mac_bookmarks_save-all-open-tabs” pixel daily and count fires.

### Impact and Risks
Low: Instrumentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them —>

### Quality Considerations
<!— 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
—>

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this is additive analytics instrumentation and does not change bookmark persistence logic beyond a best-effort pixel fire call.
> 
> **Overview**
> Adds instrumentation for the “Bookmark All Tabs” flow by firing a new `GeneralPixel.bookmarksSaveAllOpenTabs` with `.dailyAndCount` frequency when the user saves all open tabs.
> 
> Introduces the new pixel event mapping (`m_mac_bookmarks_save-all-open-tabs`) in `GeneralPixel` and adds a corresponding definition in `bookmarks_pixels.json5`; `BookmarkAllTabsDialogViewModel` now injects `PixelFiring` (defaulting to `PixelKit.shared`) to emit the event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55f3c8ee6b0cf5906b55eba3f50047624801e85e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->