### PR TITLE
[iOS] Fix missing bottom bar divider in minimal chrome landscape

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1889,7 +1889,11 @@ class MainViewController: UIViewController {
         chromeManager.attach(to: tab.webView.scrollView)
         themeColorManager.attach(to: tab)
         tab.chromeDelegate = self
-        tab.updateWebViewBottomAnchor(for: viewCoordinator.toolbar.alpha)
+        tab.updateWebViewBottomAnchor(for: currentBarsVisibility)
+
+        if isInMinimalChromeLayout {
+            tab.borderView.isBottomVisible = appSettings.currentAddressBarPosition.isBottom
+        }
 
         refreshControls()
     }
@@ -2102,6 +2106,10 @@ class MainViewController: UIViewController {
                 self.omniBar.beginEditing(animated: false)
             }
 
+            if self.isInMinimalChromeLayout && self.viewCoordinator.addressBarPosition.isBottom {
+                self.currentTab?.updateWebViewBottomAnchor(for: self.currentBarsVisibility)
+            }
+
             ViewHighlighter.updatePositions()
             self.recomputeOmnibarEditingHeightIfNeeded()
         }
@@ -2212,13 +2220,13 @@ class MainViewController: UIViewController {
         viewCoordinator.navigationBarContainer.transform = .identity
         viewCoordinator.omniBar.barView.setLayoutMode(.compact, animated: false)
         viewCoordinator.resetMinimalChromeLayout()
+        currentTab?.borderView.isBottomVisible = true
     }
 
     private func applyMinimalChromeWidth() {
         viewCoordinator.tabBarContainer.isHidden = true
         viewCoordinator.toolbar.isHidden = true
-        let bottomHeight = toolbarHeight + view.safeAreaInsets.bottom
-        viewCoordinator.constraints.toolbarBottom.constant = bottomHeight
+        viewCoordinator.constraints.toolbarBottom.constant = minimalChromeBottomHeight
         setMinimalChromeMode(true)
         viewCoordinator.omniBar.enterPhoneState()
         viewCoordinator.moveAddressBarToPosition(appSettings.currentAddressBarPosition)
@@ -2228,6 +2236,7 @@ class MainViewController: UIViewController {
         } else {
             viewCoordinator.resetMinimalChromeLayout()
         }
+        currentTab?.borderView.isBottomVisible = appSettings.currentAddressBarPosition.isBottom
 
         swipeTabsCoordinator?.isEnabled = true
     }
@@ -3145,6 +3154,9 @@ extension MainViewController: BrowserChromeDelegate {
     }
 
     var isToolbarHidden: Bool {
+        if isInMinimalChromeLayout {
+            return viewCoordinator.navigationBarContainer.alpha < 1
+        }
         return viewCoordinator.toolbar.isHidden || viewCoordinator.toolbar.alpha < 1
     }
 
@@ -3153,7 +3165,23 @@ extension MainViewController: BrowserChromeDelegate {
     }
     
     var barsMaxHeight: CGFloat {
-        max(toolbarHeight, viewCoordinator.omniBar.barView.expectedHeight)
+        let height = max(toolbarHeight, viewCoordinator.omniBar.barView.expectedHeight)
+        if isInMinimalChromeLayout && viewCoordinator.addressBarPosition.isBottom {
+            return height + view.safeAreaInsets.bottom
+        }
+        return height
+    }
+
+    var minimalChromeBottomHeight: CGFloat {
+        toolbarHeight + view.safeAreaInsets.bottom
+    }
+
+    /// Current visibility fraction of the chrome bars (1.0 = fully visible, 0.0 = hidden).
+    /// In minimal chrome the toolbar is hidden so we read the navigation bar container alpha instead.
+    var currentBarsVisibility: CGFloat {
+        viewCoordinator.toolbar.isHidden
+            ? viewCoordinator.navigationBarContainer.alpha
+            : viewCoordinator.toolbar.alpha
     }
 
     // 1.0 - full size, 0.0 - hidden

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -82,7 +82,7 @@ extension MainViewController {
         switch action {
         case .unbindInactiveNonAITab:
             refreshInactiveNonAITab(tab: tab, coordinator: coordinator)
-            tab.updateWebViewBottomAnchor(for: viewCoordinator.toolbar.alpha)
+            tab.updateWebViewBottomAnchor(for: currentBarsVisibility)
             return
         case .refreshAITab(let behavior):
             let completedRefresh = refreshAITab(tab: tab, coordinator: coordinator, behavior: behavior)
@@ -93,7 +93,7 @@ extension MainViewController {
             refreshNonAITab(tab: tab, coordinator: coordinator)
         }
 
-        tab.updateWebViewBottomAnchor(for: viewCoordinator.toolbar.alpha)
+        tab.updateWebViewBottomAnchor(for: currentBarsVisibility)
     }
 
     func applyUnifiedInputChromeBackground(_ state: UnifiedInputChromeBackgroundState, updateWebView: Bool = true) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214003406133562?focus=true
Tech Design URL:
CC:

### Description
Fixes the OmniBar bottom divider being invisible in iPhone landscape with minimal chrome and bottom address bar. Also fixes an unwanted bottom border when the address bar is set to top.

Root cause: commit 61e362563c simplified `barsMaxHeight`, breaking the web view bottom offset in minimal chrome landscape. During rotation, stale portrait safe area insets pushed the content container down, hiding the border view behind the navigation bar container.

Fix: correct `barsMaxHeight` to include safe area insets in minimal chrome, read `navigationBarContainer.alpha` instead of stale `toolbar.alpha`, recalculate constraints in the rotation completion block with settled insets, and manage `borderView.isBottomVisible` based on address bar position.

### Testing Steps
1. Settings > Address Bar > Bottom, open a webpage on iPhone
2. Rotate to landscape, verify divider above OmniBar is visible immediately.
3. Scroll to hide/show the bar, verify divider should reappear correctly.
4. Switch to Address Bar > Top, rotate to landscape, verify no unwanted bottom border at home indicator.
5. Rotate back to portrait, verify normal chrome restored.
6. Smoke check iPad for regressions.

### Impact and Risks
Low - scoped to minimal chrome layout paths, only affects iPhone landscape.

#### What could go wrong?
Scroll-to-hide could be affected by `barsMaxHeight` change, but `BarsAnimator` uses its own `combinedBarsHeight` independently.

### Quality Considerations
N/A

### Notes to Reviewer
Key insight: `UIView.alpha` retains its value after `isHidden = true`, so `toolbar.alpha` silently returned stale values in minimal chrome. The new `currentBarsVisibility` property routes to the correct alpha source.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped to iPhone minimal-chrome layout/rotation paths, adjusting only layout constants and border visibility logic; main risk is unintended webview offset changes during bar hide/show.
> 
> **Overview**
> Fixes minimal-chrome bottom bar divider and web content offset issues in landscape by updating webview bottom anchoring to use a new `currentBarsVisibility` (falls back to `navigationBarContainer.alpha` when the toolbar is hidden) and recalculating the anchor after rotation once safe-area insets settle.
> 
> Adjusts minimal-chrome sizing (`barsMaxHeight` and `minimalChromeBottomHeight`) to include bottom safe-area when the address bar is at the bottom, and explicitly toggles `borderView.isBottomVisible` based on address bar position (including resetting it when exiting minimal chrome).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c633c2352c335817938c1c87901f833a4147e2c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->