### PR TITLE
[iOS] [Hack Day] Swipe-to-twirl Dax on new tab page

### DIFF
--- a/iOS/DuckDuckGo/NewTabPageDaxLogoView.swift
+++ b/iOS/DuckDuckGo/NewTabPageDaxLogoView.swift
@@ -20,12 +20,15 @@
 import SwiftUI
 
 struct NewTabPageDaxLogoView: View {
+    var rotation: Angle = .zero
+
     var body: some View {
         VStack(spacing: 12) {
             Image(.home)
                 .resizable()
                 .aspectRatio(1, contentMode: .fit)
                 .frame(width: 96)
+                .rotationEffect(rotation)
             Image(.textDuckDuckGo)
         }
     }

--- a/iOS/DuckDuckGo/NewTabPageView.swift
+++ b/iOS/DuckDuckGo/NewTabPageView.swift
@@ -30,6 +30,8 @@ struct NewTabPageView: View {
     @ObservedObject private var messagesModel: NewTabPageMessagesModel
     @ObservedObject private var favoritesViewModel: FavoritesViewModel
 
+    @State private var daxRotation: Angle = .zero
+
     let isFocussedState: Bool
     let narrowLayoutInLandscape: Bool
     let dismissKeyboardOnScroll: Bool
@@ -66,6 +68,17 @@ struct NewTabPageView: View {
                             }
                         })
                         .onEnded({ _ in viewModel.endDragging() })
+                )
+                .simultaneousGesture(
+                    DragGesture()
+                        .onChanged { value in
+                            daxRotation = .degrees(value.translation.width * 1.2)
+                        }
+                        .onEnded { _ in
+                            withAnimation(.spring(response: 0.6, dampingFraction: 0.5)) {
+                                daxRotation = .zero
+                            }
+                        }
                 )
         }
     }
@@ -135,7 +148,7 @@ private extension NewTabPageView {
         GeometryReader { proxy in
             ZStack {
                 if shouldShowLogoInEmptyState {
-                    NewTabPageDaxLogoView()
+                    NewTabPageDaxLogoView(rotation: daxRotation)
                 }
 
                 ScrollView {


### PR DESCRIPTION
Task/Issue URL:
Tech Design URL:
CC:

### Description

Playful pilot: adds a swipe-to-twirl animation to the Dax logo on the new tab page empty state. Horizontal drag rotates the Dax image proportionally (1.2° per point of translation); releasing springs it back to upright with a bouncy animation.

Scope is intentionally narrow:
- Only affects the empty-state Dax logo (shown when no favorites are present and no home messages).
- The "DuckDuckGo" wordmark below the logo is unaffected.
- Implemented as a `simultaneousGesture`, so existing scrolling and the drag-tracked keyboard dismiss continue to work unchanged.

### Testing Steps

1. Check out this branch and run on an iOS simulator or device.
2. Open a new tab with no favorites saved and no home messages — the large Dax logo should appear.
3. Swipe horizontally anywhere on the screen — the Dax image should rotate proportionally while your finger moves.
4. Release — the Dax image should spring back to upright.
5. Confirm normal behaviors still work: scrolling the home page (with favorites/messages present), tapping favorites, tapping home messages, and the keyboard dismiss on scroll.


https://github.com/user-attachments/assets/9b5f3233-8065-4b01-9d22-04f7654ee154



### Impact and Risks

Low — visual-only change to one view on the new tab page. No new dependencies, no data access, no change to existing flows.

#### What could go wrong?

- **Gesture conflicts with scroll / existing drag**: mitigated by using `simultaneousGesture`, which coexists with the existing gesture that drives `viewModel.beginDragging/endDragging` and with the `ScrollView`.
- **Reduce Motion**: the current implementation does not check `@Environment(\.accessibilityReduceMotion)`. Acceptable for a pilot; would want to gate on that value before shipping broadly.

### Quality Considerations

- **Performance**: a single `rotationEffect` transform animated with SwiftUI's built-in spring — negligible cost.
- **Edge cases**: landscape / split view / small screens / Dark Mode / Dynamic Type — all unaffected since the change only adds a rotation transform to the existing Dax image.
- **Privacy/security**: none impacted.

### Notes to Reviewer

Playful exploration / pilot — not tied to a roadmap task. Looking for a quick "this is fun, keep iterating" vs "not worth it" gut-check rather than a rigorous review. If the rotation feel (speed / spring) needs tuning, the two knobs are the `1.2` multiplier in `NewTabPageView.swift` and the `.spring(response:dampingFraction:)` parameters on release.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)