### PR TITLE
[macOS] Fix DeallocationTests crash with CSS 14.0.0

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -2477,6 +2477,8 @@
 		8477AF2E2EBB440D00849EA5 /* DownloadsWebViewMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8477AF2C2EBB440D00849EA5 /* DownloadsWebViewMock.swift */; };
 		84796D752E67000C007E6F9F /* FireDialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84796D742E67000C007E6F9F /* FireDialogView.swift */; };
 		84796D762E67000C007E6F9F /* FireDialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84796D742E67000C007E6F9F /* FireDialogView.swift */; };
+		84814EDF2F9600EF00BAA76B /* NewTabPageOmnibarActionsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DDC4B232E2E4CB60084146D /* NewTabPageOmnibarActionsHandlerTests.swift */; };
+		84814EE02F9600EF00BAA76B /* NewTabPageOmnibarActionsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DDC4B232E2E4CB60084146D /* NewTabPageOmnibarActionsHandlerTests.swift */; };
 		848231842F57E3FE00553470 /* CrashReportingFactory+makeCrashReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848231832F57E3FE00553470 /* CrashReportingFactory+makeCrashReporting.swift */; };
 		848231852F57E3FE00553470 /* CrashReportingFactory+makeCrashReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848231832F57E3FE00553470 /* CrashReportingFactory+makeCrashReporting.swift */; };
 		848231962F58051E00553470 /* ApplicationBuildType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848231952F58051E00553470 /* ApplicationBuildType.swift */; };
@@ -16378,6 +16380,7 @@
 				B62A234129C41D4400D22475 /* HistoryIntegrationTests.swift in Sources */,
 				8434E6B32DB0148C008FFA3D /* BookmarksBarViewModelTests.swift in Sources */,
 				B644B43E29D5682B003FA9AB /* SearchNonexistentDomainTests.swift in Sources */,
+				84814EE02F9600EF00BAA76B /* NewTabPageOmnibarActionsHandlerTests.swift in Sources */,
 				B6F6B0032F1E1C2C00A1B2C3 /* WindowOpenSecurityTests.swift in Sources */,
 				8477AF2D2EBB440D00849EA5 /* DownloadsWebViewMock.swift in Sources */,
 				3706FEA5293F662100E42796 /* CoreDataEncryptionTesting.xcdatamodeld in Sources */,
@@ -16444,6 +16447,7 @@
 				4B1AD92125FC474E00261379 /* CoreDataEncryptionTesting.xcdatamodeld in Sources */,
 				8434E6B22DB0148C008FFA3D /* BookmarksBarViewModelTests.swift in Sources */,
 				B62A234029C41D4400D22475 /* HistoryIntegrationTests.swift in Sources */,
+				84814EDF2F9600EF00BAA76B /* NewTabPageOmnibarActionsHandlerTests.swift in Sources */,
 				8477AF2E2EBB440D00849EA5 /* DownloadsWebViewMock.swift in Sources */,
 				B644B43D29D56829003FA9AB /* SearchNonexistentDomainTests.swift in Sources */,
 				B6F6B0022F1E1C2C00A1B2C3 /* WindowOpenSecurityTests.swift in Sources */,

--- a/macOS/IntegrationTests/App/DeallocationTests.swift
+++ b/macOS/IntegrationTests/App/DeallocationTests.swift
@@ -111,8 +111,8 @@ final class DeallocationTests: XCTestCase {
 
             // `showWindow: false` would still open a window, but not activate it, which seems to upset CI
             WindowsManager.openNewWindow()
-            WindowsManager.openNewWindow(with: .duckDuckGo, source: .ui, isBurner: false)
-            WindowsManager.openNewWindow(with: .duckDuckGo, source: .ui, isBurner: true)
+            WindowsManager.openNewWindow(with: URL(string: "data:,Hello%2C%20World%21")!, source: .ui, isBurner: false)
+            WindowsManager.openNewWindow(with: URL(string: "data:,Hello%2C%20World%21")!, source: .ui, isBurner: true)
 
             for i in 0..<Application.appDelegate.windowControllersManager.mainWindowControllers.count {
                 Application.appDelegate.windowControllersManager.mainWindowControllers[i].mainViewController.tabCollectionViewModel

--- a/macOS/IntegrationTests/NewTabPage/NewTabPageOmnibarActionsHandlerTests.swift
+++ b/macOS/IntegrationTests/NewTabPage/NewTabPageOmnibarActionsHandlerTests.swift
@@ -56,6 +56,7 @@ final class NewTabPageOmnibarActionsHandlerTests: XCTestCase {
 
     override func tearDown() {
         autoreleasepool {
+            firedPixels = []
             promptHandler = nil
             windowControllersManager = nil
             tabsPreferences = nil
@@ -99,7 +100,7 @@ final class NewTabPageOmnibarActionsHandlerTests: XCTestCase {
     func testWhenSubmitAIChatOnSameTab_ThenAIChatOpens() {
         let target: NewTabPageDataModel.OpenTarget = .sameTab
 
-        handler.submitChat("duckduckgo", target: target)
+        handler.submitChat("duckduckgo", target: target, modelId: nil, images: nil)
 
         XCTAssert(windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel.tabs.last?.url?.isDuckAIURL ?? false)
         XCTAssertEqual(windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel.tabs.count, 1)
@@ -109,7 +110,7 @@ final class NewTabPageOmnibarActionsHandlerTests: XCTestCase {
     func testWhenSubmitAIChatOnNewTab_ThenNewTabOpensWithAIChat() {
         let target: NewTabPageDataModel.OpenTarget = .newTab
 
-        handler.submitChat("duckduckgo", target: target)
+        handler.submitChat("duckduckgo", target: target, modelId: nil, images: nil)
 
         XCTAssert(windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel.tabs.last?.url?.isDuckAIURL ?? false)
         XCTAssertEqual(windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel.tabs.count, 2)
@@ -145,7 +146,7 @@ final class NewTabPageOmnibarActionsHandlerTests: XCTestCase {
 
     @MainActor
     func testViewAllAiChats_opensNewAIChatTab() {
-        handler.viewAllAiChats(target: .sameTab)
+        handler.viewAllAiChats(target: .newTab)
 
         XCTAssert(windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel.tabs.last?.url?.isDuckAIURL ?? false)
         XCTAssertEqual(windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel.tabs.count, 2)

--- a/macOS/IntegrationTests/NewTabPage/NewTabPageOmnibarActionsHandlerTests.swift
+++ b/macOS/IntegrationTests/NewTabPage/NewTabPageOmnibarActionsHandlerTests.swift
@@ -22,6 +22,7 @@ import NewTabPage
 import AIChat
 import Common
 import Combine
+import SharedTestUtilities
 
 final class NewTabPageOmnibarActionsHandlerTests: XCTestCase {
 
@@ -31,6 +32,7 @@ final class NewTabPageOmnibarActionsHandlerTests: XCTestCase {
     private var tabsPreferences: TabsPreferences!
     private var tab: Tab!
     private var window: NSWindow!
+    private var schemeHandler: TestSchemeHandler!
 
     private var firedPixels: [String] = []
 
@@ -38,6 +40,7 @@ final class NewTabPageOmnibarActionsHandlerTests: XCTestCase {
     override func setUp() {
         autoreleasepool {
             firedPixels = []
+            schemeHandler = TestSchemeHandler()
             promptHandler = AIChatPromptHandler.shared
             windowControllersManager = Application.appDelegate.windowControllersManager
             tabsPreferences = TabsPreferences(persistor: MockTabsPreferencesPersistor(), windowControllersManager: windowControllersManager)
@@ -49,7 +52,7 @@ final class NewTabPageOmnibarActionsHandlerTests: XCTestCase {
                 isCommandPressed: { false },
                 firePixel: { [weak self] event in self?.firedPixels.append(event.name) }
             )
-            tab = Tab(content: .newtab)
+            tab = Tab(content: .newtab, webViewConfiguration: schemeHandler.webViewConfiguration())
             window = WindowsManager.openNewWindow(with: tab)!
         }
     }
@@ -63,6 +66,7 @@ final class NewTabPageOmnibarActionsHandlerTests: XCTestCase {
             tab = nil
             window?.close()
             window = nil
+            schemeHandler = nil
         }
     }
 

--- a/macOS/IntegrationTests/NewTabPage/NewTabPageOmnibarActionsHandlerTests.swift
+++ b/macOS/IntegrationTests/NewTabPage/NewTabPageOmnibarActionsHandlerTests.swift
@@ -22,7 +22,6 @@ import NewTabPage
 import AIChat
 import Common
 import Combine
-import SharedTestUtilities
 
 final class NewTabPageOmnibarActionsHandlerTests: XCTestCase {
 
@@ -32,7 +31,6 @@ final class NewTabPageOmnibarActionsHandlerTests: XCTestCase {
     private var tabsPreferences: TabsPreferences!
     private var tab: Tab!
     private var window: NSWindow!
-    private var schemeHandler: TestSchemeHandler!
 
     private var firedPixels: [String] = []
 
@@ -40,7 +38,6 @@ final class NewTabPageOmnibarActionsHandlerTests: XCTestCase {
     override func setUp() {
         autoreleasepool {
             firedPixels = []
-            schemeHandler = TestSchemeHandler()
             promptHandler = AIChatPromptHandler.shared
             windowControllersManager = Application.appDelegate.windowControllersManager
             tabsPreferences = TabsPreferences(persistor: MockTabsPreferencesPersistor(), windowControllersManager: windowControllersManager)
@@ -52,7 +49,7 @@ final class NewTabPageOmnibarActionsHandlerTests: XCTestCase {
                 isCommandPressed: { false },
                 firePixel: { [weak self] event in self?.firedPixels.append(event.name) }
             )
-            tab = Tab(content: .newtab, webViewConfiguration: schemeHandler.webViewConfiguration())
+            tab = Tab(content: .newtab)
             window = WindowsManager.openNewWindow(with: tab)!
         }
     }
@@ -66,7 +63,6 @@ final class NewTabPageOmnibarActionsHandlerTests: XCTestCase {
             tab = nil
             window?.close()
             window = nil
-            schemeHandler = nil
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1214067738586364
Tech Design URL: N/A
CC: N/A

### Description
- `DeallocationTests.testWhenLastTabClosed_windowIsDeallocated` was navigating to `https://duckduckgo.com` (via `.duckDuckGo` content) without a `TestSchemeHandler`, triggering the `Tab.willStart()` integration-test navigation guard added in Nov 2025 — replaced with `data:` URLs, matching the approach already used by the sibling test `testWindowsDeallocation()`
- `NewTabPageOmnibarActionsHandlerTests` (previously a dangling file not compiled into any target) now compiles: fixed `submitChat` calls to include the required `modelId`/`images` parameters, corrected `testViewAllAiChats_opensNewAIChatTab` to use `.newTab` target (was `.sameTab` but asserting 2 tabs), and added `firedPixels = []` to `tearDown` to satisfy the test isolation checker

### Testing Steps
- Run `DeallocationTests/testWhenLastTabClosed_windowIsDeallocated` in the Integration Tests target — should pass without SIGTRAP
- Run all `NewTabPageOmnibarActionsHandlerTests` — all 9 tests should pass

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- `testWhenLastTabClosed_windowIsDeallocated` used `.duckDuckGo` intentionally to test window deallocation with a "real" URL content type — replacing with `data:` means it no longer exercises that exact code path, but deallocation behaviour is the same regardless of URL scheme

### Quality Considerations
- Test-only change; no production code modified
- Both test classes verified passing locally (run together in sequence to confirm test isolation)

### Notes to Reviewer
The root crash: CSS 14.0.0 NTP JavaScript triggers a real `https://duckduckgo.com` navigation during page initialisation. Any integration test that creates a window/tab loading the NTP without a registered `TestSchemeHandler` will hit `Tab.willStart()`'s fatalError. The fix for `DeallocationTests` is minimal and matches the existing pattern in the same file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust fixtures and expectations; minimal risk outside potential CI behavior differences due to the new `data:` URL loading path.
> 
> **Overview**
> Fixes macOS integration-test instability by updating `DeallocationTests.testWhenLastTabClosed_windowIsDeallocated` to open windows with a `data:` URL instead of `.duckDuckGo`, avoiding real navigation side effects during CI.
> 
> Also wires `NewTabPageOmnibarActionsHandlerTests` into the Xcode test target and updates the tests to match current APIs (adds `modelId`/`images` args), corrects the `viewAllAiChats` open target to `.newTab`, and resets `firedPixels` in `tearDown` for test isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b1fc360579d1ba5aab7242cf74b9e5894e04035. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->