### PR TITLE
[iOS] FreemiumDBPUserStateManager implementation

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Package.resolved
+++ b/SharedPackages/DataBrokerProtectionCore/Package.resolved
@@ -1,13 +1,12 @@
 {
-  "originHash" : "597542faae66ce6fe059c54c3c8afddc10b367e5a72eef61cf689ff1497ecb6b",
   "pins" : [
     {
       "identity" : "content-scope-scripts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "5c616fb4064c32fb1e5f7de96916ca9b89646f75",
-        "version" : "14.0.0"
+        "revision" : "13976e04d81eefac5a9c718d886ce99460a9123b",
+        "version" : "13.29.0"
       }
     },
     {
@@ -42,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/privacy-dashboard",
       "state" : {
-        "revision" : "40a8c752fb73a15738899dc0edb5e17e33302a37",
-        "version" : "9.10.1"
+        "revision" : "a3adc679f86a3276dfb12ddf4a379b17c80dfc60",
+        "version" : "9.10.0"
       }
     },
     {
@@ -119,5 +118,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/SharedPackages/DataBrokerProtectionCore/Package.resolved
+++ b/SharedPackages/DataBrokerProtectionCore/Package.resolved
@@ -1,12 +1,13 @@
 {
+  "originHash" : "597542faae66ce6fe059c54c3c8afddc10b367e5a72eef61cf689ff1497ecb6b",
   "pins" : [
     {
       "identity" : "content-scope-scripts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "13976e04d81eefac5a9c718d886ce99460a9123b",
-        "version" : "13.29.0"
+        "revision" : "5c616fb4064c32fb1e5f7de96916ca9b89646f75",
+        "version" : "14.0.0"
       }
     },
     {
@@ -41,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/privacy-dashboard",
       "state" : {
-        "revision" : "a3adc679f86a3276dfb12ddf4a379b17c80dfc60",
-        "version" : "9.10.0"
+        "revision" : "40a8c752fb73a15738899dc0edb5e17e33302a37",
+        "version" : "9.10.1"
       }
     },
     {
@@ -118,5 +119,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
@@ -850,8 +850,12 @@ public final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecu
     public func updateRemovedDate(for extractedProfileId: Int64, with date: Date?) throws {
     }
 
+    public var hasMatchesToReturn = false
+    public var hasMatchesError: Error?
+
     public func hasMatches() throws -> Bool {
-        false
+        if let error = hasMatchesError { throw error }
+        return hasMatchesToReturn
     }
 
     public func fetchChildBrokers(for parentBroker: String) throws -> [DataBroker] {
@@ -1283,8 +1287,12 @@ public final class MockDatabase: DataBrokerProtectionRepository {
         optOutToReturn
     }
 
+    public var hasMatchesToReturn = false
+    public var hasMatchesError: Error?
+
     public func hasMatches() throws -> Bool {
-        false
+        if let error = hasMatchesError { throw error }
+        return hasMatchesToReturn
     }
 
     public func matchRemovedByUser(_ matchID: Int64) throws {

--- a/iOS/DuckDuckGo/AppServices/DBPService.swift
+++ b/iOS/DuckDuckGo/AppServices/DBPService.swift
@@ -50,7 +50,14 @@ final class DBPService: NSObject {
                 authenticationManager: authManager,
                 pixelHandler: notificationPixelHandler
             )
-            let eventsHandler = BrokerProfileJobEventsHandler(userNotificationService: notificationService)
+            let freemiumDBPUserStateManager = DefaultFreemiumDBPUserStateManager(
+                userDefaults: .dbp,
+                isUserAuthenticated: { [authManager] in await authManager.isUserAuthenticated }
+            )
+            let eventsHandler = BrokerProfileJobEventsHandler(
+                userNotificationService: notificationService,
+                freemiumUserStateManager: freemiumDBPUserStateManager
+            )
 
             #if DEBUG
             let isWebViewInspectable = true
@@ -82,6 +89,7 @@ final class DBPService: NSObject {
                     return view
                 },
                 eventsHandler: eventsHandler,
+                freemiumDBPUserStateManager: freemiumDBPUserStateManager,
                 isWebViewInspectable: isWebViewInspectable,
                 freeTrialConversionService: appDependencies.freeTrialConversionService)
         } else {

--- a/iOS/DuckDuckGo/AppServices/DBPService.swift
+++ b/iOS/DuckDuckGo/AppServices/DBPService.swift
@@ -52,7 +52,8 @@ final class DBPService: NSObject {
             )
             let freemiumDBPUserStateManager = DefaultFreemiumDBPUserStateManager(
                 userDefaults: .dbp,
-                isUserAuthenticated: { [authManager] in await authManager.isUserAuthenticated }
+                isUserAuthenticated: { [authManager] in await authManager.isUserAuthenticated },
+                isFreemiumEnabled: { [featureFlagger] in featureFlagger.isFreemiumPIREnabled }
             )
             let eventsHandler = BrokerProfileJobEventsHandler(
                 userNotificationService: notificationService,

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
@@ -923,23 +923,14 @@ private extension DataBrokerProtectionIOSManager {
 
 private extension DataBrokerProtectionIOSManager {
 
-    /// Applies side-effects tied to a scan-operations completion callback. Used from both
-    /// `startImmediateScanOperations()` and `coordinatorIsReadyForScanOperations()`.
-    ///
-    /// - `.firstScanCompletedAndMatchesFound` always fires when the DB reports matches. This
-    ///   is pre-branch behavior: the completion block fired it on both normally-finished and
-    ///   interrupted runs, and downstream notification scheduling depends on it.
-    /// - The freemium `firstScanResult` write is gated on `didCompleteNormally`. It's a
-    ///   branch-introduced side-effect and is first-write-wins, so an interrupted run's
-    ///   mid-scan DB snapshot must not permanently lock the wrong value. A transient DB read
-    ///   error is also handled — if `hasMatches()` throws, nothing fires or persists and a
-    ///   later successful scan captures the correct outcome.
-    func applyScanCompletionSideEffects(didCompleteNormally: Bool) async {
+    /// Handles common completion work for immediate scan operations.
+    /// The queue also runs completion for interrupted scans; only normal completions may persist first-write-wins freemium state.
+    func handleScanOperationsCompletion(scanCompletedNormally: Bool) async {
         guard let hasMatches = try? database.hasMatches() else { return }
         if hasMatches {
             eventsHandler.fire(.firstScanCompletedAndMatchesFound)
         }
-        guard didCompleteNormally else { return }
+        guard scanCompletedNormally else { return }
         await freemiumDBPUserStateManager.recordFirstScanResultIfNeeded(hasMatches: hasMatches)
     }
 
@@ -955,25 +946,21 @@ extension DataBrokerProtectionIOSManager {
         }
 
         await checkForEmailConfirmationData()
-        // `JobQueueManager` invokes this completion block on both normal finish AND on
-        // interruption (e.g. when `appDidBecomeActive` kicks off a replacement run mid-scan).
-        // The errorHandler tells us which one; thread that signal into the completion so we
-        // can gate the branch-introduced freemium write on real completion. Pre-existing
-        // side-effects (`.firstScanCompletedAndMatchesFound`) stay unconditional.
-        var didCompleteNormally = false
+        // Completion also runs for interrupted scans; the error handler is the normal-finish signal.
+        var scanCompletedNormally = false
         queueManager.startImmediateScanOperationsIfPermitted(
             showWebView: false,
             jobDependencies: jobDependencies,
             errorHandler: { [weak self] errors in
                 if errors?.oneTimeError == nil {
-                    didCompleteNormally = true
+                    scanCompletedNormally = true
                     self?.eventsHandler.fire(.firstScanCompleted)
                 }
             }
         ) { [weak self] in
             guard let self else { return }
             Task {
-                await self.applyScanCompletionSideEffects(didCompleteNormally: didCompleteNormally)
+                await self.handleScanOperationsCompletion(scanCompletedNormally: scanCompletedNormally)
                 DispatchQueue.main.async {
                     backgroundAssertion.release()
                 }
@@ -1065,23 +1052,21 @@ extension DataBrokerProtectionIOSManager: DBPContinuedProcessingDelegate {
         }
 
         await checkForEmailConfirmationData()
-        // See startImmediateScanOperations for the rationale. Continued-processing's
-        // `.scanPhaseCompleted` emission is explicitly unchanged — that's pre-branch behavior;
-        // revisiting how the coordinator handles interrupted scans is a separate concern.
-        var didCompleteNormally = false
+        // Same completion semantics as `startImmediateScanOperations()`.
+        var scanCompletedNormally = false
         queueManager.startImmediateScanOperationsIfPermitted(
             showWebView: false,
             jobDependencies: jobDependencies,
             errorHandler: { [weak self] errors in
                 if errors?.oneTimeError == nil {
-                    didCompleteNormally = true
+                    scanCompletedNormally = true
                     self?.eventsHandler.fire(.firstScanCompleted)
                 }
             }
         ) { [weak self] in
             guard let self else { return }
             Task {
-                await self.applyScanCompletionSideEffects(didCompleteNormally: didCompleteNormally)
+                await self.handleScanOperationsCompletion(scanCompletedNormally: scanCompletedNormally)
                 DispatchQueue.main.async {
                     Task { [weak self] in
                         await self?.continuedProcessingCoordinator.didEmit(event: .scanPhaseCompleted)

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
@@ -935,6 +935,10 @@ private extension DataBrokerProtectionIOSManager {
         await freemiumDBPUserStateManager.recordFirstScanResultIfNeeded(hasMatches: hasMatches)
     }
 
+}
+
+extension DataBrokerProtectionIOSManager {
+
     @MainActor
     func startImmediateScanOperations() async {
         Logger.dataBrokerProtection.log("Starting immediate scan operations")

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
@@ -923,18 +923,23 @@ private extension DataBrokerProtectionIOSManager {
 
 private extension DataBrokerProtectionIOSManager {
 
-    /// Shared completion-block logic for scan operations. Fires the existing
-    /// `.firstScanCompletedAndMatchesFound` event for the notification service and
-    /// records the first-scan outcome into freemium state. Called from both
+    /// Applies side-effects tied to a scan-operations completion callback. Used from both
     /// `startImmediateScanOperations()` and `coordinatorIsReadyForScanOperations()`.
-    func handleScanCompletion() async {
-        // A transient `database.hasMatches()` failure must not permanently record `.noMatches`:
-        // `firstScanResult` is first-write-wins, so a bogus result would stick forever. Skip the
-        // record on error and let a later successful scan capture the correct outcome.
+    ///
+    /// - `.firstScanCompletedAndMatchesFound` always fires when the DB reports matches. This
+    ///   is pre-branch behavior: the completion block fired it on both normally-finished and
+    ///   interrupted runs, and downstream notification scheduling depends on it.
+    /// - The freemium `firstScanResult` write is gated on `didCompleteNormally`. It's a
+    ///   branch-introduced side-effect and is first-write-wins, so an interrupted run's
+    ///   mid-scan DB snapshot must not permanently lock the wrong value. A transient DB read
+    ///   error is also handled — if `hasMatches()` throws, nothing fires or persists and a
+    ///   later successful scan captures the correct outcome.
+    func applyScanCompletionSideEffects(didCompleteNormally: Bool) async {
         guard let hasMatches = try? database.hasMatches() else { return }
         if hasMatches {
             eventsHandler.fire(.firstScanCompletedAndMatchesFound)
         }
+        guard didCompleteNormally else { return }
         await freemiumDBPUserStateManager.recordFirstScanResultIfNeeded(hasMatches: hasMatches)
     }
 
@@ -950,18 +955,25 @@ extension DataBrokerProtectionIOSManager {
         }
 
         await checkForEmailConfirmationData()
+        // `JobQueueManager` invokes this completion block on both normal finish AND on
+        // interruption (e.g. when `appDidBecomeActive` kicks off a replacement run mid-scan).
+        // The errorHandler tells us which one; thread that signal into the completion so we
+        // can gate the branch-introduced freemium write on real completion. Pre-existing
+        // side-effects (`.firstScanCompletedAndMatchesFound`) stay unconditional.
+        var didCompleteNormally = false
         queueManager.startImmediateScanOperationsIfPermitted(
             showWebView: false,
             jobDependencies: jobDependencies,
             errorHandler: { [weak self] errors in
                 if errors?.oneTimeError == nil {
+                    didCompleteNormally = true
                     self?.eventsHandler.fire(.firstScanCompleted)
                 }
             }
         ) { [weak self] in
             guard let self else { return }
             Task {
-                await self.handleScanCompletion()
+                await self.applyScanCompletionSideEffects(didCompleteNormally: didCompleteNormally)
                 DispatchQueue.main.async {
                     backgroundAssertion.release()
                 }
@@ -1053,18 +1065,23 @@ extension DataBrokerProtectionIOSManager: DBPContinuedProcessingDelegate {
         }
 
         await checkForEmailConfirmationData()
+        // See startImmediateScanOperations for the rationale. Continued-processing's
+        // `.scanPhaseCompleted` emission is explicitly unchanged — that's pre-branch behavior;
+        // revisiting how the coordinator handles interrupted scans is a separate concern.
+        var didCompleteNormally = false
         queueManager.startImmediateScanOperationsIfPermitted(
             showWebView: false,
             jobDependencies: jobDependencies,
             errorHandler: { [weak self] errors in
                 if errors?.oneTimeError == nil {
+                    didCompleteNormally = true
                     self?.eventsHandler.fire(.firstScanCompleted)
                 }
             }
         ) { [weak self] in
             guard let self else { return }
             Task {
-                await self.handleScanCompletion()
+                await self.applyScanCompletionSideEffects(didCompleteNormally: didCompleteNormally)
                 DispatchQueue.main.async {
                     Task { [weak self] in
                         await self?.continuedProcessingCoordinator.didEmit(event: .scanPhaseCompleted)

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
@@ -923,6 +923,18 @@ private extension DataBrokerProtectionIOSManager {
 
 private extension DataBrokerProtectionIOSManager {
 
+    /// Shared completion-block logic for scan operations. Fires the existing
+    /// `.firstScanCompletedAndMatchesFound` event for the notification service and
+    /// records the first-scan outcome into freemium state. Called from both
+    /// `startImmediateScanOperations()` and `coordinatorIsReadyForScanOperations()`.
+    func handleScanCompletion() async {
+        let hasMatches = (try? database.hasMatches()) ?? false
+        if hasMatches {
+            eventsHandler.fire(.firstScanCompletedAndMatchesFound)
+        }
+        await freemiumDBPUserStateManager.recordFirstScanResultIfNeeded(hasMatches: hasMatches)
+    }
+
     @MainActor
     func startImmediateScanOperations() async {
         Logger.dataBrokerProtection.log("Starting immediate scan operations")
@@ -940,12 +952,12 @@ private extension DataBrokerProtectionIOSManager {
                 }
             }
         ) { [weak self] in
-            if let hasMatches = try? self?.database.hasMatches(), hasMatches {
-                self?.eventsHandler.fire(.firstScanCompletedAndMatchesFound)
-            }
-
-            DispatchQueue.main.async {
-                backgroundAssertion.release()
+            guard let self else { return }
+            Task {
+                await self.handleScanCompletion()
+                DispatchQueue.main.async {
+                    backgroundAssertion.release()
+                }
             }
         }
     }
@@ -1043,15 +1055,15 @@ extension DataBrokerProtectionIOSManager: DBPContinuedProcessingDelegate {
                 }
             }
         ) { [weak self] in
-            if let hasMatches = try? self?.database.hasMatches(), hasMatches {
-                self?.eventsHandler.fire(.firstScanCompletedAndMatchesFound)
-            }
-
-            DispatchQueue.main.async {
-                Task { [weak self] in
-                    await self?.continuedProcessingCoordinator.didEmit(event: .scanPhaseCompleted)
+            guard let self else { return }
+            Task {
+                await self.handleScanCompletion()
+                DispatchQueue.main.async {
+                    Task { [weak self] in
+                        await self?.continuedProcessingCoordinator.didEmit(event: .scanPhaseCompleted)
+                    }
+                    backgroundAssertion.release()
                 }
-                backgroundAssertion.release()
             }
         }
     }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
@@ -928,7 +928,10 @@ private extension DataBrokerProtectionIOSManager {
     /// records the first-scan outcome into freemium state. Called from both
     /// `startImmediateScanOperations()` and `coordinatorIsReadyForScanOperations()`.
     func handleScanCompletion() async {
-        let hasMatches = (try? database.hasMatches()) ?? false
+        // A transient `database.hasMatches()` failure must not permanently record `.noMatches`:
+        // `firstScanResult` is first-write-wins, so a bogus result would stick forever. Skip the
+        // record on error and let a later successful scan capture the correct outcome.
+        guard let hasMatches = try? database.hasMatches() else { return }
         if hasMatches {
             eventsHandler.fire(.firstScanCompletedAndMatchesFound)
         }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManagerProvider.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManagerProvider.swift
@@ -52,6 +52,7 @@ public class DataBrokerProtectionIOSManagerProvider {
                                   quickLinkOpenURLHandler: @escaping (URL) -> Void,
                                   feedbackViewCreator: @escaping () -> (any View),
                                   eventsHandler: EventMapping<JobEvent>,
+                                  freemiumDBPUserStateManager: FreemiumDBPUserStateManaging,
                                   isWebViewInspectable: Bool = false,
                                   freeTrialConversionService: FreeTrialConversionInstrumentationService? = nil) -> DataBrokerProtectionIOSManager? {
         let sharedPixelsHandler = DataBrokerProtectionSharedPixelsHandler(pixelKit: pixelKit, platform: .iOS)
@@ -164,7 +165,8 @@ public class DataBrokerProtectionIOSManagerProvider {
             wideEvent: wideEvent,
             eventsHandler: eventsHandler,
             isWebViewInspectable: isWebViewInspectable,
-            freeTrialConversionService: freeTrialConversionService
+            freeTrialConversionService: freeTrialConversionService,
+            freemiumDBPUserStateManager: freemiumDBPUserStateManager
         )
     }
 }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DefaultFreemiumDBPUserStateManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DefaultFreemiumDBPUserStateManager.swift
@@ -79,7 +79,7 @@ public final class DefaultFreemiumDBPUserStateManager: FreemiumDBPUserStateManag
         persistFirstScanResultIfAbsent(hasMatches: hasMatches)
     }
 
-    public func recordSubscriptionUpgradeIfNeeded() async {
+    public func recordSubscriptionUpgradeIfEligible() async {
         // By contract, the caller drives this from a real purchase-success / transition
         // signal, so we do NOT check isUserAuthenticated here. See spec §3.
         persistSubscriptionUpgradeIfEligible()

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DefaultFreemiumDBPUserStateManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DefaultFreemiumDBPUserStateManager.swift
@@ -58,10 +58,27 @@ public final class DefaultFreemiumDBPUserStateManager: FreemiumDBPUserStateManag
         return userDefaults.object(forKey: Keys.upgradeToSubscriptionTimestamp) as? Date
     }
 
-    // MARK: - Write-side methods (implemented in later tasks)
+    // MARK: - Write-side methods
 
     public func recordProfileSavedIfNeeded() async {
         guard await !isUserAuthenticated() else { return }
+        persistProfileSaved()
+    }
+
+    public func recordFirstScanResultIfNeeded(hasMatches: Bool) async {
+        guard await !isUserAuthenticated() else { return }
+        persistFirstScanResultIfAbsent(hasMatches: hasMatches)
+    }
+
+    public func recordSubscriptionUpgradeIfNeeded() async {
+        // By contract, the caller drives this from a real purchase-success / transition
+        // signal, so we do NOT check isUserAuthenticated here. See spec §3.
+        persistSubscriptionUpgradeIfEligible()
+    }
+
+    // MARK: - Private synchronous helpers
+
+    private func persistProfileSaved() {
         lock.lock()
         defer { lock.unlock() }
         userDefaults.set(true, forKey: Keys.didActivate)
@@ -70,8 +87,7 @@ public final class DefaultFreemiumDBPUserStateManager: FreemiumDBPUserStateManag
         }
     }
 
-    public func recordFirstScanResultIfNeeded(hasMatches: Bool) async {
-        guard await !isUserAuthenticated() else { return }
+    private func persistFirstScanResultIfAbsent(hasMatches: Bool) {
         lock.lock()
         defer { lock.unlock() }
         guard userDefaults.string(forKey: Keys.firstScanResult) == nil else { return }
@@ -79,9 +95,7 @@ public final class DefaultFreemiumDBPUserStateManager: FreemiumDBPUserStateManag
         userDefaults.set(value.rawValue, forKey: Keys.firstScanResult)
     }
 
-    public func recordSubscriptionUpgradeIfNeeded() async {
-        // By contract, the caller drives this from a real purchase-success / transition
-        // signal, so we do NOT check isUserAuthenticated here. See spec §3.
+    private func persistSubscriptionUpgradeIfEligible() {
         lock.lock()
         defer { lock.unlock() }
         guard userDefaults.bool(forKey: Keys.didActivate) else { return }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DefaultFreemiumDBPUserStateManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DefaultFreemiumDBPUserStateManager.swift
@@ -71,7 +71,12 @@ public final class DefaultFreemiumDBPUserStateManager: FreemiumDBPUserStateManag
     }
 
     public func recordFirstScanResultIfNeeded(hasMatches: Bool) async {
-        fatalError("Not implemented")
+        guard await !isUserAuthenticated() else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        guard userDefaults.string(forKey: Keys.firstScanResult) == nil else { return }
+        let value: FreemiumFirstScanResult = hasMatches ? .matchesFound : .noMatches
+        userDefaults.set(value.rawValue, forKey: Keys.firstScanResult)
     }
 
     public func recordSubscriptionUpgradeIfNeeded() async {

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DefaultFreemiumDBPUserStateManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DefaultFreemiumDBPUserStateManager.swift
@@ -6,6 +6,15 @@
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import Foundation

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DefaultFreemiumDBPUserStateManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DefaultFreemiumDBPUserStateManager.swift
@@ -73,6 +73,11 @@ public final class DefaultFreemiumDBPUserStateManager: FreemiumDBPUserStateManag
     }
 
     public func resetAllState() {
-        fatalError("Not implemented")
+        lock.lock()
+        defer { lock.unlock() }
+        userDefaults.removeObject(forKey: Keys.didActivate)
+        userDefaults.removeObject(forKey: Keys.firstProfileSavedTimestamp)
+        userDefaults.removeObject(forKey: Keys.firstScanResult)
+        userDefaults.removeObject(forKey: Keys.upgradeToSubscriptionTimestamp)
     }
 }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DefaultFreemiumDBPUserStateManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DefaultFreemiumDBPUserStateManager.swift
@@ -1,0 +1,78 @@
+//
+//  DefaultFreemiumDBPUserStateManager.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//
+
+import Foundation
+
+/// UserDefaults-backed implementation of `FreemiumDBPUserStateManaging`.
+/// Every read and write goes through a single `NSLock` so concurrent callers
+/// cannot race on guarded read-modify-write sequences.
+public final class DefaultFreemiumDBPUserStateManager: FreemiumDBPUserStateManaging {
+
+    private enum Keys {
+        static let didActivate = "ios.browser.freemium.dbp.did.activate"
+        static let firstProfileSavedTimestamp = "ios.browser.freemium.dbp.first.profile.saved.timestamp"
+        static let firstScanResult = "ios.browser.freemium.dbp.first.scan.result"
+        static let upgradeToSubscriptionTimestamp = "ios.browser.freemium.dbp.upgrade.to.subscription.timestamp"
+    }
+
+    private let userDefaults: UserDefaults
+    private let isUserAuthenticated: () async -> Bool
+    private let lock = NSLock()
+
+    public init(userDefaults: UserDefaults, isUserAuthenticated: @escaping () async -> Bool) {
+        self.userDefaults = userDefaults
+        self.isUserAuthenticated = isUserAuthenticated
+    }
+
+    // MARK: - Read-side getters
+
+    public var didActivate: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return userDefaults.bool(forKey: Keys.didActivate)
+    }
+
+    public var firstProfileSavedTimestamp: Date? {
+        lock.lock()
+        defer { lock.unlock() }
+        return userDefaults.object(forKey: Keys.firstProfileSavedTimestamp) as? Date
+    }
+
+    public var firstScanResult: FreemiumFirstScanResult? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let raw = userDefaults.string(forKey: Keys.firstScanResult) else { return nil }
+        return FreemiumFirstScanResult(rawValue: raw)
+    }
+
+    public var upgradeToSubscriptionTimestamp: Date? {
+        lock.lock()
+        defer { lock.unlock() }
+        return userDefaults.object(forKey: Keys.upgradeToSubscriptionTimestamp) as? Date
+    }
+
+    // MARK: - Write-side methods (implemented in later tasks)
+
+    public func recordProfileSavedIfNeeded() async {
+        fatalError("Not implemented")
+    }
+
+    public func recordFirstScanResultIfNeeded(hasMatches: Bool) async {
+        fatalError("Not implemented")
+    }
+
+    public func recordSubscriptionUpgradeIfNeeded() async {
+        fatalError("Not implemented")
+    }
+
+    public func resetAllState() {
+        fatalError("Not implemented")
+    }
+}

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DefaultFreemiumDBPUserStateManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DefaultFreemiumDBPUserStateManager.swift
@@ -80,7 +80,13 @@ public final class DefaultFreemiumDBPUserStateManager: FreemiumDBPUserStateManag
     }
 
     public func recordSubscriptionUpgradeIfNeeded() async {
-        fatalError("Not implemented")
+        // By contract, the caller drives this from a real purchase-success / transition
+        // signal, so we do NOT check isUserAuthenticated here. See spec §3.
+        lock.lock()
+        defer { lock.unlock() }
+        guard userDefaults.bool(forKey: Keys.didActivate) else { return }
+        guard userDefaults.object(forKey: Keys.upgradeToSubscriptionTimestamp) == nil else { return }
+        userDefaults.set(Date(), forKey: Keys.upgradeToSubscriptionTimestamp)
     }
 
     public func resetAllState() {

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DefaultFreemiumDBPUserStateManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DefaultFreemiumDBPUserStateManager.swift
@@ -61,7 +61,13 @@ public final class DefaultFreemiumDBPUserStateManager: FreemiumDBPUserStateManag
     // MARK: - Write-side methods (implemented in later tasks)
 
     public func recordProfileSavedIfNeeded() async {
-        fatalError("Not implemented")
+        guard await !isUserAuthenticated() else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        userDefaults.set(true, forKey: Keys.didActivate)
+        if userDefaults.object(forKey: Keys.firstProfileSavedTimestamp) == nil {
+            userDefaults.set(Date(), forKey: Keys.firstProfileSavedTimestamp)
+        }
     }
 
     public func recordFirstScanResultIfNeeded(hasMatches: Bool) async {

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DefaultFreemiumDBPUserStateManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DefaultFreemiumDBPUserStateManager.swift
@@ -33,11 +33,17 @@ public final class DefaultFreemiumDBPUserStateManager: FreemiumDBPUserStateManag
 
     private let userDefaults: UserDefaults
     private let isUserAuthenticated: () async -> Bool
+    private let isFreemiumEnabled: () -> Bool
     private let lock = NSLock()
 
-    public init(userDefaults: UserDefaults, isUserAuthenticated: @escaping () async -> Bool) {
+    public init(
+        userDefaults: UserDefaults,
+        isUserAuthenticated: @escaping () async -> Bool,
+        isFreemiumEnabled: @escaping () -> Bool
+    ) {
         self.userDefaults = userDefaults
         self.isUserAuthenticated = isUserAuthenticated
+        self.isFreemiumEnabled = isFreemiumEnabled
     }
 
     // MARK: - Read-side getters
@@ -70,11 +76,13 @@ public final class DefaultFreemiumDBPUserStateManager: FreemiumDBPUserStateManag
     // MARK: - Write-side methods
 
     public func recordProfileSavedIfNeeded() async {
+        guard isFreemiumEnabled() else { return }
         guard await !isUserAuthenticated() else { return }
         persistProfileSaved()
     }
 
     public func recordFirstScanResultIfNeeded(hasMatches: Bool) async {
+        guard isFreemiumEnabled() else { return }
         guard await !isUserAuthenticated() else { return }
         persistFirstScanResultIfAbsent(hasMatches: hasMatches)
     }
@@ -82,14 +90,21 @@ public final class DefaultFreemiumDBPUserStateManager: FreemiumDBPUserStateManag
     public func recordSubscriptionUpgradeIfEligible() async {
         // By contract, the caller drives this from a real purchase-success / transition
         // signal, so we do NOT check isUserAuthenticated here. See spec §3.
+        guard isFreemiumEnabled() else { return }
         persistSubscriptionUpgradeIfEligible()
     }
 
     // MARK: - Private synchronous helpers
 
+    // Each helper re-checks `isFreemiumEnabled()` under the lock so the gate is atomic with
+    // the write. The async callers also check upfront as a fast path, but the flag can
+    // transition off while those methods are suspended on `await isUserAuthenticated()`;
+    // re-checking here keeps the "flag off ⇒ no writes" invariant regardless of timing.
+
     private func persistProfileSaved() {
         lock.lock()
         defer { lock.unlock() }
+        guard isFreemiumEnabled() else { return }
         userDefaults.set(true, forKey: Keys.didActivate)
         if userDefaults.object(forKey: Keys.firstProfileSavedTimestamp) == nil {
             userDefaults.set(Date(), forKey: Keys.firstProfileSavedTimestamp)
@@ -99,6 +114,7 @@ public final class DefaultFreemiumDBPUserStateManager: FreemiumDBPUserStateManag
     private func persistFirstScanResultIfAbsent(hasMatches: Bool) {
         lock.lock()
         defer { lock.unlock() }
+        guard isFreemiumEnabled() else { return }
         guard userDefaults.string(forKey: Keys.firstScanResult) == nil else { return }
         let value: FreemiumFirstScanResult = hasMatches ? .matchesFound : .noMatches
         userDefaults.set(value.rawValue, forKey: Keys.firstScanResult)
@@ -107,6 +123,7 @@ public final class DefaultFreemiumDBPUserStateManager: FreemiumDBPUserStateManag
     private func persistSubscriptionUpgradeIfEligible() {
         lock.lock()
         defer { lock.unlock() }
+        guard isFreemiumEnabled() else { return }
         guard userDefaults.bool(forKey: Keys.didActivate) else { return }
         guard userDefaults.object(forKey: Keys.upgradeToSubscriptionTimestamp) == nil else { return }
         userDefaults.set(Date(), forKey: Keys.upgradeToSubscriptionTimestamp)

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/FreemiumDBPUserStateManaging.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/FreemiumDBPUserStateManaging.swift
@@ -17,6 +17,12 @@
 //  limitations under the License.
 //
 
+/// The outcome of a freemium user's first scan. Stored as a raw string in UserDefaults.
+public enum FreemiumFirstScanResult: String, Codable {
+    case noMatches
+    case matchesFound
+}
+
 /// Minimal interface for freemium user state needed by the iOS PIR manager.
 /// The full implementation is provided by `FreemiumDBPUserStateManager`.
 public protocol FreemiumDBPUserStateManaging {

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/FreemiumDBPUserStateManaging.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/FreemiumDBPUserStateManaging.swift
@@ -17,21 +17,56 @@
 //  limitations under the License.
 //
 
+import Foundation
+
 /// The outcome of a freemium user's first scan. Stored as a raw string in UserDefaults.
 public enum FreemiumFirstScanResult: String, Codable {
     case noMatches
     case matchesFound
 }
 
-/// Minimal interface for freemium user state needed by the iOS PIR manager.
-/// The full implementation is provided by `FreemiumDBPUserStateManager`.
+/// Persists freemium user state across sessions. Callers use the `record…IfNeeded`
+/// methods for writes; auth gating, first-write guards, and write serialization are
+/// the implementation's responsibility.
 public protocol FreemiumDBPUserStateManaging {
     /// Whether the user has activated the freemium DBP feature (saved a profile and started scanning).
     var didActivate: Bool { get }
+
+    /// Timestamp of the first time the user saved their profile via the freemium flow.
+    var firstProfileSavedTimestamp: Date? { get }
+
+    /// Result of the first freemium scan (not the most recent).
+    var firstScanResult: FreemiumFirstScanResult? { get }
+
+    /// Timestamp of the moment the user upgraded from freemium to a paid subscription.
+    var upgradeToSubscriptionTimestamp: Date? { get }
+
+    /// Records a successful profile save for unauthenticated users. First-write on timestamp.
+    func recordProfileSavedIfNeeded() async
+
+    /// Records the first freemium scan's result. First-scan-wins: later scans are ignored.
+    func recordFirstScanResultIfNeeded(hasMatches: Bool) async
+
+    /// Records the moment the user upgrades to a paid subscription. Must only be called
+    /// on a real purchase/upgrade signal — not from a generic "current state is subscribed"
+    /// listener. See spec §3.
+    func recordSubscriptionUpgradeIfNeeded() async
+
+    /// Clears every stored value. For debug tools.
+    func resetAllState()
 }
 
 /// No-op default used until the real FreemiumDBPUserStateManager is wired in.
-/// Always returns `didActivate = false`, preserving pre-freemium behavior.
+/// Reads return pre-freemium defaults; writes are dropped.
 struct DisabledFreemiumDBPUserStateManager: FreemiumDBPUserStateManaging {
     var didActivate: Bool { false }
+    var firstProfileSavedTimestamp: Date? { nil }
+    var firstScanResult: FreemiumFirstScanResult? { nil }
+    var upgradeToSubscriptionTimestamp: Date? { nil }
+
+    func recordProfileSavedIfNeeded() async {}
+    func recordFirstScanResultIfNeeded(hasMatches: Bool) async {}
+    func recordSubscriptionUpgradeIfNeeded() async {}
+
+    func resetAllState() {}
 }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/FreemiumDBPUserStateManaging.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/FreemiumDBPUserStateManaging.swift
@@ -58,15 +58,17 @@ public protocol FreemiumDBPUserStateManaging {
 
 /// No-op default used until the real FreemiumDBPUserStateManager is wired in.
 /// Reads return pre-freemium defaults; writes are dropped.
-struct DisabledFreemiumDBPUserStateManager: FreemiumDBPUserStateManaging {
-    var didActivate: Bool { false }
-    var firstProfileSavedTimestamp: Date? { nil }
-    var firstScanResult: FreemiumFirstScanResult? { nil }
-    var upgradeToSubscriptionTimestamp: Date? { nil }
+public struct DisabledFreemiumDBPUserStateManager: FreemiumDBPUserStateManaging {
+    public init() {}
 
-    func recordProfileSavedIfNeeded() async {}
-    func recordFirstScanResultIfNeeded(hasMatches: Bool) async {}
-    func recordSubscriptionUpgradeIfNeeded() async {}
+    public var didActivate: Bool { false }
+    public var firstProfileSavedTimestamp: Date? { nil }
+    public var firstScanResult: FreemiumFirstScanResult? { nil }
+    public var upgradeToSubscriptionTimestamp: Date? { nil }
 
-    func resetAllState() {}
+    public func recordProfileSavedIfNeeded() async {}
+    public func recordFirstScanResultIfNeeded(hasMatches: Bool) async {}
+    public func recordSubscriptionUpgradeIfNeeded() async {}
+
+    public func resetAllState() {}
 }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/FreemiumDBPUserStateManaging.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/FreemiumDBPUserStateManaging.swift
@@ -50,7 +50,7 @@ public protocol FreemiumDBPUserStateManaging {
     /// Records the moment the user upgrades to a paid subscription. Must only be called
     /// on a real purchase/upgrade signal — not from a generic "current state is subscribed"
     /// listener. See spec §3.
-    func recordSubscriptionUpgradeIfNeeded() async
+    func recordSubscriptionUpgradeIfEligible() async
 
     /// Clears every stored value. For debug tools.
     func resetAllState()
@@ -68,7 +68,7 @@ public struct DisabledFreemiumDBPUserStateManager: FreemiumDBPUserStateManaging 
 
     public func recordProfileSavedIfNeeded() async {}
     public func recordFirstScanResultIfNeeded(hasMatches: Bool) async {}
-    public func recordSubscriptionUpgradeIfNeeded() async {}
+    public func recordSubscriptionUpgradeIfEligible() async {}
 
     public func resetAllState() {}
 }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/Notifications/BrokerProfileJobEventsHandler.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/Notifications/BrokerProfileJobEventsHandler.swift
@@ -24,27 +24,40 @@ import DataBrokerProtectionCore
 public class BrokerProfileJobEventsHandler: EventMapping<JobEvent> {
 
     private let userNotificationService: DataBrokerProtectionUserNotificationService
+    private let freemiumUserStateManager: FreemiumDBPUserStateManaging
 
-    public init(userNotificationService: DataBrokerProtectionUserNotificationService) {
+    public init(
+        userNotificationService: DataBrokerProtectionUserNotificationService,
+        freemiumUserStateManager: FreemiumDBPUserStateManaging = DisabledFreemiumDBPUserStateManager()
+    ) {
         self.userNotificationService = userNotificationService
-        super.init { event, _, _, _ in
+        self.freemiumUserStateManager = freemiumUserStateManager
+        super.init { event, _, _, onComplete in
             switch event {
             case .profileSaved:
                 userNotificationService.resetFirstScanCompletedNotificationState()
                 userNotificationService.requestNotificationPermission()
+                Task {
+                    await freemiumUserStateManager.recordProfileSavedIfNeeded()
+                    onComplete(nil)
+                }
             case .firstScanCompleted:
                 userNotificationService.sendFirstScanCompletedNotification()
+                onComplete(nil)
             case .firstScanCompletedAndMatchesFound:
                 userNotificationService.scheduleCheckInNotificationIfPossible()
+                onComplete(nil)
             case .firstProfileRemoved:
                 userNotificationService.sendFirstRemovedNotificationIfPossible()
+                onComplete(nil)
             case .allProfilesRemoved:
                 userNotificationService.sendAllInfoRemovedNotificationIfPossible()
+                onComplete(nil)
             }
         }
     }
 
     override init(mapping: @escaping EventMapping<JobEvent>.Mapping) {
-        fatalError("Use init(userNotificationService:)")
+        fatalError("Use init(userNotificationService:freemiumUserStateManager:)")
     }
 }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/BrokerProfileJobEventsHandlerFreemiumTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/BrokerProfileJobEventsHandlerFreemiumTests.swift
@@ -1,6 +1,5 @@
 //
 //  BrokerProfileJobEventsHandlerFreemiumTests.swift
-//  DuckDuckGo
 //
 //  Copyright © 2026 DuckDuckGo. All rights reserved.
 //

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/BrokerProfileJobEventsHandlerFreemiumTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/BrokerProfileJobEventsHandlerFreemiumTests.swift
@@ -36,7 +36,8 @@ final class BrokerProfileJobEventsHandlerFreemiumTests: XCTestCase {
         isAuthenticated = false
         stateManager = DefaultFreemiumDBPUserStateManager(
             userDefaults: userDefaults,
-            isUserAuthenticated: { [self] in isAuthenticated }
+            isUserAuthenticated: { [self] in isAuthenticated },
+            isFreemiumEnabled: { true }
         )
         notificationService = MockDataBrokerProtectionUserNotificationService()
         sut = BrokerProfileJobEventsHandler(

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/BrokerProfileJobEventsHandlerFreemiumTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/BrokerProfileJobEventsHandlerFreemiumTests.swift
@@ -88,7 +88,6 @@ final class BrokerProfileJobEventsHandlerFreemiumTests: XCTestCase {
         await fireAndAwait(.profileSaved)
         let firstTimestamp = stateManager.firstProfileSavedTimestamp
 
-        try? await Task.sleep(nanoseconds: 10_000_000)
         await fireAndAwait(.profileSaved)
 
         XCTAssertEqual(stateManager.firstProfileSavedTimestamp, firstTimestamp)

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/BrokerProfileJobEventsHandlerFreemiumTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/BrokerProfileJobEventsHandlerFreemiumTests.swift
@@ -1,0 +1,116 @@
+//
+//  BrokerProfileJobEventsHandlerFreemiumTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import DataBrokerProtectionCore
+@testable import DataBrokerProtection_iOS
+
+final class BrokerProfileJobEventsHandlerFreemiumTests: XCTestCase {
+
+    private var userDefaults: UserDefaults!
+    private var suiteName: String!
+    private var isAuthenticated = false
+    private var stateManager: DefaultFreemiumDBPUserStateManager!
+    private var notificationService: MockDataBrokerProtectionUserNotificationService!
+    private var sut: BrokerProfileJobEventsHandler!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "BrokerProfileJobEventsHandlerFreemiumTests.\(UUID().uuidString)"
+        userDefaults = UserDefaults(suiteName: suiteName)!
+        isAuthenticated = false
+        stateManager = DefaultFreemiumDBPUserStateManager(
+            userDefaults: userDefaults,
+            isUserAuthenticated: { [self] in isAuthenticated }
+        )
+        notificationService = MockDataBrokerProtectionUserNotificationService()
+        sut = BrokerProfileJobEventsHandler(
+            userNotificationService: notificationService,
+            freemiumUserStateManager: stateManager
+        )
+    }
+
+    override func tearDown() {
+        userDefaults.removePersistentDomain(forName: suiteName)
+        sut = nil
+        notificationService = nil
+        stateManager = nil
+        userDefaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    private func fireAndAwait(_ event: JobEvent) async {
+        await withCheckedContinuation { cont in
+            sut.fire(event, onComplete: { _ in cont.resume() })
+        }
+    }
+
+    // MARK: - .profileSaved
+
+    func test_profileSaved_unauthenticated_writesFreemiumState() async {
+        isAuthenticated = false
+
+        await fireAndAwait(.profileSaved)
+
+        XCTAssertTrue(stateManager.didActivate)
+        XCTAssertNotNil(stateManager.firstProfileSavedTimestamp)
+    }
+
+    func test_profileSaved_authenticated_writesNothing() async {
+        isAuthenticated = true
+
+        await fireAndAwait(.profileSaved)
+
+        XCTAssertFalse(stateManager.didActivate)
+        XCTAssertNil(stateManager.firstProfileSavedTimestamp)
+    }
+
+    func test_profileSaved_firedTwice_timestampDoesNotChange() async {
+        isAuthenticated = false
+
+        await fireAndAwait(.profileSaved)
+        let firstTimestamp = stateManager.firstProfileSavedTimestamp
+
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        await fireAndAwait(.profileSaved)
+
+        XCTAssertEqual(stateManager.firstProfileSavedTimestamp, firstTimestamp)
+    }
+
+    // MARK: - other events produce no freemium writes from this handler
+
+    func test_firstScanCompleted_unauthenticated_noFreemiumWrites() async {
+        isAuthenticated = false
+
+        await fireAndAwait(.firstScanCompleted)
+
+        XCTAssertFalse(stateManager.didActivate)
+        XCTAssertNil(stateManager.firstScanResult)
+    }
+
+    func test_firstScanCompletedAndMatchesFound_unauthenticated_noFreemiumWrites() async {
+        isAuthenticated = false
+
+        await fireAndAwait(.firstScanCompletedAndMatchesFound)
+
+        XCTAssertFalse(stateManager.didActivate)
+        XCTAssertNil(stateManager.firstScanResult)
+    }
+}

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerScanCompletionTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerScanCompletionTests.swift
@@ -81,8 +81,8 @@ final class DataBrokerProtectionIOSManagerScanCompletionTests: XCTestCase {
         deps.authenticationManager.isUserAuthenticatedValue = authenticated
 
         await sut.startImmediateScanOperations()
-        // The callback's Task fires `.firstScanCompletedAndMatchesFound` inside
-        // `handleScanCompletion` when hasMatches is true, so we can anchor the wait on that.
+        // The callback's Task fires `.firstScanCompletedAndMatchesFound` when hasMatches is true,
+        // so we can anchor the wait on that.
         // Otherwise we wait for a freemium write (unauthenticated hasMatches=false case).
         await awaitCondition {
             deps.eventsHandler.firstScanCompletedAndMatchesFoundFired
@@ -108,7 +108,7 @@ final class DataBrokerProtectionIOSManagerScanCompletionTests: XCTestCase {
 
     func test_pathA_authenticated_persistsNothing() async {
         let deps = await runPathA(hasMatches: true, authenticated: true)
-        // firstScanCompletedAndMatchesFoundFired proves `handleScanCompletion` actually ran;
+        // firstScanCompletedAndMatchesFoundFired proves the completion handler actually ran;
         // without it, a no-op callback could silently pass the "stays nil" assertion.
         XCTAssertTrue(deps.eventsHandler.firstScanCompletedAndMatchesFoundFired)
         XCTAssertNil(stateManager.firstScanResult)

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerScanCompletionTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerScanCompletionTests.swift
@@ -1,0 +1,140 @@
+//
+//  DataBrokerProtectionIOSManagerScanCompletionTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DataBrokerProtection_iOS
+import DataBrokerProtectionCore
+import DataBrokerProtectionCoreTestsUtils
+
+@MainActor
+final class DataBrokerProtectionIOSManagerScanCompletionTests: XCTestCase {
+
+    private var userDefaults: UserDefaults!
+    private var suiteName: String!
+    private var isAuthenticated = false
+    private var stateManager: DefaultFreemiumDBPUserStateManager!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "DataBrokerProtectionIOSManagerScanCompletionTests.\(UUID().uuidString)"
+        userDefaults = UserDefaults(suiteName: suiteName)!
+        isAuthenticated = false
+        stateManager = DefaultFreemiumDBPUserStateManager(
+            userDefaults: userDefaults,
+            isUserAuthenticated: { [self] in isAuthenticated }
+        )
+    }
+
+    override func tearDown() {
+        userDefaults.removePersistentDomain(forName: suiteName)
+        stateManager = nil
+        userDefaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    /// Spins the runloop until `stateManager.firstScanResult` is non-nil or the timeout expires.
+    /// The scan-completion callback spawns a `Task` that isn't awaited by the mock queue manager,
+    /// so we poll briefly. Timeout is conservative so the test fails fast on real regressions.
+    private func awaitFirstScanResult(timeout: TimeInterval = 1.0) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if stateManager.firstScanResult != nil { return }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+
+    // MARK: - Path A: startImmediateScanOperations completion block
+
+    private func runPathA(hasMatches: Bool, authenticated: Bool) async {
+        isAuthenticated = authenticated
+        let (sut, deps) = DBPContinuedProcessingTestUtils.makeTestIOSManager(
+            freemiumDBPUserStateManagerOverride: stateManager
+        )
+        deps.database.hasMatchesToReturn = hasMatches
+        deps.authenticationManager.isUserAuthenticatedValue = authenticated
+
+        await sut.startImmediateScanOperations()
+        await awaitFirstScanResult()
+        _ = sut  // keep sut alive through the callback
+    }
+
+    func test_pathA_unauthenticated_hasMatchesTrue_persistsMatchesFound() async {
+        await runPathA(hasMatches: true, authenticated: false)
+        XCTAssertEqual(stateManager.firstScanResult, .matchesFound)
+    }
+
+    func test_pathA_unauthenticated_hasMatchesFalse_persistsNoMatches() async {
+        await runPathA(hasMatches: false, authenticated: false)
+        XCTAssertEqual(stateManager.firstScanResult, .noMatches)
+    }
+
+    func test_pathA_authenticated_persistsNothing() async {
+        await runPathA(hasMatches: true, authenticated: true)
+        XCTAssertNil(stateManager.firstScanResult)
+    }
+
+    // MARK: - Path B: coordinatorIsReadyForScanOperations completion block
+
+    private func runPathB(hasMatches: Bool, authenticated: Bool) async {
+        isAuthenticated = authenticated
+        let (sut, deps) = DBPContinuedProcessingTestUtils.makeTestIOSManager(
+            freemiumDBPUserStateManagerOverride: stateManager
+        )
+        deps.database.hasMatchesToReturn = hasMatches
+        deps.authenticationManager.isUserAuthenticatedValue = authenticated
+
+        await sut.coordinatorIsReadyForScanOperations()
+        await awaitFirstScanResult()
+        _ = sut
+    }
+
+    func test_pathB_unauthenticated_hasMatchesTrue_persistsMatchesFound() async {
+        await runPathB(hasMatches: true, authenticated: false)
+        XCTAssertEqual(stateManager.firstScanResult, .matchesFound)
+    }
+
+    func test_pathB_unauthenticated_hasMatchesFalse_persistsNoMatches() async {
+        await runPathB(hasMatches: false, authenticated: false)
+        XCTAssertEqual(stateManager.firstScanResult, .noMatches)
+    }
+
+    func test_pathB_authenticated_persistsNothing() async {
+        await runPathB(hasMatches: true, authenticated: true)
+        XCTAssertNil(stateManager.firstScanResult)
+    }
+
+    // MARK: - Cross-path first-scan-wins
+
+    func test_pathA_thenPathB_firstScanWins() async {
+        await runPathA(hasMatches: false, authenticated: false)
+        XCTAssertEqual(stateManager.firstScanResult, .noMatches)
+
+        await runPathB(hasMatches: true, authenticated: false)
+        XCTAssertEqual(stateManager.firstScanResult, .noMatches)
+    }
+
+    func test_pathB_thenPathA_firstScanWins() async {
+        await runPathB(hasMatches: true, authenticated: false)
+        XCTAssertEqual(stateManager.firstScanResult, .matchesFound)
+
+        await runPathA(hasMatches: false, authenticated: false)
+        XCTAssertEqual(stateManager.firstScanResult, .matchesFound)
+    }
+}

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerScanCompletionTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerScanCompletionTests.swift
@@ -197,6 +197,53 @@ final class DataBrokerProtectionIOSManagerScanCompletionTests: XCTestCase {
         await runPathA(hasMatches: true, authenticated: false)
         XCTAssertEqual(stateManager.firstScanResult, .matchesFound)
     }
+
+    // MARK: - Interrupted runs: freemium write is gated, pre-existing event fire is preserved
+
+    func test_pathA_unauthenticated_interruptedRun_doesNotWriteFirstScanResult_butStillFiresMatchesFound() async {
+        isAuthenticated = false
+        let (sut, deps) = DBPContinuedProcessingTestUtils.makeTestIOSManager(
+            freemiumDBPUserStateManagerOverride: stateManager
+        )
+        deps.database.hasMatchesToReturn = true
+        deps.authenticationManager.isUserAuthenticatedValue = false
+        deps.queueManager.startImmediateScanOperationsIfPermittedCompletionError =
+            DataBrokerProtectionJobsErrorCollection(oneTimeError: BrokerProfileJobQueueError.interrupted)
+
+        await sut.startImmediateScanOperations()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        _ = sut
+
+        // Branch-new behavior: interrupted run must not first-write-lock firstScanResult.
+        XCTAssertNil(stateManager.firstScanResult)
+        XCTAssertFalse(deps.eventsHandler.firstScanCompletedFired)
+        // Pre-existing behavior: `.firstScanCompletedAndMatchesFound` still fires on
+        // interruption when hasMatches is true, matching the pre-branch completion block.
+        XCTAssertTrue(deps.eventsHandler.firstScanCompletedAndMatchesFoundFired)
+
+        // A later non-interrupted run still records correctly.
+        await runPathA(hasMatches: true, authenticated: false)
+        XCTAssertEqual(stateManager.firstScanResult, .matchesFound)
+    }
+
+    func test_pathB_unauthenticated_interruptedRun_doesNotWriteFirstScanResult_butStillFiresMatchesFound() async {
+        isAuthenticated = false
+        let (sut, deps) = DBPContinuedProcessingTestUtils.makeTestIOSManager(
+            freemiumDBPUserStateManagerOverride: stateManager
+        )
+        deps.database.hasMatchesToReturn = true
+        deps.authenticationManager.isUserAuthenticatedValue = false
+        deps.queueManager.startImmediateScanOperationsIfPermittedCompletionError =
+            DataBrokerProtectionJobsErrorCollection(oneTimeError: BrokerProfileJobQueueError.interrupted)
+
+        await sut.coordinatorIsReadyForScanOperations()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        _ = sut
+
+        XCTAssertNil(stateManager.firstScanResult)
+        XCTAssertFalse(deps.eventsHandler.firstScanCompletedFired)
+        XCTAssertTrue(deps.eventsHandler.firstScanCompletedAndMatchesFoundFired)
+    }
 }
 
 private enum ScanCompletionTestError: Error {

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerScanCompletionTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerScanCompletionTests.swift
@@ -49,74 +49,111 @@ final class DataBrokerProtectionIOSManagerScanCompletionTests: XCTestCase {
         super.tearDown()
     }
 
-    /// Spins the runloop until `stateManager.firstScanResult` is non-nil or the timeout expires.
-    /// The scan-completion callback spawns a `Task` that isn't awaited by the mock queue manager,
-    /// so we poll briefly. Timeout is conservative so the test fails fast on real regressions.
-    private func awaitFirstScanResult(timeout: TimeInterval = 1.0) async {
+    /// Polls until `predicate()` returns true or the timeout elapses. Used to wait for the
+    /// scan-completion `Task` to drain; when the predicate stays false on purpose (e.g. the
+    /// authenticated no-write case), callers should assert a separate side-effect that the
+    /// callback ran (see `firstScanCompletedFired` / `firstScanCompletedAndMatchesFoundFired`).
+    private func awaitCondition(
+        timeout: TimeInterval = 1.0,
+        _ predicate: () -> Bool
+    ) async {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
-            if stateManager.firstScanResult != nil { return }
+            if predicate() { return }
             try? await Task.sleep(nanoseconds: 10_000_000)
         }
     }
 
     // MARK: - Path A: startImmediateScanOperations completion block
 
-    private func runPathA(hasMatches: Bool, authenticated: Bool) async {
+    @discardableResult
+    private func runPathA(
+        hasMatches: Bool,
+        authenticated: Bool,
+        hasMatchesError: Error? = nil
+    ) async -> IOSManagerTestDependencies {
         isAuthenticated = authenticated
         let (sut, deps) = DBPContinuedProcessingTestUtils.makeTestIOSManager(
             freemiumDBPUserStateManagerOverride: stateManager
         )
         deps.database.hasMatchesToReturn = hasMatches
+        deps.database.hasMatchesError = hasMatchesError
         deps.authenticationManager.isUserAuthenticatedValue = authenticated
 
         await sut.startImmediateScanOperations()
-        await awaitFirstScanResult()
-        _ = sut  // keep sut alive through the callback
+        // The callback's Task fires `.firstScanCompletedAndMatchesFound` inside
+        // `handleScanCompletion` when hasMatches is true, so we can anchor the wait on that.
+        // Otherwise we wait for a freemium write (unauthenticated hasMatches=false case).
+        await awaitCondition {
+            deps.eventsHandler.firstScanCompletedAndMatchesFoundFired
+                || stateManager.firstScanResult != nil
+        }
+        _ = sut
+        return deps
     }
 
     func test_pathA_unauthenticated_hasMatchesTrue_persistsMatchesFound() async {
-        await runPathA(hasMatches: true, authenticated: false)
+        let deps = await runPathA(hasMatches: true, authenticated: false)
         XCTAssertEqual(stateManager.firstScanResult, .matchesFound)
+        XCTAssertTrue(deps.eventsHandler.firstScanCompletedFired)
+        XCTAssertTrue(deps.eventsHandler.firstScanCompletedAndMatchesFoundFired)
     }
 
     func test_pathA_unauthenticated_hasMatchesFalse_persistsNoMatches() async {
-        await runPathA(hasMatches: false, authenticated: false)
+        let deps = await runPathA(hasMatches: false, authenticated: false)
         XCTAssertEqual(stateManager.firstScanResult, .noMatches)
+        XCTAssertTrue(deps.eventsHandler.firstScanCompletedFired)
+        XCTAssertFalse(deps.eventsHandler.firstScanCompletedAndMatchesFoundFired)
     }
 
     func test_pathA_authenticated_persistsNothing() async {
-        await runPathA(hasMatches: true, authenticated: true)
+        let deps = await runPathA(hasMatches: true, authenticated: true)
+        // firstScanCompletedAndMatchesFoundFired proves `handleScanCompletion` actually ran;
+        // without it, a no-op callback could silently pass the "stays nil" assertion.
+        XCTAssertTrue(deps.eventsHandler.firstScanCompletedAndMatchesFoundFired)
         XCTAssertNil(stateManager.firstScanResult)
     }
 
     // MARK: - Path B: coordinatorIsReadyForScanOperations completion block
 
-    private func runPathB(hasMatches: Bool, authenticated: Bool) async {
+    @discardableResult
+    private func runPathB(
+        hasMatches: Bool,
+        authenticated: Bool,
+        hasMatchesError: Error? = nil
+    ) async -> IOSManagerTestDependencies {
         isAuthenticated = authenticated
         let (sut, deps) = DBPContinuedProcessingTestUtils.makeTestIOSManager(
             freemiumDBPUserStateManagerOverride: stateManager
         )
         deps.database.hasMatchesToReturn = hasMatches
+        deps.database.hasMatchesError = hasMatchesError
         deps.authenticationManager.isUserAuthenticatedValue = authenticated
 
         await sut.coordinatorIsReadyForScanOperations()
-        await awaitFirstScanResult()
+        await awaitCondition {
+            deps.eventsHandler.firstScanCompletedAndMatchesFoundFired
+                || stateManager.firstScanResult != nil
+        }
         _ = sut
+        return deps
     }
 
     func test_pathB_unauthenticated_hasMatchesTrue_persistsMatchesFound() async {
-        await runPathB(hasMatches: true, authenticated: false)
+        let deps = await runPathB(hasMatches: true, authenticated: false)
         XCTAssertEqual(stateManager.firstScanResult, .matchesFound)
+        XCTAssertTrue(deps.eventsHandler.firstScanCompletedAndMatchesFoundFired)
     }
 
     func test_pathB_unauthenticated_hasMatchesFalse_persistsNoMatches() async {
-        await runPathB(hasMatches: false, authenticated: false)
+        let deps = await runPathB(hasMatches: false, authenticated: false)
         XCTAssertEqual(stateManager.firstScanResult, .noMatches)
+        XCTAssertFalse(deps.eventsHandler.firstScanCompletedAndMatchesFoundFired)
     }
 
     func test_pathB_authenticated_persistsNothing() async {
-        await runPathB(hasMatches: true, authenticated: true)
+        let deps = await runPathB(hasMatches: true, authenticated: true)
+        XCTAssertTrue(deps.eventsHandler.firstScanCompletedAndMatchesFoundFired)
         XCTAssertNil(stateManager.firstScanResult)
     }
 
@@ -137,4 +174,31 @@ final class DataBrokerProtectionIOSManagerScanCompletionTests: XCTestCase {
         await runPathA(hasMatches: false, authenticated: false)
         XCTAssertEqual(stateManager.firstScanResult, .matchesFound)
     }
+
+    // MARK: - Transient DB error leaves firstScanResult unset
+
+    func test_pathA_unauthenticated_hasMatchesThrows_leavesFirstScanResultNil() async {
+        isAuthenticated = false
+        let (sut, deps) = DBPContinuedProcessingTestUtils.makeTestIOSManager(
+            freemiumDBPUserStateManagerOverride: stateManager
+        )
+        deps.database.hasMatchesError = ScanCompletionTestError.hasMatchesFailed
+        deps.authenticationManager.isUserAuthenticatedValue = false
+
+        await sut.startImmediateScanOperations()
+        // Give the Task time to drain; nothing should land in state.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        _ = sut
+
+        XCTAssertNil(stateManager.firstScanResult)
+        XCTAssertFalse(deps.eventsHandler.firstScanCompletedAndMatchesFoundFired)
+
+        // A later successful scan must still be able to record the correct outcome.
+        await runPathA(hasMatches: true, authenticated: false)
+        XCTAssertEqual(stateManager.firstScanResult, .matchesFound)
+    }
+}
+
+private enum ScanCompletionTestError: Error {
+    case hasMatchesFailed
 }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerScanCompletionTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerScanCompletionTests.swift
@@ -36,7 +36,8 @@ final class DataBrokerProtectionIOSManagerScanCompletionTests: XCTestCase {
         isAuthenticated = false
         stateManager = DefaultFreemiumDBPUserStateManager(
             userDefaults: userDefaults,
-            isUserAuthenticated: { [self] in isAuthenticated }
+            isUserAuthenticated: { [self] in isAuthenticated },
+            isFreemiumEnabled: { true }
         )
     }
 

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerScanCompletionTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerScanCompletionTests.swift
@@ -1,6 +1,5 @@
 //
 //  DataBrokerProtectionIOSManagerScanCompletionTests.swift
-//  DuckDuckGo
 //
 //  Copyright © 2026 DuckDuckGo. All rights reserved.
 //

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DefaultFreemiumDBPUserStateManagerTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DefaultFreemiumDBPUserStateManagerTests.swift
@@ -4,6 +4,18 @@
 //
 //  Copyright © 2026 DuckDuckGo. All rights reserved.
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
 
 import XCTest
 @testable import DataBrokerProtection_iOS

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DefaultFreemiumDBPUserStateManagerTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DefaultFreemiumDBPUserStateManagerTests.swift
@@ -24,12 +24,14 @@ final class DefaultFreemiumDBPUserStateManagerTests: XCTestCase {
     private var userDefaults: UserDefaults!
     private var suiteName: String!
     private var isAuthenticatedReturnValue = false
+    private var isFreemiumEnabledReturnValue = true
 
     override func setUp() {
         super.setUp()
         suiteName = "DefaultFreemiumDBPUserStateManagerTests.\(UUID().uuidString)"
         userDefaults = UserDefaults(suiteName: suiteName)!
         isAuthenticatedReturnValue = false
+        isFreemiumEnabledReturnValue = true
     }
 
     override func tearDown() {
@@ -42,7 +44,8 @@ final class DefaultFreemiumDBPUserStateManagerTests: XCTestCase {
     private func makeSUT() -> DefaultFreemiumDBPUserStateManager {
         DefaultFreemiumDBPUserStateManager(
             userDefaults: userDefaults,
-            isUserAuthenticated: { [self] in isAuthenticatedReturnValue }
+            isUserAuthenticated: { [self] in isAuthenticatedReturnValue },
+            isFreemiumEnabled: { [self] in isFreemiumEnabledReturnValue }
         )
     }
 
@@ -231,5 +234,78 @@ final class DefaultFreemiumDBPUserStateManagerTests: XCTestCase {
         await sut.recordSubscriptionUpgradeIfEligible()
 
         XCTAssertEqual(sut.upgradeToSubscriptionTimestamp, priorDate)
+    }
+
+    // MARK: - Feature-flag gate on writes (persisted state outlives flag transitions)
+
+    func test_recordProfileSavedIfNeeded_flagDisabled_writesNothing() async {
+        isAuthenticatedReturnValue = false
+        isFreemiumEnabledReturnValue = false
+        let sut = makeSUT()
+
+        await sut.recordProfileSavedIfNeeded()
+
+        XCTAssertFalse(sut.didActivate)
+        XCTAssertNil(sut.firstProfileSavedTimestamp)
+    }
+
+    func test_recordFirstScanResultIfNeeded_flagDisabled_writesNothing() async {
+        isAuthenticatedReturnValue = false
+        isFreemiumEnabledReturnValue = false
+        let sut = makeSUT()
+
+        await sut.recordFirstScanResultIfNeeded(hasMatches: true)
+
+        XCTAssertNil(sut.firstScanResult)
+    }
+
+    func test_recordSubscriptionUpgradeIfEligible_flagDisabled_writesNothing() async {
+        userDefaults.set(true, forKey: "ios.browser.freemium.dbp.did.activate")
+        isFreemiumEnabledReturnValue = false
+        let sut = makeSUT()
+
+        await sut.recordSubscriptionUpgradeIfEligible()
+
+        XCTAssertNil(sut.upgradeToSubscriptionTimestamp)
+    }
+
+    // The async write methods check `isFreemiumEnabled()` up front as a fast path, but the
+    // flag can flip off while they're suspended on `await isUserAuthenticated()`. The sync
+    // persist helpers re-check the flag under the lock to keep the gate atomic with the
+    // write. These tests simulate the transition by flipping the flag from inside the auth
+    // closure — the auth closure runs after the first flag check and before the persist
+    // helper runs.
+
+    func test_recordProfileSavedIfNeeded_flagFlipsOffDuringAuthCheck_writesNothing() async {
+        isFreemiumEnabledReturnValue = true
+        let sut = DefaultFreemiumDBPUserStateManager(
+            userDefaults: userDefaults,
+            isUserAuthenticated: { [self] in
+                isFreemiumEnabledReturnValue = false
+                return false
+            },
+            isFreemiumEnabled: { [self] in isFreemiumEnabledReturnValue }
+        )
+
+        await sut.recordProfileSavedIfNeeded()
+
+        XCTAssertFalse(sut.didActivate)
+        XCTAssertNil(sut.firstProfileSavedTimestamp)
+    }
+
+    func test_recordFirstScanResultIfNeeded_flagFlipsOffDuringAuthCheck_writesNothing() async {
+        isFreemiumEnabledReturnValue = true
+        let sut = DefaultFreemiumDBPUserStateManager(
+            userDefaults: userDefaults,
+            isUserAuthenticated: { [self] in
+                isFreemiumEnabledReturnValue = false
+                return false
+            },
+            isFreemiumEnabled: { [self] in isFreemiumEnabledReturnValue }
+        )
+
+        await sut.recordFirstScanResultIfNeeded(hasMatches: true)
+
+        XCTAssertNil(sut.firstScanResult)
     }
 }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DefaultFreemiumDBPUserStateManagerTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DefaultFreemiumDBPUserStateManagerTests.swift
@@ -56,23 +56,6 @@ final class DefaultFreemiumDBPUserStateManagerTests: XCTestCase {
         XCTAssertNil(sut.upgradeToSubscriptionTimestamp)
     }
 
-    // MARK: - didActivate
-
-    func test_didActivate_returnsPersistedValue() {
-        userDefaults.set(true, forKey: "ios.browser.freemium.dbp.did.activate")
-        let sut = makeSUT()
-        XCTAssertTrue(sut.didActivate)
-    }
-
-    // MARK: - firstProfileSavedTimestamp
-
-    func test_firstProfileSavedTimestamp_returnsPersistedValue() {
-        let date = Date(timeIntervalSince1970: 1_700_000_000)
-        userDefaults.set(date, forKey: "ios.browser.freemium.dbp.first.profile.saved.timestamp")
-        let sut = makeSUT()
-        XCTAssertEqual(sut.firstProfileSavedTimestamp, date)
-    }
-
     // MARK: - firstScanResult
 
     func test_firstScanResult_returnsMatchesFound_whenRawStringMatches() {
@@ -91,15 +74,6 @@ final class DefaultFreemiumDBPUserStateManagerTests: XCTestCase {
         userDefaults.set("garbage", forKey: "ios.browser.freemium.dbp.first.scan.result")
         let sut = makeSUT()
         XCTAssertNil(sut.firstScanResult)
-    }
-
-    // MARK: - upgradeToSubscriptionTimestamp
-
-    func test_upgradeToSubscriptionTimestamp_returnsPersistedValue() {
-        let date = Date(timeIntervalSince1970: 1_700_000_000)
-        userDefaults.set(date, forKey: "ios.browser.freemium.dbp.upgrade.to.subscription.timestamp")
-        let sut = makeSUT()
-        XCTAssertEqual(sut.upgradeToSubscriptionTimestamp, date)
     }
 
     // MARK: - resetAllState
@@ -225,22 +199,22 @@ final class DefaultFreemiumDBPUserStateManagerTests: XCTestCase {
         XCTAssertTrue(sut.firstScanResult == .matchesFound || sut.firstScanResult == .noMatches)
     }
 
-    // MARK: - recordSubscriptionUpgradeIfNeeded
+    // MARK: - recordSubscriptionUpgradeIfEligible
 
-    func test_recordSubscriptionUpgradeIfNeeded_didActivateFalse_doesNothing() async {
+    func test_recordSubscriptionUpgradeIfEligible_didActivateFalse_doesNothing() async {
         let sut = makeSUT()
 
-        await sut.recordSubscriptionUpgradeIfNeeded()
+        await sut.recordSubscriptionUpgradeIfEligible()
 
         XCTAssertNil(sut.upgradeToSubscriptionTimestamp)
     }
 
-    func test_recordSubscriptionUpgradeIfNeeded_didActivateTrue_noPriorTimestamp_setsTimestamp() async throws {
+    func test_recordSubscriptionUpgradeIfEligible_didActivateTrue_noPriorTimestamp_setsTimestamp() async throws {
         userDefaults.set(true, forKey: "ios.browser.freemium.dbp.did.activate")
         let sut = makeSUT()
 
         let before = Date()
-        await sut.recordSubscriptionUpgradeIfNeeded()
+        await sut.recordSubscriptionUpgradeIfEligible()
         let after = Date()
 
         let timestamp = try XCTUnwrap(sut.upgradeToSubscriptionTimestamp)
@@ -248,13 +222,13 @@ final class DefaultFreemiumDBPUserStateManagerTests: XCTestCase {
         XCTAssertLessThanOrEqual(timestamp, after)
     }
 
-    func test_recordSubscriptionUpgradeIfNeeded_priorTimestamp_doesNotOverwrite() async {
+    func test_recordSubscriptionUpgradeIfEligible_priorTimestamp_doesNotOverwrite() async {
         let priorDate = Date(timeIntervalSince1970: 1_600_000_000)
         userDefaults.set(true, forKey: "ios.browser.freemium.dbp.did.activate")
         userDefaults.set(priorDate, forKey: "ios.browser.freemium.dbp.upgrade.to.subscription.timestamp")
         let sut = makeSUT()
 
-        await sut.recordSubscriptionUpgradeIfNeeded()
+        await sut.recordSubscriptionUpgradeIfEligible()
 
         XCTAssertEqual(sut.upgradeToSubscriptionTimestamp, priorDate)
     }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DefaultFreemiumDBPUserStateManagerTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DefaultFreemiumDBPUserStateManagerTests.swift
@@ -1,0 +1,93 @@
+//
+//  DefaultFreemiumDBPUserStateManagerTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+
+import XCTest
+@testable import DataBrokerProtection_iOS
+
+final class DefaultFreemiumDBPUserStateManagerTests: XCTestCase {
+
+    private var userDefaults: UserDefaults!
+    private var suiteName: String!
+    private var isAuthenticatedReturnValue = false
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "DefaultFreemiumDBPUserStateManagerTests.\(UUID().uuidString)"
+        userDefaults = UserDefaults(suiteName: suiteName)!
+        isAuthenticatedReturnValue = false
+    }
+
+    override func tearDown() {
+        userDefaults.removePersistentDomain(forName: suiteName)
+        userDefaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    private func makeSUT() -> DefaultFreemiumDBPUserStateManager {
+        DefaultFreemiumDBPUserStateManager(
+            userDefaults: userDefaults,
+            isUserAuthenticated: { [self] in isAuthenticatedReturnValue }
+        )
+    }
+
+    // MARK: - Getter defaults
+
+    func test_getters_returnDefaults_whenNoKeysSet() {
+        let sut = makeSUT()
+        XCTAssertFalse(sut.didActivate)
+        XCTAssertNil(sut.firstProfileSavedTimestamp)
+        XCTAssertNil(sut.firstScanResult)
+        XCTAssertNil(sut.upgradeToSubscriptionTimestamp)
+    }
+
+    // MARK: - didActivate
+
+    func test_didActivate_returnsPersistedValue() {
+        userDefaults.set(true, forKey: "ios.browser.freemium.dbp.did.activate")
+        let sut = makeSUT()
+        XCTAssertTrue(sut.didActivate)
+    }
+
+    // MARK: - firstProfileSavedTimestamp
+
+    func test_firstProfileSavedTimestamp_returnsPersistedValue() {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        userDefaults.set(date, forKey: "ios.browser.freemium.dbp.first.profile.saved.timestamp")
+        let sut = makeSUT()
+        XCTAssertEqual(sut.firstProfileSavedTimestamp, date)
+    }
+
+    // MARK: - firstScanResult
+
+    func test_firstScanResult_returnsMatchesFound_whenRawStringMatches() {
+        userDefaults.set("matchesFound", forKey: "ios.browser.freemium.dbp.first.scan.result")
+        let sut = makeSUT()
+        XCTAssertEqual(sut.firstScanResult, .matchesFound)
+    }
+
+    func test_firstScanResult_returnsNoMatches_whenRawStringMatches() {
+        userDefaults.set("noMatches", forKey: "ios.browser.freemium.dbp.first.scan.result")
+        let sut = makeSUT()
+        XCTAssertEqual(sut.firstScanResult, .noMatches)
+    }
+
+    func test_firstScanResult_returnsNil_whenRawStringInvalid() {
+        userDefaults.set("garbage", forKey: "ios.browser.freemium.dbp.first.scan.result")
+        let sut = makeSUT()
+        XCTAssertNil(sut.firstScanResult)
+    }
+
+    // MARK: - upgradeToSubscriptionTimestamp
+
+    func test_upgradeToSubscriptionTimestamp_returnsPersistedValue() {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        userDefaults.set(date, forKey: "ios.browser.freemium.dbp.upgrade.to.subscription.timestamp")
+        let sut = makeSUT()
+        XCTAssertEqual(sut.upgradeToSubscriptionTimestamp, date)
+    }
+}

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DefaultFreemiumDBPUserStateManagerTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DefaultFreemiumDBPUserStateManagerTests.swift
@@ -1,6 +1,5 @@
 //
 //  DefaultFreemiumDBPUserStateManagerTests.swift
-//  DuckDuckGo
 //
 //  Copyright © 2026 DuckDuckGo. All rights reserved.
 //

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DefaultFreemiumDBPUserStateManagerTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DefaultFreemiumDBPUserStateManagerTests.swift
@@ -107,4 +107,44 @@ final class DefaultFreemiumDBPUserStateManagerTests: XCTestCase {
         XCTAssertNil(sut.firstScanResult)
         XCTAssertNil(sut.upgradeToSubscriptionTimestamp)
     }
+
+    // MARK: - recordProfileSavedIfNeeded
+
+    func test_recordProfileSavedIfNeeded_unauthenticated_setsDidActivateAndTimestamp() async throws {
+        isAuthenticatedReturnValue = false
+        let sut = makeSUT()
+
+        let before = Date()
+        await sut.recordProfileSavedIfNeeded()
+        let after = Date()
+
+        XCTAssertTrue(sut.didActivate)
+        let timestamp = try XCTUnwrap(sut.firstProfileSavedTimestamp)
+        XCTAssertGreaterThanOrEqual(timestamp, before)
+        XCTAssertLessThanOrEqual(timestamp, after)
+    }
+
+    func test_recordProfileSavedIfNeeded_authenticated_writesNothing() async {
+        isAuthenticatedReturnValue = true
+        let sut = makeSUT()
+
+        await sut.recordProfileSavedIfNeeded()
+
+        XCTAssertFalse(sut.didActivate)
+        XCTAssertNil(sut.firstProfileSavedTimestamp)
+    }
+
+    func test_recordProfileSavedIfNeeded_secondCall_doesNotOverwriteTimestamp() async {
+        isAuthenticatedReturnValue = false
+        let sut = makeSUT()
+
+        await sut.recordProfileSavedIfNeeded()
+        let firstTimestamp = sut.firstProfileSavedTimestamp
+
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        await sut.recordProfileSavedIfNeeded()
+
+        XCTAssertTrue(sut.didActivate)
+        XCTAssertEqual(sut.firstProfileSavedTimestamp, firstTimestamp)
+    }
 }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DefaultFreemiumDBPUserStateManagerTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DefaultFreemiumDBPUserStateManagerTests.swift
@@ -213,4 +213,38 @@ final class DefaultFreemiumDBPUserStateManagerTests: XCTestCase {
         XCTAssertNotNil(sut.firstScanResult)
         XCTAssertTrue(sut.firstScanResult == .matchesFound || sut.firstScanResult == .noMatches)
     }
+
+    // MARK: - recordSubscriptionUpgradeIfNeeded
+
+    func test_recordSubscriptionUpgradeIfNeeded_didActivateFalse_doesNothing() async {
+        let sut = makeSUT()
+
+        await sut.recordSubscriptionUpgradeIfNeeded()
+
+        XCTAssertNil(sut.upgradeToSubscriptionTimestamp)
+    }
+
+    func test_recordSubscriptionUpgradeIfNeeded_didActivateTrue_noPriorTimestamp_setsTimestamp() async throws {
+        userDefaults.set(true, forKey: "ios.browser.freemium.dbp.did.activate")
+        let sut = makeSUT()
+
+        let before = Date()
+        await sut.recordSubscriptionUpgradeIfNeeded()
+        let after = Date()
+
+        let timestamp = try XCTUnwrap(sut.upgradeToSubscriptionTimestamp)
+        XCTAssertGreaterThanOrEqual(timestamp, before)
+        XCTAssertLessThanOrEqual(timestamp, after)
+    }
+
+    func test_recordSubscriptionUpgradeIfNeeded_priorTimestamp_doesNotOverwrite() async {
+        let priorDate = Date(timeIntervalSince1970: 1_600_000_000)
+        userDefaults.set(true, forKey: "ios.browser.freemium.dbp.did.activate")
+        userDefaults.set(priorDate, forKey: "ios.browser.freemium.dbp.upgrade.to.subscription.timestamp")
+        let sut = makeSUT()
+
+        await sut.recordSubscriptionUpgradeIfNeeded()
+
+        XCTAssertEqual(sut.upgradeToSubscriptionTimestamp, priorDate)
+    }
 }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DefaultFreemiumDBPUserStateManagerTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DefaultFreemiumDBPUserStateManagerTests.swift
@@ -147,4 +147,70 @@ final class DefaultFreemiumDBPUserStateManagerTests: XCTestCase {
         XCTAssertTrue(sut.didActivate)
         XCTAssertEqual(sut.firstProfileSavedTimestamp, firstTimestamp)
     }
+
+    // MARK: - recordFirstScanResultIfNeeded
+
+    func test_recordFirstScanResultIfNeeded_unauthenticated_hasMatchesTrue_setsMatchesFound() async {
+        isAuthenticatedReturnValue = false
+        let sut = makeSUT()
+
+        await sut.recordFirstScanResultIfNeeded(hasMatches: true)
+
+        XCTAssertEqual(sut.firstScanResult, .matchesFound)
+    }
+
+    func test_recordFirstScanResultIfNeeded_unauthenticated_hasMatchesFalse_setsNoMatches() async {
+        isAuthenticatedReturnValue = false
+        let sut = makeSUT()
+
+        await sut.recordFirstScanResultIfNeeded(hasMatches: false)
+
+        XCTAssertEqual(sut.firstScanResult, .noMatches)
+    }
+
+    func test_recordFirstScanResultIfNeeded_authenticated_writesNothing() async {
+        isAuthenticatedReturnValue = true
+        let sut = makeSUT()
+
+        await sut.recordFirstScanResultIfNeeded(hasMatches: true)
+
+        XCTAssertNil(sut.firstScanResult)
+    }
+
+    func test_recordFirstScanResultIfNeeded_priorNoMatches_withMatchesTrue_staysNoMatches() async {
+        isAuthenticatedReturnValue = false
+        let sut = makeSUT()
+
+        await sut.recordFirstScanResultIfNeeded(hasMatches: false)
+        await sut.recordFirstScanResultIfNeeded(hasMatches: true)
+
+        XCTAssertEqual(sut.firstScanResult, .noMatches)
+    }
+
+    func test_recordFirstScanResultIfNeeded_priorMatchesFound_withMatchesFalse_staysMatchesFound() async {
+        isAuthenticatedReturnValue = false
+        let sut = makeSUT()
+
+        await sut.recordFirstScanResultIfNeeded(hasMatches: true)
+        await sut.recordFirstScanResultIfNeeded(hasMatches: false)
+
+        XCTAssertEqual(sut.firstScanResult, .matchesFound)
+    }
+
+    func test_recordFirstScanResultIfNeeded_concurrentCalls_produceDeterministicSingleWrite() async {
+        isAuthenticatedReturnValue = false
+        let sut = makeSUT()
+
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<50 {
+                let hasMatches = i % 2 == 0
+                group.addTask {
+                    await sut.recordFirstScanResultIfNeeded(hasMatches: hasMatches)
+                }
+            }
+        }
+
+        XCTAssertNotNil(sut.firstScanResult)
+        XCTAssertTrue(sut.firstScanResult == .matchesFound || sut.firstScanResult == .noMatches)
+    }
 }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DefaultFreemiumDBPUserStateManagerTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DefaultFreemiumDBPUserStateManagerTests.swift
@@ -90,4 +90,21 @@ final class DefaultFreemiumDBPUserStateManagerTests: XCTestCase {
         let sut = makeSUT()
         XCTAssertEqual(sut.upgradeToSubscriptionTimestamp, date)
     }
+
+    // MARK: - resetAllState
+
+    func test_resetAllState_clearsEveryKey() {
+        userDefaults.set(true, forKey: "ios.browser.freemium.dbp.did.activate")
+        userDefaults.set(Date(), forKey: "ios.browser.freemium.dbp.first.profile.saved.timestamp")
+        userDefaults.set("matchesFound", forKey: "ios.browser.freemium.dbp.first.scan.result")
+        userDefaults.set(Date(), forKey: "ios.browser.freemium.dbp.upgrade.to.subscription.timestamp")
+
+        let sut = makeSUT()
+        sut.resetAllState()
+
+        XCTAssertFalse(sut.didActivate)
+        XCTAssertNil(sut.firstProfileSavedTimestamp)
+        XCTAssertNil(sut.firstScanResult)
+        XCTAssertNil(sut.upgradeToSubscriptionTimestamp)
+    }
 }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/Mocks.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/Mocks.swift
@@ -123,6 +123,35 @@ final class MockContinuedProcessingCoordinatorDelegate: DBPContinuedProcessingDe
 
 final class MockFreemiumDBPUserStateManager: FreemiumDBPUserStateManaging {
     var didActivate: Bool = false
+    var firstProfileSavedTimestamp: Date? = nil
+    var firstScanResult: FreemiumFirstScanResult? = nil
+    var upgradeToSubscriptionTimestamp: Date? = nil
+
+    // Test controls
+    var recordProfileSavedIfNeededCallCount = 0
+    var recordFirstScanResultIfNeededCalls: [Bool] = []
+    var recordSubscriptionUpgradeIfNeededCallCount = 0
+    var resetAllStateCallCount = 0
+
+    func recordProfileSavedIfNeeded() async {
+        recordProfileSavedIfNeededCallCount += 1
+    }
+
+    func recordFirstScanResultIfNeeded(hasMatches: Bool) async {
+        recordFirstScanResultIfNeededCalls.append(hasMatches)
+    }
+
+    func recordSubscriptionUpgradeIfNeeded() async {
+        recordSubscriptionUpgradeIfNeededCallCount += 1
+    }
+
+    func resetAllState() {
+        resetAllStateCallCount += 1
+        didActivate = false
+        firstProfileSavedTimestamp = nil
+        firstScanResult = nil
+        upgradeToSubscriptionTimestamp = nil
+    }
 }
 
 final class MockBGTask: DBPIOSInterface.BGTaskHandling {

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/Mocks.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/Mocks.swift
@@ -123,9 +123,9 @@ final class MockContinuedProcessingCoordinatorDelegate: DBPContinuedProcessingDe
 
 final class MockFreemiumDBPUserStateManager: FreemiumDBPUserStateManaging {
     var didActivate: Bool = false
-    var firstProfileSavedTimestamp: Date? = nil
-    var firstScanResult: FreemiumFirstScanResult? = nil
-    var upgradeToSubscriptionTimestamp: Date? = nil
+    var firstProfileSavedTimestamp: Date?
+    var firstScanResult: FreemiumFirstScanResult?
+    var upgradeToSubscriptionTimestamp: Date?
 
     // Test controls
     var recordProfileSavedIfNeededCallCount = 0

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/Mocks.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/Mocks.swift
@@ -130,7 +130,7 @@ final class MockFreemiumDBPUserStateManager: FreemiumDBPUserStateManaging {
     // Test controls
     var recordProfileSavedIfNeededCallCount = 0
     var recordFirstScanResultIfNeededCalls: [Bool] = []
-    var recordSubscriptionUpgradeIfNeededCallCount = 0
+    var recordSubscriptionUpgradeIfEligibleCallCount = 0
     var resetAllStateCallCount = 0
 
     func recordProfileSavedIfNeeded() async {
@@ -141,8 +141,8 @@ final class MockFreemiumDBPUserStateManager: FreemiumDBPUserStateManaging {
         recordFirstScanResultIfNeededCalls.append(hasMatches)
     }
 
-    func recordSubscriptionUpgradeIfNeeded() async {
-        recordSubscriptionUpgradeIfNeededCallCount += 1
+    func recordSubscriptionUpgradeIfEligible() async {
+        recordSubscriptionUpgradeIfEligibleCallCount += 1
     }
 
     func resetAllState() {

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/Utils.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/Utils.swift
@@ -38,11 +38,13 @@ struct IOSManagerTestDependencies {
 enum DBPContinuedProcessingTestUtils {
     static func makeTestIOSManager(
         featureFlagger: MockDBPFeatureFlagger = MockDBPFeatureFlagger(),
-        continuedProcessingCoordinator: MockContinuedProcessingCoordinator = MockContinuedProcessingCoordinator()
+        continuedProcessingCoordinator: MockContinuedProcessingCoordinator = MockContinuedProcessingCoordinator(),
+        freemiumDBPUserStateManagerOverride: FreemiumDBPUserStateManaging? = nil
     ) -> (DataBrokerProtectionIOSManager, IOSManagerTestDependencies) {
         return IOSManagerTestDependenciesStore().makeTestIOSManager(
             featureFlagger: featureFlagger,
-            continuedProcessingCoordinator: continuedProcessingCoordinator
+            continuedProcessingCoordinator: continuedProcessingCoordinator,
+            freemiumDBPUserStateManagerOverride: freemiumDBPUserStateManagerOverride
         )
     }
 
@@ -94,11 +96,13 @@ enum DBPContinuedProcessingTestUtils {
 
         func makeTestIOSManager(
             featureFlagger: MockDBPFeatureFlagger,
-            continuedProcessingCoordinator: MockContinuedProcessingCoordinator
+            continuedProcessingCoordinator: MockContinuedProcessingCoordinator,
+            freemiumDBPUserStateManagerOverride: FreemiumDBPUserStateManaging? = nil
         ) -> (DataBrokerProtectionIOSManager, IOSManagerTestDependencies) {
             let manager = makeManager(
                 featureFlagger: featureFlagger,
-                continuedProcessingCoordinator: continuedProcessingCoordinator
+                continuedProcessingCoordinator: continuedProcessingCoordinator,
+                freemiumDBPUserStateManagerOverride: freemiumDBPUserStateManagerOverride
             )
             reset(manager: manager)
 
@@ -118,7 +122,8 @@ enum DBPContinuedProcessingTestUtils {
 
         private func makeManager(
             featureFlagger: MockDBPFeatureFlagger,
-            continuedProcessingCoordinator: MockContinuedProcessingCoordinator
+            continuedProcessingCoordinator: MockContinuedProcessingCoordinator,
+            freemiumDBPUserStateManagerOverride: FreemiumDBPUserStateManaging? = nil
         ) -> DataBrokerProtectionIOSManager {
             jobDependencies.database = database
 
@@ -140,7 +145,7 @@ enum DBPContinuedProcessingTestUtils {
                 wideEvent: nil,
                 eventsHandler: eventsHandler,
                 engagementPixelsRepository: MockDataBrokerProtectionEngagementPixelsRepository(),
-                freemiumDBPUserStateManager: freemiumDBPUserStateManager,
+                freemiumDBPUserStateManager: (freemiumDBPUserStateManagerOverride ?? freemiumDBPUserStateManager),
                 continuedProcessingCoordinator: continuedProcessingCoordinator,
                 shouldRegisterBackgroundTaskHandler: false
             )


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210938375848294
Tech Design URL: 
CC: @THISISDINOSAUR 

### Description

Adds the concrete `DefaultFreemiumDBPUserStateManager` on iOS and wires it into the PIR flow. Completing this subtask activates the auth-gate relaxation in #4461: `didActivate` now flips to `true` at profile-save, so freemium users can actually run scans.

Production changes (stacked on top of `jozsef/freemium-pir-auth-gate`):

- **Protocol expansion.** `FreemiumDBPUserStateManaging` adds read/write methods.
- **`DefaultFreemiumDBPUserStateManager`** UserDefaults-backed default implementation.
- **`BrokerProfileJobEventsHandler`**  will now update the state manager when profile is saved.
- **`handleScanCompletion()` helper on `DataBrokerProtectionIOSManager`.** Deduplicates the scan-completion logic across both scan paths and records the freemium scan result. Skips the write if the DB read fails, so a transient error can't permanently stamp the wrong result.

Out of scope: `recordSubscriptionUpgradeIfNeeded()` exists on the protocol and manager but has no production caller yet. This will come later when working on pixels.

### Testing Steps

Green CI, there are no entry points yet.

### Impact and Risks

Low: No entry points + guarded by feature flag.

#### What could go wrong?

- DB read error on the first scan. Freemium result is recorded only once, so a throw during the very first scan could lock in a wrong "no matches" result forever. Handled by skipping the write on error; the next successful scan still gets to record.
- Concurrent scan completions across both paths. Two scan completions could race to record the result. The state manager serializes all reads and writes through a lock, so the first one wins.

### Quality Considerations

- **Persistence.** UserDefaults `.dbp` suite, key namespace `ios.browser.freemium.dbp.*` — iOS-scoped so there can be no collision with macOS's `macos.browser.freemium.dbp.*` keys.
- **Concurrency.** All reads and writes pass through one `NSLock`. Lock acquisition happens *after* the async auth check, so the lock is never held across a suspension point — avoids the Swift 6 concurrency checker error.
- **Cross-platform.** iOS intentionally diverges from `macOS/LocalPackages/Freemium/FreemiumDBPUserStateManager.swift`: simpler enum (`FreemiumFirstScanResult`) instead of macOS's `FreemiumDBPMatchResults` struct; drops macOS-only notification/dismissal flags. Spec call: RMF on iOS can't template counts, so the struct adds no value there.
- **Testability.** 34 new tests: 20 state-manager unit tests, 5 handler integration tests, 9 scan-completion integration tests including cross-path and DB-error cases.

### Notes to Reviewer

- **Stacked on #4461.** This PR targets `jozsef/freemium-pir-auth-gate`. Review that one first; I'll retarget this to `main` once it merges.
- **Subscription-upgrade caller is intentionally deferred** to the attribution-pixel subtask.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new UserDefaults-backed freemium state and wires it into scan completion and profile-save events; mistakes here could mis-record first-scan outcomes or affect scan gating despite feature-flag checks.
> 
> **Overview**
> Implements iOS freemium PIR user-state persistence via a new `DefaultFreemiumDBPUserStateManager` and expands `FreemiumDBPUserStateManaging` to track activation, first profile-save timestamp, first-scan result, and (future) upgrade timestamp, with serialized writes and first-write-wins semantics.
> 
> Wires this state into the PIR flow: `DBPService` now constructs/injects the manager, `BrokerProfileJobEventsHandler` records activation on `.profileSaved`, and `DataBrokerProtectionIOSManager` centralizes scan-completion handling to both fire the existing “matches found” event and (only on normal completion) persist the first-scan match result, skipping writes when `database.hasMatches()` fails.
> 
> Adds/updates test support and coverage, including configurable `hasMatches()` behavior in DB mocks and new unit/integration tests for state persistence, event handling, and both scan-completion paths (including interrupted and DB-error scenarios).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e69d88cd52379297bd7613b65352403d4133a350. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->