### PR TITLE
[iOS] UTI: inline dismiss button at top position

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -312,11 +312,8 @@ class SwitchBarTextEntryView: UIView {
         buttonsView.isAIVoiceChatEnabled = handler.isAIVoiceChatEnabled && handler.currentToggleState == .aiChat
 
         if newButtonState != currentButtonState {
-            // Prevent unexpected animations of this change — the state assignment cascades
-            // to `clearButton.isHidden` which UIStackView would otherwise animate when the
-            // change lands inside an active animation block (e.g. the UTI reveal). Laying
-            // out `self` (not just `buttonsView`) ensures `buttonsView`'s own frame settles
-            // inside this non-animated block instead of in a later layout pass.
+            // UIStackView animates `isHidden` changes that land inside an animation block;
+            // lay out `self` so `buttonsView`'s frame settles here, not on a later pass.
             UIView.performWithoutAnimation {
                 currentButtonState = newButtonState
                 adjustTextViewContentInset()

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -312,12 +312,15 @@ class SwitchBarTextEntryView: UIView {
         buttonsView.isAIVoiceChatEnabled = handler.isAIVoiceChatEnabled && handler.currentToggleState == .aiChat
 
         if newButtonState != currentButtonState {
-            currentButtonState = newButtonState
-
-            // Prevent unexpected animations of this change
+            // Prevent unexpected animations of this change — the state assignment cascades
+            // to `clearButton.isHidden` which UIStackView would otherwise animate when the
+            // change lands inside an active animation block (e.g. the UTI reveal). Laying
+            // out `self` (not just `buttonsView`) ensures `buttonsView`'s own frame settles
+            // inside this non-animated block instead of in a later layout pass.
             UIView.performWithoutAnimation {
+                currentButtonState = newButtonState
                 adjustTextViewContentInset()
-                buttonsView.layoutIfNeeded()
+                layoutIfNeeded()
             }
         }
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -524,6 +524,10 @@ private extension MainViewController {
     func dismissUnifiedToggleInputToOmnibar(coordinator: UnifiedToggleInputCoordinator) {
         applyUnifiedInputChromeBackground(.standardChrome)
         let isTopPosition = coordinator.cardPosition == .top
+        // Capture the activation sequence so that if the user re-activates the omnibar
+        // while this dismiss animation is in flight, the completion becomes a no-op and
+        // does not tear down the new session.
+        let activationSequenceAtDismissStart = coordinator.omnibarActivationSequence
         if isTopPosition && coordinator.isToggleEnabled {
             coordinator.viewController.animateToggleHide(additionalAnimations: { [weak self] in
                 guard let self else { return }
@@ -531,6 +535,7 @@ private extension MainViewController {
                 self.viewCoordinator.unifiedInputContentContainer.alpha = 0
             }, completion: { [weak self] in
                 guard let self, let coordinator = self.unifiedToggleInputCoordinator else { return }
+                guard coordinator.omnibarActivationSequence == activationSequenceAtDismissStart else { return }
                 self.viewCoordinator.unifiedInputContentContainer.isHidden = true
                 self.viewCoordinator.unifiedInputContentContainer.alpha = 1
                 coordinator.deactivateToOmnibar(resetView: false, animateDismiss: false)
@@ -542,6 +547,7 @@ private extension MainViewController {
                 self.viewCoordinator.unifiedInputContentContainer.alpha = 0
             }, completion: { [weak self] _ in
                 guard let self, let coordinator = self.unifiedToggleInputCoordinator else { return }
+                guard coordinator.omnibarActivationSequence == activationSequenceAtDismissStart else { return }
                 self.viewCoordinator.unifiedInputContentContainer.isHidden = true
                 self.viewCoordinator.unifiedInputContentContainer.alpha = 1
                 coordinator.deactivateToOmnibar(resetView: false, animateDismiss: false)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -466,7 +466,7 @@ extension MainViewController {
         let contentVC = coordinator.contentViewController
         contentVC.suggestionTrayDependencies = suggestionTrayDependencies
         contentVC.delegate = self
-        let dismissHandler: () -> Void = { [weak self] in
+        contentVC.onDismissRequested = { [weak self] in
             guard let self, let coordinator = self.unifiedToggleInputCoordinator else { return }
             if coordinator.isOmnibarSession {
                 self.dismissUnifiedToggleInputToOmnibar(coordinator: coordinator)
@@ -474,8 +474,6 @@ extension MainViewController {
                 coordinator.showCollapsed()
             }
         }
-        contentVC.onDismissRequested = dismissHandler
-        coordinator.viewController.onInlineDismissTapped = dismissHandler
         contentVC.onSwipeDownRequested = { [weak self] in
             guard let self, let coordinator = self.unifiedToggleInputCoordinator else { return }
             coordinator.dismissOmnibarKeyboard()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -466,7 +466,7 @@ extension MainViewController {
         let contentVC = coordinator.contentViewController
         contentVC.suggestionTrayDependencies = suggestionTrayDependencies
         contentVC.delegate = self
-        contentVC.onDismissRequested = { [weak self] in
+        let dismissHandler: () -> Void = { [weak self] in
             guard let self, let coordinator = self.unifiedToggleInputCoordinator else { return }
             if coordinator.isOmnibarSession {
                 self.dismissUnifiedToggleInputToOmnibar(coordinator: coordinator)
@@ -474,6 +474,8 @@ extension MainViewController {
                 coordinator.showCollapsed()
             }
         }
+        contentVC.onDismissRequested = dismissHandler
+        coordinator.viewController.onInlineDismissTapped = dismissHandler
         contentVC.onSwipeDownRequested = { [weak self] in
             guard let self, let coordinator = self.unifiedToggleInputCoordinator else { return }
             coordinator.dismissOmnibarKeyboard()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -524,10 +524,6 @@ private extension MainViewController {
     func dismissUnifiedToggleInputToOmnibar(coordinator: UnifiedToggleInputCoordinator) {
         applyUnifiedInputChromeBackground(.standardChrome)
         let isTopPosition = coordinator.cardPosition == .top
-        // Capture the activation sequence so that if the user re-activates the omnibar
-        // while this dismiss animation is in flight, the completion becomes a no-op and
-        // does not tear down the new session.
-        let activationSequenceAtDismissStart = coordinator.omnibarActivationSequence
         if isTopPosition && coordinator.isToggleEnabled {
             coordinator.viewController.animateToggleHide(additionalAnimations: { [weak self] in
                 guard let self else { return }
@@ -535,7 +531,6 @@ private extension MainViewController {
                 self.viewCoordinator.unifiedInputContentContainer.alpha = 0
             }, completion: { [weak self] in
                 guard let self, let coordinator = self.unifiedToggleInputCoordinator else { return }
-                guard coordinator.omnibarActivationSequence == activationSequenceAtDismissStart else { return }
                 self.viewCoordinator.unifiedInputContentContainer.isHidden = true
                 self.viewCoordinator.unifiedInputContentContainer.alpha = 1
                 coordinator.deactivateToOmnibar(resetView: false, animateDismiss: false)
@@ -547,7 +542,6 @@ private extension MainViewController {
                 self.viewCoordinator.unifiedInputContentContainer.alpha = 0
             }, completion: { [weak self] _ in
                 guard let self, let coordinator = self.unifiedToggleInputCoordinator else { return }
-                guard coordinator.omnibarActivationSequence == activationSequenceAtDismissStart else { return }
                 self.viewCoordinator.unifiedInputContentContainer.isHidden = true
                 self.viewCoordinator.unifiedInputContentContainer.alpha = 1
                 coordinator.deactivateToOmnibar(resetView: false, animateDismiss: false)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIRenderState.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIRenderState.swift
@@ -28,6 +28,7 @@ struct UTIRenderState: Equatable {
     var isToolbarSubmitHidden: Bool
     var inactiveAppearance: Bool
     var isFloatingSubmitVisible: Bool
+    var isToggleEnabled: Bool
     var contentInputMode: TextEntryMode
     var inputMode: TextEntryMode
 
@@ -44,9 +45,11 @@ struct UTIRenderState: Equatable {
     }
 
     /// The inline dismiss (X inside the card's top row) takes over when the expanded card is
-    /// anchored at the top; otherwise the floating dismiss in the content container is used.
+    /// anchored at the top with the Search/Duck.ai toggle enabled. When the toggle setting is
+    /// disabled, the card has no top row to host the X, so the floating dismiss in the content
+    /// container is used instead.
     var isInlineDismissActive: Bool {
-        cardPosition == .top && isExpanded
+        cardPosition == .top && isExpanded && isToggleEnabled
     }
 
     var isFloatingDismissVisible: Bool {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIRenderState.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIRenderState.swift
@@ -28,7 +28,6 @@ struct UTIRenderState: Equatable {
     var isToolbarSubmitHidden: Bool
     var inactiveAppearance: Bool
     var isFloatingSubmitVisible: Bool
-    var isInlineDismissActive: Bool
     var contentInputMode: TextEntryMode
     var inputMode: TextEntryMode
 
@@ -44,11 +43,12 @@ struct UTIRenderState: Equatable {
         )
     }
 
-    /// The floating dismiss control (owned by the content container) is shown whenever content
-    /// is visible but the inline dismiss button in the card is not currently taking over. At
-    /// `.bottom` the inline dismiss never applies, and at `.top` the inline dismiss only takes
-    /// over once the Search/Duck.ai toggle is in place (i.e. not during keyboard-presentation
-    /// transients and not when the toggle setting is disabled).
+    /// The inline dismiss (X inside the card's top row) takes over when the expanded card is
+    /// anchored at the top; otherwise the floating dismiss in the content container is used.
+    var isInlineDismissActive: Bool {
+        cardPosition == .top && isExpanded
+    }
+
     var isFloatingDismissVisible: Bool {
         isContentVisible && !isInlineDismissActive
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIRenderState.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIRenderState.swift
@@ -28,6 +28,7 @@ struct UTIRenderState: Equatable {
     var isToolbarSubmitHidden: Bool
     var inactiveAppearance: Bool
     var isFloatingSubmitVisible: Bool
+    var isInlineDismissActive: Bool
     var contentInputMode: TextEntryMode
     var inputMode: TextEntryMode
 
@@ -41,6 +42,15 @@ struct UTIRenderState: Equatable {
             inputMode: inputMode,
             isTopBarPosition: usesOmnibarMargins
         )
+    }
+
+    /// The floating dismiss control (owned by the content container) is shown whenever content
+    /// is visible but the inline dismiss button in the card is not currently taking over. At
+    /// `.bottom` the inline dismiss never applies, and at `.top` the inline dismiss only takes
+    /// over once the Search/Duck.ai toggle is in place (i.e. not during keyboard-presentation
+    /// transients and not when the toggle setting is disabled).
+    var isFloatingDismissVisible: Bool {
+        isContentVisible && !isInlineDismissActive
     }
 
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -700,6 +700,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             isToolbarSubmitHidden: cardPosition == .top && isOmnibarSession,
             inactiveAppearance: inactiveAppearance,
             isFloatingSubmitVisible: isFloatingSubmitVisible,
+            isToggleEnabled: isToggleEnabled,
             contentInputMode: inputMode,
             inputMode: inputMode
         )

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -121,11 +121,6 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     private(set) var isInputVisibleForKeyboard: Bool = true
     private var isAwaitingTopOmnibarKeyboardPresentation = false
     private var topOmnibarKeyboardPresentationFallback: DispatchWorkItem?
-    /// Incremented each time a new omnibar session is activated. Dismiss flows capture this
-    /// value before starting their animation and compare it in the completion, so that if the
-    /// user re-activates while the dismiss animation is in flight the completion becomes a
-    /// no-op rather than tearing down the newly started session.
-    private(set) var omnibarActivationSequence: Int = 0
 
     private(set) var currentText: String = ""
     var hasActiveChat: Bool { boundUserScript != nil }
@@ -329,7 +324,6 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     func activateFromOmnibar(prefilledText: String? = nil, inputMode: TextEntryMode = .search, cardPosition: UnifiedToggleInputCardPosition = .top) {
         let effectiveInputMode = isToggleEnabled ? inputMode : .search
         cancelTopOmnibarKeyboardPresentationFallback()
-        omnibarActivationSequence &+= 1
         isAwaitingTopOmnibarKeyboardPresentation = cardPosition == .top
         displayState = .omnibar(.active)
         setInitialInputMode(effectiveInputMode)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -691,11 +691,6 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             && cardPosition == .top
             && inputMode == .aiChat
 
-        // The inline dismiss (X inside the card's top row) applies whenever the expanded
-        // card is anchored at the top. At the bottom, dismissal uses the floating button
-        // in the content container.
-        let isInlineDismissActive = cardPosition == .top && isExpanded
-
         return UTIRenderState(
             isInputVisible: isInputVisible,
             isContentVisible: isContentVisible,
@@ -705,7 +700,6 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             isToolbarSubmitHidden: cardPosition == .top && isOmnibarSession,
             inactiveAppearance: inactiveAppearance,
             isFloatingSubmitVisible: isFloatingSubmitVisible,
-            isInlineDismissActive: isInlineDismissActive,
             contentInputMode: inputMode,
             inputMode: inputMode
         )
@@ -907,6 +901,12 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
 
     func unifiedToggleInputVCDidChangeHeight(_ vc: UnifiedToggleInputViewController) {
         delegate?.unifiedToggleInputDidChangeHeight()
+    }
+
+    func unifiedToggleInputVCDidTapInlineDismiss(_ vc: UnifiedToggleInputViewController) {
+        // The inline X dismisses the same way the floating X does — forward to the
+        // content container's shared handler so both controls route through one path.
+        contentViewController.onDismissRequested?()
     }
 }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -121,6 +121,11 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     private(set) var isInputVisibleForKeyboard: Bool = true
     private var isAwaitingTopOmnibarKeyboardPresentation = false
     private var topOmnibarKeyboardPresentationFallback: DispatchWorkItem?
+    /// Incremented each time a new omnibar session is activated. Dismiss flows capture this
+    /// value before starting their animation and compare it in the completion, so that if the
+    /// user re-activates while the dismiss animation is in flight the completion becomes a
+    /// no-op rather than tearing down the newly started session.
+    private(set) var omnibarActivationSequence: Int = 0
 
     private(set) var currentText: String = ""
     var hasActiveChat: Bool { boundUserScript != nil }
@@ -324,6 +329,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     func activateFromOmnibar(prefilledText: String? = nil, inputMode: TextEntryMode = .search, cardPosition: UnifiedToggleInputCardPosition = .top) {
         let effectiveInputMode = isToggleEnabled ? inputMode : .search
         cancelTopOmnibarKeyboardPresentationFallback()
+        omnibarActivationSequence &+= 1
         isAwaitingTopOmnibarKeyboardPresentation = cardPosition == .top
         displayState = .omnibar(.active)
         setInitialInputMode(effectiveInputMode)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -315,7 +315,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         viewController.apply(renderState.viewConfig, animated: false)
         applyToolbarPresentation()
         viewController.deactivateInput()
-        contentViewController.setDismissButtonVisible(renderState.isContentVisible)
+        contentViewController.setDismissButtonVisible(renderState.isFloatingDismissVisible)
         intentSubject.send(.hide)
     }
 
@@ -347,7 +347,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             textState = .prefilledSelected
         }
 
-        contentViewController.setDismissButtonVisible(renderState.isContentVisible)
+        contentViewController.setDismissButtonVisible(renderState.isFloatingDismissVisible)
         let expandedHeight = omnibarEditingHeight()
 
         if cardPosition == .top && isToggleEnabled {
@@ -394,12 +394,12 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             viewController.apply(renderState.viewConfig, animated: false)
             applyToolbarPresentation()
             viewController.deactivateInput()
-            contentViewController.setDismissButtonVisible(renderState.isContentVisible)
+            contentViewController.setDismissButtonVisible(renderState.isFloatingDismissVisible)
         } else {
             applyToolbarPresentation()
             viewController.deactivateInput()
             let renderState = computeRenderState()
-            contentViewController.setDismissButtonVisible(renderState.isContentVisible)
+            contentViewController.setDismissButtonVisible(renderState.isFloatingDismissVisible)
         }
         intentSubject.send(.hideOmnibarEditing(animated: animateDismiss))
     }
@@ -499,7 +499,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             displayState = .omnibar(.active)
             let renderState = computeRenderState()
             viewController.apply(renderState.viewConfig, animated: false)
-            contentViewController.setDismissButtonVisible(renderState.isContentVisible)
+            contentViewController.setDismissButtonVisible(renderState.isFloatingDismissVisible)
             intentSubject.send(.showOmnibarActive)
         case (.omnibar(.active), true):
             cancelTopOmnibarKeyboardPresentationFallback()
@@ -507,11 +507,11 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         case (.aiTab(.expanded), false) where isAITabSearch:
             let renderState = computeRenderState()
             viewController.apply(renderState.viewConfig, animated: false)
-            contentViewController.setDismissButtonVisible(renderState.isContentVisible)
+            contentViewController.setDismissButtonVisible(renderState.isFloatingDismissVisible)
         case (.aiTab(.expanded), true) where isAITabSearch:
             let renderState = computeRenderState()
             viewController.apply(renderState.viewConfig, animated: false)
-            contentViewController.setDismissButtonVisible(renderState.isContentVisible)
+            contentViewController.setDismissButtonVisible(renderState.isFloatingDismissVisible)
         default:
             break
         }
@@ -565,7 +565,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         displayState = .omnibar(.inactive)
         let renderState = computeRenderState()
         viewController.apply(renderState.viewConfig, animated: false)
-        contentViewController.setDismissButtonVisible(renderState.isContentVisible)
+        contentViewController.setDismissButtonVisible(renderState.isFloatingDismissVisible)
         intentSubject.send(.showOmnibarInactive)
     }
 
@@ -641,7 +641,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
 
     func applyDismissButtonVisibility() {
         let renderState = computeRenderState()
-        contentViewController.setDismissButtonVisible(renderState.isContentVisible)
+        contentViewController.setDismissButtonVisible(renderState.isFloatingDismissVisible)
     }
 
     // MARK: - Render State
@@ -691,6 +691,11 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             && cardPosition == .top
             && inputMode == .aiChat
 
+        // The inline dismiss (X inside the card's top row) applies whenever the expanded
+        // card is anchored at the top. At the bottom, dismissal uses the floating button
+        // in the content container.
+        let isInlineDismissActive = cardPosition == .top && isExpanded
+
         return UTIRenderState(
             isInputVisible: isInputVisible,
             isContentVisible: isContentVisible,
@@ -700,6 +705,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             isToolbarSubmitHidden: cardPosition == .top && isOmnibarSession,
             inactiveAppearance: inactiveAppearance,
             isFloatingSubmitVisible: isFloatingSubmitVisible,
+            isInlineDismissActive: isInlineDismissActive,
             contentInputMode: inputMode,
             inputMode: inputMode
         )

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -667,22 +667,17 @@ private extension UnifiedToggleInputView {
         onInlineDismissTapped?()
     }
 
+    /// Flat, circular button styled to sit inside the card's top row. The floating dismiss
+    /// button in the content container uses Liquid Glass on iOS 26, but inside the card the
+    /// design calls for a flat control.
     static func makeInlineDismissButton() -> UIButton {
-        let button: UIButton
-        if #available(iOS 26, *) {
-            var config = UIButton.Configuration.glass()
-            config.image = UIImage(systemName: "xmark")
-            config.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 12, weight: .medium)
-            button = UIButton(configuration: config)
-        } else {
-            button = UIButton(type: .system)
-            let image = UIImage(systemName: "xmark")?
-                .withConfiguration(UIImage.SymbolConfiguration(pointSize: 12, weight: .medium))
-            button.setImage(image, for: .normal)
-            button.tintColor = UIColor(designSystemColor: .textPrimary)
-            button.backgroundColor = UIColor(designSystemColor: .controlsFillPrimary)
-            button.layer.cornerRadius = Constants.inlineDismissSize / 2
-        }
+        let button = UIButton(type: .system)
+        let image = UIImage(systemName: "xmark")?
+            .withConfiguration(UIImage.SymbolConfiguration(pointSize: 12, weight: .medium))
+        button.setImage(image, for: .normal)
+        button.tintColor = UIColor(designSystemColor: .textPrimary)
+        button.backgroundColor = UIColor(designSystemColor: .controlsFillPrimary)
+        button.layer.cornerRadius = Constants.inlineDismissSize / 2
         button.translatesAutoresizingMaskIntoConstraints = false
         button.accessibilityLabel = UserText.keyCommandClose
         button.alpha = 0

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -290,6 +290,7 @@ final class UnifiedToggleInputView: UIView {
     private var toggleTopConstraint: NSLayoutConstraint!
     private var toggleTrailingConstraint: NSLayoutConstraint!
     private var toggleHeightConstraint: NSLayoutConstraint!
+    private var inlineDismissHeightConstraint: NSLayoutConstraint!
     private var inputTopConstraint: NSLayoutConstraint!
     private var toolbarBottomConstraint: NSLayoutConstraint!
     private var attachmentsStripHeightConstraint: NSLayoutConstraint!
@@ -658,9 +659,12 @@ private extension UnifiedToggleInputView {
 
     /// Apply visibility without touching the toggle trailing constraint. Intended for use
     /// inside existing animation blocks so that opacity and layout animate together.
+    /// The height collapses to 0 when hidden so the button grows/shrinks alongside the
+    /// toggle's own height animation, mirroring its reveal behaviour.
     func applyInlineDismissVisibility(_ visible: Bool) {
         inlineDismissButton.alpha = visible ? 1 : 0
         inlineDismissButton.isUserInteractionEnabled = visible
+        inlineDismissHeightConstraint.constant = visible ? Constants.inlineDismissSize : 0
     }
 
     @objc func handleInlineDismissTap() {
@@ -783,6 +787,7 @@ private extension UnifiedToggleInputView {
         toggleTopConstraint = toggleView.topAnchor.constraint(equalTo: cardView.topAnchor, constant: 0)
         toggleHeightConstraint = toggleView.heightAnchor.constraint(equalToConstant: 0)
         toggleTrailingConstraint = toggleView.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -Constants.toggleHorizontalPadding)
+        inlineDismissHeightConstraint = inlineDismissButton.heightAnchor.constraint(equalToConstant: 0)
         inputTopConstraint = textEntryView.topAnchor.constraint(equalTo: toggleView.bottomAnchor, constant: 0)
         toolbarBottomConstraint = toolsToolbar.bottomAnchor.constraint(equalTo: cardView.bottomAnchor)
         attachmentsStripHeightConstraint = attachmentsStrip.heightAnchor.constraint(equalToConstant: 0)
@@ -802,7 +807,7 @@ private extension UnifiedToggleInputView {
             inlineDismissButton.topAnchor.constraint(equalTo: cardView.topAnchor, constant: Constants.toggleTopPadding),
             inlineDismissButton.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -Constants.inlineDismissTrailingPadding),
             inlineDismissButton.widthAnchor.constraint(equalToConstant: Constants.inlineDismissSize),
-            inlineDismissButton.heightAnchor.constraint(equalToConstant: Constants.inlineDismissSize),
+            inlineDismissHeightConstraint,
 
             inputTopConstraint,
             textEntryView.leadingAnchor.constraint(equalTo: cardView.leadingAnchor),

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -61,7 +61,6 @@ final class UnifiedToggleInputView: UIView {
         static let cardVerticalMargin: CGFloat = 8
         static let cardHorizontalMarginBottom: CGFloat = 12
         static let cardVerticalMarginBottom: CGFloat = 8
-        static let cardTrailingMarginWithDismiss: CGFloat = 68
         static let cardCornerRadiusExpanded: CGFloat = 24
         static let cardCornerRadiusCollapsed: CGFloat = 16
         static let toggleTopPadding: CGFloat = 8
@@ -72,6 +71,14 @@ final class UnifiedToggleInputView: UIView {
         static let toggleDisabledSearchTopPadding: CGFloat = 10
         static let toolbarHeight: CGFloat = 56
         static let expandedBorderWidth: CGFloat = 0.5
+        static let inlineDismissSize: CGFloat = 40
+        static let inlineDismissTrailingPadding: CGFloat = 8
+        static let toggleInlineDismissSpacing: CGFloat = 6
+
+        /// Trailing constant for the toggle when the inline dismiss button shares the top row.
+        static var toggleTrailingWithInlineDismiss: CGFloat {
+            -(inlineDismissTrailingPadding + inlineDismissSize + toggleInlineDismissSpacing)
+        }
     }
 
     // MARK: - Hit Testing
@@ -87,7 +94,9 @@ final class UnifiedToggleInputView: UIView {
 
     var cardPosition: UnifiedToggleInputCardPosition = .bottom {
         didSet {
-            guard cardPosition != oldValue, isExpanded else { return }
+            guard cardPosition != oldValue else { return }
+            refreshInlineDismissPresentation(animated: false)
+            guard isExpanded else { return }
             let allCorners: CACornerMask = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
             cardView.layer.maskedCorners = allCorners
             expandedShadow0.shadowOffset = CGSize(width: 0, height: 8)
@@ -180,6 +189,7 @@ final class UnifiedToggleInputView: UIView {
 
     var onAttachTapped: (() -> Void)?
     var onAttachmentRemoved: ((UUID) -> Void)?
+    var onInlineDismissTapped: (() -> Void)?
 
     // MARK: - Attachment API
 
@@ -225,6 +235,7 @@ final class UnifiedToggleInputView: UIView {
 
     private let cardView = UIView()
     private let toggleView = UnifiedToggleInputToggleView()
+    private lazy var inlineDismissButton: UIButton = Self.makeInlineDismissButton()
     private let attachmentsStrip = UnifiedToggleInputAttachmentsStripView()
     private let toolsToolbar = UnifiedToggleInputToolbarView()
     // MARK: - Shadow Layers
@@ -277,6 +288,7 @@ final class UnifiedToggleInputView: UIView {
     private var cardBottomConstraint: NSLayoutConstraint!
     private var cardCollapsedHeightConstraint: NSLayoutConstraint!
     private var toggleTopConstraint: NSLayoutConstraint!
+    private var toggleTrailingConstraint: NSLayoutConstraint!
     private var toggleHeightConstraint: NSLayoutConstraint!
     private var inputTopConstraint: NSLayoutConstraint!
     private var toolbarBottomConstraint: NSLayoutConstraint!
@@ -388,21 +400,18 @@ final class UnifiedToggleInputView: UIView {
         let effectiveToggleEnabled = isToggleEnabled && showToggle
         let toggleHeight: CGFloat = (expanded && effectiveToggleEnabled) ? Constants.toggleHeight : 0
         let showToolbar = expanded && effectiveToggleEnabled && toggleView.selectedMode == .aiChat
+        // The card reserves space for the inline X whenever it's expanded at `.top`, so the
+        // toggle's width is stable across the toggle-hidden transient. Visibility of the X
+        // itself is gated on the toggle actually being shown, so the X can fade in together
+        // with the toggle via `animateToggleReveal` rather than snapping in on activation.
+        let reservesInlineDismissSpace = expanded && cardPosition == .top
+        let showInlineDismiss = reservesInlineDismissSpace && effectiveToggleEnabled
 
         let hLeadingMargin: CGFloat
         let hTrailingMargin: CGFloat
-        let usesDismissMargin = expanded && cardPosition == .top
-        if expanded && !usesOmnibarMargins {
-            if cardPosition == .bottom {
-                hLeadingMargin = Constants.cardHorizontalMarginBottom
-                hTrailingMargin = Constants.cardHorizontalMarginBottom
-            } else {
-                hLeadingMargin = Constants.cardHorizontalMargin
-                hTrailingMargin = usesDismissMargin ? Constants.cardTrailingMarginWithDismiss : Constants.cardHorizontalMargin
-            }
-        } else if expanded && cardPosition == .top {
-            hLeadingMargin = Constants.cardHorizontalMargin
-            hTrailingMargin = usesDismissMargin ? Constants.cardTrailingMarginWithDismiss : Constants.cardHorizontalMargin
+        if expanded && cardPosition == .bottom && !usesOmnibarMargins {
+            hLeadingMargin = Constants.cardHorizontalMarginBottom
+            hTrailingMargin = Constants.cardHorizontalMarginBottom
         } else {
             hLeadingMargin = Constants.cardHorizontalMargin
             hTrailingMargin = Constants.cardHorizontalMargin
@@ -442,10 +451,14 @@ final class UnifiedToggleInputView: UIView {
             self.cardBottomConstraint.constant = -vMargin
             self.toggleTopConstraint.constant = (expanded && effectiveToggleEnabled) ? Constants.toggleTopPadding : 0
             self.toggleHeightConstraint.constant = toggleHeight
+            self.toggleTrailingConstraint.constant = reservesInlineDismissSpace
+                ? Constants.toggleTrailingWithInlineDismiss
+                : -Constants.toggleHorizontalPadding
             let toggleDisabledSearchPadding = expanded && !self.isToggleEnabled && showToggle && self.handler.currentToggleState == .search && self.cardPosition == .bottom
             self.inputTopConstraint.constant = expanded && effectiveToggleEnabled ? Constants.toggleBottomPadding : (toggleDisabledSearchPadding ? Constants.toggleDisabledSearchTopPadding : 0)
             self.toolbarBottomConstraint.constant = toggleDisabledSearchPadding ? -Constants.toggleDisabledSearchTopPadding : 0
             self.toggleView.alpha = (expanded && effectiveToggleEnabled) ? 1 : 0
+            self.applyInlineDismissVisibility(showInlineDismiss)
             self.toolbarHeightConstraint.constant = showToolbar ? Constants.toolbarHeight : 0
             self.toolsToolbar.alpha = showToolbar ? 1 : 0
             self.updateAttachmentsStripLayout()
@@ -490,15 +503,13 @@ final class UnifiedToggleInputView: UIView {
                 self.toggleTopConstraint.constant = Constants.toggleTopPadding
                 self.toggleHeightConstraint.constant = Constants.toggleHeight
                 self.toggleView.alpha = 1
+                self.applyInlineDismissVisibility(self.cardPosition == .top)
                 self.inputTopConstraint.constant = Constants.toggleBottomPadding
                 self.cardView.layer.borderWidth = showToolbar ? Constants.expandedBorderWidth : 0
                 self.cardView.layer.borderColor = showToolbar ? self.expandedBorderColor : UIColor.clear.cgColor
                 self.toolbarHeightConstraint.constant = showToolbar ? Constants.toolbarHeight : 0
                 self.toolsToolbar.alpha = showToolbar ? 1 : 0
                 self.updateAttachmentsStripLayout()
-                if self.cardPosition == .top {
-                    self.cardTrailingConstraint.constant = -Constants.cardTrailingMarginWithDismiss
-                }
                 additionalAnimations?()
                 self.layoutIfNeeded()
             },
@@ -514,10 +525,6 @@ final class UnifiedToggleInputView: UIView {
             return
         }
 
-        if cardPosition == .top {
-            cardTrailingConstraint.constant = -Constants.cardHorizontalMargin
-        }
-
         UIView.animate(
             withDuration: Constants.animationDuration,
             delay: 0,
@@ -527,6 +534,7 @@ final class UnifiedToggleInputView: UIView {
                 self.toggleTopConstraint.constant = 0
                 self.toggleHeightConstraint.constant = 0
                 self.toggleView.alpha = 0
+                self.applyInlineDismissVisibility(false)
                 self.inputTopConstraint.constant = 0
                 self.toolbarHeightConstraint.constant = 0
                 self.toolsToolbar.alpha = 0
@@ -549,10 +557,9 @@ final class UnifiedToggleInputView: UIView {
                 self.cardView.layer.maskedCorners = allCorners
                 self.expandedShadow0.shadowOffset = CGSize(width: 0, height: 8)
                 self.expandedShadow1.shadowOffset = CGSize(width: 0, height: 2)
-                let trailingMargin = self.cardPosition == .top ? Constants.cardTrailingMarginWithDismiss : Constants.cardHorizontalMargin
                 self.cardTopConstraint.constant = Constants.cardVerticalMargin
                 self.cardLeadingConstraint.constant = Constants.cardHorizontalMargin
-                self.cardTrailingConstraint.constant = -trailingMargin
+                self.cardTrailingConstraint.constant = -Constants.cardHorizontalMargin
                 self.cardBottomConstraint.constant = -Constants.cardVerticalMargin
                 self.toolbarHeightConstraint.constant = 0
                 self.toolsToolbar.alpha = 0
@@ -567,7 +574,7 @@ final class UnifiedToggleInputView: UIView {
                     trailingMargin = Constants.cardHorizontalMarginBottom
                 } else {
                     leadingMargin = Constants.cardHorizontalMargin
-                    trailingMargin = self.cardPosition == .top ? Constants.cardTrailingMarginWithDismiss : Constants.cardHorizontalMargin
+                    trailingMargin = Constants.cardHorizontalMargin
                 }
                 let verticalMargin: CGFloat = (!self.usesOmnibarMargins && self.cardPosition == .bottom)
                     ? Constants.cardVerticalMarginBottom
@@ -619,6 +626,71 @@ final class UnifiedToggleInputView: UIView {
     }
 }
 
+// MARK: - Inline Dismiss
+
+private extension UnifiedToggleInputView {
+
+    /// The inline dismiss (X) button is part of the card's top row when the card is anchored
+    /// at the top of the screen. When anchored at the bottom, the dismiss button is rendered
+    /// as a separate floating control in the content container, so the inline one stays hidden.
+    var shouldShowInlineDismiss: Bool {
+        isExpanded && cardPosition == .top
+    }
+
+    /// Updates layout and opacity so the toggle either reserves space for the inline dismiss
+    /// button or expands to fill the card's top row. Safe to call outside of animation blocks.
+    func refreshInlineDismissPresentation(animated: Bool) {
+        let shouldShow = shouldShowInlineDismiss
+        toggleTrailingConstraint.constant = shouldShow
+            ? Constants.toggleTrailingWithInlineDismiss
+            : -Constants.toggleHorizontalPadding
+
+        applyInlineDismissVisibility(shouldShow)
+
+        if animated {
+            UIView.animate(withDuration: Constants.animationDuration, delay: 0, options: .curveEaseInOut) {
+                self.layoutIfNeeded()
+            }
+        } else {
+            layoutIfNeeded()
+        }
+    }
+
+    /// Apply visibility without touching the toggle trailing constraint. Intended for use
+    /// inside existing animation blocks so that opacity and layout animate together.
+    func applyInlineDismissVisibility(_ visible: Bool) {
+        inlineDismissButton.alpha = visible ? 1 : 0
+        inlineDismissButton.isUserInteractionEnabled = visible
+    }
+
+    @objc func handleInlineDismissTap() {
+        onInlineDismissTapped?()
+    }
+
+    static func makeInlineDismissButton() -> UIButton {
+        let button: UIButton
+        if #available(iOS 26, *) {
+            var config = UIButton.Configuration.glass()
+            config.image = UIImage(systemName: "xmark")
+            config.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 12, weight: .medium)
+            button = UIButton(configuration: config)
+        } else {
+            button = UIButton(type: .system)
+            let image = UIImage(systemName: "xmark")?
+                .withConfiguration(UIImage.SymbolConfiguration(pointSize: 12, weight: .medium))
+            button.setImage(image, for: .normal)
+            button.tintColor = UIColor(designSystemColor: .textPrimary)
+            button.backgroundColor = UIColor(designSystemColor: .controlsFillPrimary)
+            button.layer.cornerRadius = Constants.inlineDismissSize / 2
+        }
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.accessibilityLabel = UserText.keyCommandClose
+        button.alpha = 0
+        button.isUserInteractionEnabled = false
+        return button
+    }
+}
+
 // MARK: - Setup
 
 private extension UnifiedToggleInputView {
@@ -651,6 +723,9 @@ private extension UnifiedToggleInputView {
             }
         }
         addSubview(toggleView)
+
+        inlineDismissButton.addTarget(self, action: #selector(handleInlineDismissTap), for: .primaryActionTriggered)
+        addSubview(inlineDismissButton)
 
         textEntryView.translatesAutoresizingMaskIntoConstraints = false
         textEntryView.isExpandable = false
@@ -712,6 +787,7 @@ private extension UnifiedToggleInputView {
         cardCollapsedHeightConstraint.isActive = true
         toggleTopConstraint = toggleView.topAnchor.constraint(equalTo: cardView.topAnchor, constant: 0)
         toggleHeightConstraint = toggleView.heightAnchor.constraint(equalToConstant: 0)
+        toggleTrailingConstraint = toggleView.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -Constants.toggleHorizontalPadding)
         inputTopConstraint = textEntryView.topAnchor.constraint(equalTo: toggleView.bottomAnchor, constant: 0)
         toolbarBottomConstraint = toolsToolbar.bottomAnchor.constraint(equalTo: cardView.bottomAnchor)
         attachmentsStripHeightConstraint = attachmentsStrip.heightAnchor.constraint(equalToConstant: 0)
@@ -725,8 +801,13 @@ private extension UnifiedToggleInputView {
 
             toggleTopConstraint,
             toggleView.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: Constants.toggleHorizontalPadding),
-            toggleView.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -Constants.toggleHorizontalPadding),
+            toggleTrailingConstraint,
             toggleHeightConstraint,
+
+            inlineDismissButton.topAnchor.constraint(equalTo: cardView.topAnchor, constant: Constants.toggleTopPadding),
+            inlineDismissButton.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -Constants.inlineDismissTrailingPadding),
+            inlineDismissButton.widthAnchor.constraint(equalToConstant: Constants.inlineDismissSize),
+            inlineDismissButton.heightAnchor.constraint(equalToConstant: Constants.inlineDismissSize),
 
             inputTopConstraint,
             textEntryView.leadingAnchor.constraint(equalTo: cardView.leadingAnchor),

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -95,7 +95,7 @@ final class UnifiedToggleInputView: UIView {
     var cardPosition: UnifiedToggleInputCardPosition = .bottom {
         didSet {
             guard cardPosition != oldValue else { return }
-            refreshInlineDismissPresentation(animated: false)
+            refreshInlineDismissPresentation()
             guard isExpanded else { return }
             let allCorners: CACornerMask = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
             cardView.layer.maskedCorners = allCorners
@@ -631,30 +631,15 @@ final class UnifiedToggleInputView: UIView {
 
 private extension UnifiedToggleInputView {
 
-    /// The inline dismiss (X) button is part of the card's top row when the card is anchored
-    /// at the top of the screen. When anchored at the bottom, the dismiss button is rendered
-    /// as a separate floating control in the content container, so the inline one stays hidden.
-    var shouldShowInlineDismiss: Bool {
-        isExpanded && cardPosition == .top
-    }
-
     /// Updates layout and opacity so the toggle either reserves space for the inline dismiss
     /// button or expands to fill the card's top row. Safe to call outside of animation blocks.
-    func refreshInlineDismissPresentation(animated: Bool) {
-        let shouldShow = shouldShowInlineDismiss
+    func refreshInlineDismissPresentation() {
+        let shouldShow = isExpanded && cardPosition == .top
         toggleTrailingConstraint.constant = shouldShow
             ? Constants.toggleTrailingWithInlineDismiss
             : -Constants.toggleHorizontalPadding
-
         applyInlineDismissVisibility(shouldShow)
-
-        if animated {
-            UIView.animate(withDuration: Constants.animationDuration, delay: 0, options: .curveEaseInOut) {
-                self.layoutIfNeeded()
-            }
-        } else {
-            layoutIfNeeded()
-        }
+        layoutIfNeeded()
     }
 
     /// Apply visibility without touching the toggle trailing constraint. Intended for use

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -74,10 +74,7 @@ final class UnifiedToggleInputView: UIView {
         static let inlineDismissSize: CGFloat = 40
         static let inlineDismissTrailingPadding: CGFloat = 8
         static let toggleInlineDismissSpacing: CGFloat = 6
-        /// Trailing margin used at `.top` when the Search/Duck.ai toggle is disabled in
-        /// settings, so the floating X in the content container has room to sit outside the
-        /// card. With the toggle enabled the inline X lives inside the card and the card
-        /// spans the full width.
+        /// Carves room for the floating X at `.top` when the toggle is disabled.
         static let cardTrailingMarginWithFloatingDismiss: CGFloat = 68
 
         /// Trailing constant for the toggle when the inline dismiss button shares the top row.
@@ -649,7 +646,7 @@ private extension UnifiedToggleInputView {
     /// Updates layout and opacity so the toggle either reserves space for the inline dismiss
     /// button or expands to fill the card's top row. Safe to call outside of animation blocks.
     func refreshInlineDismissPresentation() {
-        let shouldShow = isExpanded && cardPosition == .top
+        let shouldShow = isExpanded && cardPosition == .top && isToggleEnabled
         toggleTrailingConstraint.constant = shouldShow
             ? Constants.toggleTrailingWithInlineDismiss
             : -Constants.toggleHorizontalPadding

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -74,6 +74,11 @@ final class UnifiedToggleInputView: UIView {
         static let inlineDismissSize: CGFloat = 40
         static let inlineDismissTrailingPadding: CGFloat = 8
         static let toggleInlineDismissSpacing: CGFloat = 6
+        /// Trailing margin used at `.top` when the Search/Duck.ai toggle is disabled in
+        /// settings, so the floating X in the content container has room to sit outside the
+        /// card. With the toggle enabled the inline X lives inside the card and the card
+        /// spans the full width.
+        static let cardTrailingMarginWithFloatingDismiss: CGFloat = 68
 
         /// Trailing constant for the toggle when the inline dismiss button shares the top row.
         static var toggleTrailingWithInlineDismiss: CGFloat {
@@ -415,7 +420,7 @@ final class UnifiedToggleInputView: UIView {
             hTrailingMargin = Constants.cardHorizontalMarginBottom
         } else {
             hLeadingMargin = Constants.cardHorizontalMargin
-            hTrailingMargin = Constants.cardHorizontalMargin
+            hTrailingMargin = cardTrailingMargin
         }
 
         let vMargin: CGFloat
@@ -560,7 +565,7 @@ final class UnifiedToggleInputView: UIView {
                 self.expandedShadow1.shadowOffset = CGSize(width: 0, height: 2)
                 self.cardTopConstraint.constant = Constants.cardVerticalMargin
                 self.cardLeadingConstraint.constant = Constants.cardHorizontalMargin
-                self.cardTrailingConstraint.constant = -Constants.cardHorizontalMargin
+                self.cardTrailingConstraint.constant = -self.cardTrailingMargin
                 self.cardBottomConstraint.constant = -Constants.cardVerticalMargin
                 self.toolbarHeightConstraint.constant = 0
                 self.toolsToolbar.alpha = 0
@@ -575,7 +580,7 @@ final class UnifiedToggleInputView: UIView {
                     trailingMargin = Constants.cardHorizontalMarginBottom
                 } else {
                     leadingMargin = Constants.cardHorizontalMargin
-                    trailingMargin = Constants.cardHorizontalMargin
+                    trailingMargin = self.cardTrailingMargin
                 }
                 let verticalMargin: CGFloat = (!self.usesOmnibarMargins && self.cardPosition == .bottom)
                     ? Constants.cardVerticalMarginBottom
@@ -594,6 +599,16 @@ final class UnifiedToggleInputView: UIView {
     }
 
     // MARK: - Private
+
+    /// Card trailing margin for the current state. Carves out room for the floating X in
+    /// the content container when the toggle is disabled at `.top`; otherwise the card
+    /// spans the full width to host the inline X.
+    private var cardTrailingMargin: CGFloat {
+        let needsFloatingDismissCarveOut = isExpanded && cardPosition == .top && !isToggleEnabled
+        return needsFloatingDismissCarveOut
+            ? Constants.cardTrailingMarginWithFloatingDismiss
+            : Constants.cardHorizontalMargin
+    }
 
     private func updateToolbarVisibility(for mode: TextEntryMode, animated: Bool) {
         guard isExpanded else { return }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -35,6 +35,7 @@ protocol UnifiedToggleInputViewControllerDelegate: AnyObject {
     func unifiedToggleInputVC(_ vc: UnifiedToggleInputViewController, didRemoveAttachment id: UUID)
     func unifiedToggleInputVCDidChangeAttachments(_ vc: UnifiedToggleInputViewController)
     func unifiedToggleInputVCDidChangeHeight(_ vc: UnifiedToggleInputViewController)
+    func unifiedToggleInputVCDidTapInlineDismiss(_ vc: UnifiedToggleInputViewController)
 }
 
 // MARK: - View Controller
@@ -276,12 +277,11 @@ final class UnifiedToggleInputViewController: UIViewController {
             delegate?.unifiedToggleInputVCDidChangeAttachments(self)
         }
         barView.onInlineDismissTapped = { [weak self] in
-            self?.onInlineDismissTapped?()
+            guard let self else { return }
+            delegate?.unifiedToggleInputVCDidTapInlineDismiss(self)
         }
         view = barView
     }
-
-    var onInlineDismissTapped: (() -> Void)?
 }
 
 // MARK: - UnifiedToggleInputViewDelegate

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -275,8 +275,13 @@ final class UnifiedToggleInputViewController: UIViewController {
             guard let self else { return }
             delegate?.unifiedToggleInputVCDidChangeAttachments(self)
         }
+        barView.onInlineDismissTapped = { [weak self] in
+            self?.onInlineDismissTapped?()
+        }
         view = barView
     }
+
+    var onInlineDismissTapped: (() -> Void)?
 }
 
 // MARK: - UnifiedToggleInputViewDelegate

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIRenderStateTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIRenderStateTests.swift
@@ -208,4 +208,35 @@ final class UTIRenderStateTests: XCTestCase {
         let state = sut.computeRenderState()
         XCTAssertEqual(state.contentInputMode, .aiChat)
     }
+
+    // MARK: - Inline / Floating Dismiss
+
+    func test_inlineDismiss_activeAtTopWhenExpanded() {
+        sut.activateFromOmnibar(cardPosition: .top)
+        XCTAssertTrue(sut.computeRenderState().isInlineDismissActive)
+    }
+
+    func test_inlineDismiss_hiddenAtBottomPosition() {
+        sut.activateFromOmnibar(cardPosition: .bottom)
+        XCTAssertFalse(sut.computeRenderState().isInlineDismissActive)
+    }
+
+    func test_inlineDismiss_hiddenWhenCollapsed() {
+        sut.showCollapsed()
+        XCTAssertFalse(sut.computeRenderState().isInlineDismissActive)
+    }
+
+    func test_floatingDismiss_visibleAtBottomWithContent() {
+        sut.activateFromOmnibar(cardPosition: .bottom)
+        XCTAssertTrue(sut.computeRenderState().isFloatingDismissVisible)
+    }
+
+    func test_floatingDismiss_hiddenAtTopWhenInlineDismissActive() {
+        sut.activateFromOmnibar(cardPosition: .top)
+        XCTAssertFalse(sut.computeRenderState().isFloatingDismissVisible)
+    }
+
+    func test_floatingDismiss_hiddenWhenContentHidden() {
+        XCTAssertFalse(sut.computeRenderState().isFloatingDismissVisible)
+    }
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIRenderStateTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIRenderStateTests.swift
@@ -221,6 +221,20 @@ final class UTIRenderStateTests: XCTestCase {
         XCTAssertFalse(sut.computeRenderState().isInlineDismissActive)
     }
 
+    func test_inlineDismiss_hiddenWhenToggleDisabled() {
+        sut = UnifiedToggleInputCoordinator(isToggleEnabled: false)
+        sut.activateFromOmnibar(cardPosition: .top)
+        XCTAssertFalse(sut.computeRenderState().isInlineDismissActive)
+    }
+
+    func test_floatingDismiss_visibleAtTopWhenToggleDisabled() {
+        // Regression: with the toggle setting off, the card has no top row for the inline X;
+        // the floating X must still appear so users can dismiss the omnibar session.
+        sut = UnifiedToggleInputCoordinator(isToggleEnabled: false)
+        sut.activateFromOmnibar(cardPosition: .top)
+        XCTAssertTrue(sut.computeRenderState().isFloatingDismissVisible)
+    }
+
     func test_inlineDismiss_hiddenWhenCollapsed() {
         sut.showCollapsed()
         XCTAssertFalse(sut.computeRenderState().isInlineDismissActive)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214150889924047

### Description

At `.top` address-bar position, the Unified Toggle Input card now includes the dismiss (X) button inline in its top row, aligned with the Search/Duck.ai segmented toggle, and the card spans the full screen width (minus standard margins). The previous 68pt trailing carve-out for the floating X is gone when the toggle is enabled. `.bottom` position is unchanged — the floating X still lives in the content container there. When the Search/Duck.ai toggle is disabled in settings, the previous 68pt carve-out and the floating X are preserved so users can still dismiss the omnibar session.

Also fixes a related bug: when tapping the address bar with a prefilled URL, the text field's clear (×) button would appear to slide in from the right edge. Root cause was `UIStackView` animating the hidden-item reveal because `buttonsView.layoutIfNeeded()` in `SwitchBarTextEntryView.updateButtonState` only laid out the buttonsView's subtree — the buttonsView's own frame change landed on a later layout pass that was captured by the outer UTI reveal animation. Fix: wrap the state assignment in `performWithoutAnimation` and lay out `self` (the text entry view) so the frame settles inside the non-animated block.

### Testing Steps

1. Open the iOS app on a device/simulator and ensure **address bar position = top** in Settings → Appearance.
2. Visit any URL (e.g. `https://duckduckgo.com`).
3. Tap the address bar. Expect:
   - UTI card appears at the top spanning the full width (16pt margins left/right).
   - Segmented toggle (Search / Duck.ai) appears on the top row, with the X dismiss button **inside** the card, aligned with the toggle on the right.
   - Address/search input field is on the second row, full width.
4. Tap the X inside the card. Expect: card dismisses back to the omnibar with the usual animation.
5. Re-open the address bar (URL still prefilled) and quickly tap X close, then immediately tap the address bar again. Expect: the clear (×) button in the text field **does not** slide in from the right edge — it appears in place.
6. Change address bar position to **bottom** in Settings. Repeat steps 2–4. Expect: X dismiss button is still the floating circle in the top-right corner of the screen (no inline X inside the card). Nothing should look different from before this PR.
7. Go to Settings → AI Features and disable the Search/Duck.ai toggle (i.e. set to "Search only"). At `.top` position, tap the address bar on a page with a URL. Expect: the card is narrower (68pt trailing carve-out) and the floating X sits outside the card on the right — just like before this branch. You must be able to tap the floating X to dismiss.

### Impact and Risks

**Low–Medium.**
- UI-only change scoped to the Unified Toggle Input's `.top`-position layout. `.bottom`-position behaviour is explicitly untouched and covered by new render-state tests.
- Main risk surface is the `.top` activation/dismiss animation state machine (`setExpanded` / `animateToggleReveal` / `animateToggleHide` / `setInactiveCardAppearance`) — all code paths were updated consistently to drive the new inline button's alpha + height via a single helper.
- Secondary fix in `SwitchBarTextEntryView.updateButtonState` changes the layout scope from `buttonsView.layoutIfNeeded()` to `layoutIfNeeded()` (on `self`, the text entry view). Shared with the omnibar editing flow; in practice this just forces the stack's frame to resolve one layer up, which is the intent. Worth a look in review.
- Toggle-disabled fallback (no inline X, floating X preserved with 68pt carve-out) is covered by a dedicated regression test.
- Feature is behind the existing `.unifiedToggleInput` feature flag (inherited from the UTI project), so any regression is contained to users with that flag on.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/layout change affecting Unified Toggle Input’s top-position expansion/dismiss behavior and related coordinator render-state logic; risk is mainly around animation/layout regressions and dismiss visibility when the toggle is disabled.
> 
> **Overview**
> Adds an **inline dismiss (X) button inside the Unified Toggle Input card** when the card is expanded at `.top` with the Search/Duck.ai toggle enabled, and updates layout constraints so the card can use full trailing width in that case while preserving the old trailing carve-out + floating dismiss when the toggle is disabled.
> 
> Refactors dismiss visibility decisions into `UTIRenderState` (`isInlineDismissActive` / `isFloatingDismissVisible`) and routes the inline dismiss tap through the coordinator to the existing content-container dismiss handler; adds unit tests covering the inline vs floating dismiss rules.
> 
> Fixes a related UI glitch in `SwitchBarTextEntryView.updateButtonState` by forcing layout on the whole view inside `performWithoutAnimation` to prevent `UIStackView` hidden-state changes from animating during omnibar reveal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bea3f3c0d2d1b361daa48a901ac0dafa29341b30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->