### PR TITLE
Fix missing margin between input bar and escape hatch card

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/ChatHistory/AIChatHistoryListViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/ChatHistory/AIChatHistoryListViewController.swift
@@ -160,15 +160,9 @@ final class AIChatHistoryListViewController: UIViewController {
         viewModel.$filteredSuggestions
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                guard let self else { return }
-                self.tableView.reloadData()
-                self.updateScrollEnabled()
+                self?.tableView.reloadData()
             }
             .store(in: &cancellables)
-    }
-
-    private func updateScrollEnabled() {
-        tableView.isScrollEnabled = !chats.isEmpty
     }
 
     func setScrollableTitle(_ title: String?) {
@@ -269,7 +263,6 @@ final class AIChatHistoryListViewController: UIViewController {
             addChild(hosting)
             updateTableHeader()
             hosting.didMove(toParent: self)
-            updateScrollEnabled()
         } else {
             if let hosting = escapeHatchHostingController {
                 hosting.willMove(toParent: nil)
@@ -278,7 +271,6 @@ final class AIChatHistoryListViewController: UIViewController {
             }
             escapeHatchHostingController = nil
             updateTableHeader()
-            updateScrollEnabled()
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1214007360181768?focus=true

### Description
On the Duck.ai side of the unified toggle input, when there are no recent chats, the "Return to…" escape hatch card was flush against the input bar with no visible margin between them.


### Testing Steps
1. Build
2. Make sure you don’t have any recent chats
3. Visit s site
4. Open a new tab and toggle the duck.ai side and verify there is a visible gap between the "Ask privately" bar and the "Return to…” card.
6. Create a few chats so recent chats exist, then reopen the tab. Verify the list renders and scrolls normally.
7. Switch to the Search side and verify there are no layout regressions.

### Impact and Risks

Low. Visual-only fix on the Duck.ai side of the unified toggle input.

#### What could go wrong?

Allowing the table view to bounce when the content fits within the frame could be perceived as minor UX noise. This was the only reason `updateScrollEnabled()` existed; in practice bouncing an empty list is harmless and standard UITableView behavior.

### Quality Considerations

- Edge cases checked: no chats with escape hatch shown, with recent chats, and search side.
- No performance impact.
- No new API surface or monitoring needed.

### Notes to Reviewer

The regression was introduced in #4248 (Unified Input Part 6-4). The new layout depends on `safeAreaInsets.top` participating in `adjustedContentInset`, which UIKit skips on non-scrollable axes. Removing `updateScrollEnabled()` is the smallest change that restores the expected behavior; an equivalent alternative would be setting `tableView.contentInsetAdjustmentBehavior = .always`.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 004af822e5715c6673b6c4e21697b89f589c58d8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>