### PR TITLE
Duck.ai native storage: add getChat, deleteFiles, and pixels

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatScriptUserValues.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatScriptUserValues.swift
@@ -87,6 +87,7 @@ public struct AIChatNativeConfigValues: Codable {
     public let supportsAIChatSync: Bool
     public let supportsMultipleContexts: Bool
     public let supportsTabPicker: Bool
+    public let supportsNativeStorage: Bool
 
     public static var defaultValues: AIChatNativeConfigValues {
 #if os(iOS)
@@ -105,7 +106,8 @@ public struct AIChatNativeConfigValues: Codable {
                                         supportsHomePageEntryPoint: true,
                                         supportsOpenAIChatLink: true,
                                         supportsAIChatSync: false,
-                                        supportsMultipleContexts: false)
+                                        supportsMultipleContexts: false,
+                                        supportsNativeStorage: false)
 #endif
 
 #if os(macOS)
@@ -124,7 +126,8 @@ public struct AIChatNativeConfigValues: Codable {
                                         supportsHomePageEntryPoint: true,
                                         supportsOpenAIChatLink: true,
                                         supportsAIChatSync: false,
-                                        supportsMultipleContexts: false)
+                                        supportsMultipleContexts: false,
+                                        supportsNativeStorage: false)
 #endif
     }
 
@@ -144,7 +147,8 @@ public struct AIChatNativeConfigValues: Codable {
                 supportsOpenAIChatLink: Bool = true,
                 supportsAIChatSync: Bool,
                 supportsMultipleContexts: Bool = false,
-                supportsTabPicker: Bool = false) {
+                supportsTabPicker: Bool = false,
+                supportsNativeStorage: Bool = false) {
         self.isAIChatHandoffEnabled = isAIChatHandoffEnabled
         self.platform = Platform.name
         self.supportsClosingAIChat = supportsClosingAIChat
@@ -163,6 +167,7 @@ public struct AIChatNativeConfigValues: Codable {
         self.supportsAIChatSync = supportsAIChatSync
         self.supportsMultipleContexts = supportsMultipleContexts
         self.supportsTabPicker = supportsTabPicker
+        self.supportsNativeStorage = supportsNativeStorage
     }
 }
 

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageBootstrapScriptRefresher.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageBootstrapScriptRefresher.swift
@@ -1,0 +1,70 @@
+//
+//  DuckAiNativeStorageBootstrapScriptRefresher.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import os.log
+import UserScript
+import WebKit
+
+/// Rebuilds `DuckAiNativeStorageBootstrapUserScript` with a current snapshot of native storage
+/// and reinstalls it on a `WKUserContentController` alongside the caller-provided static scripts.
+///
+/// Needed because `WKUserScript.source` is frozen at creation time: a bootstrap installed once at
+/// tab setup goes stale as soon as the FE writes new entry values, causing a flash on reload.
+/// Callers should invoke `refresh(on:staticScripts:)` before each navigation to Duck.ai.
+public final class DuckAiNativeStorageBootstrapScriptRefresher {
+
+    private let handler: DuckAiNativeStorageHandling
+    private let originRules: [HostnameMatchingRule]
+
+    public init(handler: DuckAiNativeStorageHandling, originRules: [HostnameMatchingRule]) {
+        self.handler = handler
+        self.originRules = originRules
+    }
+
+    /// Returns `true` when `url`'s host matches any of the configured origin rules — use this to
+    /// decide whether a navigation needs a bootstrap refresh. Mirrors the guard embedded in the
+    /// script's JS so the Swift-side scope check and the runtime scope check stay in sync.
+    public func isInScope(url: URL) -> Bool {
+        guard let host = url.host?.lowercased() else { return false }
+        return originRules.contains { rule in
+            switch rule {
+            case .exact(let ruleHost):
+                return host == ruleHost.lowercased()
+            case .exactOrSubdomain(let ruleHost), .etldPlus1(let ruleHost):
+                let lowered = ruleHost.lowercased()
+                return host == lowered || host.hasSuffix("." + lowered)
+            }
+        }
+    }
+
+    /// Wipes all user scripts from `userContentController`, reinstalls the provided static scripts,
+    /// then appends a freshly built bootstrap script with the current native storage snapshot.
+    @MainActor
+    public func refresh(on userContentController: WKUserContentController, staticScripts: [WKUserScript]) {
+        let bootstrap = DuckAiNativeStorageBootstrapUserScript(handler: handler, allowedOrigins: originRules)
+        let wkBootstrap = bootstrap.makeWKUserScriptSync()
+
+        userContentController.removeAllUserScripts()
+        for script in staticScripts {
+            userContentController.addUserScript(script)
+        }
+        userContentController.addUserScript(wkBootstrap)
+        Logger.aiChat.debug("[NativeStorage] Bootstrap script refreshed (\(staticScripts.count) static scripts preserved)")
+    }
+}

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageBootstrapUserScript.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageBootstrapUserScript.swift
@@ -1,0 +1,100 @@
+//
+//  DuckAiNativeStorageBootstrapUserScript.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import UserScript
+import WebKit
+
+/// Injects a snapshot of allowed list native-storage entries on the `window` object
+/// before any page script runs. Exists to eliminate the first-render theme flash
+/// on Duck.ai by exposing `setting_kae` and `duckaiSidebarCollapsed` synchronously,
+/// bypassing the async messaging bridge for these two keys only.
+public final class DuckAiNativeStorageBootstrapUserScript: NSObject, UserScript {
+
+    /// Entries allowed to leave native storage via this early-injection path.
+    /// Keep this set minimal — any key here is visible to the page content world before Duck.ai scripts run.
+    public static let exposedKeys: Set<String> = ["setting_kae", "duckaiSidebarCollapsed"]
+
+    public let source: String
+    public let injectionTime: WKUserScriptInjectionTime = .atDocumentStart
+    public let forMainFrameOnly: Bool = true
+    public var requiresRunInPageContentWorld: Bool { true }
+    public let messageNames: [String] = []
+
+    public init(handler: DuckAiNativeStorageHandling, allowedOrigins: [HostnameMatchingRule]) {
+        self.source = Self.buildSource(handler: handler, allowedOrigins: allowedOrigins)
+        super.init()
+    }
+
+    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        // Intentionally empty — this script has no message handlers.
+    }
+
+    // MARK: - Source construction
+
+    private static func buildSource(handler: DuckAiNativeStorageHandling, allowedOrigins: [HostnameMatchingRule]) -> String {
+        let entries = allowedEntries(from: handler)
+        let json = jsonString(for: entries)
+        let guardExpression = originGuardExpression(for: allowedOrigins)
+        return """
+        (function() {
+          if (!(\(guardExpression))) return;
+          window.__nativeStorageEntries = \(json);
+        })();
+        """
+    }
+
+    private static func allowedEntries(from handler: DuckAiNativeStorageHandling) -> [String: Any] {
+        guard let all = try? handler.getAllEntries() else { return [:] }
+        return all.filter { exposedKeys.contains($0.key) }
+    }
+
+    private static func jsonString(for entries: [String: Any]) -> String {
+        guard JSONSerialization.isValidJSONObject(entries),
+              let data = try? JSONSerialization.data(withJSONObject: entries, options: [.sortedKeys]),
+              let string = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return string
+    }
+
+    private static func originGuardExpression(for rules: [HostnameMatchingRule]) -> String {
+        guard !rules.isEmpty else { return "false" }
+        return rules.map(hostnameCheck(for:)).joined(separator: " || ")
+    }
+
+    private static func hostnameCheck(for rule: HostnameMatchingRule) -> String {
+        switch rule {
+        case .exact(let hostname):
+            return "location.hostname === \(jsStringLiteral(hostname))"
+        case .exactOrSubdomain(let hostname), .etldPlus1(let hostname):
+            let exact = "location.hostname === \(jsStringLiteral(hostname))"
+            let suffix = "location.hostname.endsWith(\(jsStringLiteral("." + hostname)))"
+            return "(\(exact) || \(suffix))"
+        }
+    }
+
+    private static func jsStringLiteral(_ value: String) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: [value]),
+              let array = String(data: data, encoding: .utf8) else {
+            return "\"\""
+        }
+        // Strip the surrounding [ ] to get the quoted-and-escaped string.
+        return String(array.dropFirst().dropLast())
+    }
+}

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageHandler.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageHandler.swift
@@ -87,6 +87,10 @@ public final class DuckAiNativeStorageHandler: DuckAiNativeStorageHandling {
         try dataStore.putChats(chats)
     }
 
+    public func getChat(chatId: String) throws -> DuckAiChatRecord? {
+        try dataStore.getChat(chatId: chatId)
+    }
+
     public func getAllChats() throws -> [DuckAiChatRecord] {
         try dataStore.getAllChats()
     }
@@ -115,6 +119,10 @@ public final class DuckAiNativeStorageHandler: DuckAiNativeStorageHandling {
 
     public func deleteFile(uuid: String) throws {
         try dataStore.deleteFile(uuid: uuid)
+    }
+
+    public func deleteFiles(chatId: String) throws {
+        try dataStore.deleteFiles(chatId: chatId)
     }
 
     public func deleteAllFiles() throws {

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageHandling.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageHandling.swift
@@ -35,6 +35,7 @@ public protocol DuckAiNativeStorageHandling {
 
     func putChat(chatId: String, data: Data) throws
     func putChats(_ chats: [DuckAiChatRecord]) throws
+    func getChat(chatId: String) throws -> DuckAiChatRecord?
     func getAllChats() throws -> [DuckAiChatRecord]
     func deleteChat(chatId: String) throws
     func deleteAllChats() throws
@@ -45,6 +46,7 @@ public protocol DuckAiNativeStorageHandling {
     func getFile(uuid: String) throws -> DuckAiFileContent?
     func listFiles() throws -> [DuckAiFileMetadata]
     func deleteFile(uuid: String) throws
+    func deleteFiles(chatId: String) throws
     func deleteAllFiles() throws
 
     // MARK: - Migration

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStoragePixelFiring.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStoragePixelFiring.swift
@@ -1,0 +1,57 @@
+//
+//  DuckAiNativeStoragePixelFiring.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public enum DuckAiNativeStorageEvent {
+    // Initialization
+    case initSuccess
+    case initError(Error)
+
+    // Migration
+    case migrationDone(key: String)
+    case migrationDoneBlankKey
+    case migrationStarted
+    case migrationAlreadyDone
+    case migrationError(Error)
+
+    // Entries errors (previously Settings)
+    case settingsPutError(Error)
+    case settingsGetError(Error)
+    case settingsDeleteError(Error)
+
+    // Chat errors
+    case chatPutError(Error)
+    case chatGetError(Error)
+    case chatDeleteError(Error)
+
+    // File errors
+    case filePutError(Error)
+    case fileGetError(Error)
+    case fileListError(Error)
+    case fileDeleteError(Error)
+}
+
+public protocol DuckAiNativeStoragePixelFiring {
+    func fire(_ event: DuckAiNativeStorageEvent)
+}
+
+public struct NullDuckAiNativeStoragePixelFiring: DuckAiNativeStoragePixelFiring {
+    public init() {}
+    public func fire(_ event: DuckAiNativeStorageEvent) {}
+}

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageProvider.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageProvider.swift
@@ -32,25 +32,35 @@ public final class DuckAiNativeStorageProvider {
 
     public let handler: DuckAiNativeStorageHandling
 
-    public init(containerURL: URL, keyStoreProvider: DuckAiKeyStoreProvider) throws {
-        let fileManager = FileManager.default
-        try fileManager.createDirectory(at: containerURL, withIntermediateDirectories: true)
+    public init(
+        containerURL: URL,
+        keyStoreProvider: DuckAiKeyStoreProvider,
+        pixelFiring: DuckAiNativeStoragePixelFiring = NullDuckAiNativeStoragePixelFiring()
+    ) throws {
+        do {
+            let fileManager = FileManager.default
+            try fileManager.createDirectory(at: containerURL, withIntermediateDirectories: true)
 
-        let encryptionKey = try keyStoreProvider.getOrCreateKey()
+            let encryptionKey = try keyStoreProvider.getOrCreateKey()
 
-        let settingsStore = try KeyValueFileStore(
-            location: containerURL,
-            name: "settings.plist"
-        )
-        let dataStore = try DuckAiNativeDataStore(
-            databaseURL: containerURL.appendingPathComponent("chats.db"),
-            filesDirectoryURL: containerURL.appendingPathComponent("files"),
-            key: encryptionKey
-        )
-        self.handler = DuckAiNativeStorageHandler(
-            settingsStore: settingsStore.throwingKeyedStoring(),
-            dataStore: dataStore
-        )
-        Logger.aiChat.debug("DuckAiNativeStorageProvider: Initialized at \(containerURL.path)")
+            let settingsStore = try KeyValueFileStore(
+                location: containerURL,
+                name: "settings.plist"
+            )
+            let dataStore = try DuckAiNativeDataStore(
+                databaseURL: containerURL.appendingPathComponent("chats.db"),
+                filesDirectoryURL: containerURL.appendingPathComponent("files"),
+                key: encryptionKey
+            )
+            self.handler = DuckAiNativeStorageHandler(
+                settingsStore: settingsStore.throwingKeyedStoring(),
+                dataStore: dataStore
+            )
+            Logger.aiChat.debug("DuckAiNativeStorageProvider: Initialized at \(containerURL.path)")
+            pixelFiring.fire(.initSuccess)
+        } catch {
+            pixelFiring.fire(.initError(error))
+            throw error
+        }
     }
 }

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageUserScript.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageUserScript.swift
@@ -32,12 +32,18 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
     public let messageOriginPolicy: MessageOriginPolicy
 
     private let handler: DuckAiNativeStorageHandling
+    private let pixelFiring: DuckAiNativeStoragePixelFiring
     private let storageQueue = DispatchQueue(label: "com.duckduckgo.native-storage", qos: .userInitiated)
 
     // MARK: - Initialization
 
-    public init(handler: DuckAiNativeStorageHandling, originRules: [HostnameMatchingRule]) {
+    public init(
+        handler: DuckAiNativeStorageHandling,
+        originRules: [HostnameMatchingRule],
+        pixelFiring: DuckAiNativeStoragePixelFiring = NullDuckAiNativeStoragePixelFiring()
+    ) {
         self.handler = handler
+        self.pixelFiring = pixelFiring
         self.messageOriginPolicy = .only(rules: originRules)
         super.init()
         Logger.aiChat.debug("[NativeStorage] Created with origin rules: \(originRules.map { String(describing: $0) }.joined(separator: ", "))")
@@ -70,6 +76,7 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
         // Chats
         case .putChat: return putChat
         case .putChats: return putChats
+        case .getChat: return getChat
         case .getAllChats: return getAllChats
         case .deleteChat: return deleteChat
         case .deleteAllChats: return deleteAllChats
@@ -79,6 +86,7 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
         case .getFile: return getFile
         case .listFiles: return listFiles
         case .deleteFile: return deleteFile
+        case .deleteFiles: return deleteFiles
         case .deleteAllFiles: return deleteAllFiles
 
         // Migration
@@ -120,6 +128,7 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
             Logger.aiChat.debug("DuckAiNativeStorage: putEntry '\(key)' succeeded")
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: putEntry failed for key '\(key)': \(error.localizedDescription)")
+            pixelFiring.fire(.settingsPutError(error))
         }
         return nil
     }
@@ -139,6 +148,7 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
             return EntryValueResponse(value: AnyCodableValue(value ?? NSNull()))
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: getEntry failed for key '\(key)': \(error.localizedDescription)")
+            pixelFiring.fire(.settingsGetError(error))
             return EntryValueResponse(value: AnyCodableValue(NSNull()))
         }
     }
@@ -153,6 +163,7 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
             return AllEntriesResponse(entries: entries.mapValues { AnyCodableValue($0) })
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: getAllEntries failed: \(error.localizedDescription)")
+            pixelFiring.fire(.settingsGetError(error))
             return AllEntriesResponse(entries: [:])
         }
     }
@@ -171,6 +182,7 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
             Logger.aiChat.debug("DuckAiNativeStorage: deleteEntry '\(key)' succeeded")
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: deleteEntry failed for key '\(key)': \(error.localizedDescription)")
+            pixelFiring.fire(.settingsDeleteError(error))
         }
         return nil
     }
@@ -184,6 +196,7 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
             Logger.aiChat.debug("DuckAiNativeStorage: deleteAllEntries succeeded")
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: deleteAllEntries failed: \(error.localizedDescription)")
+            pixelFiring.fire(.settingsDeleteError(error))
         }
         return nil
     }
@@ -202,6 +215,7 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
             Logger.aiChat.debug("DuckAiNativeStorage: replaceAllEntries succeeded with \(entries.count) keys")
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: replaceAllEntries failed: \(error.localizedDescription)")
+            pixelFiring.fire(.settingsDeleteError(error))
         }
         return nil
     }
@@ -224,6 +238,7 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
             Logger.aiChat.debug("DuckAiNativeStorage: putChat '\(chatId)' succeeded (\(jsonData.count) bytes)")
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: putChat failed for \(chatId): \(error.localizedDescription)")
+            pixelFiring.fire(.chatPutError(error))
         }
         return nil
     }
@@ -251,7 +266,37 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
             return SuccessResponse(success: true)
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: putChats failed: \(error.localizedDescription)")
+            pixelFiring.fire(.chatPutError(error))
             return SuccessResponse(success: false)
+        }
+    }
+
+    private func getChat(params: Any, message: UserScriptMessage) async -> Encodable? {
+        Logger.aiChat.debug("DuckAiNativeStorage: ← getChat called")
+        guard let dict = params as? [String: Any],
+              let chatId = dict["chatId"] as? String else {
+            Logger.aiChat.error("DuckAiNativeStorage: getChat — invalid params")
+            return GetChatResponse(chat: nil)
+        }
+        do {
+            guard let record = try await performStorageOperation({
+                try self.handler.getChat(chatId: chatId)
+            }) else {
+                Logger.aiChat.debug("DuckAiNativeStorage: getChat '\(chatId)' → not found")
+                return GetChatResponse(chat: nil)
+            }
+            guard let obj = try? JSONSerialization.jsonObject(with: record.data) as? [String: Any] else {
+                Logger.aiChat.error("DuckAiNativeStorage: getChat '\(chatId)' — stored data is not valid JSON")
+                return GetChatResponse(chat: nil)
+            }
+            var dict = obj.mapValues { AnyCodableValue($0) }
+            dict["chatId"] = AnyCodableValue(record.chatId)
+            Logger.aiChat.debug("DuckAiNativeStorage: getChat '\(chatId)' → found (\(record.data.count) bytes)")
+            return GetChatResponse(chat: dict)
+        } catch {
+            Logger.aiChat.error("DuckAiNativeStorage: getChat failed for \(chatId): \(error.localizedDescription)")
+            pixelFiring.fire(.chatGetError(error))
+            return GetChatResponse(chat: nil)
         }
     }
 
@@ -264,6 +309,7 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
             }
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: getAllChats failed: \(error.localizedDescription)")
+            pixelFiring.fire(.chatGetError(error))
             return AllChatsResponse(chats: [])
         }
         let chats: [[String: AnyCodableValue]] = chatRecords.compactMap { record in
@@ -290,6 +336,7 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
             Logger.aiChat.debug("DuckAiNativeStorage: deleteChat '\(chatId)' succeeded")
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: deleteChat failed for \(chatId): \(error.localizedDescription)")
+            pixelFiring.fire(.chatDeleteError(error))
         }
         return nil
     }
@@ -303,6 +350,7 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
             Logger.aiChat.debug("DuckAiNativeStorage: deleteAllChats succeeded")
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: deleteAllChats failed: \(error.localizedDescription)")
+            pixelFiring.fire(.chatDeleteError(error))
         }
         return nil
     }
@@ -330,6 +378,7 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
             Logger.aiChat.debug("DuckAiNativeStorage: putFile '\(uuid)' stored successfully")
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: putFile failed for \(uuid): \(error.localizedDescription)")
+            pixelFiring.fire(.filePutError(error))
         }
         return nil
     }
@@ -357,6 +406,7 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
             return storedDict.mapValues { AnyCodableValue($0) }
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: getFile failed for \(uuid): \(error.localizedDescription)")
+            pixelFiring.fire(.fileGetError(error))
             return nil
         }
     }
@@ -373,6 +423,7 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
             })
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: listFiles failed: \(error.localizedDescription)")
+            pixelFiring.fire(.fileListError(error))
             return ListFilesResponse(files: [])
         }
     }
@@ -391,6 +442,26 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
             Logger.aiChat.debug("DuckAiNativeStorage: deleteFile '\(uuid)' succeeded")
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: deleteFile failed for \(uuid): \(error.localizedDescription)")
+            pixelFiring.fire(.fileDeleteError(error))
+        }
+        return nil
+    }
+
+    private func deleteFiles(params: Any, message: UserScriptMessage) async -> Encodable? {
+        Logger.aiChat.debug("DuckAiNativeStorage: ← deleteFiles called")
+        guard let dict = params as? [String: Any],
+              let chatId = dict["chatId"] as? String, !chatId.isEmpty else {
+            Logger.aiChat.error("DuckAiNativeStorage: deleteFiles — invalid params (missing chatId)")
+            return nil
+        }
+        do {
+            try await performStorageOperation {
+                try self.handler.deleteFiles(chatId: chatId)
+            }
+            Logger.aiChat.debug("DuckAiNativeStorage: deleteFiles '\(chatId)' succeeded")
+        } catch {
+            Logger.aiChat.error("DuckAiNativeStorage: deleteFiles failed for \(chatId): \(error.localizedDescription)")
+            pixelFiring.fire(.fileDeleteError(error))
         }
         return nil
     }
@@ -404,6 +475,7 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
             Logger.aiChat.debug("DuckAiNativeStorage: deleteAllFiles succeeded")
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: deleteAllFiles failed: \(error.localizedDescription)")
+            pixelFiring.fire(.fileDeleteError(error))
         }
         return nil
     }
@@ -422,27 +494,35 @@ public final class DuckAiNativeStorageUserScript: NSObject, Subfeature {
                 try self.handler.isMigrationDone(key: key)
             }
             Logger.aiChat.debug("DuckAiNativeStorage: isMigrationDone('\(key)') → \(done)")
+            if done {
+                pixelFiring.fire(.migrationAlreadyDone)
+            }
             return MigrationDoneResponse(value: done)
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: isMigrationDone failed: \(error.localizedDescription)")
+            pixelFiring.fire(.migrationError(error))
             return MigrationDoneResponse(value: false)
         }
     }
 
     private func markMigrationDone(params: Any, message: UserScriptMessage) async -> Encodable? {
         Logger.aiChat.debug("DuckAiNativeStorage: ← markMigrationDone called")
-        guard let dict = params as? [String: Any],
-              let key = dict["key"] as? String else {
+        pixelFiring.fire(.migrationStarted)
+        let key = (params as? [String: Any])?["key"] as? String ?? ""
+        guard !key.isEmpty else {
             Logger.aiChat.error("DuckAiNativeStorage: markMigrationDone — invalid params (missing key)")
+            pixelFiring.fire(.migrationDoneBlankKey)
             return nil
         }
         do {
             try await performStorageOperation {
                 try self.handler.markMigrationDone(key: key)
             }
+            pixelFiring.fire(.migrationDone(key: key))
             Logger.aiChat.debug("DuckAiNativeStorage: markMigrationDone('\(key)') succeeded")
         } catch {
             Logger.aiChat.error("DuckAiNativeStorage: markMigrationDone failed: \(error.localizedDescription)")
+            pixelFiring.fire(.migrationError(error))
         }
         return nil
     }
@@ -487,6 +567,10 @@ private struct AllEntriesResponse: Encodable {
 
 private struct AllChatsResponse: Encodable {
     let chats: [[String: AnyCodableValue]]
+}
+
+private struct GetChatResponse: Encodable {
+    let chat: [String: AnyCodableValue]?
 }
 
 private struct FileMetadataResponse: Encodable {

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageUserScriptMessages.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageUserScriptMessages.swift
@@ -30,6 +30,7 @@ public enum DuckAiNativeStorageUserScriptMessages: String, CaseIterable {
     // Chats
     case putChat
     case putChats
+    case getChat
     case getAllChats
     case deleteChat
     case deleteAllChats
@@ -39,6 +40,7 @@ public enum DuckAiNativeStorageUserScriptMessages: String, CaseIterable {
     case getFile
     case listFiles
     case deleteFile
+    case deleteFiles
     case deleteAllFiles
 
     // Migration

--- a/SharedPackages/AIChat/Sources/AIChatDebugServer/DuckAiStorageDebugServer.swift
+++ b/SharedPackages/AIChat/Sources/AIChatDebugServer/DuckAiStorageDebugServer.swift
@@ -44,7 +44,7 @@ public final class DuckAiStorageDebugServer {
 
     private let port: UInt16
 
-    public init(storageHandler: DuckAiNativeStorageHandling, port: UInt16 = 8080) {
+    public init(storageHandler: DuckAiNativeStorageHandling, port: UInt16 = 8473) {
         self.port = port
         self.server = DebugHTTPServer(port: port)
         self.storageHandler = storageHandler

--- a/SharedPackages/AIChat/Tests/AIChatTests/LocalSuggestionsReaderTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/LocalSuggestionsReaderTests.swift
@@ -239,12 +239,17 @@ private final class CapturingStorageHandler: DuckAiNativeStorageHandling {
     func replaceAllEntries(_ entries: [String: Any]) throws {}
     func putChat(chatId: String, data: Data) throws {}
     func putChats(_ chats: [DuckAiChatRecord]) throws {}
+    func getChat(chatId: String) throws -> DuckAiChatRecord? {
+        if let error = errorToThrow { throw error }
+        return chatsToReturn.first { $0.chatId == chatId }
+    }
     func deleteChat(chatId: String) throws {}
     func deleteAllChats() throws {}
     func putFile(uuid: String, chatId: String, data: Data) throws {}
     func getFile(uuid: String) throws -> DuckAiFileContent? { nil }
     func listFiles() throws -> [DuckAiFileMetadata] { [] }
     func deleteFile(uuid: String) throws {}
+    func deleteFiles(chatId: String) throws {}
     func deleteAllFiles() throws {}
     func isMigrationDone() throws -> Bool { false }
     func isMigrationDone(key: String) throws -> Bool { false }

--- a/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeStorageBootstrapScriptRefresherTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeStorageBootstrapScriptRefresherTests.swift
@@ -1,0 +1,151 @@
+//
+//  DuckAiNativeStorageBootstrapScriptRefresherTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UserScript
+import WebKit
+import XCTest
+@testable import AIChat
+
+@MainActor
+final class DuckAiNativeStorageBootstrapScriptRefresherTests: XCTestCase {
+
+    private var mockHandler: MockDuckAiNativeStorageHandler!
+    private var userContentController: WKUserContentController!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        mockHandler = MockDuckAiNativeStorageHandler()
+        userContentController = WKUserContentController()
+    }
+
+    func testWhenRefreshedThenContentControllerHasAllStaticScriptsPlusBootstrap() {
+        let staticScript = WKUserScript(source: "window.__static = 1;", injectionTime: .atDocumentEnd, forMainFrameOnly: false)
+        let sut = DuckAiNativeStorageBootstrapScriptRefresher(
+            handler: mockHandler,
+            originRules: [.exactOrSubdomain(hostname: "duck.ai")]
+        )
+
+        sut.refresh(on: userContentController, staticScripts: [staticScript])
+
+        XCTAssertEqual(userContentController.userScripts.count, 2)
+        XCTAssertTrue(userContentController.userScripts.contains { $0.source.contains("__static = 1") })
+        XCTAssertTrue(userContentController.userScripts.contains { $0.source.contains("__nativeStorageEntries") })
+    }
+
+    func testWhenRefreshedThenBootstrapSourceReflectsCurrentHandlerState() throws {
+        mockHandler.stubbedGetAllEntries = ["setting_kae": "d"]
+        let sut = DuckAiNativeStorageBootstrapScriptRefresher(
+            handler: mockHandler,
+            originRules: [.exactOrSubdomain(hostname: "duck.ai")]
+        )
+
+        sut.refresh(on: userContentController, staticScripts: [])
+
+        let bootstrap = try XCTUnwrap(userContentController.userScripts.first { $0.source.contains("__nativeStorageEntries") })
+        XCTAssertTrue(bootstrap.source.contains("\"setting_kae\":\"d\""))
+    }
+
+    func testWhenRefreshedTwiceThenOnlyOneBootstrapRemains() {
+        let sut = DuckAiNativeStorageBootstrapScriptRefresher(
+            handler: mockHandler,
+            originRules: [.exactOrSubdomain(hostname: "duck.ai")]
+        )
+
+        mockHandler.stubbedGetAllEntries = ["setting_kae": "d"]
+        sut.refresh(on: userContentController, staticScripts: [])
+
+        mockHandler.stubbedGetAllEntries = ["setting_kae": "l"]
+        sut.refresh(on: userContentController, staticScripts: [])
+
+        let bootstraps = userContentController.userScripts.filter { $0.source.contains("__nativeStorageEntries") }
+        XCTAssertEqual(bootstraps.count, 1)
+        XCTAssertTrue(bootstraps[0].source.contains("\"setting_kae\":\"l\""))
+        XCTAssertFalse(bootstraps[0].source.contains("\"setting_kae\":\"d\""))
+    }
+
+    func testWhenRefreshedThenStaticScriptsArePreservedAcrossCalls() {
+        let staticScript = WKUserScript(source: "window.__static = 1;", injectionTime: .atDocumentStart, forMainFrameOnly: false)
+        let sut = DuckAiNativeStorageBootstrapScriptRefresher(
+            handler: mockHandler,
+            originRules: []
+        )
+
+        sut.refresh(on: userContentController, staticScripts: [staticScript])
+        sut.refresh(on: userContentController, staticScripts: [staticScript])
+
+        XCTAssertEqual(userContentController.userScripts.filter { $0.source.contains("__static = 1") }.count, 1)
+    }
+
+    // MARK: - isInScope
+
+    func testWhenExactRuleMatchesHostThenIsInScopeIsTrue() {
+        let sut = DuckAiNativeStorageBootstrapScriptRefresher(
+            handler: mockHandler,
+            originRules: [.exact(hostname: "debug.example.com")]
+        )
+        XCTAssertTrue(sut.isInScope(url: URL(string: "https://debug.example.com/chat")!))
+    }
+
+    func testWhenExactRuleDoesNotMatchHostThenIsInScopeIsFalse() {
+        let sut = DuckAiNativeStorageBootstrapScriptRefresher(
+            handler: mockHandler,
+            originRules: [.exact(hostname: "debug.example.com")]
+        )
+        XCTAssertFalse(sut.isInScope(url: URL(string: "https://other.example.com/")!))
+    }
+
+    func testWhenExactOrSubdomainRuleMatchesExactHostThenIsInScopeIsTrue() {
+        let sut = DuckAiNativeStorageBootstrapScriptRefresher(
+            handler: mockHandler,
+            originRules: [.exactOrSubdomain(hostname: "duck.ai")]
+        )
+        XCTAssertTrue(sut.isInScope(url: URL(string: "https://duck.ai/")!))
+    }
+
+    func testWhenExactOrSubdomainRuleMatchesSubdomainThenIsInScopeIsTrue() {
+        let sut = DuckAiNativeStorageBootstrapScriptRefresher(
+            handler: mockHandler,
+            originRules: [.exactOrSubdomain(hostname: "duck.ai")]
+        )
+        XCTAssertTrue(sut.isInScope(url: URL(string: "https://euw-serp-dev-testing19.duck.ai/")!))
+    }
+
+    func testWhenHostSharesOnlySuffixWithoutLeadingDotThenIsInScopeIsFalse() {
+        let sut = DuckAiNativeStorageBootstrapScriptRefresher(
+            handler: mockHandler,
+            originRules: [.exactOrSubdomain(hostname: "duck.ai")]
+        )
+        XCTAssertFalse(sut.isInScope(url: URL(string: "https://evilduck.ai/")!))
+    }
+
+    func testWhenUrlHasNoHostThenIsInScopeIsFalse() {
+        let sut = DuckAiNativeStorageBootstrapScriptRefresher(
+            handler: mockHandler,
+            originRules: [.exactOrSubdomain(hostname: "duck.ai")]
+        )
+        XCTAssertFalse(sut.isInScope(url: URL(string: "about:blank")!))
+    }
+
+    func testWhenNoOriginRulesThenIsInScopeIsFalse() {
+        let sut = DuckAiNativeStorageBootstrapScriptRefresher(
+            handler: mockHandler,
+            originRules: []
+        )
+        XCTAssertFalse(sut.isInScope(url: URL(string: "https://duck.ai/")!))
+    }
+}

--- a/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeStorageBootstrapUserScriptTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeStorageBootstrapUserScriptTests.swift
@@ -1,0 +1,128 @@
+//
+//  DuckAiNativeStorageBootstrapUserScriptTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UserScript
+import WebKit
+import XCTest
+@testable import AIChat
+
+final class DuckAiNativeStorageBootstrapUserScriptTests: XCTestCase {
+
+    private var mockHandler: MockDuckAiNativeStorageHandler!
+
+    override func setUp() {
+        super.setUp()
+        mockHandler = MockDuckAiNativeStorageHandler()
+    }
+
+    // MARK: - UserScript protocol conformance
+
+    func testWhenInitializedThenInjectionTimeIsAtDocumentStart() {
+        let sut = DuckAiNativeStorageBootstrapUserScript(handler: mockHandler, allowedOrigins: [])
+        XCTAssertEqual(sut.injectionTime, .atDocumentStart)
+    }
+
+    func testWhenInitializedThenForMainFrameOnlyIsTrue() {
+        let sut = DuckAiNativeStorageBootstrapUserScript(handler: mockHandler, allowedOrigins: [])
+        XCTAssertTrue(sut.forMainFrameOnly)
+    }
+
+    func testWhenInitializedThenRequiresPageContentWorldIsTrue() {
+        let sut = DuckAiNativeStorageBootstrapUserScript(handler: mockHandler, allowedOrigins: [])
+        XCTAssertTrue(sut.requiresRunInPageContentWorld)
+    }
+
+    func testWhenInitializedThenMessageNamesIsEmpty() {
+        let sut = DuckAiNativeStorageBootstrapUserScript(handler: mockHandler, allowedOrigins: [])
+        XCTAssertTrue(sut.messageNames.isEmpty)
+    }
+
+    // MARK: - Whitelisting
+
+    func testWhenHandlerReturnsAllowedlistedEntriesThenSourceContainsThem() {
+        mockHandler.stubbedGetAllEntries = [
+            "setting_kae": "d",
+            "duckaiSidebarCollapsed": true
+        ]
+        let sut = DuckAiNativeStorageBootstrapUserScript(handler: mockHandler, allowedOrigins: [])
+        XCTAssertTrue(sut.source.contains("\"setting_kae\":\"d\""))
+        XCTAssertTrue(sut.source.contains("\"duckaiSidebarCollapsed\":true"))
+    }
+
+    func testWhenHandlerReturnsNonAllowedlistedEntriesThenSourceOmitsThem() {
+        mockHandler.stubbedGetAllEntries = [
+            "setting_kae": "d",
+            "someOtherKey": "private-value"
+        ]
+        let sut = DuckAiNativeStorageBootstrapUserScript(handler: mockHandler, allowedOrigins: [])
+        XCTAssertFalse(sut.source.contains("someOtherKey"))
+        XCTAssertFalse(sut.source.contains("private-value"))
+    }
+
+    func testWhenHandlerReturnsNoAllowedlistedEntriesThenSourceAssignsEmptyObject() {
+        mockHandler.stubbedGetAllEntries = ["randomKey": "randomValue"]
+        let sut = DuckAiNativeStorageBootstrapUserScript(handler: mockHandler, allowedOrigins: [])
+        XCTAssertTrue(sut.source.contains("window.__nativeStorageEntries = {}"))
+    }
+
+    func testWhenHandlerGetAllEntriesThrowsThenSourceAssignsEmptyObject() {
+        mockHandler.stubbedGetAllEntriesError = NSError(domain: "test", code: 1)
+        let sut = DuckAiNativeStorageBootstrapUserScript(handler: mockHandler, allowedOrigins: [])
+        XCTAssertTrue(sut.source.contains("window.__nativeStorageEntries = {}"))
+    }
+
+    // MARK: - Hostname guard
+
+    func testWhenAllowedOriginsIsEmptyThenGuardFailsClosed() {
+        mockHandler.stubbedGetAllEntries = ["setting_kae": "d"]
+        let sut = DuckAiNativeStorageBootstrapUserScript(handler: mockHandler, allowedOrigins: [])
+        // With no allowed origins, the assignment must be unreachable.
+        XCTAssertTrue(sut.source.contains("if (!(false)) return"))
+    }
+
+    func testWhenAllowedOriginsContainsExactRuleThenSourceUsesStrictEquality() {
+        let sut = DuckAiNativeStorageBootstrapUserScript(
+            handler: mockHandler,
+            allowedOrigins: [.exact(hostname: "debug.example.com")]
+        )
+        XCTAssertTrue(sut.source.contains("location.hostname === \"debug.example.com\""))
+        XCTAssertFalse(sut.source.contains("endsWith"))
+    }
+
+    func testWhenAllowedOriginsContainsExactOrSubdomainRuleThenSourceChecksSuffix() {
+        let sut = DuckAiNativeStorageBootstrapUserScript(
+            handler: mockHandler,
+            allowedOrigins: [.exactOrSubdomain(hostname: "duck.ai")]
+        )
+        XCTAssertTrue(sut.source.contains("location.hostname === \"duck.ai\""))
+        XCTAssertTrue(sut.source.contains("location.hostname.endsWith(\".duck.ai\")"))
+    }
+
+    func testWhenAllowedOriginsHasMultipleRulesThenSourceJoinsWithOr() {
+        let sut = DuckAiNativeStorageBootstrapUserScript(
+            handler: mockHandler,
+            allowedOrigins: [
+                .exactOrSubdomain(hostname: "duck.ai"),
+                .exact(hostname: "debug.example.com")
+            ]
+        )
+        XCTAssertTrue(sut.source.contains("location.hostname === \"duck.ai\""))
+        XCTAssertTrue(sut.source.contains("location.hostname === \"debug.example.com\""))
+        XCTAssertTrue(sut.source.contains(" || "))
+    }
+}

--- a/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeStorageHandlerTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeStorageHandlerTests.swift
@@ -223,9 +223,29 @@ final class DuckAiNativeStorageHandlerTests: XCTestCase {
         XCTAssertEqual(mockDataStore.deleteAllChatsCallCount, 1)
     }
 
+    func testWhenGetChatThenDelegatesToDataStore() throws {
+        mockDataStore.stubbedChat = DuckAiChatRecord(chatId: "c1", data: Data("x".utf8))
+        let result = try handler.getChat(chatId: "c1")
+        XCTAssertEqual(mockDataStore.getChatCallCount, 1)
+        XCTAssertEqual(mockDataStore.lastGetChatId, "c1")
+        XCTAssertEqual(result?.chatId, "c1")
+    }
+
+    func testWhenGetChatNotFoundThenReturnsNil() throws {
+        mockDataStore.stubbedChat = nil
+        let result = try handler.getChat(chatId: "missing")
+        XCTAssertNil(result)
+    }
+
     func testWhenPutFileThenDelegatesToDataStore() throws {
         try handler.putFile(uuid: "f1", chatId: "c1", data: Data())
         XCTAssertEqual(mockDataStore.putFileCallCount, 1)
+    }
+
+    func testWhenDeleteFilesByChatIdThenDelegatesToDataStore() throws {
+        try handler.deleteFiles(chatId: "c1")
+        XCTAssertEqual(mockDataStore.deleteFilesByChatIdCallCount, 1)
+        XCTAssertEqual(mockDataStore.lastDeleteFilesChatId, "c1")
     }
 
     func testWhenDeleteAllFilesThenDelegatesToDataStore() throws {
@@ -248,6 +268,10 @@ private final class MockDuckAiNativeDataStore: DuckAiNativeDataStoring {
     var putChatsCallCount = 0
     var lastPutChats: [DuckAiChatRecord]?
 
+    var getChatCallCount = 0
+    var lastGetChatId: String?
+    var stubbedChat: DuckAiChatRecord?
+
     var deleteChatCallCount = 0
     var lastDeleteChatId: String?
 
@@ -267,6 +291,9 @@ private final class MockDuckAiNativeDataStore: DuckAiNativeDataStoring {
     var deleteFileCallCount = 0
     var lastDeleteFileUuid: String?
 
+    var deleteFilesByChatIdCallCount = 0
+    var lastDeleteFilesChatId: String?
+
     var deleteAllFilesCallCount = 0
 
     func putChat(chatId: String, data: Data) throws {
@@ -278,6 +305,12 @@ private final class MockDuckAiNativeDataStore: DuckAiNativeDataStoring {
     func putChats(_ chats: [DuckAiChatRecord]) throws {
         putChatsCallCount += 1
         lastPutChats = chats
+    }
+
+    func getChat(chatId: String) throws -> DuckAiChatRecord? {
+        getChatCallCount += 1
+        lastGetChatId = chatId
+        return stubbedChat
     }
 
     func getAllChats() throws -> [DuckAiChatRecord] {
@@ -314,6 +347,11 @@ private final class MockDuckAiNativeDataStore: DuckAiNativeDataStoring {
     func deleteFile(uuid: String) throws {
         deleteFileCallCount += 1
         lastDeleteFileUuid = uuid
+    }
+
+    func deleteFiles(chatId: String) throws {
+        deleteFilesByChatIdCallCount += 1
+        lastDeleteFilesChatId = chatId
     }
 
     func deleteAllFiles() throws {

--- a/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeStorageUserScriptTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeStorageUserScriptTests.swift
@@ -20,6 +20,7 @@ import XCTest
 import UserScript
 import WebKit
 import DuckAiDataStore
+import BrowserServicesKitTestsUtils
 @testable import AIChat
 
 final class DuckAiNativeStorageUserScriptTests: XCTestCase {
@@ -59,14 +60,14 @@ final class DuckAiNativeStorageUserScriptTests: XCTestCase {
 
     func testWhenMarkMigrationDoneWithValidKeyThenFiresStartedAndDonePixels() async throws {
         let handler = try XCTUnwrap(sut.handler(forMethodNamed: "markMigrationDone"))
-        _ = try await handler(["key": "chats"], MockUserScriptMessage())
+        _ = try await handler(["key": "chats"], WKScriptMessage.mock())
         XCTAssertTrue(mockPixelFiring.firedEvents.contains { if case .migrationStarted = $0 { return true }; return false })
         XCTAssertTrue(mockPixelFiring.firedEvents.contains { if case .migrationDone(let k) = $0, k == "chats" { return true }; return false })
     }
 
     func testWhenMarkMigrationDoneWithMissingKeyThenFiresStartedAndBlankKeyPixels() async throws {
         let handler = try XCTUnwrap(sut.handler(forMethodNamed: "markMigrationDone"))
-        _ = try await handler([String: Any](), MockUserScriptMessage())
+        _ = try await handler([String: Any](), WKScriptMessage.mock())
         XCTAssertTrue(mockPixelFiring.firedEvents.contains { if case .migrationStarted = $0 { return true }; return false })
         XCTAssertTrue(mockPixelFiring.firedEvents.contains { if case .migrationDoneBlankKey = $0 { return true }; return false })
         XCTAssertFalse(mockPixelFiring.firedEvents.contains { if case .migrationDone = $0 { return true }; return false })
@@ -75,26 +76,16 @@ final class DuckAiNativeStorageUserScriptTests: XCTestCase {
     func testWhenIsMigrationDoneReturnsTrueThenFiresAlreadyDonePixel() async throws {
         mockHandler.stubbedIsMigrationDone = true
         let handler = try XCTUnwrap(sut.handler(forMethodNamed: "isMigrationDone"))
-        _ = try await handler(["key": "chats"], MockUserScriptMessage())
+        _ = try await handler(["key": "chats"], WKScriptMessage.mock())
         XCTAssertTrue(mockPixelFiring.firedEvents.contains { if case .migrationAlreadyDone = $0 { return true }; return false })
     }
 
     func testWhenIsMigrationDoneReturnsFalseThenDoesNotFireAlreadyDonePixel() async throws {
         mockHandler.stubbedIsMigrationDone = false
         let handler = try XCTUnwrap(sut.handler(forMethodNamed: "isMigrationDone"))
-        _ = try await handler(["key": "chats"], MockUserScriptMessage())
+        _ = try await handler(["key": "chats"], WKScriptMessage.mock())
         XCTAssertFalse(mockPixelFiring.firedEvents.contains { if case .migrationAlreadyDone = $0 { return true }; return false })
     }
-}
-
-// MARK: - UserScriptMessage mock
-
-private struct MockUserScriptMessage: UserScriptMessage {
-    var messageName: String = ""
-    var messageBody: Any = [:]
-    var messageHost: String = ""
-    var messageWebView: WKWebView?
-    var isMainFrame: Bool = true
 }
 
 // MARK: - Test helpers

--- a/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeStorageUserScriptTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeStorageUserScriptTests.swift
@@ -18,19 +18,24 @@
 
 import XCTest
 import UserScript
+import WebKit
 import DuckAiDataStore
 @testable import AIChat
 
 final class DuckAiNativeStorageUserScriptTests: XCTestCase {
 
-    var sut: DuckAiNativeStorageUserScript!
+    private var sut: DuckAiNativeStorageUserScript!
+    private var mockHandler: MockDuckAiNativeStorageHandler!
+    private var mockPixelFiring: MockDuckAiNativeStoragePixelFiring!
 
     override func setUp() {
         super.setUp()
-        let mockHandler = MockDuckAiNativeStorageHandler()
+        mockHandler = MockDuckAiNativeStorageHandler()
+        mockPixelFiring = MockDuckAiNativeStoragePixelFiring()
         sut = DuckAiNativeStorageUserScript(
             handler: mockHandler,
-            originRules: [.exact(hostname: "duck.ai")]
+            originRules: [.exact(hostname: "duck.ai")],
+            pixelFiring: mockPixelFiring
         )
     }
 
@@ -49,11 +54,52 @@ final class DuckAiNativeStorageUserScriptTests: XCTestCase {
         let handler = sut.handler(forMethodNamed: "unknownMethod")
         XCTAssertNil(handler)
     }
+
+    // MARK: - markMigrationDone pixel firing
+
+    func testWhenMarkMigrationDoneWithValidKeyThenFiresStartedAndDonePixels() async throws {
+        let handler = try XCTUnwrap(sut.handler(forMethodNamed: "markMigrationDone"))
+        _ = try await handler(["key": "chats"], WKScriptMessage())
+        XCTAssertTrue(mockPixelFiring.firedEvents.contains { if case .migrationStarted = $0 { return true }; return false })
+        XCTAssertTrue(mockPixelFiring.firedEvents.contains { if case .migrationDone(let k) = $0, k == "chats" { return true }; return false })
+    }
+
+    func testWhenMarkMigrationDoneWithMissingKeyThenFiresStartedAndBlankKeyPixels() async throws {
+        let handler = try XCTUnwrap(sut.handler(forMethodNamed: "markMigrationDone"))
+        _ = try await handler([String: Any](), WKScriptMessage())
+        XCTAssertTrue(mockPixelFiring.firedEvents.contains { if case .migrationStarted = $0 { return true }; return false })
+        XCTAssertTrue(mockPixelFiring.firedEvents.contains { if case .migrationDoneBlankKey = $0 { return true }; return false })
+        XCTAssertFalse(mockPixelFiring.firedEvents.contains { if case .migrationDone = $0 { return true }; return false })
+    }
+
+    func testWhenIsMigrationDoneReturnsTrueThenFiresAlreadyDonePixel() async throws {
+        mockHandler.stubbedIsMigrationDone = true
+        let handler = try XCTUnwrap(sut.handler(forMethodNamed: "isMigrationDone"))
+        _ = try await handler(["key": "chats"], WKScriptMessage())
+        XCTAssertTrue(mockPixelFiring.firedEvents.contains { if case .migrationAlreadyDone = $0 { return true }; return false })
+    }
+
+    func testWhenIsMigrationDoneReturnsFalseThenDoesNotFireAlreadyDonePixel() async throws {
+        mockHandler.stubbedIsMigrationDone = false
+        let handler = try XCTUnwrap(sut.handler(forMethodNamed: "isMigrationDone"))
+        _ = try await handler(["key": "chats"], WKScriptMessage())
+        XCTAssertFalse(mockPixelFiring.firedEvents.contains { if case .migrationAlreadyDone = $0 { return true }; return false })
+    }
+}
+
+// MARK: - Test helpers
+
+final class MockDuckAiNativeStoragePixelFiring: DuckAiNativeStoragePixelFiring {
+    var firedEvents: [DuckAiNativeStorageEvent] = []
+
+    func fire(_ event: DuckAiNativeStorageEvent) { firedEvents.append(event) }
 }
 
 // MARK: - Mock
 
-private final class MockDuckAiNativeStorageHandler: DuckAiNativeStorageHandling {
+final class MockDuckAiNativeStorageHandler: DuckAiNativeStorageHandling {
+    var stubbedIsMigrationDone = false
+
     func putEntry(key: String, value: Any) throws {}
     func getEntry(key: String) throws -> Any? { nil }
     func getAllEntries() throws -> [String: Any] { [:] }
@@ -62,6 +108,7 @@ private final class MockDuckAiNativeStorageHandler: DuckAiNativeStorageHandling 
     func replaceAllEntries(_ entries: [String: Any]) throws {}
     func putChat(chatId: String, data: Data) throws {}
     func putChats(_ chats: [DuckAiChatRecord]) throws {}
+    func getChat(chatId: String) throws -> DuckAiChatRecord? { nil }
     func getAllChats() throws -> [DuckAiChatRecord] { [] }
     func deleteChat(chatId: String) throws {}
     func deleteAllChats() throws {}
@@ -69,8 +116,9 @@ private final class MockDuckAiNativeStorageHandler: DuckAiNativeStorageHandling 
     func getFile(uuid: String) throws -> DuckAiFileContent? { nil }
     func listFiles() throws -> [DuckAiFileMetadata] { [] }
     func deleteFile(uuid: String) throws {}
+    func deleteFiles(chatId: String) throws {}
     func deleteAllFiles() throws {}
-    func isMigrationDone() throws -> Bool { false }
-    func isMigrationDone(key: String) throws -> Bool { false }
+    func isMigrationDone() throws -> Bool { stubbedIsMigrationDone }
+    func isMigrationDone(key: String) throws -> Bool { stubbedIsMigrationDone }
     func markMigrationDone(key: String) throws {}
 }

--- a/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeStorageUserScriptTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeStorageUserScriptTests.swift
@@ -100,10 +100,15 @@ final class MockDuckAiNativeStoragePixelFiring: DuckAiNativeStoragePixelFiring {
 
 final class MockDuckAiNativeStorageHandler: DuckAiNativeStorageHandling {
     var stubbedIsMigrationDone = false
+    var stubbedGetAllEntries: [String: Any] = [:]
+    var stubbedGetAllEntriesError: Error?
 
     func putEntry(key: String, value: Any) throws {}
     func getEntry(key: String) throws -> Any? { nil }
-    func getAllEntries() throws -> [String: Any] { [:] }
+    func getAllEntries() throws -> [String: Any] {
+        if let stubbedGetAllEntriesError { throw stubbedGetAllEntriesError }
+        return stubbedGetAllEntries
+    }
     func deleteEntry(key: String) throws {}
     func deleteAllEntries() throws {}
     func replaceAllEntries(_ entries: [String: Any]) throws {}

--- a/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeStorageUserScriptTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeStorageUserScriptTests.swift
@@ -59,14 +59,14 @@ final class DuckAiNativeStorageUserScriptTests: XCTestCase {
 
     func testWhenMarkMigrationDoneWithValidKeyThenFiresStartedAndDonePixels() async throws {
         let handler = try XCTUnwrap(sut.handler(forMethodNamed: "markMigrationDone"))
-        _ = try await handler(["key": "chats"], WKScriptMessage())
+        _ = try await handler(["key": "chats"], MockUserScriptMessage())
         XCTAssertTrue(mockPixelFiring.firedEvents.contains { if case .migrationStarted = $0 { return true }; return false })
         XCTAssertTrue(mockPixelFiring.firedEvents.contains { if case .migrationDone(let k) = $0, k == "chats" { return true }; return false })
     }
 
     func testWhenMarkMigrationDoneWithMissingKeyThenFiresStartedAndBlankKeyPixels() async throws {
         let handler = try XCTUnwrap(sut.handler(forMethodNamed: "markMigrationDone"))
-        _ = try await handler([String: Any](), WKScriptMessage())
+        _ = try await handler([String: Any](), MockUserScriptMessage())
         XCTAssertTrue(mockPixelFiring.firedEvents.contains { if case .migrationStarted = $0 { return true }; return false })
         XCTAssertTrue(mockPixelFiring.firedEvents.contains { if case .migrationDoneBlankKey = $0 { return true }; return false })
         XCTAssertFalse(mockPixelFiring.firedEvents.contains { if case .migrationDone = $0 { return true }; return false })
@@ -75,16 +75,26 @@ final class DuckAiNativeStorageUserScriptTests: XCTestCase {
     func testWhenIsMigrationDoneReturnsTrueThenFiresAlreadyDonePixel() async throws {
         mockHandler.stubbedIsMigrationDone = true
         let handler = try XCTUnwrap(sut.handler(forMethodNamed: "isMigrationDone"))
-        _ = try await handler(["key": "chats"], WKScriptMessage())
+        _ = try await handler(["key": "chats"], MockUserScriptMessage())
         XCTAssertTrue(mockPixelFiring.firedEvents.contains { if case .migrationAlreadyDone = $0 { return true }; return false })
     }
 
     func testWhenIsMigrationDoneReturnsFalseThenDoesNotFireAlreadyDonePixel() async throws {
         mockHandler.stubbedIsMigrationDone = false
         let handler = try XCTUnwrap(sut.handler(forMethodNamed: "isMigrationDone"))
-        _ = try await handler(["key": "chats"], WKScriptMessage())
+        _ = try await handler(["key": "chats"], MockUserScriptMessage())
         XCTAssertFalse(mockPixelFiring.firedEvents.contains { if case .migrationAlreadyDone = $0 { return true }; return false })
     }
+}
+
+// MARK: - UserScriptMessage mock
+
+private struct MockUserScriptMessage: UserScriptMessage {
+    var messageName: String = ""
+    var messageBody: Any = [:]
+    var messageHost: String = ""
+    var messageWebView: WKWebView?
+    var isMainFrame: Bool = true
 }
 
 // MARK: - Test helpers

--- a/SharedPackages/BrowserServicesKit/Sources/DuckAiDataStore/DuckAiNativeDataStore.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DuckAiDataStore/DuckAiNativeDataStore.swift
@@ -158,6 +158,17 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
         }
     }
 
+    public func getChat(chatId: String) throws -> DuckAiChatRecord? {
+        do {
+            return try dbQueue.read { db in
+                guard let record = try ChatRecord.fetchOne(db, key: chatId) else { return nil }
+                return DuckAiChatRecord(chatId: record.chatId, data: record.data)
+            }
+        } catch {
+            throw DuckAiNativeDataStoreError.databaseError(error)
+        }
+    }
+
     public func getAllChats() throws -> [DuckAiChatRecord] {
         do {
             return try dbQueue.read { db in
@@ -275,6 +286,33 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
         do {
             try dbQueue.write { db in
                 try db.execute(sql: "DELETE FROM duck_ai_files WHERE uuid = ?", arguments: [normalizedUUID])
+            }
+        } catch {
+            throw DuckAiNativeDataStoreError.databaseError(error)
+        }
+    }
+
+    public func deleteFiles(chatId: String) throws {
+        let fileNames: [String]
+        do {
+            fileNames = try dbQueue.read { db in
+                try FileRecord
+                    .filter(Column("chatId") == chatId)
+                    .fetchAll(db)
+                    .map { $0.filePath }
+            }
+        } catch {
+            throw DuckAiNativeDataStoreError.databaseError(error)
+        }
+
+        for fileName in fileNames {
+            let fileURL = filesDirectoryURL.appendingPathComponent(fileName)
+            try? FileManager.default.removeItem(at: fileURL)
+        }
+
+        do {
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM duck_ai_files WHERE chatId = ?", arguments: [chatId])
             }
         } catch {
             throw DuckAiNativeDataStoreError.databaseError(error)

--- a/SharedPackages/BrowserServicesKit/Sources/DuckAiDataStore/DuckAiNativeDataStoring.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DuckAiDataStore/DuckAiNativeDataStoring.swift
@@ -24,6 +24,7 @@ public protocol DuckAiNativeDataStoring {
 
     func putChat(chatId: String, data: Data) throws
     func putChats(_ chats: [DuckAiChatRecord]) throws
+    func getChat(chatId: String) throws -> DuckAiChatRecord?
     func getAllChats() throws -> [DuckAiChatRecord]
     func deleteChat(chatId: String) throws
     func deleteAllChats() throws
@@ -34,6 +35,7 @@ public protocol DuckAiNativeDataStoring {
     func getFile(uuid: String) throws -> DuckAiFileContent?
     func listFiles() throws -> [DuckAiFileMetadata]
     func deleteFile(uuid: String) throws
+    func deleteFiles(chatId: String) throws
     func deleteAllFiles() throws
 }
 

--- a/SharedPackages/BrowserServicesKit/Tests/DuckAiDataStoreTests/DuckAiNativeDataStoreChatsTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DuckAiDataStoreTests/DuckAiNativeDataStoreChatsTests.swift
@@ -97,4 +97,21 @@ final class DuckAiNativeDataStoreChatsTests: XCTestCase {
     func testWhenDeleteNonExistentChatThenNoError() throws {
         XCTAssertNoThrow(try sut.deleteChat(chatId: "non-existent"))
     }
+
+    func testWhenGetChatOnExistingIdThenReturnsRecord() throws {
+        try sut.putChat(chatId: "chat-1", data: Data("one".utf8))
+        try sut.putChat(chatId: "chat-2", data: Data("two".utf8))
+
+        let record = try sut.getChat(chatId: "chat-2")
+
+        XCTAssertEqual(record, DuckAiChatRecord(chatId: "chat-2", data: Data("two".utf8)))
+    }
+
+    func testWhenGetChatOnMissingIdThenReturnsNil() throws {
+        try sut.putChat(chatId: "chat-1", data: Data("one".utf8))
+
+        let record = try sut.getChat(chatId: "chat-missing")
+
+        XCTAssertNil(record)
+    }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/DuckAiDataStoreTests/DuckAiNativeDataStoreFilesTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DuckAiDataStoreTests/DuckAiNativeDataStoreFilesTests.swift
@@ -196,6 +196,29 @@ final class DuckAiNativeDataStoreFilesTests: XCTestCase {
         }
     }
 
+    func testWhenDeleteFilesByChatIdThenOnlyThatChatsFilesAreRemoved() throws {
+        let uuidChat1A = "A1B2C3D4-E5F6-7890-ABCD-EF1234567890"
+        let uuidChat1B = "B2C3D4E5-F6A7-8901-BCDE-F12345678901"
+        let uuidChat2 = "C3D4E5F6-A7B8-9012-CDEF-123456789012"
+
+        try sut.putFile(uuid: uuidChat1A, chatId: "chat-1", data: Data("a".utf8))
+        try sut.putFile(uuid: uuidChat1B, chatId: "chat-1", data: Data("b".utf8))
+        try sut.putFile(uuid: uuidChat2, chatId: "chat-2", data: Data("c".utf8))
+
+        try sut.deleteFiles(chatId: "chat-1")
+
+        let remaining = try sut.listFiles()
+        XCTAssertEqual(remaining.map { $0.uuid }, [uuidChat2])
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: filesDirectory.appendingPathComponent(uuidChat1A).path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: filesDirectory.appendingPathComponent(uuidChat1B).path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: filesDirectory.appendingPathComponent(uuidChat2).path))
+    }
+
+    func testWhenDeleteFilesForChatWithNoFilesThenNoError() throws {
+        XCTAssertNoThrow(try sut.deleteFiles(chatId: "non-existent"))
+    }
+
     func testWhenFileEncryptedWithDifferentKeyThenGetFileThrowsFileReadError() throws {
         let uuid = "A1B2C3D4-E5F6-7890-ABCD-EF1234567890"
         let data = Data("secret".utf8)

--- a/SharedPackages/DebugServer/Sources/DebugServer/DebugHTTPServer.swift
+++ b/SharedPackages/DebugServer/Sources/DebugServer/DebugHTTPServer.swift
@@ -25,7 +25,7 @@ import os
 /// Register routes with `addRoute(_:method:handler:)` before calling `start()`.
 ///
 /// ```swift
-/// let server = DebugHTTPServer(port: 8080)
+/// let server = DebugHTTPServer(port: 8473)
 /// server.addRoute("/api/data", method: .GET) { request in
 ///     .json(someData)
 /// }
@@ -56,8 +56,8 @@ public final class DebugHTTPServer: HTTPServerProtocol {
 
     /// Creates a new debug server.
     ///
-    /// - Parameter port: The TCP port to listen on. Defaults to `8080`.
-    public init(port: UInt16 = 8080) {
+    /// - Parameter port: The TCP port to listen on. Defaults to `8473`.
+    public init(port: UInt16 = 8473) {
         self.port = port
         self.queue = DispatchQueue(label: "com.debugserver.listener", qos: .userInitiated)
     }

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1512,6 +1512,26 @@ extension Pixel {
         case aiChatContextualAutoAttachDAU
         case aiChatIsEnabledDaily
 
+        case aiChatNativeStorageMigrationDoneUnique(key: String)
+        case aiChatNativeStorageMigrationDoneCount(key: String)
+        case aiChatNativeStorageMigrationDoneBlankCount
+
+        case duckAiNativeStorageInitSuccess
+        case duckAiNativeStorageInitError
+        case duckAiNativeStorageMigrationStarted
+        case duckAiNativeStorageMigrationAlreadyDone
+        case duckAiNativeStorageMigrationError
+        case duckAiNativeStorageSettingsPutError
+        case duckAiNativeStorageSettingsGetError
+        case duckAiNativeStorageSettingsDeleteError
+        case duckAiNativeStorageChatPutError
+        case duckAiNativeStorageChatGetError
+        case duckAiNativeStorageChatDeleteError
+        case duckAiNativeStorageFilePutError
+        case duckAiNativeStorageFileGetError
+        case duckAiNativeStorageFileListError
+        case duckAiNativeStorageFileDeleteError
+
         case aiChatOmnibarSidebarButtonTapped
         case aiChatOmnibarNewChatButtonTapped
         
@@ -3122,6 +3142,26 @@ extension Pixel.Event {
         case .aiChatExperimentalAddressBarIsEnabledDaily: return "m_aichat_experimental_address_bar_is_enabled_daily"
         case .aiChatContextualAutoAttachDAU: return "m_aichat_contextual_auto_attach_dau"
         case .aiChatIsEnabledDaily: return "m_aichat_is_enabled_daily"
+
+        case .aiChatNativeStorageMigrationDoneUnique(let key): return "m_aichat_native_storage_migration_done_\(key)_unique"
+        case .aiChatNativeStorageMigrationDoneCount(let key): return "m_aichat_native_storage_migration_done_\(key)_count"
+        case .aiChatNativeStorageMigrationDoneBlankCount: return "m_aichat_native_storage_migration_done_blank_count"
+
+        case .duckAiNativeStorageInitSuccess: return "m_duck-ai_native-storage_init_success"
+        case .duckAiNativeStorageInitError: return "m_duck-ai_native-storage_init_error"
+        case .duckAiNativeStorageMigrationStarted: return "m_duck-ai_native-storage_migration_started"
+        case .duckAiNativeStorageMigrationAlreadyDone: return "m_duck-ai_native-storage_migration_already-done"
+        case .duckAiNativeStorageMigrationError: return "m_duck-ai_native-storage_migration_error"
+        case .duckAiNativeStorageSettingsPutError: return "m_duck-ai_native-storage_settings-put_error"
+        case .duckAiNativeStorageSettingsGetError: return "m_duck-ai_native-storage_settings-get_error"
+        case .duckAiNativeStorageSettingsDeleteError: return "m_duck-ai_native-storage_settings-delete_error"
+        case .duckAiNativeStorageChatPutError: return "m_duck-ai_native-storage_chat-put_error"
+        case .duckAiNativeStorageChatGetError: return "m_duck-ai_native-storage_chat-get_error"
+        case .duckAiNativeStorageChatDeleteError: return "m_duck-ai_native-storage_chat-delete_error"
+        case .duckAiNativeStorageFilePutError: return "m_duck-ai_native-storage_file-put_error"
+        case .duckAiNativeStorageFileGetError: return "m_duck-ai_native-storage_file-get_error"
+        case .duckAiNativeStorageFileListError: return "m_duck-ai_native-storage_file-list_error"
+        case .duckAiNativeStorageFileDeleteError: return "m_duck-ai_native-storage_file-delete_error"
 
         case .aiChatOmnibarSidebarButtonTapped: return "m_aichat_omnibar_sidebar_button_tapped"
         case .aiChatOmnibarNewChatButtonTapped: return "m_aichat_omnibar_new_chat_button_tapped"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -3143,9 +3143,9 @@ extension Pixel.Event {
         case .aiChatContextualAutoAttachDAU: return "m_aichat_contextual_auto_attach_dau"
         case .aiChatIsEnabledDaily: return "m_aichat_is_enabled_daily"
 
-        case .aiChatNativeStorageMigrationDoneUnique(let key): return "m_aichat_native_storage_migration_done_\(key)_unique"
-        case .aiChatNativeStorageMigrationDoneCount(let key): return "m_aichat_native_storage_migration_done_\(key)_count"
-        case .aiChatNativeStorageMigrationDoneBlankCount: return "m_aichat_native_storage_migration_done_blank_count"
+        case .aiChatNativeStorageMigrationDoneUnique(let key): return "m_duck-ai_native-storage_migration_done_\(key)_unique"
+        case .aiChatNativeStorageMigrationDoneCount(let key): return "m_duck-ai_native-storage_migration_done_\(key)_count"
+        case .aiChatNativeStorageMigrationDoneBlankCount: return "m_duck-ai_native-storage_migration_done_blank_count"
 
         case .duckAiNativeStorageInitSuccess: return "m_duck-ai_native-storage_init_success"
         case .duckAiNativeStorageInitError: return "m_duck-ai_native-storage_init_error"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1512,9 +1512,9 @@ extension Pixel {
         case aiChatContextualAutoAttachDAU
         case aiChatIsEnabledDaily
 
-        case aiChatNativeStorageMigrationDoneUnique(key: String)
-        case aiChatNativeStorageMigrationDoneCount(key: String)
-        case aiChatNativeStorageMigrationDoneBlankCount
+        case duckAiNativeStorageMigrationDoneUnique(key: String)
+        case duckAiNativeStorageMigrationDoneCount(key: String)
+        case duckAiNativeStorageMigrationDoneBlankCount
 
         case duckAiNativeStorageInitSuccess
         case duckAiNativeStorageInitError
@@ -3143,9 +3143,9 @@ extension Pixel.Event {
         case .aiChatContextualAutoAttachDAU: return "m_aichat_contextual_auto_attach_dau"
         case .aiChatIsEnabledDaily: return "m_aichat_is_enabled_daily"
 
-        case .aiChatNativeStorageMigrationDoneUnique(let key): return "m_duck-ai_native-storage_migration_done_\(key)_unique"
-        case .aiChatNativeStorageMigrationDoneCount(let key): return "m_duck-ai_native-storage_migration_done_\(key)_count"
-        case .aiChatNativeStorageMigrationDoneBlankCount: return "m_duck-ai_native-storage_migration_done_blank_count"
+        case .duckAiNativeStorageMigrationDoneUnique(let key): return "m_duck-ai_native-storage_migration_done_\(key)_unique"
+        case .duckAiNativeStorageMigrationDoneCount(let key): return "m_duck-ai_native-storage_migration_done_\(key)_count"
+        case .duckAiNativeStorageMigrationDoneBlankCount: return "m_duck-ai_native-storage_migration_done_blank_count"
 
         case .duckAiNativeStorageInitSuccess: return "m_duck-ai_native-storage_init_success"
         case .duckAiNativeStorageInitError: return "m_duck-ai_native-storage_init_error"

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -273,7 +273,8 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
             supportsHomePageEntryPoint: defaults.supportsHomePageEntryPoint,
             supportsOpenAIChatLink: defaults.supportsOpenAIChatLink,
             supportsAIChatSync: featureFlagger.isFeatureOn(.aiChatSync) && !fireMode,
-            supportsMultipleContexts: supportsContextualMode && featureFlagger.isFeatureOn(.multiplePageContexts)
+            supportsMultipleContexts: supportsContextualMode && featureFlagger.isFeatureOn(.multiplePageContexts),
+            supportsNativeStorage: featureFlagger.isFeatureOn(.aiChatNativeStorage)
         )
     }
 

--- a/iOS/DuckDuckGo/AIChatDebugView.swift
+++ b/iOS/DuckDuckGo/AIChatDebugView.swift
@@ -319,7 +319,7 @@ private struct AIChatStorageServerSection: View {
                     Text("Server running")
                         .foregroundColor(.green)
                     if let ip = serverState.localIPAddress {
-                        Text("http://\(ip):8080")
+                        Text("http://\(ip):8473")
                             .font(.system(.body, design: .monospaced))
                             .textSelection(.enabled)
                     }

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -409,10 +409,10 @@ struct DuckAiNativeStoragePixelAdapter: DuckAiNativeStoragePixelFiring {
         case .initError(let error):
             Pixel.fire(pixel: .duckAiNativeStorageInitError, error: error)
         case .migrationDone(let key):
-            UniquePixel.fire(pixel: .aiChatNativeStorageMigrationDoneUnique(key: key))
-            Pixel.fire(pixel: .aiChatNativeStorageMigrationDoneCount(key: key))
+            UniquePixel.fire(pixel: .duckAiNativeStorageMigrationDoneUnique(key: key))
+            Pixel.fire(pixel: .duckAiNativeStorageMigrationDoneCount(key: key))
         case .migrationDoneBlankKey:
-            Pixel.fire(pixel: .aiChatNativeStorageMigrationDoneBlankCount)
+            Pixel.fire(pixel: .duckAiNativeStorageMigrationDoneBlankCount)
         case .migrationStarted:
             Pixel.fire(pixel: .duckAiNativeStorageMigrationStarted)
         case .migrationAlreadyDone:

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -344,7 +344,11 @@ struct Launching: LaunchingHandling {
         let containerURL = groupContainer.appendingPathComponent(DuckAiNativeStorageProvider.directoryName)
         do {
             let keyStoreProvider = DuckAiKeyStoreProvider(accessGroup: Global.appConfigurationGroupName)
-            return try DuckAiNativeStorageProvider(containerURL: containerURL, keyStoreProvider: keyStoreProvider).handler
+            return try DuckAiNativeStorageProvider(
+                containerURL: containerURL,
+                keyStoreProvider: keyStoreProvider,
+                pixelFiring: DuckAiNativeStoragePixelAdapter()
+            ).handler
         } catch {
             Logger.aiChat.error("[NativeStorage] Handler init failed: \(error)")
             return nil
@@ -394,4 +398,47 @@ extension Launching {
                   lastBackgroundDateStorage: lastBackgroundDateStorage)
     }
 
+}
+
+struct DuckAiNativeStoragePixelAdapter: DuckAiNativeStoragePixelFiring {
+
+    func fire(_ event: DuckAiNativeStorageEvent) {
+        switch event {
+        case .initSuccess:
+            Pixel.fire(pixel: .duckAiNativeStorageInitSuccess)
+        case .initError(let error):
+            Pixel.fire(pixel: .duckAiNativeStorageInitError, error: error)
+        case .migrationDone(let key):
+            UniquePixel.fire(pixel: .aiChatNativeStorageMigrationDoneUnique(key: key))
+            Pixel.fire(pixel: .aiChatNativeStorageMigrationDoneCount(key: key))
+        case .migrationDoneBlankKey:
+            Pixel.fire(pixel: .aiChatNativeStorageMigrationDoneBlankCount)
+        case .migrationStarted:
+            Pixel.fire(pixel: .duckAiNativeStorageMigrationStarted)
+        case .migrationAlreadyDone:
+            Pixel.fire(pixel: .duckAiNativeStorageMigrationAlreadyDone)
+        case .migrationError(let error):
+            Pixel.fire(pixel: .duckAiNativeStorageMigrationError, error: error)
+        case .settingsPutError(let error):
+            Pixel.fire(pixel: .duckAiNativeStorageSettingsPutError, error: error)
+        case .settingsGetError(let error):
+            Pixel.fire(pixel: .duckAiNativeStorageSettingsGetError, error: error)
+        case .settingsDeleteError(let error):
+            Pixel.fire(pixel: .duckAiNativeStorageSettingsDeleteError, error: error)
+        case .chatPutError(let error):
+            Pixel.fire(pixel: .duckAiNativeStorageChatPutError, error: error)
+        case .chatGetError(let error):
+            Pixel.fire(pixel: .duckAiNativeStorageChatGetError, error: error)
+        case .chatDeleteError(let error):
+            Pixel.fire(pixel: .duckAiNativeStorageChatDeleteError, error: error)
+        case .filePutError(let error):
+            Pixel.fire(pixel: .duckAiNativeStorageFilePutError, error: error)
+        case .fileGetError(let error):
+            Pixel.fire(pixel: .duckAiNativeStorageFileGetError, error: error)
+        case .fileListError(let error):
+            Pixel.fire(pixel: .duckAiNativeStorageFileListError, error: error)
+        case .fileDeleteError(let error):
+            Pixel.fire(pixel: .duckAiNativeStorageFileDeleteError, error: error)
+        }
+    }
 }

--- a/iOS/DuckDuckGo/UserScripts.swift
+++ b/iOS/DuckDuckGo/UserScripts.swift
@@ -120,7 +120,8 @@ final class UserScripts: UserScriptsProvider {
             }
             duckAiNativeStorageUserScript = DuckAiNativeStorageUserScript(
                 handler: duckAiNativeStorageHandler,
-                originRules: originRules
+                originRules: originRules,
+                pixelFiring: DuckAiNativeStoragePixelAdapter()
             )
         } else {
             duckAiNativeStorageUserScript = nil
@@ -209,5 +210,5 @@ final class UserScripts: UserScriptsProvider {
             return wkUserScripts
         }
     }
-    
+
 }

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
@@ -1,0 +1,160 @@
+// Native storage pixels for Duck.ai.
+// The migration_done_{key}_unique/_count/_blank_count set mirrors Android's
+// per-key migration telemetry. The duck-ai_native-storage_* set tracks init,
+// migration lifecycle, and error events across Settings (Entries), Chats, and Files.
+{
+    "m_aichat_native_storage_migration_done_chats_unique": {
+        "description": "Fires once per install when Duck.ai migration from web to native storage completes for chats",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_native_storage_migration_done_chats_count": {
+        "description": "Count of Duck.ai chats migration completion notifications from the web frontend",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_native_storage_migration_done_files_unique": {
+        "description": "Fires once per install when Duck.ai migration from web to native storage completes for files",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_native_storage_migration_done_files_count": {
+        "description": "Count of Duck.ai files migration completion notifications from the web frontend",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_native_storage_migration_done_entries_unique": {
+        "description": "Fires once per install when Duck.ai migration from web to native storage completes for entries (general-purpose key-value store)",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_native_storage_migration_done_entries_count": {
+        "description": "Count of Duck.ai entries migration completion notifications from the web frontend",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_native_storage_migration_done_blank_count": {
+        "description": "Count of Duck.ai markMigrationDone messages received with a missing or blank key, indicating a protocol error from the frontend",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_duck-ai_native-storage_init_success": {
+        "description": "Fires when DuckAiNativeStorageProvider initializes successfully",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_duck-ai_native-storage_init_error": {
+        "description": "Fires when DuckAiNativeStorageProvider init fails (DB or directory creation)",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    },
+    "m_duck-ai_native-storage_migration_started": {
+        "description": "Fires when the web layer calls markMigrationDone (migration was attempted)",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_duck-ai_native-storage_migration_already-done": {
+        "description": "Fires when isMigrationDone returns true (page load found migration already complete)",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_duck-ai_native-storage_migration_error": {
+        "description": "Fires when isMigrationDone or markMigrationDone throws",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    },
+    "m_duck-ai_native-storage_settings-put_error": {
+        "description": "Fires when putEntry (Settings) fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    },
+    "m_duck-ai_native-storage_settings-get_error": {
+        "description": "Fires when getEntry or getAllEntries (Settings) fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    },
+    "m_duck-ai_native-storage_settings-delete_error": {
+        "description": "Fires when deleteEntry, deleteAllEntries, or replaceAllEntries (Settings) fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    },
+    "m_duck-ai_native-storage_chat-put_error": {
+        "description": "Fires when putChat or putChats fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    },
+    "m_duck-ai_native-storage_chat-get_error": {
+        "description": "Fires when getChat or getAllChats fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    },
+    "m_duck-ai_native-storage_chat-delete_error": {
+        "description": "Fires when deleteChat or deleteAllChats fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    },
+    "m_duck-ai_native-storage_file-put_error": {
+        "description": "Fires when putFile fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    },
+    "m_duck-ai_native-storage_file-get_error": {
+        "description": "Fires when getFile fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    },
+    "m_duck-ai_native-storage_file-list_error": {
+        "description": "Fires when listFiles fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    },
+    "m_duck-ai_native-storage_file-delete_error": {
+        "description": "Fires when deleteFile, deleteFiles (by chatId), or deleteAllFiles fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "errorDomain", "errorCode"]
+    }
+}

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
@@ -3,49 +3,49 @@
 // per-key migration telemetry. The duck-ai_native-storage_* set tracks init,
 // migration lifecycle, and error events across Settings (Entries), Chats, and Files.
 {
-    "m_aichat_native_storage_migration_done_chats_unique": {
+    "m_duck-ai_native-storage_migration_done_chats_unique": {
         "description": "Fires once per install when Duck.ai migration from web to native storage completes for chats",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
-    "m_aichat_native_storage_migration_done_chats_count": {
+    "m_duck-ai_native-storage_migration_done_chats_count": {
         "description": "Count of Duck.ai chats migration completion notifications from the web frontend",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
-    "m_aichat_native_storage_migration_done_files_unique": {
+    "m_duck-ai_native-storage_migration_done_files_unique": {
         "description": "Fires once per install when Duck.ai migration from web to native storage completes for files",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
-    "m_aichat_native_storage_migration_done_files_count": {
+    "m_duck-ai_native-storage_migration_done_files_count": {
         "description": "Count of Duck.ai files migration completion notifications from the web frontend",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
-    "m_aichat_native_storage_migration_done_entries_unique": {
+    "m_duck-ai_native-storage_migration_done_entries_unique": {
         "description": "Fires once per install when Duck.ai migration from web to native storage completes for entries (general-purpose key-value store)",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
-    "m_aichat_native_storage_migration_done_entries_count": {
+    "m_duck-ai_native-storage_migration_done_entries_count": {
         "description": "Count of Duck.ai entries migration completion notifications from the web frontend",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
-    "m_aichat_native_storage_migration_done_blank_count": {
+    "m_duck-ai_native-storage_migration_done_blank_count": {
         "description": "Count of Duck.ai markMigrationDone messages received with a missing or blank key, indicating a protocol error from the frontend",
         "owners": ["Bunn"],
         "triggers": ["other"],

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
@@ -102,7 +102,8 @@ extension AIChatMessageHandler {
             supportsOpenAIChatLink: defaults.supportsOpenAIChatLink,
             supportsAIChatSync: featureFlagger.isFeatureOn(.aiChatSync) && !isFireWindow,
             supportsMultipleContexts: featureFlagger.isFeatureOn(.aiChatPageContext) && featureFlagger.isFeatureOn(.aiChatMultiplePageContexts),
-            supportsTabPicker: featureFlagger.isFeatureOn(.aiChatPageContext) && featureFlagger.isFeatureOn(.aiChatAttachMoreTabs)
+            supportsTabPicker: featureFlagger.isFeatureOn(.aiChatPageContext) && featureFlagger.isFeatureOn(.aiChatAttachMoreTabs),
+            supportsNativeStorage: featureFlagger.isFeatureOn(.aiChatNativeStorage)
         )
     }
 

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -846,7 +846,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let nativeStorageContainerURL = appSupportURL.appendingPathComponent(DuckAiNativeStorageProvider.directoryName)
             do {
                 let keyStoreProvider = DuckAiKeyStoreProvider()
-                duckAiNativeStorageHandler = try DuckAiNativeStorageProvider(containerURL: nativeStorageContainerURL, keyStoreProvider: keyStoreProvider).handler
+                duckAiNativeStorageHandler = try DuckAiNativeStorageProvider(
+                    containerURL: nativeStorageContainerURL,
+                    keyStoreProvider: keyStoreProvider,
+                    pixelFiring: DuckAiNativeStoragePixelAdapter()
+                ).handler
             } catch {
                 Logger.aiChat.error("[NativeStorage] Handler init failed: \(error)")
                 duckAiNativeStorageHandler = nil
@@ -2319,4 +2323,47 @@ private extension FeatureFlagLocalOverrides {
         }
     }
 
+}
+
+struct DuckAiNativeStoragePixelAdapter: DuckAiNativeStoragePixelFiring {
+
+    func fire(_ event: DuckAiNativeStorageEvent) {
+        switch event {
+        case .initSuccess:
+            PixelKit.fire(GeneralPixel.duckAiNativeStorageInitSuccess)
+        case .initError(let error):
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageInitError, error: error))
+        case .migrationDone(let key):
+            PixelKit.fire(GeneralPixel.aiChatNativeStorageMigrationDoneUnique(key: key), frequency: .uniqueByName)
+            PixelKit.fire(GeneralPixel.aiChatNativeStorageMigrationDoneCount(key: key))
+        case .migrationDoneBlankKey:
+            PixelKit.fire(GeneralPixel.aiChatNativeStorageMigrationDoneBlankCount)
+        case .migrationStarted:
+            PixelKit.fire(GeneralPixel.duckAiNativeStorageMigrationStarted)
+        case .migrationAlreadyDone:
+            PixelKit.fire(GeneralPixel.duckAiNativeStorageMigrationAlreadyDone)
+        case .migrationError(let error):
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageMigrationError, error: error))
+        case .settingsPutError(let error):
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageSettingsPutError, error: error))
+        case .settingsGetError(let error):
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageSettingsGetError, error: error))
+        case .settingsDeleteError(let error):
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageSettingsDeleteError, error: error))
+        case .chatPutError(let error):
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageChatPutError, error: error))
+        case .chatGetError(let error):
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageChatGetError, error: error))
+        case .chatDeleteError(let error):
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageChatDeleteError, error: error))
+        case .filePutError(let error):
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageFilePutError, error: error))
+        case .fileGetError(let error):
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageFileGetError, error: error))
+        case .fileListError(let error):
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageFileListError, error: error))
+        case .fileDeleteError(let error):
+            PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageFileDeleteError, error: error))
+        }
+    }
 }

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -2334,10 +2334,10 @@ struct DuckAiNativeStoragePixelAdapter: DuckAiNativeStoragePixelFiring {
         case .initError(let error):
             PixelKit.fire(DebugEvent(GeneralPixel.duckAiNativeStorageInitError, error: error))
         case .migrationDone(let key):
-            PixelKit.fire(GeneralPixel.aiChatNativeStorageMigrationDoneUnique(key: key), frequency: .uniqueByName)
-            PixelKit.fire(GeneralPixel.aiChatNativeStorageMigrationDoneCount(key: key))
+            PixelKit.fire(GeneralPixel.duckAiNativeStorageMigrationDoneUnique(key: key), frequency: .uniqueByName)
+            PixelKit.fire(GeneralPixel.duckAiNativeStorageMigrationDoneCount(key: key))
         case .migrationDoneBlankKey:
-            PixelKit.fire(GeneralPixel.aiChatNativeStorageMigrationDoneBlankCount)
+            PixelKit.fire(GeneralPixel.duckAiNativeStorageMigrationDoneBlankCount)
         case .migrationStarted:
             PixelKit.fire(GeneralPixel.duckAiNativeStorageMigrationStarted)
         case .migrationAlreadyDone:

--- a/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -301,6 +301,26 @@ enum GeneralPixel: PixelKitEvent {
     case hideAIGeneratedImagesButtonClicked
     case openDuckAIButtonClick
 
+    case aiChatNativeStorageMigrationDoneUnique(key: String)
+    case aiChatNativeStorageMigrationDoneCount(key: String)
+    case aiChatNativeStorageMigrationDoneBlankCount
+
+    case duckAiNativeStorageInitSuccess
+    case duckAiNativeStorageInitError
+    case duckAiNativeStorageMigrationStarted
+    case duckAiNativeStorageMigrationAlreadyDone
+    case duckAiNativeStorageMigrationError
+    case duckAiNativeStorageSettingsPutError
+    case duckAiNativeStorageSettingsGetError
+    case duckAiNativeStorageSettingsDeleteError
+    case duckAiNativeStorageChatPutError
+    case duckAiNativeStorageChatGetError
+    case duckAiNativeStorageChatDeleteError
+    case duckAiNativeStorageFilePutError
+    case duckAiNativeStorageFileGetError
+    case duckAiNativeStorageFileListError
+    case duckAiNativeStorageFileDeleteError
+
     case protectionToggledOffBreakageReport
     case debugBreakageExperiment
 
@@ -1016,6 +1036,26 @@ enum GeneralPixel: PixelKitEvent {
         case .hideAIGeneratedImagesButtonClicked: return "m_mac_aichat_hide_ai_generated_images_button_clicked"
         case .openDuckAIButtonClick: return "m_mac_serp_settings_open_duck_ai_button_click"
 
+        case .aiChatNativeStorageMigrationDoneUnique(let key): return "m_mac_aichat_native_storage_migration_done_\(key)_u"
+        case .aiChatNativeStorageMigrationDoneCount(let key): return "m_mac_aichat_native_storage_migration_done_\(key)_count"
+        case .aiChatNativeStorageMigrationDoneBlankCount: return "m_mac_aichat_native_storage_migration_done_blank_count"
+
+        case .duckAiNativeStorageInitSuccess: return "m_mac_duck-ai_native-storage_init_success"
+        case .duckAiNativeStorageInitError: return "m_mac_duck-ai_native-storage_init_error"
+        case .duckAiNativeStorageMigrationStarted: return "m_mac_duck-ai_native-storage_migration_started"
+        case .duckAiNativeStorageMigrationAlreadyDone: return "m_mac_duck-ai_native-storage_migration_already-done"
+        case .duckAiNativeStorageMigrationError: return "m_mac_duck-ai_native-storage_migration_error"
+        case .duckAiNativeStorageSettingsPutError: return "m_mac_duck-ai_native-storage_settings-put_error"
+        case .duckAiNativeStorageSettingsGetError: return "m_mac_duck-ai_native-storage_settings-get_error"
+        case .duckAiNativeStorageSettingsDeleteError: return "m_mac_duck-ai_native-storage_settings-delete_error"
+        case .duckAiNativeStorageChatPutError: return "m_mac_duck-ai_native-storage_chat-put_error"
+        case .duckAiNativeStorageChatGetError: return "m_mac_duck-ai_native-storage_chat-get_error"
+        case .duckAiNativeStorageChatDeleteError: return "m_mac_duck-ai_native-storage_chat-delete_error"
+        case .duckAiNativeStorageFilePutError: return "m_mac_duck-ai_native-storage_file-put_error"
+        case .duckAiNativeStorageFileGetError: return "m_mac_duck-ai_native-storage_file-get_error"
+        case .duckAiNativeStorageFileListError: return "m_mac_duck-ai_native-storage_file-list_error"
+        case .duckAiNativeStorageFileDeleteError: return "m_mac_duck-ai_native-storage_file-delete_error"
+
         case .protectionToggledOffBreakageReport: return "m_mac_protection-toggled-off-breakage-report"
         case .debugBreakageExperiment: return "m_mac_debug_breakage_experiment_u"
 
@@ -1723,6 +1763,24 @@ enum GeneralPixel: PixelKitEvent {
                 .serpSettingsKeyValueStoreWriteError,
                 .hideAIGeneratedImagesButtonClicked,
                 .openDuckAIButtonClick,
+                .aiChatNativeStorageMigrationDoneUnique,
+                .aiChatNativeStorageMigrationDoneCount,
+                .aiChatNativeStorageMigrationDoneBlankCount,
+                .duckAiNativeStorageInitSuccess,
+                .duckAiNativeStorageInitError,
+                .duckAiNativeStorageMigrationStarted,
+                .duckAiNativeStorageMigrationAlreadyDone,
+                .duckAiNativeStorageMigrationError,
+                .duckAiNativeStorageSettingsPutError,
+                .duckAiNativeStorageSettingsGetError,
+                .duckAiNativeStorageSettingsDeleteError,
+                .duckAiNativeStorageChatPutError,
+                .duckAiNativeStorageChatGetError,
+                .duckAiNativeStorageChatDeleteError,
+                .duckAiNativeStorageFilePutError,
+                .duckAiNativeStorageFileGetError,
+                .duckAiNativeStorageFileListError,
+                .duckAiNativeStorageFileDeleteError,
                 .protectionToggledOffBreakageReport,
                 .debugBreakageExperiment,
                 .passwordImportKeychainPrompt,

--- a/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -301,9 +301,9 @@ enum GeneralPixel: PixelKitEvent {
     case hideAIGeneratedImagesButtonClicked
     case openDuckAIButtonClick
 
-    case aiChatNativeStorageMigrationDoneUnique(key: String)
-    case aiChatNativeStorageMigrationDoneCount(key: String)
-    case aiChatNativeStorageMigrationDoneBlankCount
+    case duckAiNativeStorageMigrationDoneUnique(key: String)
+    case duckAiNativeStorageMigrationDoneCount(key: String)
+    case duckAiNativeStorageMigrationDoneBlankCount
 
     case duckAiNativeStorageInitSuccess
     case duckAiNativeStorageInitError
@@ -1036,9 +1036,9 @@ enum GeneralPixel: PixelKitEvent {
         case .hideAIGeneratedImagesButtonClicked: return "m_mac_aichat_hide_ai_generated_images_button_clicked"
         case .openDuckAIButtonClick: return "m_mac_serp_settings_open_duck_ai_button_click"
 
-        case .aiChatNativeStorageMigrationDoneUnique(let key): return "m_mac_aichat_native_storage_migration_done_\(key)_u"
-        case .aiChatNativeStorageMigrationDoneCount(let key): return "m_mac_aichat_native_storage_migration_done_\(key)_count"
-        case .aiChatNativeStorageMigrationDoneBlankCount: return "m_mac_aichat_native_storage_migration_done_blank_count"
+        case .duckAiNativeStorageMigrationDoneUnique(let key): return "m_mac_duck-ai_native-storage_migration_done_\(key)_u"
+        case .duckAiNativeStorageMigrationDoneCount(let key): return "m_mac_duck-ai_native-storage_migration_done_\(key)_count"
+        case .duckAiNativeStorageMigrationDoneBlankCount: return "m_mac_duck-ai_native-storage_migration_done_blank_count"
 
         case .duckAiNativeStorageInitSuccess: return "m_mac_duck-ai_native-storage_init_success"
         case .duckAiNativeStorageInitError: return "m_mac_duck-ai_native-storage_init_error"
@@ -1763,9 +1763,9 @@ enum GeneralPixel: PixelKitEvent {
                 .serpSettingsKeyValueStoreWriteError,
                 .hideAIGeneratedImagesButtonClicked,
                 .openDuckAIButtonClick,
-                .aiChatNativeStorageMigrationDoneUnique,
-                .aiChatNativeStorageMigrationDoneCount,
-                .aiChatNativeStorageMigrationDoneBlankCount,
+                .duckAiNativeStorageMigrationDoneUnique,
+                .duckAiNativeStorageMigrationDoneCount,
+                .duckAiNativeStorageMigrationDoneBlankCount,
                 .duckAiNativeStorageInitSuccess,
                 .duckAiNativeStorageInitError,
                 .duckAiNativeStorageMigrationStarted,

--- a/macOS/DuckDuckGo/Tab/TabExtensions/AIChatTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/AIChatTabExtension.swift
@@ -20,7 +20,10 @@ import Navigation
 import Foundation
 import Combine
 import FeatureFlags
+import os.log
+import Persistence
 import PrivacyConfig
+import UserScript
 import WebKit
 import AIChat
 import BrowserServicesKit
@@ -38,6 +41,7 @@ final class AIChatTabExtension {
     private weak var webView: WKWebView?
     private let featureDiscovery: FeatureDiscovery
     private let featureFlagger: FeatureFlagger
+    private let bootstrapRefresher: DuckAiNativeStorageBootstrapScriptRefresher?
 
     private(set) weak var aiChatUserScript: AIChatUserScript? {
         didSet {
@@ -49,10 +53,18 @@ final class AIChatTabExtension {
          webViewPublisher: some Publisher<WKWebView, Never>,
          isLoadedInSidebar: Bool,
          featureDiscovery: FeatureDiscovery = DefaultFeatureDiscovery(),
-         featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger) {
+         featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
+         duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = NSApp.delegateTyped.duckAiNativeStorageHandler,
+         aiChatDebugURLSettings: (any KeyedStoring<AIChatDebugURLSettings>)? = nil) {
         self.isLoadedInSidebar = isLoadedInSidebar
         self.featureDiscovery = featureDiscovery
         self.featureFlagger = featureFlagger
+        let debugSettings: any KeyedStoring<AIChatDebugURLSettings> = if let aiChatDebugURLSettings { aiChatDebugURLSettings } else { UserDefaults.standard.keyedStoring() }
+        self.bootstrapRefresher = Self.makeBootstrapRefresher(
+            featureFlagger: featureFlagger,
+            handler: duckAiNativeStorageHandler,
+            aiChatDebugURLSettings: debugSettings
+        )
         pageContextRequestedPublisher = pageContextRequestedSubject.eraseToAnyPublisher()
         pageContextConsumedPublisher = pageContextConsumedSubject.eraseToAnyPublisher()
         pageContextRemovedPublisher = pageContextRemovedSubject.eraseToAnyPublisher()
@@ -200,6 +212,8 @@ final class AIChatTabExtension {
 extension AIChatTabExtension: NavigationResponder {
 
     func decidePolicy(for navigationAction: NavigationAction, preferences: inout NavigationPreferences) async -> NavigationActionPolicy? {
+        refreshNativeStorageBootstrapIfNeeded(for: navigationAction)
+
         // Only handle sidebar, user-initiated, cross-document navigations; otherwise let them proceed normally
         guard isLoadedInSidebar,
               !navigationAction.navigationType.isSameDocumentNavigation,
@@ -233,6 +247,47 @@ extension AIChatTabExtension: NavigationResponder {
         if navigation.url.isDuckAIURL {
             featureDiscovery.setWasUsedBefore(.aiChat)
         }
+    }
+}
+
+// MARK: - Native Storage Bootstrap Refresh
+
+extension AIChatTabExtension {
+
+    @MainActor
+    fileprivate func refreshNativeStorageBootstrapIfNeeded(for navigationAction: NavigationAction) {
+        guard let bootstrapRefresher else {
+            Logger.aiChat.debug("[NativeStorage] Skipping bootstrap refresh: refresher unavailable (flag off or handler nil)")
+            return
+        }
+        guard !navigationAction.navigationType.isSameDocumentNavigation else { return }
+        guard bootstrapRefresher.isInScope(url: navigationAction.url) else {
+            Logger.aiChat.debug("[NativeStorage] Skipping bootstrap refresh: \(navigationAction.url.host ?? "<nil>") out of scope")
+            return
+        }
+        guard let webView else {
+            Logger.aiChat.debug("[NativeStorage] Skipping bootstrap refresh: webView not yet available")
+            return
+        }
+        guard let userContentController = webView.configuration.userContentController as? UserContentController else {
+            Logger.aiChat.debug("[NativeStorage] Skipping bootstrap refresh: user content controller cast failed")
+            return
+        }
+        let staticScripts = userContentController.contentBlockingAssets?.wkUserScripts ?? []
+        bootstrapRefresher.refresh(on: userContentController, staticScripts: staticScripts)
+    }
+
+    fileprivate static func makeBootstrapRefresher(
+        featureFlagger: FeatureFlagger,
+        handler: DuckAiNativeStorageHandling?,
+        aiChatDebugURLSettings: any KeyedStoring<AIChatDebugURLSettings>
+    ) -> DuckAiNativeStorageBootstrapScriptRefresher? {
+        guard featureFlagger.isFeatureOn(.aiChatNativeStorage), let handler else { return nil }
+        var originRules: [HostnameMatchingRule] = [.exactOrSubdomain(hostname: "duck.ai")]
+        if let customHostname = aiChatDebugURLSettings.customURLHostname {
+            originRules.append(.exact(hostname: customHostname))
+        }
+        return DuckAiNativeStorageBootstrapScriptRefresher(handler: handler, originRules: originRules)
     }
 }
 

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -106,7 +106,8 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
             }
             duckAiNativeStorageUserScript = DuckAiNativeStorageUserScript(
                 handler: duckAiNativeStorageHandler,
-                originRules: originRules
+                originRules: originRules,
+                pixelFiring: DuckAiNativeStoragePixelAdapter()
             )
         } else {
             duckAiNativeStorageUserScript = nil

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
@@ -1,0 +1,160 @@
+// Native storage pixels for Duck.ai.
+// The migration_done_{key}_u/_count/_blank_count set mirrors Android's
+// per-key migration telemetry. The duck-ai_native-storage_* set tracks init,
+// migration lifecycle, and error events across Settings (Entries), Chats, and Files.
+{
+    "m_mac_aichat_native_storage_migration_done_chats_u": {
+        "description": "Fires once per install when Duck.ai migration from web to native storage completes for chats",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_aichat_native_storage_migration_done_chats_count": {
+        "description": "Count of Duck.ai chats migration completion notifications from the web frontend",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_aichat_native_storage_migration_done_files_u": {
+        "description": "Fires once per install when Duck.ai migration from web to native storage completes for files",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_aichat_native_storage_migration_done_files_count": {
+        "description": "Count of Duck.ai files migration completion notifications from the web frontend",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_aichat_native_storage_migration_done_entries_u": {
+        "description": "Fires once per install when Duck.ai migration from web to native storage completes for entries (general-purpose key-value store)",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_aichat_native_storage_migration_done_entries_count": {
+        "description": "Count of Duck.ai entries migration completion notifications from the web frontend",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_aichat_native_storage_migration_done_blank_count": {
+        "description": "Count of Duck.ai markMigrationDone messages received with a missing or blank key, indicating a protocol error from the frontend",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_duck-ai_native-storage_init_success": {
+        "description": "Fires when DuckAiNativeStorageProvider initializes successfully",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_duck-ai_native-storage_init_error": {
+        "description": "Fires when DuckAiNativeStorageProvider init fails (DB or directory creation)",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+    },
+    "m_mac_duck-ai_native-storage_migration_started": {
+        "description": "Fires when the web layer calls markMigrationDone (migration was attempted)",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_duck-ai_native-storage_migration_already-done": {
+        "description": "Fires when isMigrationDone returns true (page load found migration already complete)",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_duck-ai_native-storage_migration_error": {
+        "description": "Fires when isMigrationDone or markMigrationDone throws",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+    },
+    "m_mac_duck-ai_native-storage_settings-put_error": {
+        "description": "Fires when putEntry (Settings) fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+    },
+    "m_mac_duck-ai_native-storage_settings-get_error": {
+        "description": "Fires when getEntry or getAllEntries (Settings) fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+    },
+    "m_mac_duck-ai_native-storage_settings-delete_error": {
+        "description": "Fires when deleteEntry, deleteAllEntries, or replaceAllEntries (Settings) fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+    },
+    "m_mac_duck-ai_native-storage_chat-put_error": {
+        "description": "Fires when putChat or putChats fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+    },
+    "m_mac_duck-ai_native-storage_chat-get_error": {
+        "description": "Fires when getChat or getAllChats fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+    },
+    "m_mac_duck-ai_native-storage_chat-delete_error": {
+        "description": "Fires when deleteChat or deleteAllChats fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+    },
+    "m_mac_duck-ai_native-storage_file-put_error": {
+        "description": "Fires when putFile fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+    },
+    "m_mac_duck-ai_native-storage_file-get_error": {
+        "description": "Fires when getFile fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+    },
+    "m_mac_duck-ai_native-storage_file-list_error": {
+        "description": "Fires when listFiles fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+    },
+    "m_mac_duck-ai_native-storage_file-delete_error": {
+        "description": "Fires when deleteFile, deleteFiles (by chatId), or deleteAllFiles fails",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+    }
+}

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_native_storage_pixels.json5
@@ -3,49 +3,49 @@
 // per-key migration telemetry. The duck-ai_native-storage_* set tracks init,
 // migration lifecycle, and error events across Settings (Entries), Chats, and Files.
 {
-    "m_mac_aichat_native_storage_migration_done_chats_u": {
+    "m_mac_duck-ai_native-storage_migration_done_chats_u": {
         "description": "Fires once per install when Duck.ai migration from web to native storage completes for chats",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource"]
     },
-    "m_mac_aichat_native_storage_migration_done_chats_count": {
+    "m_mac_duck-ai_native-storage_migration_done_chats_count": {
         "description": "Count of Duck.ai chats migration completion notifications from the web frontend",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource"]
     },
-    "m_mac_aichat_native_storage_migration_done_files_u": {
+    "m_mac_duck-ai_native-storage_migration_done_files_u": {
         "description": "Fires once per install when Duck.ai migration from web to native storage completes for files",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource"]
     },
-    "m_mac_aichat_native_storage_migration_done_files_count": {
+    "m_mac_duck-ai_native-storage_migration_done_files_count": {
         "description": "Count of Duck.ai files migration completion notifications from the web frontend",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource"]
     },
-    "m_mac_aichat_native_storage_migration_done_entries_u": {
+    "m_mac_duck-ai_native-storage_migration_done_entries_u": {
         "description": "Fires once per install when Duck.ai migration from web to native storage completes for entries (general-purpose key-value store)",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource"]
     },
-    "m_mac_aichat_native_storage_migration_done_entries_count": {
+    "m_mac_duck-ai_native-storage_migration_done_entries_count": {
         "description": "Count of Duck.ai entries migration completion notifications from the web frontend",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource"]
     },
-    "m_mac_aichat_native_storage_migration_done_blank_count": {
+    "m_mac_duck-ai_native-storage_migration_done_blank_count": {
         "description": "Count of Duck.ai markMigrationDone messages received with a missing or blank key, indicating a protocol error from the frontend",
         "owners": ["Bunn"],
         "triggers": ["other"],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213993353027286?focus=true
Tech Design URL:
CC:

### Description
Adds the two previously-missing Duck.ai native-storage bridge methods (`getChat(chatId)` and `deleteFiles(chatId)`) so the Apple API matches the approved spec and Android. Wires the full set of native-storage pixels — initialization, migration lifecycle, and per-operation error pixels for Entries/Chats/Files — on both iOS and macOS with platform-appropriate prefixes. Error pixels forward only `errorCode` + `errorDomain` via the existing Pixel/PixelKit helpers, which intentionally exclude `localizedDescription` and arbitrary `userInfo`.

### Testing Steps
Check https://app.asana.com/1/137249556945/project/72649045549333/task/1214035791283493?focus=true for extra info

1. Set duck.ai URL to https://euw-serp-dev-testing19.duck.ai/
2. Open new chats, create images, add images to chats
3. Se the privacy config file for macOS and iOS
4. Restart the app
5. Check if all the data is there
6. Check the logs to see if it's being accessed thru the native storage
7. Check the file system on macOS to see if the files are there (~/Library/Application Support/DuckAiNativeStorage
8. On duck.ai, create new chats, delete chats, see if it works as expected.

### Impact and Risks
Low — additive pixels and two new JS-bridge methods, all behind the existing `duckAiNativeStorage` feature flag.

#### What could go wrong?
A new migration key sent by the frontend wouldn't have a matching entry in the JSON5 pixel definitions and would fail pixel validation until added.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new native-storage bridge operations (chat read and per-chat file deletion) plus early page script injection and broad pixel firing; mistakes could affect persisted chat/file data deletion or leak whitelisted values into web content, though it’s gated by the `aiChatNativeStorage` flag.
> 
> **Overview**
> Adds the missing Duck.ai native-storage bridge methods to match the approved spec: `getChat(chatId)` and `deleteFiles(chatId)` (delete all files for a chat), plumbing them through the handler protocol, user script message surface, and the encrypted `DuckAiNativeDataStore`.
> 
> Introduces an early-injected bootstrap user script (and a `WKUserScript` refresher used on macOS navigations) that exposes a *small allowlist* of native-storage keys on `window` at document start to avoid UI flash, scoped to configured Duck.ai host rules.
> 
> Wires full native-storage telemetry on iOS and macOS: provider init success/failure, migration lifecycle, and per-operation error pixels for entries/chats/files (including new JSON5 pixel definitions), and updates native config to advertise `supportsNativeStorage`; also changes the debug storage server default port to `8473`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e85b5a6f8f905ba2aaad58dc8e871f25d365ced5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->