### PR TITLE
macOS: Fixes an issue that caused sites to fail to load

### DIFF
--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -1563,8 +1563,7 @@ extension Tab/*: NavigationResponder*/ { // to be moved to Tab+Navigation.swift
 
     func renderingProgressDidChange(progressEvents: UInt) {
         // Emit only after first paint event, when the white background content is not visible anymore
-        let events = _WKRenderingProgressEvents(rawValue: progressEvents)
-        if events.contains(.firstVisuallyNonEmptyLayout) {
+        if progressEvents >= _WKRenderingProgressEvents.firstVisuallyNonEmptyLayout.rawValue {
             webViewRenderingProgressDidChangePublisher.send()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1213659555956031/task/1214137732388403?focus=true

### Description

We've reason to believe a change we pushed recently is causing site loading issues for some users.  This PR provides a more defensive approach that's guaranteed to work at least as well as the original code.

### Testing Steps

Just load sites, make sure they work fine.  We have no reproduction steps for this issue.

### Impact and Risks

Low risk - this change is inherently more defensive than our fix, and more permissive than the original code.
Impact is high IF this is causing trouble, which is unclear.

#### What could go wrong?

Nothing I can think of.

### Quality Considerations

NA

### Notes to Reviewer

NA

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-condition change that only affects when a UI unlock signal is emitted; main risk is showing the webview slightly earlier than intended.
> 
> **Overview**
> Loosens the delayed webview presentation “first paint” gate by changing `Tab.renderingProgressDidChange` to emit once `progressEvents` reaches *or exceeds* `_WKRenderingProgressEvents.firstVisuallyNonEmptyLayout`, rather than requiring that specific bit to be present.
> 
> This makes the rendering-progress unlock more defensive against missing/interpreted rendering milestones, helping avoid cases where tab content might stay hidden and appear to “not load.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 219647ff903000e7b2553b1d460634d51cdc9bbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->