### PR TITLE
[iOS] Defer web extension loading to first foreground transition

### DIFF
--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -84,6 +84,7 @@ final class MainCoordinator {
     private var darkReaderCancellables = Set<AnyCancellable>()
     private var youTubeAdBlockingCancellable: AnyCancellable?
     private var webExtensionLoadTask: Task<Void, Never>?
+    private var isWebExtensionLoadPending = false
     private var privacyConfigurationManager: PrivacyConfigurationManaging?
     private let keyValueStore: ThrowingKeyValueStoring
 
@@ -364,14 +365,7 @@ final class MainCoordinator {
     private func initializeWebExtensions() {
         guard webExtensionManager == nil else {
             // Already initialized, just reload extensions and re-register tabs
-            webExtensionLoadTask?.cancel()
-            webExtensionLoadTask = Task { @MainActor [weak self] in
-                await self?.webExtensionManager?.loadInstalledExtensions()
-                guard !Task.isCancelled else { return }
-                await self?.syncEmbeddedExtensions()
-                guard !Task.isCancelled else { return }
-                self?.webExtensionEventsCoordinator?.registerExistingTabsAndWindow()
-            }
+            scheduleExtensionLoad()
             return
         }
 
@@ -396,9 +390,19 @@ final class MainCoordinator {
         controller.setWebExtensionManager(webExtensionManager)
         subscribeToDarkReaderChanges()
 
-        // Load extensions asynchronously - the controller is already attached to tabs
+        // Defer extension loading until the app reaches the foreground
+        // (applicationDidBecomeActive) to ensure the WebKit process and
+        // protected data are fully available. Loading too early during launch
+        // can cause WKWebExtensionErrorInvalidArchive errors on iOS.
+        isWebExtensionLoadPending = true
+    }
+
+    @available(iOS 18.4, *)
+    private func scheduleExtensionLoad() {
+        isWebExtensionLoadPending = false
+        webExtensionLoadTask?.cancel()
         webExtensionLoadTask = Task { @MainActor [weak self] in
-            await webExtensionManager.loadInstalledExtensions()
+            await self?.webExtensionManager?.loadInstalledExtensions()
             guard !Task.isCancelled else { return }
             await self?.syncEmbeddedExtensions()
             guard !Task.isCancelled else { return }
@@ -526,14 +530,10 @@ final class MainCoordinator {
     // MARK: App Lifecycle handling
 
     func onForeground(isFirstForeground: Bool) {
-        // Apply tracker animation suppression based on launch source
-        // Must be called after launchSourceManager.handleAppAction sets the source
         if isFirstForeground {
             tabManager.applyTrackerAnimationSuppressionBasedOnLaunchSource()
         }
 
-        // Clear external launch flags when app comes to foreground
-        // This ensures flags are reset for subsequent in-app navigations
         tabManager.clearExternalLaunchFlags()
 
         controller.showBars()
@@ -542,6 +542,9 @@ final class MainCoordinator {
         fireDailyAdBlockingPixel()
 
         if #available(iOS 18.4, *) {
+            if isWebExtensionLoadPending {
+                scheduleExtensionLoad()
+            }
             webExtensionEventsCoordinator?.didFocusWindow()
         }
     }

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -394,7 +394,11 @@ final class MainCoordinator {
         // (applicationDidBecomeActive) to ensure the WebKit process and
         // protected data are fully available. Loading too early during launch
         // can cause WKWebExtensionErrorInvalidArchive errors on iOS.
-        isWebExtensionLoadPending = true
+        if UIApplication.shared.applicationState == .active {
+            scheduleExtensionLoad()
+        } else {
+            isWebExtensionLoadPending = true
+        }
     }
 
     @available(iOS 18.4, *)

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -452,6 +452,7 @@ final class MainCoordinator {
     }
 
     private func clearWebExtensionReferences() {
+        isWebExtensionLoadPending = false
         webExtensionLoadTask?.cancel()
         webExtensionLoadTask = nil
         webExtensionManager = nil

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -535,10 +535,14 @@ final class MainCoordinator {
     // MARK: App Lifecycle handling
 
     func onForeground(isFirstForeground: Bool) {
+        // Apply tracker animation suppression based on launch source
+        // Must be called after launchSourceManager.handleAppAction sets the source
         if isFirstForeground {
             tabManager.applyTrackerAnimationSuppressionBasedOnLaunchSource()
         }
 
+        // Clear external launch flags when app comes to foreground
+        // This ensures flags are reset for subsequent in-app navigations
         tabManager.clearExternalLaunchFlags()
 
         controller.showBars()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200848783441532/task/1214156699597062
Tech Design URL: N/A
CC:

### Description

Defers web extension loading (`loadInstalledExtensions` + `syncEmbeddedExtensions`) from early in the launch sequence (`didFinishLaunchingWithOptions`) to the first foreground transition (`applicationDidBecomeActive`).

We observed `WKWebExtensionErrorDomain` error code 9 (`WKWebExtensionErrorInvalidArchive`) on iOS through the `m.web.extension.load.error` (~450) and `m.web.extension.embedded.install.error` (~640) pixels. The errors are evenly distributed across all iOS versions, and the bundled zip files are structurally valid — pointing to an early-launch timing issue where the WebKit process or protected data may not be fully available.

The `WebExtensionManager` is still created synchronously during launch (so it's available for tab restoration). Only the expensive `WKWebExtension(resourceBaseURL:)` calls are deferred until the app is confirmed active.

### Testing Steps

1. Run the iOS app on an iOS 18.4+ device or simulator with the `webExtensions` and `embeddedExtension` feature flags enabled
2. Verify that web extensions load correctly after the app reaches the foreground (autoconsent/cookie popup management should work on supported sites -- https://privacy-test-pages.site/features/autoconsent/index.html) e.g. filter logs by "WebExtensions" subsystem.
3. Background the app and return — verify extensions remain functional
4. Use the Fire Button to clear data — verify extensions reload successfully afterward

### Impact and Risks

Low — extensions load slightly later in the startup sequence but the same functionality is preserved. The `WebExtensionManager` is still created synchronously so tab restoration is unaffected.

#### What could go wrong?

- Extensions could take marginally longer to become active on cold launch (the delay is from `didFinishLaunchingWithOptions` to `applicationDidBecomeActive`, typically sub-second)
- If `onForeground(isFirstForeground:)` is not called for some reason (e.g., app launched directly into background), extensions would not load until the app next enters the foreground. This is acceptable since extensions are only useful when the app is visible.

### Quality Considerations

- No new edge cases introduced — the same `scheduleExtensionLoad()` method is used for all paths (first launch, feature flag toggle, re-initialization)
- Existing paths that trigger extension loading while the app is active (Fire button reload, feature flag changes, dark reader/ad blocking setting changes) are unaffected
- Monitor `m.web.extension.load.error` and `m.web.extension.embedded.install.error` pixels after release to confirm reduction in `WKWebExtensionErrorInvalidArchive` errors

### Notes to Reviewer

The core idea is decoupling manager creation (synchronous, needed early) from extension loading (async, needs WebKit process readiness). The `isWebExtensionLoadPending` flag bridges the two — set during `initializeWebExtensions()`, consumed in `onForeground()`.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle/timing change limited to web extension loading; primary risk is extensions becoming available slightly later or not loading until the next foreground transition in atypical launch states.
> 
> **Overview**
> Defers WebExtension loading work in `MainCoordinator` so `loadInstalledExtensions`/`syncEmbeddedExtensions` is scheduled only once the app is active, avoiding early-launch WebKit failures.
> 
> Adds an `isWebExtensionLoadPending` flag and a new `scheduleExtensionLoad()` helper to centralize task cancellation/restart, trigger pending loads during `onForeground`, and reset the pending state when web extensions are cleared/disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26b5c77ff316baf36fa5223a767a9eeecc9738f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->