### PR TITLE
Auto-create Asana tasks for new subscription funnel origins

### DIFF
--- a/.github/workflows/sync_subscription_funnels_to_asana.yml
+++ b/.github/workflows/sync_subscription_funnels_to_asana.yml
@@ -22,26 +22,68 @@ jobs:
       - name: Create Asana tasks for new funnel names
         env:
           ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ASANA_PARENT_TASK_GID: "1209784982258586"
+          ASANA_TEMPLATE_TASK_GID: "1213541048287202"
+          ASANA_WORKSPACE_GID: "137249556945"
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
         run: |
+          # Fetch template task and extract body below the "---" separator
+          template_notes=$(curl -s \
+            -H "Authorization: Bearer $ASANA_ACCESS_TOKEN" \
+            "https://app.asana.com/api/1.0/tasks/$ASANA_TEMPLATE_TASK_GID?opt_fields=notes" \
+            | jq -r '.data.notes')
+          template_body=$(echo "$template_notes" | awk '/^-{10,}/{found=1; next} found{print}')
+
+          # Resolve PR author's Asana user GID via their commit email
+          author_email=$(curl -s \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/$REPO/commits/$PR_HEAD_SHA" \
+            | jq -r '.commit.author.email // empty')
+
+          asana_assignee_gid=""
+          if [ -n "$author_email" ]; then
+            asana_assignee_gid=$(curl -s \
+              -H "Authorization: Bearer $ASANA_ACCESS_TOKEN" \
+              "https://app.asana.com/api/1.0/workspaces/$ASANA_WORKSPACE_GID/users?opt_fields=gid,email" \
+              | jq -r --arg email "$author_email" '.data[] | select(.email == $email) | .gid' | head -1)
+            echo "Author email: $author_email → Asana GID: ${asana_assignee_gid:-not found}"
+          else
+            echo "Could not resolve commit email for $PR_AUTHOR; task will be unassigned"
+          fi
+
           create_task() {
             local funnel_name="$1"
             local platform="$2"
 
+            # Fill template body: substitute "insert origins here" with the actual funnel name
+            local filled_body
+            filled_body=$(echo "$template_body" | awk -v name="$funnel_name" '{gsub("insert origins here", name); print}')
+
             local notes
-            notes=$(printf 'New funnel added: %s\nAuthor: %s\nPR: %s\nPlatform: %s\nDescription: %s' \
-              "$funnel_name" "$PR_AUTHOR" "$PR_URL" "$platform" "$PR_TITLE")
+            notes=$(printf 'GitHub: @%s | Platform: %s | PR: %s\n%s' \
+              "$PR_AUTHOR" "$platform" "$PR_URL" "$filled_body")
 
             local payload
-            payload=$(jq -n \
-              --arg name "New subscription funnel on ${platform}: ${funnel_name}" \
-              --arg notes "$notes" \
-              --arg parent "$ASANA_PARENT_TASK_GID" \
-              '{data: {name: $name, notes: $notes, parent: $parent}}')
+            if [ -n "$asana_assignee_gid" ]; then
+              payload=$(jq -n \
+                --arg name "$funnel_name" \
+                --arg notes "$notes" \
+                --arg parent "$ASANA_PARENT_TASK_GID" \
+                --arg assignee "$asana_assignee_gid" \
+                '{data: {name: $name, notes: $notes, parent: $parent, assignee: $assignee}}')
+            else
+              payload=$(jq -n \
+                --arg name "$funnel_name" \
+                --arg notes "$notes" \
+                --arg parent "$ASANA_PARENT_TASK_GID" \
+                '{data: {name: $name, notes: $notes, parent: $parent}}')
+            fi
 
             local response http_code
             response=$(curl -s -w "\n%{http_code}" -X POST \
@@ -52,7 +94,7 @@ jobs:
             http_code=$(echo "$response" | tail -n1)
 
             if [ "$http_code" -eq 201 ]; then
-              echo "✅ Created Asana task: New subscription funnel on ${platform}: ${funnel_name}"
+              echo "✅ Created Asana task: ${funnel_name} (${platform})"
             else
               echo "❌ Failed to create task for ${funnel_name} (${platform}): HTTP ${http_code}"
               echo "$response" | head -n -1

--- a/.github/workflows/sync_subscription_funnels_to_asana.yml
+++ b/.github/workflows/sync_subscription_funnels_to_asana.yml
@@ -1,0 +1,92 @@
+name: Sync new subscription funnels to Asana
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+    paths:
+      - 'iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift'
+      - 'macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift'
+
+jobs:
+  sync-funnels:
+    if: github.event.pull_request.merged == true
+    name: "Create Asana tasks for new subscription funnels"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create Asana tasks for new funnel names
+        env:
+          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          ASANA_PARENT_TASK_GID: "1209784982258586"
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          create_task() {
+            local funnel_name="$1"
+            local platform="$2"
+
+            local notes
+            notes=$(printf 'New funnel added: %s\nAuthor: %s\nPR: %s\nPlatform: %s\nDescription: %s' \
+              "$funnel_name" "$PR_AUTHOR" "$PR_URL" "$platform" "$PR_TITLE")
+
+            local payload
+            payload=$(jq -n \
+              --arg name "New subscription funnel on ${platform}: ${funnel_name}" \
+              --arg notes "$notes" \
+              --arg parent "$ASANA_PARENT_TASK_GID" \
+              '{data: {name: $name, notes: $notes, parent: $parent}}')
+
+            local response http_code
+            response=$(curl -s -w "\n%{http_code}" -X POST \
+              "https://app.asana.com/api/1.0/tasks" \
+              -H "Authorization: Bearer $ASANA_ACCESS_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "$payload")
+            http_code=$(echo "$response" | tail -n1)
+
+            if [ "$http_code" -eq 201 ]; then
+              echo "✅ Created Asana task: New subscription funnel on ${platform}: ${funnel_name}"
+            else
+              echo "❌ Failed to create task for ${funnel_name} (${platform}): HTTP ${http_code}"
+              echo "$response" | head -n -1
+              exit 1
+            fi
+          }
+
+          process_file() {
+            local file="$1"
+            local platform="$2"
+
+            local new_funnels
+            new_funnels=$(
+              git diff "$BASE_SHA" HEAD -- "$file" \
+                | grep '^+' \
+                | grep -v '^+++' \
+                | grep -oP '"funnel_[^"]+"' \
+                | tr -d '"'
+            )
+
+            if [ -z "$new_funnels" ]; then
+              echo "No new funnel names detected in $file"
+              return
+            fi
+
+            while IFS= read -r funnel_name; do
+              [ -n "$funnel_name" ] && create_task "$funnel_name" "$platform"
+            done <<< "$new_funnels"
+          }
+
+          process_file \
+            "iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift" \
+            "iOS"
+
+          process_file \
+            "macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift" \
+            "macOS"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207260194172075/task/1214148689093862?focus=true
Tech Design URL:
CC:

### Description

Adds a GitHub Action that automatically creates an Asana subtask whenever a new `funnel_*` origin is merged to `main` on iOS or macOS.

- Triggers on merged PRs that touch `SubscriptionFunnelOrigin.swift` (iOS or macOS)
- Diffs against the PR base to extract newly added `funnel_*` values
- For each new funnel, creates a subtask under [Subscription Entry Points](https://app.asana.com/1/137249556945/project/1207260194172075/task/1209784982258586) using the [standard entry point template](https://app.asana.com/1/137249556945/project/1207260194172075/task/1213541048287202?focus=true), assigned to the PR author

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Merge a PR that adds a new `funnel_*` value to `SubscriptionFunnelOrigin.swift` on iOS or macOS
2. Confirm the GitHub Action runs and creates an Asana subtask under the Subscription Entry Points task
3. Confirm the subtask is assigned to the PR author and follows the standard template format

### Impact and Risks

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
**None: Internal tooling**

#### What could go wrong?

- **Asana token expires or loses permissions** — the Action fails with a non-201 response and surfaces the error in workflow logs; no silent failures
- **PR author's commit email doesn't match their Asana account** — task is created unassigned; engineer can assign manually

### Quality Considerations

- No impact on app code or user-facing features
- Fails loudly on API errors (non-zero exit code surfaces in CI)
- Gracefully handles missing assignee without blocking task creation

### Notes to Reviewer

Infrastructure-only change — no Swift code changed. The `ASANA_ACCESS_TOKEN` secret is already present in repo Actions secrets.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)