### PR TITLE
[iOS][Pixels] Fix Missing parameters for iOS TDS Pixel definition

### DIFF
--- a/iOS/PixelDefinitions/pixels/definitions/configuration.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/configuration.json5
@@ -40,7 +40,23 @@
         "owners": ["alessandroboron", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion", "errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
+        "parameters": [
+            "appVersion",
+            "errorCode",
+            "errorDomain",
+            "underlyingErrorCode",
+            "underlyingErrorDomain",
+            {
+                "key": "experimentName",
+                "description": "The name of the active TDS experiment Name with Cohort if any. Example: 'tdsNextExperiment007_treatment'",
+                "type": "string"
+            },
+            {
+                "key": "etag",
+                "description": "The etag associated with the TDS. Sent only if TDS experiment is active. Example: '%2272ae7e75715adc6ff4173767c337615c%22'",
+                "type": "string"
+            }
+        ]
     },
     "m_debug_remotemessagingconfig_load_failed": {
         "description": "Fired when the RMF configuration file fails to load",
@@ -62,7 +78,23 @@
         "owners": ["alessandroboron", "samsymons"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion", "errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
+        "parameters": [
+            "appVersion",
+            "errorCode",
+            "errorDomain",
+            "underlyingErrorCode",
+            "underlyingErrorDomain",
+            {
+                "key": "experimentName",
+                "description": "The name of the active TDS experiment Name with Cohort if any. Example: 'tdsNextExperiment007_treatment'",
+                "type": "string"
+            },
+            {
+                "key": "etag",
+                "description": "The etag associated with the TDS. Sent only if TDS experiment is active. Example: '%2272ae7e75715adc6ff4173767c337615c%22'",
+                "type": "string"
+            }
+        ]
     },
 
     "m_debug_privacyconfiguration_load_failed_vpn": {

--- a/iOS/PixelDefinitions/pixels/definitions/default-browser-prompt-inactive-user.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/default-browser-prompt-inactive-user.json5
@@ -52,17 +52,10 @@
             // Commonly used param, defined in params_dictionary.json.
             "appVersion",
             "pixelSource",
-            // Default Parameters for errors "e" and "d"
-            {
-                "key": "e",
-                "description": "The error code if present.",
-                "type": "string"
-            },
-            {
-                "key": "d",
-                "description": "The domain of the error. e.g. NSCocoaErrorDomain",
-                "type": "string"
-            }
+            "errorDomain",
+            "errorCode",
+            "underlyingErrorDomain",
+            "underlyingErrorCode"
         ]
     },
     "m_debug_set-as-default-prompt_failed-to-save-inactive-modal-shown": {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1214053508886208?focus=true
Tech Design URL:
CC:

### Description

This PR fixes:
- Missing parameter in the pixel configuration definition when TDS experiment is active.
- Use common error parameters for default browser inactive user error pixels  

### Testing Steps
1. Ensure CI is green.

### Impact and Risks
None: Pixel definition

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: JSON5 pixel definition updates only, expanding reported metadata and aligning error parameter keys; main risk is downstream analytics expecting the old parameter names.
> 
> **Overview**
> Adds `experimentName` and `etag` parameters to the TDS load/parse failure pixels (`m_debug_trackerdataset_load_failed` and `m_debug_trackerdataset_parse_failed`) so failures can be attributed when a TDS experiment is active.
> 
> Standardizes the default-browser inactive-user debug error pixel parameters by replacing the custom `e`/`d` keys with the common `errorDomain`/`errorCode` plus underlying error fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1b56ce622970926fe35de0e745ca12ab071a015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->