### PR TITLE
[executor] Fix Opt+Shift+Left/Right word-by-word selection contraction in address bar

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextEditor.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextEditor.swift
@@ -276,13 +276,29 @@ final class AddressBarTextEditor: NSTextView {
         return NSRange(range, in: string)
     }
 
-    private func nextWordSelectionIndex(backwards: Bool) -> Int? {
+    /// Returns the character index of the next word boundary in the given direction.
+    /// - Parameters:
+    ///   - backwards: Search direction — `true` = move left, `false` = move right.
+    ///   - cursorOverride: When supplied, use this NSRange integer offset as the starting cursor
+    ///     position instead of `self.selectedRange()`. This avoids mutating the selection (and
+    ///     triggering address-bar observers) just to feed a different position into this function.
+    private func nextWordSelectionIndex(backwards: Bool, cursorOverride: Int? = nil) -> Int? {
         let string = self.string
 
-        guard let selectableRange = addressBar?.stringValueWithoutSuffixRange,
-              let selectedRange = Range(selectedRange(), in: string)?.clamped(to: selectableRange) else { return nil }
+        guard let selectableRange = addressBar?.stringValueWithoutSuffixRange else { return nil }
 
-        var index = backwards ? selectedRange.lowerBound : selectedRange.upperBound
+        let startIndex: String.Index
+        if let override = cursorOverride {
+            // Convert the NSRange integer offset to a String.Index, clamped to the selectable range.
+            let clampedOffset = min(override, string.utf16.count)
+            let rawIdx = String.Index(utf16Offset: clampedOffset, in: string)
+            startIndex = min(max(rawIdx, selectableRange.lowerBound), selectableRange.upperBound)
+        } else {
+            guard let selectedRange = Range(selectedRange(), in: string)?.clamped(to: selectableRange) else { return nil }
+            startIndex = backwards ? selectedRange.lowerBound : selectedRange.upperBound
+        }
+
+        var index = startIndex
         var searchRange: Range<String.Index> {
             backwards ? selectableRange.lowerBound..<index : index..<selectableRange.upperBound
         }
@@ -317,9 +333,22 @@ final class AddressBarTextEditor: NSTextView {
 
     override func moveWordRightAndModifySelection(_ sender: Any?) {
         let selectedRange = self.selectedRange()
-        guard selectionAffinity == .downstream || selectedRange.length == 0 else {
-            // current selection is from right to left: reset selection to the upper bound
-            self.selectedRange = NSRange(location: selectedRange.upperBound, length: 0)
+        if selectionAffinity == .upstream && selectedRange.length > 0 {
+            // Upstream selection (right-to-left): contract from the left end by one word.
+            // Use cursorOverride so we don't mutate self.selectedRange (which would fire address-bar
+            // observers and corrupt the string state before nextWordSelectionIndex can read it).
+            let newLowerBound = nextWordSelectionIndex(backwards: false, cursorOverride: selectedRange.location)
+            guard let newLowerBound else { return }
+            if newLowerBound >= selectedRange.upperBound {
+                // Contraction exhausted the selection — collapse to the right end.
+                self.setSelectedRange(NSRange(location: selectedRange.upperBound, length: 0), affinity: .downstream, stillSelecting: false)
+            } else {
+                self.setSelectedRange(
+                    NSRange(location: newLowerBound, length: selectedRange.upperBound - newLowerBound),
+                    affinity: .upstream,
+                    stillSelecting: false
+                )
+            }
             return
         }
         guard let index = nextWordSelectionIndex(backwards: false) else { return }
@@ -331,9 +360,24 @@ final class AddressBarTextEditor: NSTextView {
 
     override func moveWordLeftAndModifySelection(_ sender: Any?) {
         let selectedRange = self.selectedRange()
-        guard selectionAffinity == .upstream || selectedRange.length == 0 else {
-            // current selection is from left to right: reset selection to the upper bound
-            self.selectedRange = NSRange(location: selectedRange.lowerBound, length: 0)
+        if selectedRange.length > 0 {
+            // There is an existing selection: contract from the right end by one word.
+            // This handles both downstream (left-to-right) and upstream (right-to-left, e.g. after
+            // Cmd+A) affinities — in both cases Opt+Shift+Left should shrink from the right.
+            // Use cursorOverride so we don't mutate self.selectedRange (which would fire address-bar
+            // observers and corrupt the string state before nextWordSelectionIndex can read it).
+            let newUpperBound = nextWordSelectionIndex(backwards: true, cursorOverride: selectedRange.upperBound)
+            guard let newUpperBound else { return }
+            if newUpperBound <= selectedRange.location {
+                // Contraction exhausted the selection — collapse to the left end.
+                self.setSelectedRange(NSRange(location: selectedRange.location, length: 0), affinity: .upstream, stillSelecting: false)
+            } else {
+                self.setSelectedRange(
+                    NSRange(location: selectedRange.location, length: newUpperBound - selectedRange.location),
+                    affinity: .downstream,
+                    stillSelecting: false
+                )
+            }
             return
         }
         guard let index = nextWordSelectionIndex(backwards: true) else { return }

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextEditor.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextEditor.swift
@@ -360,14 +360,24 @@ final class AddressBarTextEditor: NSTextView {
 
     override func moveWordLeftAndModifySelection(_ sender: Any?) {
         let selectedRange = self.selectedRange()
-        if selectedRange.length > 0 {
-            // There is an existing selection: contract from the right end by one word.
-            // This handles both downstream (left-to-right) and upstream (right-to-left, e.g. after
-            // Cmd+A) affinities — in both cases Opt+Shift+Left should shrink from the right.
+        // Compute the leftmost selectable offset (i.e. the start of the URL portion, ignoring any suffix).
+        // If the selection already starts there we cannot extend further left, so we must contract
+        // from the right end instead (this is the Cmd+A / focus-with-full-selection case).
+        let selectableLowerBound = (addressBar?.stringValueWithoutSuffixRange)
+            .map { NSRange($0, in: self.string).location } ?? 0
+        let isAtSelectableStart = selectedRange.location <= selectableLowerBound
+
+        // Contract from the right end when:
+        // - The selection has `.downstream` affinity (cursor is at the right end — Opt+Shift+Left
+        //   shrinks the selection by moving the cursor leftward), OR
+        // - The selection has `.upstream` affinity but already starts at the leftmost selectable
+        //   position (e.g. after Cmd+A), so it cannot grow any further left.
+        // Otherwise (`.upstream` selection with room to grow), extend the left edge further left —
+        // this preserves the natural "Opt+Shift+Left, Opt+Shift+Left" extension flow.
+        if selectedRange.length > 0 && (selectionAffinity == .downstream || isAtSelectableStart) {
             // Use cursorOverride so we don't mutate self.selectedRange (which would fire address-bar
             // observers and corrupt the string state before nextWordSelectionIndex can read it).
-            let newUpperBound = nextWordSelectionIndex(backwards: true, cursorOverride: selectedRange.upperBound)
-            guard let newUpperBound else { return }
+            guard let newUpperBound = nextWordSelectionIndex(backwards: true, cursorOverride: selectedRange.upperBound) else { return }
             if newUpperBound <= selectedRange.location {
                 // Contraction exhausted the selection — collapse to the left end.
                 self.setSelectedRange(NSRange(location: selectedRange.location, length: 0), affinity: .upstream, stillSelecting: false)
@@ -380,8 +390,10 @@ final class AddressBarTextEditor: NSTextView {
             }
             return
         }
-        guard let index = nextWordSelectionIndex(backwards: true) else { return }
 
+        // Extend the left edge of the selection (or move the caret left if there is no selection).
+        // For an upstream selection this grows it further left; for an empty selection it creates one.
+        guard let index = nextWordSelectionIndex(backwards: true, cursorOverride: selectedRange.location) else { return }
         let range = NSRange(location: index, length: selectedRange.upperBound - index)
         self.setSelectedRange(range, affinity: .upstream, stillSelecting: false)
         self.scrollToSelectionStart()

--- a/macOS/UITests/AddressBarKeyboardShortcutsTests.swift
+++ b/macOS/UITests/AddressBarKeyboardShortcutsTests.swift
@@ -173,6 +173,31 @@ class AddressBarKeyboardShortcutsTests: UITestCase {
         )
     }
 
+    /// Regression test for: pressing Opt+Shift+Left twice in succession (with no prior selection)
+    /// must EXTEND the selection further left on the second press — not collapse the upstream
+    /// selection that the first press just created. This mirrors standard NSTextView behaviour
+    /// where consecutive Opt+Shift+Left presses keep extending the selection word-by-word.
+    func test_addressBar_optShiftLeft_twiceInSuccession_extendsSelectionWordByWord() throws {
+        // Start: cursor at end of URL (setUp typed it without pressing Enter).
+        // First press: creates an upstream selection covering the last word ("translation/").
+        addressBarTextField.typeKey(.leftArrow, modifierFlags: [.option, .shift])
+        // Second press: must extend the selection further left by one more word ("results/").
+        // If the bug is present, the second press hits the contraction branch and collapses
+        // the upstream selection, leaving only an empty caret at the first word boundary.
+        addressBarTextField.typeKey(.leftArrow, modifierFlags: [.option, .shift])
+
+        // Delete what is now selected. With the fix, "results/translation/" is selected and
+        // removed. Without the fix, the selection was collapsed and nothing is deleted.
+        addressBarTextField.typeKey(.delete, modifierFlags: [])
+        let remaining = try XCTUnwrap(addressBarTextField.value as? String).removingTagLine()
+
+        XCTAssertEqual(
+            remaining,
+            "https://duckduckgo.com/duckduckgo-help-pages/",
+            "Two consecutive Opt+Shift+Left presses must extend the selection across two words (\"results/translation/\"). If the upstream selection from the first press is being collapsed instead of extended on the second press, only the last word \"translation/\" is removed (or nothing is removed at all)."
+        )
+    }
+
     /// Regression test for: Opt+Shift+Right when address bar has a full upstream selection should CONTRACT
     /// the selection by one word from the left end — not collapse the cursor to the right end.
     func test_addressBar_optShiftRight_contractsSelectionWordByWord_whenFullySelected() throws {

--- a/macOS/UITests/AddressBarKeyboardShortcutsTests.swift
+++ b/macOS/UITests/AddressBarKeyboardShortcutsTests.swift
@@ -149,6 +149,57 @@ class AddressBarKeyboardShortcutsTests: UITestCase {
         )
     }
 
+    /// Regression test for: Opt+Shift+Left when address bar has a full downstream selection (e.g. after Cmd+A or focusing
+    /// a loaded URL) should CONTRACT the selection by one word from the right end — not collapse the cursor to position 0.
+    func test_addressBar_optShiftLeft_contractsSelectionWordByWord_whenFullySelected() throws {
+        // Start: URL typed with cursor at end (setUp typed the URL without pressing Enter)
+        // Select the entire URL (downstream selection — same state as focusing a loaded address bar)
+        addressBarTextField.typeKey("a", modifierFlags: .command)
+
+        // Opt+Shift+Left: must contract the selection from the right end by one word ("translation/")
+        // leaving the rest of the URL selected. This is the behaviour under test.
+        addressBarTextField.typeKey(.leftArrow, modifierFlags: [.option, .shift])
+
+        // Delete the selection that should now be everything EXCEPT "translation/"
+        addressBarTextField.typeKey(.delete, modifierFlags: [])
+        let remaining = try XCTUnwrap(addressBarTextField.value as? String).removingTagLine()
+
+        // If the bug is present, Opt+Shift+Left collapses the cursor to position 0 (no selection),
+        // so nothing is deleted and the full URL is still in the field.
+        XCTAssertEqual(
+            remaining,
+            "translation/",
+            "Opt+Shift+Left with a fully-selected URL should contract the selection by one word from the right end, leaving only the last word component. If the full URL is present, the selection was not contracted — the cursor was collapsed to position 0 instead."
+        )
+    }
+
+    /// Regression test for: Opt+Shift+Right when address bar has a full upstream selection should CONTRACT
+    /// the selection by one word from the left end — not collapse the cursor to the right end.
+    func test_addressBar_optShiftRight_contractsSelectionWordByWord_whenFullySelected() throws {
+        // Select the entire URL, then reverse to upstream affinity by pressing Shift+Left once
+        // (so we have an upstream selection anchored at the end, cursor at start)
+        addressBarTextField.typeKey("a", modifierFlags: .command)   // downstream: cursor at end
+        addressBarTextField.typeKey(.rightArrow, modifierFlags: .shift) // no-op (already at end), keeps downstream
+        // Re-select upstream: go to end, then Shift+Cmd+Left to select all from the right
+        addressBarTextField.typeKey(.rightArrow, modifierFlags: .command) // cursor to end
+        addressBarTextField.typeKey(.leftArrow, modifierFlags: [.command, .shift]) // Shift+Cmd+Left → select all upstream
+
+        // Opt+Shift+Right: must contract the upstream selection from the left end by one word ("https")
+        addressBarTextField.typeKey(.rightArrow, modifierFlags: [.option, .shift])
+
+        // Delete the remaining selection
+        addressBarTextField.typeKey(.delete, modifierFlags: [])
+        let remaining = try XCTUnwrap(addressBarTextField.value as? String).removingTagLine()
+
+        // If working correctly, "https" (first word) is no longer in the selection and survives.
+        // The rest was selected and deleted.
+        XCTAssertEqual(
+            remaining,
+            "https",
+            "Opt+Shift+Right with a fully upstream-selected URL should contract the selection by one word from the left end."
+        )
+    }
+
     func test_addressBar_url_word_canBeSelectedByDoubleClick() throws {
         addressBarTextField
             .typeKey(.leftArrow,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1214071796247142

### Description

- Fixes Opt+Shift+Left/Right word-by-word selection in the macOS address bar so it matches standard macOS text-field behaviour. Original report: `Opt + Shift + ←` was acting like `Cmd + Shift + ←` after select-all (jumping the cursor to position 0 instead of contracting the selection word-by-word from the right).
- `moveWordLeftAndModifySelection`: contracts from the right end **only** when the selection has `.downstream` affinity (cursor on the right) **or** the selection already starts at the leftmost selectable position (Cmd+A / focus-with-full-selection — can't extend further left). Otherwise extends the left edge further left, preserving the natural `Opt+Shift+Left, Opt+Shift+Left` extension flow.
- `moveWordRightAndModifySelection`: already correctly gated on `.upstream` affinity; no logic change.
- `nextWordSelectionIndex`: takes a new optional `cursorOverride: Int?` parameter so callers can pass an arbitrary starting offset without temporarily mutating `self.selectedRange` (which fires address-bar observers and corrupts the string state mid-call).
- Adds three regression UITests in `AddressBarKeyboardShortcutsTests` covering full-selection contraction (left and right after Cmd+A / Cmd+Shift+Left) and consecutive-Opt+Shift+Left extension.

### Testing Steps

1. Type a URL in the address bar (don't press Enter).
2. `Cmd+A` to select the entire URL, then `Opt+Shift+Left`. The selection should contract from the right by one word (the last path segment is no longer selected). Repeat: each press shrinks the selection from the right.
3. `Cmd+Shift+Left` (upstream select-all), then `Opt+Shift+Right`. The selection should contract from the left by one word.
4. Click somewhere in the middle of the URL to deselect, putting the caret in the middle.
5. `Opt+Shift+Left`. The selection grows leftward by one word.
6. `Opt+Shift+Left` again. The selection should grow another word leftward (NOT collapse to a caret — this is the Bugbot regression).
7. `Opt+Shift+Right` from the upstream selection in step 5. The selection contracts from the left.

### Impact and Risks

**Impact Level: Low**

Scoped to the macOS address-bar word-selection contraction logic; no other surfaces use these `NSTextView` overrides. Three regression UITests cover the affected key combinations.

#### What could go wrong?

- Subtle selection-affinity edge cases could behave differently. Mitigated by:
  - Explicit decision rule: contraction happens only when `.downstream` or already at the selectable-range start; extension happens otherwise.
  - Three regression UITests covering the three observable behaviours (Opt+Shift+Left after Cmd+A → contract; Opt+Shift+Right after Cmd+Shift+Left → contract; Opt+Shift+Left twice from no selection → extend).
- A non-zero `selectableLowerBound` (an address bar with a non-selectable URL prefix) is handled: once the selection bumps up against that lower bound, the extend branch falls through to contraction on the next press.

### Quality Considerations

- **Edge cases**: empty selection (extend branch handles it identically to before), selection at the start of the selectable range with `.upstream` affinity (Cmd+A — contract from right), `.downstream` selection contracted to the left edge (collapses to a caret with `.upstream` affinity).
- **Performance**: identical — same number of `nextWordSelectionIndex` calls per key press.
- **Privacy/security**: none — pure UI behaviour change in the address bar.

### Notes to Reviewer

This is a continuation of an `[executor]` automated fix. The previous commit `b576054` removed the affinity check entirely, which fixed the original Cmd+A bug but broke the `Opt+Shift+Left, Opt+Shift+Left` extension flow (caught by Cursor Bugbot). Commit `2a30843` re-introduces affinity awareness but combines it with a `selectableLowerBound` check so the original Cmd+A scenario still works.