### PR TITLE
Fix missing removal-verification case in PIR wide events 

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/BrokerProfileScanSubJob.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/BrokerProfileScanSubJob.swift
@@ -85,7 +85,8 @@ struct BrokerProfileScanSubJob {
         let stageCalculator = scanContext.stageCalculator
 
         let metadata = ScanWideEventRecorder.Metadata(
-            from: brokerProfileQueryData.scanJobData,
+            scanHistoryEvents: brokerProfileQueryData.scanJobDataHistoryEventsSortedEarliestFirst,
+            optOutsHistoryEvents: brokerProfileQueryData.optOutJobDataHistoryEventsSortedWithinOptOutEarliestFirst,
             referenceDate: stageCalculator.startTime,
             isFreeScan: !isAuthenticated
         )

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/WideEvent/ScanWideEventRecorder.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/WideEvent/ScanWideEventRecorder.swift
@@ -134,49 +134,46 @@ final class ScanWideEventRecorder {
 }
 
 extension ScanWideEventRecorder.Metadata {
-    /// This initializes the metadata for the wide event based on history events
+    /// This initializes the metadata for the wide event based on history events.
     ///
-    /// Look for scan success event (matchesFound, noMatchFound) in the history
-    /// - intervalStart is set to when the first .scanStarted after the most recent success event occurs,
-    ///   falls back to referenceDate otherwise
-    /// - attemptNumber is the number of .scanStarted events after the most recent success event + 1,
-    ///   falls back 1 otherwise
-    /// - attemptType follows OperationPreferredDateCalculator.dateForScanOperation logic:
-    ///   - set to confirmationOptOutScan if the most recent event is optOutRequested
-    ///   - set to maintenanceScan if the most recent event is either optOutConfirmed, noMatchFound, matchesFound, or reAppearence (sic)
-    ///   - set to newScan if there has been no scan success event, maintenanceScan otherwise
-    init(from scanJobData: ScanJobData, referenceDate: Date, isFreeScan: Bool) {
-        let sortedEvents = scanJobData.historyEvents.sorted { $0.date < $1.date }
+    /// attemptNumber / intervalStart are derived from the scan job's history:
+    /// - intervalStart is set to when the first .scanStarted after the most recent scan success event
+    ///   (matchesFound, noMatchFound) occurs, falling back to referenceDate.
+    /// - attemptNumber is the count of .scanStarted events after the most recent scan success event + 1,
+    ///   falling back to 1.
+    ///
+    /// attemptType mirrors the confirmOptOutScan branch of OperationPreferredDateCalculator.dateForScanOperation:
+    /// - confirmOptOutScan if any opt-out job's most recent event is .optOutRequested.
+    /// - maintenanceScan if there has been a prior scan success.
+    /// - newScan otherwise.
+    /// - Parameters:
+    ///   - scanHistoryEvents: Scan job history events, sorted earliest-first.
+    ///   - optOutsHistoryEvents: Each opt-out job's history events, sorted earliest-first within each inner array.
+    init(scanHistoryEvents: [HistoryEvent],
+         optOutsHistoryEvents: [[HistoryEvent]],
+         referenceDate: Date,
+         isFreeScan: Bool) {
+        let lastSuccessDate = scanHistoryEvents.last(where: { $0.isScanSuccessEvent() })?.date
 
-        let lastSuccessDate = sortedEvents.last(where: { $0.isScanSuccessEvent() })?.date
-
-        let eventsAfterLastSuccess = sortedEvents.filter { event in
+        let attemptsInCurrentCycle = scanHistoryEvents.filter { event in
+            guard case .scanStarted = event.type else { return false }
             guard let lastSuccessDate else { return true }
             return event.date > lastSuccessDate
         }
 
-        let attemptsInCurrentCycle = eventsAfterLastSuccess.filter { event in
-            if case .scanStarted = event.type {
-                return true
-            }
-            return false
-        }
-
         let attemptNumber = max(attemptsInCurrentCycle.count + 1, 1)
-        let intervalStart = attemptsInCurrentCycle.map { $0.date }.min() ?? referenceDate
+        let intervalStart = attemptsInCurrentCycle.first?.date ?? referenceDate
 
-        let latestEvent = sortedEvents.last
+        let latestOptOutEvents = optOutsHistoryEvents.compactMap { $0.last }
+        let hasPendingOptOutConfirmation = latestOptOutEvents.contains { $0.type == .optOutRequested }
+
         let attemptType: ScanWideEventData.AttemptType
-        switch latestEvent?.type {
-        case .optOutRequested:
+        if hasPendingOptOutConfirmation {
             attemptType = .confirmOptOutScan
-        case .optOutConfirmed,
-             .noMatchFound,
-             .matchesFound,
-             .reAppearence:
+        } else if lastSuccessDate != nil {
             attemptType = .maintenanceScan
-        default:
-            attemptType = (lastSuccessDate == nil) ? .newScan : .maintenanceScan
+        } else {
+            attemptType = .newScan
         }
 
         self.intervalStart = intervalStart

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/ScanWideEventRecorderTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/ScanWideEventRecorderTests.swift
@@ -43,11 +43,11 @@ final class ScanWideEventRecorderTests: XCTestCase {
 
     func testMetadataForInitialScanUsesReferenceDateAndNewScan() {
         let referenceDate = Date(timeIntervalSince1970: 500)
-        let scanJob = ScanJobData(brokerId: 1,
-                                  profileQueryId: 1,
-                                  historyEvents: [])
 
-        let metadata = ScanWideEventRecorder.Metadata(from: scanJob, referenceDate: referenceDate, isFreeScan: false)
+        let metadata = ScanWideEventRecorder.Metadata(scanHistoryEvents: [],
+                                                      optOutsHistoryEvents: [],
+                                                      referenceDate: referenceDate,
+                                                      isFreeScan: false)
 
         XCTAssertEqual(metadata.intervalStart, referenceDate)
         XCTAssertEqual(metadata.attemptNumber, 1)
@@ -56,49 +56,68 @@ final class ScanWideEventRecorderTests: XCTestCase {
 
     func testMetadataCountsAttemptsSinceLastSuccess() {
         let referenceDate = Date(timeIntervalSince1970: 10_000)
-        let historyEvents: [HistoryEvent] = [
+        let scanHistoryEvents: [HistoryEvent] = [
             HistoryEvent(brokerId: 1, profileQueryId: 1, type: .scanStarted, date: Date(timeIntervalSince1970: 1_000)),
             HistoryEvent(brokerId: 1, profileQueryId: 1, type: .matchesFound(count: 2), date: Date(timeIntervalSince1970: 2_000)),
             HistoryEvent(brokerId: 1, profileQueryId: 1, type: .scanStarted, date: Date(timeIntervalSince1970: 3_000)),
             HistoryEvent(brokerId: 1, profileQueryId: 1, type: .error(error: .unknown("failed")), date: Date(timeIntervalSince1970: 3_500)),
             HistoryEvent(brokerId: 1, profileQueryId: 1, type: .scanStarted, date: Date(timeIntervalSince1970: 4_000))
         ]
-        let scanJob = ScanJobData(brokerId: 1,
-                                  profileQueryId: 1,
-                                  historyEvents: historyEvents)
 
-        let metadata = ScanWideEventRecorder.Metadata(from: scanJob, referenceDate: referenceDate, isFreeScan: false)
+        let metadata = ScanWideEventRecorder.Metadata(scanHistoryEvents: scanHistoryEvents,
+                                                      optOutsHistoryEvents: [],
+                                                      referenceDate: referenceDate,
+                                                      isFreeScan: false)
 
         XCTAssertEqual(metadata.attemptNumber, 3, "Two attempts recorded after success plus the new one about to start.")
         XCTAssertEqual(metadata.intervalStart, Date(timeIntervalSince1970: 3_000))
         XCTAssertEqual(metadata.attemptType, .maintenanceScan)
     }
 
-    func testMetadataUsesConfirmationAttemptWhenLastEventIsOptOutRequested() {
+    func testMetadataUsesConfirmationAttemptWhenOptOutRequestedIsLatestOptOutEvent() {
         let referenceDate = Date(timeIntervalSince1970: 20_000)
-        let historyEvents: [HistoryEvent] = [
+        let scanHistoryEvents: [HistoryEvent] = [
             HistoryEvent(brokerId: 1, profileQueryId: 1, type: .scanStarted, date: Date(timeIntervalSince1970: 5_000)),
-            HistoryEvent(brokerId: 1, profileQueryId: 1, type: .matchesFound(count: 1), date: Date(timeIntervalSince1970: 5_500)),
-            HistoryEvent(brokerId: 1, profileQueryId: 1, type: .optOutRequested, date: Date(timeIntervalSince1970: 6_000))
+            HistoryEvent(brokerId: 1, profileQueryId: 1, type: .matchesFound(count: 1), date: Date(timeIntervalSince1970: 5_500))
         ]
-        let scanJob = ScanJobData(brokerId: 1,
-                                  profileQueryId: 1,
-                                  historyEvents: historyEvents)
+        let optOutHistoryEvents: [HistoryEvent] = [
+            HistoryEvent(extractedProfileId: 1, brokerId: 1, profileQueryId: 1, type: .optOutStarted, date: Date(timeIntervalSince1970: 5_800)),
+            HistoryEvent(extractedProfileId: 1, brokerId: 1, profileQueryId: 1, type: .optOutRequested, date: Date(timeIntervalSince1970: 6_000))
+        ]
 
-        let metadata = ScanWideEventRecorder.Metadata(from: scanJob, referenceDate: referenceDate, isFreeScan: false)
+        let metadata = ScanWideEventRecorder.Metadata(scanHistoryEvents: scanHistoryEvents,
+                                                      optOutsHistoryEvents: [optOutHistoryEvents],
+                                                      referenceDate: referenceDate,
+                                                      isFreeScan: false)
 
         XCTAssertEqual(metadata.attemptType, .confirmOptOutScan)
-        XCTAssertEqual(metadata.attemptNumber, 1)
-        XCTAssertEqual(metadata.intervalStart, referenceDate)
+    }
+
+    func testMetadataFallsBackToMaintenanceScanWhenLatestOptOutEventIsConfirmed() {
+        let referenceDate = Date(timeIntervalSince1970: 20_000)
+        let scanHistoryEvents: [HistoryEvent] = [
+            HistoryEvent(brokerId: 1, profileQueryId: 1, type: .matchesFound(count: 1), date: Date(timeIntervalSince1970: 5_500))
+        ]
+        let optOutHistoryEvents: [HistoryEvent] = [
+            HistoryEvent(extractedProfileId: 1, brokerId: 1, profileQueryId: 1, type: .optOutRequested, date: Date(timeIntervalSince1970: 6_000)),
+            HistoryEvent(extractedProfileId: 1, brokerId: 1, profileQueryId: 1, type: .optOutConfirmed, date: Date(timeIntervalSince1970: 7_000))
+        ]
+
+        let metadata = ScanWideEventRecorder.Metadata(scanHistoryEvents: scanHistoryEvents,
+                                                      optOutsHistoryEvents: [optOutHistoryEvents],
+                                                      referenceDate: referenceDate,
+                                                      isFreeScan: false)
+
+        XCTAssertEqual(metadata.attemptType, .maintenanceScan)
     }
 
     func testMetadataIncludesIsFreeScanWhenProvided() {
         let referenceDate = Date(timeIntervalSince1970: 500)
-        let scanJob = ScanJobData(brokerId: 1,
-                                  profileQueryId: 1,
-                                  historyEvents: [])
 
-        let metadata = ScanWideEventRecorder.Metadata(from: scanJob, referenceDate: referenceDate, isFreeScan: true)
+        let metadata = ScanWideEventRecorder.Metadata(scanHistoryEvents: [],
+                                                      optOutsHistoryEvents: [],
+                                                      referenceDate: referenceDate,
+                                                      isFreeScan: true)
 
         XCTAssertTrue(metadata.isFreeScan)
     }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1214050916756577?focus=true
Tech Design URL:
CC:

### Description

Existing wide event implementation doesn’t report `removal-verification` case due to scan history event usage. Instead of just relying on them, we need opt-out history events too.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. CI passes
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wide-event metadata derivation for scan flows, which can alter reported attempt type/intervals and downstream analytics. Logic is covered by updated/added unit tests but impacts production telemetry behavior.
> 
> **Overview**
> Fixes scan wide-events misclassifying the *removal-verification* (`confirmOptOutScan`) case by deriving `ScanWideEventRecorder.Metadata` from both scan history and opt-out job history, not just scan events.
> 
> Updates scan execution to pass pre-sorted scan/opt-out history into the recorder, simplifies interval-start selection to the first post-success `.scanStarted`, and adds/adjusts tests for the new opt-out-driven attempt-type behavior (including confirmed-vs-requested opt-out cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e9dabb33510be7315752880687bfa97059f680f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->