### PR TITLE
Dedupe removal-confirmation pixel on maintenance scans

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/BrokerProfileScanSubJob.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/BrokerProfileScanSubJob.swift
@@ -470,7 +470,7 @@ struct BrokerProfileScanSubJob {
         try database.add(event)
     }
 
-    private func markSavedProfilesAsRemovedAndNotifyUser(
+    internal func markSavedProfilesAsRemovedAndNotifyUser(
         removedProfiles: [ExtractedProfile],
         brokerId: Int64,
         profileQueryId: Int64,
@@ -513,7 +513,9 @@ struct BrokerProfileScanSubJob {
 
                 Logger.dataBrokerProtection.log("Profile removed from optOutsData: \(String(describing: removedProfile))")
 
-                if let attempt = try database.fetchAttemptInformation(for: extractedProfileId),
+                // Fire only on the transition to removed (pre-scan removedDate == nil).
+                if removedProfile.removedDate == nil,
+                   let attempt = try database.fetchAttemptInformation(for: extractedProfileId),
                    let attemptUUID = UUID(uuidString: attempt.attemptId) {
                     let now = Date()
                     let calculateDurationSinceLastStage = now.timeIntervalSince(attempt.lastStageDate) * 1000

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileScanSubJobTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileScanSubJobTests.swift
@@ -566,6 +566,55 @@ final class BrokerProfileScanSubJobTests: XCTestCase {
         XCTAssertTrue(removedProfiles.isEmpty)
     }
 
+    // MARK: - markSavedProfilesAsRemovedAndNotifyUser
+
+    func testMarkSavedProfilesAsRemovedAndNotifyUser_whenProfileIsNewlyRemoved_firesTransitionPixels() throws {
+        MockDataBrokerProtectionPixelsHandler.lastPixelsFired = []
+        mockDatabase.attemptInformation = .mock
+        let identifiers = makeFixtureIdentifiers()
+        let brokerData = makeFixtureBrokerProfileQueryData()
+
+        try sut.markSavedProfilesAsRemovedAndNotifyUser(
+            removedProfiles: [.mockWithoutRemovedDate],
+            brokerId: identifiers.brokerId,
+            profileQueryId: identifiers.profileQueryId,
+            brokerProfileQueryData: brokerData,
+            database: mockDatabase,
+            pixelHandler: mockPixelHandler,
+            eventsHandler: mockEventsHandler,
+            featureFlagger: MockDBPFeatureFlagger()
+        )
+
+        let firedNames = MockDataBrokerProtectionPixelsHandler.lastPixelsFired.map(\.name)
+        XCTAssertTrue(firedNames.contains("dbp_optout_process_success"))
+        XCTAssertTrue(firedNames.contains("dbp_optout_stage_finish"))
+    }
+
+    func testMarkSavedProfilesAsRemovedAndNotifyUser_whenProfileAlreadyHasRemovedDate_doesNotFireTransitionPixels() throws {
+        // Maintenance-scan scenario: the profile was already confirmed removed on a prior scan
+        // (removedDate set) but the current scan still doesn't find it, so it re-enters the
+        // confirmation path with stored attempt info. The transition pixels must NOT re-fire.
+        MockDataBrokerProtectionPixelsHandler.lastPixelsFired = []
+        mockDatabase.attemptInformation = .mock
+        let identifiers = makeFixtureIdentifiers()
+        let brokerData = makeFixtureBrokerProfileQueryData()
+
+        try sut.markSavedProfilesAsRemovedAndNotifyUser(
+            removedProfiles: [.mockWithRemovedDate],
+            brokerId: identifiers.brokerId,
+            profileQueryId: identifiers.profileQueryId,
+            brokerProfileQueryData: brokerData,
+            database: mockDatabase,
+            pixelHandler: mockPixelHandler,
+            eventsHandler: mockEventsHandler,
+            featureFlagger: MockDBPFeatureFlagger()
+        )
+
+        let firedNames = MockDataBrokerProtectionPixelsHandler.lastPixelsFired.map(\.name)
+        XCTAssertFalse(firedNames.contains("dbp_optout_process_success"))
+        XCTAssertFalse(firedNames.contains("dbp_optout_stage_finish"))
+    }
+
     // MARK: - handleRemovedProfiles
 
     func testHandleRemovedProfiles_callsMarkRemovedAndNotify() throws {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214086580272186

### Description

`m.{mac,ios}.dbp.optout.process.success` (and its paired stage pixel `dbp_optout_stage_finish`) fire on every maintenance scan for a profile that was already confirmed removed, instead of once on the transition. 

Root cause: `BrokerProfileScanSubJob.markSavedProfilesAsRemovedAndNotifyUser` fires the two pixels whenever the scan's `removedProfiles` list contains a profile with stored opt-out attempt information. Attempt info persists after the first confirmation, so on every subsequent scan that still doesn't find the profile, the fire site re-enters and re-fires the pixels. 

Fix: gate the two transition pixels with `removedProfile.removedDate == nil`. `removedDate` on the pre-scan struct snapshot is `nil` only on the scan that first confirms removal; it's non-nil on every maintenance scan afterward. Narrow, pixel-only change — the rest of the confirmation path (history events, `updateRemovedDate` restamping, wide-event completion, `allProfilesRemoved` user notification) is untouched to keep the blast radius minimal.

Also made `markSavedProfilesAsRemovedAndNotifyUser` `internal` (consistent with the neighboring `detectRemovedProfiles` / `handleRemovedProfiles` helpers) to drive it directly from tests.

### Testing Steps

CI passes.

### Impact and Risks

**Low.** Pixel-only change. Suppresses duplicate telemetry; no user-visible behavior or DB state changes. Expect metrics to be affected.

#### What could go wrong?

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only gate telemetry pixel firing based on `removedDate`, plus adds unit coverage; no change to core scan/DB update behavior beyond suppressing duplicate metrics.
> 
> **Overview**
> Prevents duplicate opt-out completion telemetry on maintenance scans by only firing `optOutFinish`/`optOutSuccess` when a removed profile is *newly* confirmed removed (`removedDate == nil`) in `markSavedProfilesAsRemovedAndNotifyUser`.
> 
> Makes `markSavedProfilesAsRemovedAndNotifyUser` `internal` for direct testing, and adds unit tests to verify pixels fire on the transition scan but not on subsequent scans where `removedDate` is already set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d1ad99f20ee9311b83a371fc8ba93d7207b174a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
