### PR TITLE
Fix epbf and m_forget-all-pressed_settings pixel schemas

### DIFF
--- a/iOS/PixelDefinitions/pixels/definitions/broken_site_reporting.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/broken_site_reporting.json5
@@ -28,6 +28,7 @@
                     "login",
                     "other",
                     "paywall",
+                    "popups-not-opening",
                     "shopping",
                     "videos"
                 ]

--- a/iOS/PixelDefinitions/pixels/definitions/forget_all.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/forget_all.json5
@@ -17,7 +17,10 @@
         "description": "Fired when user pressed the button to clear data in Data Clearing Settings",
         "owners": ["dus7", "hassaanelgarem"],
         "triggers": ["other"],
-        "suffixes": ["daily_standard", "platform", "form_factor"],
+        "suffixes": [
+            ["daily", "platform", "form_factor"],
+            ["platform", "form_factor"]
+        ],
         "parameters": ["appVersion"]
     },
     "mf": {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214113755545751?focus=true
Tech Design URL:
CC:

### Description

Fixes two pixel schema mismatches surfaced by the production pixel validator:

- added `popups-not-opening` as `category` to `epbf`.
- Replaced with an array-of-arrays (`anyOf`) pattern that validates both the daily and base variants from a single definition for `m_forget-all-pressed_settings`.

### Testing Steps
1. Run `./iOS/scripts/validate_pixels.sh` with a simulator booted and the app exercised, confirm that `m_forget-all-pressed_settings_ios_phone` now reports as Valid (was Invalid before).
2. In the simulator, trigger a broken-site report via Privacy Dashboard with category "Pop-ups don't open", confirm `epbf` validates.

### Impact and Risks
None. Pixel definition-only change, no behavior or code paths affected.

#### What could go wrong?
N/A

### Quality Considerations
--

### Notes to Reviewer
--

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust pixel definition schemas/enums and suffix validation, with no app runtime behavior changes.
> 
> **Overview**
> Fixes production pixel-validator mismatches in iOS pixel definitions.
> 
> Updates `epbf` (broken site reporting) to allow the `popups-not-opening` category, and changes `m_forget-all-pressed_settings` to accept both *daily* and *base* suffix variants via an array-of-arrays (`anyOf`-style) `suffixes` schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccc5d11ddc2d072ee71816d4f28375b8f73f2bb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->