### PR TITLE
macOS 13.7.8 favicon crash workaround

### DIFF
--- a/macOS/DuckDuckGo/Common/View/SwiftUI/LoginFaviconView.swift
+++ b/macOS/DuckDuckGo/Common/View/SwiftUI/LoginFaviconView.swift
@@ -24,10 +24,20 @@ struct LoginFaviconView: View {
     let domain: String
     let generatedIconLetters: String
     let faviconManagement: FaviconManagement = NSApp.delegateTyped.faviconManager
+    let osVersion: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion
+
+    private var displayableFaviconImage: NSImage? {
+        // Workaround for favicon rendering crashes on macOS 13.7.8.
+        guard (osVersion.majorVersion, osVersion.minorVersion, osVersion.patchVersion) != (13, 7, 8) else {
+            return nil
+        }
+
+        return faviconManagement.getCachedFavicon(for: domain, sizeCategory: .small)?.image
+    }
 
     var body: some View {
         Group {
-            if let image = faviconManagement.getCachedFavicon(for: domain, sizeCategory: .small)?.image {
+            if let image = displayableFaviconImage {
                 Image(nsImage: image)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
@@ -42,7 +52,7 @@ struct LoginFaviconView: View {
     }
 
     var favicon: NSImage? {
-        return faviconManagement.getCachedFavicon(for: domain, sizeCategory: .small)?.image ?? .login
+        return displayableFaviconImage ?? .login
     }
 
 }

--- a/macOS/DuckDuckGo/Common/View/SwiftUI/LoginFaviconView.swift
+++ b/macOS/DuckDuckGo/Common/View/SwiftUI/LoginFaviconView.swift
@@ -27,12 +27,15 @@ struct LoginFaviconView: View {
     let osVersion: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion
 
     private var displayableFaviconImage: NSImage? {
-        // Workaround for favicon rendering crashes on macOS 13.7.8.
-        guard (osVersion.majorVersion, osVersion.minorVersion, osVersion.patchVersion) != (13, 7, 8) else {
+        // Workaround for favicon rendering crashes on Ventura 13.7.8 and newer 13.x patches.
+        switch (osVersion.majorVersion, osVersion.minorVersion, osVersion.patchVersion) {
+        case let (13, minor, _) where minor > 7:
             return nil
+        case let (13, 7, patch) where patch >= 8:
+            return nil
+        default:
+            return faviconManagement.getCachedFavicon(for: domain, sizeCategory: .small)?.image
         }
-
-        return faviconManagement.getCachedFavicon(for: domain, sizeCategory: .small)?.image
     }
 
     var body: some View {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1214254059025791?focus=true
Tech Design URL:
CC:

### Description
Display LetterIconView instead of any cached favicons in the Password Management window on macOS 13.7.8 due to NSImage crash reports 

### Testing Steps
1. Save a couple of logins, and visit the password manager and confirm the favicons are displayed (as usual) 
2. Modify L31 of `LoginFaviconView` to match your OS version
3. Re-launch the app and confirm that you now see the fallback two letter generated favicons instead

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

--
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change gated by OS version, intended to avoid a Ventura-specific `NSImage` crash. Main risk is unintended favicon suppression on misdetected OS versions.
> 
> **Overview**
> Adds an OS-version gate in `LoginFaviconView` to **skip rendering cached favicons on macOS Ventura 13.7.8+ (and later 13.x)** due to crash reports, falling back to `LetterIconView`/`.login` instead.
> 
> Refactors favicon access through a single `displayableFaviconImage` property so both the SwiftUI `Image` and the `favicon` accessor share the same workaround logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6ed4fbb4f46dd0db384277ac2c458d3b6f40d42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->