### PR TITLE
[iOS] Fix Fire mode UI issues 

### DIFF
--- a/iOS/DuckDuckGo/BrowserChromeButton.swift
+++ b/iOS/DuckDuckGo/BrowserChromeButton.swift
@@ -108,6 +108,14 @@ class BrowserChromeButton: UIButton {
         configuration?.image = image
     }
 
+    var hasImage: Bool {
+        configuration?.image != nil
+    }
+
+    var hasTitle: Bool {
+        !(configuration?.title?.isEmpty ?? true) || !(currentTitle?.isEmpty ?? true)
+    }
+
     override func setNeedsDisplay() {
         border?.layer.borderColor = UIColor(designSystemColor: .lines).cgColor
         super.setNeedsDisplay()

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -517,7 +517,6 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
             searchAreaView.trailingAnchor.constraint(equalTo: searchAreaContainerView.trailingAnchor),
 
             searchAreaContainerView.centerXAnchor.constraint(equalTo: centerXAnchor),
-            readableSearchAreaWidth,
 
             activeOutlineView.leadingAnchor.constraint(equalTo: searchAreaContainerView.leadingAnchor, constant: -Metrics.activeBorderWidth),
             activeOutlineView.trailingAnchor.constraint(equalTo: searchAreaContainerView.trailingAnchor, constant: Metrics.activeBorderWidth),

--- a/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
+++ b/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
@@ -88,7 +88,6 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
         let item = BrowserChromeButton.createToolbarButtonItem(title: UserText.keyCommandNewTab, image: DesignSystemImages.Glyphs.Size24.add) { [weak self] in
             self?.onPlusButtonTapped?()
         }
-        Self.applyIconConstraints(to: item)
         return item
     }()
 
@@ -96,7 +95,6 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
         let item = BrowserChromeButton.createToolbarButtonItem(title: "Close all tabs and clear data", image: DesignSystemImages.Glyphs.Size24.fireSolid) { [weak self] in
             self?.onFireButtonTapped?()
         }
-        Self.applyIconConstraints(to: item)
         return item
     }()
 
@@ -104,7 +102,6 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
         let item = BrowserChromeButton.createToolbarButtonItem(title: UserText.navigationTitleDone, image: DesignSystemImages.Glyphs.Size24.arrowLeft) { [weak self] in
             self?.onDoneButtonTapped?()
         }
-        Self.applyIconConstraints(to: item)
         return item
     }()
 
@@ -127,7 +124,6 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
 
     lazy var menuButton: UIBarButtonItem = {
         let item = BrowserChromeButton.createToolbarButtonItem(title: "More Menu", image: DesignSystemImages.Glyphs.Size24.moreApple)
-        Self.applyIconConstraints(to: item)
         return item
     }()
 
@@ -135,13 +131,11 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
         let item = BrowserChromeButton.createToolbarButtonItem(title: "", image: nil) { [weak self] in
             self?.onTabStyleButtonTapped?()
         }
-        Self.applyIconConstraints(to: item)
         return item
     }()
 
     lazy var editButton: UIBarButtonItem = {
         let item = BrowserChromeButton.createToolbarButtonItem(title: UserText.actionGenericEdit, image: DesignSystemImages.Glyphs.Size24.menuDotsVertical)
-        Self.applyIconConstraints(to: item)
         return item
     }()
 
@@ -165,7 +159,6 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
         let item = BrowserChromeButton.createToolbarButtonItem(title: UserText.duckAiFeatureName, image: DesignSystemImages.Glyphs.Size24.aiChat) { [weak self] in
             self?.onDuckChatTapped?()
         }
-        Self.applyIconConstraints(to: item)
         return item
     }()
 
@@ -194,14 +187,6 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
     private static let buttonSize: CGFloat = 44
 
     init() { }
-
-    private static func applyIconConstraints(to item: UIBarButtonItem) {
-        guard let view = item.customView else { return }
-        NSLayoutConstraint.activate([
-            view.widthAnchor.constraint(equalTo: view.heightAnchor),
-            view.widthAnchor.constraint(equalToConstant: buttonSize),
-        ])
-    }
 
     private static func applyTextConstraints(to item: UIBarButtonItem) {
         guard let view = item.customView else { return }

--- a/iOS/DuckDuckGo/TabSwitcherTitleBarView.swift
+++ b/iOS/DuckDuckGo/TabSwitcherTitleBarView.swift
@@ -139,12 +139,19 @@ final class TabSwitcherTitleBarView: UIView {
 
     private func applyButtonConstraints(to view: UIView) {
         guard managedButtonConstraints[view] == nil else { return }
+        // Only icon buttons should be forced to a square 44×44.
+        guard isIconButton(view) else { return }
         let constraints = [
             view.widthAnchor.constraint(equalToConstant: Metrics.buttonSize),
             view.widthAnchor.constraint(equalTo: view.heightAnchor),
         ]
         NSLayoutConstraint.activate(constraints)
         managedButtonConstraints[view] = constraints
+    }
+
+    private func isIconButton(_ view: UIView) -> Bool {
+        guard let button = view as? BrowserChromeButton else { return true }
+        return button.hasImage && !button.hasTitle
     }
 
     private func removeButtonConstraints(from stack: UIStackView) {

--- a/iOS/DuckDuckGo/TabSwitcherTitleBarView.swift
+++ b/iOS/DuckDuckGo/TabSwitcherTitleBarView.swift
@@ -65,6 +65,7 @@ final class TabSwitcherTitleBarView: UIView {
     }()
 
     private weak var currentCenterView: UIView?
+    private var managedButtonConstraints: [UIView: [NSLayoutConstraint]] = [:]
 
     private var leadingStackCenterY: NSLayoutConstraint!
     private var trailingStackCenterY: NSLayoutConstraint!
@@ -119,13 +120,39 @@ final class TabSwitcherTitleBarView: UIView {
     }
 
     func setLeadingButtons(_ buttons: [UIView]) {
+        removeButtonConstraints(from: leadingButtonsStack)
         leadingButtonsStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
-        buttons.forEach { leadingButtonsStack.addArrangedSubview($0) }
+        buttons.forEach {
+            applyButtonConstraints(to: $0)
+            leadingButtonsStack.addArrangedSubview($0)
+        }
     }
 
     func setTrailingButtons(_ buttons: [UIView]) {
+        removeButtonConstraints(from: trailingButtonsStack)
         trailingButtonsStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
-        buttons.forEach { trailingButtonsStack.addArrangedSubview($0) }
+        buttons.forEach {
+            applyButtonConstraints(to: $0)
+            trailingButtonsStack.addArrangedSubview($0)
+        }
+    }
+
+    private func applyButtonConstraints(to view: UIView) {
+        guard managedButtonConstraints[view] == nil else { return }
+        let constraints = [
+            view.widthAnchor.constraint(equalToConstant: Metrics.buttonSize),
+            view.widthAnchor.constraint(equalTo: view.heightAnchor),
+        ]
+        NSLayoutConstraint.activate(constraints)
+        managedButtonConstraints[view] = constraints
+    }
+
+    private func removeButtonConstraints(from stack: UIStackView) {
+        for view in stack.arrangedSubviews {
+            if let constraints = managedButtonConstraints.removeValue(forKey: view) {
+                NSLayoutConstraint.deactivate(constraints)
+            }
+        }
     }
 
     func updateForAddressBarPosition(isBottom: Bool) {

--- a/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
@@ -145,11 +145,7 @@ class ToWebViewTransition: WebViewTransition {
               let rowIndex = tabSwitcherViewController.tabsModel.indexOf(tab: tab),
               let layoutAttr = tabSwitcherViewController.collectionView.layoutAttributesForItem(at: IndexPath(row: rowIndex, section: 0))
         else {
-            // The destination tab is no longer a web view (e.g. the user tapped "+" to add a new tab,
-            // which switches the current tab to a new home tab before this animation runs). Without
-            // this fallback the tab switcher would snap off-screen with no animation, causing a
-            // visible glitch when the new NTP fades in afterwards. Fall back to a simple crossfade
-            // to mirror ToHomeScreenTransition's behaviour for the equivalent case.
+            // Crossfade fallback when destination is no longer a web view; mirrors ToHomeScreenTransition.
             if let mainViewController = transitionContext.viewController(forKey: .to) as? MainViewController {
                 mainViewController.view.alpha = 1
             }

--- a/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
@@ -145,7 +145,21 @@ class ToWebViewTransition: WebViewTransition {
               let rowIndex = tabSwitcherViewController.tabsModel.indexOf(tab: tab),
               let layoutAttr = tabSwitcherViewController.collectionView.layoutAttributesForItem(at: IndexPath(row: rowIndex, section: 0))
         else {
-            transitionContext.completeTransition(true)
+            // The destination tab is no longer a web view (e.g. the user tapped "+" to add a new tab,
+            // which switches the current tab to a new home tab before this animation runs). Without
+            // this fallback the tab switcher would snap off-screen with no animation, causing a
+            // visible glitch when the new NTP fades in afterwards. Fall back to a simple crossfade
+            // to mirror ToHomeScreenTransition's behaviour for the equivalent case.
+            if let mainViewController = transitionContext.viewController(forKey: .to) as? MainViewController {
+                mainViewController.view.alpha = 1
+            }
+            UIView.animate(withDuration: TabSwitcherTransition.Constants.duration, animations: {
+                self.tabSwitcherViewController.view.alpha = 0
+            }, completion: { _ in
+                self.solidBackground.removeFromSuperview()
+                self.imageContainer.removeFromSuperview()
+                transitionContext.completeTransition(true)
+            })
             return
         }
                 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1214247168950098?focus=true

### Description
This PR fixes two distinct issues in the tab switcher:

**1. Toolbar icon misalignment**
- Icons in the toolbar shifted positions slightly when transitioning between the main view and the tab switcher (regression caused by #4499
- Centralizes topbar button sizing in `TabSwitcherTitleBarView` so the same width/height constraints are applied regardless of which screen owns the buttons. Constraints are tracked per-view and torn down when buttons are removed to avoid duplicate/conflicting constraints across transitions.

**2. Flicker when creating a new tab from a non-empty tab**
- Tapping "+" in the tab switcher while the current tab was non-empty caused the tab switcher to snap off-screen with no animation before the new NTP faded in, producing a visible glitch.
- Adds a crossfade fallback in `ToWebViewTransition` for the case where the destination tab is no longer a web view, mirroring `ToHomeScreenTransition`'s behaviour for the equivalent case.

**3. Chat icon not aligned between tab switcher and omnibar on large devices (iPhone Pro Max)**
- Fixes a layout bug in `DefaultOmniBarView` where the `readableSearchAreaWidth` constraint was being unconditionally activated at setup time. The constraint is created with `isActive = false` and is intended to be toggled on/off only by `applyLayoutMode(_:)` (active only in `.expandedPad` mode). However, it was also passed into the bulk `NSLayoutConstraint.activate([...])` call right after, which silently re-activated it for **every** layout mode — overriding the explicit `isActive = false` set on the line above.
- That meant the search area was being sized against the `readableContentGuide` even on phones, producing slightly different widths depending on safe-area state and contributing to layout instability during the tab switcher transition.
- Removing the entry from the bulk activate call restores `applyLayoutMode(_:)` as the single source of truth for this constraint, matching the original intent. The constraint is still created, stored, and toggled for `.expandedPad` exactly as before.

### Testing Steps

**Icon misalignment:**
1. Open the app on iPhone and iPad
2. Open the tab switcher from the main view and return to the tab — verify toolbar icons (back/forward, fire, tabs, menu, AI chat) do not shift position during or after the transition.
3. Repeat with the address bar at the top and at the bottom.
4. Repeat on a Plus-size iPhone and on iPad to confirm the layout is consistent on larger devices.

**New-tab flicker:**
1. While viewing a non-empty web tab, open the tab switcher and tap the "+" button to create a new tab. Confirm the transition crossfades smoothly into the new tab page with no snap/glitch.
2. Repeat step 5 starting from an empty (NTP) tab to confirm no regression in the existing path.
3. Verify the standard tab switcher → tab → tab switcher round-trip animations still work as before.

**Omnibar width on phones vs iPad:**
1. On iPad, verify the omnibar still uses the readable-width sizing in expanded layout (search area is centered and not stretched to the full window width on wide windows / split view).
2. On iPhone (Pro Max), verify the omnibar uses the full available width and that the chats icon is aligned with the tab switcher.

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- Topbar button sizing is now owned by `TabSwitcherTitleBarView`. If a future caller passes buttons that already carry their own width/height constraints, they could conflict. Mitigation: constraints are tracked per view in `managedButtonConstraints` and only applied once.
- The new `ToWebViewTransition` fallback path runs whenever the destination is not a web tab. Mitigation: it mirrors the existing behavior of `ToHomeScreenTransition` (simple crossfade) and cleans up its overlay views on completion.
- Removing `readableSearchAreaWidth` could in theory affect the omnibar's max width on very wide layouts. Mitigation: covered by the iPad/Plus testing steps above.

### Quality Considerations
- Edge cases: button list is replaced (not appended) on each call to `setLeading/TrailingButtons`, so old constraints are deactivated before new ones are applied to avoid leaks or duplicate constraints across transitions.
- Performance: the change is constraint-only and does not add new layout passes; the crossfade fallback uses the same duration/style as existing tab switcher transitions.
- Monitoring/analytics: no new pixels — purely a layout/animation fix.
- Documentation: inline comment added in `ToWebViewTransition` explaining why the fallback animation is needed.
- Privacy/security: no impact.

### Notes to Reviewer
- Three commits, each scoped to one concern: (1) move button size constraints to the title bar, (2) drop the readable-width constraint affecting large devices, (3) crossfade fallback for `ToWebViewTransition` when the destination is not a web tab.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes auto-layout constraint ownership for tab switcher buttons and alters the transition fallback path, which could cause new constraint conflicts or animation edge cases across device sizes.
> 
> **Overview**
> Fixes several tab switcher UI regressions by **centralizing toolbar button sizing and improving transition behavior**.
> 
> `TabSwitcherTitleBarView` now applies and manages the 44×44 square constraints for *icon-only* buttons (tracking and deactivating constraints when buttons are swapped), and `TabSwitcherBarsStateHandler` stops applying per-button icon constraints.
> 
> `DefaultOmniBarView` no longer bulk-activates `readableSearchAreaWidth`, restoring `applyLayoutMode(_:)` as the single source of truth so phone layouts don’t incorrectly constrain to readable width. `ToWebViewTransition` adds a crossfade fallback when the destination isn’t a web view, preventing a snap/flicker when creating a new tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ec8998c30616495f7f3bfa4b44f68c533690f26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->