### PR TITLE
[macOS] Fix race condition between extension load and sync on startup

### DIFF
--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager+EmbeddedExtensions.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager+EmbeddedExtensions.swift
@@ -27,11 +27,16 @@ extension WebExtensionManager {
 
     /// Syncs embedded extensions from the registry based on the enabled types.
     /// Installs/upgrades enabled extensions and uninstalls disabled ones.
-    /// Call this after `loadInstalledExtensions()`.
+    /// Call this after `loadInstalledExtensions()`, or use `loadAndSyncExtensions(enabledTypes:)`.
     /// - Parameter enabledTypes: The set of extension types that should be installed.
     ///   Extensions not in this set will be uninstalled if previously installed.
     @MainActor
     public func syncEmbeddedExtensions(enabledTypes: Set<DuckDuckGoWebExtensionType>) async {
+        guard !isLoadingInstalledExtensions else {
+            Logger.webExtensions.debug("⏳ Skipping sync — load in progress, sync will run after load completes")
+            return
+        }
+
         Logger.webExtensions.debug("🔄 Syncing embedded extensions...")
 
         for descriptor in EmbeddedWebExtensionRegistry.all {

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager.swift
@@ -58,7 +58,7 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
     /// Used to prevent `syncEmbeddedExtensions` from interleaving during load,
     /// which can cause race conditions where sync deletes files that load still needs.
     @MainActor
-    public private(set) var isLoadingInstalledExtensions = false
+    private(set) var isLoadingInstalledExtensions = false
 
     /// Pixel firing for analytics.
     let pixelFiring: WebExtensionPixelFiring

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager.swift
@@ -392,6 +392,7 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
     @MainActor
     public func loadAndSyncExtensions(enabledTypes: Set<DuckDuckGoWebExtensionType>) async {
         await loadInstalledExtensions()
+        guard !Task.isCancelled else { return }
         await syncEmbeddedExtensions(enabledTypes: enabledTypes)
     }
 

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager.swift
@@ -54,6 +54,12 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
     /// The scriptlet configuration, if scriptlet support is enabled.
     private let scriptletConfiguration: ScriptletConfiguration?
 
+    /// Tracks whether `loadInstalledExtensions()` is currently running.
+    /// Used to prevent `syncEmbeddedExtensions` from interleaving during load,
+    /// which can cause race conditions where sync deletes files that load still needs.
+    @MainActor
+    public private(set) var isLoadingInstalledExtensions = false
+
     /// Pixel firing for analytics.
     let pixelFiring: WebExtensionPixelFiring
 
@@ -319,6 +325,9 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
 
     @MainActor
     public func loadInstalledExtensions() async {
+        isLoadingInstalledExtensions = true
+        defer { isLoadingInstalledExtensions = false }
+
         eventsListener.controller = controller
 
         lifecycleDelegate?.webExtensionManagerWillLoadExtensions(self)
@@ -375,6 +384,15 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
         }
 
         notifyUpdate()
+    }
+
+    /// Loads installed extensions and then syncs embedded extensions as an atomic sequence.
+    /// This prevents race conditions where a concurrent sync could delete extension files
+    /// that the loader still needs.
+    @MainActor
+    public func loadAndSyncExtensions(enabledTypes: Set<DuckDuckGoWebExtensionType>) async {
+        await loadInstalledExtensions()
+        await syncEmbeddedExtensions(enabledTypes: enabledTypes)
     }
 
     // MARK: - Lookups

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -366,11 +366,10 @@ final class MainCoordinator {
             // Already initialized, just reload extensions and re-register tabs
             webExtensionLoadTask?.cancel()
             webExtensionLoadTask = Task { @MainActor [weak self] in
-                await self?.webExtensionManager?.loadInstalledExtensions()
+                guard let self, let manager = self.webExtensionManager as? WebExtensionManager else { return }
+                await self.loadAndSyncEmbeddedExtensions(manager)
                 guard !Task.isCancelled else { return }
-                await self?.syncEmbeddedExtensions()
-                guard !Task.isCancelled else { return }
-                self?.webExtensionEventsCoordinator?.registerExistingTabsAndWindow()
+                self.webExtensionEventsCoordinator?.registerExistingTabsAndWindow()
             }
             return
         }
@@ -398,11 +397,10 @@ final class MainCoordinator {
 
         // Load extensions asynchronously - the controller is already attached to tabs
         webExtensionLoadTask = Task { @MainActor [weak self] in
-            await webExtensionManager.loadInstalledExtensions()
+            guard let self else { return }
+            await self.loadAndSyncEmbeddedExtensions(webExtensionManager)
             guard !Task.isCancelled else { return }
-            await self?.syncEmbeddedExtensions()
-            guard !Task.isCancelled else { return }
-            self?.webExtensionEventsCoordinator?.registerExistingTabsAndWindow()
+            self.webExtensionEventsCoordinator?.registerExistingTabsAndWindow()
         }
     }
 
@@ -430,6 +428,17 @@ final class MainCoordinator {
         isSyncingEmbeddedExtensions = true
         defer { isSyncingEmbeddedExtensions = false }
 
+        await webExtensionManager.syncEmbeddedExtensions(enabledTypes: enabledEmbeddedExtensionTypes())
+    }
+
+    @available(iOS 18.4, *)
+    @MainActor
+    private func loadAndSyncEmbeddedExtensions(_ webExtensionManager: WebExtensionManager) async {
+        await webExtensionManager.loadAndSyncExtensions(enabledTypes: enabledEmbeddedExtensionTypes())
+    }
+
+    @available(iOS 18.4, *)
+    private func enabledEmbeddedExtensionTypes() -> Set<DuckDuckGoWebExtensionType> {
         var enabledTypes: Set<DuckDuckGoWebExtensionType> = []
         if featureFlagger.isFeatureOn(.embeddedExtension) {
             enabledTypes.insert(.embedded)
@@ -440,7 +449,7 @@ final class MainCoordinator {
         if controller.adBlockingAvailability.isEnabled {
             enabledTypes.insert(.adBlockingExtension)
         }
-        await webExtensionManager.syncEmbeddedExtensions(enabledTypes: enabledTypes)
+        return enabledTypes
     }
 
     private func clearWebExtensionReferences() {

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1904,8 +1904,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
             // Load extensions asynchronously - the controller is already attached to tabs
             Task {
-                await webExtensionManager.loadInstalledExtensions()
-                await syncEmbeddedExtensions()
+                await self.loadAndSyncEmbeddedExtensions(webExtensionManager)
             }
         } else {
             webExtensionManager = nil
@@ -1916,9 +1915,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @MainActor
     private func initializeWebExtensions() async {
         guard webExtensionManager == nil else {
-            // Already initialized, just load extensions
-            await (webExtensionManager as? WebExtensionManager)?.loadInstalledExtensions()
-            await syncEmbeddedExtensions()
+            if let manager = webExtensionManager as? WebExtensionManager {
+                await loadAndSyncEmbeddedExtensions(manager)
+            }
             return
         }
 
@@ -1930,8 +1929,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         self.webExtensionManager = webExtensionManager
 
-        await webExtensionManager.loadInstalledExtensions()
-        await syncEmbeddedExtensions()
+        await loadAndSyncEmbeddedExtensions(webExtensionManager)
     }
 
     @available(macOS 15.4, *)
@@ -1943,6 +1941,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         isSyncingEmbeddedExtensions = true
         defer { isSyncingEmbeddedExtensions = false }
 
+        await webExtensionManager.syncEmbeddedExtensions(enabledTypes: enabledEmbeddedExtensionTypes())
+    }
+
+    @available(macOS 15.4, *)
+    @MainActor
+    private func loadAndSyncEmbeddedExtensions(_ webExtensionManager: WebExtensionManager) async {
+        await webExtensionManager.loadAndSyncExtensions(enabledTypes: enabledEmbeddedExtensionTypes())
+    }
+
+    @available(macOS 15.4, *)
+    private func enabledEmbeddedExtensionTypes() -> Set<DuckDuckGoWebExtensionType> {
         var enabledTypes: Set<DuckDuckGoWebExtensionType> = []
         if featureFlagger.isFeatureOn(.embeddedExtension) {
             enabledTypes.insert(.embedded)
@@ -1953,7 +1962,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if adBlockingAvailability.isEnabled {
             enabledTypes.insert(.adBlockingExtension)
         }
-        await webExtensionManager.syncEmbeddedExtensions(enabledTypes: enabledTypes)
+        return enabledTypes
     }
 
     @available(macOS 15.4, *)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200848783441532/task/1214156699597063?focus=true
Tech Design URL: N/A
CC:

### Description

Fixes a race condition between `loadInstalledExtensions()` and `syncEmbeddedExtensions()` during app startup that causes `WebExtensionLoaderError.extensionNotFound` errors (visible as `m.mac.web.extension.load.error` pixel spikes since macOS 1.186.1).

The root cause is that `WebExtensionFeatureFlagHandler` wraps its callbacks in `Task { @MainActor in }`, allowing `syncEmbeddedExtensions()` to interleave with `loadInstalledExtensions()` at `await` suspension points. When sync detects a version bump, it uninstalls the old extension (deleting files from disk), while the loader still holds stale identifiers pointing to those deleted files.

The fix:
- Adds an `isLoadingInstalledExtensions` flag to `WebExtensionManager` that prevents `syncEmbeddedExtensions` from running during load
- Introduces `loadAndSyncExtensions(enabledTypes:)` that performs both operations as an atomic sequence
- Updates both macOS and iOS call sites to use the new atomic method
- Extracts `enabledEmbeddedExtensionTypes()` helper on both platforms to reduce duplication

### Testing Steps

1. Launch the app with web extensions enabled (autoconsent, Dark Reader, or ad blocking)
2. Verify extensions load without errors in the console
3. Toggle Dark Reader / ad blocking on and off — verify extensions sync correctly
4. Fire (clear data) and verify extensions reload properly afterward

### Impact and Risks

**Low** — This is a targeted fix in the web extensions startup flow. The guard is conservative (skips sync during load, which is safe because sync always follows load).

#### What could go wrong?

- If a feature flag publisher fires `syncEmbeddedExtensions` while load is in progress, the sync will be skipped. This is intentional and safe because `loadAndSyncExtensions` calls sync immediately after load completes.
- If a standalone `syncEmbeddedExtensions` call (e.g., from Dark Reader toggle) arrives during load, it returns early. The next explicit sync trigger will pick up the change.

### Quality Considerations

- The fix lives in the shared `WebExtensions` package and protects both macOS and iOS
- No protocol or test mock changes required — new API is on the concrete `WebExtensionManager` class only
- The iOS Fire path (`MainViewController`) which calls `loadInstalledExtensions()` alone is unaffected
- Task cancellation checks are preserved between load and sync

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the web extension startup flow on both macOS and iOS by serializing load+sync and skipping sync during load; risk is moderate because it touches extension lifecycle timing and could delay or miss a sync trigger if not followed up properly.
> 
> **Overview**
> Fixes a startup race where `syncEmbeddedExtensions` could uninstall/upgrade embedded extensions while `loadInstalledExtensions` was still loading them from disk.
> 
> `WebExtensionManager` now tracks `isLoadingInstalledExtensions`, makes `syncEmbeddedExtensions` a no-op during load, and adds `loadAndSyncExtensions(enabledTypes:)` to run load→sync as an atomic sequence.
> 
> macOS `AppDelegate` and iOS `MainCoordinator` are updated to use the new load+sync entry point, and both extract an `enabledEmbeddedExtensionTypes()` helper to compute which embedded extensions should be installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0383a7066cd626dbc98b4a1f84a55a562080d05a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->