### PR TITLE
[macOS] Duck.ai last model pick-up consistency

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatPreferencesPersistor.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatPreferencesPersistor.swift
@@ -16,16 +16,22 @@
 //  limitations under the License.
 //
 
+import Combine
 import Foundation
 import Persistence
 
 public protocol AIChatPreferencesPersisting {
     var selectedModelId: String? { get set }
+    /// Emits the new value whenever `selectedModelId` changes through this persistor instance.
+    /// Consumers that need cross-component sync must share the same instance.
+    var selectedModelIdPublisher: AnyPublisher<String?, Never> { get }
     /// The short display name of the last selected model, used to show the button before models are fetched.
     var selectedModelShortName: String? { get set }
 }
 
-public struct AIChatPreferencesPersistor: AIChatPreferencesPersisting {
+/// Reference type so that a single instance can be shared across components (e.g. the native address-bar
+/// omnibar and the New Tab Page omnibar) and both observe the same `selectedModelIdPublisher`.
+public final class AIChatPreferencesPersistor: AIChatPreferencesPersisting {
 
     enum Key: String {
         case selectedModelId = "aichat.omnibar.selected-model-id"
@@ -33,6 +39,7 @@ public struct AIChatPreferencesPersistor: AIChatPreferencesPersisting {
     }
 
     private let keyValueStore: ThrowingKeyValueStoring
+    private let selectedModelIdSubject = PassthroughSubject<String?, Never>()
 
     public init(keyValueStore: ThrowingKeyValueStoring = UserDefaults.standard) {
         self.keyValueStore = keyValueStore
@@ -41,12 +48,19 @@ public struct AIChatPreferencesPersistor: AIChatPreferencesPersisting {
     public var selectedModelId: String? {
         get { try? keyValueStore.object(forKey: Key.selectedModelId.rawValue) as? String }
         set {
+            let current = try? keyValueStore.object(forKey: Key.selectedModelId.rawValue) as? String
+            guard newValue != current else { return }
             if let value = newValue {
                 try? keyValueStore.set(value, forKey: Key.selectedModelId.rawValue)
             } else {
                 try? keyValueStore.removeObject(forKey: Key.selectedModelId.rawValue)
             }
+            selectedModelIdSubject.send(newValue)
         }
+    }
+
+    public var selectedModelIdPublisher: AnyPublisher<String?, Never> {
+        selectedModelIdSubject.eraseToAnyPublisher()
     }
 
     public var selectedModelShortName: String? {

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatPreferencesPersistorTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatPreferencesPersistorTests.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import Combine
 import XCTest
 import AIChat
 
@@ -82,5 +83,44 @@ final class AIChatPreferencesPersistorTests: XCTestCase {
 
         // Then
         XCTAssertEqual(secondPersistor.selectedModelId, "gpt-4o-mini")
+    }
+
+    // MARK: - selectedModelIdPublisher
+
+    func testSelectedModelIdPublisher_emitsOnEveryDistinctWrite() {
+        var received: [String?] = []
+        let cancellable = persistor.selectedModelIdPublisher.sink { received.append($0) }
+
+        persistor.selectedModelId = "gpt-4o-mini"
+        persistor.selectedModelId = "claude-sonnet-4-5"
+        persistor.selectedModelId = nil
+
+        cancellable.cancel()
+        XCTAssertEqual(received, ["gpt-4o-mini", "claude-sonnet-4-5", nil])
+    }
+
+    func testSelectedModelIdPublisher_dedupsIdenticalWrites() {
+        var received: [String?] = []
+        let cancellable = persistor.selectedModelIdPublisher.sink { received.append($0) }
+
+        persistor.selectedModelId = "gpt-4o-mini"
+        persistor.selectedModelId = "gpt-4o-mini"   // no-op, publisher must not emit
+        persistor.selectedModelId = "claude-sonnet-4-5"
+
+        cancellable.cancel()
+        XCTAssertEqual(received, ["gpt-4o-mini", "claude-sonnet-4-5"])
+    }
+
+    func testSelectedModelIdPublisher_isInstanceScoped() {
+        // Two persistors on the same store: a write on one MUST NOT emit on the other's publisher.
+        // (Callers that want cross-component propagation share a single persistor instance.)
+        let otherPersistor = AIChatPreferencesPersistor(keyValueStore: userDefaults)
+        var received: [String?] = []
+        let cancellable = otherPersistor.selectedModelIdPublisher.sink { received.append($0) }
+
+        persistor.selectedModelId = "gpt-4o-mini"
+
+        cancellable.cancel()
+        XCTAssertEqual(received, [])
     }
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIModelStoreTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIModelStoreTests.swift
@@ -18,6 +18,7 @@
 //
 
 import AIChat
+import Combine
 import XCTest
 @testable import DuckDuckGo
 
@@ -203,6 +204,7 @@ final class UTIModelStoreTests: XCTestCase {
 private final class StubPreferences: AIChatPreferencesPersisting {
     var selectedModelId: String?
     var selectedModelShortName: String?
+    var selectedModelIdPublisher: AnyPublisher<String?, Never> { Empty().eraseToAnyPublisher() }
 }
 
 private final class StubModelsService: AIChatModelsProviding {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
@@ -18,6 +18,7 @@
 //
 
 import AIChat
+import Combine
 import XCTest
 @testable import DuckDuckGo
 
@@ -216,4 +217,5 @@ private final class SpyUnifiedToggleInputDelegate: UnifiedToggleInputDelegate {
 private final class StubAIChatPreferences: AIChatPreferencesPersisting {
     var selectedModelId: String?
     var selectedModelShortName: String?
+    var selectedModelIdPublisher: AnyPublisher<String?, Never> { Empty().eraseToAnyPublisher() }
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -1384,6 +1384,7 @@ private final class MockUnifiedToggleInputDelegate: UnifiedToggleInputDelegate {
 private final class MockAIChatPreferences: AIChatPreferencesPersisting {
     var selectedModelId: String?
     var selectedModelShortName: String?
+    var selectedModelIdPublisher: AnyPublisher<String?, Never> { Empty().eraseToAnyPublisher() }
 }
 
 private final class MockToggleModeStorage: ToggleModeStoring {

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -228,6 +228,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let aiChatPreferences: AIChatPreferences
     private(set) var aiChatHistoryCleaner: AIChatHistoryCleaning!
 
+    /// Shared across the native address-bar omnibar and the New Tab Page omnibar so that model-selection
+    /// changes in either propagate through `selectedModelIdPublisher` to the other.
+    let aiChatPreferencesPersistor: AIChatPreferencesPersisting = AIChatPreferencesPersistor()
+
     private(set) lazy var aiChatSuggestionsReader: AIChatSuggestionsReading = MainActor.assumeMainThread {
         AIChatSuggestionsReader(
             suggestionsReader: SuggestionsReader(

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -314,7 +314,8 @@ final class MainViewController: NSViewController {
         let aiChatOmnibarController = AIChatOmnibarController(
             aiChatTabOpener: aiChatTabOpener,
             tabCollectionViewModel: tabCollectionViewModel,
-            suggestionsReader: suggestionsReader
+            suggestionsReader: suggestionsReader,
+            preferences: NSApp.delegateTyped.aiChatPreferencesPersistor
         )
 
         aiChatOmnibarContainerViewController = AIChatOmnibarContainerViewController(

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
@@ -117,7 +117,8 @@ extension NewTabPageActionsManager {
         let omnibarConfigProvider = NewTabPageOmnibarConfigProvider(
             keyValueStore: keyValueStore,
             aiChatShortcutSettingProvider: newTabPageAIChatShortcutSettingProvider,
-            featureFlagger: featureFlagger
+            featureFlagger: featureFlagger,
+            aiChatPreferencesPersistor: NSApp.delegateTyped.aiChatPreferencesPersistor
         )
         let aiChatsProvider = NewTabPageOmnibarAiChatsProvider(
             featureFlagger: featureFlagger,

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
@@ -94,42 +94,23 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
     private let featureFlagger: FeatureFlagger
     private let firePixel: (PixelKitEvent) -> Void
     private var aiChatPreferencesPersistor: AIChatPreferencesPersisting
-    private let aiChatModelSelectionObserver: UserDefaults
     private let showCustomizePopoverSubject = PassthroughSubject<Bool, Never>()
     private let modeSubject = PassthroughSubject<NewTabPageDataModel.OmnibarMode, Never>()
-    private let selectedModelIdSubject = PassthroughSubject<String?, Never>()
     @Published private var hasExcessChats = false
     private var aiChatsProviderCancellable: AnyCancellable?
-    private var userDefaultsChangeCancellable: AnyCancellable?
-    private var lastObservedModelId: String?
 
     init(keyValueStore: ThrowingKeyValueStoring,
          aiChatShortcutSettingProvider: NewTabPageAIChatShortcutSettingProviding,
          featureFlagger: FeatureFlagger,
          aiChatPreferencesPersistor: AIChatPreferencesPersisting = AIChatPreferencesPersistor(),
-         aiChatModelSelectionObserver: UserDefaults = .standard,
          firePixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0, frequency: .dailyAndStandard) }) {
         self.keyValueStore = keyValueStore
         self.aiChatShortcutSettingProvider = aiChatShortcutSettingProvider
         self.featureFlagger = featureFlagger
         self.aiChatPreferencesPersistor = aiChatPreferencesPersistor
-        self.aiChatModelSelectionObserver = aiChatModelSelectionObserver
         self.firePixel = firePixel
 
         Self.migrateLegacySelectedModelIdIfNeeded(from: keyValueStore, into: &self.aiChatPreferencesPersistor)
-
-        self.lastObservedModelId = aiChatPreferencesPersistor.selectedModelId
-
-        userDefaultsChangeCancellable = NotificationCenter.default
-            .publisher(for: UserDefaults.didChangeNotification, object: aiChatModelSelectionObserver)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                guard let self else { return }
-                let current = self.aiChatPreferencesPersistor.selectedModelId
-                guard current != self.lastObservedModelId else { return }
-                self.lastObservedModelId = current
-                self.selectedModelIdSubject.send(current)
-            }
     }
 
     @MainActor
@@ -206,7 +187,7 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
     }
 
     var selectedModelIdPublisher: AnyPublisher<String?, Never> {
-        selectedModelIdSubject.eraseToAnyPublisher()
+        aiChatPreferencesPersistor.selectedModelIdPublisher
     }
 
     var selectedModelShortName: String? {

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
@@ -77,7 +77,6 @@ final class NewTabPageAIChatShortcutSettingProvider: NewTabPageAIChatShortcutSet
 final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
     private enum Key: String {
         case newTabPageOmnibarMode
-        case newTabPageSelectedModelId
     }
 
     private enum Constants: Int {
@@ -88,19 +87,40 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
     private let aiChatShortcutSettingProvider: NewTabPageAIChatShortcutSettingProviding
     private let featureFlagger: FeatureFlagger
     private let firePixel: (PixelKitEvent) -> Void
+    private var aiChatPreferencesPersistor: AIChatPreferencesPersisting
+    private let aiChatModelSelectionObserver: UserDefaults
     private let showCustomizePopoverSubject = PassthroughSubject<Bool, Never>()
     private let modeSubject = PassthroughSubject<NewTabPageDataModel.OmnibarMode, Never>()
+    private let selectedModelIdSubject = PassthroughSubject<String?, Never>()
     @Published private var hasExcessChats = false
     private var aiChatsProviderCancellable: AnyCancellable?
+    private var userDefaultsChangeCancellable: AnyCancellable?
+    private var lastObservedModelId: String?
 
     init(keyValueStore: ThrowingKeyValueStoring,
          aiChatShortcutSettingProvider: NewTabPageAIChatShortcutSettingProviding,
          featureFlagger: FeatureFlagger,
+         aiChatPreferencesPersistor: AIChatPreferencesPersisting = AIChatPreferencesPersistor(),
+         aiChatModelSelectionObserver: UserDefaults = .standard,
          firePixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0, frequency: .dailyAndStandard) }) {
         self.keyValueStore = keyValueStore
         self.aiChatShortcutSettingProvider = aiChatShortcutSettingProvider
         self.featureFlagger = featureFlagger
+        self.aiChatPreferencesPersistor = aiChatPreferencesPersistor
+        self.aiChatModelSelectionObserver = aiChatModelSelectionObserver
         self.firePixel = firePixel
+        self.lastObservedModelId = aiChatPreferencesPersistor.selectedModelId
+
+        userDefaultsChangeCancellable = NotificationCenter.default
+            .publisher(for: UserDefaults.didChangeNotification, object: aiChatModelSelectionObserver)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                let current = self.aiChatPreferencesPersistor.selectedModelId
+                guard current != self.lastObservedModelId else { return }
+                self.lastObservedModelId = current
+                self.selectedModelIdSubject.send(current)
+            }
     }
 
     @MainActor
@@ -165,23 +185,19 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
 
     var selectedModelId: String? {
         get {
-            do {
-                return try keyValueStore.object(forKey: Key.newTabPageSelectedModelId.rawValue) as? String
-            } catch {
-                Logger.newTabPageOmnibar.error("Failed to retrieve selectedModelId from keyValueStore: \(error.localizedDescription)")
-                return nil
-            }
+            aiChatPreferencesPersistor.selectedModelId
         }
         set {
-            do {
-                try keyValueStore.set(newValue, forKey: Key.newTabPageSelectedModelId.rawValue)
-                if newValue != nil {
-                    PixelKit.fire(AIChatPixel.aiChatNtpModelSelected, frequency: .dailyAndCount, includeAppVersionParameter: true)
-                }
-            } catch {
-                Logger.newTabPageOmnibar.error("Failed to set selectedModelId in keyValueStore: \(error.localizedDescription)")
+            guard newValue != aiChatPreferencesPersistor.selectedModelId else { return }
+            aiChatPreferencesPersistor.selectedModelId = newValue
+            if newValue != nil {
+                PixelKit.fire(AIChatPixel.aiChatNtpModelSelected, frequency: .dailyAndCount, includeAppVersionParameter: true)
             }
         }
+    }
+
+    var selectedModelIdPublisher: AnyPublisher<String?, Never> {
+        selectedModelIdSubject.eraseToAnyPublisher()
     }
 
     var showCustomizePopover: Bool {

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
@@ -79,6 +79,12 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
         case newTabPageOmnibarMode
     }
 
+    private enum LegacyKey: String {
+        /// Previously-used per-NTP key. Migrated into `AIChatPreferencesPersisting.selectedModelId`
+        /// (shared with the native omnibar) on first init after the unification, then removed.
+        case newTabPageSelectedModelId
+    }
+
     private enum Constants: Int {
         case maxNumberOfPopoverPresentations = 5
     }
@@ -109,6 +115,9 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
         self.aiChatPreferencesPersistor = aiChatPreferencesPersistor
         self.aiChatModelSelectionObserver = aiChatModelSelectionObserver
         self.firePixel = firePixel
+
+        Self.migrateLegacySelectedModelIdIfNeeded(from: keyValueStore, into: &self.aiChatPreferencesPersistor)
+
         self.lastObservedModelId = aiChatPreferencesPersistor.selectedModelId
 
         userDefaultsChangeCancellable = NotificationCenter.default
@@ -232,6 +241,22 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
                 guard let self else { return }
                 self.hasExcessChats = hasExcess
             }
+    }
+
+    /// One-time migration: copy the old NTP-only model id into the shared `AIChatPreferencesPersisting`
+    /// store when the shared value is absent, then drop the legacy key so subsequent launches skip the work.
+    private static func migrateLegacySelectedModelIdIfNeeded(
+        from keyValueStore: ThrowingKeyValueStoring,
+        into persistor: inout AIChatPreferencesPersisting
+    ) {
+        let legacyKey = LegacyKey.newTabPageSelectedModelId.rawValue
+        guard let legacyValue = try? keyValueStore.object(forKey: legacyKey) as? String else {
+            return
+        }
+        if persistor.selectedModelId == nil {
+            persistor.selectedModelId = legacyValue
+        }
+        try? keyValueStore.removeObject(forKey: legacyKey)
     }
 
 }

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
@@ -209,6 +209,15 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
         selectedModelIdSubject.eraseToAnyPublisher()
     }
 
+    var selectedModelShortName: String? {
+        get {
+            aiChatPreferencesPersistor.selectedModelShortName
+        }
+        set {
+            aiChatPreferencesPersistor.selectedModelShortName = newValue
+        }
+    }
+
     var showCustomizePopover: Bool {
         get {
             // We no longer present the tooltip

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
@@ -254,6 +254,11 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
 
     /// One-time migration: copy the old NTP-only model id into the shared `AIChatPreferencesPersisting`
     /// store when the shared value is absent, then drop the legacy key so subsequent launches skip the work.
+    ///
+    /// The legacy NTP store never cached a short name, so on the upgrade path we seed it with the
+    /// model id as a placeholder. This keeps the native omnibar's model picker visible on first
+    /// launch post-upgrade (the picker is hidden when both `models` and `selectedModelShortName`
+    /// are empty). The real short name replaces the placeholder once the models fetch completes.
     private static func migrateLegacySelectedModelIdIfNeeded(
         from keyValueStore: ThrowingKeyValueStoring,
         into persistor: inout AIChatPreferencesPersisting
@@ -264,6 +269,9 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
         }
         if persistor.selectedModelId == nil {
             persistor.selectedModelId = legacyValue
+            if persistor.selectedModelShortName == nil {
+                persistor.selectedModelShortName = legacyValue
+            }
         }
         try? keyValueStore.removeObject(forKey: legacyKey)
     }

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
@@ -119,13 +119,17 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             configProvider.showCustomizePopover = showCustomizePopover
         }
         if let selectedModelId = config.selectedModelId {
+            // Only refresh the cached short name when the id actually changes. Echoing back the
+            // same id (e.g. on web launch) must not overwrite a valid cache with `nil` just
+            // because `lastFetchedSections` hasn't been populated yet on this side.
+            let didChangeModelId = configProvider.selectedModelId != selectedModelId
             configProvider.selectedModelId = selectedModelId
-            // Cache the short name so the native omnibar can render the correct label before
-            // its own models fetch completes — otherwise it briefly shows the previous pick.
-            configProvider.selectedModelShortName = modelsProvider?.lastFetchedSections?
-                .flatMap(\.items)
-                .first(where: { $0.id == selectedModelId })?
-                .shortName
+            if didChangeModelId {
+                configProvider.selectedModelShortName = modelsProvider?.lastFetchedSections?
+                    .flatMap(\.items)
+                    .first(where: { $0.id == selectedModelId })?
+                    .shortName
+            }
         }
         return nil
     }

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
@@ -54,11 +54,12 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
         self.actionHandler = actionHandler
         super.init()
 
-        Publishers.Merge4(
+        Publishers.MergeMany(
             configProvider.isAIChatShortcutEnabledPublisher.map { _ in () }.eraseToAnyPublisher(),
             configProvider.isAIChatSettingVisiblePublisher.map { _ in () }.eraseToAnyPublisher(),
             configProvider.modePublisher.map { _ in () }.eraseToAnyPublisher(),
-            configProvider.showViewAllAiChatsPublisher.map { _ in () }.eraseToAnyPublisher()
+            configProvider.showViewAllAiChatsPublisher.map { _ in () }.eraseToAnyPublisher(),
+            configProvider.selectedModelIdPublisher.map { _ in () }.eraseToAnyPublisher()
         )
         .sink { [weak self] _ in
             Task { @MainActor in

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
@@ -120,6 +120,12 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
         }
         if let selectedModelId = config.selectedModelId {
             configProvider.selectedModelId = selectedModelId
+            // Cache the short name so the native omnibar can render the correct label before
+            // its own models fetch completes — otherwise it briefly shows the previous pick.
+            configProvider.selectedModelShortName = modelsProvider?.lastFetchedSections?
+                .flatMap(\.items)
+                .first(where: { $0.id == selectedModelId })?
+                .shortName
         }
         return nil
     }

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
@@ -41,4 +41,8 @@ public protocol NewTabPageOmnibarConfigProviding: AnyObject {
 
     var selectedModelId: String? { get set }
     var selectedModelIdPublisher: AnyPublisher<String?, Never> { get }
+
+    /// Short display name that the native omnibar can show before its own models fetch completes.
+    /// Mirrors the native `AIChatPreferencesPersisting.selectedModelShortName`.
+    var selectedModelShortName: String? { get set }
 }

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
@@ -40,4 +40,5 @@ public protocol NewTabPageOmnibarConfigProviding: AnyObject {
     var isAIChatToolsEnabled: Bool { get }
 
     var selectedModelId: String? { get set }
+    var selectedModelIdPublisher: AnyPublisher<String?, Never> { get }
 }

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarConfigProvider.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarConfigProvider.swift
@@ -57,4 +57,6 @@ final class MockNewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProvidin
     var selectedModelIdPublisher: AnyPublisher<String?, Never> {
         $selectedModelId.dropFirst().eraseToAnyPublisher()
     }
+
+    var selectedModelShortName: String?
 }

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarConfigProvider.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarConfigProvider.swift
@@ -52,5 +52,9 @@ final class MockNewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProvidin
 
     var isAIChatToolsEnabled: Bool = false
 
-    var selectedModelId: String?
+    @Published var selectedModelId: String?
+
+    var selectedModelIdPublisher: AnyPublisher<String?, Never> {
+        $selectedModelId.dropFirst().eraseToAnyPublisher()
+    }
 }

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
@@ -114,6 +114,22 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
         XCTAssertNil(configProvider.selectedModelShortName)
     }
 
+    @MainActor
+    func testWhenSetConfigWithUnchangedModelIdAndEmptyLookupThenCachedShortNameIsPreserved() async throws {
+        // Given — id already stored with a cached short name, and models haven't been fetched yet
+        configProvider.selectedModelId = "gpt-4o-mini"
+        configProvider.selectedModelShortName = "G4m"
+        modelsProvider.lastFetchedSections = nil
+
+        // When — web echoes back the same id (typical on launch)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, selectedModelId: "gpt-4o-mini", aiModelSections: nil)
+        try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
+
+        // Then — cached short name is preserved (not wiped by a failed lookup)
+        XCTAssertEqual(configProvider.selectedModelId, "gpt-4o-mini")
+        XCTAssertEqual(configProvider.selectedModelShortName, "G4m")
+    }
+
     // MARK: - getSuggestions
 
     func testGetSuggestionsReturnsSuggestionsFromProvider() async throws {

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
@@ -24,6 +24,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
     private var suggestionsProvider: MockNewTabPageOmnibarSuggestionsProvider!
     private var aiChatsProvider: MockNewTabPageOmnibarAiChatsProvider!
     private var configProvider: MockNewTabPageOmnibarConfigProvider!
+    private var modelsProvider: StubNewTabPageOmnibarModelsProvider!
     private var actionHandler: NewTabPageOmnibarActionsHandling!
     private var client: NewTabPageOmnibarClient!
     private var userScript: NewTabPageUserScript!
@@ -35,10 +36,12 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
         suggestionsProvider = MockNewTabPageOmnibarSuggestionsProvider()
         aiChatsProvider = MockNewTabPageOmnibarAiChatsProvider()
         configProvider = MockNewTabPageOmnibarConfigProvider()
+        modelsProvider = StubNewTabPageOmnibarModelsProvider()
         actionHandler = MockNewTabPageOmnibarActionsHandler()
         client = NewTabPageOmnibarClient(configProvider: configProvider,
                                          suggestionsProvider: suggestionsProvider,
                                          aiChatsProvider: aiChatsProvider,
+                                         modelsProvider: modelsProvider,
                                          actionHandler: actionHandler)
 
         userScript = NewTabPageUserScript()
@@ -77,6 +80,38 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
         let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, selectedModelId: "gpt-4o-mini", aiModelSections: nil)
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
         XCTAssertEqual(configProvider.selectedModelId, "gpt-4o-mini")
+    }
+
+    @MainActor
+    func testWhenSetConfigWithSelectedModelIdThenShortNameIsCachedFromModelsProvider() async throws {
+        modelsProvider.lastFetchedSections = [
+            NewTabPageDataModel.AIModelSection(header: nil, items: [
+                NewTabPageDataModel.AIModelItem(id: "gpt-4o-mini", name: "GPT-4o mini", shortName: "G4m", isEnabled: true, supportsImageUpload: false),
+                NewTabPageDataModel.AIModelItem(id: "maverick", name: "Maverick", shortName: "Maverick", isEnabled: true, supportsImageUpload: false)
+            ])
+        ]
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, selectedModelId: "maverick", aiModelSections: nil)
+
+        try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
+
+        XCTAssertEqual(configProvider.selectedModelId, "maverick")
+        XCTAssertEqual(configProvider.selectedModelShortName, "Maverick")
+    }
+
+    @MainActor
+    func testWhenSetConfigWithUnknownModelIdThenShortNameIsCleared() async throws {
+        configProvider.selectedModelShortName = "StaleName"
+        modelsProvider.lastFetchedSections = [
+            NewTabPageDataModel.AIModelSection(header: nil, items: [
+                NewTabPageDataModel.AIModelItem(id: "gpt-4o-mini", name: "GPT-4o mini", shortName: "G4m", isEnabled: true, supportsImageUpload: false)
+            ])
+        ]
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, selectedModelId: "brand-new-model", aiModelSections: nil)
+
+        try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
+
+        XCTAssertEqual(configProvider.selectedModelId, "brand-new-model")
+        XCTAssertNil(configProvider.selectedModelShortName)
     }
 
     // MARK: - getSuggestions
@@ -224,5 +259,13 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
         let action = NewTabPageDataModel.SubmitChatAction(chat: "Hello Chat", target: .newWindow, modelId: "gpt-4o-mini", images: [image])
         try await messageHelper.handleMessageExpectingNilResponse(named: .submitChat, parameters: action)
         await fulfillment(of: [expectation], timeout: 1)
+    }
+}
+
+private final class StubNewTabPageOmnibarModelsProvider: NewTabPageOmnibarModelsProviding {
+    var lastFetchedSections: [NewTabPageDataModel.AIModelSection]?
+
+    func fetchAIModelSections() async -> [NewTabPageDataModel.AIModelSection] {
+        lastFetchedSections ?? []
     }
 }

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -488,6 +488,7 @@ private class AIChatMockSearchPreferencesPersistor: SearchPreferencesPersistor {
 private class MockAIChatPreferencesPersisting: AIChatPreferencesPersisting {
     var selectedModelId: String?
     var selectedModelShortName: String?
+    var selectedModelIdPublisher: AnyPublisher<String?, Never> { Empty().eraseToAnyPublisher() }
 }
 
 // MARK: - Mock Models Service

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarAiChatsProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarAiChatsProviderTests.swift
@@ -277,7 +277,7 @@ private final class MockAiChatsConfigProvider: NewTabPageOmnibarConfigProviding 
     var isAIChatToolsEnabled: Bool = false
     var selectedModelId: String?
     var selectedModelIdPublisher: AnyPublisher<String?, Never> {Just(nil).eraseToAnyPublisher() }
-    var selectedModelShortName: String? = nil
+    var selectedModelShortName: String?
 }
 
 private extension AIChatSuggestion {

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarAiChatsProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarAiChatsProviderTests.swift
@@ -277,6 +277,7 @@ private final class MockAiChatsConfigProvider: NewTabPageOmnibarConfigProviding 
     var isAIChatToolsEnabled: Bool = false
     var selectedModelId: String?
     var selectedModelIdPublisher: AnyPublisher<String?, Never> {Just(nil).eraseToAnyPublisher() }
+    var selectedModelShortName: String? = nil
 }
 
 private extension AIChatSuggestion {

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarAiChatsProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarAiChatsProviderTests.swift
@@ -276,6 +276,7 @@ private final class MockAiChatsConfigProvider: NewTabPageOmnibarConfigProviding 
     var showViewAllAiChatsPublisher: AnyPublisher<Bool, Never> { Just(false).eraseToAnyPublisher() }
     var isAIChatToolsEnabled: Bool = false
     var selectedModelId: String?
+    var selectedModelIdPublisher: AnyPublisher<String?, Never> {Just(nil).eraseToAnyPublisher() }
 }
 
 private extension AIChatSuggestion {

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarConfigProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarConfigProviderTests.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import AIChat
 import Combine
 import XCTest
 import Persistence
@@ -252,6 +253,119 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
         XCTAssertTrue(provider.showViewAllAiChats)
     }
 
+    // MARK: - selectedModelId (shared with native omnibar)
+
+    private func makeProvider(
+        persistor: AIChatPreferencesPersisting,
+        observer: UserDefaults
+    ) throws -> NewTabPageOmnibarConfigProvider {
+        NewTabPageOmnibarConfigProvider(
+            keyValueStore: try makeStore(),
+            aiChatShortcutSettingProvider: MockNewTabPageAIChatShortcutSettingProvider(),
+            featureFlagger: MockFeatureFlagger(),
+            aiChatPreferencesPersistor: persistor,
+            aiChatModelSelectionObserver: observer,
+            firePixel: { _ in }
+        )
+    }
+
+    func testSelectedModelId_readsFromInjectedPersistor() throws {
+        let persistor = MockAIChatPreferencesPersisting()
+        persistor.selectedModelId = "gpt-4o-mini"
+        let provider = try makeProvider(persistor: persistor, observer: .standard)
+
+        XCTAssertEqual(provider.selectedModelId, "gpt-4o-mini")
+    }
+
+    func testSelectedModelId_writesThroughToInjectedPersistor() throws {
+        let persistor = MockAIChatPreferencesPersisting()
+        let provider = try makeProvider(persistor: persistor, observer: .standard)
+
+        provider.selectedModelId = "claude-4"
+        XCTAssertEqual(persistor.selectedModelId, "claude-4")
+
+        provider.selectedModelId = nil
+        XCTAssertNil(persistor.selectedModelId)
+    }
+
+    func testSelectedModelIdPublisher_emitsWhenSharedStorageChanges() throws {
+        let suiteName = "NewTabPageOmnibarConfigProviderTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let persistor = AIChatPreferencesPersistor(keyValueStore: defaults)
+        let provider = try makeProvider(persistor: persistor, observer: defaults)
+
+        let exp = expectation(description: "publisher emits")
+        var received: [String?] = []
+        let cancellable = provider.selectedModelIdPublisher.sink { value in
+            received.append(value)
+            exp.fulfill()
+        }
+
+        // Simulate a native-side change writing directly through its own AIChatPreferencesPersistor
+        // instance on the same UserDefaults (the shared storage).
+        var nativePersistor: AIChatPreferencesPersisting = AIChatPreferencesPersistor(keyValueStore: defaults)
+        nativePersistor.selectedModelId = "maverick"
+
+        wait(for: [exp], timeout: 1.0)
+        cancellable.cancel()
+
+        XCTAssertEqual(received, ["maverick"])
+    }
+
+    func testSelectedModelIdPublisher_doesNotEmitForUnchangedValue() throws {
+        let suiteName = "NewTabPageOmnibarConfigProviderTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        var persistor: AIChatPreferencesPersisting = AIChatPreferencesPersistor(keyValueStore: defaults)
+        persistor.selectedModelId = "maverick"
+
+        let provider = try makeProvider(persistor: persistor, observer: defaults)
+
+        var received: [String?] = []
+        let cancellable = provider.selectedModelIdPublisher.sink { received.append($0) }
+
+        // Write the same value via the shared storage — lastObservedModelId should dedup.
+        persistor.selectedModelId = "maverick"
+
+        // Pump the main runloop so any receive(on:) blocks would fire.
+        let pump = expectation(description: "runloop")
+        DispatchQueue.main.async { pump.fulfill() }
+        wait(for: [pump], timeout: 1.0)
+
+        cancellable.cancel()
+        XCTAssertEqual(received, [])
+    }
+
+    func testSelectedModelId_setterIsReentrancySafe() throws {
+        // Regression: assigning through the provider used to crash in AIChatPreferencesPersistor
+        // when the UserDefaults.didChangeNotification sink read the same var while the setter
+        // still held exclusive-write access.
+        let suiteName = "NewTabPageOmnibarConfigProviderTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let persistor = AIChatPreferencesPersistor(keyValueStore: defaults)
+        let provider = try makeProvider(persistor: persistor, observer: defaults)
+
+        let exp = expectation(description: "publisher emits after setter")
+        var received: String?
+        let cancellable = provider.selectedModelIdPublisher.sink { value in
+            received = value
+            exp.fulfill()
+        }
+
+        provider.selectedModelId = "claude-4"
+
+        wait(for: [exp], timeout: 1.0)
+        cancellable.cancel()
+
+        XCTAssertEqual(received, "claude-4")
+        XCTAssertEqual(persistor.selectedModelId, "claude-4")
+    }
+
     @MainActor
     func testShowViewAllAiChatsPublisher_emitsWhenExcessChanges() throws {
         let store = try makeStore()
@@ -276,6 +390,11 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
 }
 
 // MARK: - Mocks
+
+private final class MockAIChatPreferencesPersisting: AIChatPreferencesPersisting {
+    var selectedModelId: String?
+    var selectedModelShortName: String?
+}
 
 private final class MockAIChatExcessProvider: NewTabPageOmnibarAiChatsProviding {
 

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarConfigProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarConfigProviderTests.swift
@@ -381,6 +381,17 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
         XCTAssertNil(store.underlyingDict[legacyModelIdKey])
     }
 
+    func testMigration_seedsShortNamePlaceholderWhenSharedStoreIsEmpty() throws {
+        // Legacy NTP store never cached a short name. Without a placeholder the native
+        // model picker is hidden on first launch post-upgrade until models fetch completes.
+        let store = try makeStore(underlying: [legacyModelIdKey: "maverick"])
+        let persistor = MockAIChatPreferencesPersisting()
+
+        _ = try makeProvider(persistor: persistor, observer: .standard, keyValueStore: store)
+
+        XCTAssertEqual(persistor.selectedModelShortName, "maverick")
+    }
+
     func testMigration_preservesSharedValueAndDropsLegacyKey() throws {
         let store = try makeStore(underlying: [legacyModelIdKey: "maverick"])
         let persistor = MockAIChatPreferencesPersisting()
@@ -390,6 +401,18 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
 
         XCTAssertEqual(persistor.selectedModelId, "gpt-5")
         XCTAssertNil(store.underlyingDict[legacyModelIdKey])
+    }
+
+    func testMigration_doesNotOverwriteExistingShortName() throws {
+        // Native omnibar users may already have a cached short name. Migration must not clobber it.
+        let store = try makeStore(underlying: [legacyModelIdKey: "maverick"])
+        let persistor = MockAIChatPreferencesPersisting()
+        persistor.selectedModelId = "gpt-5"
+        persistor.selectedModelShortName = "GPT-5"
+
+        _ = try makeProvider(persistor: persistor, observer: .standard, keyValueStore: store)
+
+        XCTAssertEqual(persistor.selectedModelShortName, "GPT-5")
     }
 
     func testMigration_noOpWhenLegacyKeyAbsent() throws {

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarConfigProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarConfigProviderTests.swift
@@ -259,7 +259,6 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
 
     private func makeProvider(
         persistor: AIChatPreferencesPersisting,
-        observer: UserDefaults,
         keyValueStore: ThrowingKeyValueStoring? = nil
     ) throws -> NewTabPageOmnibarConfigProvider {
         NewTabPageOmnibarConfigProvider(
@@ -267,7 +266,6 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
             aiChatShortcutSettingProvider: MockNewTabPageAIChatShortcutSettingProvider(),
             featureFlagger: MockFeatureFlagger(),
             aiChatPreferencesPersistor: persistor,
-            aiChatModelSelectionObserver: observer,
             firePixel: { _ in }
         )
     }
@@ -275,14 +273,14 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
     func testSelectedModelId_readsFromInjectedPersistor() throws {
         let persistor = MockAIChatPreferencesPersisting()
         persistor.selectedModelId = "gpt-4o-mini"
-        let provider = try makeProvider(persistor: persistor, observer: .standard)
+        let provider = try makeProvider(persistor: persistor)
 
         XCTAssertEqual(provider.selectedModelId, "gpt-4o-mini")
     }
 
     func testSelectedModelId_writesThroughToInjectedPersistor() throws {
         let persistor = MockAIChatPreferencesPersisting()
-        let provider = try makeProvider(persistor: persistor, observer: .standard)
+        let provider = try makeProvider(persistor: persistor)
 
         provider.selectedModelId = "claude-4"
         XCTAssertEqual(persistor.selectedModelId, "claude-4")
@@ -291,82 +289,22 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
         XCTAssertNil(persistor.selectedModelId)
     }
 
-    func testSelectedModelIdPublisher_emitsWhenSharedStorageChanges() throws {
-        let suiteName = "NewTabPageOmnibarConfigProviderTests.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-
-        let persistor = AIChatPreferencesPersistor(keyValueStore: defaults)
-        let provider = try makeProvider(persistor: persistor, observer: defaults)
-
-        let exp = expectation(description: "publisher emits")
-        var received: [String?] = []
-        let cancellable = provider.selectedModelIdPublisher.sink { value in
-            received.append(value)
-            exp.fulfill()
-        }
-
-        // Simulate a native-side change writing directly through its own AIChatPreferencesPersistor
-        // instance on the same UserDefaults (the shared storage).
-        var nativePersistor: AIChatPreferencesPersisting = AIChatPreferencesPersistor(keyValueStore: defaults)
-        nativePersistor.selectedModelId = "maverick"
-
-        wait(for: [exp], timeout: 1.0)
-        cancellable.cancel()
-
-        XCTAssertEqual(received, ["maverick"])
-    }
-
-    func testSelectedModelIdPublisher_doesNotEmitForUnchangedValue() throws {
-        let suiteName = "NewTabPageOmnibarConfigProviderTests.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-
-        var persistor: AIChatPreferencesPersisting = AIChatPreferencesPersistor(keyValueStore: defaults)
-        persistor.selectedModelId = "maverick"
-
-        let provider = try makeProvider(persistor: persistor, observer: defaults)
+    func testSelectedModelIdPublisher_forwardsFromSharedPersistor() throws {
+        // Native and NTP hold the same persistor. A write on the "native" side must reach
+        // the NTP provider's publisher so JS gets notified via omnibar_onConfigUpdate.
+        let persistor = MockAIChatPreferencesPersisting()
+        let provider = try makeProvider(persistor: persistor)
 
         var received: [String?] = []
         let cancellable = provider.selectedModelIdPublisher.sink { received.append($0) }
 
-        // Write the same value via the shared storage — lastObservedModelId should dedup.
         persistor.selectedModelId = "maverick"
-
-        // Pump the main runloop so any receive(on:) blocks would fire.
-        let pump = expectation(description: "runloop")
-        DispatchQueue.main.async { pump.fulfill() }
-        wait(for: [pump], timeout: 1.0)
+        persistor.selectedModelId = "maverick"   // dedup in persistor → no second emit
+        persistor.selectedModelId = "claude-4"
+        persistor.selectedModelId = nil
 
         cancellable.cancel()
-        XCTAssertEqual(received, [])
-    }
-
-    func testSelectedModelId_setterIsReentrancySafe() throws {
-        // Regression: assigning through the provider used to crash in AIChatPreferencesPersistor
-        // when the UserDefaults.didChangeNotification sink read the same var while the setter
-        // still held exclusive-write access.
-        let suiteName = "NewTabPageOmnibarConfigProviderTests.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-
-        let persistor = AIChatPreferencesPersistor(keyValueStore: defaults)
-        let provider = try makeProvider(persistor: persistor, observer: defaults)
-
-        let exp = expectation(description: "publisher emits after setter")
-        var received: String?
-        let cancellable = provider.selectedModelIdPublisher.sink { value in
-            received = value
-            exp.fulfill()
-        }
-
-        provider.selectedModelId = "claude-4"
-
-        wait(for: [exp], timeout: 1.0)
-        cancellable.cancel()
-
-        XCTAssertEqual(received, "claude-4")
-        XCTAssertEqual(persistor.selectedModelId, "claude-4")
+        XCTAssertEqual(received, ["maverick", "claude-4", nil])
     }
 
     // MARK: - legacy model id migration
@@ -375,7 +313,7 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
         let store = try makeStore(underlying: [legacyModelIdKey: "maverick"])
         let persistor = MockAIChatPreferencesPersisting()
 
-        _ = try makeProvider(persistor: persistor, observer: .standard, keyValueStore: store)
+        _ = try makeProvider(persistor: persistor, keyValueStore: store)
 
         XCTAssertEqual(persistor.selectedModelId, "maverick")
         XCTAssertNil(store.underlyingDict[legacyModelIdKey])
@@ -387,7 +325,7 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
         let store = try makeStore(underlying: [legacyModelIdKey: "maverick"])
         let persistor = MockAIChatPreferencesPersisting()
 
-        _ = try makeProvider(persistor: persistor, observer: .standard, keyValueStore: store)
+        _ = try makeProvider(persistor: persistor, keyValueStore: store)
 
         XCTAssertEqual(persistor.selectedModelShortName, "maverick")
     }
@@ -397,7 +335,7 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
         let persistor = MockAIChatPreferencesPersisting()
         persistor.selectedModelId = "gpt-5"
 
-        _ = try makeProvider(persistor: persistor, observer: .standard, keyValueStore: store)
+        _ = try makeProvider(persistor: persistor, keyValueStore: store)
 
         XCTAssertEqual(persistor.selectedModelId, "gpt-5")
         XCTAssertNil(store.underlyingDict[legacyModelIdKey])
@@ -410,7 +348,7 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
         persistor.selectedModelId = "gpt-5"
         persistor.selectedModelShortName = "GPT-5"
 
-        _ = try makeProvider(persistor: persistor, observer: .standard, keyValueStore: store)
+        _ = try makeProvider(persistor: persistor, keyValueStore: store)
 
         XCTAssertEqual(persistor.selectedModelShortName, "GPT-5")
     }
@@ -419,7 +357,7 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
         let store = try makeStore()
         let persistor = MockAIChatPreferencesPersisting()
 
-        _ = try makeProvider(persistor: persistor, observer: .standard, keyValueStore: store)
+        _ = try makeProvider(persistor: persistor, keyValueStore: store)
 
         XCTAssertNil(persistor.selectedModelId)
         XCTAssertNil(store.underlyingDict[legacyModelIdKey])
@@ -430,14 +368,14 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
         let persistor = MockAIChatPreferencesPersisting()
 
         // First launch: migrates.
-        _ = try makeProvider(persistor: persistor, observer: .standard, keyValueStore: store)
+        _ = try makeProvider(persistor: persistor, keyValueStore: store)
         XCTAssertEqual(persistor.selectedModelId, "maverick")
 
         // Simulate the user picking a new model after migration.
         persistor.selectedModelId = "claude-4"
 
         // Second launch: legacy key is gone, so nothing is overwritten.
-        _ = try makeProvider(persistor: persistor, observer: .standard, keyValueStore: store)
+        _ = try makeProvider(persistor: persistor, keyValueStore: store)
         XCTAssertEqual(persistor.selectedModelId, "claude-4")
     }
 
@@ -467,8 +405,16 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
 // MARK: - Mocks
 
 private final class MockAIChatPreferencesPersisting: AIChatPreferencesPersisting {
-    var selectedModelId: String?
+    private let subject = PassthroughSubject<String?, Never>()
+
+    var selectedModelId: String? {
+        didSet {
+            guard selectedModelId != oldValue else { return }
+            subject.send(selectedModelId)
+        }
+    }
     var selectedModelShortName: String?
+    var selectedModelIdPublisher: AnyPublisher<String?, Never> { subject.eraseToAnyPublisher() }
 }
 
 private final class MockAIChatExcessProvider: NewTabPageOmnibarAiChatsProviding {

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarConfigProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarConfigProviderTests.swift
@@ -255,12 +255,15 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
 
     // MARK: - selectedModelId (shared with native omnibar)
 
+    private let legacyModelIdKey = "newTabPageSelectedModelId"
+
     private func makeProvider(
         persistor: AIChatPreferencesPersisting,
-        observer: UserDefaults
+        observer: UserDefaults,
+        keyValueStore: ThrowingKeyValueStoring? = nil
     ) throws -> NewTabPageOmnibarConfigProvider {
         NewTabPageOmnibarConfigProvider(
-            keyValueStore: try makeStore(),
+            keyValueStore: try keyValueStore ?? makeStore(),
             aiChatShortcutSettingProvider: MockNewTabPageAIChatShortcutSettingProvider(),
             featureFlagger: MockFeatureFlagger(),
             aiChatPreferencesPersistor: persistor,
@@ -363,6 +366,55 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
         cancellable.cancel()
 
         XCTAssertEqual(received, "claude-4")
+        XCTAssertEqual(persistor.selectedModelId, "claude-4")
+    }
+
+    // MARK: - legacy model id migration
+
+    func testMigration_copiesLegacyValueWhenSharedStoreIsEmpty() throws {
+        let store = try makeStore(underlying: [legacyModelIdKey: "maverick"])
+        let persistor = MockAIChatPreferencesPersisting()
+
+        _ = try makeProvider(persistor: persistor, observer: .standard, keyValueStore: store)
+
+        XCTAssertEqual(persistor.selectedModelId, "maverick")
+        XCTAssertNil(store.underlyingDict[legacyModelIdKey])
+    }
+
+    func testMigration_preservesSharedValueAndDropsLegacyKey() throws {
+        let store = try makeStore(underlying: [legacyModelIdKey: "maverick"])
+        let persistor = MockAIChatPreferencesPersisting()
+        persistor.selectedModelId = "gpt-5"
+
+        _ = try makeProvider(persistor: persistor, observer: .standard, keyValueStore: store)
+
+        XCTAssertEqual(persistor.selectedModelId, "gpt-5")
+        XCTAssertNil(store.underlyingDict[legacyModelIdKey])
+    }
+
+    func testMigration_noOpWhenLegacyKeyAbsent() throws {
+        let store = try makeStore()
+        let persistor = MockAIChatPreferencesPersisting()
+
+        _ = try makeProvider(persistor: persistor, observer: .standard, keyValueStore: store)
+
+        XCTAssertNil(persistor.selectedModelId)
+        XCTAssertNil(store.underlyingDict[legacyModelIdKey])
+    }
+
+    func testMigration_runsOnlyOnce() throws {
+        let store = try makeStore(underlying: [legacyModelIdKey: "maverick"])
+        let persistor = MockAIChatPreferencesPersisting()
+
+        // First launch: migrates.
+        _ = try makeProvider(persistor: persistor, observer: .standard, keyValueStore: store)
+        XCTAssertEqual(persistor.selectedModelId, "maverick")
+
+        // Simulate the user picking a new model after migration.
+        persistor.selectedModelId = "claude-4"
+
+        // Second launch: legacy key is gone, so nothing is overwritten.
+        _ = try makeProvider(persistor: persistor, observer: .standard, keyValueStore: store)
         XCTAssertEqual(persistor.selectedModelId, "claude-4")
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1214148331342596?focus=true
Tech Design URL:
CC:

### Description
Unifies the Duck.ai model selection between the native omnibar and the NTP (webview) omnibar so that changing the model in either one is reflected in the other.

Both omnibars previously tracked their own picks:

 | Omnibar | UserDefaults key |
 |---|---|
 | Native | `aichat.omnibar.selected-model-id` (`AIChatPreferencesPersisting`) |
 | NTP | `newTabPageSelectedModelId` (`NewTabPageOmnibarConfigProvider`) |

Changes:
- `NewTabPageOmnibarConfigProvider.selectedModelId` now reads/writes through the shared `AIChatPreferencesPersisting` (same key as native).
- Added `selectedModelIdPublisher` to the provider, backed by `UserDefaults.didChangeNotification` (received on the main queue to avoid a Swift exclusive-access crash in the struct's setter).
- `NewTabPageOmnibarClient` subscribes to that publisher and calls `notifyConfigUpdated()` so JS receives the new model via `omnibar_onConfigUpdate` when the native side changes it.
- One-time migration: on init, if the legacy `newTabPageSelectedModelId` key exists, copy it into the shared key (only when the shared key is empty) and drop the legacy key.

### Testing Steps
1. Quit the app. Seed UserDefaults to simulate an upgrading NTP-only user:
```sh
  BID=com.duckduckgo.macos.browser.debug   # adjust for your build
  defaults delete "$BID" "aichat.omnibar.selected-model-id" 2>/dev/null
  defaults write "$BID" newTabPageSelectedModelId -string "<some-valid-model-id>"
```
2. Launch the app → open the NTP. The model picker should show the migrated model. Confirm the legacy key is gone: `defaults read "$BID" newTabPageSelectedModelId` → "does not exist".
3. Focus the address bar (native Duck.ai omnibar). The same model should be selected.
 4. Change the model in the **native** omnibar (e.g. pick Maverick). Dismiss the popover → the NTP picker reflects the new model.
5. Change the model in the **NTP** omnibar (e.g. pick GPT-5.2). Reopen the native omnibar → it shows the new model.
6. Quit and relaunch → the last selection persists on both sides.

### Impact and Risks
**Medium.** Scoped to Duck.ai omnibar model selection UX. No impact on auth, data, or navigation. The worst realistic case is the wrong default model on first launch after update for a narrow user slice.

#### What could go wrong?
- **Users who only picked in NTP lose their selection.** Mitigated by the one-time migration that copies the legacy key into the shared key before dropping it.
- **Users who picked in both omnibars:** the native value wins (single source of truth). Acceptable — the legacy NTP value is dropped, but the user still has *a* valid recent pick, and they can re-select.
- **Migration running twice** and clobbering a freshly-picked model. Migration removes the legacy key on first run, so subsequent launches are no-op. Regression test: `testMigration_runsOnlyOnce`.

### Quality Considerations
- **Edge cases:** (a) legacy key present + shared empty → migrate; (b) legacy key present + shared populated → native wins, legacy dropped; (c) neither present → no-op; (d) legacy dropped, user picks again → next launch preserves. All four are covered by tests in `NewTabPageOmnibarConfigProviderTests`.

### Notes to Reviewer
 - Please sanity-check the migration's `inout AIChatPreferencesPersisting` pattern in `migrateLegacySelectedModelIdIfNeeded(...)`. It's a `static` helper called from `init` before the notification observer is wired, so the migration write does not kick the publisher (no phantom emission to JS on launch).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistence and cross-component propagation for the selected AI model, including a one-time UserDefaults migration; regressions could cause incorrect/default model selection or stale short-name caching across omnibars.
> 
> **Overview**
> Unifies Duck.ai model selection between the native omnibar and the NTP omnibar by routing both through a shared `AIChatPreferencesPersistor` instance and notifying the NTP webview when the native selection changes.
> 
> `AIChatPreferencesPersistor` is now a reference type that exposes `selectedModelIdPublisher` (distinct-write only), `NewTabPageOmnibarConfigProvider` reads/writes `selectedModelId`/`selectedModelShortName` via that persistor, and a one-time migration copies the legacy NTP-only model key into the shared store before deleting it. `NewTabPageOmnibarClient` now triggers `omnibar_onConfigUpdate` on model changes and avoids clobbering cached short names when the model id is echoed unchanged. Tests and stubs were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0ec0a07cd9e8592b2a66fe3d05d07f48bf8669e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->