### PR TITLE
Enable fireMode and fireButtonRefinements feature flags by default

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -653,9 +653,9 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .supportsSyncChatsDeletion:
             Config(source: .remoteReleasable(.subfeature(AIChatSubfeature.supportsSyncChatsDeletion)))
         case .fireMode:
-            Config(source: .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.fireMode)))
+            Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.fireMode)))
         case .fireButtonRefinements:
-            Config(source: .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.fireButtonRefinements)))
+            Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.fireButtonRefinements)))
         case .autoplayBlocking:
             Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(iOSBrowserConfigSubfeature.autoplayBlocking)))
         case .simplifiedSyncSetupExperiment:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1214266220678879?focus=true
Tech Design URL: N/A
CC: N/A

### Description
- Set `defaultValue: .enabled` for the `fireMode` feature flag
- Set `defaultValue: .enabled` for the `fireButtonRefinements` feature flag
- Both flags remain remotely controllable via privacy config; this only changes the local fallback when the remote subfeature value is unavailable

### Testing Steps
1. Build and run the iOS app on a clean install (no privacy config fetched yet, e.g. airplane mode on first launch).
2. Verify the new fire mode UI / fire button refinements are active immediately, without waiting for a privacy config fetch.
3. Toggle the `fireMode` and `fireButtonRefinements` subfeatures off via privacy config (or internal debug menu) and confirm both features can still be remotely disabled.
4. Toggle them back on and confirm the features re-enable.

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- A user on a build that hasn't yet fetched the remote privacy config will now see the new fire mode behavior by default. Mitigation: flag is already set to be internal only before the code freeze.

### Quality Considerations
- No new code paths introduced — only default values changed.
- Pattern matches the existing `autoplayBlocking` flag in the same file.
- No privacy/security implications: no new data collection or network behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes local fallback defaults for two feature flags; remote privacy config can still disable them if needed.
> 
> **Overview**
> **Enables the `fireMode` and `fireButtonRefinements` feature flags by default** by setting `defaultValue: .enabled` in `FeatureFlag.swift`.
> 
> Both flags remain *remotely releasable* via the existing privacy config source; this change only affects behavior before a remote config value is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d452b372c7b577bd1ba83007acb275e2763e20a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->