### PR TITLE
[iOS] Fix Auto Delete clearing tabs even when Tabs toggle is off

### DIFF
--- a/iOS/DuckDuckGo/AppServices/AutoClearService.swift
+++ b/iOS/DuckDuckGo/AppServices/AutoClearService.swift
@@ -24,6 +24,7 @@ protocol AutoClearServiceProtocol {
 
     var autoClearTask: Task<Void, Never>? { get }
     var isClearingEnabled: Bool { get }
+    var isTabClearingEnabled: Bool { get }
     func waitForDataCleared() async
 
 }
@@ -39,6 +40,10 @@ final class AutoClearService: AutoClearServiceProtocol {
 
     var isClearingEnabled: Bool {
         autoClear.isClearingEnabled
+    }
+
+    var isTabClearingEnabled: Bool {
+        autoClear.isTabClearingEnabled
     }
 
     init(autoClear: AutoClearing,

--- a/iOS/DuckDuckGo/AutoClear.swift
+++ b/iOS/DuckDuckGo/AutoClear.swift
@@ -24,6 +24,7 @@ import Core
 protocol AutoClearing {
 
     var isClearingEnabled: Bool { get }
+    var isTabClearingEnabled: Bool { get }
     func clearDataIfEnabled(launching: Bool, applicationState: DataStoreWarmup.ApplicationState) async
 
     var isClearingDue: Bool { get }
@@ -40,6 +41,11 @@ final class AutoClear: AutoClearing {
 
     var isClearingEnabled: Bool {
         return AutoClearSettingsModel(settings: appSettings) != nil
+    }
+
+    var isTabClearingEnabled: Bool {
+        guard let settings = AutoClearSettingsModel(settings: appSettings) else { return false }
+        return settings.action.contains(.tabs)
     }
 
     init(worker: FireExecuting,

--- a/iOS/DuckDuckGo/LaunchTask/ClearInteractionStateTask.swift
+++ b/iOS/DuckDuckGo/LaunchTask/ClearInteractionStateTask.swift
@@ -28,7 +28,7 @@ struct ClearInteractionStateTask: LaunchTask {
     var name: String = "Clear Interaction State"
 
     func run(context: LaunchTaskContext) {
-        guard !autoClearService.isClearingEnabled, let interactionStateSource else {
+        guard !autoClearService.isTabClearingEnabled, let interactionStateSource else {
             context.finish()
             return
         }

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -474,7 +474,8 @@ final class MainCoordinator {
         let normalModel: TabsModel
         let fireModel: TabsModel
 
-        if AutoClearSettingsModel(settings: appSettings) != nil {
+        if let autoClearSettings = AutoClearSettingsModel(settings: appSettings),
+           autoClearSettings.action.contains(.tabs) {
             normalModel = TabsModel(desktop: isPadDevice, mode: .normal)
             fireModel = TabsModel(desktop: isPadDevice, mode: .fire)
             tabsPersistence.clearAll()

--- a/iOS/DuckDuckGoTests/AppServices/AutoClearServiceTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/AutoClearServiceTests.swift
@@ -38,6 +38,10 @@ final class MockAutoClear: AutoClearing {
         isClearingEnabledValue
     }
 
+    var isTabClearingEnabled: Bool {
+        isClearingEnabledValue
+    }
+
     func clearDataIfEnabled(launching: Bool, applicationState: DataStoreWarmup.ApplicationState) async {
         clearDataIfEnabledCalled = true
         lastLaunchingValue = launching

--- a/iOS/DuckDuckGoTests/UIInteractionManagerTests.swift
+++ b/iOS/DuckDuckGoTests/UIInteractionManagerTests.swift
@@ -36,6 +36,7 @@ final class MockAuthenticationService: AuthenticationServiceProtocol {
 final class MockAutoClearService: AutoClearServiceProtocol {
 
     var isClearingEnabled: Bool = true
+    var isTabClearingEnabled: Bool = true
     var autoClearTask: Task<Void, Never>?
 
     var waitForDataClearedCalled = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1214086321342090?focus=true

### Description
This PR fixes tabs being unconditionally deleted on app launch when any Auto Delete option is enabled, even if the user has turned off the Tabs toggle
* Root cause: MainCoordinator.prepareTabsModel() checked AutoClearSettingsModel(settings:) != nil to decide whether to wipe all tabs on launch. This condition is true whenever any auto-clear action is configured (e.g. cookies/site data only), regardless of whether .tabs is included. As a result, enabling Auto Delete with only "Cookies and Site Data" still destroyed all tabs at startup — before the auto-clear logic (which correctly respects the granular options) even ran.
* Fix: Add an additional check for .tabs being present in the auto-clear action, so tabs are only wiped at model-preparation time when the user has explicitly opted in to clearing tabs

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->

1. Open Settings → Data Clearing → Automatically Delete Data
2. Enable Auto Delete
3. Turn off the Tabs toggle (leave Cookies and Site Data on)
4. Open several tabs and navigate to different websites
5. Kill the app (swipe away from app switcher)
6. Relaunch the app
7. Verify tabs are preserved (not deleted)
8. Now turn the Tabs toggle back on
9. Kill and relaunch the app
10. Verify tabs are deleted as expected

### Impact and Risks
This fixes a high-impact issue. But it doesn't add risk of side effects because the fix's scope is small.

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches launch-time tab persistence/cleanup conditions; a small logic change, but regressions could impact whether users keep or lose tabs on startup.
> 
> **Overview**
> Fixes Auto Delete tab wiping to only happen when the user has explicitly enabled the *Tabs* auto-clear option.
> 
> This introduces `isTabClearingEnabled` on `AutoClearing`/`AutoClearServiceProtocol`, uses it to gate launch-time tab model/persistence clearing in `MainCoordinator.prepareTabsModel`, and updates `ClearInteractionStateTask` to only skip cleanup when tab-clearing is enabled (with corresponding test mock updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e116bf051015c80097abb4b301c4c6830649f055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->