### PR TITLE
Fix capitalisation of "Duck.ai" in onboarding copy

### DIFF
--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -2352,7 +2352,7 @@ public struct UserText {
 
             public static let fireOnboardingTitle = NotLocalizedString(
                 "onboarding.highlights.duckAIQueryExperiment.fire.title",
-                value: "That’s duck.ai!",
+                value: "That’s Duck.ai!",
                 comment: "Experiment-only fire onboarding title shown after the first Duck.ai response."
             )
             public static let fireOnboardingMessage = NotLocalizedString(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1214060691829797?focus=true
Tech Design URL: N/A
CC: N/A

### Description
- Capitalises `Duck.ai` correctly in the `fireOnboardingTitle` string used in the Duck.ai query experiment onboarding flow (`"That's duck.ai!"` → `"That's Duck.ai!"`)

### Testing Steps
- Run the iOS app with the Duck.ai query experiment enabled
- Complete a Duck.ai query during onboarding
- Verify the fire onboarding title shows "That's Duck.ai!" with correct capitalisation

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- No risks; single character change in a `NotLocalizedString` constant

### Quality Considerations
- The string is marked `NotLocalizedString`, so no locale/translation files are affected
- The apostrophe character (U+2019, curly quote) is unchanged — only `d` → `D`

### Notes to Reviewer
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk copy-only change to a single `NotLocalizedString` constant; no logic, localization files, or behavior changes.
> 
> **Overview**
> Fixes capitalization of the Duck.ai branding in the experiment-only onboarding fire title by changing "That’s duck.ai!" to "That’s Duck.ai!" in `UserText.swift`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 818282cd00397b168e3eedfa9b4e577ca3921fcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->