### PR TITLE
Rename AIChatSubfeature case to nativeDataAccess

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -467,7 +467,7 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     case omnibarWebSearch
 
     /// Enables querying AI Chat data directly from local storage instead of via webview
-    case localStorageManipulation
+    case nativeDataAccess
 }
 
 public enum HtmlNewTabPageSubfeature: String, Equatable, PrivacySubfeature {

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -664,7 +664,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .aiChatNativeStorage:
             Config(source: .remoteReleasable(.subfeature(AIChatSubfeature.nativeStorage)))
         case .aiChatNativeDataAccess:
-            Config(source: .remoteReleasable(.subfeature(AIChatSubfeature.localStorageManipulation)))
+            Config(source: .remoteReleasable(.subfeature(AIChatSubfeature.nativeDataAccess)))
         case .filterAddressBarUpdates:
             Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.filterAddressBarUpdates)))
         }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -600,7 +600,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .aiChatNativeStorage:
             Config(source: .remoteReleasable(.subfeature(AIChatSubfeature.nativeStorage)), category: .duckAI)
         case .aiChatNativeDataAccess:
-            Config(source: .remoteReleasable(.subfeature(AIChatSubfeature.localStorageManipulation)), category: .duckAI)
+            Config(source: .remoteReleasable(.subfeature(AIChatSubfeature.nativeDataAccess)), category: .duckAI)
         case .autoplayPolicy:
             Config(defaultValue: .disabled, source: .remoteReleasable(.subfeature(MacOSBrowserConfigSubfeature.autoplayPolicy)), supportsLocalOverriding: true)
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1214035791283490?focus=true
Tech Design URL:
CC:

### Description
Renames the `AIChatSubfeature.localStorageManipulation` privacy config subfeature case to `nativeDataAccess`. This aligns the subfeature name with the corresponding feature flag (`aiChatNativeDataAccess`) and the updated remote config key.

### Testing Steps
1. Open the app and verify AI Chat features still work as expected.
2. Confirm the `aiChatNativeDataAccess` feature flag resolves correctly via the internal feature flags debug screen.

### Impact and Risks
None — this is a rename of a subfeature raw value to match the updated remote config key.

#### What could go wrong?
If the remote config hasn't been updated to use `nativeDataAccess`, the subfeature would fail to resolve until the config is deployed.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk rename that only changes the remote privacy-config subfeature key backing `aiChatNativeDataAccess`; main risk is the flag not resolving if server-side config still uses the old `localStorageManipulation` key.
> 
> **Overview**
> Renames the AI Chat privacy-config subfeature case from `localStorageManipulation` to `nativeDataAccess` to match the `aiChatNativeDataAccess` feature flag and updated remote config key.
> 
> Updates iOS and macOS feature-flag configurations to reference `AIChatSubfeature.nativeDataAccess` so remote rollout continues to resolve against the new key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dee299e15cea1c22388882c02496f1c610ca523c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->