### PR TITLE
[iOS] Fix debug sheet randomly appearing on foreground; add disable toggle

### DIFF
--- a/iOS/DuckDuckGo/AppUserDefaults.swift
+++ b/iOS/DuckDuckGo/AppUserDefaults.swift
@@ -108,6 +108,7 @@ public class AppUserDefaults: AppSettings {
         static let autofillDebugScriptEnabledKey = "com.duckduckgo.ios.debug.autofillDebugScriptEnabled"
         static let contentScopeDebugStateEnabledKey = "com.duckduckgo.ios.debug.contentScopeDebugStateEnabled"
         static let onboardingIsNewUserKey = "com.duckduckgo.ios.debug.onboardingIsNewUser"
+        static let shakeToOpenDebugMenuEnabledKey = "com.duckduckgo.ios.debug.shakeToOpenDebugMenuEnabled"
     }
 
     private var userDefaults: UserDefaults? {
@@ -448,6 +449,16 @@ public class AppUserDefaults: AppSettings {
 
         set {
             userDefaults?.set(newValue, forKey: DebugKeys.inspectableWebViewsEnabledKey)
+        }
+    }
+
+    var shakeToOpenDebugMenuEnabled: Bool {
+        get {
+            return userDefaults?.object(forKey: DebugKeys.shakeToOpenDebugMenuEnabledKey) as? Bool ?? true
+        }
+
+        set {
+            userDefaults?.set(newValue, forKey: DebugKeys.shakeToOpenDebugMenuEnabledKey)
         }
     }
 

--- a/iOS/DuckDuckGo/DebugScreensViewController.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewController.swift
@@ -48,6 +48,14 @@ struct DebugScreensView: View {
         List {
             if !model.isSearching {
                 Section {
+                    Toggle(isOn: $model.isShakeToOpenDebugMenuEnabled) {
+                        Label {
+                            Text(verbatim: "Shake to Open Debug Menu")
+                        } icon: {
+                            Image(systemName: "hand.wave")
+                        }
+                    }
+
                     VStack(alignment: .leading, spacing: 8) {
                         Label("Shake your device or press \u{2303}\u{2318}Z in the Simulator to open this screen quickly.", systemImage: "info.circle")
                         // swiftlint:disable:next force_try

--- a/iOS/DuckDuckGo/DebugScreensViewModel.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewModel.swift
@@ -41,6 +41,12 @@ class DebugScreensViewModel: ObservableObject {
         }
     }
 
+    @Published var isShakeToOpenDebugMenuEnabled = true {
+        didSet {
+            AppUserDefaults().shakeToOpenDebugMenuEnabled = isShakeToOpenDebugMenuEnabled
+        }
+    }
+
     @Published var filter = "" {
         didSet {
             refreshFilter()
@@ -95,6 +101,7 @@ class DebugScreensViewModel: ObservableObject {
     func refreshToggles() {
         self.isInternalUser = dependencies.internalUserDecider.isInternalUser
         self.isInspectibleWebViewsEnabled = AppUserDefaults().inspectableWebViewEnabled
+        self.isShakeToOpenDebugMenuEnabled = AppUserDefaults().shakeToOpenDebugMenuEnabled
     }
 
     func refreshFilter() {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -82,6 +82,9 @@ struct StartupOnboardingDecision {
 
 class MainViewController: UIViewController {
 
+    /// iOS may deliver buffered accelerometer data as a spurious shake when returning from background.
+    private static let shakeIgnoreIntervalAfterForeground: TimeInterval = 1.0
+
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return ThemeManager.shared.currentTheme.statusBarStyle
     }
@@ -200,6 +203,7 @@ class MainViewController: UIViewController {
     private var feedbackCancellable: AnyCancellable?
     private var aiChatCancellables = Set<AnyCancellable>()
     private var settingsCancellables = Set<AnyCancellable>()
+    private var lastForegroundEntryDate = Date.distantPast
     private var syncRecoveryPromptService: SyncRecoveryPromptService?
     private var currentNTPEscapeHatch: EscapeHatchModel?
     private var hasCompletedInitialLoad = false
@@ -1697,6 +1701,8 @@ class MainViewController: UIViewController {
     }
     
     func onForeground() {
+        lastForegroundEntryDate = Date()
+
         fireExperimentalAddressBarPixel()
         fireIPadToggleStateOnAppOpenPixel()
         fireContextualAutoAttachPixel()
@@ -3778,17 +3784,20 @@ extension MainViewController: OmniBarDelegate {
     }
 
     override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
-        if motion == .motionShake, featureFlagger.internalUserDecider.isInternalUser || isDebugBuild {
-            var topVC: UIViewController = self
-            while let presented = topVC.presentedViewController {
-                topVC = presented
-            }
-            if !(topVC is DebugScreensViewController),
-               !((topVC as? UINavigationController)?.viewControllers.first is DebugScreensViewController) {
-                segueToDebugSettings()
-            }
+        defer { super.motionEnded(motion, with: event) }
+
+        guard motion == .motionShake, featureFlagger.internalUserDecider.isInternalUser || isDebugBuild else { return }
+        guard AppUserDefaults().shakeToOpenDebugMenuEnabled else { return }
+        guard Date().timeIntervalSince(lastForegroundEntryDate) > Self.shakeIgnoreIntervalAfterForeground else { return }
+
+        var topVC: UIViewController = self
+        while let presented = topVC.presentedViewController {
+            topVC = presented
         }
-        super.motionEnded(motion, with: event)
+        if !(topVC is DebugScreensViewController),
+           !((topVC as? UINavigationController)?.viewControllers.first is DebugScreensViewController) {
+            segueToDebugSettings()
+        }
     }
 
     func performCancel() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201392122292466/task/1213919690338649

### Description

Fixes the internal-tester report that the debug sheet appears unexpectedly when bringing the app back from background. Root cause: iOS can deliver buffered `motionShake` events shortly after the app becomes active, and our shake-to-debug handler (added in #4199) had no temporal guard.

Two changes:
- `MainViewController.motionEnded` now ignores shakes for 1s after `onForeground()`.
- New debug toggle **Shake to Open Debug Menu** (default ON) lets anyone disable shake-triggered debug sheet entirely. Persisted in `AppUserDefaults`.

The toggle lives in the first section of the debug screen, above the "Shake your device…" explainer, alongside `Internal User` and `Inspectable WebViews` in styling.

Out of scope: the separate long-press-settings double-present report — already addressed on main.

### Testing Steps

1. Enable Internal User in Debug menu (or run a debug build).
2. Shake the device (Ctrl+⌘+Z in the Simulator) — debug sheet appears.
3. Background the app, bring it back to foreground. Within 1s of foregrounding, the debug sheet should **not** appear even if a stray shake event was delivered by iOS.
4. After >1s in foreground, shake again — debug sheet appears normally.
5. Open debug menu → toggle **Shake to Open Debug Menu** OFF. Dismiss. Shake — debug sheet should not appear.
6. Re-enable the toggle — shake works again.

### Impact and Risks

Low. Debug-only path, gated on `isInternalUser || isDebugBuild`. No production code path affected.

#### What could go wrong?

- 1s window is arbitrary; if iOS delivers stale shakes >1s after foreground, the fix won't catch them. Acceptable because the toggle gives users an escape hatch, and 1s covers the known iOS delivery timing.
- Users who shake the device intentionally within 1s of foregrounding will need to shake again — negligible UX cost on a debug affordance.

### Notes to Reviewer

- No unit tests — debug-only surface, agreed during scoping.
- `lastForegroundEntryDate` default is `.distantPast`, so the very first shake right after app launch still works.
- `AppUserDefaults.shakeToOpenDebugMenuEnabled` defaults to `true` so existing users keep current behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to the debug menu entry path and remain gated by `isInternalUser || isDebugBuild`. Main behavior change is an added 1s shake-suppression window after foreground which could delay intentional debug access briefly.
> 
> **Overview**
> Prevents the debug screens sheet from opening unexpectedly on app foreground by ignoring `motionShake` events for ~1s after `onForeground()`.
> 
> Adds a new **Shake to Open Debug Menu** toggle (default ON) to the debug screens UI, persists it via `AppUserDefaults`, and gates the shake handler in `MainViewController.motionEnded` on this setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2d09c1c653d4004168082965ad1bca7cfe7767e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->