### PR TITLE
Remove customXSafariRedirectHandling feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -241,8 +241,6 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213557229772465?focus=true
     case autoplayBlocking
 
-    case customXSafariRedirectHandling
-
     case crashReportOptInStatusResetting
 
     case fireproofingETLDPlus1

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -357,9 +357,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1202500774821704/task/1212559012504218
     case autoplayBlocking
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213554455515126?focus=true
-    case customXSafariRedirectHandling
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213617478454569?focus=true
     case simplifiedSyncSetupExperiment
 
@@ -643,8 +640,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.fireButtonRefinements)))
         case .autoplayBlocking:
             Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.autoplayBlocking)))
-        case .customXSafariRedirectHandling:
-            Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.customXSafariRedirectHandling)))
         case .simplifiedSyncSetupExperiment:
             Config(source: .remoteReleasable(.subfeature(SyncSubfeature.simplifiedSyncSetupExperiment)), cohortType: SimplifiedSyncSetupExperimentCohort.self)
         case .aiChatOmnibarDefaultPosition:

--- a/iOS/DuckDuckGo/SafariRedirectHandler.swift
+++ b/iOS/DuckDuckGo/SafariRedirectHandler.swift
@@ -59,14 +59,12 @@ final class SafariRedirectHandler: SafariRedirectHandling {
     }
 
     private let tld: TLD
-    private let featureFlagger: FeatureFlagger
     private var hostStates: [String: HostState] = [:]
 
     weak var delegate: SafariRedirectHandlerDelegate?
 
-    init(tld: TLD, featureFlagger: FeatureFlagger) {
+    init(tld: TLD) {
         self.tld = tld
-        self.featureFlagger = featureFlagger
     }
 
     func isAfterSuppressedXSafariRedirect(for url: URL) -> Bool {
@@ -75,8 +73,7 @@ final class SafariRedirectHandler: SafariRedirectHandling {
     }
 
     func handleRedirect(to url: URL) -> Bool {
-        guard url.scheme == Constants.safariRedirectScheme,
-              featureFlagger.isFeatureOn(.customXSafariRedirectHandling) else { return false }
+        guard url.scheme == Constants.safariRedirectScheme else { return false }
 
         guard let host = domain(for: url) else { return false }
         var state = hostStates[host, default: HostState()]

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -173,7 +173,7 @@ class TabViewController: UIViewController {
 
     private var httpsForced: Bool = false
     private(set) lazy var safariRedirectHandler: SafariRedirectHandler = {
-        let handler = SafariRedirectHandler(tld: AppDependencyProvider.shared.storageCache.tld, featureFlagger: featureFlagger)
+        let handler = SafariRedirectHandler(tld: AppDependencyProvider.shared.storageCache.tld)
         handler.delegate = self
         return handler
     }()

--- a/iOS/DuckDuckGoTests/SafariRedirectHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/SafariRedirectHandlerTests.swift
@@ -51,15 +51,6 @@ final class SafariRedirectHandlerTests: XCTestCase {
         XCTAssertFalse(handler.handleRedirect(to: httpURL))
     }
 
-    func testHandleRedirectReturnsFalseWhenFeatureFlagDisabled() {
-        let disabledHandler = SafariRedirectHandler(tld: TLD())
-        let mockDelegate = MockSafariRedirectHandlerDelegate()
-        disabledHandler.delegate = mockDelegate
-
-        XCTAssertFalse(disabledHandler.handleRedirect(to: xSafariURL))
-        XCTAssertTrue(mockDelegate.presentedAlerts.isEmpty)
-    }
-
     // MARK: - First redirect shows Alert 1
 
     func testFirstRedirectShowsTryOpenAlert() {

--- a/iOS/DuckDuckGoTests/SafariRedirectHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/SafariRedirectHandlerTests.swift
@@ -34,7 +34,7 @@ final class SafariRedirectHandlerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        handler = SafariRedirectHandler(tld: TLD(), featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.customXSafariRedirectHandling]))
+        handler = SafariRedirectHandler(tld: TLD())
         delegate = MockSafariRedirectHandlerDelegate()
         handler.delegate = delegate
     }
@@ -52,7 +52,7 @@ final class SafariRedirectHandlerTests: XCTestCase {
     }
 
     func testHandleRedirectReturnsFalseWhenFeatureFlagDisabled() {
-        let disabledHandler = SafariRedirectHandler(tld: TLD(), featureFlagger: MockFeatureFlagger())
+        let disabledHandler = SafariRedirectHandler(tld: TLD())
         let mockDelegate = MockSafariRedirectHandlerDelegate()
         disabledHandler.delegate = mockDelegate
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213995046172527?focus=true
Tech Design URL:
CC:

### Description
Removes the `customXSafariRedirectHandling` feature flag and makes Safari x-redirect handling always-on.

### Testing Steps
1. Open the app and navigate to a site known to trigger `x-safari-https` redirects (e.g., a site that redirects from HTTP to HTTPS via Safari's scheme)
2. Verify the redirect is suppressed as before.

### Impact and Risks
Low - removes a feature flag for behavior that has been enabled for a long time already.

#### What could go wrong?
--

### Quality Considerations
--

### Notes to Reviewer
--

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a long-enabled feature flag and makes the existing `x-safari-https` redirect suppression path unconditional; main risk is any unexpected behavior change on sites that trigger this scheme now affecting all users.
> 
> **Overview**
> **Always enables `x-safari-https` handling** by removing the `customXSafariRedirectHandling` gate in `SafariRedirectHandler.handleRedirect` and dropping the `FeatureFlagger` dependency from its initializer.
> 
> **Cleans up flag plumbing** by deleting the flag from `PrivacyFeature`/`FeatureFlag` and its remote config mapping, updating `TabViewController` construction, and removing the now-obsolete “feature disabled” unit test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6b9a3fc7549346fc7dea58fb011f7290cf2d4e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->