### PR TITLE
macOS: Feature flag Sync & Backup This Device Only promo

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -552,6 +552,7 @@ public enum SyncSubfeature: String, PrivacySubfeature {
     case syncIdentities
     case aiChatSync
     case simplifiedSyncSetupExperiment
+    case allowSingleDeviceOnConnectScreen
 }
 
 public enum AutoconsentSubfeature: String, PrivacySubfeature {

--- a/macOS/DuckDuckGo/Preferences/Model/LegacySyncPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/LegacySyncPreferences.swift
@@ -276,6 +276,12 @@ final class LegacySyncPreferences: ObservableObject, SyncUI_macOS.ManagementView
         }
     }
 
+    private func updateSingleDeviceSyncPromoVisibility() {
+        let isFlagEnabled = featureFlagger.isFeatureOn(.allowSingleDeviceOnConnectScreen)
+        let isSyncInactive = syncService.account == nil
+        managementDialogModel.shouldShowSingleDeviceSyncPromoOnSyncWithAnotherDeviceScreen = isFlagEnabled && isSyncInactive
+    }
+
     private func setUpObservables() {
         syncService.featureFlagsPublisher
             .dropFirst()
@@ -292,6 +298,7 @@ final class LegacySyncPreferences: ObservableObject, SyncUI_macOS.ManagementView
                 let isEnabled = self.featureFlagger.isFeatureOn(.aiChatSync)
                 self.isAIChatSyncEnabled = isEnabled
                 self.managementDialogModel.isAIChatSyncEnabled = isEnabled
+                self.updateSingleDeviceSyncPromoVisibility()
             }
             .store(in: &cancellables)
 
@@ -300,7 +307,9 @@ final class LegacySyncPreferences: ObservableObject, SyncUI_macOS.ManagementView
             .asVoid()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
-                self?.refreshDevices()
+                guard let self else { return }
+                self.refreshDevices()
+                self.updateSingleDeviceSyncPromoVisibility()
             }
             .store(in: &cancellables)
 

--- a/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
@@ -131,7 +131,9 @@ final class SyncDialogController {
             .asVoid()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
-                self?.refreshDevices()
+                guard let self else { return }
+                self.refreshDevices()
+                self.updateSingleDeviceSyncPromoVisibility()
             }
             .store(in: &cancellables)
 
@@ -153,6 +155,7 @@ final class SyncDialogController {
             .sink { [weak self] in
                 guard let self else { return }
                 self.managementDialogModel.isAIChatSyncEnabled = self.featureFlagger.isFeatureOn(.aiChatSync)
+                self.updateSingleDeviceSyncPromoVisibility()
             }
             .store(in: &cancellables)
     }
@@ -168,6 +171,12 @@ final class SyncDialogController {
     }
 
     // MARK: - Private Helper Methods
+
+    private func updateSingleDeviceSyncPromoVisibility() {
+        let isFlagEnabled = featureFlagger.isFeatureOn(.allowSingleDeviceOnConnectScreen)
+        let isSyncInactive = syncService.account == nil
+        managementDialogModel.shouldShowSingleDeviceSyncPromoOnSyncWithAnotherDeviceScreen = isFlagEnabled && isSyncInactive
+    }
 
     @MainActor
     private func presentDialog(for currentDialog: ManagementDialogKind) {

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -92,6 +92,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866717382557
     case syncSetupBarcodeIsUrlBased
 
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214232292928824
+    case allowSingleDeviceOnConnectScreen
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866615684438
     case exchangeKeysToSyncWithAnotherDevice
 
@@ -448,6 +451,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(.subfeature(DBPSubfeature.webViewUserAgent)), category: .dbp)
         case .syncSetupBarcodeIsUrlBased:
             Config(source: .remoteReleasable(.subfeature(SyncSubfeature.syncSetupBarcodeIsUrlBased)), category: .sync)
+        case .allowSingleDeviceOnConnectScreen:
+            Config(source: .remoteReleasable(.subfeature(SyncSubfeature.allowSingleDeviceOnConnectScreen)), category: .sync)
         case .exchangeKeysToSyncWithAnotherDevice:
             Config(source: .remoteReleasable(.subfeature(SyncSubfeature.exchangeKeysToSyncWithAnotherDevice)), category: .sync)
         case .canScanUrlBasedSyncSetupBarcodes:

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/ViewModels/ManagementDialogModel.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/ViewModels/ManagementDialogModel.swift
@@ -47,6 +47,7 @@ public final class ManagementDialogModel: ObservableObject {
     @Published public var shouldShowErrorMessage: Bool = false
     @Published public var syncErrorMessage: SyncErrorMessage?
     @Published public var isAIChatSyncEnabled: Bool = false
+    @Published public var shouldShowSingleDeviceSyncPromoOnSyncWithAnotherDeviceScreen: Bool = false
     @Published public var shouldShowSwitchAccountsMessage: Bool = false
 
     public weak var delegate: ManagementDialogModelDelegate?

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/Dialogs/SyncWithAnotherDeviceView.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/Dialogs/SyncWithAnotherDeviceView.swift
@@ -63,7 +63,9 @@ struct SyncWithAnotherDeviceView: View {
             .frame(minWidth: Metrics.contentMinWidth)
             .roundedBorder()
 
-            singleDeviceSyncPromo()
+            if model.shouldShowSingleDeviceSyncPromoOnSyncWithAnotherDeviceScreen {
+                singleDeviceSyncPromo()
+            }
         }
         buttons: {
             Button(UserText.cancel) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211264967278501/task/1214148054564514?focus=true
Tech Design URL:
CC:

### Description

This PR reverts the “Sync & Backup This Device Only” promo on the Sync With Another Device screen on macOS: https://app.asana.com/1/137249556945/project/1211264967278501/task/1214148054564513?focus=true

- The prompt is hidden unless the feature flag is enabled (default to off)
- I also noticed an issue if you interact with the prompt when sync is already enabled, so I’ve ensured it’s also hidden in this case.

<img width="442" alt="image" src="https://github.com/user-attachments/assets/463e6b5e-31ee-42e5-818f-3ffbdd2dc553" />

### Testing Steps

1. Build and run on macOS
2. Head to Settings > Sync & Backup. Ensure sync is enabled and tap Sync With Another Device.
3. In the modal that appears, ensure you don’t see the Sync & Backup This Device Only prompt.
4. Enable the feature flag: in Debug > Feature Flag Overrides, enable `Sync > allowSingleDeviceOnConnectScreen`
5. With sync still disabled, head back to the Sync With Another Device screen. Ensure you do see the prompt.
6. Enable sync.
7. Now ensure the prompt is once again no longer visible.
8. Also, verify that the button performs the expected action.


### Impact and Risks

Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?

This simply hides an existing feature behind a feature flag, so minimal impact.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to feature-flag plumbing and conditional UI visibility, with no changes to sync data flow beyond checking whether an account is active.
> 
> **Overview**
> Adds a new sync subfeature/feature flag (`allowSingleDeviceOnConnectScreen`) and wires it through the macOS feature-flag system.
> 
> Updates sync settings controllers to compute and publish `shouldShowSingleDeviceSyncPromoOnSyncWithAnotherDeviceScreen`, so the “Sync & Backup This Device Only” promo on the “Sync With Another Device” dialog is shown **only** when the flag is enabled *and* sync is currently inactive, and is hidden once sync becomes active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29bff0717b2c91849a00c0c6a21bac052a75b31c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->