### PR TITLE
[MacOS] Replace permanent CTA dismissal with 28-day cooldown

### DIFF
--- a/macOS/DuckDuckGo/HomePage/View/SubscriptionPromoDebugMenu.swift
+++ b/macOS/DuckDuckGo/HomePage/View/SubscriptionPromoDebugMenu.swift
@@ -53,15 +53,9 @@ final class SubscriptionPromoDebugMenu: NSMenuItem {
         dismissedItem.isEnabled = false
         menu.addItem(dismissedItem)
 
-        let actionedItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")
-        actionedItem.tag = 4
-        actionedItem.isEnabled = false
-        menu.addItem(actionedItem)
-
         menu.addItem(.separator())
         menu.addItem(NSMenuItem(title: "Reset Fire Tab Visit Count", action: #selector(resetFireTabVisitCount), target: self))
         menu.addItem(NSMenuItem(title: "Reset Promo Dismissed Date", action: #selector(resetPromoDismissedDate), target: self))
-        menu.addItem(NSMenuItem(title: "Reset Promo Actioned", action: #selector(resetPromoActioned), target: self))
         menu.addItem(NSMenuItem(title: "Reset Promo Display Count", action: #selector(resetPromoDisplayCount), target: self))
         menu.addItem(NSMenuItem(title: "Reset Promo Display Window Start", action: #selector(resetPromoDisplayWindowStart), target: self))
         menu.addItem(.separator())
@@ -80,11 +74,6 @@ final class SubscriptionPromoDebugMenu: NSMenuItem {
         p.promoDismissedDate = nil
     }
 
-    @objc func resetPromoActioned() {
-        var p = persistor
-        p.promoActioned = false
-    }
-
     @objc func resetPromoDisplayCount() {
         var p = persistor
         p.promoDisplayCount = 0
@@ -100,7 +89,6 @@ final class SubscriptionPromoDebugMenu: NSMenuItem {
         var p = persistor
         p.fireTabVisitCount = 0
         p.promoDismissedDate = nil
-        p.promoActioned = false
         p.promoDisplayCount = 0
         p.promoDisplayWindowStart = nil
     }
@@ -119,8 +107,6 @@ extension SubscriptionPromoDebugMenu: NSMenuDelegate {
         let daysSinceLastDismissed = daysSinceLastDismissed.map { "\($0)" } ?? "N/A"
         menu.item(withTag: 3)?.title = "👀 Dismissed: \(isDismissed) (days since: \(daysSinceLastDismissed))"
 
-        let isActioned = persistor.promoActioned
-        menu.item(withTag: 4)?.title = "👀 CTA Actioned: \(isActioned)"
     }
 
     private var daysSinceLastDismissed: Int? {

--- a/macOS/DuckDuckGo/HomePage/View/SubscriptionPromoViewModel.swift
+++ b/macOS/DuckDuckGo/HomePage/View/SubscriptionPromoViewModel.swift
@@ -27,7 +27,6 @@ import Subscription
 protocol SubscriptionPromoPersisting {
     var fireTabVisitCount: Int { get set }
     var promoDismissedDate: Date? { get set }
-    var promoActioned: Bool { get set }
     var promoDisplayCount: Int { get set }
     var promoDisplayWindowStart: Date? { get set }
 }
@@ -37,7 +36,6 @@ struct SubscriptionPromoUserDefaultsPersistor: SubscriptionPromoPersisting {
     enum Key: String {
         case fireTabVisitCount = "subscription-promo.fire-tab-visit-count"
         case promoDismissedDate = "subscription-promo.dismissed-date"
-        case promoActioned = "subscription-promo.actioned"
         case promoDisplayCount = "subscription-promo.display-count"
         case promoDisplayWindowStart = "subscription-promo.display-window-start"
     }
@@ -62,11 +60,6 @@ struct SubscriptionPromoUserDefaultsPersistor: SubscriptionPromoPersisting {
                 keyValueStore.removeObject(forKey: Key.promoDismissedDate.rawValue)
             }
         }
-    }
-
-    var promoActioned: Bool {
-        get { keyValueStore.object(forKey: Key.promoActioned.rawValue) as? Bool ?? false }
-        set { keyValueStore.set(newValue, forKey: Key.promoActioned.rawValue) }
     }
 
     var promoDisplayCount: Int {
@@ -147,8 +140,7 @@ final class SubscriptionPromoViewModel: ObservableObject {
 
     func onPromoButtonTapped() {
         pixelFiring?.fire(SubscriptionPromoPixel.promoCtaActioned(isEligibleForFreeTrial: isEligibleForFreeTrial))
-        persistor.promoActioned = true
-        shouldShowPromo = false
+        persistor.promoDismissedDate = Date()
         onButtonAction?()
     }
 
@@ -157,8 +149,7 @@ final class SubscriptionPromoViewModel: ObservableObject {
     /// - US locale only
     /// - Non-subscriber only
     /// - Fire Tab visited >= 3 times
-    /// - User has not already actioned (tapped "Try for Free" / "Learn More")
-    /// - Not dismissed within the 28-day cooldown
+    /// - Not dismissed or CTA actioned within the 28-day cooldown
     /// - Not shown more than 4 times in any given 28-day rolling window
     private func evaluatePromoVisibility() {
         shouldShowPromo = false
@@ -168,7 +159,6 @@ final class SubscriptionPromoViewModel: ObservableObject {
         guard isUSLocale else { return }
         guard !subscriptionManager.isSubscriptionPresent() else { return }
         guard persistor.fireTabVisitCount >= Self.requiredVisitCount else { return }
-        guard !persistor.promoActioned else { return }
         guard !isDismissedWithinCooldown else { return }
         guard !hasReachedDisplayLimit else { return }
 

--- a/macOS/UnitTests/HomePage/SubscriptionPromoViewModelTests.swift
+++ b/macOS/UnitTests/HomePage/SubscriptionPromoViewModelTests.swift
@@ -87,14 +87,24 @@ final class SubscriptionPromoViewModelTests: XCTestCase {
         XCTAssertFalse(sut.shouldShowPromo)
     }
 
-    func testWhenPromoActioned_ThenDoesNotShowPromo() {
+    func testWhenCtaActionedWithinCooldown_ThenDoesNotShowPromo() {
         persistor.fireTabVisitCount = 3
-        persistor.promoActioned = true
+        persistor.promoDismissedDate = Date()
         sut = makeSUT()
 
         sut.updateForTab(.notEvaluated)
 
         XCTAssertFalse(sut.shouldShowPromo)
+    }
+
+    func testWhenCtaActionedAfterCooldown_ThenShowsPromo() {
+        persistor.fireTabVisitCount = 3
+        persistor.promoDismissedDate = Calendar.current.date(byAdding: .day, value: -29, to: Date())
+        sut = makeSUT()
+
+        sut.updateForTab(.notEvaluated)
+
+        XCTAssertTrue(sut.shouldShowPromo)
     }
 
     // MARK: - Dismiss Cooldown
@@ -301,7 +311,7 @@ final class SubscriptionPromoViewModelTests: XCTestCase {
         XCTAssertNotNil(persistor.promoDismissedDate)
     }
 
-    func testOnPromoButtonTappedSetsActionedAndHidesPromo() {
+    func testOnPromoButtonTappedSetsDismissedDateButKeepsPromoVisible() {
         persistor.fireTabVisitCount = 3
         sut = makeSUT()
         sut.updateForTab(.notEvaluated)
@@ -309,8 +319,19 @@ final class SubscriptionPromoViewModelTests: XCTestCase {
 
         sut.onPromoButtonTapped()
 
-        XCTAssertFalse(sut.shouldShowPromo)
-        XCTAssertTrue(persistor.promoActioned)
+        XCTAssertTrue(sut.shouldShowPromo, "Promo stays visible on current tab after CTA tap")
+        XCTAssertNotNil(persistor.promoDismissedDate)
+    }
+
+    func testAfterCtaTapped_NewTabDoesNotShowPromo() {
+        persistor.fireTabVisitCount = 3
+        sut = makeSUT()
+        sut.updateForTab(.notEvaluated)
+        sut.onPromoButtonTapped()
+
+        sut.updateForTab(.notEvaluated)
+
+        XCTAssertFalse(sut.shouldShowPromo, "Promo should not show on new tabs after CTA tap")
     }
 
     // MARK: - Helpers
@@ -358,7 +379,6 @@ final class SubscriptionPromoViewModelTests: XCTestCase {
 final class MockSubscriptionPromoPersisting: SubscriptionPromoPersisting {
     var fireTabVisitCount: Int = 0
     var promoDismissedDate: Date?
-    var promoActioned: Bool = false
     var promoDisplayCount: Int = 0
     var promoDisplayWindowStart: Date?
 }


### PR DESCRIPTION
## Summary
- CTA button tap now starts a 28-day cooldown instead of permanently hiding the promo
- Promo stays visible on the current tab after CTA tap, disappears on subsequent tabs
- Removed `promoActioned` flag — both dismiss (X) and CTA now use the same `promoDismissedDate` cooldown mechanism

## Test plan
- [ ] Tap CTA → verify promo stays visible on current tab
- [ ] Open new fire tab after CTA tap → verify promo does not show
- [ ] Wait 28 days (or reset via debug menu) → verify promo reappears
- [ ] Tap close (X) → verify promo hides immediately on current tab
- [ ] Run `SubscriptionPromoViewModelTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the promo visibility state machine and persistence by removing the permanent `promoActioned` flag and reusing `promoDismissedDate`, which can alter when the promo appears for existing users.
> 
> **Overview**
> Promo CTA taps no longer permanently disable the Fire Window subscription promo; instead they set `promoDismissedDate` to start the same 28-day cooldown used by dismiss (X), while keeping the promo visible on the current tab.
> 
> Removes the persisted `promoActioned` state (and related debug menu items) and updates `SubscriptionPromoViewModelTests` to cover CTA cooldown behavior and the “visible on current tab, hidden on subsequent tabs” flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01ae362580c50c13fba9d8a9193d81ddab09372e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->