### PR TITLE
Fix autocomplete flash on keyboard mic double-tap

### DIFF
--- a/iOS/Core/StringExtension.swift
+++ b/iOS/Core/StringExtension.swift
@@ -85,11 +85,13 @@ extension String {
 // MARK: - Input Sanitization
 
 extension String {
-    /// Returns the string with `U+FFFC OBJECT REPLACEMENT CHARACTER` removed — the
-    /// placeholder iOS keyboard dictation inserts while listening, before committing
-    /// or cancelling the recognised text.
+    /// A "listening" placeholder inserted by iOS dictation
+    /// before the recognised text is committed or cancelled.
+    private static let dictationPlaceholder: Character = "\u{FFFC}"
+
+    /// Returns the string with the dictation-placeholder character removed.
     public var strippingDictationPlaceholder: String {
-        guard contains("\u{FFFC}") else { return self }
-        return replacingOccurrences(of: "\u{FFFC}", with: "")
+        guard contains(Self.dictationPlaceholder) else { return self }
+        return replacingOccurrences(of: String(Self.dictationPlaceholder), with: "")
     }
 }

--- a/iOS/Core/StringExtension.swift
+++ b/iOS/Core/StringExtension.swift
@@ -81,3 +81,15 @@ extension String {
         return URL(trimmedAddressBarString: self)
     }
 }
+
+// MARK: - Input Sanitization
+
+extension String {
+    /// Returns the string with `U+FFFC OBJECT REPLACEMENT CHARACTER` removed — the
+    /// placeholder iOS keyboard dictation inserts while listening, before committing
+    /// or cancelling the recognised text.
+    public var strippingDictationPlaceholder: String {
+        guard contains("\u{FFFC}") else { return self }
+        return replacingOccurrences(of: "\u{FFFC}", with: "")
+    }
+}

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -588,7 +588,7 @@ extension SwitchBarTextEntryView: UITextViewDelegate {
         updatePlaceholderVisibility()
         updateButtonState()
         updateTextViewHeight()
-        handler.updateCurrentText(textView.text ?? "")
+        handler.updateCurrentText((textView.text ?? "").strippingDictationPlaceholder)
         handler.markUserInteraction()
 
         // On iPad, reload input views on each keystroke (old behavior, without fade-out animation)

--- a/iOS/DuckDuckGo/OmniBarViewController.swift
+++ b/iOS/DuckDuckGo/OmniBarViewController.swift
@@ -813,7 +813,7 @@ class OmniBarViewController: UIViewController, OmniBar {
     }
 
     @objc private func textDidChange() {
-        let newQuery = textField.text ?? ""
+        let newQuery = (textField.text ?? "").strippingDictationPlaceholder
         omniDelegate?.onOmniQueryUpdated(newQuery)
         if newQuery.isEmpty {
             refreshState(state.onTextClearedState)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1212571157082244?focus=true
Tech Design URL:
CC:

### Description

Double-tapping the iOS system keyboard microphone (without speaking) causes stale history autocomplete suggestions to flash in the address bar suggestion tray.

Root cause: iOS keyboard dictation inserts `U+FFFC` into the text field as a "listening" placeholder while the mic orb spins. That character is non-whitespace, so it passes `isEmpty`/`isBlank` checks, is treated as a real query by the suggestion pipeline, and triggers an autocomplete load against local history.

Fix sanitizes the input via `String.strippingDictationPlaceholder` helper, applied in `OmniBarViewController.textDidChange` and `SwitchBarTextEntryView.textViewDidChange`. All downstream state (clear-button vs mic, placeholder visibility, suggestion tray decision, URL parsing) then sees a consistent "empty while dictation listening" view. When real dictation commits, the final text contains no `U+FFFC` and flows through unchanged.

### Testing Steps

1. Clear history via Fire, then perform a few searches so there is recent history to surface as autocomplete.
2. Close the tab and open a new one, focus the address bar while empty.
3. Double-tap the iOS system keyboard microphone button so dictation enters the listening state (spinner showing) without recognizing speech.
4. Verify no autocomplete suggestions flash in the suggestion tray, favorites tray (or nothing) shows as expected.
5. Repeat with the address bar pre-populated with a URL (focus an existing tab's address bar), verify same behavior.
6. Repeat with the unified Search/Duck.ai switch bar, verify same behavior.
7. Sanity check: dictate a real query, verify the recognized text commits normally and suggestions appear as expected.

### Impact and Risks

Low. The sanitization removes a single Unicode character (`U+FFFC`) that has no legitimate use in user-entered search queries or URLs, and only runs on the text-change path for the two input views.

#### What could go wrong?

- A user pastes content containing `U+FFFC` (e.g. attributed text with attachments). That character would be stripped before querying. Acceptable, it has no meaning as a search term or URL component.
- Performance regression on every keystroke. Addressed by the `contains` pre-check which short-circuits before any allocation when the character is absent (the common case).

### Quality Considerations

Edge case: if a future iOS change uses a different sentinel character for dictation placeholder, this fix would not cover it. The helper is localized and easy to extend.

### Notes to Reviewer

--

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only sanitizes live text-change input by removing a single iOS dictation placeholder character, with minimal impact to normal typing and URL/query handling.
> 
> **Overview**
> Prevents stale autocomplete/history suggestions from flashing when iOS dictation is activated/cancelled by **sanitizing the live query text**.
> 
> Adds `String.strippingDictationPlaceholder` to remove the `U+FFFC` dictation “listening” placeholder, and applies it to the text-change paths in `OmniBarViewController.textDidChange` and `SwitchBarTextEntryView.textViewDidChange` so downstream state treats dictation-listening as an empty query.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da4d2be8a629ad781ade20e26635de247be1f6ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->