### PR TITLE
Prevent overfiring of OmniBar collection view layout

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2060,7 +2060,7 @@ class MainViewController: UIViewController {
 
         refreshUnifiedToggleInput(for: tab)
 
-        if minimalChromeSettings.isFeatureEnabled && !AppWidthObserver.shared.isPad {
+        if isInMinimalChromeLayout != isMinimalChromeMode() {
             applyWidth()
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1214191970756636?focus=true
Tech Design URL:
CC:

### Description

`MainViewController.didUpdateCurrentTab(_:)` called `applyWidth()` on every tab update whenever the minimal chrome feature flag was enabled on iPhone. This triggered redundant OmniBar collection view layout passes and was implicated in OmniBar crashes.

The call now checks for an actual layout-state mismatch: `applyWidth()` fires only when the current `isInMinimalChromeLayout` value does not match what `isMinimalChromeMode()` currently resolves to. When the layout already matches the desired mode, no relayout is requested.

### Testing Steps

1. Enable the minimal chrome feature flag on iPhone.
2. Open a couple of tabs and switch between them repeatedly, verify no OmniBar crashes and layout remains stable.
3. Rotate the device between portrait and landscape with minimal chrome on, verify OmniBar transitions in and out of the minimal layout correctly.
4. Toggle between an AI tab and a standard tab, verify minimal chrome layout updates as expected.
5. Repeat on iPad to confirm no regression in the non-minimal-chrome path.

### Impact and Risks

Low. One-line change narrowing when `applyWidth()` is invoked on tab updates. The layout is still applied whenever the mode actually changes.

#### What could go wrong?
--

### Quality Considerations

Reduces redundant collection view layout passes on iPhone when minimal chrome is enabled, which should mitigate the OmniBar crash reports tied to overfiring layout.

### Notes to Reviewer
--

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes a single condition to reduce unnecessary `applyWidth()` calls, with behavior only differing when minimal chrome state hasn’t actually changed.
> 
> **Overview**
> Prevents redundant OmniBar relayouts during `didUpdateCurrentTab(_:)` by calling `applyWidth()` only when the current minimal-chrome layout state (`isInMinimalChromeLayout`) differs from the desired mode (`isMinimalChromeMode()`). This reduces repeated collection view layout passes (and potential crashes) while still updating width when the minimal chrome mode actually changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41676ad5ea90069d06667545d30386bbf8baa2e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->