### PR TITLE
[IOS][Onboarding Rebranding Animations] Fix bubble linear positioning and bold font for trackers

### DIFF
--- a/SharedPackages/Onboarding/Sources/Onboarding/Rebranding/Shared/RebrandedContextualDaxDialogContent.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Rebranding/Shared/RebrandedContextualDaxDialogContent.swift
@@ -199,7 +199,7 @@ private extension OnboardingRebranding {
                 #if os(iOS)
                 if let title {
                     let titleAlignment = titleTextAlignment ?? theme.contextualOnboardingMetrics.contextualTitleTextAlignment
-                    TypingText(String(title.characters), onTypingFinished: {
+                    TypingText(title, onTypingFinished: {
                         startTypingMessage = true
                     })
                         .font(theme.typography.contextual.title)
@@ -207,7 +207,7 @@ private extension OnboardingRebranding {
                         .frame(maxWidth: .infinity, alignment: Alignment(titleAlignment))
                 }
                 let messageAlignment = messageTextAlignment ?? theme.contextualOnboardingMetrics.contextualBodyTextAlignment
-                TypingText(String(message.characters), startAnimating: title != nil ? $startTypingMessage : .constant(true))
+                TypingText(message, startAnimating: title != nil ? $startTypingMessage : .constant(true))
                     .font(theme.typography.contextual.body)
                     .multilineTextAlignment(messageAlignment)
                     .frame(maxWidth: .infinity, alignment: Alignment(messageAlignment))

--- a/SharedPackages/Onboarding/Sources/Onboarding/SwiftUIExtensions/TypingTextAnimation.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/SwiftUIExtensions/TypingTextAnimation.swift
@@ -116,7 +116,7 @@ private final class TypingAnimationState: ObservableObject {
 ///   `TypingText` animations in the subtree (used for tap-to-skip).
 /// - When `accessibilityReduceMotion` is enabled, the full text appears immediately.
 public struct TypingText: View {
-    private let text: String
+    private let attributedText: AttributedString
     private let startAnimating: Binding<Bool>
     private let onTypingFinished: (() -> Void)?
 
@@ -124,10 +124,14 @@ public struct TypingText: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.typingAnimationSkip) private var skipAnimation
 
-    public init(_ text: String, startAnimating: Binding<Bool> = .constant(true), onTypingFinished: (() -> Void)? = nil) {
-        self.text = text
+    public init(_ attributedText: AttributedString, startAnimating: Binding<Bool> = .constant(true), onTypingFinished: (() -> Void)? = nil) {
+        self.attributedText = attributedText
         self.startAnimating = startAnimating
         self.onTypingFinished = onTypingFinished
+    }
+
+    public init(_ text: String, startAnimating: Binding<Bool> = .constant(true), onTypingFinished: (() -> Void)? = nil) {
+        self.init(AttributedString(text), startAnimating: startAnimating, onTypingFinished: onTypingFinished)
     }
 
     /// Builds an `AttributedString` where the first `visibleCount` characters inherit
@@ -135,39 +139,41 @@ public struct TypingText: View {
     /// Because the full text is always rendered, line breaks never shift.
     private var revealedText: Text {
         if state.isFinished {
-            return Text(text)
+            return Text(attributedText)
         }
-        let chars = Array(text)
-        let visible = AttributedString(String(chars.prefix(state.visibleCount)))
-        var hidden = AttributedString(String(chars.suffix(from: state.visibleCount)))
-        hidden.foregroundColor = .clear
-        return Text(visible) + Text(hidden)
+
+        let splitIndex = attributedText.characters.index(attributedText.startIndex, offsetBy: state.visibleCount)
+        let visibleAttributedString = AttributedString(attributedText[..<splitIndex])
+        var hiddenAttributedString = AttributedString(attributedText[splitIndex...])
+        hiddenAttributedString.foregroundColor = .clear
+
+        return Text(visibleAttributedString) + Text(hiddenAttributedString)
     }
 
     public var body: some View {
         revealedText
             .onChange(of: skipAnimation) { shouldSkip in
-                if shouldSkip { state.skip(totalCount: text.count, onFinished: onTypingFinished) }
+                if shouldSkip { state.skip(totalCount: attributedText.characters.count, onFinished: onTypingFinished) }
             }
             .onChange(of: startAnimating.wrappedValue) { shouldAnimate in
                 if shouldAnimate {
                     if reduceMotion {
-                        state.skip(totalCount: text.count, onFinished: onTypingFinished)
+                        state.skip(totalCount: attributedText.characters.count, onFinished: onTypingFinished)
                     } else {
-                        state.start(totalCount: text.count, onFinished: onTypingFinished)
+                        state.start(totalCount: attributedText.characters.count, onFinished: onTypingFinished)
                     }
                 } else {
                     state.stop()
                 }
             }
             .onChange(of: reduceMotion) { shouldReduce in
-                if shouldReduce { state.skip(totalCount: text.count, onFinished: onTypingFinished) }
+                if shouldReduce { state.skip(totalCount: attributedText.characters.count, onFinished: onTypingFinished) }
             }
             .onAppear {
                 if reduceMotion || skipAnimation {
-                    state.skip(totalCount: text.count, onFinished: onTypingFinished)
+                    state.skip(totalCount: attributedText.characters.count, onFinished: onTypingFinished)
                 } else if startAnimating.wrappedValue {
-                    state.start(totalCount: text.count, onFinished: onTypingFinished)
+                    state.start(totalCount: attributedText.characters.count, onFinished: onTypingFinished)
                 }
             }
             .onDisappear { state.stop() }

--- a/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/Rebranding/RebrandedContextualDaxDialogFactory.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/Rebranding/RebrandedContextualDaxDialogFactory.swift
@@ -323,4 +323,3 @@ private extension RebrandedContextualDaxDialogFactory {
     }
 
 }
-

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/Components/AddressBarPositionPicker/RebrandedOnboardingAddressBarPositionPicker.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/Components/AddressBarPositionPicker/RebrandedOnboardingAddressBarPositionPicker.swift
@@ -60,7 +60,7 @@ private enum AddressBarPositionPickerMetrics {
     static let textSpacing: CGFloat = 0
     static let cornerRadius: CGFloat = 16.0
     static let borderWidth: CGFloat = 1.0
-    static let minHeight: CGFloat = 63.0
+    static let maxHeight: CGFloat = 63.0
     static let borderLightColor = Color.black.opacity(0.18)
     static let borderDarkColor = Color.white.opacity(0.18)
 
@@ -125,7 +125,7 @@ private struct AddressBarPositionButtonStyle: ButtonStyle {
             .multilineTextAlignment(.leading)
             .lineLimit(nil)
             .padding()
-            .frame(minWidth: 0, maxWidth: .infinity, minHeight: AddressBarPositionPickerMetrics.minHeight)
+            .frame(minWidth: 0, maxWidth: .infinity, maxHeight: AddressBarPositionPickerMetrics.maxHeight)
             .background(backgroundColor(isSelected: isSelected, isPressed: configuration.isPressed))
             .cornerRadius(AddressBarPositionPickerMetrics.cornerRadius)
             .contentShape(Rectangle())

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/Components/AddressBarPositionPicker/RebrandedOnboardingAddressBarPositionPicker.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/Rebranding/Components/AddressBarPositionPicker/RebrandedOnboardingAddressBarPositionPicker.swift
@@ -125,7 +125,7 @@ private struct AddressBarPositionButtonStyle: ButtonStyle {
             .multilineTextAlignment(.leading)
             .lineLimit(nil)
             .padding()
-            .frame(minWidth: 0, maxWidth: .infinity, maxHeight: AddressBarPositionPickerMetrics.maxHeight)
+            .frame(minWidth: 0, maxWidth: .infinity, minHeight: AddressBarPositionPickerMetrics.maxHeight, maxHeight: AddressBarPositionPickerMetrics.maxHeight)
             .background(backgroundColor(isSelected: isSelected, isPressed: configuration.isPressed))
             .cornerRadius(AddressBarPositionPickerMetrics.cornerRadius)
             .contentShape(Rectangle())

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/OmniBar/MockOmniBar.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/OmniBar/MockOmniBar.swift
@@ -141,6 +141,8 @@ final class MockOmniBar: OmniBar {
         var onCustomizableButtonPressed: (() -> Void)?
         var onAIChatLeftButtonPressed: (() -> Void)?
         var onAIChatBrandingPressed: (() -> Void)?
+        var onMenuButtonLongPressed: (() -> Void)?
+        var onSettingsButtonLongPressed: (() -> Void)?
 
         static func create() -> Self {
             Self.init()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214073565693402
Tech Design URL:
CC:

### Description

This PR addresses: 
- AL3/ https://app.asana.com/1/137249556945/task/1214073565693402 -> Commit: https://github.com/duckduckgo/apple-browsers/commit/520c331c11f456e0e1c21975d3bf33c43fc6f6b0
- BG5/ Bold font for trackers -> Commit: https://github.com/duckduckgo/apple-browsers/commit/2ee1e38443a4721a56412c21320fedb89b9ef089

### Testing Steps
1. Launch Rebranded onboarding.
2. Verify that between step 3 4 and 5 of the linear flow the bubble vertical position stays the same.
3. Verify that trackers blocked showed in bold.

### Impact and Risks
Low: These are visual changes fixes

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes: updates the typing animation to operate on `AttributedString` and tweaks onboarding layout sizing and test mocks, with minimal impact outside presentation and animation behavior.
> 
> **Overview**
> **Improves rebranded onboarding text rendering and layout stability.** `TypingText` now animates `AttributedString` directly (with a `String` convenience init), and contextual Dax dialog content passes attributed title/message through the typing animation so markdown/bold styling is preserved during reveal.
> 
> Also fixes a linear onboarding layout issue by constraining the address bar position picker buttons to a fixed height (min+max), and extends `MockOmniBar` with long-press callbacks for menu/settings buttons to match updated UI interactions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68c5140f6d8b512abb8263b90178d2c8cca49e73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->