### PR TITLE
[iOS] Add delete button to autocomplete history rows

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -231,8 +231,8 @@ extension Pixel {
         case autocompleteDisplayedLocalFavorite
         case autocompleteDisplayedLocalHistory
         case autocompleteDisplayedOpenedTab
-        case autocompleteSwipeToDelete
-        case autocompleteSwipeToDeleteDaily
+        case autocompleteDeleteHistoryEntry
+        case autocompleteDeleteHistoryEntryDaily
 
         case feedbackPositive
         case feedbackNegativePrefix(category: String)
@@ -1994,8 +1994,8 @@ extension Pixel.Event {
         case .autocompleteDisplayedLocalFavorite: return "m_autocomplete_display_local_favorite"
         case .autocompleteDisplayedLocalHistory: return "m_autocomplete_display_local_history"
         case .autocompleteDisplayedOpenedTab: return "m_autocomplete_display_switch_to_tab"
-        case .autocompleteSwipeToDelete: return "m_autocomplete_result_deleted"
-        case .autocompleteSwipeToDeleteDaily: return "m_autocomplete_result_deleted_daily"
+        case .autocompleteDeleteHistoryEntry: return "m_autocomplete_result_deleted"
+        case .autocompleteDeleteHistoryEntryDaily: return "m_autocomplete_result_deleted_daily"
 
         case .feedbackPositive: return "mfbs_positive_submit"
         case .feedbackNegativePrefix(category: let category): return "mfbs_negative_\(category)"

--- a/iOS/DuckDuckGo/AutocompleteView.swift
+++ b/iOS/DuckDuckGo/AutocompleteView.swift
@@ -144,47 +144,14 @@ private struct SuggestionsSection: View {
                  Button {
                      onSuggestionSelected(suggestions[index])
                  } label: {
-                    SuggestionView(model: suggestions[index], query: query)
+                    SuggestionView(model: suggestions[index],
+                                   query: query,
+                                   onDelete: { onSuggestionDeleted(suggestions[index]) })
                  }
                  .listRowBackground(autocompleteViewModel.selection == suggestions[index] ? selectedColor : unselectedColor)
                  .listRowInsets(Metrics.rowInsets)
                  .listRowSeparatorTint(Color(designSystemColor: .lines), edges: [.bottom])
-                 .modifier(SwipeDeleteHistoryModifier(suggestion: suggestions[index], onSuggestionDeleted: onSuggestionDeleted))
             }
-        }
-    }
-
-}
-
-private struct SwipeDeleteHistoryModifier: ViewModifier {
-
-    @EnvironmentObject var autocompleteViewModel: AutocompleteViewModel
-
-    let suggestion: AutocompleteViewModel.SuggestionModel
-    var onSuggestionDeleted: (AutocompleteViewModel.SuggestionModel) -> Void
-
-    func body(content: Content) -> some View {
-        /// Swipe-to-delete is disabled when Duck.ai toggle is enabled to avoid gesture conflict
-        if autocompleteViewModel.isSwipeToDeleteEnabled {
-            switch suggestion.suggestion {
-            case .historyEntry:
-                content.swipeActions {
-                    Button(role: .destructive) {
-                        onSuggestionDeleted(suggestion)
-                    } label: {
-                        Label {
-                            Text("Delete")
-                        } icon: {
-                            Image(uiImage: DesignSystemImages.Glyphs.Size24.trash)
-                        }
-                    }
-                }
-
-            default:
-                content
-            }
-        } else {
-            content
         }
     }
 
@@ -196,6 +163,7 @@ private struct SuggestionView: View {
 
     let model: AutocompleteViewModel.SuggestionModel
     let query: String?
+    let onDelete: () -> Void
 
     var tapAheadImage: Image? {
         guard model.canShowTapAhead else { return nil }
@@ -235,13 +203,15 @@ private struct SuggestionView: View {
             case .historyEntry(_, let url, _) where url.isDuckDuckGoSearch:
                 SuggestionListItem(icon: Image(uiImage: DesignSystemImages.Glyphs.Size24.history),
                                    title: url.searchQuery ?? "",
-                                   subtitle: UserText.autocompleteSearchDuckDuckGo)
+                                   subtitle: UserText.autocompleteSearchDuckDuckGo,
+                                   onDelete: onDelete)
                 .accessibilityIdentifier("Autocomplete.Suggestions.ListItem.SERPHistory-\(url.searchQuery ?? "")")
 
             case .historyEntry(let title, let url, _):
                 SuggestionListItem(icon: Image(uiImage: DesignSystemImages.Glyphs.Size24.history),
                                    title: title ?? "",
-                                   subtitle: url.formattedForSuggestion())
+                                   subtitle: url.formattedForSuggestion(),
+                                   onDelete: onDelete)
                 .accessibilityIdentifier("Autocomplete.Suggestions.ListItem.History-\(url.formattedForSuggestion())")
 
             case .openTab(title: let title, url: let url, _, _):
@@ -277,13 +247,15 @@ private struct SuggestionListItem: View {
     let query: String?
     let indicator: Image?
     let onTapIndicator: (() -> Void)?
+    let onDelete: (() -> Void)?
 
     init(icon: Image,
          title: String,
          subtitle: String? = nil,
          query: String? = nil,
          indicator: Image? = nil,
-         onTapIndicator: ( () -> Void)? = nil) {
+         onTapIndicator: ( () -> Void)? = nil,
+         onDelete: (() -> Void)? = nil) {
 
         self.icon = icon
         self.title = title
@@ -291,6 +263,7 @@ private struct SuggestionListItem: View {
         self.query = query
         self.indicator = indicator
         self.onTapIndicator = onTapIndicator
+        self.onDelete = onDelete
     }
 
     var body: some View {
@@ -330,8 +303,8 @@ private struct SuggestionListItem: View {
             }
             .padding(.leading, Metrics.verticalSpacing)
 
-            if indicator == nil {
-                // No indicator means we want to preserve the room for icon,
+            if indicator == nil && onDelete == nil {
+                // No trailing accessory means we want to preserve the room for icon,
                 // so all the titles from other cells are aligned.
                 Spacer(minLength: Metrics.trailingPadding)
             } else {
@@ -345,6 +318,15 @@ private struct SuggestionListItem: View {
                     })
                     .tintIfAvailable(Color.init(designSystemColor: .iconsSecondary))
                     .padding(.leading, Metrics.indicatorLeadingPadding)
+            } else if let onDelete {
+                Image(uiImage: DesignSystemImages.Glyphs.Size16.clear)
+                    .highPriorityGesture(TapGesture().onEnded {
+                        onDelete()
+                    })
+                    .tintIfAvailable(Color(designSystemColor: .iconsSecondary))
+                    .padding(.leading, Metrics.indicatorLeadingPadding)
+                    .accessibilityIdentifier("Autocomplete.Suggestions.ListItem.DeleteButton")
+                    .accessibilityLabel(UserText.actionDelete)
             }
         }
     }

--- a/iOS/DuckDuckGo/AutocompleteViewController.swift
+++ b/iOS/DuckDuckGo/AutocompleteViewController.swift
@@ -104,12 +104,10 @@ class AutocompleteViewController: UIHostingController<AutocompleteView> {
         self.featureFlagger = featureFlagger
         self.aiChatSettings = aiChatSettings
 
-        let isAIChatSearchInputUserSettingsEnabled = aiChatSettings.isAIChatSearchInputUserSettingsEnabled
         let isAddressBarAtBottom = appSettings.currentAddressBarPosition == .bottom
         self.showAskAIChat = aiChatSettings.isAIChatEnabled
         self.model = AutocompleteViewModel(isAddressBarAtBottom: isAddressBarAtBottom,
-                                           showAskAIChat: showAskAIChat,
-                                           isSwipeToDeleteEnabled: !isAIChatSearchInputUserSettingsEnabled)
+                                           showAskAIChat: showAskAIChat)
 
         super.init(rootView: AutocompleteView(model: model))
         self.model.delegate = self

--- a/iOS/DuckDuckGo/AutocompleteViewController.swift
+++ b/iOS/DuckDuckGo/AutocompleteViewController.swift
@@ -353,8 +353,8 @@ extension AutocompleteViewController: AutocompleteViewModelDelegate {
         case .historyEntry(_, let url, _):
             Task {
                 await historyManager.deleteHistoryForURL(url)
-                Pixel.fire(pixel: .autocompleteSwipeToDelete)
-                DailyPixel.fireDaily(.autocompleteSwipeToDeleteDaily)
+                Pixel.fire(pixel: .autocompleteDeleteHistoryEntry)
+                DailyPixel.fireDaily(.autocompleteDeleteHistoryEntryDaily)
                 requestSuggestions(query: self.query)
             }
         default:

--- a/iOS/DuckDuckGo/AutocompleteViewModel.swift
+++ b/iOS/DuckDuckGo/AutocompleteViewModel.swift
@@ -62,13 +62,11 @@ class AutocompleteViewModel: ObservableObject {
 
     let isAddressBarAtBottom: Bool
     let showAskAIChat: Bool
-    let isSwipeToDeleteEnabled: Bool
     var suggestionFilter: AutocompleteSuggestionFilter = .all
 
-    init(isAddressBarAtBottom: Bool, showAskAIChat: Bool, isSwipeToDeleteEnabled: Bool) {
+    init(isAddressBarAtBottom: Bool, showAskAIChat: Bool) {
         self.isAddressBarAtBottom = isAddressBarAtBottom
         self.showAskAIChat = showAskAIChat
-        self.isSwipeToDeleteEnabled = isSwipeToDeleteEnabled
     }
 
     func updateSuggestions(_ suggestions: SuggestionResult) {

--- a/iOS/DuckDuckGoTests/Autocomplete/AutocompleteViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/Autocomplete/AutocompleteViewModelTests.swift
@@ -23,8 +23,8 @@ import Suggestions
 
 final class AutocompleteViewModelTests: XCTestCase {
 
-    private func makeViewModel(showAskAIChat: Bool = false, isSwipeToDeleteEnabled: Bool = false) -> (AutocompleteViewModel, MockAutocompleteViewModelDelegate) {
-        let vm = AutocompleteViewModel(isAddressBarAtBottom: false, showAskAIChat: showAskAIChat, isSwipeToDeleteEnabled: isSwipeToDeleteEnabled)
+    private func makeViewModel(showAskAIChat: Bool = false) -> (AutocompleteViewModel, MockAutocompleteViewModelDelegate) {
+        let vm = AutocompleteViewModel(isAddressBarAtBottom: false, showAskAIChat: showAskAIChat)
         let delegate = MockAutocompleteViewModelDelegate()
         vm.delegate = delegate
         return (vm, delegate)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213803971908100
Tech Design URL:
CC:

### Description

Replaces the hidden swipe-to-delete UX on autocomplete history rows with a visible clear (X) button. Swipe-to-delete was disabled entirely when the Duck.ai search-input toggle was on to avoid gesture conflict, leaving those users with no way to remove past queries from autocomplete. The new button makes deletion discoverable for everyone and works regardless of the Duck.ai toggle state.

Also renames the `autocompleteSwipeToDelete` / `autocompleteSwipeToDeleteDaily` Swift enum cases to `autocompleteDeleteHistoryEntry` / `autocompleteDeleteHistoryEntryDaily` now that the firing site is no longer a swipe.

### Testing Steps

1. Browse a few pages and run a few searches so history is populated.
2. Type a query that surfaces both browser and SERP history in autocomplete.
3. Verify an X (clear) icon appears on the right of each history row, and not on other row types (search phrases, bookmarks, favorites, open tabs, Ask AI).
4. Tap the X on a history row, verify the row is removed from the list and the relevant pixel fires (`m_autocomplete_result_deleted`, `m_autocomplete_result_deleted_daily`).
5. Tap anywhere on the row outside the X icon, verify navigation still happens (row selection) rather than delete.
6. Toggle the Duck.ai search-input setting ON, repeat steps 3 to 6, verify deletion works the same way and swiping on a row no longer triggers a delete action.

### Impact and Risks

Low. Scoped to autocomplete UI and one small init-site plumbing change. No storage or data layer changes. Pixel wire names unchanged.

#### What could go wrong?

- A tap on the X could propagate into the row Button tap and cause a navigation alongside the delete. Mitigated by using `highPriorityGesture(TapGesture())` on the icon, matching the pattern already used for the tap-ahead indicator on phrase rows.

### Quality Considerations

Accessibility: the delete icon has an `accessibilityIdentifier` (`Autocomplete.Suggestions.ListItem.DeleteButton`) and an `accessibilityLabel` using the existing `UserText.actionDelete` string, so VoiceOver and UI tests can target it.

### Notes to Reviewer

- The pixel Swift rename is cosmetic. Names are intentionally unchanged to keep the existing dashboards intact.
- Known limitation carried over from the swipe implementation: `historyManager.deleteHistoryForURL` burns the whole eTLD+1 domain rather than the single URL. Deliberately not changed in this PR to match existing behavior.


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/telemetry change limited to autocomplete rows and history deletion; main risk is gesture/tap handling accidentally triggering both delete and selection.
> 
> **Overview**
> Replaces swipe-to-delete for autocomplete *history* suggestions with a visible trailing clear (X) button, wiring taps on the icon to delete the history entry while leaving row taps to select/navigate.
> 
> Removes the now-unused swipe-to-delete enable/disable plumbing from `AutocompleteViewModel`/controller (previously gated by Duck.ai settings), and renames the fired pixels from `autocompleteSwipeToDelete*` to `autocompleteDeleteHistoryEntry*` while keeping the underlying pixel names unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d39b650c7c94796227b425ed3fdaf2df7d0e94e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->