### PR TITLE
[iOS] [Debug] Add Pixels preset filter and fix export in Log Viewer

### DIFF
--- a/iOS/DuckDuckGo/LogViewer/LogEntry+Formatting.swift
+++ b/iOS/DuckDuckGo/LogViewer/LogEntry+Formatting.swift
@@ -102,15 +102,6 @@ struct LogFilter {
         return true
     }
 
-    func matchesPreset(_ entry: FormattedLogEntry) -> Bool {
-        if let subsystem = subsystemFilter, !subsystem.isEmpty {
-            guard entry.subsystem.lowercased().contains(subsystem.lowercased()) else { return false }
-        }
-        if let category = categoryFilter, !category.isEmpty {
-            guard entry.category.lowercased().contains(category.lowercased()) else { return false }
-        }
-        return true
-    }
     
     static let allLogsFilter = LogFilter(
         subsystemFilter: nil,

--- a/iOS/DuckDuckGo/LogViewer/LogEntry+Formatting.swift
+++ b/iOS/DuckDuckGo/LogViewer/LogEntry+Formatting.swift
@@ -98,7 +98,17 @@ struct LogFilter {
                    entry.subsystem.lowercased().contains(searchString) ||
                    entry.category.lowercased().contains(searchString)
         }
-        
+
+        return true
+    }
+
+    func matchesPreset(_ entry: FormattedLogEntry) -> Bool {
+        if let subsystem = subsystemFilter, !subsystem.isEmpty {
+            guard entry.subsystem.lowercased().contains(subsystem.lowercased()) else { return false }
+        }
+        if let category = categoryFilter, !category.isEmpty {
+            guard entry.category.lowercased().contains(category.lowercased()) else { return false }
+        }
         return true
     }
     
@@ -110,6 +120,16 @@ struct LogFilter {
         filterEmptySubsystems: true,
         filterAppleLogs: true
     )
+
+    static let pixelFilter = LogFilter(
+        subsystemFilter: "Pixel",
+        categoryFilter: nil,
+        levelFilter: nil,
+        searchText: nil,
+        filterEmptySubsystems: false,
+        filterAppleLogs: false
+    )
+
 }
 
 extension OSLogEntryLog.Level {

--- a/iOS/DuckDuckGo/LogViewer/LogFilterViewController.swift
+++ b/iOS/DuckDuckGo/LogViewer/LogFilterViewController.swift
@@ -115,19 +115,29 @@ extension LogFilterViewController: UITableViewDataSource {
     
     enum Section: Int, CaseIterable {
         case toggleFilters = 0
-        case customFilters = 1
-        case logLevel = 2
-        
+        case presets = 1
+        case customFilters = 2
+        case logLevel = 3
+
         var title: String {
             switch self {
             case .toggleFilters:
                 return "Filter Options"
+            case .presets:
+                return "Presets"
             case .customFilters:
                 return "Custom Filters"
             case .logLevel:
                 return "Minimum Log Level"
             }
         }
+    }
+
+    enum PresetRow: Int, CaseIterable {
+        case pixels = 0
+
+        var title: String { "Pixels" }
+        var filter: LogFilter { .pixelFilter }
     }
     
     enum ToggleFilterRow: Int, CaseIterable {
@@ -166,6 +176,8 @@ extension LogFilterViewController: UITableViewDataSource {
         guard let sectionType = Section(rawValue: section) else { return 0 }
         
         switch sectionType {
+        case .presets:
+            return PresetRow.allCases.count
         case .toggleFilters:
             return ToggleFilterRow.allCases.count
         case .customFilters:
@@ -188,6 +200,8 @@ extension LogFilterViewController: UITableViewDataSource {
         guard let sectionType = Section(rawValue: indexPath.section) else { return cell }
         
         switch sectionType {
+        case .presets:
+            configurePresetCell(cell, at: indexPath)
         case .toggleFilters:
             configureToggleFilterCell(cell, at: indexPath)
         case .customFilters:
@@ -199,6 +213,17 @@ extension LogFilterViewController: UITableViewDataSource {
         return cell
     }
     
+    private func configurePresetCell(_ cell: UITableViewCell, at indexPath: IndexPath) {
+        guard let row = PresetRow(rawValue: indexPath.row) else { return }
+        let isSelected = currentFilter.subsystemFilter == row.filter.subsystemFilter
+            && currentFilter.categoryFilter == row.filter.categoryFilter
+        cell.textLabel?.text = row.title
+        cell.textLabel?.textColor = isSelected
+            ? cell.tintColor
+            : UIColor(designSystemColor: .textPrimary)
+        cell.accessoryType = isSelected ? .checkmark : .none
+    }
+
     private func configureToggleFilterCell(_ cell: UITableViewCell, at indexPath: IndexPath) {
         guard let toggleRow = ToggleFilterRow(rawValue: indexPath.row) else { return }
         
@@ -253,8 +278,9 @@ extension LogFilterViewController: UITableViewDelegate {
         guard let sectionType = Section(rawValue: indexPath.section) else { return }
         
         switch sectionType {
+        case .presets:
+            handlePresetSelection(at: indexPath)
         case .toggleFilters:
-            // Toggle switches handle their own actions, no selection needed
             break
         case .customFilters:
             handleCustomFilterSelection(at: indexPath)
@@ -263,6 +289,13 @@ extension LogFilterViewController: UITableViewDelegate {
         }
     }
     
+    private func handlePresetSelection(at indexPath: IndexPath) {
+        guard let row = PresetRow(rawValue: indexPath.row) else { return }
+        currentFilter = row.filter
+        tableView.reloadSections(IndexSet(integer: Section.presets.rawValue), with: .none)
+        doneTapped()
+    }
+
     private func handleCustomFilterSelection(at indexPath: IndexPath) {
         guard let filterRow = CustomFilterRow(rawValue: indexPath.row) else { return }
         

--- a/iOS/DuckDuckGo/LogViewer/LogViewerDataSource.swift
+++ b/iOS/DuckDuckGo/LogViewer/LogViewerDataSource.swift
@@ -68,7 +68,7 @@ final class LogViewerDataSource {
         refresh()
     }
     
-    func exportLogsToFile() -> URL? {
+    func exportLogsToFile(entries: [FormattedLogEntry]? = nil) -> URL? {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
         let timestamp = dateFormatter.string(from: Date())
@@ -79,8 +79,8 @@ final class LogViewerDataSource {
         let consoleFormatter = DateFormatter()
         consoleFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSSSS"
         consoleFormatter.timeZone = TimeZone.current
-        
-        let logContent: String = logEntries.map { entry in
+
+        let logContent: String = (entries ?? logEntries).map { entry in
             let timestamp = consoleFormatter.string(from: entry.timestamp)
             let processName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "DuckDuckGo"
             return "\(timestamp) \(processName)\(entry.level.displayName): (\(entry.subsystem)) [\(entry.category)] \(entry.message)"

--- a/iOS/DuckDuckGo/LogViewer/LogViewerViewController.swift
+++ b/iOS/DuckDuckGo/LogViewer/LogViewerViewController.swift
@@ -77,14 +77,6 @@ final class LogViewerViewController: UIViewController {
         return button
     }()
     
-    private lazy var presetSegmentedControl: UISegmentedControl = {
-        let control = UISegmentedControl(items: ["All", "Pixels"])
-        control.translatesAutoresizingMaskIntoConstraints = false
-        control.selectedSegmentIndex = 0
-        control.addTarget(self, action: #selector(presetChanged(_:)), for: .valueChanged)
-        return control
-    }()
-
     private lazy var loadingSpinner: UIActivityIndicatorView = {
         let spinner = UIActivityIndicatorView(style: .medium)
         spinner.translatesAutoresizingMaskIntoConstraints = false
@@ -95,7 +87,6 @@ final class LogViewerViewController: UIViewController {
     
     private let dataSource = LogViewerDataSource()
     private var filteredEntries: [FormattedLogEntry] = []
-    private var activePreset: LogFilter?
     private var isLoading = false
     private let dependencies: DebugScreen.Dependencies
     
@@ -122,16 +113,11 @@ final class LogViewerViewController: UIViewController {
         definesPresentationContext = true
         navigationItem.rightBarButtonItems = [exportButton, filterButton, refreshButton]
 
-        view.addSubview(presetSegmentedControl)
         view.addSubview(tableView)
         view.addSubview(loadingSpinner)
 
         NSLayoutConstraint.activate([
-            presetSegmentedControl.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8),
-            presetSegmentedControl.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-            presetSegmentedControl.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
-
-            tableView.topAnchor.constraint(equalTo: presetSegmentedControl.bottomAnchor, constant: 8),
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
@@ -143,11 +129,6 @@ final class LogViewerViewController: UIViewController {
         dataSource.refresh()
     }
     
-    @objc private func presetChanged(_ sender: UISegmentedControl) {
-        activePreset = sender.selectedSegmentIndex == 1 ? .pixelFilter : nil
-        applySearchFilter()
-    }
-
     @objc private func refreshButtonTapped() {
         guard !isLoading else { return }
         dataSource.refresh()
@@ -155,7 +136,7 @@ final class LogViewerViewController: UIViewController {
     
     
     @objc private func exportButtonTapped() {
-        guard let logFileURL = dataSource.exportLogsToFile() else {
+        guard let logFileURL = dataSource.exportLogsToFile(entries: filteredEntries) else {
             let alert = UIAlertController(
                 title: "Export Failed",
                 message: "Failed to create log file for export.",
@@ -195,12 +176,6 @@ final class LogViewerViewController: UIViewController {
     private func applySearchFilter() {
         let searchText = searchController.searchBar.text
 
-        var entries = dataSource.logEntries
-
-        if let preset = activePreset {
-            entries = entries.filter { preset.matchesPreset($0) }
-        }
-
         if let searchText = searchText, !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             let searchFilter = LogFilter(
                 subsystemFilter: dataSource.currentFilter.subsystemFilter,
@@ -210,9 +185,9 @@ final class LogViewerViewController: UIViewController {
                 filterEmptySubsystems: dataSource.currentFilter.filterEmptySubsystems,
                 filterAppleLogs: dataSource.currentFilter.filterAppleLogs
             )
-            filteredEntries = entries.filter { searchFilter.matches($0) }
+            filteredEntries = dataSource.logEntries.filter { searchFilter.matches($0) }
         } else {
-            filteredEntries = entries
+            filteredEntries = dataSource.logEntries
         }
 
         tableView.reloadData()
@@ -301,8 +276,6 @@ extension LogViewerViewController: UISearchResultsUpdating {
 
 extension LogViewerViewController: LogFilterViewControllerDelegate {
     func logFilterViewController(_ controller: LogFilterViewController, didUpdateFilter filter: LogFilter) {
-        presetSegmentedControl.selectedSegmentIndex = 0
-        activePreset = nil
         dataSource.updateFilter(filter)
         controller.dismiss(animated: true)
     }

--- a/iOS/DuckDuckGo/LogViewer/LogViewerViewController.swift
+++ b/iOS/DuckDuckGo/LogViewer/LogViewerViewController.swift
@@ -77,6 +77,14 @@ final class LogViewerViewController: UIViewController {
         return button
     }()
     
+    private lazy var presetSegmentedControl: UISegmentedControl = {
+        let control = UISegmentedControl(items: ["All", "Pixels"])
+        control.translatesAutoresizingMaskIntoConstraints = false
+        control.selectedSegmentIndex = 0
+        control.addTarget(self, action: #selector(presetChanged(_:)), for: .valueChanged)
+        return control
+    }()
+
     private lazy var loadingSpinner: UIActivityIndicatorView = {
         let spinner = UIActivityIndicatorView(style: .medium)
         spinner.translatesAutoresizingMaskIntoConstraints = false
@@ -87,6 +95,7 @@ final class LogViewerViewController: UIViewController {
     
     private let dataSource = LogViewerDataSource()
     private var filteredEntries: [FormattedLogEntry] = []
+    private var activePreset: LogFilter?
     private var isLoading = false
     private let dependencies: DebugScreen.Dependencies
     
@@ -113,15 +122,20 @@ final class LogViewerViewController: UIViewController {
         definesPresentationContext = true
         navigationItem.rightBarButtonItems = [exportButton, filterButton, refreshButton]
 
+        view.addSubview(presetSegmentedControl)
         view.addSubview(tableView)
         view.addSubview(loadingSpinner)
-        
+
         NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            presetSegmentedControl.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8),
+            presetSegmentedControl.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            presetSegmentedControl.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+
+            tableView.topAnchor.constraint(equalTo: presetSegmentedControl.bottomAnchor, constant: 8),
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            
+
             loadingSpinner.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             loadingSpinner.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         ])
@@ -129,6 +143,11 @@ final class LogViewerViewController: UIViewController {
         dataSource.refresh()
     }
     
+    @objc private func presetChanged(_ sender: UISegmentedControl) {
+        activePreset = sender.selectedSegmentIndex == 1 ? .pixelFilter : nil
+        applySearchFilter()
+    }
+
     @objc private func refreshButtonTapped() {
         guard !isLoading else { return }
         dataSource.refresh()
@@ -175,7 +194,13 @@ final class LogViewerViewController: UIViewController {
     
     private func applySearchFilter() {
         let searchText = searchController.searchBar.text
-        
+
+        var entries = dataSource.logEntries
+
+        if let preset = activePreset {
+            entries = entries.filter { preset.matchesPreset($0) }
+        }
+
         if let searchText = searchText, !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             let searchFilter = LogFilter(
                 subsystemFilter: dataSource.currentFilter.subsystemFilter,
@@ -185,12 +210,11 @@ final class LogViewerViewController: UIViewController {
                 filterEmptySubsystems: dataSource.currentFilter.filterEmptySubsystems,
                 filterAppleLogs: dataSource.currentFilter.filterAppleLogs
             )
-            
-            filteredEntries = dataSource.logEntries.filter { searchFilter.matches($0) }
+            filteredEntries = entries.filter { searchFilter.matches($0) }
         } else {
-            filteredEntries = dataSource.logEntries
+            filteredEntries = entries
         }
-        
+
         tableView.reloadData()
         scrollToBottom()
     }
@@ -277,6 +301,8 @@ extension LogViewerViewController: UISearchResultsUpdating {
 
 extension LogViewerViewController: LogFilterViewControllerDelegate {
     func logFilterViewController(_ controller: LogFilterViewController, didUpdateFilter filter: LogFilter) {
+        presetSegmentedControl.selectedSegmentIndex = 0
+        activePreset = nil
         dataSource.updateFilter(filter)
         controller.dismiss(animated: true)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214135910870782?focus=true

### Description
- Adds a **Pixels preset** to the Log Viewer filter sheet (between Filter Options and Custom Filters) — one tap to scope logs to PixelKit subsystem entries, with a checkmark + blue tint to indicate active selection
- Fixes the export button to export the currently visible (post-filter) entries instead of all raw log entries

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Open the app in a debug build → Settings → Debug → Log Viewer
2. Tap the filter icon (top right) → confirm a "Presets" section appears between "Filter Options" and "Custom Filters"
3. Tap "Pixels" → confirm the sheet dismisses and the log list scopes to PixelKit entries only
4. Re-open the filter sheet → confirm "Pixels" row shows blue text and a checkmark
5. With Pixels preset active, tap the export button → confirm the exported file contains only the filtered pixel entries, not all logs
6. Clear the filter (open filter sheet, select a different option) → confirm checkmark clears and all logs return

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-04-20 at 14 02 53" src="https://github.com/user-attachments/assets/646c723a-a19b-4276-9609-15acb4abc526" />

### Impact and Risks

#### What could go wrong?
Low: Debug-only screen, no impact on production behaviour or user data.

### Quality Considerations
Only affects the debug Log Viewer screen. No production code paths changed.

### Notes to Reviewer
Export was previously always exporting all `logEntries` regardless of active filters — this fix passes `filteredEntries` to the export function.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)