### PR TITLE
[macOS] Reset subscription card visibility with Next Steps debug action

### DIFF
--- a/macOS/DuckDuckGo/HomePage/Model/HomePageSetUpDependencies.swift
+++ b/macOS/DuckDuckGo/HomePage/Model/HomePageSetUpDependencies.swift
@@ -42,5 +42,6 @@ final class HomePageSetUpDependencies {
         subscriptionCardPersistor.clear()
         continueSetUpModelPersistor.clear()
         nextStepsCardsPersistor.clear()
+        subscriptionCardVisibilityManager.refreshVisibilityAfterDebugReset()
     }
 }

--- a/macOS/DuckDuckGo/HomePage/Model/HomePageSubscriptionCardVisibilityManager.swift
+++ b/macOS/DuckDuckGo/HomePage/Model/HomePageSubscriptionCardVisibilityManager.swift
@@ -24,6 +24,8 @@ protocol HomePageSubscriptionCardVisibilityManaging {
     var shouldShowSubscriptionCardPublisher: Published<Bool>.Publisher { get }
     var shouldShowSubscriptionCard: Bool { get }
     func dismissSubscriptionCard()
+    /// Re-run visibility setup after persisted subscription card state was cleared (e.g. `subscriptionCardPersistor.clear()`).
+    func refreshVisibilityAfterDebugReset()
 }
 
 final class HomePageSubscriptionCardVisibilityManager: HomePageSubscriptionCardVisibilityManaging {
@@ -54,12 +56,21 @@ final class HomePageSubscriptionCardVisibilityManager: HomePageSubscriptionCardV
         updateVisibility()
     }
 
+    func refreshVisibilityAfterDebugReset() {
+        cancellables.removeAll()
+        Task { @MainActor in
+            await setup()
+        }
+    }
+
     private func setup() async {
         let userHasCachedSubscription = await hasCachedSubscription()
         if userHasCachedSubscription {
             // Prevent card from showing again, even if user removes subscription from device.
             persistor.userHadSubscription = true
         }
+        // Align in-memory subscription state before subscription to prevent stale value from being used.
+        hasSubscriptionSubject.send(userHasCachedSubscription)
 
         // Avoid setting up the observers if the user has already had a subscription.
         guard !persistor.userHadSubscription else {
@@ -84,8 +95,6 @@ final class HomePageSubscriptionCardVisibilityManager: HomePageSubscriptionCardV
         // Observe eligibility conditions
         observeSubscriptionChanges()
         checkPurchaseEligibility()
-
-        hasSubscriptionSubject.send(userHasCachedSubscription)
     }
 
     private func hasCachedSubscription() async -> Bool {

--- a/macOS/UnitTests/HomePage/Mocks/MockHomePageSubscriptionCardVisibilityManaging.swift
+++ b/macOS/UnitTests/HomePage/Mocks/MockHomePageSubscriptionCardVisibilityManaging.swift
@@ -30,4 +30,6 @@ final class MockHomePageSubscriptionCardVisibilityManaging: HomePageSubscription
         shouldShowSubscriptionCard = false
         dismissCalled = true
     }
+
+    func refreshVisibilityAfterDebugReset() {}
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1214176159430751?focus=true
Tech Design URL:
CC:

### Description

This updates the "Reset Next Steps" debug action to refresh the subscription card visibility after the persisted card settings are cleared, allowing the card to be shown again in internal testing.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Build and run the app.
2. Go to Debug -> New Tab Page -> Reset Next Steps.
3. Add a subscription to the browser, e.g. with Debug -> Subscription -> I Have a Subscription.
4. Remove the subscription, e.g. with Debug -> Subscription -> Remove Subscription From This Device.
5. Optionally: close and restart the browser.
6. Go through each of the Next Steps cards and confirm the subscription card is **not** shown. (Subscription card should not be shown if there is a cached subscription on the device.)
7. Go to Debug -> New Tab Page -> Reset Next Steps.
8. Go through each of the Next Steps cards and confirm the subscription card **is** shown. (Visibility is refreshed with the debug action.)

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
9. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low: Improvement to internal debug action

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to internal/debug reset behavior and subscription card visibility state re-initialization, with minimal impact on user-facing flows.
> 
> **Overview**
> The Next Steps debug reset (`HomePageSetUpDependencies.clearAll()`) now also refreshes subscription card visibility after clearing persisted state, so internal testers can see the subscription card again without restarting.
> 
> `HomePageSubscriptionCardVisibilityManager` adds `refreshVisibilityAfterDebugReset()` to drop existing Combine observers and re-run async `setup()`, and it now syncs the in-memory `hasSubscription` subject before wiring publishers to avoid using a stale cached value. Test mocks are updated to satisfy the new protocol requirement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db2a3a5ecc8273d1031c515a29330be7b11afd20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->