### PR TITLE
Hide Web Search tool when selected Duck.ai model does not support it

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -333,6 +333,10 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         omnibarController.isWebSearchEnabled && omnibarController.selectedModelSupportsWebSearch
     }
 
+    private var shouldShowWebSearchChip: Bool {
+        shouldShowToolsButton && omnibarController.isWebSearchMode && omnibarController.selectedModelSupportsWebSearch
+    }
+
     private var shouldShowImageUpload: Bool {
         omnibarController.isImageGenerationMode || omnibarController.selectedModelSupportsImageUpload
     }
@@ -350,7 +354,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     private func updateToolButtonsVisibility(isEnabled: Bool) {
         toolsButton.isHidden = !shouldShowToolsButton
         imageGenActiveButton.isHidden = !shouldShowToolsButton || !omnibarController.isImageGenerationMode
-        webSearchActiveButton.isHidden = !shouldShowToolsButton || !omnibarController.isWebSearchMode || !omnibarController.selectedModelSupportsWebSearch
+        webSearchActiveButton.isHidden = !shouldShowWebSearchChip
         imageUploadButton.isHidden = !shouldShowAttachments || !shouldShowImageUpload
         imageUploadButton.isEnabled = !attachmentsContainerView.isFull
         modelPickerButton.isHidden = !shouldShowModelPicker

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -322,8 +322,15 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     // MARK: - Tool Button Visibility
 
     private var shouldShowToolsButton: Bool {
-        omnibarController.isOmnibarToolsEnabled
-            && (omnibarController.isImageGenerationEnabled || omnibarController.isWebSearchEnabled)
+        omnibarController.isOmnibarToolsEnabled && (isImageGenerationItemVisible || isWebSearchItemVisible)
+    }
+
+    private var isImageGenerationItemVisible: Bool {
+        omnibarController.isImageGenerationEnabled
+    }
+
+    private var isWebSearchItemVisible: Bool {
+        omnibarController.isWebSearchEnabled && omnibarController.selectedModelSupportsWebSearch
     }
 
     private var shouldShowImageUpload: Bool {
@@ -794,7 +801,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
             menu.addItem(createImageItem)
         }
 
-        if omnibarController.isWebSearchEnabled && omnibarController.selectedModelSupportsWebSearch {
+        if isWebSearchItemVisible {
             let webSearchItem = NSMenuItem()
             webSearchItem.attributedTitle = toolsMenuItemAttributedTitle(
                 title: UserText.aiChatWebSearchButtonLabel,
@@ -1055,6 +1062,10 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         omnibarController.updateSelectedModel(model.id)
         modelPickerButton.modelName = model.shortName
         updateImageUploadVisibility(supportsImageUpload: model.supportsImageUpload)
+        // Refresh tool button visibility so the tools button disappears / reappears when the
+        // new model changes what the menu would show (e.g. only Web Search is flag-enabled and
+        // the newly selected model doesn't support it — the button would otherwise pop an empty menu).
+        updateToolButtonsVisibility(isEnabled: omnibarController.isOmnibarToolsEnabled)
         updateReasoningPickerVisibility()
         PixelKit.fire(AIChatPixel.aiChatAddressBarModelSelected, frequency: .dailyAndCount, includeAppVersionParameter: true)
     }

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -343,7 +343,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     private func updateToolButtonsVisibility(isEnabled: Bool) {
         toolsButton.isHidden = !shouldShowToolsButton
         imageGenActiveButton.isHidden = !shouldShowToolsButton || !omnibarController.isImageGenerationMode
-        webSearchActiveButton.isHidden = !shouldShowToolsButton || !omnibarController.isWebSearchMode
+        webSearchActiveButton.isHidden = !shouldShowToolsButton || !omnibarController.isWebSearchMode || !omnibarController.selectedModelSupportsWebSearch
         imageUploadButton.isHidden = !shouldShowAttachments || !shouldShowImageUpload
         imageUploadButton.isEnabled = !attachmentsContainerView.isFull
         modelPickerButton.isHidden = !shouldShowModelPicker
@@ -794,7 +794,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
             menu.addItem(createImageItem)
         }
 
-        if omnibarController.isWebSearchEnabled {
+        if omnibarController.isWebSearchEnabled && omnibarController.selectedModelSupportsWebSearch {
             let webSearchItem = NSMenuItem()
             webSearchItem.attributedTitle = toolsMenuItemAttributedTitle(
                 title: UserText.aiChatWebSearchButtonLabel,
@@ -1002,6 +1002,10 @@ final class AIChatOmnibarContainerViewController: NSViewController {
                 modelPickerButton.modelName = persistedModelShortName
                 // Refresh image upload visibility with updated supportsImageUpload
                 updateImageUploadVisibility(supportsImageUpload: omnibarController.selectedModelSupportsImageUpload)
+                // Refresh tool button visibility so the Web Search chip reflects the loaded
+                // model's `supportedTools` (belt-and-braces — the controller also clears
+                // `activeToolMode` when the persisted model doesn't support web search).
+                updateToolButtonsVisibility(isEnabled: omnibarController.isOmnibarToolsEnabled)
                 updateReasoningPickerVisibility()
             }
     }

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -214,6 +214,7 @@ final class AIChatOmnibarController {
                 self.models = remoteModels.map { AIChatModel(remoteModel: $0, userTier: userTier) }
                 self.clearStaleModelSelectionIfNeeded()
                 self.clearStaleReasoningEffortIfNeeded()
+                self.deactivateWebSearchIfUnsupported()
             } catch is CancellationError {
                 return
             } catch {
@@ -321,6 +322,14 @@ final class AIChatOmnibarController {
         return models.first(where: { $0.id == persistedModelId })?.supportsImageUpload ?? true
     }
 
+    /// Whether the currently selected model supports the WebSearch tool.
+    /// Returns true when models are unavailable (conservative default — Web Search menu item
+    /// remains visible until the model list is known).
+    var selectedModelSupportsWebSearch: Bool {
+        guard !models.isEmpty else { return true }
+        return models.first(where: { $0.id == persistedModelId })?.supportedTools.contains(.webSearch) ?? true
+    }
+
     /// Image formats supported by the currently selected model (e.g. ["png", "jpeg", "webp"]).
     /// Returns a default set when models are unavailable.
     var selectedModelImageFormats: [String] {
@@ -375,6 +384,15 @@ final class AIChatOmnibarController {
         // The newly selected model may not support the previously persisted reasoning effort.
         // Clearing here keeps stale-effort handling in one place (see `clearStaleReasoningEffortIfNeeded`).
         clearStaleReasoningEffortIfNeeded()
+        deactivateWebSearchIfUnsupported()
+    }
+
+    /// Clears Web Search mode if the currently selected model doesn't support the WebSearch tool.
+    /// Submitting a web-search prompt to an unsupported model fails on the duck.ai page, so the
+    /// mode must not remain active across a switch into such a model.
+    private func deactivateWebSearchIfUnsupported() {
+        guard isWebSearchMode, !selectedModelSupportsWebSearch else { return }
+        activeToolMode = nil
     }
 
     /// Updates the current text being typed by the user

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -327,7 +327,7 @@ final class AIChatOmnibarController {
     /// remains visible until the model list is known).
     var selectedModelSupportsWebSearch: Bool {
         guard !models.isEmpty else { return true }
-        return models.first(where: { $0.id == persistedModelId })?.supportedTools.contains(.webSearch) ?? true
+        return models.first(where: { $0.id == persistedModelId })?.supportsTool(.webSearch) ?? true
     }
 
     /// Image formats supported by the currently selected model (e.g. ["png", "jpeg", "webp"]).

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -424,6 +424,100 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         XCTAssertTrue(controller.models.isEmpty)
     }
 
+    // MARK: - Web Search Model Support Tests
+
+    func testWhenModelsNotLoaded_ThenSelectedModelSupportsWebSearchDefaultsToTrue() {
+        // Then — conservative default keeps the Tools menu item visible until we know otherwise
+        XCTAssertTrue(controller.models.isEmpty)
+        XCTAssertTrue(controller.selectedModelSupportsWebSearch)
+    }
+
+    func testWhenSelectedModelSupportsWebSearch_ThenSelectedModelSupportsWebSearchReturnsTrue() async {
+        // Given
+        mockModelsService.modelsToReturn = [
+            makeRemoteModel(id: "ws-model", supportedTools: ["WebSearch"])
+        ]
+        mockPreferences.selectedModelId = "ws-model"
+
+        // When
+        controller.onOmnibarActivated()
+        await waitForModels()
+
+        // Then
+        XCTAssertTrue(controller.selectedModelSupportsWebSearch)
+    }
+
+    func testWhenSelectedModelDoesNotSupportWebSearch_ThenSelectedModelSupportsWebSearchReturnsFalse() async {
+        // Given — model advertises other tools but not WebSearch
+        mockModelsService.modelsToReturn = [
+            makeRemoteModel(id: "no-ws-model", supportedTools: ["NewsSearch"])
+        ]
+        mockPreferences.selectedModelId = "no-ws-model"
+
+        // When
+        controller.onOmnibarActivated()
+        await waitForModels()
+
+        // Then
+        XCTAssertFalse(controller.selectedModelSupportsWebSearch)
+    }
+
+    func testWhenSwitchingToUnsupportedModel_ThenWebSearchModeIsDeactivated() async {
+        // Given
+        mockModelsService.modelsToReturn = [
+            makeRemoteModel(id: "ws-supported", supportedTools: ["WebSearch"]),
+            makeRemoteModel(id: "ws-unsupported", supportedTools: [])
+        ]
+        mockPreferences.selectedModelId = "ws-supported"
+        controller.onOmnibarActivated()
+        await waitForModels()
+        controller.toggleWebSearchMode()
+        XCTAssertTrue(controller.isWebSearchMode)
+
+        // When
+        controller.updateSelectedModel("ws-unsupported")
+
+        // Then
+        XCTAssertFalse(controller.isWebSearchMode)
+    }
+
+    func testWhenSwitchingBetweenSupportingModels_ThenWebSearchModeIsPreserved() async {
+        // Given
+        mockModelsService.modelsToReturn = [
+            makeRemoteModel(id: "ws-a", supportedTools: ["WebSearch"]),
+            makeRemoteModel(id: "ws-b", supportedTools: ["WebSearch"])
+        ]
+        mockPreferences.selectedModelId = "ws-a"
+        controller.onOmnibarActivated()
+        await waitForModels()
+        controller.toggleWebSearchMode()
+        XCTAssertTrue(controller.isWebSearchMode)
+
+        // When
+        controller.updateSelectedModel("ws-b")
+
+        // Then
+        XCTAssertTrue(controller.isWebSearchMode)
+    }
+
+    func testWhenFetchModelsRevealsUnsupportedPersistedModel_ThenWebSearchModeIsDeactivated() async {
+        // Given — user toggled Web Search before models loaded (conservative default allowed it),
+        // persisted model turns out not to support it
+        mockModelsService.modelsToReturn = [
+            makeRemoteModel(id: "no-ws", supportedTools: [])
+        ]
+        mockPreferences.selectedModelId = "no-ws"
+        controller.toggleWebSearchMode()
+        XCTAssertTrue(controller.isWebSearchMode)
+
+        // When
+        controller.onOmnibarActivated()
+        await waitForModels()
+
+        // Then
+        XCTAssertFalse(controller.isWebSearchMode)
+    }
+
     // MARK: - Reasoning Effort Tests
 
     func testWhenReasoningEffortFeatureFlagEnabled_ThenIsReasoningEffortEnabledIsTrue() {
@@ -671,6 +765,7 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         id: String,
         supportsImageUpload: Bool = false,
         entityHasAccess: Bool = true,
+        supportedTools: [String] = [],
         supportedReasoningEffort: [String] = []
     ) -> AIChatRemoteModel {
         AIChatRemoteModel(
@@ -680,7 +775,7 @@ final class AIChatOmnibarControllerTests: XCTestCase {
             provider: "openai",
             entityHasAccess: entityHasAccess,
             supportsImageUpload: supportsImageUpload,
-            supportedTools: [],
+            supportedTools: supportedTools,
             supportedReasoningEffort: supportedReasoningEffort,
             accessTier: entityHasAccess ? ["free"] : ["plus", "pro"]
         )


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1214064925948848?focus=true
Tech Design URL:
CC:

### Description

Hide the Web Search item from the address bar Duck.ai Tools menu when the selected model's `supportedTools` (from `duck.ai/duckchat/v1/models`) does not include `WebSearch`. If Web Search is active when the user switches to a model that doesn't support it — or when a persisted unsupported model is revealed after models load — it is automatically deactivated. Without this, submitting a web-search prompt to a non-supporting model produces an error on the duck.ai page after submission.

Mirrors the Windows browser fix in duckduckgo/windows-browser#7359.

### Testing Steps

Feature flags to enable: `aiChatOmnibarTools`, `aiChatOmnibarWebSearch`.

1. Focus the address bar, switch to Duck.ai mode, open the Tools menu with a supporting model (e.g. GPT-4o) — Web Search item is listed.
2. Activate Web Search — chip appears next to the input.
3. Open the model picker and switch to a model that doesn't support web search (e.g. `gpt-oss`) — Web Search disappears from the Tools menu and the chip is removed.
4. Switch back to a supporting model — Web Search reappears in the Tools menu, stays deselected.
6. Switch between two supporting models with Web Search active — Web Search stays active.
7. Disable the `aiChatOmnibarWebSearch` feature flag — Web Search stays hidden regardless of model support (regression check).

### Impact and Risks

Low — gates an existing UI element on an already-decoded API field (`AIChatModel.supportedTools`). New unit tests in `AIChatOmnibarControllerTests` cover the supported/unsupported cases plus model-switching behavior.

#### What could go wrong?


### Quality Considerations

-

### Notes to Reviewer

-


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state gating change that only affects when Web Search can be selected; main risk is accidental regression in tool visibility or mode persistence during model loading/switching.
> 
> **Overview**
> Web Search in the Duck.ai omnibar is now **gated by the selected model’s `supportedTools`**: the Tools menu item and active chip are hidden when the current model doesn’t support `WebSearch`.
> 
> The controller adds `selectedModelSupportsWebSearch` and automatically **deactivates Web Search mode** when models load or the user switches to an unsupported model, preventing invalid submissions. New unit tests cover supported/unsupported models, mode deactivation on switch/load, and preservation when switching between supporting models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fa4082236c7135743c6e7bd7feb2754c11e8a85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->