### PR TITLE
Avoid autofill test state carrying over between tests

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/SecureVault/CredentialsDatabaseCleanerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/SecureVault/CredentialsDatabaseCleanerTests.swift
@@ -37,6 +37,22 @@ final class MockEventMapper: EventMapping<CredentialsCleanupError> {
     }
 }
 
+/// On iOS, `DefaultAutofillDatabaseProvider` ignores its `file` parameter and routes
+/// the database through `migrateDatabaseToSharedStorageIfNeeded`, which redirects to a
+/// fixed default path.  Injecting this manager makes the provider use the caller-supplied
+/// URL instead, giving each test its own isolated database.
+final class TemporaryDatabaseFileStorageManager: FileStorageManaging {
+    private let databaseURL: URL
+
+    init(databaseURL: URL) {
+        self.databaseURL = databaseURL
+    }
+
+    func migrateDatabaseToSharedStorageIfNeeded(from: URL, to: URL) throws -> URL {
+        return databaseURL
+    }
+}
+
 final class MockSecureVaultErrorReporter: SecureVaultReporting {
     var _secureVaultInitFailed: (SecureStorageError) -> Void = { _ in }
     func secureVaultError(_ error: SecureStorageError) {
@@ -75,7 +91,11 @@ final class CredentialsDatabaseCleanerTests: XCTestCase {
         try super.setUpWithError()
 
         databaseLocation = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".db")
-        databaseProvider = try DefaultAutofillDatabaseProvider(file: databaseLocation, key: simpleL1Key)
+        databaseProvider = try DefaultAutofillDatabaseProvider(
+            file: databaseLocation,
+            key: simpleL1Key,
+            fileStorageManager: TemporaryDatabaseFileStorageManager(databaseURL: databaseLocation)
+        )
         secureVaultFactory = AutofillVaultFactory.testFactory(databaseProvider: databaseProvider)
         secureVault = try secureVaultFactory.makeVault(reporter: nil)
         _ = try secureVault.authWith(password: "abcd".data(using: .utf8)!)
@@ -85,6 +105,10 @@ final class CredentialsDatabaseCleanerTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        databaseCleaner = nil
+        secureVault = nil
+        secureVaultFactory = nil
+        databaseProvider = nil
         try deleteDbFile()
         try super.tearDownWithError()
     }

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/SecureVault/CreditCardsDatabaseCleanerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/SecureVault/CreditCardsDatabaseCleanerTests.swift
@@ -53,7 +53,11 @@ final class CreditCardsDatabaseCleanerTests: XCTestCase {
         try super.setUpWithError()
 
         databaseLocation = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".db")
-        databaseProvider = try DefaultAutofillDatabaseProvider(file: databaseLocation, key: simpleL1Key)
+        databaseProvider = try DefaultAutofillDatabaseProvider(
+            file: databaseLocation,
+            key: simpleL1Key,
+            fileStorageManager: TemporaryDatabaseFileStorageManager(databaseURL: databaseLocation)
+        )
         secureVaultFactory = AutofillVaultFactory.testFactory(databaseProvider: databaseProvider)
         secureVault = try secureVaultFactory.makeVault(reporter: nil)
         _ = try secureVault.authWith(password: "abcd".data(using: .utf8)!)
@@ -63,6 +67,10 @@ final class CreditCardsDatabaseCleanerTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        databaseCleaner = nil
+        secureVault = nil
+        secureVaultFactory = nil
+        databaseProvider = nil
         try deleteDbFile()
         try super.tearDownWithError()
     }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1214087249841186?focus=true
Tech Design URL:
CC:

### Description

This PR fixes an issue where autofill state was carrying over between test iterations. This affected #4462, which adds the ability for CI runs to check for test failures more strictly.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI is green

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust database path injection and cleanup to avoid cross-test state; no production runtime logic is modified.
> 
> **Overview**
> Fixes flaky/stateful autofill vault cleaner tests on iOS by ensuring each test run uses its own isolated database file.
> 
> Adds a test-only `TemporaryDatabaseFileStorageManager` that overrides `DefaultAutofillDatabaseProvider`’s iOS migration-to-shared-storage behavior, and updates both `CredentialsDatabaseCleanerTests` and `CreditCardsDatabaseCleanerTests` to inject it plus explicitly nil out vault/provider/cleaner references in `tearDownWithError` before deleting temp DB files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48a785c2e7e4a6839d85f8833cbc5f942a078f64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->