### PR TITLE
Fix broken tab rendering when duplicating a tab

### DIFF
--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
@@ -789,10 +789,11 @@ final class TabCollectionViewModel: NSObject {
 
         let tabCopy = Tab(
             content: tab.content.loadedFromCache(),
+            title: tab.title,
             favicon: tab.favicon,
             interactionStateData: tab.interactionStateData,
             shouldLoadInBackground: true,
-            burnerMode: burnerMode
+            burnerMode: tab.burnerMode
         )
         let newIndex = tabIndex.makeNext()
 

--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
@@ -787,13 +787,7 @@ final class TabCollectionViewModel: NSObject {
             return
         }
 
-        let tabCopy = AnyTab.unloaded(UnloadedTab(
-            content: tab.content.loadedFromCache(),
-            title: tab.title,
-            favicon: tab.favicon,
-            burnerMode: tab.burnerMode,
-            interactionStateData: tab.interactionStateData
-        ))
+        let tabCopy = Tab(content: tab.content.loadedFromCache(), favicon: tab.favicon, interactionStateData: tab.interactionStateData, shouldLoadInBackground: true, burnerMode: burnerMode)
         let newIndex = tabIndex.makeNext()
 
         tabCollection(for: tabIndex)?.insert(tabCopy, at: newIndex.item)

--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
@@ -787,7 +787,13 @@ final class TabCollectionViewModel: NSObject {
             return
         }
 
-        let tabCopy = Tab(content: tab.content.loadedFromCache(), favicon: tab.favicon, interactionStateData: tab.interactionStateData, shouldLoadInBackground: true, burnerMode: burnerMode)
+        let tabCopy = Tab(
+            content: tab.content.loadedFromCache(),
+            favicon: tab.favicon,
+            interactionStateData: tab.interactionStateData,
+            shouldLoadInBackground: true,
+            burnerMode: burnerMode
+        )
         let newIndex = tabIndex.makeNext()
 
         tabCollection(for: tabIndex)?.insert(tabCopy, at: newIndex.item)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1213659555956031/task/1214175883656703

### Description

Duplicating a tab created the copy as `AnyTab.unloaded`, which caused `select(at:)` to take the materialize path. This fired `didReplaceTabAt` → `reloadItems(at:)` before the collection view had been told about the insert, leaving the tab bar in an inconsistent state (tabs visually stacking on top of each other).

The fix inserts the duplicate as a loaded `Tab` instead. This avoids the materialize path during selection, so the collection view receives the insert and select notifications in the correct order. The source tab is still not materialized (preserving the intent of 5125f8176a).

### Testing Steps

1. Open a few tabs in the browser.
2. Right-click on a tab and select "Duplicate Tab".
3. Verify the duplicated tab appears correctly next to the original tab in the tab bar.
4. Verify tabs don't visually stack or overlap.
5. Repeat with pinned and unpinned tabs.

### Impact and Risks

Low — fixes a visual bug in tab duplication. The change is scoped to a single method (`duplicateTab(at:)`) in `TabCollectionViewModel`.

#### What could go wrong?

The duplicated tab is now inserted as a loaded `Tab` rather than an unloaded one, which means it will use slightly more memory upfront. However, since `shouldLoadInBackground: true` is set, this matches the expected behavior for a tab the user explicitly duplicated.

### Quality Considerations

- Edge case: duplicating a tab in a popup window still takes the redirect path and is unaffected by this change.
- No performance concern — duplicating a tab is a user-initiated, one-at-a-time action.
- No privacy/security implications.

### Notes to Reviewer

The key insight is that `AnyTab.unloaded` triggered the materialize-on-select path, which sent a reload notification before the insert notification reached the collection view. Switching to a loaded `Tab` sidesteps this entirely.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to `duplicateTab(at:)` that only affects how duplicated tabs are inserted/selected; primary risk is minor memory/runtime behavior differences from creating a loaded tab copy.
> 
> **Overview**
> Fixes tab duplication so the inserted copy is created as a loaded `Tab` (with `shouldLoadInBackground: true`) instead of `AnyTab.unloaded`.
> 
> This avoids the materialize-on-select path when immediately selecting the duplicated tab, preventing out-of-order `didReplaceTabAt`/reload notifications that left the tab bar UI in an inconsistent state (overlapping/stacked tabs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a35cafd1e785422cdf04d85f1cb9286cc94b4515. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->