### PR TITLE
Add ad blocking pixels, scriptlet lifecycle tracking, and breakage report fields

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/BrokenSiteReport.swift
@@ -108,6 +108,8 @@ public struct BrokenSiteReport {
     let breakageData: String?
     let isForceDarkModeEnabled: Bool?
     let autoplayBlockingMode: String?
+    let loadedWebExtensions: String?
+    let adBlockingExtensionScriptletsVersion: String?
 #if os(iOS)
     let siteType: SiteType
     let atb: String
@@ -148,7 +150,9 @@ public struct BrokenSiteReport {
         isForceDarkModeEnabled: Bool?,
         autoplayBlockingMode: String? = nil,
         pageLoadTiming: WKPageLoadTiming?,
-        breakageData: String? = nil
+        breakageData: String? = nil,
+        loadedWebExtensions: String? = nil,
+        adBlockingExtensionScriptletsVersion: String? = nil
     ) {
         self.siteUrl = siteUrl
         self.category = category
@@ -181,6 +185,8 @@ public struct BrokenSiteReport {
         self.autoplayBlockingMode = autoplayBlockingMode
         self.pageLoadTiming = pageLoadTiming
         self.breakageData = breakageData
+        self.loadedWebExtensions = loadedWebExtensions
+        self.adBlockingExtensionScriptletsVersion = adBlockingExtensionScriptletsVersion
     }
 #endif
 
@@ -221,7 +227,9 @@ public struct BrokenSiteReport {
         autoplayBlockingMode: String? = nil,
         isAfterSuppressedXSafariRedirect: Bool = false,
         pageLoadTiming: WKPageLoadTiming? = nil,
-        breakageData: String? = nil
+        breakageData: String? = nil,
+        loadedWebExtensions: String? = nil,
+        adBlockingExtensionScriptletsVersion: String? = nil
     ) {
         self.siteUrl = siteUrl
         self.category = category
@@ -259,6 +267,8 @@ public struct BrokenSiteReport {
         self.autoplayBlockingMode = autoplayBlockingMode
         self.isAfterSuppressedXSafariRedirect = isAfterSuppressedXSafariRedirect
         self.breakageData = breakageData
+        self.loadedWebExtensions = loadedWebExtensions
+        self.adBlockingExtensionScriptletsVersion = adBlockingExtensionScriptletsVersion
     }
 #endif
 
@@ -352,6 +362,11 @@ public struct BrokenSiteReport {
 
         if let breakageData {
             result["breakageData"] = breakageData
+        }
+
+        if let loadedWebExtensions {
+            result["loadedWebExtensions"] = loadedWebExtensions
+            result["adBlockingExtensionScriptletsVersion"] = adBlockingExtensionScriptletsVersion ?? "nil"
         }
 
         return result

--- a/SharedPackages/BrowserServicesKit/Tests/PrivacyDashboardTests/BrokenSiteReportMocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PrivacyDashboardTests/BrokenSiteReportMocks.swift
@@ -213,6 +213,73 @@ struct BrokenSiteReportMocks {
 #endif
     }
 
+    static var reportWithWebExtensions: BrokenSiteReport {
+#if os(iOS)
+        BrokenSiteReport(siteUrl: URL(string: "https://duckduckgo.com")!,
+                         category: "test",
+                         description: "test",
+                         osVersion: "test",
+                         manufacturer: "Apple",
+                         upgradedHttps: true,
+                         tdsETag: "test",
+                         configVersion: "123456789",
+                         blockedTrackerDomains: [],
+                         installedSurrogates: [],
+                         isGPCEnabled: true,
+                         ampURL: "test",
+                         urlParametersRemoved: true,
+                         protectionsState: true,
+                         reportFlow: .appMenu,
+                         siteType: .desktop,
+                         atb: "test",
+                         model: "test",
+                         errors: nil,
+                         httpStatusCodes: nil,
+                         openerContext: nil,
+                         vpnOn: false,
+                         jsPerformance: nil,
+                         userRefreshCount: 0,
+                         variant: "",
+                         cookieConsentInfo: nil,
+                         debugFlags: "",
+                         privacyExperiments: "",
+                         isPirEnabled: nil,
+                         isForceDarkModeEnabled: nil,
+                         loadedWebExtensions: "embedded,adBlocking",
+                         adBlockingExtensionScriptletsVersion: "2.0.0")
+#else
+        BrokenSiteReport(siteUrl: URL(string: "https://duckduckgo.com")!,
+                         category: "test",
+                         description: "test",
+                         osVersion: "test",
+                         manufacturer: "Apple",
+                         upgradedHttps: true,
+                         tdsETag: "test",
+                         configVersion: "123456789",
+                         blockedTrackerDomains: [],
+                         installedSurrogates: [],
+                         isGPCEnabled: true,
+                         ampURL: "test",
+                         urlParametersRemoved: true,
+                         protectionsState: true,
+                         reportFlow: .appMenu,
+                         errors: nil,
+                         httpStatusCodes: nil,
+                         openerContext: nil,
+                         vpnOn: false,
+                         jsPerformance: nil,
+                         userRefreshCount: 0,
+                         cookieConsentInfo: nil,
+                         debugFlags: "",
+                         privacyExperiments: "",
+                         isPirEnabled: nil,
+                         isForceDarkModeEnabled: nil,
+                         pageLoadTiming: nil,
+                         loadedWebExtensions: "embedded,adBlocking",
+                         adBlockingExtensionScriptletsVersion: "2.0.0")
+#endif
+    }
+
     static let decodedBreakageData = """
             {"webDetection":[{"detectorId":"adwalls.generic_en","detected":true}],"detectorData":{"botDetection":{"detected":false,"type":"botDetection","results":[]}}}
             """

--- a/SharedPackages/BrowserServicesKit/Tests/PrivacyDashboardTests/BrokenSiteReporterTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PrivacyDashboardTests/BrokenSiteReporterTests.swift
@@ -90,4 +90,32 @@ final class BrokenSiteReporterTests: XCTestCase {
         try reporter.report(BrokenSiteReportMocks.report, reportMode: .regular)
         waitForExpectations(timeout: 3)
     }
+
+    func testWhenWebExtensionFieldsProvidedThenTheyAreIncluded() throws {
+        let keyValueStore = MockKeyValueStore()
+        let expectation = expectation(description: "Pixel sent")
+
+        let reporter = BrokenSiteReporter(pixelHandler: { parameters in
+            XCTAssertEqual(parameters["loadedWebExtensions"], "embedded,adBlocking")
+            XCTAssertEqual(parameters["adBlockingExtensionScriptletsVersion"], "2.0.0")
+            expectation.fulfill()
+        }, keyValueStoring: keyValueStore)
+
+        try reporter.report(BrokenSiteReportMocks.reportWithWebExtensions, reportMode: .regular)
+        waitForExpectations(timeout: 3)
+    }
+
+    func testWhenWebExtensionFieldsAbsentThenTheyAreNotIncluded() throws {
+        let keyValueStore = MockKeyValueStore()
+        let expectation = expectation(description: "Pixel sent")
+
+        let reporter = BrokenSiteReporter(pixelHandler: { parameters in
+            XCTAssertNil(parameters["loadedWebExtensions"])
+            XCTAssertNil(parameters["adBlockingExtensionScriptletsVersion"])
+            expectation.fulfill()
+        }, keyValueStoring: keyValueStore)
+
+        try reporter.report(BrokenSiteReportMocks.report, reportMode: .regular)
+        waitForExpectations(timeout: 3)
+    }
 }

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager.swift
@@ -102,6 +102,7 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
                 scriptletProvider: scriptletConfiguration.provider,
                 installationTracker: scriptletConfiguration.installationTracker,
                 installer: scriptletConfiguration.installer,
+                pixelFiring: scriptletConfiguration.pixelFiring,
                 cacheRootDirectory: scriptletConfiguration.cacheRootDirectory,
                 installationPathResolver: self
             )

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManaging.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManaging.swift
@@ -133,3 +133,24 @@ public struct ScriptletDebugInfo: Identifiable {
 
     public var id: String { extensionType.rawValue }
 }
+
+@available(macOS 15.4, iOS 18.4, *)
+public extension WebExtensionManaging {
+
+    /// Returns a comma-separated string of short labels for all currently installed embedded extensions,
+    /// or `nil` if none are installed.
+    func loadedWebExtensionsString() -> String? {
+        let labels = DuckDuckGoWebExtensionType.allCases
+            .filter { installedEmbeddedExtension(for: $0) != nil }
+            .map(\.shortLabel)
+        return labels.isEmpty ? nil : labels.joined(separator: ",")
+    }
+
+    /// Returns the cached scriptlets version for the ad-blocking extension, or `nil` if unavailable.
+    @MainActor
+    func adBlockingScriptletsVersion() -> String? {
+        scriptletDebugInfo()
+            .first { $0.extensionType == .adBlockingExtension }?
+            .cachedVersion
+    }
+}

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Pixels/WebExtensionPixelFiring.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Pixels/WebExtensionPixelFiring.swift
@@ -33,6 +33,12 @@ public enum WebExtensionPixelEvent {
     case embeddedInstalled(type: DuckDuckGoWebExtensionType)
     case embeddedUpgraded(type: DuckDuckGoWebExtensionType, fromVersion: String?, toVersion: String?)
     case embeddedInstallError(type: DuckDuckGoWebExtensionType, error: Error)
+
+    case scriptletFetchSuccess(type: DuckDuckGoWebExtensionType, version: String, count: Int)
+    case scriptletFetchError(type: DuckDuckGoWebExtensionType, error: Error)
+    case scriptletValidationError(type: DuckDuckGoWebExtensionType, error: Error)
+    case scriptletInstalled(type: DuckDuckGoWebExtensionType, version: String)
+    case scriptletInstallError(type: DuckDuckGoWebExtensionType, error: Error)
 }
 
 /// Protocol for firing web extension pixels.

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Scriptlets/Installation/WebExtensionScriptletCoordinator.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Scriptlets/Installation/WebExtensionScriptletCoordinator.swift
@@ -49,6 +49,7 @@ public final class WebExtensionScriptletCoordinator {
     private let scriptletProvider: ScriptletProviding
     private let installationTracker: ScriptletInstallationTracking
     private let installer: ScriptletInstalling
+    private let pixelFiring: WebExtensionPixelFiring
     private let cacheRootDirectory: URL
 
     public weak var installationPathResolver: (any WebExtensionInstallationPathResolving)?
@@ -61,12 +62,14 @@ public final class WebExtensionScriptletCoordinator {
         scriptletProvider: ScriptletProviding,
         installationTracker: ScriptletInstallationTracking,
         installer: ScriptletInstalling,
+        pixelFiring: WebExtensionPixelFiring = NoOpWebExtensionPixelFiring(),
         cacheRootDirectory: URL,
         installationPathResolver: any WebExtensionInstallationPathResolving
     ) {
         self.scriptletProvider = scriptletProvider
         self.installationTracker = installationTracker
         self.installer = installer
+        self.pixelFiring = pixelFiring
         self.cacheRootDirectory = cacheRootDirectory
         self.installationPathResolver = installationPathResolver
     }
@@ -157,10 +160,12 @@ public final class WebExtensionScriptletCoordinator {
             guard !Task.isCancelled, enabledTypes.contains(type) else { return }
 
             installationTracker.setInstalledVersion(version, for: type)
+            pixelFiring.fire(.scriptletInstalled(type: type, version: version))
             Logger.webExtensions.info("[Scriptlets] Installed v\(version) for '\(type.rawValue)'")
             try await installationPathResolver?.reloadExtension(for: type)
         } catch {
             Logger.webExtensions.error("[Scriptlets] Failed to install scriptlets for '\(type.rawValue)': \(error)")
+            pixelFiring.fire(.scriptletInstallError(type: type, error: error))
         }
     }
 }

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Scriptlets/ScriptletConfiguration.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Scriptlets/ScriptletConfiguration.swift
@@ -26,17 +26,20 @@ public struct ScriptletConfiguration {
     public let provider: ScriptletProviding
     public let installationTracker: ScriptletInstallationTracking
     public let installer: ScriptletInstalling
+    public let pixelFiring: WebExtensionPixelFiring
     public let cacheRootDirectory: URL
 
     public init(
         provider: ScriptletProviding,
         installationTracker: ScriptletInstallationTracking,
         installer: ScriptletInstalling = ScriptletInstaller(),
+        pixelFiring: WebExtensionPixelFiring = NoOpWebExtensionPixelFiring(),
         cacheRootDirectory: URL
     ) {
         self.provider = provider
         self.installationTracker = installationTracker
         self.installer = installer
+        self.pixelFiring = pixelFiring
         self.cacheRootDirectory = cacheRootDirectory
     }
 }

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Scriptlets/ScriptletManager.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Scriptlets/ScriptletManager.swift
@@ -51,6 +51,7 @@ public final class ScriptletManager: ScriptletProviding {
     private let fetcher: ScriptletFetching
     private let validator: ScriptletValidating
     private let store: ScriptletStoring
+    private let pixelFiring: WebExtensionPixelFiring
     private let isProduction: Bool
 
     @Published private var availabilities: [DuckDuckGoWebExtensionType: ScriptletAvailability] = [:]
@@ -64,12 +65,14 @@ public final class ScriptletManager: ScriptletProviding {
         fetcher: ScriptletFetching,
         validator: ScriptletValidating,
         store: ScriptletStoring,
+        pixelFiring: WebExtensionPixelFiring = NoOpWebExtensionPixelFiring(),
         isProduction: Bool = true
     ) {
         self.configProvider = configProvider
         self.fetcher = fetcher
         self.validator = validator
         self.store = store
+        self.pixelFiring = pixelFiring
         self.isProduction = isProduction
     }
 
@@ -195,6 +198,7 @@ public final class ScriptletManager: ScriptletProviding {
                 Logger.webExtensions.info("[Scriptlets] Signature validation passed for '\(extensionType.rawValue)' (\(fetched.count) scriptlet(s))")
             } catch {
                 if isProduction {
+                    pixelFiring.fire(.scriptletValidationError(type: extensionType, error: error))
                     throw error
                 }
                 Logger.webExtensions.warning("[Scriptlets] Validation failed for '\(extensionType.rawValue)' (non-production, continuing): \(error)")
@@ -203,9 +207,11 @@ public final class ScriptletManager: ScriptletProviding {
             let scriptlets = try store.save(fetched, version: manifest.version, for: extensionType)
 
             availabilities[extensionType] = .available(scriptlets)
+            pixelFiring.fire(.scriptletFetchSuccess(type: extensionType, version: manifest.version, count: scriptlets.count))
             Logger.webExtensions.info("[Scriptlets] Updated to v\(manifest.version) with \(scriptlets.count) scriptlet(s) for '\(extensionType.rawValue)'")
         } catch {
             Logger.webExtensions.error("[Scriptlets] Failed to fetch/update scriptlets for '\(extensionType.rawValue)': \(error)")
+            pixelFiring.fire(.scriptletFetchError(type: extensionType, error: error))
             if let existing = existingScriptlets {
                 availabilities[extensionType] = .available(existing)
             } else {

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Scriptlets/ScriptletManagerFactory.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Scriptlets/ScriptletManagerFactory.swift
@@ -27,6 +27,7 @@ public enum ScriptletManagerFactory {
         privacyConfigManager: PrivacyConfigurationManaging,
         apiService: APIService,
         baseDirectory: URL,
+        pixelFiring: WebExtensionPixelFiring = NoOpWebExtensionPixelFiring(),
         isProduction: Bool = true,
         defaults: UserDefaults = .standard,
         installer: ScriptletInstalling = ScriptletInstaller()
@@ -52,6 +53,7 @@ public enum ScriptletManagerFactory {
             fetcher: fetcher,
             validator: validator,
             store: store,
+            pixelFiring: pixelFiring,
             isProduction: isProduction
         )
 
@@ -59,6 +61,7 @@ public enum ScriptletManagerFactory {
             provider: manager,
             installationTracker: store,
             installer: installer,
+            pixelFiring: pixelFiring,
             cacheRootDirectory: baseDirectory
         )
     }

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/WKWebExtensionContext+Extension.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/WKWebExtensionContext+Extension.swift
@@ -31,6 +31,15 @@ public enum DuckDuckGoWebExtensionType: String, Codable, CaseIterable {
     case embedded = "com.duckduckgo.web-extension.embedded"
     case darkReader = "org.duckduckgo.web-extension.darkreader"
     case adBlockingExtension = "com.duckduckgo.content-blocker-extension"
+
+    /// Short human-readable label used in breakage reports.
+    public var shortLabel: String {
+        switch self {
+        case .embedded: return "embedded"
+        case .darkReader: return "darkMode"
+        case .adBlockingExtension: return "adBlocking"
+        }
+    }
 }
 
 /// Metadata extracted from a web extension without loading it into a controller.

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1733,6 +1733,17 @@ extension Pixel {
         case webExtensionAdBlockingInstalled
         case webExtensionAdBlockingUpgraded
         case webExtensionAdBlockingInstallError
+        case webExtensionAdBlockingSettingsOpen
+        case webExtensionAdBlockingEnabled
+        case webExtensionAdBlockingDisabled
+
+        case webExtensionScriptletFetchSuccess
+        case webExtensionScriptletFetchError
+        case webExtensionScriptletValidationError
+        case webExtensionScriptletInstalled
+        case webExtensionScriptletInstallError
+
+        case webExtensionDailyAdBlockingState
     }
 
 }
@@ -3377,6 +3388,17 @@ extension Pixel.Event {
         case .webExtensionAdBlockingInstalled: return "m_web_extension_ad_blocking_installed"
         case .webExtensionAdBlockingUpgraded: return "m_web_extension_ad_blocking_upgraded"
         case .webExtensionAdBlockingInstallError: return "m_web_extension_ad_blocking_install_error"
+        case .webExtensionAdBlockingSettingsOpen: return "m_web_extension_ad_blocking_settings_open"
+        case .webExtensionAdBlockingEnabled: return "m_web_extension_ad_blocking_enabled"
+        case .webExtensionAdBlockingDisabled: return "m_web_extension_ad_blocking_disabled"
+
+        case .webExtensionScriptletFetchSuccess: return "m_web_extension_scriptlet_fetch_success"
+        case .webExtensionScriptletFetchError: return "m_web_extension_scriptlet_fetch_error"
+        case .webExtensionScriptletValidationError: return "m_web_extension_scriptlet_validation_error"
+        case .webExtensionScriptletInstalled: return "m_web_extension_scriptlet_installed"
+        case .webExtensionScriptletInstallError: return "m_web_extension_scriptlet_install_error"
+
+        case .webExtensionDailyAdBlockingState: return "m_web_extension_daily_ad_blocking_state"
         }
     }
 }

--- a/iOS/DuckDuckGo/MainViewController+Segues.swift
+++ b/iOS/DuckDuckGo/MainViewController+Segues.swift
@@ -149,7 +149,7 @@ extension MainViewController {
                                                         entryPoint: entryPoint,
                                                         privacyConfigurationManager: self.privacyConfigurationManager,
                                                         contentBlockingManager: ContentBlocking.shared.contentBlockingManager,
-                                                        breakageAdditionalInfo: self.currentTab?.makeBreakageAdditionalInfo())
+                                                        breakageAdditionalInfo: self.currentTab?.makeBreakageAdditionalInfo(webExtensionManager: webExtensionManager))
 
         currentTab?.privacyDashboard = controller
 

--- a/iOS/DuckDuckGo/PrivacyDashboard/PrivacyDashboardViewController.swift
+++ b/iOS/DuckDuckGo/PrivacyDashboard/PrivacyDashboardViewController.swift
@@ -305,6 +305,8 @@ extension PrivacyDashboardViewController {
         let isForceDarkModeEnabled: Bool?
         let autoplayBlockingMode: String?
         let isAfterSuppressedXSafariRedirect: Bool
+        let loadedWebExtensions: String?
+        let adBlockingExtensionScriptletsVersion: String?
     }
     
     enum BrokenSiteReportError: Error {
@@ -382,7 +384,9 @@ extension PrivacyDashboardViewController {
                                 isForceDarkModeEnabled: breakageAdditionalInfo.isForceDarkModeEnabled,
                                 autoplayBlockingMode: breakageAdditionalInfo.autoplayBlockingMode,
                                 isAfterSuppressedXSafariRedirect: breakageAdditionalInfo.isAfterSuppressedXSafariRedirect,
-                                breakageData: breakageData)
+                                breakageData: breakageData,
+                                loadedWebExtensions: breakageAdditionalInfo.loadedWebExtensions,
+                                adBlockingExtensionScriptletsVersion: breakageAdditionalInfo.adBlockingExtensionScriptletsVersion)
     }
 
 }

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -665,6 +665,10 @@ final class SettingsViewModel: ObservableObject {
                 guard $0 != self.state.youTubeAdBlockingEnabled else { return }
                 try? self.youTubeAdBlockingStorage.set($0, for: \YouTubeAdBlockingKeys.youTubeAdBlockingEnabled)
                 self.state.youTubeAdBlockingEnabled = $0
+                DailyPixel.fireDailyAndCount(
+                    pixel: $0 ? .webExtensionAdBlockingEnabled : .webExtensionAdBlockingDisabled,
+                    pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes
+                )
                 NotificationCenter.default.post(name: YouTubeAdBlockingStorageKeys.youTubeAdBlockingEnabledDidChangeNotification, object: nil)
             }
         )

--- a/iOS/DuckDuckGo/SettingsYouTubeAdBlockingView.swift
+++ b/iOS/DuckDuckGo/SettingsYouTubeAdBlockingView.swift
@@ -86,8 +86,8 @@ struct SettingsYouTubeAdBlockingView: View {
                                     displayMode: .inline,
                                     viewModel: viewModel)
         .onAppear {
-            DailyPixel.fireDailyAndCount(pixel: .duckPlayerSettingsOpen,
-                                         withAdditionalParameters: viewModel.featureDiscovery.addToParams([:], forFeature: .duckPlayer))
+            DailyPixel.fireDailyAndCount(pixel: .webExtensionAdBlockingSettingsOpen,
+                                         pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes)
         }
     }
 }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -47,6 +47,7 @@ import SERPSettings
 import AIChat
 import PixelKit
 import PrivacyConfig
+import WebExtensions
 
 class TabViewController: UIViewController {
 
@@ -1374,12 +1375,13 @@ class TabViewController: UIViewController {
 
     func showPrivacyDashboard() {
         Pixel.fire(pixel: .privacyDashboardOpened, withAdditionalParameters: featureDiscovery.addToParams([:], forFeature: .privacyDashboard))
+        let webExtManager = (delegate as? MainViewController)?.webExtensionManager
         let controller = PrivacyDashboardViewController(
             privacyInfo: privacyInfo,
             entryPoint: .dashboard,
             privacyConfigurationManager: privacyConfigurationManager,
             contentBlockingManager: ContentBlocking.shared.contentBlockingManager,
-            breakageAdditionalInfo: makeBreakageAdditionalInfo())
+            breakageAdditionalInfo: makeBreakageAdditionalInfo(webExtensionManager: webExtManager))
 
         guard let chromeDelegate = chromeDelegate else { return }
 
@@ -1529,10 +1531,17 @@ class TabViewController: UIViewController {
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.isLoading))
     }
 
-    public func makeBreakageAdditionalInfo() -> PrivacyDashboardViewController.BreakageAdditionalInfo? {
-        
+    public func makeBreakageAdditionalInfo(webExtensionManager: WebExtensionManaging? = nil) -> PrivacyDashboardViewController.BreakageAdditionalInfo? {
+
         guard let currentURL = url else {
             return nil
+        }
+
+        var loadedWebExtensions: String?
+        var adBlockingScriptletsVersion: String?
+        if #available(iOS 18.4, *), let webExtensionManager {
+            loadedWebExtensions = webExtensionManager.loadedWebExtensionsString()
+            adBlockingScriptletsVersion = webExtensionManager.adBlockingScriptletsVersion()
         }
 
         return PrivacyDashboardViewController.BreakageAdditionalInfo(currentURL: currentURL,
@@ -1548,7 +1557,9 @@ class TabViewController: UIViewController {
                                                                      breakageReportingSubfeature: breakageReportingSubfeature,
                                                                      isForceDarkModeEnabled: darkReaderFeatureSettings.isForceDarkModeEnabled,
                                                                      autoplayBlockingMode: featureFlagger.isFeatureOn(.autoplayBlocking) ? autoplaySettings.currentAutoplayBlockingMode.rawValue : nil,
-                                                                     isAfterSuppressedXSafariRedirect: safariRedirectHandler.isAfterSuppressedXSafariRedirect(for: currentURL))
+                                                                     isAfterSuppressedXSafariRedirect: safariRedirectHandler.isAfterSuppressedXSafariRedirect(for: currentURL),
+                                                                     loadedWebExtensions: loadedWebExtensions,
+                                                                     adBlockingExtensionScriptletsVersion: adBlockingScriptletsVersion)
     }
 
     public func print() {

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -415,6 +415,7 @@ final class MainCoordinator {
             privacyConfigManager: ContentBlocking.shared.privacyConfigurationManager,
             apiService: DefaultAPIService(),
             baseDirectory: scriptletsDirectory,
+            pixelFiring: iOSWebExtensionPixelFiring(),
             isProduction: !isDebugBuild
         )
     }
@@ -535,6 +536,8 @@ final class MainCoordinator {
         controller.showBars()
         controller.onForeground()
 
+        fireDailyAdBlockingPixel()
+
         if #available(iOS 18.4, *) {
             webExtensionEventsCoordinator?.didFocusWindow()
         }
@@ -549,6 +552,14 @@ final class MainCoordinator {
 
     private func resetAppStartTime() {
         controller.appDidFinishLaunchingStartTime = nil
+    }
+
+    private func fireDailyAdBlockingPixel() {
+        let isEnabled = controller.adBlockingAvailability.isEnabled
+        DailyPixel.fire(
+            pixel: .webExtensionDailyAdBlockingState,
+            withAdditionalParameters: ["is_enabled": isEnabled ? "true" : "false"]
+        )
     }
 
 }

--- a/iOS/DuckDuckGo/WebExtensions/WebExtensionPixelFiring+iOS.swift
+++ b/iOS/DuckDuckGo/WebExtensions/WebExtensionPixelFiring+iOS.swift
@@ -122,9 +122,39 @@ struct iOSWebExtensionPixelFiring: WebExtensionPixelFiring {
                 pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
                 error: error
             )
-        case .scriptletFetchSuccess, .scriptletFetchError, .scriptletValidationError,
-             .scriptletInstalled, .scriptletInstallError:
-            break
+        case .scriptletFetchSuccess(let type, let version, let count):
+            DailyPixel.fireDailyAndCount(
+                pixel: .webExtensionScriptletFetchSuccess,
+                pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
+                withAdditionalParameters: ["extension_type": type.rawValue, "version": version, "count": "\(count)"]
+            )
+        case .scriptletFetchError(let type, let error):
+            DailyPixel.fireDailyAndCount(
+                pixel: .webExtensionScriptletFetchError,
+                pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
+                error: error,
+                withAdditionalParameters: ["extension_type": type.rawValue]
+            )
+        case .scriptletValidationError(let type, let error):
+            DailyPixel.fireDailyAndCount(
+                pixel: .webExtensionScriptletValidationError,
+                pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
+                error: error,
+                withAdditionalParameters: ["extension_type": type.rawValue]
+            )
+        case .scriptletInstalled(let type, let version):
+            DailyPixel.fireDailyAndCount(
+                pixel: .webExtensionScriptletInstalled,
+                pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
+                withAdditionalParameters: ["extension_type": type.rawValue, "version": version]
+            )
+        case .scriptletInstallError(let type, let error):
+            DailyPixel.fireDailyAndCount(
+                pixel: .webExtensionScriptletInstallError,
+                pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
+                error: error,
+                withAdditionalParameters: ["extension_type": type.rawValue]
+            )
         }
     }
 }

--- a/iOS/DuckDuckGo/WebExtensions/WebExtensionPixelFiring+iOS.swift
+++ b/iOS/DuckDuckGo/WebExtensions/WebExtensionPixelFiring+iOS.swift
@@ -122,6 +122,9 @@ struct iOSWebExtensionPixelFiring: WebExtensionPixelFiring {
                 pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes,
                 error: error
             )
+        case .scriptletFetchSuccess, .scriptletFetchError, .scriptletValidationError,
+             .scriptletInstalled, .scriptletInstallError:
+            break
         }
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/broken_site_reporting.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/broken_site_reporting.json5
@@ -340,6 +340,16 @@
                 "key": "extendedPerformance.totalResourcesSizeBucket",
                 "type": "string",
                 "description": "Total resources size bucket"
+            },
+            {
+                "key": "loadedWebExtensions",
+                "type": "string",
+                "description": "Comma-separated short labels of currently installed web extensions (e.g. embedded,darkMode,adBlocking)"
+            },
+            {
+                "key": "adBlockingExtensionScriptletsVersion",
+                "type": "string",
+                "description": "Cached scriptlets version for the ad-blocking web extension"
             }
         ]
     },
@@ -654,6 +664,16 @@
                 "key": "extendedPerformance.totalResourcesSizeBucket",
                 "type": "string",
                 "description": "Total resources size bucket"
+            },
+            {
+                "key": "loadedWebExtensions",
+                "type": "string",
+                "description": "Comma-separated short labels of currently installed web extensions (e.g. embedded,darkMode,adBlocking)"
+            },
+            {
+                "key": "adBlockingExtensionScriptletsVersion",
+                "type": "string",
+                "description": "Cached scriptlets version for the ad-blocking web extension"
             }
         ]
     }

--- a/iOS/PixelDefinitions/pixels/definitions/web_extensions.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/web_extensions.json5
@@ -224,5 +224,161 @@
             ["platform", "form_factor"]
         ],
         "parameters": ["appVersion", "errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
+    },
+    "m_web_extension_ad_blocking_settings_open": {
+        "description": "Fires when the user opens the YouTube Ad Blocking settings screen.",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": ["appVersion"]
+    },
+    "m_web_extension_ad_blocking_enabled": {
+        "description": "Fires when the user enables YouTube ad blocking in settings.",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": ["appVersion"]
+    },
+    "m_web_extension_ad_blocking_disabled": {
+        "description": "Fires when the user disables YouTube ad blocking in settings.",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": ["appVersion"]
+    },
+    "m_web_extension_scriptlet_fetch_success": {
+        "description": "Fires when scriptlets are successfully fetched from the server and saved to cache.",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "extension_type",
+                "type": "string",
+                "description": "The web extension type the scriptlets belong to (e.g. com.duckduckgo.content-blocker-extension)"
+            },
+            {
+                "key": "version",
+                "type": "string",
+                "description": "The version of the fetched scriptlets"
+            },
+            {
+                "key": "count",
+                "type": "string",
+                "description": "The number of scriptlet files fetched"
+            }
+        ]
+    },
+    "m_web_extension_scriptlet_fetch_error": {
+        "description": "Fires when fetching or saving scriptlets fails (network error, empty response, storage failure).",
+        "owners": ["miasma13"],
+        "triggers": ["exception"],
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": [
+            "appVersion",
+            "errorCode",
+            "errorDomain",
+            "underlyingErrorCode",
+            "underlyingErrorDomain",
+            {
+                "key": "extension_type",
+                "type": "string",
+                "description": "The web extension type the scriptlets belong to"
+            }
+        ]
+    },
+    "m_web_extension_scriptlet_validation_error": {
+        "description": "Fires when scriptlet signature validation fails in production, blocking the update.",
+        "owners": ["miasma13"],
+        "triggers": ["exception"],
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": [
+            "appVersion",
+            "errorCode",
+            "errorDomain",
+            "underlyingErrorCode",
+            "underlyingErrorDomain",
+            {
+                "key": "extension_type",
+                "type": "string",
+                "description": "The web extension type the scriptlets belong to"
+            }
+        ]
+    },
+    "m_web_extension_scriptlet_installed": {
+        "description": "Fires when scriptlets are successfully installed into a web extension directory.",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "extension_type",
+                "type": "string",
+                "description": "The web extension type the scriptlets were installed for"
+            },
+            {
+                "key": "version",
+                "type": "string",
+                "description": "The version of the installed scriptlets"
+            }
+        ]
+    },
+    "m_web_extension_scriptlet_install_error": {
+        "description": "Fires when installing scriptlets into a web extension directory fails.",
+        "owners": ["miasma13"],
+        "triggers": ["exception"],
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
+        "parameters": [
+            "appVersion",
+            "errorCode",
+            "errorDomain",
+            "underlyingErrorCode",
+            "underlyingErrorDomain",
+            {
+                "key": "extension_type",
+                "type": "string",
+                "description": "The web extension type the scriptlets were being installed for"
+            }
+        ]
+    },
+    "m_web_extension_daily_ad_blocking_state": {
+        "description": "Fires once daily to report whether YouTube ad blocking is currently enabled (feature flag on and user opted in).",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "is_enabled",
+                "type": "string",
+                "description": "Whether ad blocking is currently enabled (true/false)"
+            }
+        ]
     }
 }

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1487,6 +1487,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         fireDailyActiveUserPixels()
         fireDailyFireWindowConfigurationPixels()
         fireDailyAIChatEnabledPixel()
+        fireDailyAdBlockingPixel()
 
         fireAutoconsentDailyPixel()
         fireThemeDailyPixel()
@@ -1535,6 +1536,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func fireDailyAIChatEnabledPixel() {
         PixelKit.fire(AIChatPixel.aiChatIsEnabled(isEnabled: aiChatPreferences.isAIFeaturesEnabled), frequency: .daily)
+    }
+
+    private func fireDailyAdBlockingPixel() {
+        PixelKit.fire(WebExtensionPixel.dailyAdBlockingState(isEnabled: adBlockingAvailability.isEnabled), frequency: .daily)
     }
 
     private func fireAutoconsentDailyPixel() {
@@ -1953,6 +1958,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             privacyConfigManager: privacyFeatures.contentBlocking.privacyConfigurationManager,
             apiService: DefaultAPIService(),
             baseDirectory: scriptletsDirectory,
+            pixelFiring: MacOSWebExtensionPixelFiring(),
             isProduction: !StandardApplicationBuildType().isDebugBuild
         )
     }

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -31,6 +31,7 @@ import PixelKit
 import PrivacyConfig
 import SwiftUI
 import VPN
+import WebExtensions
 
 final class MainViewController: NSViewController {
     private(set) lazy var mainView = MainView(frame: NSRect(x: 0, y: 0, width: 600, height: 660))
@@ -148,7 +149,8 @@ final class MainViewController: NSViewController {
          pinningManager: PinningManager = NSApp.delegateTyped.pinningManager,
          duckAIChromeButtonsVisibilityManager: DuckAIChromeButtonsVisibilityManaging = LocalDuckAIChromeButtonsVisibilityManager(),
          memoryUsageMonitor: MemoryUsageMonitor = NSApp.delegateTyped.memoryUsageMonitor,
-         startupProfiler: StartupProfiler = NSApp.delegateTyped.startupProfiler
+         startupProfiler: StartupProfiler = NSApp.delegateTyped.startupProfiler,
+         adBlockingAvailability: AdBlockingAvailabilityProviding = NSApp.delegateTyped.adBlockingAvailability
     ) {
 
         self.aiChatMenuConfig = aiChatMenuConfig
@@ -237,7 +239,8 @@ final class MainViewController: NSViewController {
             dockPreferences: dockPreferences,
             accessibilityPreferences: accessibilityPreferences,
             duckPlayer: duckPlayer,
-            pinningManager: pinningManager
+            pinningManager: pinningManager,
+            adBlockingAvailability: adBlockingAvailability
         )
         aiChatCoordinator = AIChatCoordinator(
             sidebarHost: browserTabViewController,
@@ -276,6 +279,7 @@ final class MainViewController: NSViewController {
                                                                          networkProtectionStatusReporter: networkProtectionStatusReporter,
                                                                          autofillPopoverPresenter: autofillPopoverPresenter,
                                                                          brokenSitePromptLimiter: brokenSitePromptLimiter,
+                                                                         adBlockingAvailability: adBlockingAvailability,
                                                                          searchPreferences: searchPreferences,
                                                                          webTrackingProtectionPreferences: webTrackingProtectionPreferences,
                                                                          aiChatMenuConfig: aiChatMenuConfig,

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -327,8 +327,8 @@ final class AddressBarButtonsViewController: NSViewController {
           aiChatCoordinator: AIChatCoordinating,
           aiChatSettings: AIChatPreferencesStorage,
           themeManager: ThemeManaging = NSApp.delegateTyped.themeManager,
-          featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
-          adBlockingAvailability: AdBlockingAvailabilityProviding = NSApp.delegateTyped.adBlockingAvailability) {
+          featureFlagger: FeatureFlagger,
+          adBlockingAvailability: AdBlockingAvailabilityProviding) {
         self.tabCollectionViewModel = tabCollectionViewModel
         self.bookmarkManager = bookmarkManager
         self.accessibilityPreferences = accessibilityPreferences

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -24,6 +24,7 @@ import AIChat
 import UIComponents
 import PixelKit
 import PrivacyConfig
+import WebExtensions
 
 protocol AddressBarViewControllerDelegate: AnyObject {
     func resizeAddressBarForHomePage(_ addressBarViewController: AddressBarViewController)
@@ -110,6 +111,7 @@ final class AddressBarViewController: NSViewController {
     private let tabsPreferences: TabsPreferences
     private let accessibilityPreferences: AccessibilityPreferences
     private let featureFlagger: FeatureFlagger
+    private let adBlockingAvailability: AdBlockingAvailabilityProviding
 
     private var aiChatSettings: AIChatPreferencesStorage
 
@@ -210,7 +212,8 @@ final class AddressBarViewController: NSViewController {
           aiChatSettings: AIChatPreferencesStorage = DefaultAIChatPreferencesStorage(),
           aiChatMenuConfig: AIChatMenuVisibilityConfigurable,
           aiChatCoordinator: AIChatCoordinating,
-          featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger) {
+          featureFlagger: FeatureFlagger,
+          adBlockingAvailability: AdBlockingAvailabilityProviding) {
         self.tabCollectionViewModel = tabCollectionViewModel
         self.bookmarkManager = bookmarkManager
         self.privacyConfigurationManager = privacyConfigurationManager
@@ -239,6 +242,7 @@ final class AddressBarViewController: NSViewController {
         self.aiChatMenuConfig = aiChatMenuConfig
         self.aiChatCoordinator = aiChatCoordinator
         self.featureFlagger = featureFlagger
+        self.adBlockingAvailability = adBlockingAvailability
 
         super.init(coder: coder)
     }
@@ -255,7 +259,9 @@ final class AddressBarViewController: NSViewController {
                                                          aiChatTabOpener: NSApp.delegateTyped.aiChatTabOpener,
                                                          aiChatMenuConfig: aiChatMenuConfig,
                                                          aiChatCoordinator: aiChatCoordinator,
-                                                         aiChatSettings: aiChatSettings)
+                                                         aiChatSettings: aiChatSettings,
+                                                         featureFlagger: featureFlagger,
+                                                         adBlockingAvailability: adBlockingAvailability)
 
         self.addressBarButtonsViewController = controller
         controller?.delegate = self

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -32,6 +32,7 @@ import PrivacyConfig
 import Subscription
 import SubscriptionUI
 import VPN
+import WebExtensions
 
 final class NavigationBarViewController: NSViewController {
 
@@ -159,6 +160,7 @@ final class NavigationBarViewController: NSViewController {
 
     private let brokenSitePromptLimiter: BrokenSitePromptLimiter
     private let featureFlagger: FeatureFlagger
+    private let adBlockingAvailability: AdBlockingAvailabilityProviding
     private let searchPreferences: SearchPreferences
     private let aiChatMenuConfig: AIChatMenuVisibilityConfigurable
     private let aiChatCoordinator: AIChatCoordinating
@@ -227,6 +229,7 @@ final class NavigationBarViewController: NSViewController {
                        autofillPopoverPresenter: AutofillPopoverPresenter,
                        brokenSitePromptLimiter: BrokenSitePromptLimiter,
                        featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
+                       adBlockingAvailability: AdBlockingAvailabilityProviding = NSApp.delegateTyped.adBlockingAvailability,
                        searchPreferences: SearchPreferences,
                        webTrackingProtectionPreferences: WebTrackingProtectionPreferences,
                        themeManager: ThemeManaging = NSApp.delegateTyped.themeManager,
@@ -264,6 +267,7 @@ final class NavigationBarViewController: NSViewController {
                 autofillPopoverPresenter: autofillPopoverPresenter,
                 brokenSitePromptLimiter: brokenSitePromptLimiter,
                 featureFlagger: featureFlagger,
+                adBlockingAvailability: adBlockingAvailability,
                 searchPreferences: searchPreferences,
                 webTrackingProtectionPreferences: webTrackingProtectionPreferences,
                 themeManager: themeManager,
@@ -299,6 +303,7 @@ final class NavigationBarViewController: NSViewController {
         autofillPopoverPresenter: AutofillPopoverPresenter,
         brokenSitePromptLimiter: BrokenSitePromptLimiter,
         featureFlagger: FeatureFlagger,
+        adBlockingAvailability: AdBlockingAvailabilityProviding,
         searchPreferences: SearchPreferences,
         webTrackingProtectionPreferences: WebTrackingProtectionPreferences,
         themeManager: ThemeManaging,
@@ -354,6 +359,7 @@ final class NavigationBarViewController: NSViewController {
         self.fireproofDomains = fireproofDomains
         self.brokenSitePromptLimiter = brokenSitePromptLimiter
         self.featureFlagger = featureFlagger
+        self.adBlockingAvailability = adBlockingAvailability
         self.searchPreferences = searchPreferences
         self.themeManager = themeManager
         self.aiChatMenuConfig = aiChatMenuConfig
@@ -434,7 +440,9 @@ final class NavigationBarViewController: NSViewController {
                                                                       accessibilityPreferences: accessibilityPreferences,
                                                                       onboardingPixelReporter: onboardingPixelReporter,
                                                                       aiChatMenuConfig: aiChatMenuConfig,
-                                                                      aiChatCoordinator: aiChatCoordinator) else {
+                                                                      aiChatCoordinator: aiChatCoordinator,
+                                                                      featureFlagger: featureFlagger,
+                                                                      adBlockingAvailability: adBlockingAvailability) else {
             fatalError("NavigationBarViewController: Failed to init AddressBarViewController")
         }
 

--- a/macOS/DuckDuckGo/Preferences/Model/PreferencesSidebarModel.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/PreferencesSidebarModel.swift
@@ -190,7 +190,7 @@ final class PreferencesSidebarModel: ObservableObject {
         duckPlayerPreferences: DuckPlayerPreferences,
         youTubeAdBlockingPreferences: YouTubeAdBlockingPreferences,
         winBackOfferVisibilityManager: WinBackOfferVisibilityManaging,
-        adBlockingAvailability: AdBlockingAvailabilityProviding = NSApp.delegateTyped.adBlockingAvailability
+        adBlockingAvailability: AdBlockingAvailabilityProviding
     ) {
         let loadSections = { currentSubscriptionFeatures in
             return PreferencesSection.defaultSections(

--- a/macOS/DuckDuckGo/Preferences/Model/YouTubeAdBlockingPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/YouTubeAdBlockingPreferences.swift
@@ -34,6 +34,7 @@ final class YouTubeAdBlockingPreferences: ObservableObject {
     static let youTubeAdBlockingEnabledDidChangeNotification = Notification.Name("youTubeAdBlockingEnabledDidChange")
 
     private var settings: any KeyedStoring<YouTubeAdBlockingSettings>
+    private let pixelFiring: PixelFiring?
     private var cancellables = Set<AnyCancellable>()
 
     @Published
@@ -41,6 +42,9 @@ final class YouTubeAdBlockingPreferences: ObservableObject {
         didSet {
             guard youTubeAdBlockingEnabled != oldValue else { return }
             settings.youTubeAdBlockingEnabled = youTubeAdBlockingEnabled
+            pixelFiring?.fire(
+                youTubeAdBlockingEnabled ? WebExtensionPixel.adBlockingExtensionEnabled : WebExtensionPixel.adBlockingExtensionDisabled,
+                frequency: .dailyAndCount)
             NotificationCenter.default.post(name: Self.youTubeAdBlockingEnabledDidChangeNotification, object: nil)
         }
     }
@@ -98,9 +102,11 @@ final class YouTubeAdBlockingPreferences: ObservableObject {
     }
 
     init(settings: (any KeyedStoring<YouTubeAdBlockingSettings>)? = nil,
-         duckPlayerPreferences: DuckPlayerPreferences? = nil) {
+         duckPlayerPreferences: DuckPlayerPreferences? = nil,
+         pixelFiring: PixelFiring? = nil) {
         self.settings = if let settings { settings } else { UserDefaults.standard.keyedStoring() }
         self.duckPlayerPreferences = duckPlayerPreferences ?? DuckPlayerPreferences()
+        self.pixelFiring = pixelFiring
         youTubeAdBlockingEnabled = self.settings.youTubeAdBlockingEnabled ?? false
 
         self.duckPlayerPreferences.objectWillChange

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesViewController.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesViewController.swift
@@ -26,6 +26,7 @@ import VPN
 import AIChat
 import PrivacyConfig
 import Subscription
+import WebExtensions
 
 final class PreferencesViewController: NSViewController {
 
@@ -63,7 +64,8 @@ final class PreferencesViewController: NSViewController {
         youTubeAdBlockingPreferences: YouTubeAdBlockingPreferences,
         subscriptionManager: any SubscriptionManager,
         winBackOfferVisibilityManager: WinBackOfferVisibilityManaging,
-        pinningManager: PinningManager
+        pinningManager: PinningManager,
+        adBlockingAvailability: AdBlockingAvailabilityProviding
     ) {
         self.tabCollectionViewModel = tabCollectionViewModel
         self.privacyConfigurationManager = privacyConfigurationManager
@@ -89,7 +91,8 @@ final class PreferencesViewController: NSViewController {
                                         accessibilityPreferences: accessibilityPreferences,
                                         duckPlayerPreferences: duckPlayerPreferences,
                                         youTubeAdBlockingPreferences: youTubeAdBlockingPreferences,
-                                        winBackOfferVisibilityManager: winBackOfferVisibilityManager)
+                                        winBackOfferVisibilityManager: winBackOfferVisibilityManager,
+                                        adBlockingAvailability: adBlockingAvailability)
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
+++ b/macOS/DuckDuckGo/PrivacyDashboard/View/PrivacyDashboardViewController.swift
@@ -26,6 +26,7 @@ import PixelKit
 import PixelExperimentKit
 import os.log
 import FeatureFlags
+import WebExtensions
 
 protocol PrivacyDashboardViewControllerSizeDelegate: AnyObject {
 
@@ -415,6 +416,13 @@ extension PrivacyDashboardViewController {
 
         let isPirEnabled = await isPirEnabledAndUserHasProfile()
 
+        var loadedWebExtensions: String?
+        var adBlockingScriptletsVersion: String?
+        if #available(macOS 15.4, *), let webExtensionManager = NSApp.delegateTyped.webExtensionManager {
+            loadedWebExtensions = webExtensionManager.loadedWebExtensionsString()
+            adBlockingScriptletsVersion = webExtensionManager.adBlockingScriptletsVersion()
+        }
+
         let websiteBreakage = BrokenSiteReport(siteUrl: currentURL,
                                                category: category.lowercased(),
                                                description: description,
@@ -443,7 +451,9 @@ extension PrivacyDashboardViewController {
                                                isPirEnabled: isPirEnabled,
                                                isForceDarkModeEnabled: NSApp.delegateTyped.darkReaderFeatureSettings?.isForceDarkModeEnabled,
                                                pageLoadTiming: currentTab.brokenSiteInfo?.lastPageLoadTiming,
-                                               breakageData: breakageData)
+                                               breakageData: breakageData,
+                                               loadedWebExtensions: loadedWebExtensions,
+                                               adBlockingExtensionScriptletsVersion: adBlockingScriptletsVersion)
         return websiteBreakage
     }
 }

--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -33,6 +33,7 @@ import PrivacyConfig
 import Subscription
 import SwiftUI
 import UserScript
+import WebExtensions
 import WebKit
 
 protocol BrowserTabViewControllerDelegate: AnyObject {
@@ -102,6 +103,7 @@ final class BrowserTabViewController: NSViewController {
     private let subscriptionManager: any SubscriptionManager
     private let winBackOfferVisibilityManager: WinBackOfferVisibilityManaging
     private let pinningManager: PinningManager
+    private let adBlockingAvailability: AdBlockingAvailabilityProviding
 
     private let tld: TLD
 
@@ -177,6 +179,7 @@ final class BrowserTabViewController: NSViewController {
          subscriptionManager: any SubscriptionManager = NSApp.delegateTyped.subscriptionManager,
          winBackOfferVisibilityManager: WinBackOfferVisibilityManaging = NSApp.delegateTyped.winBackOfferVisibilityManager,
          pinningManager: PinningManager,
+         adBlockingAvailability: AdBlockingAvailabilityProviding = NSApp.delegateTyped.adBlockingAvailability,
          tld: TLD = NSApp.delegateTyped.tld
     ) {
         self.tabCollectionViewModel = tabCollectionViewModel
@@ -204,6 +207,7 @@ final class BrowserTabViewController: NSViewController {
         self.subscriptionManager = subscriptionManager
         self.winBackOfferVisibilityManager = winBackOfferVisibilityManager
         self.pinningManager = pinningManager
+        self.adBlockingAvailability = adBlockingAvailability
 
         self.tld = tld
         containerStackView = NSStackView()
@@ -1266,7 +1270,8 @@ final class BrowserTabViewController: NSViewController {
                 youTubeAdBlockingPreferences: YouTubeAdBlockingPreferences(duckPlayerPreferences: duckPlayer.preferences, pixelFiring: PixelKit.shared),
                 subscriptionManager: subscriptionManager,
                 winBackOfferVisibilityManager: winBackOfferVisibilityManager,
-                pinningManager: pinningManager
+                pinningManager: pinningManager,
+                adBlockingAvailability: adBlockingAvailability
             )
             preferencesViewController.delegate = self
             self.preferencesViewController = preferencesViewController

--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -1263,7 +1263,7 @@ final class BrowserTabViewController: NSViewController {
                 dockPreferences: dockPreferences,
                 accessibilityPreferences: accessibilityPreferences,
                 duckPlayerPreferences: duckPlayer.preferences,
-                youTubeAdBlockingPreferences: YouTubeAdBlockingPreferences(duckPlayerPreferences: duckPlayer.preferences),
+                youTubeAdBlockingPreferences: YouTubeAdBlockingPreferences(duckPlayerPreferences: duckPlayer.preferences, pixelFiring: PixelKit.shared),
                 subscriptionManager: subscriptionManager,
                 winBackOfferVisibilityManager: winBackOfferVisibilityManager,
                 pinningManager: pinningManager

--- a/macOS/DuckDuckGo/WebExtensions/Pixels/MacOSWebExtensionPixelFiring.swift
+++ b/macOS/DuckDuckGo/WebExtensions/Pixels/MacOSWebExtensionPixelFiring.swift
@@ -57,6 +57,20 @@ enum WebExtensionPixel: PixelKitEvent {
     case adBlockingExtensionInstalled
     case adBlockingExtensionUpgraded(fromVersion: String?, toVersion: String?)
     case adBlockingExtensionInstallError(error: Error)
+    case adBlockingExtensionEnabled
+    case adBlockingExtensionDisabled
+
+    // MARK: - Scriptlet Lifecycle
+
+    case scriptletFetchSuccess(extensionType: String, version: String, count: Int)
+    case scriptletFetchError(extensionType: String, error: Error)
+    case scriptletValidationError(extensionType: String, error: Error)
+    case scriptletInstalled(extensionType: String, version: String)
+    case scriptletInstallError(extensionType: String, error: Error)
+
+    // MARK: - Daily State
+
+    case dailyAdBlockingState(isEnabled: Bool)
 
     // MARK: - PixelKitEvent
 
@@ -100,6 +114,22 @@ enum WebExtensionPixel: PixelKitEvent {
             return "m_mac_web_extension_ad_blocking_upgraded"
         case .adBlockingExtensionInstallError:
             return "m_mac_web_extension_ad_blocking_install_error"
+        case .adBlockingExtensionEnabled:
+            return "m_mac_web_extension_ad_blocking_enabled"
+        case .adBlockingExtensionDisabled:
+            return "m_mac_web_extension_ad_blocking_disabled"
+        case .scriptletFetchSuccess:
+            return "m_mac_web_extension_scriptlet_fetch_success"
+        case .scriptletFetchError:
+            return "m_mac_web_extension_scriptlet_fetch_error"
+        case .scriptletValidationError:
+            return "m_mac_web_extension_scriptlet_validation_error"
+        case .scriptletInstalled:
+            return "m_mac_web_extension_scriptlet_installed"
+        case .scriptletInstallError:
+            return "m_mac_web_extension_scriptlet_install_error"
+        case .dailyAdBlockingState:
+            return "m_mac_web_extension_daily_ad_blocking_state"
         }
     }
 
@@ -116,6 +146,16 @@ enum WebExtensionPixel: PixelKitEvent {
                 params["to_version"] = toVersion
             }
             return params.isEmpty ? nil : params
+        case .scriptletFetchSuccess(let extensionType, let version, let count):
+            return ["extension_type": extensionType, "version": version, "count": "\(count)"]
+        case .scriptletFetchError(let extensionType, _),
+             .scriptletValidationError(let extensionType, _),
+             .scriptletInstallError(let extensionType, _):
+            return ["extension_type": extensionType]
+        case .scriptletInstalled(let extensionType, let version):
+            return ["extension_type": extensionType, "version": version]
+        case .dailyAdBlockingState(let isEnabled):
+            return ["is_enabled": isEnabled ? "true" : "false"]
         default:
             return nil
         }
@@ -187,6 +227,16 @@ struct MacOSWebExtensionPixelFiring: WebExtensionPixelFiring {
         case .embeddedInstallError(let type, let error):
             guard let macPixel = type.installErrorPixel(error: error) else { return }
             pixel = macPixel
+        case .scriptletFetchSuccess(let type, let version, let count):
+            pixel = .scriptletFetchSuccess(extensionType: type.rawValue, version: version, count: count)
+        case .scriptletFetchError(let type, let error):
+            pixel = .scriptletFetchError(extensionType: type.rawValue, error: error)
+        case .scriptletValidationError(let type, let error):
+            pixel = .scriptletValidationError(extensionType: type.rawValue, error: error)
+        case .scriptletInstalled(let type, let version):
+            pixel = .scriptletInstalled(extensionType: type.rawValue, version: version)
+        case .scriptletInstallError(let type, let error):
+            pixel = .scriptletInstallError(extensionType: type.rawValue, error: error)
         }
         PixelKit.fire(pixel, frequency: .dailyAndStandard)
     }

--- a/macOS/PixelDefinitions/pixels/definitions/web_extensions.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/web_extensions.json5
@@ -170,5 +170,136 @@
         "triggers": ["exception"],
         "suffixes": ["daily_standard"],
         "parameters": ["appVersion", "pixelSource", "errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
+    },
+    "m_mac_web_extension_ad_blocking_enabled": {
+        "description": "Fires when the user enables YouTube ad blocking in settings.",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_web_extension_ad_blocking_disabled": {
+        "description": "Fires when the user disables YouTube ad blocking in settings.",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_web_extension_scriptlet_fetch_success": {
+        "description": "Fires when scriptlets are successfully fetched from the server and saved to cache.",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "suffixes": ["daily_standard"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "extension_type",
+                "type": "string",
+                "description": "The web extension type the scriptlets belong to (e.g. com.duckduckgo.content-blocker-extension)"
+            },
+            {
+                "key": "version",
+                "type": "string",
+                "description": "The version of the fetched scriptlets"
+            },
+            {
+                "key": "count",
+                "type": "string",
+                "description": "The number of scriptlet files fetched"
+            }
+        ]
+    },
+    "m_mac_web_extension_scriptlet_fetch_error": {
+        "description": "Fires when fetching or saving scriptlets fails (network error, empty response, storage failure).",
+        "owners": ["miasma13"],
+        "triggers": ["exception"],
+        "suffixes": ["daily_standard"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "errorCode",
+            "errorDomain",
+            "underlyingErrorCode",
+            "underlyingErrorDomain",
+            {
+                "key": "extension_type",
+                "type": "string",
+                "description": "The web extension type the scriptlets belong to"
+            }
+        ]
+    },
+    "m_mac_web_extension_scriptlet_validation_error": {
+        "description": "Fires when scriptlet signature validation fails in production, blocking the update.",
+        "owners": ["miasma13"],
+        "triggers": ["exception"],
+        "suffixes": ["daily_standard"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "errorCode",
+            "errorDomain",
+            "underlyingErrorCode",
+            "underlyingErrorDomain",
+            {
+                "key": "extension_type",
+                "type": "string",
+                "description": "The web extension type the scriptlets belong to"
+            }
+        ]
+    },
+    "m_mac_web_extension_scriptlet_installed": {
+        "description": "Fires when scriptlets are successfully installed into a web extension directory.",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "suffixes": ["daily_standard"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "extension_type",
+                "type": "string",
+                "description": "The web extension type the scriptlets were installed for"
+            },
+            {
+                "key": "version",
+                "type": "string",
+                "description": "The version of the installed scriptlets"
+            }
+        ]
+    },
+    "m_mac_web_extension_scriptlet_install_error": {
+        "description": "Fires when installing scriptlets into a web extension directory fails.",
+        "owners": ["miasma13"],
+        "triggers": ["exception"],
+        "suffixes": ["daily_standard"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "errorCode",
+            "errorDomain",
+            "underlyingErrorCode",
+            "underlyingErrorDomain",
+            {
+                "key": "extension_type",
+                "type": "string",
+                "description": "The web extension type the scriptlets were being installed for"
+            }
+        ]
+    },
+    "m_mac_web_extension_daily_ad_blocking_state": {
+        "description": "Fires once daily to report whether YouTube ad blocking is currently enabled (feature flag on and user opted in).",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "is_enabled",
+                "type": "string",
+                "description": "Whether ad blocking is currently enabled (true/false)"
+            }
+        ]
     }
 }

--- a/macOS/UnitTests/Preferences/RootViewV2Tests.swift
+++ b/macOS/UnitTests/Preferences/RootViewV2Tests.swift
@@ -77,7 +77,8 @@ final class RootViewV2Tests: XCTestCase {
             accessibilityPreferences: AccessibilityPreferences(),
             duckPlayerPreferences: sharedDuckPlayerPreferences,
             youTubeAdBlockingPreferences: YouTubeAdBlockingPreferences(duckPlayerPreferences: sharedDuckPlayerPreferences),
-            winBackOfferVisibilityManager: mockWinBackOfferVisibilityManager
+            winBackOfferVisibilityManager: mockWinBackOfferVisibilityManager,
+            adBlockingAvailability: AdBlockingAvailability(featureFlagger: featureFlagger, isEnabledByUserProvider: { false })
         )
         subscriptionManager = SubscriptionManagerMock()
         subscriptionUIHandler = SubscriptionUIHandlerMock( didPerformActionCallback: { _ in })

--- a/macOS/UnitTests/Preferences/YouTubeAdBlockingPreferencesTests.swift
+++ b/macOS/UnitTests/Preferences/YouTubeAdBlockingPreferencesTests.swift
@@ -1,0 +1,95 @@
+//
+//  YouTubeAdBlockingPreferencesTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Persistence
+import PixelKit
+import PixelKitTestingUtilities
+import XCTest
+
+@testable import DuckDuckGo_Privacy_Browser
+
+final class YouTubeAdBlockingPreferencesTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private var sut: YouTubeAdBlockingPreferences!
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: "\(type(of: self))")!
+        defaults.removePersistentDomain(forName: "\(type(of: self))")
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: "\(type(of: self))")
+        defaults = nil
+        sut = nil
+        super.tearDown()
+    }
+
+    private func makeSUT(pixelFiring: PixelFiring? = nil) -> YouTubeAdBlockingPreferences {
+        YouTubeAdBlockingPreferences(
+            settings: defaults.keyedStoring(),
+            pixelFiring: pixelFiring
+        )
+    }
+
+    // MARK: - Pixel Firing
+
+    func testWhenEnablingAdBlockingThenEnabledPixelIsFired() {
+        let pixelMock = PixelKitMock(expecting: [
+            ExpectedFireCall(pixel: WebExtensionPixel.adBlockingExtensionEnabled, frequency: .dailyAndCount)
+        ])
+        sut = makeSUT(pixelFiring: pixelMock)
+
+        sut.youTubeAdBlockingEnabled = true
+
+        pixelMock.verifyExpectations(file: #file, line: #line)
+    }
+
+    func testWhenDisablingAdBlockingThenDisabledPixelIsFired() {
+        let pixelMock = PixelKitMock(expecting: [
+            ExpectedFireCall(pixel: WebExtensionPixel.adBlockingExtensionEnabled, frequency: .dailyAndCount),
+            ExpectedFireCall(pixel: WebExtensionPixel.adBlockingExtensionDisabled, frequency: .dailyAndCount)
+        ])
+        sut = makeSUT(pixelFiring: pixelMock)
+
+        sut.youTubeAdBlockingEnabled = true
+        sut.youTubeAdBlockingEnabled = false
+
+        pixelMock.verifyExpectations(file: #file, line: #line)
+    }
+
+    func testWhenSettingSameValueThenNoPixelIsFired() {
+        let pixelMock = PixelKitMock(expecting: [
+            ExpectedFireCall(pixel: WebExtensionPixel.adBlockingExtensionEnabled, frequency: .dailyAndCount)
+        ])
+        sut = makeSUT(pixelFiring: pixelMock)
+
+        sut.youTubeAdBlockingEnabled = true
+        sut.youTubeAdBlockingEnabled = true
+
+        pixelMock.verifyExpectations(file: #file, line: #line)
+    }
+
+    func testWhenNoPixelFiringInjectedThenNoPixelIsFired() {
+        sut = makeSUT(pixelFiring: nil)
+
+        sut.youTubeAdBlockingEnabled = true
+        sut.youTubeAdBlockingEnabled = false
+    }
+}

--- a/macOS/UnitTests/WebsiteBreakageReport/WebsiteBreakageReportTests.swift
+++ b/macOS/UnitTests/WebsiteBreakageReport/WebsiteBreakageReportTests.swift
@@ -170,6 +170,80 @@ class WebsiteBreakageReportTests: XCTestCase {
         XCTAssertEqual(queryItems[valueFor: "isPirEnabled"], "true")
     }
 
+    func testWebExtensionFieldsAreIncludedWhenProvided() throws {
+        let breakage = BrokenSiteReport(
+            siteUrl: URL(string: "https://example.test/")!,
+            category: "content",
+            description: nil,
+            osVersion: "15",
+            manufacturer: "Apple",
+            upgradedHttps: false,
+            tdsETag: "abc123",
+            configVersion: "123456789",
+            blockedTrackerDomains: [],
+            installedSurrogates: [],
+            isGPCEnabled: false,
+            ampURL: "",
+            urlParametersRemoved: false,
+            protectionsState: true,
+            reportFlow: .dashboard,
+            errors: nil,
+            httpStatusCodes: nil,
+            openerContext: nil,
+            vpnOn: false,
+            jsPerformance: nil,
+            userRefreshCount: 0,
+            cookieConsentInfo: nil,
+            debugFlags: "",
+            privacyExperiments: "",
+            isPirEnabled: nil,
+            isForceDarkModeEnabled: nil,
+            pageLoadTiming: nil,
+            loadedWebExtensions: "embedded,darkMode,adBlocking",
+            adBlockingExtensionScriptletsVersion: "1.2.3"
+        )
+
+        let params = breakage.requestParameters
+        XCTAssertEqual(params["loadedWebExtensions"], "embedded,darkMode,adBlocking")
+        XCTAssertEqual(params["adBlockingExtensionScriptletsVersion"], "1.2.3")
+    }
+
+    func testWebExtensionFieldsAreOmittedWhenNil() throws {
+        let breakage = BrokenSiteReport(
+            siteUrl: URL(string: "https://example.test/")!,
+            category: "content",
+            description: nil,
+            osVersion: "15",
+            manufacturer: "Apple",
+            upgradedHttps: false,
+            tdsETag: "abc123",
+            configVersion: "123456789",
+            blockedTrackerDomains: [],
+            installedSurrogates: [],
+            isGPCEnabled: false,
+            ampURL: "",
+            urlParametersRemoved: false,
+            protectionsState: true,
+            reportFlow: .dashboard,
+            errors: nil,
+            httpStatusCodes: nil,
+            openerContext: nil,
+            vpnOn: false,
+            jsPerformance: nil,
+            userRefreshCount: 0,
+            cookieConsentInfo: nil,
+            debugFlags: "",
+            privacyExperiments: "",
+            isPirEnabled: nil,
+            isForceDarkModeEnabled: nil,
+            pageLoadTiming: nil
+        )
+
+        let params = breakage.requestParameters
+        XCTAssertNil(params["loadedWebExtensions"])
+        XCTAssertNil(params["adBlockingExtensionScriptletsVersion"])
+    }
+
     func makeURLRequest(with parameters: [String: String]) -> URLRequest {
         APIRequest.Headers.setUserAgent("")
         var params = parameters


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1163321984198618/task/1213458589159293?focus=true
Tech Design URL: N/A
CC:

### Description

Adds instrumentation for the YouTube ad-blocking web extension across both platforms:

- **Ad blocking user settings pixels (iOS)**: fires when the user enables/disables YouTube ad blocking in Settings, and when the ad blocking settings screen is opened. Also fixes a bug where `SettingsYouTubeAdBlockingView` was incorrectly firing the Duck Player settings-open pixel (`m_settings_duckplayer_open`) instead of its own dedicated pixel.
- **Scriptlet pipeline pixels (iOS + macOS via shared package)**: tracks scriptlet fetch success/failure, signature validation errors, and installation success/failure with `extension_type` and `version` parameters.
- **Daily ad blocking state pixel (iOS)**: reports once daily on app foreground whether YouTube ad blocking is enabled (`is_enabled` param).
- **Breakage report fields (shared)**: adds `loadedWebExtensions` and `adBlockingExtensionScriptletsVersion` to `BrokenSiteReport` with unit tests.
- **macOS pixel wiring**: connects `iOSWebExtensionPixelFiring` and macOS `WebExtensionPixel` to the shared `WebExtensionPixelFiring` protocol for scriptlet events.

### Testing Steps

1. Enable the YouTube ad-blocking feature flag and web extensions feature flag.
2. Open Settings > YouTube Ad Blocking — verify `m_web_extension_ad_blocking_settings_open` fires (not the Duck Player pixel).
3. Toggle YouTube ad blocking on/off — verify `m_web_extension_ad_blocking_enabled` / `m_web_extension_ad_blocking_disabled` fire.
4. Background and foreground the app — verify `m_web_extension_daily_ad_blocking_state` fires with correct `is_enabled` value.
5. Trigger a scriptlet fetch (e.g. by enabling the ad-blocking extension) — verify scriptlet lifecycle pixels fire.
6. Submit a breakage report on a page with web extensions loaded — verify `loadedWebExtensions` and `adBlockingExtensionScriptletsVersion` appear in the report parameters.
7. Review pixel definitions in `web_extensions.json5` for correctness.

### Impact and Risks

Low — telemetry-only changes. No impact on user-facing functionality. Pixels use daily + count suffixes and follow existing patterns.

#### What could go wrong?

- Pixel names or parameters could be incorrect, leading to missing or malformed telemetry data. Mitigated by pixel definition validation and code review.
- The breakage report fields could be omitted if web extension manager is unavailable (pre-iOS 18.4 / pre-macOS 15.4), which is expected behavior.

### Quality Considerations

- All new pixels follow the existing `DailyPixel.fireDailyAndCount` pattern with standard suffixes.
- Breakage report changes include unit tests for both presence and absence of web extension fields.
- The settings-open pixel fix prevents inflating Duck Player metrics with ad-blocking settings visits.

### Notes to Reviewer

The iOS and macOS pixel commits mirror each other. The shared `WebExtensionPixelFiring` protocol in the WebExtensions package defines the events; each platform maps them to its own pixel system (`Pixel.Event` on iOS, `WebExtensionPixel` on macOS).

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches web extension install/sync and in-browser notification triggering on both iOS and macOS, so mistakes could affect extension availability or UI animations. Most changes are telemetry/reporting, but they sit on navigation/feature-flag paths that run frequently.
> 
> **Overview**
> Adds **YouTube ad-blocking instrumentation** across iOS and macOS: new pixels for settings open, enable/disable, and a daily "enabled state" report, plus a new OmniBar/address-bar notification to indicate "YouTube Ad Block On" and suppression rules to avoid overlapping cookie/tracker animations.
> 
> Extends **broken site reports** to optionally include `loadedWebExtensions` and `adBlockingExtensionScriptletsVersion` (with unit tests) and updates the shared WebExtensions package to track and emit **scriptlet fetch/validate/install success/failure** events via `WebExtensionPixelFiring`.
> 
> Improves web extension management by adding an `adBlockingExtension` embedded descriptor, adding feature-flag handling for the ad-blocking extension, supporting bundled extensions that `requiresExtraction`, and exposing helpers (`loadedWebExtensionsString()`, `adBlockingScriptletsVersion()`) used by the apps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4de421399f73f65cf5b3f8b2812ba8038d20347. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->