### PR TITLE
[macOS] Expand address bar on right-click

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -1004,7 +1004,11 @@ final class AddressBarViewController: NSViewController {
 
         guard selectionState != .activeWithAIChat else { return event }
 
-        // The event location is not a button so we can forward the event to the textfield
+        if self.view.window?.firstResponder !== addressBarTextField.currentEditor() {
+            self.addressBarButtonsViewController?.bookmarkButton.isHidden = true
+            self.addressBarTextField.makeMeFirstResponder()
+        }
+
         addressBarTextField.rightMouseDown(with: event)
         return nil
     }

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -1009,6 +1009,7 @@ final class AddressBarViewController: NSViewController {
             self.addressBarTextField.makeMeFirstResponder()
         }
 
+        // The event location is not a button so we can forward the event to the textfield
         addressBarTextField.rightMouseDown(with: event)
         return nil
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1214161842476705/f
Tech Design URL:
CC:

### Description

When the address bar is left-clicked, it expands to its focused (taller) height. Right-clicking (to show the context menu) did not trigger this expansion. This PR makes right-click behave consistently with left-click by making the address bar first responder before forwarding the right-click event to the text field.

### Testing Steps

1. Open DuckDuckGo browser and navigate to any page
2. Left-click on the address bar — observe it expands (gets taller)
3. Click away to unfocus the address bar
4. Right-click on the address bar — observe it now also expands before showing the context menu

### Impact and Risks

Low: Minor behavior change to address bar interaction.

#### What could go wrong?

The context menu could appear slightly differently if the expansion animation races with the menu display — verified manually that this is not the case.

### Quality Considerations

- Edge case: right-clicking when the address bar is already focused — handled by checking `firstResponder` before calling `makeMeFirstResponder()`
- No performance impact — reuses existing focus/resize logic

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI interaction tweak limited to `rightMouseDown` focus handling; main risk is minor timing/visual differences around context-menu display.
> 
> **Overview**
> Right-clicking within the address bar now first focuses/activates the address bar (including hiding the bookmark button) before forwarding the right-click to the text field, making the context-menu interaction consistent with left-click focus/expansion behavior.
> 
> This is gated to only run when the address bar editor is not already the window’s first responder and still bypasses special subviews (buttons/toggles) and AI chat mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b99aaa941226f2234f00f55eb8944a8cca0d0bd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->