### PR TITLE
iOS: Fix tools icon fading early on Duck.ai→Search transition

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIToolsController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIToolsController.swift
@@ -69,7 +69,7 @@ final class UTIToolsController {
         inputMode: TextEntryMode,
         modelStore: UTIModelStore
     ) -> Presentation {
-        guard canShowTools(displayState: displayState, inputMode: inputMode) else {
+        guard canShowTools(displayState: displayState) else {
             return .hidden
         }
 
@@ -83,12 +83,9 @@ final class UTIToolsController {
 
 private extension UTIToolsController {
 
-    func canShowTools(
-        displayState: UnifiedToggleInputDisplayState,
-        inputMode: TextEntryMode
-    ) -> Bool {
-        guard displayState != .hidden else { return false }
-        return inputMode == .aiChat
+    // Mode-gating lives at the toolbar-container level; toggling `isHidden` per-button would step-vanish before the toolbar's alpha fade completes.
+    func canShowTools(displayState: UnifiedToggleInputDisplayState) -> Bool {
+        return displayState != .hidden
     }
 
     func buildToolsMenu(

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIToolsController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIToolsController.swift
@@ -66,7 +66,6 @@ final class UTIToolsController {
 
     func presentation(
         displayState: UnifiedToggleInputDisplayState,
-        inputMode: TextEntryMode,
         modelStore: UTIModelStore
     ) -> Presentation {
         guard canShowTools(displayState: displayState) else {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -984,7 +984,6 @@ private extension UnifiedToggleInputCoordinator {
     func refreshToolsPresentation() {
         let presentation = toolsController.presentation(
             displayState: displayState,
-            inputMode: inputMode,
             modelStore: modelStore
         )
         let toolsMenu = presentation.toolsMenu.map { [weak self] menu in

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -860,6 +860,15 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         XCTAssertFalse(sut.viewController.isToolsButtonHidden)
     }
 
+    func test_toolsButton_staysUnhiddenAcrossSwitchToSearchMode_soItFadesWithTheToolbar() {
+        sut.showExpanded()
+        XCTAssertFalse(sut.viewController.isToolsButtonHidden)
+
+        sut.updateInputMode(.search, animated: true)
+
+        XCTAssertFalse(sut.viewController.isToolsButtonHidden)
+    }
+
     func test_toolsMenu_disablesWebSearchActionWhenModelDoesNotSupportIt() {
         mockPreferences.selectedModelId = "gpt-5"
         sut.modelStore.models = [makeModel(id: "gpt-5", access: true)]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214237436720200
CC: @aataraxiaa 

### Description

When swiping Duck.ai → Search, the **tools** icon was vanishing instantly while the other toolbar icons (attach, model chip, submit) faded out with the toolbar container.

Root cause: `UTIToolsController.canShowTools` gated visibility on `inputMode == .aiChat`, which on mode change triggered `toolsButton.isHidden = true` — a step change, not an animated fade. Every other toolbar icon rides the parent `toolsToolbar.alpha` animation and has no per-icon `isHidden` driver on mode change. Tools was the odd one out.

Fix: drop the `inputMode` gate from `canShowTools`. Mode-gating already lives at the toolbar-container level (alpha + height animate together for 0.2 s), so the tools button now rides the same parent fade as its siblings.

Before:
https://github.com/user-attachments/assets/123a4b71-370b-4de4-9989-3eff8602da64

After:
https://github.com/user-attachments/assets/74c71282-8717-4e21-a95c-245aa5912575

### Testing Steps

1. Expand the Duck.ai input (bottom or top position).
2. Swipe from Duck.ai → Search.
3. Verify the tools icon fades in lockstep with the attach / model-chip / submit icons instead of vanishing immediately.
4. Swipe back Search → Duck.ai and verify all icons reappear together.

### Impact and Risks

Low. Scoped to one predicate in `UTIToolsController`. All 157 `UnifiedToggleInputCoordinatorTests` pass; added `test_toolsButton_staysUnhiddenAcrossSwitchToSearchMode_soItFadesWithTheToolbar` as a regression guard.

#### What could go wrong?

In search mode the tools button is now `isHidden = false` but invisible (inside a toolbar with `alpha = 0` and `height = 0`). It isn't reachable or hit-testable while the toolbar is hidden, so no accessibility or interaction impact.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-behavior change limited to tools button visibility gating; adds a regression test to ensure the button remains unhidden during an animated switch to search mode.
> 
> **Overview**
> Prevents the tools button from being hidden immediately when switching input mode away from AI chat, so it fades out in sync with the rest of the toolbar during Duck.ai→Search transitions.
> 
> This removes `inputMode`-based gating from `UTIToolsController.presentation`/`canShowTools`, updates the coordinator call site accordingly, and adds a regression test ensuring `isToolsButtonHidden` stays `false` across an animated switch to `.search`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 719a14b3ecca3eb549a701c561134fdc943d8b9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->