### PR TITLE
macOS: Fire tab suspension pixel when no tabs are eligible

### DIFF
--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabSuspensionService.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabSuspensionService.swift
@@ -158,6 +158,14 @@ final class TabSuspensionService {
 
         guard suspendedCount > 0 else {
             Logger.tabSuspension.info("No tabs were eligible for suspension")
+            pixelFiring?.fire(
+                TabSuspensionPixel.tabSuspension(
+                    trigger: .criticalMemoryPressure,
+                    tabsSuspended: 0,
+                    memoryReclaimedMB: 0
+                ),
+                frequency: .dailyAndCount
+            )
             return
         }
 

--- a/macOS/UnitTests/TabBar/ViewModel/TabSuspensionServiceTests.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabSuspensionServiceTests.swift
@@ -218,7 +218,7 @@ final class TabSuspensionServiceTests: XCTestCase {
         XCTAssertEqual(call?.pixel.parameters?["memory_reclaimed_mb"], "0")
     }
 
-    func testWhenNoTabsSuspended_ThenPixelIsNotFired() {
+    func testWhenNoTabsSuspended_ThenPixelIsFiredWithZeroCounts() {
         featureFlagger.enabledFeatureFlags = [.tabSuspension]
         // Tab selected 5 minutes ago — won't be suspended
         let tab = Tab(content: .url(.duckDuckGo, credential: nil, source: .link), extensionsBuilder: tabExtensionsBuilder, featureFlagger: featureFlagger, lastSelectedAt: now.addingTimeInterval(-5 * 60))
@@ -228,7 +228,13 @@ final class TabSuspensionServiceTests: XCTestCase {
 
         postMemoryPressure()
 
-        XCTAssertTrue(mockPixelFiring.fireCalls.isEmpty)
+        XCTAssertEqual(mockPixelFiring.fireCalls.count, 1)
+        let call = mockPixelFiring.fireCalls.first
+        XCTAssertEqual(call?.pixel.name, "m_mac_tab_suspension")
+        XCTAssertEqual(call?.pixel.parameters?["trigger"], "critical_memory_pressure")
+        XCTAssertEqual(call?.pixel.parameters?["tabs_suspended"], "0")
+        XCTAssertEqual(call?.pixel.parameters?["memory_reclaimed_mb"], "0")
+        XCTAssertEqual(call?.frequency, .dailyAndCount)
     }
 
     func testWhenFeatureFlagDisabled_ThenPixelIsNotFired() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214253708590584?focus=true

### Description

Fires the `m_mac_tab_suspension` pixel with `tabs_suspended=0` and `memory_reclaimed_mb=0` when a critical memory pressure event finds no tabs eligible for suspension. Previously the service returned silently on this path, so we had no visibility into how often suspension runs were no-ops.

### Testing Steps

1. Run the `TabSuspensionServiceTests` suite in the `Unit Tests` target — all 14 tests should pass, including the updated `testWhenNoTabsSuspended_ThenPixelIsFiredWithZeroCounts`.

### Impact and Risks

Low — telemetry-only addition on an existing code path. No user-facing behavior changes.

#### What could go wrong?

Zero-count pixels could skew trend analysis if consumers don't differentiate suspension runs that actually suspended tabs from runs that found nothing — the `tabs_suspended` parameter distinguishes these clearly. The pixel uses `.dailyAndCount` frequency, matching the existing non-zero case, so volume is capped.

### Quality Considerations

- Pixel is gated by the `.tabSuspension` feature flag via the early `isFeatureOn` check — disabled users still fire nothing.
- `tabs_suspended` and `memory_reclaimed_mb` values go through the same `MemoryReportingBuckets` bucketing as the non-zero case.

### Notes to Reviewer

None.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk telemetry-only change: adds an extra `PixelKit` fire on an existing early-return path and updates unit tests accordingly.
> 
> **Overview**
> When a critical memory pressure event finds **no eligible tabs to suspend**, `TabSuspensionService` now fires the `m_mac_tab_suspension` pixel with `tabs_suspended=0` and `memory_reclaimed_mb=0` (using `.dailyAndCount`) instead of returning silently.
> 
> Unit tests update the previous “no pixel fired” expectation to assert the new zero-count pixel payload and frequency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e2fd27ecec3781e13c9dc9e198f4259cac8fb2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->