### PR TITLE
Change the behavior of the strict PR checks flag

### DIFF
--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -161,7 +161,7 @@ jobs:
           check_name: BSK Test Report (macOS)
           report_paths: SharedPackages/BrowserServicesKit/package-tests.xml
           require_tests: true
-          check_retries: true
+          check_retries: ${{ needs.should-run-checks.outputs.strict_mode != 'true' }}
 
       - name: Update Asana with failed unit tests
         if: always() && steps.run-unit-tests.outcome == 'failure'
@@ -283,20 +283,14 @@ jobs:
       - name: Run tests
         id: run-unit-tests-ios
         run: |
-          if [[ "${{ needs.should-run-checks.outputs.strict_mode }}" == "true" ]]; then
-            RETRY_FLAGS="-test-iterations 3"
-            echo "Strict mode enabled: running tests with $RETRY_FLAGS"
-          else
-            RETRY_FLAGS="-test-iterations 3 -retry-tests-on-failure"
-          fi
-
           set -o pipefail && xcodebuild test \
             -scheme BrowserServicesKit \
             -destination '${{ steps.select-simulator.outputs.destination }}' \
             -derivedDataPath DerivedData \
             -skipPackagePluginValidation \
             -skipMacroValidation \
-            $RETRY_FLAGS \
+            -test-iterations 3 \
+            -retry-tests-on-failure \
             CODE_SIGNING_ALLOWED=NO \
             | tee -a ios-build-log.txt \
             | xcbeautify --report junit --report-path . --junit-report-filename bsk-ios-unittests.xml
@@ -334,7 +328,7 @@ jobs:
           check_name: BSK Test Report (iOS)
           report_paths: SharedPackages/BrowserServicesKit/bsk-ios-unittests.xml
           require_tests: true
-          check_retries: true
+          check_retries: ${{ needs.should-run-checks.outputs.strict_mode != 'true' }}
 
       - name: Update Asana with failed unit tests
         if: always() && steps.run-unit-tests-ios.outcome == 'failure'

--- a/.github/workflows/dbp_pr_checks.yml
+++ b/.github/workflows/dbp_pr_checks.yml
@@ -142,7 +142,7 @@ jobs:
           check_name: DBP Test Report (macOS)
           report_paths: SharedPackages/DataBrokerProtectionCore/package-tests.xml
           require_tests: true
-          check_retries: true
+          check_retries: ${{ needs.should-run-checks.outputs.strict_mode != 'true' }}
 
       - name: Send Unit Tests Status Pixel
         if: always() && github.ref_name == 'main'
@@ -272,20 +272,14 @@ jobs:
       - name: Run tests
         id: run-unit-tests
         run: |
-          if [[ "${{ needs.should-run-checks.outputs.strict_mode }}" == "true" ]]; then
-            RETRY_FLAGS="-test-iterations 3"
-            echo "Strict mode enabled: running tests with $RETRY_FLAGS"
-          else
-            RETRY_FLAGS="-test-iterations 3 -retry-tests-on-failure"
-          fi
-
           set -o pipefail && xcodebuild test \
             -scheme DataBrokerProtectionCore \
             -destination '${{ steps.select-simulator.outputs.destination }}' \
             -derivedDataPath DerivedData \
             -skipPackagePluginValidation \
             -skipMacroValidation \
-            $RETRY_FLAGS \
+            -test-iterations 3 \
+            -retry-tests-on-failure \
             CODE_SIGNING_ALLOWED=NO \
             | tee -a ios-build-log.txt \
             | xcbeautify --report junit --report-path . --junit-report-filename dbp-ios-unittests.xml
@@ -308,7 +302,7 @@ jobs:
           check_name: DBP Test Report (iOS)
           report_paths: SharedPackages/DataBrokerProtectionCore/dbp-ios-unittests.xml
           require_tests: true
-          check_retries: true
+          check_retries: ${{ needs.should-run-checks.outputs.strict_mode != 'true' }}
 
       - name: Send Unit Tests Status Pixel
         if: always() && github.ref_name == 'main'

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -230,6 +230,7 @@ jobs:
       uses: mikepenz/action-junit-report@v3
       with:
         report_paths: iOS/unittests.xml
+        check_retries: ${{ needs.should-run-checks.outputs.strict_mode != 'true' }}
 
     - name: Update Asana with failed unit tests
       if: always() && steps.run-unit-tests.outcome == 'failure'

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -176,20 +176,14 @@ jobs:
         echo "Using iOS simulator: ${{ steps.select-simulator.outputs.ios-version }}"
         echo "Destination: ${{ steps.select-simulator.outputs.destination }}"
 
-        if [[ "${{ needs.should-run-checks.outputs.strict_mode }}" == "true" ]]; then
-          STRICT_FLAGS="-test-iterations 3"
-          echo "Strict mode enabled: running tests with $STRICT_FLAGS"
-        else
-          STRICT_FLAGS=""
-        fi
-
         set -o pipefail && xcodebuild test \
           -scheme "iOS Browser" \
           -destination "${{ steps.select-simulator.outputs.destination }}" \
           -derivedDataPath "DerivedData" \
           -skipPackagePluginValidation \
           -skipMacroValidation \
-          $STRICT_FLAGS \
+          -test-iterations 3 \
+          -retry-tests-on-failure \
           DDG_SLOW_COMPILE_CHECK_THRESHOLD=250 \
           COMPILATION_CACHE_ENABLE_CACHING=YES \
           | tee xcodebuild.log \

--- a/.github/workflows/macos_pir_end_to_end_tests.yml
+++ b/.github/workflows/macos_pir_end_to_end_tests.yml
@@ -154,13 +154,6 @@ jobs:
     - name: Run PIR e2e Tests
       id: run-tests
       run: |
-        if [[ "${{ needs.should-run-checks.outputs.strict_mode }}" == "true" ]]; then
-          RETRY_FLAGS="-test-iterations 3"
-          echo "Strict mode enabled: running tests with $RETRY_FLAGS"
-        else
-          RETRY_FLAGS="-retry-tests-on-failure -test-iterations 2"
-        fi
-
         launchctl setenv PRIVACYPRO_STAGING_ACCESS_TOKEN_V2 '${{ secrets.PRIVACYPRO_STAGING_ACCESS_TOKEN_V2 }}'
         set -o pipefail && xcodebuild test \
           -scheme "macOS PIR E2E Tests" \
@@ -170,7 +163,8 @@ jobs:
           ENABLE_TESTABILITY=true \
           COMPILATION_CACHE_ENABLE_CACHING=YES \
           "-only-testing:DBPE2ETests" \
-          $RETRY_FLAGS \
+          -test-iterations 3 \
+          -retry-tests-on-failure \
           | tee xcodebuild.log \
           | tee pir-e2e-tests.log
       env:
@@ -222,7 +216,7 @@ jobs:
       with:
         check_name: "Test Report ${{ matrix.runner }}"
         report_paths: macOS/pir-e2e-tests.xml
-        check_retries: true
+        check_retries: ${{ needs.should-run-checks.outputs.strict_mode != 'true' }}
 
     - name: Collect PIR process logs
       if: failure() || cancelled()

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -263,13 +263,6 @@ jobs:
         echo "Runner ${RUNNER_NAME} (${RUNNER_TRACKING_ID})"
         export OS_ACTIVITY_MODE=debug
 
-        if [[ "${{ needs.should-run-checks.outputs.strict_mode }}" == "true" ]]; then
-          STRICT_FLAGS="-test-iterations 3"
-          echo "Strict mode enabled: running tests with $STRICT_FLAGS"
-        else
-          STRICT_FLAGS=""
-        fi
-
         set -o pipefail && xcodebuild test \
           -scheme "${{ matrix.scheme }}" \
           -derivedDataPath "DerivedData" \
@@ -282,7 +275,8 @@ jobs:
           ONLY_ACTIVE_ARCH=${{ matrix.active-arch }} \
           COMPILATION_CACHE_ENABLE_CACHING=YES \
           "-skip-testing:${{ matrix.integration-tests-target }}" \
-          $STRICT_FLAGS \
+          -test-iterations 3 \
+          -retry-tests-on-failure \
           | tee ${{ matrix.flavor }}-unittests-xcodebuild.log \
           | sed -e 's/CoreData: error:/CoreData: [notice]:/g' -e 's/Failed to create NSXPCConnection/[notice] NSXPCConnection unavailable/g' \
           | xcbeautify --report junit --report-path . --junit-report-filename ${{ matrix.flavor }}-unittests.xml \
@@ -291,13 +285,6 @@ jobs:
     - name: Run integration tests
       id: run-integration-tests
       run: |
-        if [[ "${{ needs.should-run-checks.outputs.strict_mode }}" == "true" ]]; then
-          RETRY_FLAGS="-test-iterations 3"
-          echo "Strict mode enabled: running tests with $RETRY_FLAGS"
-        else
-          RETRY_FLAGS="-retry-tests-on-failure"
-        fi
-
         set -o pipefail && xcodebuild test \
           -scheme "${{ matrix.scheme }}" \
           -derivedDataPath "DerivedData" \
@@ -310,7 +297,8 @@ jobs:
           ONLY_ACTIVE_ARCH=${{ matrix.active-arch }} \
           COMPILATION_CACHE_ENABLE_CACHING=YES \
           "-only-testing:${{ matrix.integration-tests-target }}" \
-          $RETRY_FLAGS \
+          -test-iterations 3 \
+          -retry-tests-on-failure \
           | tee ${{ matrix.flavor }}-integrationtests-xcodebuild.log \
           | sed -e 's/CoreData: error:/CoreData: [notice]:/g' -e 's/Failed to create NSXPCConnection/[notice] NSXPCConnection unavailable/g' \
           | xcbeautify --report junit --report-path . --junit-report-filename ${{ matrix.flavor }}-integrationtests.xml \
@@ -374,7 +362,7 @@ jobs:
       with:
         check_name: "Test Report: ${{ matrix.flavor }}"
         report_paths: 'macOS/${{ matrix.flavor }}*.xml'
-        check_retries: true
+        check_retries: ${{ needs.should-run-checks.outputs.strict_mode != 'true' }}
 
     - name: Update Asana with failed unit tests
       if: always() && (steps.run-unit-tests.outcome == 'failure' || steps.run-integration-tests.outcome == 'failure')

--- a/.github/workflows/should_run_pr_checks.yml
+++ b/.github/workflows/should_run_pr_checks.yml
@@ -26,7 +26,7 @@ on:
         type: string
         default: 'Run PR Checks'
       strict_checks_label:
-        description: 'Label name that enables strict test mode (no retries, 3 iterations)'
+        description: 'Label name that enables strict test mode (surfaces flaky test iterations in the test report)'
         required: false
         type: string
         default: 'strict pr checks'


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1214087249841177?focus=true
Tech Design URL:
CC:

### Description

This PR changes the behavior of the strict PR checks label so that it disables the `check_retries` option.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that the changes make sense

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI behavior across multiple workflows, potentially affecting how flaky tests are surfaced and how PR check statuses are reported.
> 
> **Overview**
> **Updates the `strict pr checks` label behavior across iOS/macOS/BSK/DBP workflows.** All `xcodebuild test` invocations now consistently run with `-test-iterations 3` and `-retry-tests-on-failure`, removing the previous strict/non-strict branching.
> 
> When `strict_mode` is enabled, the JUnit report publishing steps now disable `action-junit-report` `check_retries` (via `check_retries: ${{ needs.should-run-checks.outputs.strict_mode != 'true' }}`), so flaky iterations are surfaced instead of being retried away. The strict label description in `should_run_pr_checks.yml` is updated to reflect this new intent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 759fa22057ce724ae0f3f8e7cb2cd0ff6a1b8fb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->