### PR TITLE
[macOS] Fix Duck.ai chrome constraint-pass crash (APPLE-MACOS-BED)

### DIFF
--- a/macOS/DuckDuckGo/Common/Extensions/NSLayoutConstraintExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/NSLayoutConstraintExtension.swift
@@ -31,6 +31,13 @@ extension NSLayoutConstraint {
         return self
     }
 
+    /// Sets `isActive` only when it differs from the target value, avoiding redundant layout invalidation.
+    func setActive(_ shouldBeActive: Bool) {
+        if isActive != shouldBeActive {
+            isActive = shouldBeActive
+        }
+    }
+
     @discardableResult
     func autoDeactivatedWhenViewIsHidden(_ view: NSView) -> Self {
         let c = view.publisher(for: \.isHidden).sink { [self /* bind the constraint lifetime to the view */] isHidden in

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -343,6 +343,16 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
         enableScrollButtons()
         subscribeToChildWindows()
         setupAccessibility()
+
+        performInitialChromeSidebarApplyIfNeeded()
+    }
+
+    private var didPerformInitialChromeSidebarApply = false
+
+    private func performInitialChromeSidebarApplyIfNeeded() {
+        guard !didPerformInitialChromeSidebarApply else { return }
+        didPerformInitialChromeSidebarApply = true
+        applyChromeSidebarFeatureFlagState(isEnabled: isChromeSidebarFeatureEnabled)
     }
 
     override func mouseDown(with event: NSEvent) {
@@ -682,12 +692,18 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
         )
         let showFullHeight = isInteracting || currentAIChatPresentationMode != .hidden
 
-        if showFullHeight {
-            duckAIChromeDividerInsetConstraint?.isActive = false
-            duckAIChromeDividerFullConstraint?.isActive = true
-        } else {
-            duckAIChromeDividerFullConstraint?.isActive = false
-            duckAIChromeDividerInsetConstraint?.isActive = true
+        let wantFullActive = showFullHeight
+        let wantInsetActive = !showFullHeight
+        let constraintsChanged = duckAIChromeDividerInsetConstraint?.isActive != wantInsetActive
+            || duckAIChromeDividerFullConstraint?.isActive != wantFullActive
+        if constraintsChanged {
+            if showFullHeight {
+                duckAIChromeDividerInsetConstraint?.isActive = false
+                duckAIChromeDividerFullConstraint?.isActive = true
+            } else {
+                duckAIChromeDividerFullConstraint?.isActive = false
+                duckAIChromeDividerInsetConstraint?.isActive = true
+            }
         }
         let colorsProvider = theme.colorsProvider
         duckAIChromeDivider?.backgroundColor = showFullHeight ?
@@ -777,7 +793,6 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
             .map { [weak self] in
                 self?.isChromeSidebarFeatureEnabled ?? false
             }
-            .prepend(isChromeSidebarFeatureEnabled)
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] isEnabled in

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -88,6 +88,8 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
     private var aiChatMenuConfigCancellable: AnyCancellable?
     private var aiChatButtonHoverCancellable: AnyCancellable?
     private var duckAIChromeButtonsVisibilityCancellable: AnyCancellable?
+    private var didPerformInitialChromeSidebarApply = false
+    private var duckAIChromeDividerShowsFullHeight: Bool?
     private var duckAIChromeDividerInsetConstraint: NSLayoutConstraint?
     private var duckAIChromeDividerFullConstraint: NSLayoutConstraint?
     private var currentAIChatPresentationMode: AIChatPresentationMode = .hidden
@@ -346,8 +348,6 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
 
         performInitialChromeSidebarApplyIfNeeded()
     }
-
-    private var didPerformInitialChromeSidebarApply = false
 
     private func performInitialChromeSidebarApplyIfNeeded() {
         guard !didPerformInitialChromeSidebarApply else { return }
@@ -691,20 +691,12 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
                             duckAIChromeSidebarButton?.isMouseDown == true
         )
         let showFullHeight = isInteracting || currentAIChatPresentationMode != .hidden
+        guard duckAIChromeDividerShowsFullHeight != showFullHeight else { return }
+        duckAIChromeDividerShowsFullHeight = showFullHeight
 
-        let wantFullActive = showFullHeight
-        let wantInsetActive = !showFullHeight
-        let constraintsChanged = duckAIChromeDividerInsetConstraint?.isActive != wantInsetActive
-            || duckAIChromeDividerFullConstraint?.isActive != wantFullActive
-        if constraintsChanged {
-            if showFullHeight {
-                duckAIChromeDividerInsetConstraint?.isActive = false
-                duckAIChromeDividerFullConstraint?.isActive = true
-            } else {
-                duckAIChromeDividerFullConstraint?.isActive = false
-                duckAIChromeDividerInsetConstraint?.isActive = true
-            }
-        }
+        duckAIChromeDividerFullConstraint?.setActive(showFullHeight)
+        duckAIChromeDividerInsetConstraint?.setActive(!showFullHeight)
+
         let colorsProvider = theme.colorsProvider
         duckAIChromeDivider?.backgroundColor = showFullHeight ?
             colorsProvider.separatorActiveColor : colorsProvider.separatorColor
@@ -764,6 +756,7 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
         self.aiChatButtonHoverCancellable = nil
         self.duckAIChromeDividerInsetConstraint = nil
         self.duckAIChromeDividerFullConstraint = nil
+        self.duckAIChromeDividerShowsFullHeight = nil
     }
 
     private func enableDuckAIChromeContextMenuOnTabBar() {

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -89,7 +89,6 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
     private var aiChatButtonHoverCancellable: AnyCancellable?
     private var duckAIChromeButtonsVisibilityCancellable: AnyCancellable?
     private var didPerformInitialChromeSidebarApply = false
-    private var duckAIChromeDividerShowsFullHeight: Bool?
     private var duckAIChromeDividerInsetConstraint: NSLayoutConstraint?
     private var duckAIChromeDividerFullConstraint: NSLayoutConstraint?
     private var currentAIChatPresentationMode: AIChatPresentationMode = .hidden
@@ -691,8 +690,6 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
                             duckAIChromeSidebarButton?.isMouseDown == true
         )
         let showFullHeight = isInteracting || currentAIChatPresentationMode != .hidden
-        guard duckAIChromeDividerShowsFullHeight != showFullHeight else { return }
-        duckAIChromeDividerShowsFullHeight = showFullHeight
 
         // Always deactivate the outgoing constraint before activating the incoming one so that
         // both height constraints on the divider are never simultaneously active.
@@ -763,7 +760,6 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
         self.aiChatButtonHoverCancellable = nil
         self.duckAIChromeDividerInsetConstraint = nil
         self.duckAIChromeDividerFullConstraint = nil
-        self.duckAIChromeDividerShowsFullHeight = nil
     }
 
     private func enableDuckAIChromeContextMenuOnTabBar() {

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -694,8 +694,15 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
         guard duckAIChromeDividerShowsFullHeight != showFullHeight else { return }
         duckAIChromeDividerShowsFullHeight = showFullHeight
 
-        duckAIChromeDividerFullConstraint?.setActive(showFullHeight)
-        duckAIChromeDividerInsetConstraint?.setActive(!showFullHeight)
+        // Always deactivate the outgoing constraint before activating the incoming one so that
+        // both height constraints on the divider are never simultaneously active.
+        if showFullHeight {
+            duckAIChromeDividerInsetConstraint?.setActive(false)
+            duckAIChromeDividerFullConstraint?.setActive(true)
+        } else {
+            duckAIChromeDividerFullConstraint?.setActive(false)
+            duckAIChromeDividerInsetConstraint?.setActive(true)
+        }
 
         let colorsProvider = theme.colorsProvider
         duckAIChromeDivider?.backgroundColor = showFullHeight ?


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214241942726370

### Description
Addresses the `APPLE-MACOS-BED` TabBarViewController cluster (8 new regressions first seen in macOS 1.186.x), all tied to the Duck.ai chrome split-button added in #3917. Exception signature: `NSGenericException: The window has been marked as needing another Update Constraints in Window pass, but it has already had more Update Constraints in Window passes than there are views in the window.` — AppKit's constraint-accumulator guard firing during the window's display cycle.

Two defensive changes in `TabBarViewController`:

1. **Idempotent `updateDuckAIChromeDividerState`** — only toggle the divider constraint `.isActive` when the target state differs from the current state. Cleaner intent, no redundant same-value writes during the startup burst (the hover KVO publishers emit ~12 initial values on setup).
2. **Deterministic initial apply** — replace `.prepend(isChromeSidebarFeatureEnabled)` in the feature-flag Combine chain with an explicit `applyChromeSidebarFeatureFlagState` call from `viewDidAppear` (guarded by a one-shot flag). Initial Duck.ai chrome setup now runs at a known lifecycle point (after the window's first layout has settled) instead of an undefined Combine-dispatch moment that could land inside a display-cycle observer.

Live flag transitions still flow through the Combine sink as before, just without the initial-value prepend.

### Testing Steps
1. Launch the macOS Browser with `aiChatChromeSidebar` enabled. Verify the Duck.ai split-button appears in the tab bar and works as before (click title → new Duck.ai tab; click sidebar button → open/close sidebar).
2. Hover over the Duck.ai segments; divider should switch to full-height on hover and back to inset on mouse-out, unchanged from before.
3. Toggle `aiChatChromeSidebar` off via Feature Flag overrides (internal users) — the split-button should be removed cleanly and the app shouldn't crash.
4. Toggle back on — the split-button should re-appear cleanly.
5. Open and close multiple new windows rapidly (Cmd+N / Cmd+W); each should get its own split-button without issue.
6. Open a Fire Window — vibrancy background + split-button should render as before.

### Impact and Risks
Low/Medium. Changes are localized to `TabBarViewController`, no public API changes, no dependency changes.

Risk surface: the initial feature-flag apply moves from a Combine-sink `.prepend()` to `viewDidAppear`. If anything downstream relied on the setup happening specifically *before* `viewDidAppear`, behaviour could shift slightly — but `viewDidAppear` still fires before any user interaction with the tab bar, so this should be imperceptible.

#### What could go wrong?
- `viewDidAppear` may fire multiple times if the view is removed and re-added to a window. The one-shot `didPerformInitialChromeSidebarApply` flag ensures the initial apply runs exactly once; later flag transitions flow through the Combine sink, as before.
- If `isChromeSidebarFeatureEnabled` changes between `viewDidLoad` and `viewDidAppear`, the subsequent sink delivery still catches the change — we just don't deliver a prepended initial value any more (handled explicitly at `viewDidAppear`).

### Quality Considerations
- Edge case: feature flag flipping during the `viewDidLoad` → `viewDidAppear` window. Covered by the Combine subscription (no prepend) plus the explicit initial apply at `viewDidAppear`.
- No performance impact — the idempotency check saves a small number of no-op writes per startup burst.
- No monitoring added in this PR. If the Sentry crash recurs after rollout, a follow-up can add a breadcrumb at `setupDuckAIChromeSegmentedControl` entry.

### Notes to Reviewer
I was **not** able to faithfully reproduce the exact natural Sentry trigger locally — the crash is a rare timing race (7 events / 2 users in 1.186.x Sentry). These are best-effort defensive fixes based on the most plausible hypothesis (setup running during a display-cycle observer phase).

A synthetic stress-harness (stripped from this PR) with multiple modes (setup/remove loops, divider toggles, a self-invalidating NSView probe, real-setup-inside-updateConstraints) confirmed that AppKit's accumulator guard is reachable for this window and that the Sentry crash stack shape is identical. Detailed investigation notes are on the Asana task.

Running tests: `TabBarViewItemTests` 26/26 pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches AppKit constraint activation and the initial feature-flag apply timing in `TabBarViewController`, which can subtly affect layout/updateConstraints ordering and UI initialization across window lifecycle events.
> 
> **Overview**
> Prevents a Tab Bar crash caused by excessive constraint invalidation during the Duck.ai chrome split-button startup/hover burst.
> 
> Adds `NSLayoutConstraint.setActive(_:)` and switches the Duck.ai divider height toggling to *idempotent* activate/deactivate calls, ensuring the two competing height constraints are never simultaneously active.
> 
> Moves the initial `aiChatChromeSidebar` feature-flag application out of the Combine `.prepend` path and into a one-shot `viewDidAppear` apply, while keeping subsequent flag transitions handled by the existing publisher sink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8bfe060162b6a94175a6701578510f12a66aa7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->