### PR TITLE
Increase a timeout to try to fix a flaky test

### DIFF
--- a/iOS/DuckDuckGoTests/StatisticsLoaderTests.swift
+++ b/iOS/DuckDuckGoTests/StatisticsLoaderTests.swift
@@ -64,7 +64,7 @@ class StatisticsLoaderTests: XCTestCase {
         testee.refreshAppRetentionAtb {
             testExpectation.fulfill()
         }
-        wait(for: [testExpectation], timeout: 5.0)
+        wait(for: [testExpectation], timeout: 10.0)
         XCTAssertTrue(mockUsageSegmentation.atbs[0].installAtb.isReturningUser)
         XCTAssertTrue(fireAppRetentionExperimentPixelsCalled)
     }
@@ -92,7 +92,7 @@ class StatisticsLoaderTests: XCTestCase {
         testee.refreshSearchRetentionAtb {
             testExpectation.fulfill()
         }
-        wait(for: [testExpectation], timeout: 5.0)
+        wait(for: [testExpectation], timeout: 10.0)
         XCTAssertFalse(mockUsageSegmentation.atbs.isEmpty)
         XCTAssertTrue(fireSearchExperimentPixelsCalled)
     }
@@ -105,7 +105,7 @@ class StatisticsLoaderTests: XCTestCase {
         testee.refreshAppRetentionAtb {
             testExpectation.fulfill()
         }
-        wait(for: [testExpectation], timeout: 5.0)
+        wait(for: [testExpectation], timeout: 10.0)
         XCTAssertFalse(mockUsageSegmentation.atbs.isEmpty)
         XCTAssertTrue(fireAppRetentionExperimentPixelsCalled)
     }
@@ -118,7 +118,7 @@ class StatisticsLoaderTests: XCTestCase {
         testee.load(shouldRefreshAtb: false) {
             testExpectation.fulfill()
         }
-        wait(for: [testExpectation], timeout: 5.0)
+        wait(for: [testExpectation], timeout: 10.0)
         XCTAssertTrue(mockUsageSegmentation.atbs.isEmpty)
     }
 
@@ -196,7 +196,7 @@ class StatisticsLoaderTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testWhenLoadHasUnsuccessfulAtbThenStoreNotUpdated() {
@@ -211,7 +211,7 @@ class StatisticsLoaderTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testWhenLoadHasUnsuccessfulExtiThenStoreNotUpdated() {
@@ -226,7 +226,7 @@ class StatisticsLoaderTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testWhenSearchRefreshHasSuccessfulAtbRequestThenSearchRetentionAtbUpdated() {
@@ -301,7 +301,7 @@ class StatisticsLoaderTests: XCTestCase {
             testExpectation.fulfill()
         }
 
-        wait(for: [testExpectation], timeout: 5.0)
+        wait(for: [testExpectation], timeout: 10.0)
         XCTAssertEqual(mockPixelFiring.lastPixelName, Pixel.Event.appInstall.name)
     }
 
@@ -420,7 +420,7 @@ class StatisticsLoaderTests: XCTestCase {
             // Then
             testExpectation.fulfill()
         }
-        wait(for: [testExpectation], timeout: 1)
+        wait(for: [testExpectation], timeout: 10.0)
         XCTAssertFalse(mockUsageSegmentation.atbs.isEmpty)
     }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1213991568494691?focus=true
Tech Design URL:
CC:

### Description

This PR bumps a timeout to try and fix a flaky test.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI is green

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that simply extend XCTest expectation timeouts to accommodate slower CI runs, with no production code impact.
> 
> **Overview**
> Reduces flakiness in `StatisticsLoaderTests` by increasing multiple XCTest `wait`/`waitForExpectations` timeouts (generally from 5s/1s to 10s) around async ATB/retention refresh and Duck.ai retention tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b92ea9b1f8da1fe689a468e8d0c550c94b8f210f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->