### PR TITLE
[iOS] Fire mode ship review copy updates

### DIFF
--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -91,8 +91,8 @@ public struct UserText {
 
     // MARK: Fire Mode Tab Switcher Tip
 
-    public static let fireModeTabSwitcherTipTitle = NotLocalizedString("fire.mode.tab.switcher.tip.title", value: "New: Fire Tabs", comment: "Title for the Fire Tabs popover tip shown on the tab switcher picker")
-    public static let fireModeTabSwitcherTipDescription = NotLocalizedString("fire.mode.tab.switcher.tip.description", value: "Try Fire Tabs to browse without saving local history.", comment: "Description for the Fire Tabs popover tip shown on the tab switcher picker")
+    public static let fireModeTabSwitcherTipTitle = NSLocalizedString("fire.mode.tab.switcher.tip.title", value: "New: Fire Tabs", comment: "Title for the Fire Tabs popover tip shown on the tab switcher picker")
+    public static let fireModeTabSwitcherTipDescription = NSLocalizedString("fire.mode.tab.switcher.tip.description", value: "Try Fire Tabs to browse without saving local history.", comment: "Description for the Fire Tabs popover tip shown on the tab switcher picker")
 
     // MARK: Fire Mode Menu Promotion
 

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -46,7 +46,7 @@ public struct UserText {
     public static let actionNewTab = NSLocalizedString("action.title.newTabAction", value: "New Tab", comment: "Create New Tab action")
     public static let actionNewFireTab = NSLocalizedString("action.title.newFireTabAction", value: "New Fire Tab", comment: "Create New Fire Tab action")
     public static let actionNewTabForUrl = NSLocalizedString("action.title.newTabForUrl", value: "Open in New Tab", comment: "Open in New Tab action")
-    public static let actionNewFireTabForUrl = NSLocalizedString("action.title.newFireTabForUrl", value: "Open in a Fire Tab", comment: "Open in New Fire Tab action")
+    public static let actionNewFireTabForUrl = NSLocalizedString("action.title.newFireTabForUrl", value: "Open in Fire Tab", comment: "Open in New Fire Tab action")
     public static let actionNewBackgroundTabForUrl = NSLocalizedString("action.title.newBackgroundTabForUrl", value: "Open in Background", comment: "Open in New Background Tab action")
     public static let actionForgetAll = NSLocalizedString("action.title.forgetAll", value: "Clear Tabs and Data", comment: "")
     public static let actionForgetAllDone = NSLocalizedString("action.title.forgetAllDone", value: "Tabs and data cleared", comment: "Confirmation message")
@@ -79,13 +79,13 @@ public struct UserText {
     public static let fireModeEmptyStateBulletHistory = NSLocalizedString("fire.mode.empty.state.bullet.history", value: "Browse without saving local history", comment: "Bullet point describing Fire Tab benefit on the empty state screen")
     public static let fireModeEmptyStateBulletAccount = NSLocalizedString("fire.mode.empty.state.bullet.account", value: "Sign in to a site with a different account", comment: "Bullet point describing Fire Tab benefit on the empty state screen")
     public static let fireModeEmptyStateBulletTroubleshoot = NSLocalizedString("fire.mode.empty.state.bullet.troubleshoot", value: "Troubleshoot websites", comment: "Bullet point describing Fire Tab benefit on the empty state screen")
-    public static let fireModeEmptyStateDescription = NSLocalizedString("fire.mode.empty.state.description", value: "Fire Tabs are isolated from other browser data, and their data is burned when you close them all. They have the same tracking protection as other tabs.", comment: "Description explaining how Fire Tabs work on the empty state screen")
+    public static let fireModeEmptyStateDescription = NSLocalizedString("fire.mode.empty.state.description", value: "Fire Tabs are isolated from other browser data. Their data is burned when you close them all. They give you the same tracking protection as other tabs.", comment: "Description explaining how Fire Tabs work on the empty state screen")
     public static let fireModeEmptyStateNewFireTab = NSLocalizedString("fire.mode.empty.state.new.fire.tab", value: "New Fire Tab", comment: "Button label to create a new Fire Tab on the empty state screen")
 
     // MARK: Fire Mode NTP Promotion
 
     public static let fireModePromotionTitle = NSLocalizedString("fire.mode.promotion.title", value: "Try Fire Tabs", comment: "Title for promotion element for pushing users to try fire mode.")
-    public static let fireModeNTPPromotionDescription = NSLocalizedString("fire.mode.ntp.promotion.description", value: "Browse without saving local history or sign in to sites with a different account.", comment: "Description for the Fire Mode promotion card shown on the new tab page")
+    public static let fireModeNTPPromotionDescription = NSLocalizedString("fire.mode.ntp.promotion.description", value: "New! Browse without saving local history or sign in to sites with a different account.", comment: "Description for the Fire Mode promotion card shown on the new tab page")
     public static let fireModeNTPPromotionPrimaryAction = NSLocalizedString("fire.mode.ntp.promotion.primary.action", value: "Try Fire Tabs", comment: "Primary action button on the Fire Mode promotion card that opens Fire Mode")
     public static let fireModeNTPPromotionDismiss = NSLocalizedString("fire.mode.ntp.promotion.dismiss", value: "Not Now", comment: "Dismiss button on the Fire Mode promotion card on the new tab page")
 

--- a/iOS/DuckDuckGo/bg.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/bg.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Отстраняване на неизправности в уебсайтове";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Разделите Fire са изолирани от другите данни на браузъра и данните в тях се изгарят, когато затворите всички такива раздели. Имат същата защита от проследяване като другите раздели.";
+"fire.mode.empty.state.description" = "Разделите Fire са изолирани от другите данни на браузъра. Когато затворите всички такива раздели, данните в тях се изгарят. Те имат същата защита от проследяване като другите раздели.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Нов раздел Fire";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Нов";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Можете да сърфирате, без да запазвате локална история или да влизате в сайтове с друг акаунт.";
+"fire.mode.ntp.promotion.description" = "Ново! Можете да сърфирате, без да запазвате локална история или да влизате в сайтове с друг акаунт.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Не сега";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Изпробвайте разделите Fire";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Изпробвайте разделите Fire, в които сърфирате, без да запазвате локална история.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Ново: Раздели Fire";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Раздел Fire";

--- a/iOS/DuckDuckGo/cs.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/cs.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Řešení problémů s webovými stránkami";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Karty Fire jsou izolované od ostatních dat prohlížeče a jejich data se spálí, jakmile je všechny zavřeš. Mají stejnou ochranu proti sledování jako ostatní karty.";
+"fire.mode.empty.state.description" = "Karty Fire jsou izolované od ostatních dat prohlížeče. Jakmile je všechny zavřeš, jejich data se vymažou. Poskytují stejnou ochranu před sledováním jako ostatní karty.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Nová karta Fire";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Nová";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Prohlížej si webové stránky bez ukládání místní historie nebo se přihlas k webovým službám pod jiným účtem.";
+"fire.mode.ntp.promotion.description" = "Novinka! Prohlížej si webové stránky bez ukládání místní historie nebo se přihlas k webovým službám pod jiným účtem.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Teď ne";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Vyzkoušet karty Fire";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Vyzkoušej karty Fire pro prohlížení bez ukládání místní historie.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Nové: Karty Fire";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Karta Fire";

--- a/iOS/DuckDuckGo/da.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/da.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Fejlfinding på websteder";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Fire-faner er isoleret fra andre browserdata, og deres data brændes, når du lukker dem alle. De har samme sporingsbeskyttelse som andre faner.";
+"fire.mode.empty.state.description" = "Fire-faner er isoleret fra andre browserdata. Dine data slettes, når du lukker dem alle. De giver dig samme sporingsbeskyttelse som andre faner.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Ny Fire-fane";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Ny";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Gennemse uden at gemme lokal historik eller logge ind på websteder med en anden konto.";
+"fire.mode.ntp.promotion.description" = "Nyt! Gennemse uden at gemme lokal historik eller logge ind på websteder med en anden konto.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Ikke nu";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Prøv Fire-faner";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Prøv Fire-faner for at surfe uden at gemme lokal historik.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Nyt: Fire-faner";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Fire-fane";

--- a/iOS/DuckDuckGo/de.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/de.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Website-Fehlerbehebung";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Fire-Tabs sind von anderen Browserdaten isoliert und ihre Daten werden gelöscht, wenn du sie alle schließt. Sie haben den gleichen Tracking-Schutz wie andere Tabs.";
+"fire.mode.empty.state.description" = "Fire Tabs sind von anderen Browserdaten isoliert. Ihre Daten werden gelöscht, wenn du alle Fenster schließt. Sie haben den gleichen Tracking-Schutz wie andere Tabs.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Neues Fire-Tab";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Neu";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Surfe, ohne den lokalen Verlauf zu speichern, oder melde dich mit einem anderen Konto auf Websites an.";
+"fire.mode.ntp.promotion.description" = "Neu! Browse, ohne den lokalen Verlauf zu speichern, oder melde dich mit einem anderen Konto auf Websites an.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Jetzt nicht";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Fire-Tabs ausprobieren";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Fire-Tabs ausprobieren, um zu surfen, ohne den lokalen Verlauf zu speichern.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Neu: Fire-Tabs";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Fire-Tab";

--- a/iOS/DuckDuckGo/el.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/el.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Αντιμετώπιση προβλημάτων ιστοτόπων";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Οι καρτέλες Fire είναι απομονωμένες από άλλα δεδομένα του προγράμματος περιήγησης και τα δεδομένα τους καίγονται όταν τις κλείνεις όλες. Έχουν την ίδια προστασία παρακολούθησης με τις άλλες καρτέλες.";
+"fire.mode.empty.state.description" = "Οι καρτέλες Fire είναι απομονωμένες από άλλα δεδομένα του προγράμματος περιήγησης. Τα δεδομένα τους καίγονται όταν τις κλείσεις όλες. Παρέχουν την ίδια προστασία παρακολούθησης με άλλες καρτέλες.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Νέα καρτέλα Fire";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Νέο";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Περιηγήσου χωρίς να αποθηκεύσεις το τοπικό ιστορικό ή συνδέσου σε ιστότοπους με διαφορετικό λογαριασμό.";
+"fire.mode.ntp.promotion.description" = "Νέο! Περιηγήσου χωρίς να αποθηκεύσεις το τοπικό ιστορικό ή συνδέσου σε ιστότοπους με διαφορετικό λογαριασμό.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Όχι τώρα";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Δοκίμασε τις καρτέλες Fire";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Δοκίμασε τις Καρτέλες Fire για περιήγηση χωρίς να αποθηκεύεις το τοπικό ιστορικό.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Νέο: Καρτέλες Fire";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Καρτέλα Fire";

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -86,7 +86,7 @@
 "action.title.newFireTabAction" = "New Fire Tab";
 
 /* Open in New Fire Tab action */
-"action.title.newFireTabForUrl" = "Open in a Fire Tab";
+"action.title.newFireTabForUrl" = "Open in Fire Tab";
 
 /* Create New Tab action */
 "action.title.newTabAction" = "New Tab";
@@ -2066,7 +2066,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Troubleshoot websites";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Fire Tabs are isolated from other browser data, and their data is burned when you close them all. They have the same tracking protection as other tabs.";
+"fire.mode.empty.state.description" = "Fire Tabs are isolated from other browser data. Their data is burned when you close them all. They give you the same tracking protection as other tabs.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "New Fire Tab";
@@ -2078,7 +2078,7 @@
 "fire.mode.menu.promotion.badge" = "New";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Browse without saving local history or sign in to sites with a different account.";
+"fire.mode.ntp.promotion.description" = "New! Browse without saving local history or sign in to sites with a different account.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Not Now";

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -2089,6 +2089,12 @@
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Try Fire Tabs";
 
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Try Fire Tabs to browse without saving local history.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "New: Fire Tabs";
+
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Fire Tab";
 

--- a/iOS/DuckDuckGo/es.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/es.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Solucionar problemas de sitios web";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Las Fire Tabs están aisladas de otros datos del navegador y sus datos se queman cuando las cierras todas. Tienen la misma protección contra el rastreo que otras pestañas.";
+"fire.mode.empty.state.description" = "Las Fire Tabs están aisladas de otros datos del navegador. Sus datos se queman cuando las cierras todas. Tienen la misma protección contra el rastreo que otras pestañas.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Nueva Fire Tab";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Nuevo";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Navega sin guardar el historial local o inicia sesión en sitios con una cuenta diferente.";
+"fire.mode.ntp.promotion.description" = "¡Nuevo! Navega sin guardar el historial local o inicia sesión en sitios con una cuenta diferente.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Ahora no";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Prueba Fire Tabs";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Prueba Fire Tabs para navegar sin guardar el historial local.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Nuevas: Pestañas Fire";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Fire tab";

--- a/iOS/DuckDuckGo/et.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/et.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Tõrkeotsing veebilehtedel";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Fire vahekaardid on teistest brauseriandmetest isoleeritud ja nende andmed põletatakse pärast seda, kui sa need kõik sulged. Neil on sama jälgimiskaitse kui teistel vahekaardil.";
+"fire.mode.empty.state.description" = "Fire vahekaardid on teistest brauseriandmetest isoleeritud. Nende andmed põletatakse, kui sa need kõik sulged. Need pakuvad sulle sama jälgimiskaitset kui teisedki vahekaardid.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Uus Fire vahekaart";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Uus";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Sirvi kohalikku ajalugu salvestamata või logi saitidele sisse teise kontoga.";
+"fire.mode.ntp.promotion.description" = "Uus! Sirvi kohalikku ajalugu salvestamata või logi saitidele sisse teise kontoga.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Mitte praegu";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Proovi Fire vahekaarte";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Proovi Fire vahekaarte, et sirvida ilma kohalikku ajalugu salvestamata.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Uus: Fire vahekaardid";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Fire vahekaart";

--- a/iOS/DuckDuckGo/fi.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fi.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Vianmääritys verkkosivustoille";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Fire-välilehdet on eristetty muista selaintiedoista, ja niiden tiedot poltetaan, kun suljet ne kaikki. Niillä on sama seurantasuoja kuin muillakin välilehdillä.";
+"fire.mode.empty.state.description" = "Fire-välilehdet on eristetty muista selaintiedoista. Niiden tiedot poltetaan, kun suljet ne kaikki. Ne antavat sinulle saman seurantasuojan kuin muutkin välilehdet.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Uusi Fire-välilehti";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Uusi";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Selaa tallentamatta paikallista historiaa tai kirjaudu sivustoille eri tilillä.";
+"fire.mode.ntp.promotion.description" = "Uutta! Selaa tallentamatta paikallista historiaa tai kirjaudu sivustoille käyttämällä eri tiliä.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Ei nyt";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Kokeile Fire-välilehtiä";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Kokeile Fire-välilehtiä selataksesi ilman paikallisen historian tallentamista.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Uutta: Fire-välilehdet";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Fire-välilehti";

--- a/iOS/DuckDuckGo/fr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fr.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Résoudre les problèmes des sites Web";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Les onglets Fire Tabs sont isolés des autres données du navigateur, et leurs données sont supprimées lorsque vous les fermez tous. Ils sont dotés de la même protection contre le pistage que les autres onglets.";
+"fire.mode.empty.state.description" = "Les onglets Fire sont isolés des autres données du navigateur. Leurs données sont supprimées lorsque vous les fermez tous. Ils sont dotés de la même protection contre le pistage que les autres onglets.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Nouveau Fire Tab";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Nouveau";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Naviguez sans enregistrer l’historique local ni vous connecter à des sites avec un autre compte.";
+"fire.mode.ntp.promotion.description" = "Nouveau ! Naviguez sans enregistrer l'historique local ni vous connecter à des sites avec un autre compte.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Pas maintenant";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Essayez les Onglets Fire";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Essayez les onglets Fire pour naviguer sans enregistrer l'historique local.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Nouveau : les onglets Fire";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Onglet Fire";

--- a/iOS/DuckDuckGo/hr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hr.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Rješavanje problema s web-stranicama";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Kartice Fire izolirane su od ostalih podataka preglednika, a njihovi se podaci brišu kada ih sve zatvoriš. Imaju istu zaštitu od praćenja kao i ostale kartice.";
+"fire.mode.empty.state.description" = "Kartice Fire izolirane su od ostalih podataka preglednika. Njihovi se podaci brišu kada ih sve zatvoriš. Daju ti istu zaštitu od praćenja kao i ostale kartice.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Nova Fire kartica";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Novo";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Pregledavaj bez spremanja lokalne povijesti ili se prijavi na web-mjesta drugim računom.";
+"fire.mode.ntp.promotion.description" = "Novo! Pregledavaj bez spremanja lokalne povijesti ili se prijavi na web-mjesta drugim računom.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Ne sada";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Isprobaj Fire kartice";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Isprobaj kartice Fire za pregledavanje bez spremanja lokalne povijesti.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Novo: kartice Fire";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Fire kartica";

--- a/iOS/DuckDuckGo/hu.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hu.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Webhelyek hibaelhárítása";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "A Fire lapok a böngésző egyéb adataitól el vannak különítve, és az összes Fire lap bezárásakor a hozzájuk tartozó adatok törlésre kerülnek. Ugyanolyan nyomkövetés elleni védelemmel rendelkeznek, mint a többi lap.";
+"fire.mode.empty.state.description" = "A Fire lapok a böngésző egyéb adataitól el vannak különítve. Az összes bezárásakor a hozzájuk tartozó adatok törlésre kerülnek. Ugyanolyan nyomkövetés elleni védelmet kínálnak, mint a többi lap.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Új Fire lap";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Új";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Böngészés a helyi előzmények mentése nélkül, vagy bejelentkezés a webhelyekre másik fiókkal.";
+"fire.mode.ntp.promotion.description" = "Újdonság! Böngészés a helyi előzmények mentése nélkül, vagy bejelentkezés a webhelyekre másik fiókkal.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Most nem";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Fire lapok kipróbálása";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Próbáld ki a Fire lapok funkciót, hogy a helyi előzmények mentése nélkül böngészhess.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Új: Fire lapok";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Fire lap";

--- a/iOS/DuckDuckGo/it.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/it.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Risolvi i problemi dei siti web";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Le Fire Tabs sono isolate dagli altri dati del browser e i loro dati vengono eliminati quando le chiudi tutte. Hanno la stessa protezione dal tracciamento delle altre schede.";
+"fire.mode.empty.state.description" = "Le schede Fire sono isolate dagli altri dati del browser. I dati vengono eliminati quando le chiudi tutte. Ti offrono la stessa protezione dal tracciamento delle altre schede.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Nuova scheda Fire";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Nuova";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Naviga senza salvare la cronologia locale o accedi a siti con un account diverso.";
+"fire.mode.ntp.promotion.description" = "Novità! Naviga senza salvare la cronologia locale o accedi ai siti con un account diverso.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Non adesso";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Prova le schede Fire";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Prova Fire Tabs per navigare senza salvare la cronologia locale.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Novità: schede Fire";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Scheda Fire";

--- a/iOS/DuckDuckGo/ja.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ja.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "ウェブサイトのトラブルシューティング";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Fireタブは他のブラウザデータから切り離されており、タブをすべて閉じるとそのデータは完全に消去されます。他のタブと同様のトラッキング防止機能も備えています。";
+"fire.mode.empty.state.description" = "Fireタブは他のブラウザデータから隔離されており、すべてのアカウントを閉じると、そのデータは焼却されます。他のタブと同様のトラッキング防止機能も備えています。";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "新しいFireタブ";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "新規";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "履歴を残さずにブラウジングしたり、別のカウントでサイトにサインインしたりできます。";
+"fire.mode.ntp.promotion.description" = "新機能！履歴を残さずに閲覧したり、別のWebサイトに別のアカウントでサインインしたりできます。";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "後で";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Fireタブを試してみる";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "履歴を保存せずに閲覧するには、Fireタブをお試しください。";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "新機能：Fireタブ";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Fireタブ";

--- a/iOS/DuckDuckGo/lt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lt.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Šalink interneto svetainių triktis";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "„Fire“ kortelės izoliuotos nuo kitų naršyklės duomenų. Kai visas jas uždarai, duomenys ištrinami. Joms taikoma tokia pati apsauga nuo sekimo kaip ir kitoms kortelėms.";
+"fire.mode.empty.state.description" = "Skirtukai „Fire“ yra izoliuoti nuo kitų naršyklės duomenų. Jų duomenys sunaikinami, kai tik juos visus uždarote. Jie suteikia tokią pačią apsaugą nuo sekimo kaip ir kiti skirtukai.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Nauja „Fire“ kortelė";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Naujas";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Naršyk ir nesaugok vietinės istorijos arba prisijunk prie svetainių su kita paskyra.";
+"fire.mode.ntp.promotion.description" = "Naujiena! Naršyk nesaugant vietinės istorijos arba prisijunk prie svetainių su kita paskyra.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Ne dabar";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Išbandyk „Fire“ korteles";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Išbandyk skirtukus „Fire Tabs“, kad naršytum nesaugodamas vietinės istorijos.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Naujiena: skirtukai „Fire Tabs“";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "„Fire“ kortelė";

--- a/iOS/DuckDuckGo/lv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lv.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Tīmekļa vietņu problēmu novēršana";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Fire cilnes ir izolētas no citiem pārlūkprogrammas datiem, un to dati tiek dzēsti, kad tās visas aizver. Tām ir tāda pati izsekošanas aizsardzība kā citām cilnēm.";
+"fire.mode.empty.state.description" = "Fire cilnes ir izolētas no citiem pārlūkprogrammas datiem. Tās visas aizverot, to dati tiek iznīcināti. Tām ir tāda pati izsekošanas aizsardzība kā citām cilnēm.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Jauna Fire cilne";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Jauns";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Pārlūko, nesaglabājot lokālo vēsturi, vai pieraksties vietnēs ar citu kontu.";
+"fire.mode.ntp.promotion.description" = "Jaunums! Pārlūko vietnes, nesaglabājot vietējo vēsturi, vai pieraksties tajās, izmantojot citu kontu.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Ne tagad";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Izmēģini Fire cilnes";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Izmēģini Fire Tabs, lai pārlūkotu, nesaglabājot vietējo vēsturi.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Jaunums: Fire cilnes";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Fire cilne";

--- a/iOS/DuckDuckGo/nb.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nb.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Feilsøk nettsteder";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Fire-faner er isolert fra andre nettleserdata, og dataene i dem blir brent når du lukker alle sammen. De har samme sporingsbeskyttelse som andre faner.";
+"fire.mode.empty.state.description" = "Fire-faner er isolert fra andre nettleserdata. Dataene deres blir slettet når du lukker alle sammen. De gir deg samme sporingsbeskyttelse som andre faner.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Ny Fire-fane";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Ny";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Surf uten å lagre lokal historikk eller logg inn på nettsteder med en annen konto.";
+"fire.mode.ntp.promotion.description" = "Nyhet! Surf uten å lagre lokal historikk eller logg inn på nettsteder med en annen konto.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Ikke nå";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Prøv Fire-faner";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Prøv Fire-faner for å surfe uten å lagre lokal historikk.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Nyhet: Fire-faner";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Fire-fane";

--- a/iOS/DuckDuckGo/nl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nl.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Problemen met websites oplossen";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Fire Tabs staan los van andere browsergegevens en de gegevens worden verwijderd wanneer je ze allemaal sluit. Ze hebben dezelfde trackingbeveiliging als andere tabbladen.";
+"fire.mode.empty.state.description" = "Fire-tabbladen zijn geïsoleerd van andere browsergegevens. Hun gegevens worden verwijderd als je ze allemaal afsluit. Ze geven je dezelfde trackingbeveiliging als andere tabbladen.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Nieuw Fire Window";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Nieuw";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Blader zonder je lokale geschiedenis op te slaan of log in op sites met een ander account.";
+"fire.mode.ntp.promotion.description" = "Nieuw! Blader zonder je lokale geschiedenis op te slaan of log in op sites met een ander account.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Niet nu";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Probeer Fire Tabs";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Probeer Fire Tabs om te browsen zonder de lokale geschiedenis op te slaan.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Nieuw: Fire-tabbladen";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Fire-tabblad";

--- a/iOS/DuckDuckGo/pl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pl.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Rozwiązuj problemy z witrynami";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Karty Fire są odizolowane od innych danych przeglądarki, a zawarte w nich dane są usuwane w chwili ich zamknięcia. Są objęte taką samą ochroną przed śledzeniem jak inne karty.";
+"fire.mode.empty.state.description" = "Karty Fire są izolowane od innych danych przeglądarki. Ich dane zostaną zniszczone, gdy zamkniesz je wszystkie. Zapewniają one taką samą ochronę przed śledzeniem jak inne karty.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Nowa karta Fire";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Nowa";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Przeglądaj bez zapisywania historii lub loguj się do witryn z innym kontem.";
+"fire.mode.ntp.promotion.description" = "Nowość! Przeglądaj bez lokalnego zapisywania historii lub loguj w witrynach z użyciem innego konta.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Nie teraz";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Wypróbuj karty Fire";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Wypróbuj karty Fire, aby przeglądać bez lokalnego zapisywania historii.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Nowe: Karty Fire";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Karta Fire";

--- a/iOS/DuckDuckGo/pt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pt.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Resolver problemas de sites";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Os separadores Fire estão isolados de outros dados do navegador e os respetivos dados são queimados quando os fechas. Têm a mesma proteção contra rastreamento que os outros separadores.";
+"fire.mode.empty.state.description" = "Os separadores Fire estão isolados de outros dados do navegador. Os dados deles são queimados quando fechas o separador. Têm a mesma proteção contra rastreio que os outros separadores.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Novo separador Fire";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Novo";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Navegue sem guardar o histórico local ou inicie sessão em sites com uma conta diferente.";
+"fire.mode.ntp.promotion.description" = "Novo! Navega sem guardar o histórico local ou inicia sessão em sites com uma conta diferente.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Agora não";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Experimenta o Fire Tabs";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Experimenta os separadores Fire para navegar sem guardar o histórico local.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Novo: Separadores Fire";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Fire Tab";

--- a/iOS/DuckDuckGo/ro.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ro.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Depanează site-uri";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Filele Fire sunt izolate de alte date din browser, iar datele lor sunt șterse când le închizi pe toate. Au aceeași protecție împotriva urmăririi ca și alte file.";
+"fire.mode.empty.state.description" = "Filele Fire sunt izolate de alte date din browser. Datele acestora sunt arse când le închizi pe toate. Acestea îți oferă aceeași protecție împotriva urmăririi ca și alte file.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Nouă filă Fire";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Nouă";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Răsfoiește fără a salva istoricul local sau conectează-te la site-uri cu un cont diferit.";
+"fire.mode.ntp.promotion.description" = "Nou! Răsfoiește fără a salva istoricul local sau conectează-te la site-uri cu un cont diferit.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Nu acum";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Încearcă filele Fire";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Încearcă filele Fire pentru a naviga fără a salva istoricul local.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Nou: file Fire";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Filă Fire";

--- a/iOS/DuckDuckGo/ru.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ru.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Устранение неполадок с сайтами";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Данные Fire-вкладок изолированы от остальной части браузера и уничтожаются при закрытии окна. Защита от отслеживания в таких вкладках не отличается от стандартной.";
+"fire.mode.empty.state.description" = "Данные на вкладках Fire Tab изолированы от прочих данных браузера. При закрытии их данные будут уничтожены. Защита от отслеживания в таких вкладках не отличается от стандартной.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Новая Fire-вкладка";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Новый";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Просматривайте сайты, не сохраняя локальную историю, или входите на сайты с другой учетной записью.";
+"fire.mode.ntp.promotion.description" = "Новинка! Просматривайте сайты, не сохраняя локальную историю, или входите на сайты с другой учетной записью.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Не сейчас";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Попробуйте Fire-вкладки";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Используйте вкладки Fire Tab, чтобы просматривать веб-страницы без сохранения локальной истории.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Новинка: вкладки Fire Tab";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Fire-вкладка";

--- a/iOS/DuckDuckGo/sk.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sk.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Riešenie problémov s webovými stránkami";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Karty Fire sú izolované od ostatných dát prehliadača a ich dáta sa spália, keď ich všetky zatvoríte. Majú rovnakú ochranu proti sledovaniu ako ostatné karty.";
+"fire.mode.empty.state.description" = "Karty Fire sú izolované od ostatných údajov prehliadača. Ich údaje sa vymažú, keď ich všetky zatvoríš. Poskytujú ti rovnakú ochranu proti sledovaniu ako ostatné karty.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Nová karta Fire";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Nové";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Prehliadaj bez lokálneho ukladania histórie alebo sa prihlasuj na stránky s iným účtom.";
+"fire.mode.ntp.promotion.description" = "Novinka! Prehliadaj bez ukladania miestnej histórie alebo sa prihlás na stránky pomocou iného účtu.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Teraz nie";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Vyskúšaj karty Fire";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Vyskúšaj karty Fire na prehliadanie bez ukladania do lokálnej histórie.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Nové: Karty Fire";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Karta Fire";

--- a/iOS/DuckDuckGo/sl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sl.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Odpravljanje težav s spletnimi mesti";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Zavihki Fire so izolirani od drugih podatkov brskalnika in njihovi podatki se izbrišejo, ko jih vse zaprete. Imajo enako zaščito pred sledenjem kot drugi zavihki.";
+"fire.mode.empty.state.description" = "Zavihki Fire so ločeni od drugih podatkov brskanja. Njihovi podatki se izbrišejo, ko jih vse zaprete. Imajo enako zaščito pred sledenjem kot drugi zavihki.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Nov zavihek Fire";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Nov";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Brskajte brez shranjevanja lokalne zgodovine ali se prijavite na spletna mesta z drugim računom.";
+"fire.mode.ntp.promotion.description" = "Novo! Brskajte brez shranjevanja lokalne zgodovine ali se prijavite na spletna mesta z drugim računom.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Ne zdaj";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Preizkusite zavihke Fire";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Preizkusite zavihke Fire za brskanje brez shranjevanja lokalne zgodovine.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Novo: zavihki Fire";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Zavihek Fire";

--- a/iOS/DuckDuckGo/sv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sv.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Felsöka webbplatser";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Fire-flikar är isolerade från andra webbläsardata, och deras data bränns när du stänger dem alla. De har samma spårningsskydd som andra flikar.";
+"fire.mode.empty.state.description" = "Fire-flikar är isolerade från andra webbläsardata. Deras data rensas när du stänger dem alla. De ger dig samma spårningsskydd som andra flikar.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Ny Fire-flik";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Ny";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Surfa utan att spara lokal historik eller logga in på webbplatser med ett annat konto.";
+"fire.mode.ntp.promotion.description" = "Nytt! Surfa utan att spara lokal historik eller logga in på webbplatser med ett annat konto.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Inte nu";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Prova Fire-flikar";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Testa Fire-flikar för att bläddra utan att spara lokal historik.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Nya: Fire-flikar";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Fire-flik";

--- a/iOS/DuckDuckGo/tr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/tr.lproj/Localizable.strings
@@ -2181,7 +2181,7 @@
 "fire.mode.empty.state.bullet.troubleshoot" = "Web sitelerindeki sorunları giderin";
 
 /* Description explaining how Fire Tabs work on the empty state screen */
-"fire.mode.empty.state.description" = "Fire Sekmeleri diğer tarayıcı verilerinden izole edilmiştir ve tümünü kapattığınızda verileri silinir. Diğer sekmelerle aynı izleme korumasına sahiptirler.";
+"fire.mode.empty.state.description" = "Fire Sekmeleri diğer tarayıcı verilerinden izole edilmiştir. Tüm pencereleri kapattığınızda verileri imha edilir. Diğer sekmelerle aynı izleme korumasını sunarlar.";
 
 /* Button label to create a new Fire Tab on the empty state screen */
 "fire.mode.empty.state.new.fire.tab" = "Yeni Fire Sekmesi";
@@ -2193,7 +2193,7 @@
 "fire.mode.menu.promotion.badge" = "Yeni";
 
 /* Description for the Fire Mode promotion card shown on the new tab page */
-"fire.mode.ntp.promotion.description" = "Yerel geçmişi kaydetmeden göz atın veya sitelerde farklı bir hesapla oturum açın.";
+"fire.mode.ntp.promotion.description" = "Yeni! Yerel geçmişi kaydetmeden göz atın veya sitelerde farklı bir hesapla oturum açın.";
 
 /* Dismiss button on the Fire Mode promotion card on the new tab page */
 "fire.mode.ntp.promotion.dismiss" = "Şimdi Değil";
@@ -2203,6 +2203,12 @@
 
 /* Title for promotion element for pushing users to try fire mode. */
 "fire.mode.promotion.title" = "Fire Sekmelerini Deneyin";
+
+/* Description for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.description" = "Yerel geçmişi kaydetmeden göz atmak için Fire Sekmelerini deneyin.";
+
+/* Title for the Fire Tabs popover tip shown on the tab switcher picker */
+"fire.mode.tab.switcher.tip.title" = "Yeni: Fire Sekmeleri";
 
 /* Title shown on the Fire tab empty state screen */
 "fire.tab.empty.state.title" = "Fire Sekmesi";


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211767540372501/task/1214223028579543?focus=true

### Description
This PR changes a couple of strings related to fire mode. It also marks existing strings ready for translation.

### Testing Steps
No testing needed.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk copy-only localization changes; main risk is missing/incorrect translations or string key mismatches affecting UI text.
> 
> **Overview**
> Updates Fire Tabs user-facing copy across the app, including the context-menu action label ("Open in Fire Tab"), the Fire Mode empty-state description, and the NTP promotion description (now prefixed with "New!").
> 
> Switches the Fire Tabs tab-switcher tip strings from `NotLocalizedString` to `NSLocalizedString` and adds the corresponding `fire.mode.tab.switcher.tip.*` translations across supported locales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 157b41969a60d78acf3c1743324535e16ba4a5ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->