### PR TITLE
[macOS] Improve geolocation provider test reliability

### DIFF
--- a/macOS/UnitTests/Geolocation/GeolocationProviderTests.swift
+++ b/macOS/UnitTests/Geolocation/GeolocationProviderTests.swift
@@ -379,31 +379,37 @@ final class GeolocationProviderTests: XCTestCase {
         let location2 = CLLocation(latitude: 10.1, longitude: -13.5)
 
         geolocationServiceMock.currentLocationPublished = .success(location1)
-        geolocationServiceMock.onSubscriptionReceived = { [geolocationServiceMock] _ in
-            if geolocationServiceMock!.history == [.locationPublished, .subscribed, .subscribed] {
-                DispatchQueue.main.async {
-                    webView2.configuration.processPool.geolocationProvider!.isPaused = true
-                    geolocationServiceMock!.currentLocationPublished = .success(location2)
-                }
-            }
-        }
 
         let e1_1 = expectation(description: "location1 received in webView1")
         let e1_2 = expectation(description: "location1 received in webView2")
         let e2_1 = expectation(description: "location2 received in webView1")
 
-        geolocationHandler = { [webView1=webView!] webView, body in
+        var webView1ReceivedLocation1 = false
+        var webView2ReceivedLocation1 = false
+        var didPauseAndPublishLocation2 = false
+
+        geolocationHandler = { [webView1=webView!, geolocationServiceMock] webView, body in
             switch (webView, try Response(body)) {
             case (webView1, Response(location1.removingAltitude())):
                 e1_1.fulfill()
+                webView1ReceivedLocation1 = true
             case (webView2, Response(location1.removingAltitude())):
                 e1_2.fulfill()
+                webView2ReceivedLocation1 = true
             case (webView1, Response(location2.removingAltitude())):
                 e2_1.fulfill()
             case (webView2, Response(location2.removingAltitude())):
                 XCTFail("webView2 Unexpectedly received location")
             default:
                 XCTFail("Unexpected result")
+            }
+
+            if webView1ReceivedLocation1 && webView2ReceivedLocation1 && !didPauseAndPublishLocation2 {
+                didPauseAndPublishLocation2 = true
+                DispatchQueue.main.async {
+                    webView2.configuration.processPool.geolocationProvider!.isPaused = true
+                    geolocationServiceMock!.currentLocationPublished = .success(location2)
+                }
             }
         }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1214132819416367?focus=true
Tech Design URL:
CC:

### Description

This PR improves reliability of geolocation provider tests by making sure that the test waits for the appropriate events to complete before asserting any state.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI is green

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only adjusts unit test coordination logic; main risk is altering test ordering assumptions and potentially masking a real concurrency issue if the new gating is incorrect.
> 
> **Overview**
> Improves reliability of `GeolocationProviderTests` by changing the multi-webview pause scenario to **wait until both web views have received the first location** before pausing `webView2` and publishing the second location.
> 
> This replaces a subscription-history-based trigger with explicit per-webview receipt flags, reducing race conditions in `testWhenOneWebViewGeolocationIsPausedThenAnotherWebViewContinuesReceivingLocationUpdates()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cd261a96dca31fe5b22252fb94af8ed5474f935. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->