### PR TITLE
[iOS] Fix Duck.ai icons not animating on first UTI toggle

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -578,7 +578,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         isAwaitingTopOmnibarKeyboardPresentation = false
         displayState = .omnibar(.inactive)
         let renderState = computeRenderState()
-        viewController.apply(renderState.viewConfig, animated: false)
+        // Animated so a concurrent mode change doesn't get snapped to final layout non-animatedly.
+        viewController.apply(renderState.viewConfig, animated: true)
         contentViewController.setDismissButtonVisible(renderState.isFloatingDismissVisible)
         intentSubject.send(.showOmnibarInactive)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214237436720175

### Description

Fixes the Duck.ai icons (tools, attachments, model chip) snapping to their final position instead of revealing smoothly the very first time the user toggles from Search to Duck.ai inside the Unified Toggle Input.

Root cause: on the first toggle, a keyboard-visibility callback fires `transitionOmnibarToInactive`, which calls `viewController.apply(config, animated: false)`. The non-animated apply synchronously runs `layoutIfNeeded()`, committing the toolbar's height (0 → 56) and alpha (0 → 1) before the mode-change animation has a chance to start. The subsequent animated path has nothing left to interpolate. On 2nd+ toggles the display state is already `.inactive`, so the callback no-ops and the animation works as intended.

Fix: pass `animated: true` to `viewController.apply` in `transitionOmnibarToInactive` so a concurrent mode change interpolates smoothly instead of snapping. For the common case (keyboard dismissed without a pending mode change) this is a no-op because `setInputMode`/`setExpanded` guard on equality.

Before:
Uploading Simulator Screen Recording - iPhone 17 Pro - 2026-04-24 at 11.47.34.mov…

After:
Uploading Simulator Screen Recording - iPhone 17 Pro - 2026-04-24 at 12.18.18.mov…

### Testing Steps

1. Build and run iOS on a simulator or device.
2. Open a new tab so the omnibar is visible.
3. Tap the omnibar to open the Unified Toggle Input (UTI) with Search mode selected.
4. Tap the **Duck.ai** side of the toggle. **Expected:** the Duck.ai icons (attach, tools, model chip) fade/slide in smoothly as the toolbar row reveals — no snap.
5. Tap **Search** — icons should animate out smoothly.
6. Tap **Duck.ai** again — icons should animate in again, matching the first toggle's behaviour.
7. Dismiss the UTI (tap away or X), reopen it, and repeat steps 4–6 to confirm the first-toggle animation is consistent across sessions.
8. Regression check: with Duck.ai already open, tap away to dismiss the keyboard (card transitions to inactive state). Confirm the card dims/inactive appearance still works and nothing jumps.

### Impact and Risks

**Low.** The change is a one-line flip from `animated: false` to `animated: true` in `transitionOmnibarToInactive`, scoped to the UTI coordinator. For the common case (keyboard dismissed without a pending mode change) the animated apply is effectively a no-op because `setInputMode`/`setExpanded` guard on equality, `setInactiveCardAppearance` runs its own animation regardless, and `cardPosition`/margin bindings don't change between `.active` and `.inactive`. The only observable difference is when a mode change is in flight — which is exactly the bug being fixed.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to make `transitionOmnibarToInactive()` apply its view config with animation, affecting only the omnibar-to-inactive UI transition timing.
> 
> **Overview**
> Prevents the Unified Toggle Input from snapping to its final layout on the first toggle by making `transitionOmnibarToInactive()` call `viewController.apply(..., animated: true)`.
> 
> This ensures concurrent mode-change animations (e.g., first switch from Search to Duck.ai) interpolate smoothly instead of being pre-committed by a non-animated layout pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a542301af16e59763d5ec9eca207e15d6bbf3e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->