### PR TITLE
[iOS] Fix OmniBar clear button stuck after search submit

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3472,9 +3472,15 @@ extension MainViewController: OmniBarDelegate {
         if !daxDialogsManager.shouldShowFireButtonPulse {
             ViewHighlighter.hideAll()
         }
+        // Hide suggestion tray before kicking off navigation. refreshOmniBar()
+        // queues an async swipe-tabs collection reload via applyWidth(); that
+        // reload re-parents the OmniBar cell and fires textFieldDidEndEditing
+        // on a later runloop tick, before dismissOmniBar reaches hideSuggestionTray.
+        // Hiding the tray up front ensures onEditingEnd sees autocomplete=false
+        // and resolves to .dismissed, not .suspended.
+        hideSuggestionTray()
         omniBar.cancel()
         loadQuery(query)
-        hideSuggestionTray()
         hideNotificationBarIfBrokenSitePromptShown()
         showHomeRowReminder()
         fireOnboardingCustomSearchPixelIfNeeded(query: query)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1214157956761227?focus=true
Tech Design URL:
CC: @edulpn 

### Description
Fixes a regression in `minimalChromeInLandscape` where submitting a search with unified toggle input OFF left the OmniBar stuck in an editing-suspended state, the clear button stayed visible, and the state persisted through navigation to the search result.

Root cause chain across the feature PRs:
- [#4242](https://github.com/duckduckgo/apple-browsers/pull/4242) moved the active OmniBar into a swipe-tabs collection view cell, so any `reloadData()` on that collection view re-parents the hosted text field and asynchronously resigns first responder.
- [#4299](https://github.com/duckduckgo/apple-browsers/pull/4299) added `applyWidth()` inside `refreshOmniBar()`, which queues an async `swipeTabsCoordinator.refresh(tabsModel:)` (a `reloadData`) every time `refreshOmniBar` runs. During search submit, `refreshOmniBar` fires multiple times as the webview kicks off navigation, so several async reloads race against `dismissOmniBar`.
- When the async reload fires first, `textFieldDidEndEditing` runs before `dismissOmniBar` reaches its `hideSuggestionTray()`. `MainViewController.onEditingEnd()` sees `isShowingAutocompleteSuggestions = true`, returns `.suspended`, and the state flips to `EditingSuspendedState(baseState: BrowsingTextEditingStartedState)`, which has `showClear = true`.

When input toggle is enabled, the bug does not happen because search submit goes through the SwitchBar, which resigns its own text view before `onOmniQuerySubmitted` runs.

Fix: hide the suggestion tray up front in `MainViewController.onOmniQuerySubmitted`, before `omniBar.cancel()` and `loadQuery(query)`. The async `textFieldDidEndEditing` then sees `autocomplete = false` and resolves to `.dismissed`, leaving state in `BrowsingNonEditingState`.

### Testing Steps
1. Enable the `minimalChromeInLandscape` feature flag in internal settings.
2. Ensure unified toggle input is OFF.
3. Open an existing tab, rotate to landscape so minimal chrome applies.
4. Tap the OmniBar, type a search query, press Enter.
5. Verify the clear button disappears as the OmniBar transitions to the browsing state, and after the page loads the OmniBar shows the URL / privacy icon correctly, not an editing-suspended state.
6. Tap a search result link from the results page, verify the OmniBar updates cleanly.
7. Repeat steps 3-5 with unified toggle input ON, verify no regression in the SwitchBar submit path.
8. Repeat in portrait with the flag enabled and toggle input OFF, verify normal search submit works.
9. Verify iPad behavior is unchanged (no minimal chrome path).

### Impact and Risks
Medium - even though the change is simple, the logic in the area is quite complex.

#### What could go wrong?
Glitching of suggestion tray. Verified manually it’s not affected.

### Quality Considerations
N/A

### Notes to Reviewer
The inline comment in `onOmniQuerySubmitted` documents the non-obvious ordering constraint.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the ordering of UI state updates during query submission, which can affect OmniBar/suggestion-tray behavior across navigation and async reload timing.
> 
> **Overview**
> Fixes a regression where submitting a query could leave the OmniBar stuck in an *editing-suspended* state (e.g., clear button visible) due to an async swipe-tabs reload triggering `textFieldDidEndEditing` before the suggestion tray was dismissed.
> 
> `MainViewController.onOmniQuerySubmitted` now hides the suggestion tray *before* cancelling the OmniBar and starting navigation (`loadQuery`), with an added comment documenting the ordering constraint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a31b52d0d848f2627577be8de571d2c95b4ca9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->