### PR TITLE
[executor] Fix pinned tabs lost after force-kill in separate-tabs mode

### DIFF
--- a/macOS/DuckDuckGo/StateRestoration/AppStateRestorationManager.swift
+++ b/macOS/DuckDuckGo/StateRestoration/AppStateRestorationManager.swift
@@ -41,6 +41,7 @@ final class AppStateRestorationManager: NSObject, AppStateRestorationManaging {
     private let tabSnapshotCleanupService: TabSnapshotCleanupService
     private var appWillRelaunchCancellable: AnyCancellable?
     private var stateChangedCancellable: AnyCancellable?
+    private var pinnedTabsCancellable: AnyCancellable?
     private let pinnedTabsManagerProvider: PinnedTabsManagerProviding = Application.appDelegate.pinnedTabsManagerProvider
     private let startupPreferences: StartupPreferences
     private let tabsPreferences: TabsPreferences
@@ -178,6 +179,28 @@ final class AppStateRestorationManager: NSObject, AppStateRestorationManaging {
             // saving of the state
             .sink { [weak self] _ in
                 self?.persistAppState()
+            }
+
+        // Persist immediately when any pinned tab collection changes so that a force-kill
+        // (e.g. during an app update) within the debounce window above doesn't lose pin changes.
+        // Watches both the shared manager (.shared mode) and per-window managers (.separate mode)
+        // by reacting to window list changes via switchToLatest.
+        // sync: true ensures the disk write completes before returning.
+        pinnedTabsCancellable = Application.appDelegate.windowControllersManager.$mainWindowControllers
+            .map { controllers -> AnyPublisher<Void, Never> in
+                let sharedPublisher = Application.appDelegate.pinnedTabsManager.tabCollection.$tabs
+                    .dropFirst().map { _ in () }.eraseToAnyPublisher()
+                let perWindowPublishers = controllers.map { controller in
+                    controller.mainViewController.tabCollectionViewModel.pinnedTabsManager
+                        .tabCollection.$tabs
+                        .dropFirst().map { _ in () }.eraseToAnyPublisher()
+                }
+                return Publishers.MergeMany([sharedPublisher] + perWindowPublishers).eraseToAnyPublisher()
+            }
+            .switchToLatest()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.persistAppState(sync: true)
             }
     }
 

--- a/macOS/DuckDuckGo/StateRestoration/AppStateRestorationManager.swift
+++ b/macOS/DuckDuckGo/StateRestoration/AppStateRestorationManager.swift
@@ -190,8 +190,8 @@ final class AppStateRestorationManager: NSObject, AppStateRestorationManaging {
             .map { controllers -> AnyPublisher<Void, Never> in
                 let sharedPublisher = Application.appDelegate.pinnedTabsManager.tabCollection.$tabs
                     .dropFirst().map { _ in () }.eraseToAnyPublisher()
-                let perWindowPublishers = controllers.map { controller in
-                    controller.mainViewController.tabCollectionViewModel.pinnedTabsManager
+                let perWindowPublishers = controllers.compactMap { controller in
+                    controller.mainViewController.tabCollectionViewModel.pinnedTabsManager?
                         .tabCollection.$tabs
                         .dropFirst().map { _ in () }.eraseToAnyPublisher()
                 }

--- a/macOS/UITests/PinnedTabsTests.swift
+++ b/macOS/UITests/PinnedTabsTests.swift
@@ -130,6 +130,37 @@ class PinnedTabsTests: UITestCase {
         assertSingleWindowScenario()
     }
 
+    func test_pinnedTabs_persistAfterForcedRestart() {
+        app.disableWarnBeforeQuitting(closeSettings: false)
+        app.disableWarnBeforeClosingPinnedTabs(closeSettings: true)
+
+        app.openSite(pageTitle: "Page #1")
+        pinCurrentPage()
+
+        // Wait less than the 1-second debounce — proves the immediate-save path,
+        // not the debounce, is what keeps pins alive across a force-kill.
+        Thread.sleep(forTimeInterval: 0.5)
+
+        // Force-terminate without calling applicationWillTerminate
+        app.terminate()
+
+        app = XCUIApplication.setUp(featureFlags: featureFlags)
+        // In UITests, opensWindowOnStartupIfNeeded is false, so the app launches without a
+        // window even when state was restored. Open one to surface the restored pinned tabs.
+        app.openNewWindow()
+        XCTAssertTrue(
+            app.windows.firstMatch.waitForExistence(timeout: UITests.Timeouts.elementExistence),
+            "App window should appear after forced restart"
+        )
+        // Use wait(for:) rather than an immediate XCTAssertEqual: the PinnedTabsView binding
+        // is set up asynchronously when the window first renders, so there is a brief delay
+        // before the radio button appears in the accessibility tree.
+        XCTAssertTrue(
+            app.wait(for: .keyPath(\.pinnedTabs.count, equalTo: 1), timeout: UITests.Timeouts.elementExistence),
+            "Pinned tab should survive a forced restart (no applicationWillTerminate)"
+        )
+    }
+
     // MARK: - Utilities
 
     private func openThreeSitesOnSameWindow() {


### PR DESCRIPTION
## Summary

- In **separate pinned tabs mode**, each window has its own `PinnedTabsManager`. The old `pinnedTabsCancellable` only subscribed to the shared manager, so pinning a tab in separate mode never triggered an immediate save.
- Added a `switchToLatest`-based subscription that watches **all** pinned tab managers (shared + per-window) and calls `persistAppState(sync: true)` immediately when any pinned tab changes — bypassing the 1-second debounce for this critical path.
- This ensures pinned tab state survives a SIGKILL (e.g. during an app update) even if the kill happens within the debounce window.

Asana: https://app.asana.com/1/137249556945/project/1199178362774117/task/1214140540432889

## Test plan

- [ ] New UITest `test_pinnedTabs_persistAfterForcedRestart` in `PinnedTabsTests`: pins a tab, waits 0.5 s (less than the 1-second debounce), force-kills the app via `app.terminate()`, relaunches, and asserts the pinned tab is still present.
- [ ] Existing `PinnedTabsTests` suite passes (pre-existing failures: `testBookmarksCanBePinned`, `testReleaseNotesCannotBePinned`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session-state persistence timing by adding synchronous disk writes on pinned-tab mutations across all windows, which could affect performance or state-save behavior if the Combine wiring misfires. Scoped to pinned-tab persistence and backed by a new UITest covering forced termination.
> 
> **Overview**
> Fixes pinned tabs being lost after a force-kill by adding an immediate persistence path in `AppStateRestorationManager` that listens to pinned-tab collection changes for both the shared and per-window pinned tabs managers and calls `persistAppState(sync: true)`.
> 
> Adds a UITest (`test_pinnedTabs_persistAfterForcedRestart`) that pins a tab, force-terminates the app before the 1s debounce elapses, relaunches, and asserts the pinned tab is restored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 749195eaa5fb090142025a6d680d6150c2bbf55a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->