### PR TITLE
Fix fire button for Duck.ai native storage

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatFeatureFlag.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatFeatureFlag.swift
@@ -22,4 +22,6 @@ public protocol AIChatFeatureFlagProviding {
     func isAIChatSyncEnabled() -> Bool
     func supportsSyncChatsDeletion() -> Bool
     func isNativeDataAccessEnabled() -> Bool
+    func isNativeDataStorageEnabled() -> Bool
+
 }

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/HistoryCleaner/HistoryCleaner.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/HistoryCleaner/HistoryCleaner.swift
@@ -77,7 +77,7 @@ public final class HistoryCleaner: HistoryCleaning {
     // MARK: - Local Storage Path
 
     private func clearLocalStorageIfAvailable(chatID: String?) -> Result<Void, Error>? {
-        guard let featureFlagProvider, featureFlagProvider.isNativeDataAccessEnabled(),
+        guard let featureFlagProvider, featureFlagProvider.isNativeDataStorageEnabled(),
               let nativeStorageHandler, (try? nativeStorageHandler.isMigrationDone()) == true else {
             return nil
         }

--- a/SharedPackages/AIChat/Tests/AIChatTests/HistoryCleanerTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/HistoryCleanerTests.swift
@@ -1,0 +1,283 @@
+//
+//  HistoryCleanerTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import DuckAiDataStore
+import PrivacyConfig
+import PrivacyConfigTestsUtils
+import WebKit
+import XCTest
+@testable import AIChat
+
+@MainActor
+final class HistoryCleanerTests: XCTestCase {
+
+    private var mockFeatureFlagger: MockFeatureFlagger!
+    private var mockFlagProvider: MockAIChatFeatureFlagProvider!
+    private var mockHandler: CallCountingStorageHandler!
+    private var mockPrivacyConfig: MockPrivacyConfigurationManager!
+
+    override func setUp() {
+        super.setUp()
+        mockFeatureFlagger = MockFeatureFlagger()
+        mockFlagProvider = MockAIChatFeatureFlagProvider()
+        mockHandler = CallCountingStorageHandler()
+        mockPrivacyConfig = MockPrivacyConfigurationManager()
+    }
+
+    override func tearDown() {
+        mockFeatureFlagger = nil
+        mockFlagProvider = nil
+        mockHandler = nil
+        mockPrivacyConfig = nil
+        super.tearDown()
+    }
+
+    private func makeSUT(
+        nativeStorageHandler: DuckAiNativeStorageHandling? = nil,
+        featureFlagProvider: AIChatFeatureFlagProviding? = nil
+    ) -> HistoryCleaner {
+        HistoryCleaner(
+            featureFlagger: mockFeatureFlagger,
+            privacyConfig: mockPrivacyConfig,
+            websiteDataStore: .nonPersistent(),
+            nativeStorageHandler: nativeStorageHandler,
+            featureFlagProvider: featureFlagProvider
+        )
+    }
+
+    // MARK: - cleanAIChatHistory (all chats)
+
+    func testWhenStorageFlagEnabledAndMigrationDoneThenCleanAIChatHistoryDeletesAllChatsAndFilesFromLocalStorage() async {
+        mockFlagProvider.isNativeDataStorageEnabledResult = true
+        mockHandler.stubbedIsMigrationDone = true
+        let sut = makeSUT(nativeStorageHandler: mockHandler, featureFlagProvider: mockFlagProvider)
+
+        let result = await sut.cleanAIChatHistory()
+
+        XCTAssertEqual(mockHandler.deleteAllChatsCallCount, 1)
+        XCTAssertEqual(mockHandler.deleteAllFilesCallCount, 1)
+        XCTAssertEqual(mockHandler.deleteChatCallCount, 0, "Single-chat delete should not be called for bulk clear")
+        XCTAssertEqual(mockHandler.deleteFileCallCount, 0, "Per-file delete should not be called for bulk clear")
+        XCTAssertNotNil(try? result.get(), "Expected success result, got \(result)")
+    }
+
+    func testWhenStorageFlagEnabledAndAccessFlagDisabledThenCleanAIChatHistoryStillUsesLocalStorage() async {
+        // Verifies the fix: the local-storage path is gated by isNativeDataStorageEnabled, not isNativeDataAccessEnabled.
+        mockFlagProvider.isNativeDataStorageEnabledResult = true
+        mockFlagProvider.isNativeDataAccessEnabledResult = false
+        mockHandler.stubbedIsMigrationDone = true
+        let sut = makeSUT(nativeStorageHandler: mockHandler, featureFlagProvider: mockFlagProvider)
+
+        let result = await sut.cleanAIChatHistory()
+
+        XCTAssertEqual(mockHandler.deleteAllChatsCallCount, 1)
+        XCTAssertEqual(mockHandler.deleteAllFilesCallCount, 1)
+        XCTAssertNotNil(try? result.get())
+    }
+
+    func testWhenStorageFlagDisabledButAccessFlagEnabledThenCleanAIChatHistoryDoesNotUseLocalStorage() {
+        // Regression guard for the pre-fix behavior: when only the access flag is on,
+        // local storage must NOT be cleared.
+        mockFlagProvider.isNativeDataStorageEnabledResult = false
+        mockFlagProvider.isNativeDataAccessEnabledResult = true
+        mockHandler.stubbedIsMigrationDone = true
+        let sut = makeSUT(nativeStorageHandler: mockHandler, featureFlagProvider: mockFlagProvider)
+
+        let deleteAllChatsNotCalled = expectation(description: "deleteAllChats should not be called")
+        deleteAllChatsNotCalled.isInverted = true
+        mockHandler.onDeleteAllChats = { deleteAllChatsNotCalled.fulfill() }
+
+        let task = Task { _ = await sut.cleanAIChatHistory() }
+
+        wait(for: [deleteAllChatsNotCalled], timeout: 0.5)
+        XCTAssertEqual(mockHandler.deleteAllChatsCallCount, 0)
+        XCTAssertEqual(mockHandler.deleteAllFilesCallCount, 0)
+
+        task.cancel()
+    }
+
+    func testWhenMigrationNotDoneThenCleanAIChatHistoryDoesNotUseLocalStorage() {
+        mockFlagProvider.isNativeDataStorageEnabledResult = true
+        mockHandler.stubbedIsMigrationDone = false
+        let sut = makeSUT(nativeStorageHandler: mockHandler, featureFlagProvider: mockFlagProvider)
+
+        let deleteAllChatsNotCalled = expectation(description: "deleteAllChats should not be called")
+        deleteAllChatsNotCalled.isInverted = true
+        mockHandler.onDeleteAllChats = { deleteAllChatsNotCalled.fulfill() }
+
+        let task = Task { _ = await sut.cleanAIChatHistory() }
+
+        wait(for: [deleteAllChatsNotCalled], timeout: 0.5)
+        XCTAssertEqual(mockHandler.deleteAllChatsCallCount, 0)
+
+        task.cancel()
+    }
+
+    func testWhenHandlerThrowsOnDeleteAllChatsThenCleanAIChatHistoryReturnsFailure() async {
+        mockFlagProvider.isNativeDataStorageEnabledResult = true
+        mockHandler.stubbedIsMigrationDone = true
+        let expectedError = NSError(domain: "test", code: 42)
+        mockHandler.stubbedDeleteAllChatsError = expectedError
+        let sut = makeSUT(nativeStorageHandler: mockHandler, featureFlagProvider: mockFlagProvider)
+
+        let result = await sut.cleanAIChatHistory()
+
+        guard case .failure(let error) = result else {
+            return XCTFail("Expected failure, got \(result)")
+        }
+        XCTAssertEqual(error as NSError, expectedError)
+        XCTAssertEqual(mockHandler.deleteAllFilesCallCount, 1, "Files should be cleared before chats")
+    }
+
+    // MARK: - deleteAIChat (single chat)
+
+    func testWhenStorageFlagEnabledAndMigrationDoneThenDeleteAIChatDeletesOnlyMatchingChatAndFiles() async {
+        mockFlagProvider.isNativeDataStorageEnabledResult = true
+        mockHandler.stubbedIsMigrationDone = true
+        mockHandler.stubbedFiles = [
+            DuckAiFileMetadata(uuid: "file-1", chatId: "target-chat", dataSize: 10),
+            DuckAiFileMetadata(uuid: "file-2", chatId: "other-chat", dataSize: 20),
+            DuckAiFileMetadata(uuid: "file-3", chatId: "target-chat", dataSize: 30)
+        ]
+        let sut = makeSUT(nativeStorageHandler: mockHandler, featureFlagProvider: mockFlagProvider)
+
+        let result = await sut.deleteAIChat(chatID: "target-chat")
+
+        XCTAssertNotNil(try? result.get())
+        XCTAssertEqual(mockHandler.deletedFileUUIDs, ["file-1", "file-3"], "Only files for target chat should be deleted")
+        XCTAssertEqual(mockHandler.deletedChatIDs, ["target-chat"], "Only target chat should be deleted")
+        XCTAssertEqual(mockHandler.deleteAllChatsCallCount, 0, "Bulk delete should not be called for single-chat delete")
+        XCTAssertEqual(mockHandler.deleteAllFilesCallCount, 0, "Bulk file delete should not be called for single-chat delete")
+    }
+
+    func testWhenDeleteAIChatWithNoMatchingFilesThenOnlyChatIsDeleted() async {
+        mockFlagProvider.isNativeDataStorageEnabledResult = true
+        mockHandler.stubbedIsMigrationDone = true
+        mockHandler.stubbedFiles = [
+            DuckAiFileMetadata(uuid: "file-1", chatId: "other-chat", dataSize: 10)
+        ]
+        let sut = makeSUT(nativeStorageHandler: mockHandler, featureFlagProvider: mockFlagProvider)
+
+        let result = await sut.deleteAIChat(chatID: "target-chat")
+
+        XCTAssertNotNil(try? result.get())
+        XCTAssertTrue(mockHandler.deletedFileUUIDs.isEmpty)
+        XCTAssertEqual(mockHandler.deletedChatIDs, ["target-chat"])
+    }
+
+    func testWhenDeleteAIChatAndListFilesThrowsThenFailureIsReturned() async {
+        mockFlagProvider.isNativeDataStorageEnabledResult = true
+        mockHandler.stubbedIsMigrationDone = true
+        let expectedError = NSError(domain: "test", code: 99)
+        mockHandler.stubbedListFilesError = expectedError
+        let sut = makeSUT(nativeStorageHandler: mockHandler, featureFlagProvider: mockFlagProvider)
+
+        let result = await sut.deleteAIChat(chatID: "target-chat")
+
+        guard case .failure(let error) = result else {
+            return XCTFail("Expected failure, got \(result)")
+        }
+        XCTAssertEqual(error as NSError, expectedError)
+        XCTAssertTrue(mockHandler.deletedChatIDs.isEmpty, "Chat should not be deleted when file listing fails")
+    }
+
+    func testWhenStorageFlagDisabledButAccessFlagEnabledThenDeleteAIChatDoesNotUseLocalStorage() {
+        mockFlagProvider.isNativeDataStorageEnabledResult = false
+        mockFlagProvider.isNativeDataAccessEnabledResult = true
+        mockHandler.stubbedIsMigrationDone = true
+        let sut = makeSUT(nativeStorageHandler: mockHandler, featureFlagProvider: mockFlagProvider)
+
+        let localPathNotUsed = expectation(description: "single-chat local delete should not run")
+        localPathNotUsed.isInverted = true
+        mockHandler.onDeleteChat = { _ in localPathNotUsed.fulfill() }
+
+        let task = Task { _ = await sut.deleteAIChat(chatID: "some-chat") }
+
+        wait(for: [localPathNotUsed], timeout: 0.5)
+        XCTAssertTrue(mockHandler.deletedChatIDs.isEmpty)
+
+        task.cancel()
+    }
+}
+
+// MARK: - Mock
+
+private final class CallCountingStorageHandler: DuckAiNativeStorageHandling {
+
+    var stubbedIsMigrationDone = false
+    var stubbedFiles: [DuckAiFileMetadata] = []
+    var stubbedListFilesError: Error?
+    var stubbedDeleteAllChatsError: Error?
+
+    var onDeleteAllChats: (() -> Void)?
+    var onDeleteChat: ((String) -> Void)?
+
+    private(set) var deleteAllChatsCallCount = 0
+    private(set) var deleteAllFilesCallCount = 0
+    private(set) var deleteChatCallCount = 0
+    private(set) var deleteFileCallCount = 0
+    private(set) var deletedChatIDs: [String] = []
+    private(set) var deletedFileUUIDs: [String] = []
+
+    func putEntry(key: String, value: Any) throws {}
+    func getEntry(key: String) throws -> Any? { nil }
+    func getAllEntries() throws -> [String: Any] { [:] }
+    func deleteEntry(key: String) throws {}
+    func deleteAllEntries() throws {}
+    func replaceAllEntries(_ entries: [String: Any]) throws {}
+
+    func putChat(chatId: String, data: Data) throws {}
+    func putChats(_ chats: [DuckAiChatRecord]) throws {}
+    func getChat(chatId: String) throws -> DuckAiChatRecord? { nil }
+    func getAllChats() throws -> [DuckAiChatRecord] { [] }
+
+    func deleteChat(chatId: String) throws {
+        deleteChatCallCount += 1
+        deletedChatIDs.append(chatId)
+        onDeleteChat?(chatId)
+    }
+
+    func deleteAllChats() throws {
+        deleteAllChatsCallCount += 1
+        onDeleteAllChats?()
+        if let error = stubbedDeleteAllChatsError { throw error }
+    }
+
+    func putFile(uuid: String, chatId: String, data: Data) throws {}
+    func getFile(uuid: String) throws -> DuckAiFileContent? { nil }
+
+    func listFiles() throws -> [DuckAiFileMetadata] {
+        if let error = stubbedListFilesError { throw error }
+        return stubbedFiles
+    }
+
+    func deleteFile(uuid: String) throws {
+        deleteFileCallCount += 1
+        deletedFileUUIDs.append(uuid)
+    }
+
+    func deleteFiles(chatId: String) throws {}
+
+    func deleteAllFiles() throws {
+        deleteAllFilesCallCount += 1
+    }
+
+    func isMigrationDone() throws -> Bool { stubbedIsMigrationDone }
+    func isMigrationDone(key: String) throws -> Bool { stubbedIsMigrationDone }
+    func markMigrationDone(key: String) throws {}
+}

--- a/SharedPackages/AIChat/Tests/AIChatTests/Mocks/MockAIChatFeatureFlagProvider.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/Mocks/MockAIChatFeatureFlagProvider.swift
@@ -22,6 +22,7 @@ final class MockAIChatFeatureFlagProvider: AIChatFeatureFlagProviding {
     var isAIChatSyncEnabledResult = true
     var supportsSyncChatsDeletionResult = true
     var isNativeDataAccessEnabledResult = false
+    var isNativeDataStorageEnabledResult = false
 
     func isAIChatSyncEnabled() -> Bool {
         return isAIChatSyncEnabledResult
@@ -33,5 +34,9 @@ final class MockAIChatFeatureFlagProvider: AIChatFeatureFlagProviding {
 
     func isNativeDataAccessEnabled() -> Bool {
         isNativeDataAccessEnabledResult
+    }
+
+    func isNativeDataStorageEnabled() -> Bool {
+        isNativeDataStorageEnabledResult
     }
 }

--- a/iOS/DuckDuckGo/AIChat/AIChatFeatureFlagProvider.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatFeatureFlagProvider.swift
@@ -40,4 +40,8 @@ struct AIChatFeatureFlagProvider: AIChatFeatureFlagProviding {
     func isNativeDataAccessEnabled() -> Bool {
         featureFlagger.isFeatureOn(for: FeatureFlag.aiChatNativeDataAccess)
     }
+
+    func isNativeDataStorageEnabled() -> Bool {
+        featureFlagger.isFeatureOn(for: FeatureFlag.aiChatNativeStorage)
+    }
 }

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -274,7 +274,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
             supportsOpenAIChatLink: defaults.supportsOpenAIChatLink,
             supportsAIChatSync: featureFlagger.isFeatureOn(.aiChatSync) && !fireMode,
             supportsMultipleContexts: supportsContextualMode && featureFlagger.isFeatureOn(.multiplePageContexts),
-            supportsNativeStorage: featureFlagger.isFeatureOn(.aiChatNativeStorage)
+            supportsNativeStorage: featureFlagger.isFeatureOn(.aiChatNativeStorage) && !fireMode
         )
     }
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -88,6 +88,42 @@ class AIChatUserScriptHandlerTests: XCTestCase {
         XCTAssertEqual(configValues?.supportsAIChatSync, false)
     }
     
+    func testWhenNativeStorageFeatureIsOnAndNotInFireModeThenSupportsNativeStorageIsTrue() {
+        // Given
+        mockFeatureFlagger.enabledFeatureFlags = [.aiChatNativeStorage]
+        aiChatUserScriptHandler.isFireModeProvider = { false }
+
+        // When
+        let configValues = aiChatUserScriptHandler.getAIChatNativeConfigValues(params: [], message: MockUserScriptMessage(name: "test", body: [:])) as? AIChatNativeConfigValues
+
+        // Then
+        XCTAssertEqual(configValues?.supportsNativeStorage, true)
+    }
+
+    func testWhenNativeStorageFeatureIsOnAndInFireModeThenSupportsNativeStorageIsFalse() {
+        // Given
+        mockFeatureFlagger.enabledFeatureFlags = [.aiChatNativeStorage]
+        aiChatUserScriptHandler.isFireModeProvider = { true }
+
+        // When
+        let configValues = aiChatUserScriptHandler.getAIChatNativeConfigValues(params: [], message: MockUserScriptMessage(name: "test", body: [:])) as? AIChatNativeConfigValues
+
+        // Then
+        XCTAssertEqual(configValues?.supportsNativeStorage, false)
+    }
+
+    func testWhenNativeStorageFeatureIsOffAndNotInFireModeThenSupportsNativeStorageIsFalse() {
+        // Given
+        mockFeatureFlagger.enabledFeatureFlags = []
+        aiChatUserScriptHandler.isFireModeProvider = { false }
+
+        // When
+        let configValues = aiChatUserScriptHandler.getAIChatNativeConfigValues(params: [], message: MockUserScriptMessage(name: "test", body: [:])) as? AIChatNativeConfigValues
+
+        // Then
+        XCTAssertEqual(configValues?.supportsNativeStorage, false)
+    }
+
     func testGetAIChatNativeConfigValuesWithFullModeFeatureAvailable() {
         // Given
         mockAIChatFullModeFeature.isAvailable = true

--- a/macOS/DuckDuckGo/AIChat/AIChatFeatureFlagProvider.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatFeatureFlagProvider.swift
@@ -39,4 +39,8 @@ struct AIChatFeatureFlagProvider: AIChatFeatureFlagProviding {
     func isNativeDataAccessEnabled() -> Bool {
         featureFlagger.isFeatureOn(.aiChatNativeDataAccess)
     }
+
+    func isNativeDataStorageEnabled() -> Bool {
+        featureFlagger.isFeatureOn(.aiChatNativeStorage)
+    }
 }

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
@@ -103,7 +103,7 @@ extension AIChatMessageHandler {
             supportsAIChatSync: featureFlagger.isFeatureOn(.aiChatSync) && !isFireWindow,
             supportsMultipleContexts: featureFlagger.isFeatureOn(.aiChatPageContext) && featureFlagger.isFeatureOn(.aiChatMultiplePageContexts),
             supportsTabPicker: featureFlagger.isFeatureOn(.aiChatPageContext) && featureFlagger.isFeatureOn(.aiChatAttachMoreTabs),
-            supportsNativeStorage: featureFlagger.isFeatureOn(.aiChatNativeStorage)
+            supportsNativeStorage: featureFlagger.isFeatureOn(.aiChatNativeStorage) && !isFireWindow
         )
     }
 

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -58,9 +58,6 @@ protocol AIChatUserScriptHandling: AnyObject {
 
     var messageHandling: AIChatMessageHandling { get }
 
-    /// Returns whether the current context is a fire window. Set by the owning tab
-    /// at wiring time — avoids walking the view hierarchy from a script message,
-    /// which is unreliable (webview may be detached, or hosted in a non-MainWindow).
     var isFireWindowProvider: (() -> Bool)? { get set }
 
     func submitAIChatNativePrompt(_ prompt: AIChatNativePrompt)

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -33,7 +33,7 @@ protocol AIChatMetricReportingHandling {
 }
 
 // swiftlint:disable inclusive_language
-protocol AIChatUserScriptHandling {
+protocol AIChatUserScriptHandling: AnyObject {
     @MainActor func openAIChatSettings(params: Any, message: UserScriptMessage) async -> Encodable?
     func getAIChatNativeConfigValues(params: Any, message: UserScriptMessage) async -> Encodable?
     func closeAIChat(params: Any, message: UserScriptMessage) async -> Encodable?

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -57,6 +57,12 @@ protocol AIChatUserScriptHandling {
     var syncStatusPublisher: AnyPublisher<AIChatSyncHandler.SyncStatus, Never> { get }
 
     var messageHandling: AIChatMessageHandling { get }
+
+    /// Returns whether the current context is a fire window. Set by the owning tab
+    /// at wiring time — avoids walking the view hierarchy from a script message,
+    /// which is unreliable (webview may be detached, or hosted in a non-MainWindow).
+    var isFireWindowProvider: (() -> Bool)? { get set }
+
     func submitAIChatNativePrompt(_ prompt: AIChatNativePrompt)
     func submitAIChatPageContext(_ pageContext: AIChatPageContextData?)
 
@@ -108,6 +114,8 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     private let freeTrialConversionService: FreeTrialConversionInstrumentationService
     private let migrationStore = AIChatMigrationStore()
 
+    var isFireWindowProvider: (() -> Bool)?
+
     init(
         storage: AIChatPreferencesStorage,
         messageHandling: AIChatMessageHandling = AIChatMessageHandler(),
@@ -152,7 +160,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     }
 
     public func getAIChatNativeConfigValues(params: Any, message: UserScriptMessage) async -> Encodable? {
-        let isFireWindow = await isFireWindowMessage(message)
+        let isFireWindow = isFireWindowProvider?() ?? false
         return messageHandling.getNativeConfigValues(isFireWindow: isFireWindow)
     }
 
@@ -623,15 +631,6 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
             return nil
         }
         return AIChatSyncHandler(sync: sync, httpRequestErrorHandler: syncErrorHandler.handleAiChatsError)
-    }
-
-    @MainActor
-    private func isFireWindowMessage(_ message: UserScriptMessage) -> Bool {
-        guard let windowController = message.messageWebView?.window?.windowController as? MainWindowController else {
-            return false
-        }
-
-        return windowController.mainViewController.isBurner
     }
 
     @MainActor

--- a/macOS/DuckDuckGo/Tab/TabExtensions/AIChatTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/AIChatTabExtension.swift
@@ -38,6 +38,7 @@ final class AIChatTabExtension {
     private var cancellables = Set<AnyCancellable>()
     private var userScriptCancellables = Set<AnyCancellable>()
     private let isLoadedInSidebar: Bool
+    private let isTabBurner: Bool
     private weak var webView: WKWebView?
     private let featureDiscovery: FeatureDiscovery
     private let featureFlagger: FeatureFlagger
@@ -52,11 +53,13 @@ final class AIChatTabExtension {
     init(scriptsPublisher: some Publisher<some AIChatUserScriptProvider, Never>,
          webViewPublisher: some Publisher<WKWebView, Never>,
          isLoadedInSidebar: Bool,
+         isTabBurner: Bool,
          featureDiscovery: FeatureDiscovery = DefaultFeatureDiscovery(),
          featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
          duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = NSApp.delegateTyped.duckAiNativeStorageHandler,
          aiChatDebugURLSettings: (any KeyedStoring<AIChatDebugURLSettings>)? = nil) {
         self.isLoadedInSidebar = isLoadedInSidebar
+        self.isTabBurner = isTabBurner
         self.featureDiscovery = featureDiscovery
         self.featureFlagger = featureFlagger
         let debugSettings: any KeyedStoring<AIChatDebugURLSettings> = if let aiChatDebugURLSettings { aiChatDebugURLSettings } else { UserDefaults.standard.keyedStoring() }
@@ -79,6 +82,9 @@ final class AIChatTabExtension {
             Task { @MainActor in
                 self?.aiChatUserScript = scripts.aiChatUserScript
                 self?.aiChatUserScript?.webView = self?.webView
+                if let isTabBurner = self?.isTabBurner {
+                    self?.aiChatUserScript?.handler.isFireWindowProvider = { isTabBurner }
+                }
 
                 // Pass the handoff payload in case it was provided before the user script was loaded
                 if let payload = self?.temporaryAIChatNativeHandoffData {

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
@@ -303,7 +303,8 @@ extension TabExtensionsBuilder {
         add {
             AIChatTabExtension(scriptsPublisher: userScripts.compactMap { $0 },
                                webViewPublisher: args.webViewFuture,
-                               isLoadedInSidebar: args.isTabLoadedInSidebar)
+                               isLoadedInSidebar: args.isTabLoadedInSidebar,
+                               isTabBurner: args.isTabBurner)
         }
 
         add {

--- a/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -112,6 +112,22 @@ struct AIChatUserScriptHandlerTests {
     }
 
     @available(iOS 16, macOS 13, *)
+    @Test("getAIChatNativeConfigValues propagates fire-window provider value", .timeLimit(.minutes(1)))
+    func testWhenFireWindowProviderReturnsTrueThenGetAIChatNativeConfigValuesPassesTrue() async {
+        handler.isFireWindowProvider = { true }
+        _ = await handler.getAIChatNativeConfigValues(params: [], message: WKScriptMessage.mock())
+        #expect(messageHandler.getNativeConfigValuesCalls == [true])
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("getAIChatNativeConfigValues defaults to false when no provider set", .timeLimit(.minutes(1)))
+    func testWhenFireWindowProviderIsNilThenGetAIChatNativeConfigValuesPassesFalse() async {
+        handler.isFireWindowProvider = nil
+        _ = await handler.getAIChatNativeConfigValues(params: [], message: WKScriptMessage.mock())
+        #expect(messageHandler.getNativeConfigValuesCalls == [false])
+    }
+
+    @available(iOS 16, macOS 13, *)
     @Test("getAIChatNativePrompt calls messageHandler", .timeLimit(.minutes(1)))
     func testThatGetAIChatNativePromptCallsMessageHandler() async {
         _ = await handler.getAIChatNativePrompt(params: [], message: WKScriptMessage.mock())

--- a/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
@@ -189,6 +189,7 @@ final class MockAIChatUserScriptHandler: AIChatUserScriptHandling {
     var didSendToSetupSync = false
 
     var messageHandling: any DuckDuckGo_Privacy_Browser.AIChatMessageHandling
+    var isFireWindowProvider: (() -> Bool)?
 
     init(messageHandling: any AIChatMessageHandling = MockAIChatMessageHandling()) {
         self.messageHandling = messageHandling


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214256154348503?focus=true
Tech Design URL:
CC:

### Description
Fixes the fire button / fire mode handling for Duck.ai: native storage is now disabled in fire windows and fire mode, and `HistoryCleaner` gates the local-storage delete path on `isNativeDataStorageEnabled` rather than `isNativeDataAccessEnabled` so the fire button actually wipes on-device chats. Also sources `isFireWindow` from the tab context instead of the view hierarchy and constrains `AIChatUserScriptHandling` to `AnyObject`.

### Testing Steps
1. Open a Fire Window/mode and load Duck.ai; confirm chats are not written to native storage while in the fire window.
2. In a regular window with native storage enabled, create a chat, then trigger the fire button and verify on-device chats and files are cleared.
3. Run the new `HistoryCleanerTests` in the AIChat package and confirm they pass.

### Impact and Risks
Medium

#### What could go wrong?
A mis-wired feature flag or tab-context lookup could cause Duck.ai chats to persist (or be cleared) against user expectation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fire-mode handling and feature-flag gating for Duck.ai native storage and history deletion, which could cause chats to persist or be cleared unexpectedly if wiring is wrong. Covered by new unit tests but impacts privacy-sensitive deletion behavior.
> 
> **Overview**
> Fixes Duck.ai *fire mode* behavior so native chat storage is **disabled in fire contexts** and on-device history clearing reliably wipes native-stored chats.
> 
> Adds a new `isNativeDataStorageEnabled` feature-flag API and updates `HistoryCleaner` to gate the local-storage deletion path on this storage flag (instead of native data access). Updates iOS and macOS user-script config to report `supportsNativeStorage` only when native storage is enabled **and not** in fire mode/window, and on macOS sources fire-window state from the tab (`AIChatTabExtension`) via an injected `isFireWindowProvider` rather than view-hierarchy lookup.
> 
> Adds focused test coverage for `HistoryCleaner` local-storage deletion behavior and for the fire-mode/window propagation affecting native storage support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e15ab3031f4cf9ab62ffe52d51fc502c57106f03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->