### PR TITLE
[iOS] Fix OmniBar flicker when opening new tab from tab switcher

### DIFF
--- a/iOS/DuckDuckGo/Transitions/HomeScreenTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/HomeScreenTransition.swift
@@ -168,7 +168,18 @@ class ToHomeScreenTransition: HomeScreenTransition {
               let rowIndex = tabSwitcherViewController.tabsModel.indexOf(tab: tab),
               let layoutAttr = tabSwitcherViewController.collectionView.layoutAttributesForItem(at: IndexPath(row: rowIndex, section: 0))
         else {
-            transitionContext.completeTransition(true)
+            // Layout attributes can be nil when a new tab was just added but the collection view
+            // hasn't laid out its cell yet. Fall back to a simple crossfade to avoid a flash.
+            if let mainViewController = transitionContext.viewController(forKey: .to) as? MainViewController {
+                mainViewController.view.alpha = 1
+            }
+            UIView.animate(withDuration: TabSwitcherTransition.Constants.duration, animations: {
+                self.tabSwitcherViewController.view.alpha = 0
+            }, completion: { _ in
+                self.solidBackground.removeFromSuperview()
+                self.imageContainer.removeFromSuperview()
+                transitionContext.completeTransition(true)
+            })
             return
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1213993054111414?focus=true
Tech Design URL:
CC:

### Description
Fixes OmniBar flickering when opening a new tab from the tab switcher.

The `ToHomeScreenTransition` guard fails when `collectionView.layoutAttributesForItem(at:)` returns nil. This happens because `tabSwitcherDidRequestNewTab` adds a new tab to the model before the tab switcher dismisses, but the collection view hasn't laid out a cell for it yet. The guard's early return called `completeTransition(true)` with no animation, causing the OmniBar to flash on then off abruptly.

The fix adds a crossfade fallback: the MainViewController is made visible and the tab switcher fades out over the standard 0.20s duration.

### Testing Steps
1. Open tab switcher and tap "+", verify smooth transition to new tab with no OmniBar flash
2. Open tab switcher and select an existing tab, verify the standard cell-to-content animation still works
3. Repeat in landscape with `minimalChromeInLandscape` flag enabled, verify same behavior

### Impact and Risks
Low — the fix is in a guard's early-return path that previously had no animation. The normal transition path is unchanged.

#### What could go wrong?
The crossfade fallback skips the cell-to-content animation, but this is acceptable since there's no cell to animate from.

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts an early-return path in `ToHomeScreenTransition` when collection view layout attributes are unavailable.
> 
> **Overview**
> Prevents a visual flash when dismissing the tab switcher after creating a new tab by handling cases where `layoutAttributesForItem(at:)` returns `nil`.
> 
> Instead of immediately completing the transition, the guard failure now makes `MainViewController` visible and performs a short crossfade that fades out the tab switcher and cleans up transition views before finishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24c9f1187f8cc323a4de7a368a1a9cc4f701b535. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->