### PR TITLE
[iOS] Fix Duck.ai UTI shadow appearing at start of transition

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -20,6 +20,7 @@
 import AIChat
 import Combine
 import DesignResourcesKit
+import UIComponents
 import UIKit
 
 // MARK: - Delegate Protocol
@@ -81,6 +82,8 @@ final class UnifiedToggleInputView: UIView {
         static var toggleTrailingWithInlineDismiss: CGFloat {
             -(inlineDismissTrailingPadding + inlineDismissSize + toggleInlineDismissSpacing)
         }
+
+        static let allCorners: CACornerMask = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
     }
 
     // MARK: - Hit Testing
@@ -99,10 +102,7 @@ final class UnifiedToggleInputView: UIView {
             guard cardPosition != oldValue else { return }
             refreshInlineDismissPresentation()
             guard isExpanded else { return }
-            let allCorners: CACornerMask = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
-            cardView.layer.maskedCorners = allCorners
-            expandedShadow0.shadowOffset = CGSize(width: 0, height: 8)
-            expandedShadow1.shadowOffset = CGSize(width: 0, height: 2)
+            cardView.layer.maskedCorners = Constants.allCorners
         }
     }
 
@@ -240,26 +240,15 @@ final class UnifiedToggleInputView: UIView {
     private lazy var inlineDismissButton: UIButton = Self.makeInlineDismissButton()
     private let attachmentsStrip = UnifiedToggleInputAttachmentsStripView()
     private let toolsToolbar = UnifiedToggleInputToolbarView()
-    // MARK: - Shadow Layers
+    // MARK: - Shadow
 
-    private let expandedShadow0: CALayer = {
-        let layer = CALayer()
-        layer.shadowColor = UIColor(designSystemColor: .shadowSecondary).cgColor
-        layer.shadowOpacity = 1.0
-        layer.shadowRadius = 32
-        layer.shadowOffset = CGSize(width: 0, height: -8)
-        layer.isHidden = true
-        return layer
-    }()
-
-    private let expandedShadow1: CALayer = {
-        let layer = CALayer()
-        layer.shadowColor = UIColor(designSystemColor: .shadowTertiary).cgColor
-        layer.shadowOpacity = 1.0
-        layer.shadowRadius = 16
-        layer.shadowOffset = CGSize(width: 0, height: -2)
-        layer.isHidden = true
-        return layer
+    // Pinned to cardView via Auto Layout; CompositeShadowView forwards cornerRadius/backgroundColor to its shadow sub-layers.
+    private let expandedShadowView: CompositeShadowView = {
+        let view = CompositeShadowView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.isUserInteractionEnabled = false
+        view.isHidden = true
+        return view
     }()
 
     // MARK: - Dynamic Colors
@@ -274,12 +263,19 @@ final class UnifiedToggleInputView: UIView {
             : UIColor.black.withAlphaComponent(0.16).cgColor
     }
 
-    private var expandedShadow0Color: CGColor {
-        UIColor(designSystemColor: .shadowSecondary).cgColor
+    private var expandedShadows: [CompositeShadowView.Shadow] {
+        [
+            .init(color: UIColor(designSystemColor: .shadowSecondary),
+                  radius: 32,
+                  offset: CGSize(width: 0, height: 8)),
+            .init(color: UIColor(designSystemColor: .shadowTertiary),
+                  radius: 16,
+                  offset: CGSize(width: 0, height: 2)),
+        ]
     }
 
-    private var expandedShadow1Color: CGColor {
-        UIColor(designSystemColor: .shadowTertiary).cgColor
+    private func cardBackgroundColor(isFireTab: Bool) -> UIColor {
+        UIColor(singleUseColor: isFireTab ? .fireModeCardBackground : .unifiedToggleInputCardBackground)
     }
 
     // MARK: - Constraints
@@ -318,20 +314,15 @@ final class UnifiedToggleInputView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        let cardFrame = cardView.frame
-        let cardPath = UIBezierPath(roundedRect: cardFrame, cornerRadius: cardView.layer.cornerRadius).cgPath
-        for shadow in [expandedShadow0, expandedShadow1] {
-            shadow.bounds = bounds
-            shadow.position = CGPoint(x: bounds.midX, y: bounds.midY)
-            shadow.shadowPath = cardPath
-        }
+        guard isExpanded else { return }
+        // Runs inside UIView.animate via layoutIfNeeded so the shadow corners animate with cardView.
+        expandedShadowView.layer.cornerRadius = cardView.layer.cornerRadius
+        expandedShadowView.layer.maskedCorners = cardView.layer.maskedCorners
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-            expandedShadow0.shadowColor = expandedShadow0Color
-            expandedShadow1.shadowColor = expandedShadow1Color
             cardView.layer.shadowColor = cardShadowColor
             if isExpanded {
                 cardView.layer.borderColor = expandedBorderColor
@@ -348,9 +339,10 @@ final class UnifiedToggleInputView: UIView {
     }
 
     private func applyFireModeAppearance(isFireTab: Bool) {
-        cardView.backgroundColor = isFireTab
-            ? UIColor(singleUseColor: .fireModeCardBackground)
-            : UIColor(singleUseColor: .unifiedToggleInputCardBackground)
+        let background = cardBackgroundColor(isFireTab: isFireTab)
+        cardView.backgroundColor = background
+        // Shadow silhouette is an opaque fill covered by cardView, so both must share the same background.
+        expandedShadowView.backgroundColor = background
         // cardView keeps the OS trait so `fireModeCardBackground` picks its light variant in light OS; content subviews force `.dark` so their dynamic colors resolve against the dark surface.
         let style: UIUserInterfaceStyle = isFireTab ? .dark : .unspecified
         // `toolsToolbar` manages its own subtree's trait so the accent submit button keeps OS trait.
@@ -449,17 +441,12 @@ final class UnifiedToggleInputView: UIView {
 
         textEntryView.isExpandable = expanded
 
-        expandedShadow0.isHidden = !expanded
-        expandedShadow1.isHidden = !expanded
-        if expanded {
-            expandedShadow0.shadowOffset = CGSize(width: 0, height: 8)
-            expandedShadow1.shadowOffset = CGSize(width: 0, height: 2)
-        }
+        expandedShadowView.isHidden = !expanded
         cardView.layer.shadowOpacity = expanded ? 0 : 1.0
         cardCollapsedHeightConstraint.constant = Constants.collapsedCardHeight
         cardCollapsedHeightConstraint.isActive = !expanded
 
-        cardView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        cardView.layer.maskedCorners = Constants.allCorners
         cardView.clipsToBounds = expanded && (usesOmnibarMargins || !isToggleEnabled)
 
         cardView.layer.borderWidth = showToolbar ? Constants.expandedBorderWidth : 0
@@ -573,13 +560,9 @@ final class UnifiedToggleInputView: UIView {
     func setInactiveCardAppearance(_ inactive: Bool) {
         guard isExpanded else { return }
 
-        let allCorners: CACornerMask = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
-
         UIView.animate(withDuration: Constants.animationDuration, delay: 0, options: .curveEaseInOut) {
             if inactive {
-                self.cardView.layer.maskedCorners = allCorners
-                self.expandedShadow0.shadowOffset = CGSize(width: 0, height: 8)
-                self.expandedShadow1.shadowOffset = CGSize(width: 0, height: 2)
+                self.cardView.layer.maskedCorners = Constants.allCorners
                 self.cardTopConstraint.constant = Constants.cardVerticalMargin
                 self.cardLeadingConstraint.constant = Constants.cardHorizontalMargin
                 self.cardTrailingConstraint.constant = -self.cardTrailingMargin
@@ -587,9 +570,7 @@ final class UnifiedToggleInputView: UIView {
                 self.toolbarHeightConstraint.constant = 0
                 self.toolsToolbar.alpha = 0
             } else {
-                self.cardView.layer.maskedCorners = allCorners
-                self.expandedShadow0.shadowOffset = CGSize(width: 0, height: 8)
-                self.expandedShadow1.shadowOffset = CGSize(width: 0, height: 2)
+                self.cardView.layer.maskedCorners = Constants.allCorners
                 let leadingMargin: CGFloat
                 let trailingMargin: CGFloat
                 if !self.usesOmnibarMargins && self.cardPosition == .bottom {
@@ -715,8 +696,9 @@ private extension UnifiedToggleInputView {
         clipsToBounds = false
         backgroundColor = .clear
 
-        layer.insertSublayer(expandedShadow0, at: 0)
-        layer.insertSublayer(expandedShadow1, at: 1)
+        // backgroundColor is applied later by `applyFireModeAppearance` (called at the end of setupUI).
+        expandedShadowView.shadows = expandedShadows
+        addSubview(expandedShadowView)
 
         cardView.translatesAutoresizingMaskIntoConstraints = false
         cardView.layer.cornerRadius = Constants.cardCornerRadiusCollapsed
@@ -726,6 +708,13 @@ private extension UnifiedToggleInputView {
         cardView.layer.shadowRadius = 12
         cardView.isUserInteractionEnabled = false
         addSubview(cardView)
+
+        NSLayoutConstraint.activate([
+            expandedShadowView.leadingAnchor.constraint(equalTo: cardView.leadingAnchor),
+            expandedShadowView.trailingAnchor.constraint(equalTo: cardView.trailingAnchor),
+            expandedShadowView.topAnchor.constraint(equalTo: cardView.topAnchor),
+            expandedShadowView.bottomAnchor.constraint(equalTo: cardView.bottomAnchor),
+        ])
 
         toggleView.translatesAutoresizingMaskIntoConstraints = false
         toggleView.alpha = 0


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214237436317431
CC:

### Description

Fixes the shadow artifact at the start of the Search → Duck.ai toggle animation. Scoped strictly to the [focused comment](https://app.asana.com/1/137249556945/task/1214153501140283/comment/1214237436317424?focus=true) — other sub-issues in the parent task are out of scope.

**Root cause:** the expanded-state shadow was drawn via two standalone `CALayer`s whose `shadowPath` was recomputed from `cardView.frame` in `layoutSubviews`. `shadowPath` has no default implicit animation on standalone CALayers, so the outline snapped to the final (taller Duck.ai) shape on frame 0 while the card itself eased from the shorter Search height.

**Fix:** replace the two ad-hoc layers with a single `CompositeShadowView` (existing component in `SharedPackages/UIComponents`, already used by `DefaultOmniBarView`, `SuggestionTrayViewController`, and others) pinned to `cardView` via Auto Layout. Because it's UIView-backed and shares cardView's constraints, its frame and cornerRadius animate with the exact same duration AND timing curve as cardView inside `UIView.animate` — no manual `CABasicAnimation` mirroring needed.

Net code change: **+44 / -55** — the refactor removes more than it adds.

Before:
https://github.com/user-attachments/assets/a211583a-ef59-4edc-bb04-afa1d65c901a

After:
https://github.com/user-attachments/assets/ff5b349d-f053-4691-b8f4-cafb05e320e9

### Testing Steps

1. Tap the omnibar to expand the UTI in **bottom** address-bar position.
2. Swipe or tap the toggle to switch from **Search → Duck.ai**.
3. Verify the shadow halo grows smoothly alongside the card, no instant end-state outline on frame 0.
4. Switch back to **Search** — shadow shrinks in lockstep with the card.
5. Repeat with **top** address-bar position (Settings → Address Bar → Top).
6. Verify in both light and dark mode.

### Impact and Risks

**Low** — purely visual refactor scoped to the shadow rendering inside `UnifiedToggleInputView`. Behaviour for `cardPosition` .top vs .bottom matches the pre-existing runtime behaviour exactly (always cast downward; see note below).

#### What could go wrong?

- Shadow silhouette peeking around cardView's corners. Mitigated by reusing cardView's `backgroundColor` on the shadow host, matching the existing `CompositeShadowView` pattern elsewhere.
- Double-painting the card background (shadow view + cardView both paint the fill). Negligible at this size and matches how other callers of `CompositeShadowView` use it.

### Quality Considerations

- Leans on the shared `CompositeShadowView` abstraction so future changes to shadow rendering flow through one component.
- Pre-existing implementation detail: the enum doc for `UnifiedToggleInputCardPosition` suggests shadows should cast in different directions per position, but the original code (at every mutation site) always used `+8 / +2` offsets regardless of position. This PR preserves that runtime behaviour — fixing the doc/impl mismatch is a separate concern outside this branch's scope.

### Notes to Reviewer

- Full investigation history is in the branch: we instrumented `os.Logger` to confirm the snap empirically before implementing, iterated through a shadowPath-mirroring CABasicAnimation, then swapped to the cleaner `CompositeShadowView` adoption.
- Videos of before/after to be added by the author.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a UI-only refactor of shadow rendering in `UnifiedToggleInputView`, with no changes to submission/toggle logic or data handling.
> 
> **Overview**
> Fixes a visual shadow “snap” at the start of the Search → Duck.ai expand/collapse animation by replacing two manually-managed `CALayer` shadows with a UIView-backed `CompositeShadowView` pinned to `cardView` via Auto Layout.
> 
> The expanded shadow styling is now configured as a pair of `CompositeShadowView.Shadow` definitions, kept in sync with the card’s corner radius/masked corners during layout, and the shadow host’s background color is matched to the card (including Fire Mode) to avoid silhouette artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d602c9bc126311b55fbc059091d92303c366d565. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->