### PR TITLE
Fix escape hatch showing URL instead of page title on cold start

### DIFF
--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -807,8 +807,8 @@ class TabViewController: UIViewController {
     
     func updateTabModel() {
         if let url = url {
-            let resolvedTitle = title ?? tabModel.link?.title
-            let link = Link(title: resolvedTitle, url: url)
+            let previousTitle = (tabModel.link?.url == url) ? tabModel.link?.title : nil
+            let link = Link(title: title ?? previousTitle, url: url)
             tabModel.link = link
         } else {
             tabModel.link = nil

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -807,7 +807,8 @@ class TabViewController: UIViewController {
     
     func updateTabModel() {
         if let url = url {
-            let link = Link(title: title, url: url)
+            let resolvedTitle = title ?? tabModel.link?.title
+            let link = Link(title: resolvedTitle, url: url)
             tabModel.link = link
         } else {
             tabModel.link = nil

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -807,8 +807,9 @@ class TabViewController: UIViewController {
     
     func updateTabModel() {
         if let url = url {
+            let hasTitle = title != nil && !title!.isEmpty
             let previousTitle = (tabModel.link?.url == url) ? tabModel.link?.title : nil
-            let link = Link(title: title ?? previousTitle, url: url)
+            let link = Link(title: hasTitle ? title : previousTitle, url: url)
             tabModel.link = link
         } else {
             tabModel.link = nil


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1214042008558081?focus=true
Tech Design URL: N/A
CC: N/A

### Description
- Preserve the persisted page title in `updateTabModel()` when the WKWebView title hasn't loaded yet, fixing the escape hatch card showing the URL/domain twice instead of the page title after cold start
- During tab restoration, setting `self.url` triggers `updateTabModel()` before `WKWebView.title` is available via KVO, which overwrites the NSCoding-persisted `Link` (which has the correct title) with a new `Link(title: nil, url:)`, causing `displayTitle` to fall back to the host

### Testing Steps
1. Open a web page with a visible title (e.g., any news site or booking site)
2. Wait for it to fully load, verify the tab shows the page title
3. Kill the app (swipe away from app switcher)
4. Wait for the idle return threshold to pass
5. Relaunch the app -- verify the NTP escape hatch card shows the page title (not the domain/URL twice)
6. Also verify that navigating to a new page still updates the title correctly (title is not "stuck" on the old one)

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- If a page changes URL without updating the title, the stale title from the previous URL could briefly persist until KVO fires. This is mitigated because `updateTabModel()` is called again when `title` changes via its `didSet`, which will overwrite with the correct value.

### Quality Considerations
- The `TabViewController.link` computed property already performs this same merge logic via `Link.merge(with:)`, so this aligns `updateTabModel()` with existing behavior
- No privacy or security implications

### Notes to Reviewer
- One-line change. The fix mirrors what `TabViewController.link` (computed property) already does via `activeLink.merge(with: storedLink)` -- it preserves the existing title when the new one is nil.


Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change to how `tabModel.link` is updated, only affecting tab title persistence when the web view title is temporarily missing during restoration.
> 
> **Overview**
> Fixes cold-start tab restoration where `updateTabModel()` could overwrite a persisted `Link` title with `nil` before `WKWebView.title` is available.
> 
> `updateTabModel()` now keeps the previously stored title for the same URL when the current `title` is empty, preventing UI surfaces (e.g., the escape hatch card) from showing the URL/domain in place of the page title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19de8764ffe400c30a4cc33bcd25e2a17368ba13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->