### PR TITLE
[iOS] Swap button position on Safari redirect alert

### DIFF
--- a/iOS/DuckDuckGo/SafariRedirectHandler.swift
+++ b/iOS/DuckDuckGo/SafariRedirectHandler.swift
@@ -135,19 +135,22 @@ final class SafariRedirectHandler: SafariRedirectHandling {
             preferredStyle: .alert
         )
 
-        alert.addAction(UIAlertAction(title: UserText.xSafariHTTPSStayInDDG, style: .cancel, handler: { [weak self] _ in
+        let stayAction = UIAlertAction(title: UserText.xSafariHTTPSStayInDDG, style: .default, handler: { [weak self] _ in
             guard let self else { return }
             DailyPixel.fireDaily(.webViewExternalSchemeNavigationXSafariHTTPSStay)
             self.hostStates[host] = HostState(isSafariRedirectSuppressed: true, alertShown: true)
             self.convertAndLoad(url: url)
-        }))
+        })
+        alert.addAction(stayAction)
 
-        alert.addAction(UIAlertAction(title: UserText.xSafariHTTPSOpenInSafari, style: .default, handler: { [weak self] _ in
+        alert.addAction(UIAlertAction(title: UserText.xSafariHTTPSOpenInSafari, style: .cancel, handler: { [weak self] _ in
             guard let self else { return }
             DailyPixel.fireDaily(.webViewExternalSchemeNavigationXSafariHTTPSOpenInSafari)
             self.hostStates[host]?.alertShown = false
             self.delegate?.safariRedirectHandler(self, didRequestOpenExternallyURL: url)
         }))
+
+        alert.preferredAction = stayAction
 
         delegate?.safariRedirectHandler(self, didRequestPresentAlert: alert)
     }

--- a/iOS/DuckDuckGo/SafariRedirectHandler.swift
+++ b/iOS/DuckDuckGo/SafariRedirectHandler.swift
@@ -143,7 +143,7 @@ final class SafariRedirectHandler: SafariRedirectHandling {
         })
         alert.addAction(stayAction)
 
-        alert.addAction(UIAlertAction(title: UserText.xSafariHTTPSOpenInSafari, style: .cancel, handler: { [weak self] _ in
+        alert.addAction(UIAlertAction(title: UserText.xSafariHTTPSOpenInSafari, style: .default, handler: { [weak self] _ in
             guard let self else { return }
             DailyPixel.fireDaily(.webViewExternalSchemeNavigationXSafariHTTPSOpenInSafari)
             self.hostStates[host]?.alertShown = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1213881847716771?focus=true
Tech Design URL:
CC:

### Description
Swaps the button positions on the initial Safari x-redirect alert so that "Stay in DuckDuckGo" appears as the first option and "Open in Safari" appears second.

Only the first alert (`showTryOpenAlert`) is changed; the loop alert is unchanged.

### Testing Steps
1. Navigate to a site that triggers an `x-safari-https` redirect (e.g. https://christiantietze.de/posts/2023/05/safari-for-mac-url-scheme/)
2. Verify the alert shows "Stay in DuckDuckGo" as the **bold first option** and "Open in Safari” as the second.
3. Tap "Stay in DuckDuckGo”. Page should load in place.
4. Trigger the redirect again on the same domain. It should be silently suppressed.
5. Trigger repeated redirects (3+) to see the loop alert — verify the order is unchanged: Go Back, Open in Safari.

### Impact and Risks
Low - button ordering in a single alert. No logic changes.

#### What could go wrong?
Moving `.cancel` to "Open in Safari" means an iPad hardware Escape key press would trigger opening Safari instead of staying. This is a minimal edge case since the alert uses `.alert` style (not dismissible by tapping outside).

### Quality Considerations
N/A

### Notes to Reviewer
For the Open in Safari, `.default` style was set to prevent choosing this action with esc key on hardware keyboard.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adjusts `UIAlertAction` styles/order and sets `preferredAction` for the initial x-safari-https redirect prompt, with no navigation or state logic changes.
> 
> **Overview**
> Updates the initial `x-safari-https` redirect alert (`showTryOpenAlert`) so **“Stay in DuckDuckGo”** is shown as the first/primary choice: it is now a `.default` action, stored as `stayAction`, and assigned to `alert.preferredAction` (bold).
> 
> This effectively swaps the prominence of the two actions while leaving the “Open in Safari” handler and the loop alert behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b287bb4624fd94940c3dc60726e4b79fb600ec1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->