### PR TITLE
[iOS] Improve sync e2e test stability

### DIFF
--- a/.maestro/shared/set_sync_dev_environment.yaml
+++ b/.maestro/shared/set_sync_dev_environment.yaml
@@ -15,7 +15,7 @@ appId: com.duckduckgo.mobile.ios
 - scrollUntilVisible:
     element: Production
     direction: DOWN
-    centerElement: true
+    centerElement: false
 - tapOn: Production
 - tapOn: Debug
 - tapOn: Settings

--- a/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
@@ -179,7 +179,6 @@ extension DebugScreensViewModel {
                 return self.debugStoryboard.instantiateViewController(identifier: "SyncDebugViewController") { coder in
                     SyncDebugViewController(coder: coder,
                                             sync: d.syncService,
-                                            keyValueStore: d.keyValueStore,
                                             bookmarksDatabase: d.bookmarksDatabase)
                 }
             }),

--- a/iOS/DuckDuckGo/SyncDebugViewController.swift
+++ b/iOS/DuckDuckGo/SyncDebugViewController.swift
@@ -18,7 +18,6 @@
 //
 
 import UIKit
-import BackgroundTasks
 import Core
 import Persistence
 import Bookmarks
@@ -29,7 +28,6 @@ class SyncDebugViewController: UITableViewController {
 
     private let titles = [
         Sections.info: "Info",
-        Sections.autoRestore: "Auto-Restore",
         Sections.models: "Models",
         Sections.environment: "Environment"
     ]
@@ -37,7 +35,6 @@ class SyncDebugViewController: UITableViewController {
     enum Sections: Int, CaseIterable {
 
         case info
-        case autoRestore
         case models
         case environment
 
@@ -61,14 +58,6 @@ class SyncDebugViewController: UITableViewController {
 
     }
 
-    enum AutoRestoreRows: Int, CaseIterable {
-
-        case decisionToggle
-        case recoverAccount
-        case simulateAppReinstallForAutoRestore
-
-    }
-
     enum EnvironmentRows: Int, CaseIterable {
 
         case toggle
@@ -77,18 +66,14 @@ class SyncDebugViewController: UITableViewController {
 
     private let bookmarksDatabase: CoreDataDatabase
     private let sync: DDGSyncing
-    private let keyValueStore: ThrowingKeyValueStoring
-    private let autoRestoreDecisionManager: SyncAutoRestoreDecisionManaging = AppDependencyProvider.shared.syncAutoRestoreDecisionManager
 
     var syncCancellable: Cancellable?
 
     init?(coder: NSCoder,
           sync: DDGSyncing,
-          keyValueStore: ThrowingKeyValueStoring,
           bookmarksDatabase: CoreDataDatabase) {
 
         self.sync = sync
-        self.keyValueStore = keyValueStore
         self.bookmarksDatabase = bookmarksDatabase
 
         super.init(coder: coder)
@@ -134,25 +119,6 @@ class SyncDebugViewController: UITableViewController {
                 cell.textLabel?.text = "Reset Favicons Fetcher onboarding dialog"
             case .some(.getRecoveryCode):
                 cell.textLabel?.text = "Paste and Copy Recovery Code"
-            case .none:
-                break
-            }
-
-        case .autoRestore:
-            switch AutoRestoreRows(rawValue: indexPath.row) {
-            case .decisionToggle:
-                cell.textLabel?.text = "Auto-Restore Opt-In"
-                let toggle = UISwitch()
-                toggle.isOn = currentAutoRestoreDecision()
-                toggle.addTarget(self, action: #selector(autoRestoreToggleChanged(_:)), for: .valueChanged)
-                cell.accessoryView = toggle
-                cell.selectionStyle = .none
-            case .recoverAccount:
-                cell.textLabel?.text = "Recover account"
-                cell.detailTextLabel?.text = "Enable Sync from preserved account"
-            case .simulateAppReinstallForAutoRestore:
-                cell.textLabel?.text = "Simulate app reinstall"
-                cell.detailTextLabel?.text = "Clears sync enabled state, keeps keychain account"
             case .none:
                 break
             }
@@ -212,7 +178,6 @@ class SyncDebugViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch Sections(rawValue: section) {
         case .info: return InfoRows.allCases.count
-        case .autoRestore: return AutoRestoreRows.allCases.count
         case .models: return ModelRows.allCases.count
         case .environment: return EnvironmentRows.allCases.count
         case .none: return 0
@@ -248,26 +213,6 @@ class SyncDebugViewController: UITableViewController {
             case .getRecoveryCode:
                 showCopyPasteCodeAlert()
             default: break
-            }
-        case .autoRestore:
-            switch AutoRestoreRows(rawValue: indexPath.row) {
-            case .recoverAccount:
-                Task { [weak self] in
-                    guard let self else { return }
-                    guard let ddgSync = sync as? DDGSync else {
-                        await self.presentAutoRestoreErrorAlert(message: "Sync service does not support recovery.")
-                        return
-                    }
-                    do {
-                        try await ddgSync.enableSyncFromPreservedAccount()
-                    } catch {
-                        await self.presentAutoRestoreErrorAlert(message: error.localizedDescription)
-                    }
-                }
-            case .simulateAppReinstallForAutoRestore:
-                presentSimulateReinstallConfirmationAlert()
-            case .decisionToggle, .none:
-                break
             }
         case .models:
             switch ModelRows(rawValue: indexPath.row) {
@@ -309,30 +254,6 @@ class SyncDebugViewController: UITableViewController {
         tableView.deselectRow(at: indexPath, animated: true)
     }
 
-    @objc private func autoRestoreToggleChanged(_ sender: UISwitch) {
-        do {
-            try autoRestoreDecisionManager.persistDecision(sender.isOn)
-        } catch {
-            sender.setOn(!sender.isOn, animated: true)
-            presentAutoRestoreErrorAlert(message: "Failed to update Auto-Restore decision.")
-        }
-    }
-
-    private func currentAutoRestoreDecision() -> Bool {
-        autoRestoreDecisionManager.existingDecision() ?? false
-    }
-
-    @MainActor
-    private func presentAutoRestoreErrorAlert(message: String) {
-        let alertController = UIAlertController(
-            title: "Auto-Restore",
-            message: message,
-            preferredStyle: .alert
-        )
-        alertController.addAction(UIAlertAction(title: "OK", style: .default))
-        present(alertController, animated: true)
-    }
-
     private func showCopyPasteCodeAlert() {
         let alertController = UIAlertController(title: "Paste and Copy Recovery Code", message: nil, preferredStyle: .alert)
 
@@ -354,41 +275,6 @@ class SyncDebugViewController: UITableViewController {
 
         // Present the alert
         present(alertController, animated: true, completion: nil)
-    }
-
-    private func presentSimulateReinstallConfirmationAlert() {
-        let alertController = UIAlertController(
-            title: "Simulate App Reinstall?",
-            message: "This clears local Sync state while keeping keychain account data for Auto-Restore testing.",
-            preferredStyle: .alert
-        )
-        alertController.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-        alertController.addAction(UIAlertAction(title: "Reset", style: .destructive) { [weak self] _ in
-            self?.simulateAppReinstallForAutoRestore()
-        })
-        present(alertController, animated: true)
-    }
-
-    private func simulateAppReinstallForAutoRestore() {
-        do {
-            try keyValueStore.removeObject(forKey: DDGSync.Constants.syncEnabledKey)
-            try keyValueStore.removeObject(forKey: DDGSync.Constants.keychainAttrMigratedKey)
-        } catch {
-            presentAutoRestoreErrorAlert(message: "Failed to reset Sync state: \(error.localizedDescription)")
-            return
-        }
-
-        // Clear legacy fallback values so migration logic does not re-enable Sync state.
-        UserDefaults.standard.removeObject(forKey: DDGSync.Constants.syncEnabledKey)
-        UserDefaults.standard.removeObject(forKey: DDGSync.Constants.keychainAttrMigratedKey)
-
-        let alertController = UIAlertController(
-            title: "Sync State Reset",
-            message: "Force quit and relaunch the app to apply reinstall-like Sync initialization behavior.",
-            preferredStyle: .alert
-        )
-        alertController.addAction(UIAlertAction(title: "OK", style: .default))
-        present(alertController, animated: true)
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1213964830865793?focus=true
Tech Design URL:
CC:

### Description
Removes section no longer needed in the Sync debug screen & updates maestro scrollUntilVisible.centerElement to false (since element it is scrolling to is the final row)

### Testing Steps
1. Confirm CI is green -> [workflow](https://github.com/duckduckgo/apple-browsers/actions/runs/24479952473)

### Impact and Risks
What's the impact on users if something goes wrong?
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to internal debug UI and test automation scripts, with no impact on production user flows or sensitive data paths.
> 
> **Overview**
> Simplifies internal Sync debug tooling by removing the **Auto-Restore** section/actions from `SyncDebugViewController`, dropping its extra dependencies (`keyValueStore`, decision manager) and updating the debug screen builder accordingly.
> 
> Updates the Maestro flow `set_sync_dev_environment.yaml` to use `scrollUntilVisible.centerElement: false` when scrolling to the final "Production" row, improving reliability of Sync environment selection during e2e tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8be527e383c96035b362b464128b86a9912576f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->