### PR TITLE
[iOS] Restore toolbar bottom constraint update after rotation

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2106,8 +2106,11 @@ class MainViewController: UIViewController {
                 self.omniBar.beginEditing(animated: false)
             }
 
-            if self.isInMinimalChromeLayout && self.viewCoordinator.addressBarPosition.isBottom {
-                self.currentTab?.updateWebViewBottomAnchor(for: self.currentBarsVisibility)
+            if self.isInMinimalChromeLayout {
+                self.viewCoordinator.constraints.toolbarBottom.constant = self.minimalChromeBottomHeight
+                if self.viewCoordinator.addressBarPosition.isBottom {
+                    self.currentTab?.updateWebViewBottomAnchor(for: self.currentBarsVisibility)
+                }
             }
 
             ViewHighlighter.updatePositions()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1214003406133562?focus=true
Tech Design URL:
CC:

### Description
Restores a line that was dropped while preparing https://github.com/duckduckgo/apple-browsers/pull/4431: updating `toolbarBottom.constant` with the settled safe area insets in the rotation completion block.

Without this, the hidden toolbar is pushed off-screen by the wrong amount after rotation because `safeAreaInsets.bottom` differs between portrait and landscape. This caused a layout gap at the bottom of the screen.

### Testing Steps
1. Enable `minimalChromeInLandscape` feature flag
2. Open a website in portrait, rotate to landscape, verify no gap at the bottom of the content area and border is visible.
4. Rotate back to portrait, verify layout is correct
5. Repeat with address bar set to bottom, verify the web view anchor updates correctly after rotation
6. Verify iPad behavior is unchanged

### Impact and Risks
Low, one-line change gated behind `isInMinimalChromeLayout`.

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Low Risk**
> Low risk, localized layout change only executed in `isInMinimalChromeLayout` rotation completion; main risk is minor UI regressions in minimal-chrome safe-area handling.
> 
> **Overview**
> Restores updating `toolbarBottom.constant` in `MainViewController.viewWillTransition`’s rotation completion block when *minimal chrome* is active, so the hidden toolbar offset matches the post-rotation safe-area insets.
> 
> Keeps the existing bottom-address-bar behavior by still recalculating the web view’s bottom anchor only when `addressBarPosition.isBottom`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 008dab44a0efc729a0e80aaed0acae3d3f2b5e26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>