### PR TITLE
Add Strict PR Checks label support

### DIFF
--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -283,14 +283,20 @@ jobs:
       - name: Run tests
         id: run-unit-tests-ios
         run: |
+          if [[ "${{ needs.should-run-checks.outputs.strict_mode }}" == "true" ]]; then
+            RETRY_FLAGS="-test-iterations 3"
+            echo "Strict mode enabled: running tests with $RETRY_FLAGS"
+          else
+            RETRY_FLAGS="-test-iterations 3 -retry-tests-on-failure"
+          fi
+
           set -o pipefail && xcodebuild test \
             -scheme BrowserServicesKit \
             -destination '${{ steps.select-simulator.outputs.destination }}' \
             -derivedDataPath DerivedData \
             -skipPackagePluginValidation \
             -skipMacroValidation \
-            -test-iterations 3 \
-            -retry-tests-on-failure \
+            $RETRY_FLAGS \
             CODE_SIGNING_ALLOWED=NO \
             | tee -a ios-build-log.txt \
             | xcbeautify --report junit --report-path . --junit-report-filename bsk-ios-unittests.xml

--- a/.github/workflows/dbp_pr_checks.yml
+++ b/.github/workflows/dbp_pr_checks.yml
@@ -272,14 +272,20 @@ jobs:
       - name: Run tests
         id: run-unit-tests
         run: |
+          if [[ "${{ needs.should-run-checks.outputs.strict_mode }}" == "true" ]]; then
+            RETRY_FLAGS="-test-iterations 3"
+            echo "Strict mode enabled: running tests with $RETRY_FLAGS"
+          else
+            RETRY_FLAGS="-test-iterations 3 -retry-tests-on-failure"
+          fi
+
           set -o pipefail && xcodebuild test \
             -scheme DataBrokerProtectionCore \
             -destination '${{ steps.select-simulator.outputs.destination }}' \
             -derivedDataPath DerivedData \
             -skipPackagePluginValidation \
             -skipMacroValidation \
-            -test-iterations 3 \
-            -retry-tests-on-failure \
+            $RETRY_FLAGS \
             CODE_SIGNING_ALLOWED=NO \
             | tee -a ios-build-log.txt \
             | xcbeautify --report junit --report-path . --junit-report-filename dbp-ios-unittests.xml

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -176,12 +176,20 @@ jobs:
         echo "Using iOS simulator: ${{ steps.select-simulator.outputs.ios-version }}"
         echo "Destination: ${{ steps.select-simulator.outputs.destination }}"
 
+        if [[ "${{ needs.should-run-checks.outputs.strict_mode }}" == "true" ]]; then
+          STRICT_FLAGS="-test-iterations 3"
+          echo "Strict mode enabled: running tests with $STRICT_FLAGS"
+        else
+          STRICT_FLAGS=""
+        fi
+
         set -o pipefail && xcodebuild test \
           -scheme "iOS Browser" \
           -destination "${{ steps.select-simulator.outputs.destination }}" \
           -derivedDataPath "DerivedData" \
           -skipPackagePluginValidation \
           -skipMacroValidation \
+          $STRICT_FLAGS \
           DDG_SLOW_COMPILE_CHECK_THRESHOLD=250 \
           COMPILATION_CACHE_ENABLE_CACHING=YES \
           | tee xcodebuild.log \

--- a/.github/workflows/macos_pir_end_to_end_tests.yml
+++ b/.github/workflows/macos_pir_end_to_end_tests.yml
@@ -154,6 +154,13 @@ jobs:
     - name: Run PIR e2e Tests
       id: run-tests
       run: |
+        if [[ "${{ needs.should-run-checks.outputs.strict_mode }}" == "true" ]]; then
+          RETRY_FLAGS="-test-iterations 3"
+          echo "Strict mode enabled: running tests with $RETRY_FLAGS"
+        else
+          RETRY_FLAGS="-retry-tests-on-failure -test-iterations 2"
+        fi
+
         launchctl setenv PRIVACYPRO_STAGING_ACCESS_TOKEN_V2 '${{ secrets.PRIVACYPRO_STAGING_ACCESS_TOKEN_V2 }}'
         set -o pipefail && xcodebuild test \
           -scheme "macOS PIR E2E Tests" \
@@ -163,8 +170,7 @@ jobs:
           ENABLE_TESTABILITY=true \
           COMPILATION_CACHE_ENABLE_CACHING=YES \
           "-only-testing:DBPE2ETests" \
-          -retry-tests-on-failure \
-          -test-iterations 2 \
+          $RETRY_FLAGS \
           | tee xcodebuild.log \
           | tee pir-e2e-tests.log
       env:

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -263,6 +263,13 @@ jobs:
         echo "Runner ${RUNNER_NAME} (${RUNNER_TRACKING_ID})"
         export OS_ACTIVITY_MODE=debug
 
+        if [[ "${{ needs.should-run-checks.outputs.strict_mode }}" == "true" ]]; then
+          STRICT_FLAGS="-test-iterations 3"
+          echo "Strict mode enabled: running tests with $STRICT_FLAGS"
+        else
+          STRICT_FLAGS=""
+        fi
+
         set -o pipefail && xcodebuild test \
           -scheme "${{ matrix.scheme }}" \
           -derivedDataPath "DerivedData" \
@@ -275,6 +282,7 @@ jobs:
           ONLY_ACTIVE_ARCH=${{ matrix.active-arch }} \
           COMPILATION_CACHE_ENABLE_CACHING=YES \
           "-skip-testing:${{ matrix.integration-tests-target }}" \
+          $STRICT_FLAGS \
           | tee ${{ matrix.flavor }}-unittests-xcodebuild.log \
           | sed -e 's/CoreData: error:/CoreData: [notice]:/g' -e 's/Failed to create NSXPCConnection/[notice] NSXPCConnection unavailable/g' \
           | xcbeautify --report junit --report-path . --junit-report-filename ${{ matrix.flavor }}-unittests.xml \
@@ -283,6 +291,13 @@ jobs:
     - name: Run integration tests
       id: run-integration-tests
       run: |
+        if [[ "${{ needs.should-run-checks.outputs.strict_mode }}" == "true" ]]; then
+          RETRY_FLAGS="-test-iterations 3"
+          echo "Strict mode enabled: running tests with $RETRY_FLAGS"
+        else
+          RETRY_FLAGS="-retry-tests-on-failure"
+        fi
+
         set -o pipefail && xcodebuild test \
           -scheme "${{ matrix.scheme }}" \
           -derivedDataPath "DerivedData" \
@@ -295,7 +310,7 @@ jobs:
           ONLY_ACTIVE_ARCH=${{ matrix.active-arch }} \
           COMPILATION_CACHE_ENABLE_CACHING=YES \
           "-only-testing:${{ matrix.integration-tests-target }}" \
-          -retry-tests-on-failure \
+          $RETRY_FLAGS \
           | tee ${{ matrix.flavor }}-integrationtests-xcodebuild.log \
           | sed -e 's/CoreData: error:/CoreData: [notice]:/g' -e 's/Failed to create NSXPCConnection/[notice] NSXPCConnection unavailable/g' \
           | xcbeautify --report junit --report-path . --junit-report-filename ${{ matrix.flavor }}-integrationtests.xml \

--- a/.github/workflows/should_run_pr_checks.yml
+++ b/.github/workflows/should_run_pr_checks.yml
@@ -25,16 +25,25 @@ on:
         required: false
         type: string
         default: 'Run PR Checks'
+      strict_checks_label:
+        description: 'Label name that enables strict test mode (no retries, 3 iterations)'
+        required: false
+        type: string
+        default: 'strict pr checks'
     outputs:
       should_run:
         description: 'Whether CI checks should run (true/false)'
         value: ${{ jobs.check.outputs.should_run }}
+      strict_mode:
+        description: 'Whether strict test mode is enabled (true/false)'
+        value: ${{ jobs.check.outputs.strict_mode }}
 
 jobs:
   check:
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
+      strict_mode: ${{ steps.check.outputs.strict_mode }}
     steps:
       - name: Evaluate run conditions
         id: check
@@ -58,4 +67,17 @@ jobs:
               echo "should_run=false" >> $GITHUB_OUTPUT
               echo "Draft PR without '${{ inputs.run_checks_label }}' label, skipping checks"
             fi
+          fi
+
+          # Check for strict mode label
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            labels='${{ toJson(github.event.pull_request.labels) }}'
+            if echo "$labels" | jq -e --arg label "${{ inputs.strict_checks_label }}" '.[] | select(.name == $label)' > /dev/null 2>&1; then
+              echo "strict_mode=true" >> $GITHUB_OUTPUT
+              echo "PR has '${{ inputs.strict_checks_label }}' label, enabling strict mode"
+            else
+              echo "strict_mode=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "strict_mode=false" >> $GITHUB_OUTPUT
           fi

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionFeatureTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionFeatureTests.swift
@@ -137,7 +137,7 @@ final class DataBrokerProtectionFeatureTests: XCTestCase {
 
         sut.pushAction(method: CCFSubscribeActionName.onActionReceived, webView: mockWebView, params: params)
 
-        await fulfillment(of: [timeoutExpectation], timeout: 3.0)
+        await fulfillment(of: [timeoutExpectation], timeout: 10.0)
 
         XCTAssertEqual(mockCSSDelegate.lastError as? DataBrokerProtectionError,
                        DataBrokerProtectionError.actionFailed(actionID: actionID, message: "Action timed out"))

--- a/iOS/DuckDuckGoTests/DuckPlayer/YoutublePlayerNavigationHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/DuckPlayer/YoutublePlayerNavigationHandlerTests.swift
@@ -276,7 +276,7 @@ class DuckPlayerNavigationHandlerTests: XCTestCase {
         let result1 = handler.handleURLChange(webView: mockWebView, previousURL: nil, newURL: youtubeURL, isNavigationError: false)
 
         // Wait less than one second before calling again
-        try? await Task.sleep(nanoseconds: 500_000_000)
+        try? await Task.sleep(nanoseconds: 100_000_000)
 
         let result2 = handler.handleURLChange(webView: mockWebView, previousURL: youtubeURL, newURL: youtubeURL, isNavigationError: false)
 

--- a/macOS/IntegrationTests/Downloads/DownloadListCoordinatorTests.swift
+++ b/macOS/IntegrationTests/Downloads/DownloadListCoordinatorTests.swift
@@ -245,8 +245,8 @@ final class DownloadListCoordinatorTests: XCTestCase {
     func testWhenDownloadAddedThenDownloadItemIsPublished() async {
         setUpCoordinator()
 
-        let destURL = fm.temporaryDirectory.appendingPathComponent("test file.pdf")
-        let tempURL = fm.temporaryDirectory.appendingPathComponent("test file.duckload")
+        let destURL = self.destURL!
+        let tempURL = self.tempURL!
         let download = WKDownloadMock(url: .duckDuckGo)
         let task = WebKitDownloadTask(download: download, destination: .preset(destURL), fireWindowSession: nil)
 

--- a/macOS/IntegrationTests/Encryption/CoreDataEncryptionTests.swift
+++ b/macOS/IntegrationTests/Encryption/CoreDataEncryptionTests.swift
@@ -34,9 +34,8 @@ class CoreDataEncryptionTests: XCTestCase {
         return transformer
     }()
 
-    static var container = CoreData.encryptionContainer()
-    static var context = container.viewContext
-    var context: NSManagedObjectContext { Self.context }
+    var container: NSPersistentContainer! = CoreData.encryptionContainer()
+    var context: NSManagedObjectContext { container.viewContext }
 
     override func setUp() {
         mockValueTransformer.numberOfTransformations = 0
@@ -44,6 +43,7 @@ class CoreDataEncryptionTests: XCTestCase {
 
     override func tearDown() {
         mockValueTransformer = nil
+        container = nil
     }
 
     func testSavingEncryptedValues() {

--- a/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
+++ b/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
@@ -459,7 +459,7 @@ final class BrowserTabViewControllerOnboardingTests: XCTestCase {
         viewController.delegate = delegate
         XCTAssertFalse(delegate.didCallHighlightFireButton)
         tab.navigateFromOnboarding(to: url)
-        wait(for: [expectation], timeout: 3.0)
+        wait(for: [expectation], timeout: 5.0)
 
         // WHEN
         factory.performOnGotItPressed()


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1214087249841177?focus=true
Tech Design URL:
CC:

### Description

This PR adds support for a `strict pr checks` label, which has all PR checks run 3 times and consider the test run a failure if any of those iterations failed (compared to today, where 1 successful iteration causes the entire test to be a success).

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. TODO after testing the change

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI test execution semantics across iOS/macOS workflows by conditionally disabling retry-on-failure, which can increase PR failure rates and CI time if misconfigured. Also adjusts a few test timeouts/sleeps which could affect test stability.
> 
> **Overview**
> Adds a PR label-controlled **strict test mode** (`strict pr checks`) to the reusable `should_run_pr_checks.yml` workflow and propagates a new `strict_mode` output.
> 
> When enabled, iOS/macOS/BSK/DBP workflows run `xcodebuild test` with `-test-iterations 3` **without** `-retry-tests-on-failure`; when not enabled, existing retry behavior is kept (and PIR e2e keeps its non-strict 2-iteration retry setup).
> 
> Includes small test-stability tweaks: increases a DBP timeout expectation to 10s, adjusts a DuckPlayer duplicate-navigation sleep to 0.1s, switches a macOS downloads test to reuse per-test temp URLs, makes Core Data encryption tests use per-instance containers (with cleanup), and bumps an onboarding wait timeout to 5s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f48fd012fd24fd218ea1d4ab1dc32e7102634eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->