### PR TITLE
[iOS] Fix SIGABRT crash caused by uncalled WebKit navigation decision handler

### DIFF
--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -2571,7 +2571,10 @@ extension TabViewController: WKNavigationDelegate {
                                 completion: @escaping (WKNavigationActionPolicy) -> Void) {
         httpsUpgradeTask = Task {
             let result = await PrivacyFeatures.httpsUpgrade.upgrade(url: url)
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled else {
+                completion(.cancel)
+                return
+            }
             switch result {
             case let .success(upgradedUrl):
                 if lastUpgradedURL != upgradedUrl {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1214152308084931?focus=true
CC: 

### Description
- Our [previous fix](https://github.com/duckduckgo/apple-browsers/pull/4132) for the SIGKILL crash (orphaned `upgradeToHttps` Task during data clearing) introduced a new SIGABRT crash. The `guard !Task.isCancelled else { return }` exits without calling `completion`, which means WebKit's `decisionHandler` is never called. WebKit's `CompletionHandlerCallChecker` detects this and aborts with: "Completion handler passed to -[TabViewController webView:decidePolicyForNavigationAction:decisionHandler:] was not called"
- Fix: call `completion(.cancel)` before returning on cancellation, satisfying WebKit's requirement that the `decisionHandler` is called exactly once while still preventing the original SIGKILL crash (stale navigation processing)

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Open a tab and navigate to an HTTP site (to trigger HTTPS upgrade check)
2. While the page is loading, tap the Fire button and confirm clearing
3. Verify the app does not crash (no SIGKILL or SIGABRT)
4. Repeat with auto-clear enabled: navigate to a site, background the app, wait for auto-clear period, return
5. Verify no crash occurs and the tab is properly cleared

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
- The `.cancel` policy sent to WebKit on cancellation could theoretically interrupt a legitimate navigation about to complete, but this only happens during data clearing when the tab is being destroyed anyway

### Quality Considerations
- Single-line change scoped to the exact defect introduced by the previous fix

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, narrowly scoped change to navigation-policy completion behavior; only affects the cancellation path of the HTTPS-upgrade async task.
> 
> **Overview**
> Prevents a WebKit `SIGABRT` caused by an uncalled navigation `decisionHandler` during HTTPS upgrade.
> 
> When the `upgradeToHttps` `Task` is cancelled, it now **calls `completion(.cancel)` before returning**, ensuring WebKit’s policy decision handler is invoked exactly once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e26d05c2d50a652ef1947607d6ba7e11a66ed6b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->