### PR TITLE
[iOS] Fix tappable area of SecondaryDestructiveButtonStyle

### DIFF
--- a/iOS/LocalPackages/DuckUI/Sources/DuckUI/Button.swift
+++ b/iOS/LocalPackages/DuckUI/Sources/DuckUI/Button.swift
@@ -139,6 +139,7 @@ public struct SecondaryDestructiveButtonStyle: ButtonStyle {
             .padding(.vertical)
             .padding(.horizontal, fullWidth ? nil : 24)
             .frame(minWidth: 0, maxWidth: fullWidth ? .infinity : nil, maxHeight: compact ? Consts.height - 10 : Consts.height)
+            .contentShape(RoundedRectangle(cornerRadius: Consts.cornerRadius))
             .background(configuration.isPressed ? pressedBackgroundColor : Color.clear)
             .overlay(
                 RoundedRectangle(cornerRadius: Consts.cornerRadius)


### PR DESCRIPTION
Task/Issue URL: N/A
Tech Design URL: N/A
CC:

### Description

Fix tappable area of `SecondaryDestructiveButtonStyle` being shrunk to the text glyphs. SwiftUI excludes `Color.clear` backgrounds from hit-testing, so added `.contentShape(RoundedRectangle)` to make the full button frame tappable.

### Testing Steps

1. Open the fire confirmation dialog (tap the fire button).
2. Tap the inner edge of the "Delete This Tab" button (inside the border, outside the text) — action should fire.

<img width="402" height="874" alt="secondary-destructive-button-tap-area" src="https://github.com/user-attachments/assets/9558650f-fd88-4043-83ab-8a0632083b0d" />

### Impact and Risks

**Low** — hit-testing only, no visual change. Applies to all callers of this shared DuckUI style (confirmed: `ScopedFireConfirmationView`, `GranularFireConfirmationView`).

#### What could go wrong?

- The style is shared across DuckUI, so other screens inherit the change.

### Quality Considerations

- **Edge cases**: `contentShape` uses the same corner radius as the overlay stroke, so the hit area never exceeds the visible border.
- **Performance**: No-op
- **Accessibility**: Unchanged
- **Documentation**: No docs affected.

### Notes to Reviewer

- Fixed at the DuckUI level rather than the call site, since the same issue would affect any current or future caller of this style.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized SwiftUI hit-testing change with no data/security impact; risk is limited to slightly altered tap behavior anywhere this shared style is used.
> 
> **Overview**
> Fixes `SecondaryDestructiveButtonStyle` hit-testing so taps register across the full button frame (including inside the border but outside the text).
> 
> This adds a `.contentShape(RoundedRectangle(cornerRadius: ...))` to the style’s label, ensuring SwiftUI includes the clear-background area in the tappable region without changing visuals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3042e72ed9f92c86c733950bb2abcc1fb2f96fcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->