### PR TITLE
Add tab suspension state to Site Breakage Report

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
@@ -117,6 +117,10 @@ public struct BrokenSiteReport {
 #endif
 
 #if os(macOS)
+    let tabSuspensionState: String?
+#endif
+
+#if os(macOS)
     public init(
         siteUrl: URL,
         category: String,
@@ -146,6 +150,7 @@ public struct BrokenSiteReport {
         privacyExperiments: String,
         isPirEnabled: Bool?,
         isForceDarkModeEnabled: Bool?,
+        tabSuspensionState: String?,
         autoplayBlockingMode: String? = nil,
         pageLoadTiming: WKPageLoadTiming?,
         breakageData: String? = nil
@@ -178,6 +183,7 @@ public struct BrokenSiteReport {
         self.privacyExperiments = privacyExperiments
         self.isPirEnabled = isPirEnabled
         self.isForceDarkModeEnabled = isForceDarkModeEnabled
+        self.tabSuspensionState = tabSuspensionState
         self.autoplayBlockingMode = autoplayBlockingMode
         self.pageLoadTiming = pageLoadTiming
         self.breakageData = breakageData
@@ -347,6 +353,12 @@ public struct BrokenSiteReport {
         result["variant"] = variant
         if isAfterSuppressedXSafariRedirect {
             result["isAfterSuppressedXSafariRedirect"] = "true"
+        }
+#endif
+
+#if os(macOS)
+        if let tabSuspensionState {
+            result["tabSuspensionState"] = tabSuspensionState
         }
 #endif
 

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
@@ -117,7 +117,7 @@ public struct BrokenSiteReport {
 #endif
 
 #if os(macOS)
-    let tabSuspensionState: String?
+    let lastTabSuspension: String?
 #endif
 
 #if os(macOS)
@@ -150,7 +150,7 @@ public struct BrokenSiteReport {
         privacyExperiments: String,
         isPirEnabled: Bool?,
         isForceDarkModeEnabled: Bool?,
-        tabSuspensionState: String?,
+        lastTabSuspension: String?,
         autoplayBlockingMode: String? = nil,
         pageLoadTiming: WKPageLoadTiming?,
         breakageData: String? = nil
@@ -183,7 +183,7 @@ public struct BrokenSiteReport {
         self.privacyExperiments = privacyExperiments
         self.isPirEnabled = isPirEnabled
         self.isForceDarkModeEnabled = isForceDarkModeEnabled
-        self.tabSuspensionState = tabSuspensionState
+        self.lastTabSuspension = lastTabSuspension
         self.autoplayBlockingMode = autoplayBlockingMode
         self.pageLoadTiming = pageLoadTiming
         self.breakageData = breakageData
@@ -357,8 +357,8 @@ public struct BrokenSiteReport {
 #endif
 
 #if os(macOS)
-        if let tabSuspensionState {
-            result["tabSuspensionState"] = tabSuspensionState
+        if let lastTabSuspension {
+            result["lastTabSuspension"] = lastTabSuspension
         }
 #endif
 

--- a/SharedPackages/BrowserServicesKit/Tests/PrivacyDashboardTests/BrokenSiteReportMocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PrivacyDashboardTests/BrokenSiteReportMocks.swift
@@ -81,6 +81,7 @@ struct BrokenSiteReportMocks {
                          privacyExperiments: "experiment1:control,experiment2:treatment",
                          isPirEnabled: nil,
                          isForceDarkModeEnabled: nil,
+                         lastTabSuspension: nil,
                          pageLoadTiming: nil)
 #endif
     }
@@ -145,6 +146,7 @@ struct BrokenSiteReportMocks {
                          privacyExperiments: "experiment1:control,experiment2:treatment",
                          isPirEnabled: nil,
                          isForceDarkModeEnabled: nil,
+                         lastTabSuspension: nil,
                          pageLoadTiming: nil)
 #endif
     }
@@ -209,6 +211,7 @@ struct BrokenSiteReportMocks {
                          privacyExperiments: "experiment1:control,experiment2:treatment",
                          isPirEnabled: nil,
                          isForceDarkModeEnabled: nil,
+                         lastTabSuspension: nil,
                          pageLoadTiming: nil)
 #endif
     }
@@ -277,6 +280,7 @@ struct BrokenSiteReportMocks {
                          privacyExperiments: "",
                          isPirEnabled: nil,
                          isForceDarkModeEnabled: nil,
+                         lastTabSuspension: nil,
                          pageLoadTiming: nil,
                          breakageData: decodedBreakageData)
 #endif

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "95948cfa9413b9c9674d256fadfa0a51f27fbb944872918bc4dd087d38527468",
+  "originHash" : "2dec8d991f6b4ed549a5e11211fda5e1aa2876235534439f5412b822f6854e89",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "fd16d76fd8b9a976d88bfb6cacc05ca8d19c91b6",
         "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "content-scope-scripts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
+      "state" : {
+        "revision" : "454f3131bbbdc19a4bf5bc1c2aabf1725cc9f5fc",
+        "version" : "13.41.0"
       }
     },
     {

--- a/macOS/DuckDuckGo/Feedback/View/FeedbackViewController.swift
+++ b/macOS/DuckDuckGo/Feedback/View/FeedbackViewController.swift
@@ -353,7 +353,7 @@ extension FeedbackViewController: NSTextViewDelegate {
 
 }
 
-extension URL {
+fileprivate extension URL {
 
     func trimmingQueryItemsAndFragment() -> URL? {
         var components = URLComponents(url: self, resolvingAgainstBaseURL: true)

--- a/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
+++ b/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
@@ -442,7 +442,7 @@ extension PrivacyDashboardViewController {
                                                privacyExperiments: currentTab.privacyInfo?.privacyExperimentCohorts ?? "",
                                                isPirEnabled: isPirEnabled,
                                                isForceDarkModeEnabled: NSApp.delegateTyped.darkReaderFeatureSettings?.isForceDarkModeEnabled,
-                                               tabSuspensionState: currentTab.tabSuspension?.suspensionState.rawValue,
+                                               lastTabSuspension: currentTab.tabSuspension?.lastSuspensionState.rawValue,
                                                pageLoadTiming: currentTab.brokenSiteInfo?.lastPageLoadTiming,
                                                breakageData: breakageData)
         return websiteBreakage

--- a/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
+++ b/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
@@ -442,6 +442,7 @@ extension PrivacyDashboardViewController {
                                                privacyExperiments: currentTab.privacyInfo?.privacyExperimentCohorts ?? "",
                                                isPirEnabled: isPirEnabled,
                                                isForceDarkModeEnabled: NSApp.delegateTyped.darkReaderFeatureSettings?.isForceDarkModeEnabled,
+                                               tabSuspensionState: currentTab.tabSuspension?.suspensionState.rawValue,
                                                pageLoadTiming: currentTab.brokenSiteInfo?.lastPageLoadTiming,
                                                breakageData: breakageData)
         return websiteBreakage

--- a/macOS/DuckDuckGo/Tab/Model/UnloadedTab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/UnloadedTab.swift
@@ -111,6 +111,10 @@ final class UnloadedTab: Identifiable {
             tab.tabSnapshots?.setIdentifier(snapshotId)
         }
 
+        if isSuspended {
+            tab.tabSuspension?.lastSuspendedURL = content.urlForWebView
+        }
+
         return tab
     }
 }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
@@ -358,6 +358,7 @@ extension TabExtensionsBuilder {
                 featureFlagger: dependencies.featureFlagger,
                 aiChatSessionStore: dependencies.aiChatSessionStore,
                 privacyConfigurationManager: dependencies.privacyFeatures.contentBlocking.privacyConfigurationManager,
+                tld: dependencies.privacyFeatures.contentBlocking.tld,
                 isTabPinned: args.isTabPinned
             )
         }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabSuspensionExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabSuspensionExtension.swift
@@ -86,7 +86,7 @@ final class TabSuspensionExtension {
         aiChatSessionStore.sessions[tabID] != nil
     }
 
-    var suspensionState: SuspensionState {
+    var lastSuspensionState: SuspensionState {
         switch (lastSuspendedURL, tabContent.urlForWebView) {
         case (nil, _):
             return .never
@@ -193,7 +193,7 @@ final class TabSuspensionExtension {
 protocol TabSuspensionExtensionProtocol: AnyObject, NavigationResponder {
     var canBeSuspended: Bool { get }
     var hasVideoInPictureInPicture: Bool { get set }
-    var suspensionState: TabSuspensionExtension.SuspensionState { get }
+    var lastSuspensionState: TabSuspensionExtension.SuspensionState { get }
     var lastSuspendedURL: URL? { get set }
 }
 

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabSuspensionExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabSuspensionExtension.swift
@@ -55,6 +55,13 @@ extension WKWebView: TabSuspensionWebViewChecking {
 
 final class TabSuspensionExtension {
 
+    enum SuspensionState: String {
+        case never
+        case sameURL
+        case sameDomain
+        case differentDomain
+    }
+
     private var cancellables = Set<AnyCancellable>()
 
     private weak var webView: TabSuspensionWebViewChecking?
@@ -68,10 +75,24 @@ final class TabSuspensionExtension {
 
     var hasVideoInPictureInPicture: Bool = false
     var isDisplayingPDF: Bool = false
+    var lastSuspendedURL: URL? = nil
     private(set) var pageReportsUnableToSuspend: Bool = false
 
     private var hasActiveAIChatSession: Bool {
         aiChatSessionStore.sessions[tabID] != nil
+    }
+
+    var suspensionState: SuspensionState {
+        switch (lastSuspendedURL, tabContent.urlForWebView) {
+        case (nil, _):
+            return .never
+        case let (a, b) where a == b:
+            return .sameURL
+        case let (a, b) where a?.host == b?.host:
+            return .sameDomain
+        default:
+            return .differentDomain
+        }
     }
 
     var canBeSuspended: Bool {
@@ -162,6 +183,8 @@ final class TabSuspensionExtension {
 protocol TabSuspensionExtensionProtocol: AnyObject, NavigationResponder {
     var canBeSuspended: Bool { get }
     var hasVideoInPictureInPicture: Bool { get set }
+    var suspensionState: TabSuspensionExtension.SuspensionState { get }
+    var lastSuspendedURL: URL? { get set }
 }
 
 extension TabSuspensionExtension: TabSuspensionExtensionProtocol, TabExtension {

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabSuspensionExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabSuspensionExtension.swift
@@ -17,6 +17,7 @@
 //
 
 import Combine
+import Common
 import Foundation
 import Navigation
 import PrivacyConfig
@@ -58,6 +59,8 @@ final class TabSuspensionExtension {
     enum SuspensionState: String {
         case never
         case sameURL
+        case samePath
+        case sameHostname
         case sameDomain
         case differentDomain
     }
@@ -72,10 +75,11 @@ final class TabSuspensionExtension {
     private let aiChatSessionStore: AIChatSessionStoring
     private let featureFlagger: FeatureFlagger
     private let privacyConfigurationManager: PrivacyConfigurationManaging
+    private let tld: TLD
 
     var hasVideoInPictureInPicture: Bool = false
     var isDisplayingPDF: Bool = false
-    var lastSuspendedURL: URL? = nil
+    var lastSuspendedURL: URL?
     private(set) var pageReportsUnableToSuspend: Bool = false
 
     private var hasActiveAIChatSession: Bool {
@@ -86,9 +90,13 @@ final class TabSuspensionExtension {
         switch (lastSuspendedURL, tabContent.urlForWebView) {
         case (nil, _):
             return .never
-        case let (a, b) where a == b:
+        case (.some(let a), .some(let b)) where a == b:
             return .sameURL
-        case let (a, b) where a?.host == b?.host:
+        case (.some(let a), .some(let b)) where a.trimmingQueryItemsAndFragment() == b.trimmingQueryItemsAndFragment():
+            return .samePath
+        case (.some(let a), .some(let b)) where a.host == b.host:
+            return .sameHostname
+        case (.some(let a), .some(let b)) where tld.eTLDplus1(a.host) == tld.eTLDplus1(b.host):
             return .sameDomain
         default:
             return .differentDomain
@@ -155,6 +163,7 @@ final class TabSuspensionExtension {
         featureFlagger: FeatureFlagger,
         aiChatSessionStore: AIChatSessionStoring,
         privacyConfigurationManager: PrivacyConfigurationManaging,
+        tld: TLD,
         isTabPinned: @escaping () -> Bool
     ) {
         self.tabID = tabID
@@ -162,6 +171,7 @@ final class TabSuspensionExtension {
         self.privacyConfigurationManager = privacyConfigurationManager
         self.isTabPinned = isTabPinned
         self.aiChatSessionStore = aiChatSessionStore
+        self.tld = tld
 
         contentPublisher.sink { [weak self] content in
             self?.tabContent = content

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabSuspensionExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabSuspensionExtension.swift
@@ -96,7 +96,7 @@ final class TabSuspensionExtension {
             return .samePath
         case (.some(let a), .some(let b)) where a.host == b.host:
             return .sameHostname
-        case (.some(let a), .some(let b)) where tld.eTLDplus1(a.host) == tld.eTLDplus1(b.host):
+        case (.some(let a), .some(let b)) where tld.eTLDplus1(a.host) != nil && tld.eTLDplus1(a.host) == tld.eTLDplus1(b.host):
             return .sameDomain
         default:
             return .differentDomain

--- a/macOS/UnitTests/PrivacyReferenceTests/BrokenSiteReportingReferenceTests.swift
+++ b/macOS/UnitTests/PrivacyReferenceTests/BrokenSiteReportingReferenceTests.swift
@@ -100,7 +100,7 @@ final class BrokenSiteReportingReferenceTests: XCTestCase {
                                             privacyExperiments: "",
                                             isPirEnabled: nil,
                                             isForceDarkModeEnabled: nil,
-                                            tabSuspensionState: nil,
+                                            lastTabSuspension: nil,
                                             pageLoadTiming: nil)
 
             let request = makeURLRequest(with: breakage.requestParameters)

--- a/macOS/UnitTests/PrivacyReferenceTests/BrokenSiteReportingReferenceTests.swift
+++ b/macOS/UnitTests/PrivacyReferenceTests/BrokenSiteReportingReferenceTests.swift
@@ -100,6 +100,7 @@ final class BrokenSiteReportingReferenceTests: XCTestCase {
                                             privacyExperiments: "",
                                             isPirEnabled: nil,
                                             isForceDarkModeEnabled: nil,
+                                            tabSuspensionState: nil,
                                             pageLoadTiming: nil)
 
             let request = makeURLRequest(with: breakage.requestParameters)

--- a/macOS/UnitTests/TabExtensionsTests/TabSuspensionExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/TabSuspensionExtensionTests.swift
@@ -493,6 +493,18 @@ final class TabSuspensionExtensionTests: XCTestCase {
         XCTAssertEqual(sut.lastSuspensionState, .differentDomain)
     }
 
+    @MainActors
+    func testWhenLastSuspendedURLHasDifferentIPAddresses_ThenSuspensionStateIsDifferentDomain() throws {
+        let currentURL = try XCTUnwrap(URL(string: "http://10.0.0.1"))
+        let suspendedURL = try XCTUnwrap(URL(string: "https://10.0.0.2/"))
+        sut = makeSUT()
+        contentPublisher.send(.url(currentURL, credential: nil, source: .link))
+
+        sut.lastSuspendedURL = suspendedURL
+
+        XCTAssertEqual(sut.lastSuspensionState, .differentDomain)
+    }
+
     @MainActor
     func testWhenLastSuspendedURLIsNotNilAndContentHasNoURL_ThenSuspensionStateIsDifferentDomain() {
         sut = makeSUT()

--- a/macOS/UnitTests/TabExtensionsTests/TabSuspensionExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/TabSuspensionExtensionTests.swift
@@ -432,7 +432,7 @@ final class TabSuspensionExtensionTests: XCTestCase {
 
         sut.lastSuspendedURL = nil
 
-        XCTAssertEqual(sut.suspensionState, .never)
+        XCTAssertEqual(sut.lastSuspensionState, .never)
     }
 
     @MainActor
@@ -442,7 +442,7 @@ final class TabSuspensionExtensionTests: XCTestCase {
 
         sut.lastSuspendedURL = .duckDuckGo
 
-        XCTAssertEqual(sut.suspensionState, .sameURL)
+        XCTAssertEqual(sut.lastSuspensionState, .sameURL)
     }
 
     @MainActor
@@ -454,7 +454,7 @@ final class TabSuspensionExtensionTests: XCTestCase {
 
         sut.lastSuspendedURL = suspendedURL
 
-        XCTAssertEqual(sut.suspensionState, .samePath)
+        XCTAssertEqual(sut.lastSuspensionState, .samePath)
     }
 
     @MainActor
@@ -465,7 +465,7 @@ final class TabSuspensionExtensionTests: XCTestCase {
 
         sut.lastSuspendedURL = .duckDuckGo
 
-        XCTAssertEqual(sut.suspensionState, .sameHostname)
+        XCTAssertEqual(sut.lastSuspensionState, .sameHostname)
     }
 
     @MainActor
@@ -477,7 +477,7 @@ final class TabSuspensionExtensionTests: XCTestCase {
 
         sut.lastSuspendedURL = suspendedURL
 
-        XCTAssertEqual(sut.suspensionState, .sameDomain)
+        XCTAssertEqual(sut.lastSuspensionState, .sameDomain)
     }
 
     @MainActor
@@ -488,7 +488,7 @@ final class TabSuspensionExtensionTests: XCTestCase {
 
         sut.lastSuspendedURL = .duckDuckGo
 
-        XCTAssertEqual(sut.suspensionState, .differentDomain)
+        XCTAssertEqual(sut.lastSuspensionState, .differentDomain)
     }
 
     @MainActor
@@ -498,7 +498,7 @@ final class TabSuspensionExtensionTests: XCTestCase {
 
         sut.lastSuspendedURL = .duckDuckGo
 
-        XCTAssertEqual(sut.suspensionState, .differentDomain)
+        XCTAssertEqual(sut.lastSuspensionState, .differentDomain)
     }
 }
 

--- a/macOS/UnitTests/TabExtensionsTests/TabSuspensionExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/TabSuspensionExtensionTests.swift
@@ -493,7 +493,7 @@ final class TabSuspensionExtensionTests: XCTestCase {
         XCTAssertEqual(sut.lastSuspensionState, .differentDomain)
     }
 
-    @MainActors
+    @MainActor
     func testWhenLastSuspendedURLHasDifferentIPAddresses_ThenSuspensionStateIsDifferentDomain() throws {
         let currentURL = try XCTUnwrap(URL(string: "http://10.0.0.1"))
         let suspendedURL = try XCTUnwrap(URL(string: "https://10.0.0.2/"))

--- a/macOS/UnitTests/TabExtensionsTests/TabSuspensionExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/TabSuspensionExtensionTests.swift
@@ -68,7 +68,7 @@ final class TabSuspensionExtensionTests: XCTestCase {
     }
 
     @MainActor
-    private func makeSUT(tld: TLD = TLD()) -> TabSuspensionExtension {
+    private func makeSUT() -> TabSuspensionExtension {
         TabSuspensionExtension(
             tabID: tabID,
             webViewPublisher: webViewPublisher,
@@ -77,7 +77,7 @@ final class TabSuspensionExtensionTests: XCTestCase {
             featureFlagger: featureFlagger,
             aiChatSessionStore: aiChatSessionStore,
             privacyConfigurationManager: privacyConfigurationManager,
-            tld: tld,
+            tld: TLD(),
             isTabPinned: { [unowned self] in self.isPinned }
         )
     }
@@ -459,11 +459,12 @@ final class TabSuspensionExtensionTests: XCTestCase {
 
     @MainActor
     func testWhenLastSuspendedURLHasSameHostButDifferentPath_ThenSuspensionStateIsSameHostname() throws {
-        let url = try XCTUnwrap(URL(string: "https://duckduckgo.com/about"))
+        let currentURL = try XCTUnwrap(URL(string: "https://duckduckgo.com/about"))
+        let suspendedURL = try XCTUnwrap(URL(string: "https://duckduckgo.com/"))
         sut = makeSUT()
-        contentPublisher.send(.url(url, credential: nil, source: .link))
+        contentPublisher.send(.url(currentURL, credential: nil, source: .link))
 
-        sut.lastSuspendedURL = .duckDuckGo
+        sut.lastSuspendedURL = suspendedURL
 
         XCTAssertEqual(sut.lastSuspensionState, .sameHostname)
     }
@@ -472,7 +473,7 @@ final class TabSuspensionExtensionTests: XCTestCase {
     func testWhenLastSuspendedURLHasSameETLDPlus1ButDifferentHost_ThenSuspensionStateIsSameDomain() throws {
         let currentURL = try XCTUnwrap(URL(string: "https://www.example.com/page"))
         let suspendedURL = try XCTUnwrap(URL(string: "https://mail.example.com/inbox"))
-        sut = makeSUT(tld: TLD())
+        sut = makeSUT()
         contentPublisher.send(.url(currentURL, credential: nil, source: .link))
 
         sut.lastSuspendedURL = suspendedURL
@@ -482,11 +483,12 @@ final class TabSuspensionExtensionTests: XCTestCase {
 
     @MainActor
     func testWhenLastSuspendedURLHasDifferentDomain_ThenSuspensionStateIsDifferentDomain() throws {
-        let url = try XCTUnwrap(URL(string: "https://example.com"))
+        let currentURL = try XCTUnwrap(URL(string: "https://example.com"))
+        let suspendedURL = try XCTUnwrap(URL(string: "https://duckduckgo.com/"))
         sut = makeSUT()
-        contentPublisher.send(.url(url, credential: nil, source: .link))
+        contentPublisher.send(.url(currentURL, credential: nil, source: .link))
 
-        sut.lastSuspendedURL = .duckDuckGo
+        sut.lastSuspendedURL = suspendedURL
 
         XCTAssertEqual(sut.lastSuspensionState, .differentDomain)
     }

--- a/macOS/UnitTests/TabExtensionsTests/TabSuspensionExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/TabSuspensionExtensionTests.swift
@@ -17,6 +17,7 @@
 //
 
 import Combine
+import Common
 @testable import Navigation
 import PrivacyConfig
 import PrivacyConfigTestsUtils
@@ -67,7 +68,7 @@ final class TabSuspensionExtensionTests: XCTestCase {
     }
 
     @MainActor
-    private func makeSUT() -> TabSuspensionExtension {
+    private func makeSUT(tld: TLD = TLD()) -> TabSuspensionExtension {
         TabSuspensionExtension(
             tabID: tabID,
             webViewPublisher: webViewPublisher,
@@ -76,6 +77,7 @@ final class TabSuspensionExtensionTests: XCTestCase {
             featureFlagger: featureFlagger,
             aiChatSessionStore: aiChatSessionStore,
             privacyConfigurationManager: privacyConfigurationManager,
+            tld: tld,
             isTabPinned: { [unowned self] in self.isPinned }
         )
     }
@@ -444,18 +446,42 @@ final class TabSuspensionExtensionTests: XCTestCase {
     }
 
     @MainActor
-    func testWhenLastSuspendedURLHasSameHostButDifferentPath_ThenSuspensionStateIsSameDomain() throws {
+    func testWhenLastSuspendedURLHasSamePathButDifferentQuery_ThenSuspensionStateIsSamePath() throws {
+        let currentURL = try XCTUnwrap(URL(string: "https://duckduckgo.com/about?q=test"))
+        let suspendedURL = try XCTUnwrap(URL(string: "https://duckduckgo.com/about?q=other"))
+        sut = makeSUT()
+        contentPublisher.send(.url(currentURL, credential: nil, source: .link))
+
+        sut.lastSuspendedURL = suspendedURL
+
+        XCTAssertEqual(sut.suspensionState, .samePath)
+    }
+
+    @MainActor
+    func testWhenLastSuspendedURLHasSameHostButDifferentPath_ThenSuspensionStateIsSameHostname() throws {
         let url = try XCTUnwrap(URL(string: "https://duckduckgo.com/about"))
         sut = makeSUT()
         contentPublisher.send(.url(url, credential: nil, source: .link))
 
         sut.lastSuspendedURL = .duckDuckGo
 
+        XCTAssertEqual(sut.suspensionState, .sameHostname)
+    }
+
+    @MainActor
+    func testWhenLastSuspendedURLHasSameETLDPlus1ButDifferentHost_ThenSuspensionStateIsSameDomain() throws {
+        let currentURL = try XCTUnwrap(URL(string: "https://www.example.com/page"))
+        let suspendedURL = try XCTUnwrap(URL(string: "https://mail.example.com/inbox"))
+        sut = makeSUT(tld: TLD())
+        contentPublisher.send(.url(currentURL, credential: nil, source: .link))
+
+        sut.lastSuspendedURL = suspendedURL
+
         XCTAssertEqual(sut.suspensionState, .sameDomain)
     }
 
     @MainActor
-    func testWhenLastSuspendedURLHasDifferentHost_ThenSuspensionStateIsDifferentDomain() throws {
+    func testWhenLastSuspendedURLHasDifferentDomain_ThenSuspensionStateIsDifferentDomain() throws {
         let url = try XCTUnwrap(URL(string: "https://example.com"))
         sut = makeSUT()
         contentPublisher.send(.url(url, credential: nil, source: .link))

--- a/macOS/UnitTests/TabExtensionsTests/TabSuspensionExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/TabSuspensionExtensionTests.swift
@@ -420,6 +420,60 @@ final class TabSuspensionExtensionTests: XCTestCase {
 
         XCTAssertFalse(sut.pageReportsUnableToSuspend)
     }
+
+    // MARK: - Suspension State
+
+    @MainActor
+    func testWhenLastSuspendedURLIsNil_ThenSuspensionStateIsNever() {
+        sut = makeSUT()
+        contentPublisher.send(.url(.duckDuckGo, credential: nil, source: .link))
+
+        sut.lastSuspendedURL = nil
+
+        XCTAssertEqual(sut.suspensionState, .never)
+    }
+
+    @MainActor
+    func testWhenLastSuspendedURLMatchesCurrentURL_ThenSuspensionStateIsSameURL() {
+        sut = makeSUT()
+        contentPublisher.send(.url(.duckDuckGo, credential: nil, source: .link))
+
+        sut.lastSuspendedURL = .duckDuckGo
+
+        XCTAssertEqual(sut.suspensionState, .sameURL)
+    }
+
+    @MainActor
+    func testWhenLastSuspendedURLHasSameHostButDifferentPath_ThenSuspensionStateIsSameDomain() throws {
+        let url = try XCTUnwrap(URL(string: "https://duckduckgo.com/about"))
+        sut = makeSUT()
+        contentPublisher.send(.url(url, credential: nil, source: .link))
+
+        sut.lastSuspendedURL = .duckDuckGo
+
+        XCTAssertEqual(sut.suspensionState, .sameDomain)
+    }
+
+    @MainActor
+    func testWhenLastSuspendedURLHasDifferentHost_ThenSuspensionStateIsDifferentDomain() throws {
+        let url = try XCTUnwrap(URL(string: "https://example.com"))
+        sut = makeSUT()
+        contentPublisher.send(.url(url, credential: nil, source: .link))
+
+        sut.lastSuspendedURL = .duckDuckGo
+
+        XCTAssertEqual(sut.suspensionState, .differentDomain)
+    }
+
+    @MainActor
+    func testWhenLastSuspendedURLIsNotNilAndContentHasNoURL_ThenSuspensionStateIsDifferentDomain() {
+        sut = makeSUT()
+        contentPublisher.send(.none)
+
+        sut.lastSuspendedURL = .duckDuckGo
+
+        XCTAssertEqual(sut.suspensionState, .differentDomain)
+    }
 }
 
 // MARK: - MockTabSuspensionWebView

--- a/macOS/UnitTests/WebsiteBreakageReport/WebsiteBreakageReportTests.swift
+++ b/macOS/UnitTests/WebsiteBreakageReport/WebsiteBreakageReportTests.swift
@@ -85,7 +85,7 @@ class WebsiteBreakageReportTests: XCTestCase {
             privacyExperiments: "",
             isPirEnabled: nil,
             isForceDarkModeEnabled: nil,
-            tabSuspensionState: nil,
+            lastTabSuspension: nil,
             pageLoadTiming: nil
         )
 
@@ -140,7 +140,7 @@ class WebsiteBreakageReportTests: XCTestCase {
             privacyExperiments: "",
             isPirEnabled: true,
             isForceDarkModeEnabled: nil,
-            tabSuspensionState: nil,
+            lastTabSuspension: nil,
             pageLoadTiming: nil
         )
 

--- a/macOS/UnitTests/WebsiteBreakageReport/WebsiteBreakageReportTests.swift
+++ b/macOS/UnitTests/WebsiteBreakageReport/WebsiteBreakageReportTests.swift
@@ -85,6 +85,7 @@ class WebsiteBreakageReportTests: XCTestCase {
             privacyExperiments: "",
             isPirEnabled: nil,
             isForceDarkModeEnabled: nil,
+            tabSuspensionState: nil,
             pageLoadTiming: nil
         )
 
@@ -139,6 +140,7 @@ class WebsiteBreakageReportTests: XCTestCase {
             privacyExperiments: "",
             isPirEnabled: true,
             isForceDarkModeEnabled: nil,
+            tabSuspensionState: nil,
             pageLoadTiming: nil
         )
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1213842248026145?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1213985847677255

### Description

Adds a `lastTabSuspension` parameter to the Site Breakage Report, indicating the tab's suspension state relative to the current URL when a breakage report is submitted. This helps diagnose whether tab suspension may be contributing to reported site breakage.

Changes:
- Added `SuspensionState` enum to `TabSuspensionExtension` with states: `never`, `sameURL`, `samePath`, `sameHostname`, `sameDomain`, `differentDomain`
- Added `lastSuspendedURL` and `lastSuspensionState` to `TabSuspensionExtensionProtocol`
- Set `lastSuspendedURL` when restoring a suspended tab from `UnloadedTab`
- Passed `lastTabSuspension` through `BrokenSiteReport` to include it in report parameters
- Made `URL.trimmingQueryItemsAndFragment()` in `FeedbackViewController` fileprivate to resolve ambiguity with the shared extension

### Testing Steps
1. Enable `tabSuspension` and `tabSuspensionDebugging` feature flags.
2. Filter Xcode logs by `epbf` (it's the Site Breakage pixel)
3. Visit a website in tab A
4. Open a new tab (tab B)
5. Suspend tab A using context menu
6. Activate tab A, open privacy dashboard -> _Report a problem with this website -> The site is not working as expected -> anything -> Send Report_
7. Verify that the pixel contains `"lastTabSuspension": "sameURL"`
8. Navigate to another domain and report site breakage. Verify that the pixel contains `"lastTabSuspension": "differentDomain"`
9. Report site breakage from tab B. Verify that the pixel contains `"lastTabSuspension": "never"`
10. If you want you can test other enum cases, but they're covered with unit tests and I have tested them myself.

### Impact and Risks
Low: Adds a new optional parameter to the breakage report payload. No changes to existing functionality.

#### What could go wrong?
- The `lastTabSuspension` field could be missing from reports if the tab suspension extension is not available, but this is handled gracefully (the field is optional and omitted when nil).

### Quality Considerations
- The suspension state comparison uses eTLD+1 via the `TLD` utility for domain-level matching, consistent with existing privacy logic in the codebase.
- New unit tests cover all suspension state transitions.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new breakage-report telemetry derived from tab suspension state and threads new state through tab restoration and extension dependencies, which could affect reporting accuracy and tab-suspension behavior if miscomputed. Functional impact is limited because the field is optional and only appended to report parameters when available.
> 
> **Overview**
> **Adds macOS-only `lastTabSuspension` to broken site reports** by extending `BrokenSiteReport` and including the value in request parameters when non-nil.
> 
> Computes this value via new `TabSuspensionExtension.SuspensionState` (tracking similarity between the last suspended URL and current URL using path/host/eTLD+1) and persists `lastSuspendedURL` when materializing restored suspended tabs. Updates wiring to pass `TLD` into `TabSuspensionExtension`, adjusts mocks/reference tests, and adds unit tests covering all suspension-state cases.
> 
> Also scopes a local `URL.trimmingQueryItemsAndFragment()` extension to `fileprivate` and updates SwiftPM resolution (adds `content-scope-scripts` pin).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f434f3b3df710c12b16a4781510521b0040732e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->