### PR TITLE
Add experiment pixels for simplified sync setup

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncConnectionController.swift
@@ -293,6 +293,8 @@ public class SyncConnectionController: SyncConnectionControlling {
                 try await syncService.transmitExchangeRecoveryKey(for: exchangeMessage)
             } catch {
                 await delegate?.controllerDidError(.failedToTransmitExchangeRecoveryKey, underlyingError: error, setupRole: .sharer)
+                (await state.getExchanger())?.stopPolling()
+                return
             }
 
             delegate?.controllerDidFinishTransmittingRecoveryKey()

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncConnectionControllerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncConnectionControllerTests.swift
@@ -218,6 +218,33 @@ final class SyncConnectionControllerTests: XCTestCase {
         XCTAssertEqual(error, SyncConnectionError.failedToTransmitExchangeRecoveryKey)
     }
 
+    @MainActor
+    func test_startExchangeMode_recoveryKeyTransmitFails_doesNotNotifyFinish() async throws {
+        let remoteExchanger = MockRemoteKeyExchanging()
+        givenExchangerPollForPublicKeySucceeds(remoteExchanger)
+
+        let exchangeRecoveryKeyTransmitter = MockExchangeRecoveryKeyTransmitting()
+        exchangeRecoveryKeyTransmitter.sendError = SyncError.unableToDecodeResponse("")
+        dependencies.createExchangeRecoveryKeyTransmitterStub = exchangeRecoveryKeyTransmitter
+
+        let didErrorExpectation = expectation(description: "Delegate receives transmit error")
+        delegate.didErrorCalled = {
+            didErrorExpectation.fulfill()
+        }
+
+        let didFinishExpectation = expectation(description: "Delegate should not report transmit success")
+        didFinishExpectation.isInverted = true
+        delegate.didFinishTransmittingRecoveryKeyCalled = {
+            didFinishExpectation.fulfill()
+        }
+
+        _ = try await controller.startExchangeMode()
+
+        await fulfillment(of: [didErrorExpectation, didFinishExpectation], timeout: 1.0)
+        XCTAssertEqual(delegate.didErrorErrors?.error, .failedToTransmitExchangeRecoveryKey)
+        XCTAssertEqual(remoteExchanger.stopPollingCalled, 1)
+    }
+
     private func givenExchangerPollForPublicKeySucceeds(_ exchanger: MockRemoteKeyExchanging = MockRemoteKeyExchanging()) {
         let expectedMessage = ExchangeMessage(keyId: "keyID", publicKey: .init(), deviceName: "")
         exchanger.pollForPublicKeyResult = expectedMessage

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -2185,6 +2185,7 @@
 		ED3811FB2F3F362700F0D0DD /* MockAutofillOnboardingExperimentPixelFiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3811FA2F3F362700F0D0DD /* MockAutofillOnboardingExperimentPixelFiring.swift */; };
 		ED48ED462F3CC88400FBAFFF /* AutofillOnboardingExperimentPixels.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED48ED452F3CC88400FBAFFF /* AutofillOnboardingExperimentPixels.swift */; };
 		ED4B3F3D2F191E5F006C5FE4 /* PrivacyConfig in Frameworks */ = {isa = PBXBuildFile; productRef = ED4B3F3C2F191E5F006C5FE4 /* PrivacyConfig */; };
+		EDDEC0152F99679E00FBE920 /* SyncSetupExperimentPixels.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDEC0142F99679E00FBE920 /* SyncSetupExperimentPixels.swift */; };
 		EE00D2D72DFB2D4900B79E9D /* AutofillUsageStore+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00D2D62DFB2D4000B79E9D /* AutofillUsageStore+App.swift */; };
 		EE00D2D82DFC3A3300B79E9D /* UserDefaults+Autofill.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00D2D32DFB295000B79E9D /* UserDefaults+Autofill.swift */; };
 		EE0153E12A6EABE0002A8B26 /* NetworkProtectionConvenienceInitialisers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0153E02A6EABE0002A8B26 /* NetworkProtectionConvenienceInitialisers.swift */; };
@@ -4762,6 +4763,7 @@
 		ED3811FA2F3F362700F0D0DD /* MockAutofillOnboardingExperimentPixelFiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAutofillOnboardingExperimentPixelFiring.swift; sourceTree = "<group>"; };
 		ED48ED452F3CC88400FBAFFF /* AutofillOnboardingExperimentPixels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillOnboardingExperimentPixels.swift; sourceTree = "<group>"; };
 		EDB06E4C5FAE7E6BC7CDC6CC /* RebrandedOnboardingView+AppIconPickerContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "RebrandedOnboardingView+AppIconPickerContent.swift"; sourceTree = "<group>"; };
+		EDDEC0142F99679E00FBE920 /* SyncSetupExperimentPixels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncSetupExperimentPixels.swift; sourceTree = "<group>"; };
 		EE00D2D32DFB295000B79E9D /* UserDefaults+Autofill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Autofill.swift"; sourceTree = "<group>"; };
 		EE00D2D62DFB2D4000B79E9D /* AutofillUsageStore+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AutofillUsageStore+App.swift"; sourceTree = "<group>"; };
 		EE0153E02A6EABE0002A8B26 /* NetworkProtectionConvenienceInitialisers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionConvenienceInitialisers.swift; sourceTree = "<group>"; };
@@ -7554,6 +7556,7 @@
 		85F98F8C296F0ED100742F4A /* Sync */ = {
 			isa = PBXGroup;
 			children = (
+				EDDEC0142F99679E00FBE920 /* SyncSetupExperimentPixels.swift */,
 				37DF000929F9C416002B7D3E /* SyncMetadataDatabase.swift */,
 				37CBCA9D2A8A659C0050218F /* SyncSettingsAdapter.swift */,
 				372A0FEF2B2389590033BF7F /* SyncMetricsEventsHandler.swift */,
@@ -12038,6 +12041,7 @@
 				CBAD0F3B2D02EE5B006267B8 /* IdleReturnCohort.swift in Sources */,
 				80A09D522F6B854400AACDEE /* URLCacheFireWorker.swift in Sources */,
 				CBAD0F2D2D02EE50006267B8 /* IdleReturnEligibilityManager.swift in Sources */,
+				EDDEC0152F99679E00FBE920 /* SyncSetupExperimentPixels.swift in Sources */,
 				2CCD716C578642B8BC760D55 /* NTPAfterIdleInstrumentation.swift in Sources */,
 				CBAD0F252D02EE49006267B8 /* LastBackgroundDateStore.swift in Sources */,
 				CB3C788A2D06D3A700A7E4ED /* Background.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -2182,6 +2182,7 @@
 		EA90A5267F61028E3525A81E /* RebrandedAppIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D67C082BD4927358D771DB /* RebrandedAppIconPicker.swift */; };
 		EAB19EDA268963510015D3EA /* DomainMatchingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB19ED9268963510015D3EA /* DomainMatchingTests.swift */; };
 		EB636BDE30C2031DD6A90899 /* StartupOnboardingCover.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD8CF8E4B152CDB3A4ACB14C /* StartupOnboardingCover.swift */; };
+		ED225CE02F9FCBA500B6E6CB /* MockSyncSetupExperimentPixelFiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED225CDF2F9FCBA500B6E6CB /* MockSyncSetupExperimentPixelFiring.swift */; };
 		ED3811FB2F3F362700F0D0DD /* MockAutofillOnboardingExperimentPixelFiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3811FA2F3F362700F0D0DD /* MockAutofillOnboardingExperimentPixelFiring.swift */; };
 		ED48ED462F3CC88400FBAFFF /* AutofillOnboardingExperimentPixels.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED48ED452F3CC88400FBAFFF /* AutofillOnboardingExperimentPixels.swift */; };
 		ED4B3F3D2F191E5F006C5FE4 /* PrivacyConfig in Frameworks */ = {isa = PBXBuildFile; productRef = ED4B3F3C2F191E5F006C5FE4 /* PrivacyConfig */; };
@@ -4760,6 +4761,7 @@
 		EA39B7E1268A1A35000C62CD /* privacy-reference-tests */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = folder; name = "privacy-reference-tests"; path = "../SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Resources/privacy-reference-tests"; sourceTree = SOURCE_ROOT; };
 		EA8E5DCD620608EB3A162D3D /* AIChatTabChatHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabChatHeaderView.swift; sourceTree = "<group>"; };
 		EAB19ED9268963510015D3EA /* DomainMatchingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainMatchingTests.swift; sourceTree = "<group>"; };
+		ED225CDF2F9FCBA500B6E6CB /* MockSyncSetupExperimentPixelFiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSyncSetupExperimentPixelFiring.swift; sourceTree = "<group>"; };
 		ED3811FA2F3F362700F0D0DD /* MockAutofillOnboardingExperimentPixelFiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAutofillOnboardingExperimentPixelFiring.swift; sourceTree = "<group>"; };
 		ED48ED452F3CC88400FBAFFF /* AutofillOnboardingExperimentPixels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillOnboardingExperimentPixels.swift; sourceTree = "<group>"; };
 		EDB06E4C5FAE7E6BC7CDC6CC /* RebrandedOnboardingView+AppIconPickerContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "RebrandedOnboardingView+AppIconPickerContent.swift"; sourceTree = "<group>"; };
@@ -6356,6 +6358,7 @@
 		569437222BDD402600C0881B /* Sync */ = {
 			isa = PBXGroup;
 			children = (
+				ED225CDF2F9FCBA500B6E6CB /* MockSyncSetupExperimentPixelFiring.swift */,
 				569437232BDD405400C0881B /* SyncBookmarksAdapterTests.swift */,
 				569437282BDD487600C0881B /* SyncCredentialsAdapterTests.swift */,
 				C1D3C56C2E895B820086A2BD /* SyncCreditCardsAdapterTests.swift */,
@@ -13277,6 +13280,7 @@
 				98E564A22DE8EDCE00E6E75F /* CapturingSyncPausedStateManager.swift in Sources */,
 				9FE7CD5C2E14C6CD006691AB /* DefaultBrowserPromptUserActivityManagerTests.swift in Sources */,
 				9F387DDA2EA87C0F006861F8 /* PromptCooldownManagerTests.swift in Sources */,
+				ED225CE02F9FCBA500B6E6CB /* MockSyncSetupExperimentPixelFiring.swift in Sources */,
 				98E563F72DE8B32D00E6E75F /* OnboardingHostingControllerMock.swift in Sources */,
 				BBFF22EF2F3469160055A710 /* MockFreeTrialConversionInstrumentationService.swift in Sources */,
 				98E563F82DE8B32D00E6E75F /* MockOmniBar.swift in Sources */,

--- a/iOS/DuckDuckGo/SyncSettingsViewController+PDFRendering.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+PDFRendering.swift
@@ -89,14 +89,7 @@ extension SyncSettingsViewController {
             guard case .copyToPasteboard = activity, didComplete else {
                 return
             }
-            guard let code = try? SyncCode.decodeBase64String(code) else {
-                return
-            }
-            if code.connect != nil {
-                Pixel.fire(pixel: .syncSetupBarcodeCodeCopied, withAdditionalParameters: [PixelParameters.source: SyncSetupSource.connect.rawValue])
-            } else if code.exchangeKey != nil {
-                Pixel.fire(pixel: .syncSetupBarcodeCodeCopied, withAdditionalParameters: [PixelParameters.source: SyncSetupSource.exchange.rawValue])
-            }
+            self.fireBarcodeCodeCopiedPixel(for: code)
         }
     }
 

--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -179,6 +179,8 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                     try await self.syncService.createAccount(deviceName: self.deviceName, deviceType: self.deviceType)
                     let additionalParameters = self.source.map { ["source": $0] } ?? [:]
                     try await Pixel.fire(pixel: .syncSignupDirect, withAdditionalParameters: additionalParameters, includedParameters: [.appVersion])
+                    self.syncSetupExperimentPixels.fireSignupDirect()
+                    self.syncSetupExperimentPixels.fireSetupEndedSuccessful()
                     AutofillOnboardingExperimentPixelReporter().fireSyncEnabled(true)
                     self.viewModel.syncEnabled(recoveryCode: self.recoveryCode)
                     self.refreshDevices()
@@ -200,6 +202,8 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                 try await self.syncService.createAccount(deviceName: self.deviceName, deviceType: self.deviceType)
                 let additionalParameters = self.source.map { ["source": $0] } ?? [:]
                 try await Pixel.fire(pixel: .syncSignupDirect, withAdditionalParameters: additionalParameters, includedParameters: [.appVersion])
+                self.syncSetupExperimentPixels.fireSignupDirect()
+                self.syncSetupExperimentPixels.fireSetupEndedSuccessful()
                 AutofillOnboardingExperimentPixelReporter().fireSyncEnabled(true)
                 optionsViewModel.syncEnabled(recoveryCode: self.recoveryCode)
                 self.enableAutoRestoreByDefaultIfNeeded()
@@ -660,6 +664,7 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
             if let onPresentPixelInfo {
                 let pixelSource = self.source ?? onPresentPixelInfo.source.rawValue
                 Pixel.fire(onPresentPixelInfo.pixel, withAdditionalParameters: [PixelParameters.source: pixelSource])
+                self.syncSetupExperimentPixels.fireBarcodeScreenShown()
             }
         }
     }
@@ -692,6 +697,7 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                     do {
                         try await self.syncService.disconnect()
                         Pixel.fire(pixel: .syncDisabled)
+                        self.syncSetupExperimentPixels.fireSyncDisabled()
                         AutofillOnboardingExperimentPixelReporter().fireSyncEnabled(false)
                         self.viewModel.isSyncEnabled = false
                         self.syncPausedStateManager.syncDidTurnOff()
@@ -727,6 +733,7 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                     do {
                         try await self.syncService.disconnect()
                         Pixel.fire(pixel: .syncDisabled)
+                        self.syncSetupExperimentPixels.fireSyncDisabled()
                         AutofillOnboardingExperimentPixelReporter().fireSyncEnabled(false)
                         self.syncPausedStateManager.syncDidTurnOff()
                         continuation.resume(returning: true)
@@ -756,6 +763,7 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                     do {
                         try await self?.syncService.deleteAccount()
                         Pixel.fire(pixel: .syncDisabledAndDeleted, withAdditionalParameters: [PixelParameters.connectedDevices: "\(deviceCount)"])
+                        self?.syncSetupExperimentPixels.fireSyncDisabledAndDeleted()
                         AutofillOnboardingExperimentPixelReporter().fireSyncEnabled(false)
                         self?.viewModel.isSyncEnabled = false
                         self?.syncPausedStateManager.syncDidTurnOff()
@@ -801,9 +809,11 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
 
     func codeEntryScreenShown() {
         Pixel.fire(pixel: .syncSetupManualCodeEntryScreenShown, includedParameters: [.appVersion])
+        syncSetupExperimentPixels.fireManualCodeEntryScreenShown()
     }
 
-    func codeCopied() {
+    func codeCopied(_ code: String) {
+        fireBarcodeCodeCopiedPixel(for: code)
         ActionMessageView.present(message: UserText.simplifiedCodeCopiedToast)
     }
 

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -99,6 +99,7 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
     var onConfirmAndDeleteAllData: (() -> Void)?
 
     let useSimplifiedLayout: Bool
+    let syncSetupExperimentPixels: SyncSetupExperimentPixelFiring
 
     // For some reason, on iOS 14, the viewDidLoad wasn't getting called so do some setup here
     init(
@@ -112,7 +113,8 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
         pairingInfo: PairingInfo? = nil,
         featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
         syncAutoRestoreHandler: SyncAutoRestoreHandling,
-        syncSettingsStore: KeyValueStoring = UserDefaults.standard
+        syncSettingsStore: KeyValueStoring = UserDefaults.standard,
+        syncSetupExperimentPixels: SyncSetupExperimentPixelFiring = SyncSetupExperimentPixelReporter()
     ) {
         self.syncService = syncService
         self.syncBookmarksAdapter = syncBookmarksAdapter
@@ -124,6 +126,7 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
         self.featureFlagger = featureFlagger
         self.syncAutoRestoreHandler = syncAutoRestoreHandler
         self.syncSettingsStore = syncSettingsStore
+        self.syncSetupExperimentPixels = syncSetupExperimentPixels
 
         let viewModel = SyncSettingsViewModel(
             isOnDevEnvironment: { syncService.serverEnvironment == .development },
@@ -433,11 +436,13 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
     private func handlePairingConfirmation() {
         askForAuthThenStartPairing()
         Pixel.fire(pixel: .syncSetupDeepLinkFlowStarted, includedParameters: [.appVersion])
+        syncSetupExperimentPixels.fireDeepLinkFlowStarted()
     }
 
     private func handlePairingCancellation() {
         pairingInfo = nil
         Pixel.fire(pixel: .syncSetupDeepLinkFlowAbandoned, includedParameters: [.appVersion])
+        syncSetupExperimentPixels.fireDeepLinkFlowAbandoned()
     }
 }
 
@@ -467,6 +472,7 @@ extension SyncSettingsViewController: ScanOrPasteCodeViewModelDelegate {
         let registeredDevices = try await syncService.login(recoveryKey, deviceName: deviceName, deviceType: deviceType)
         mapDevices(registeredDevices)
         Pixel.fire(pixel: .syncLogin, includedParameters: [.appVersion])
+        syncSetupExperimentPixels.fireLogin()
         AutofillOnboardingExperimentPixelReporter().fireSyncEnabled(true)
         presentSyncCompletionAfterDelay()
     }
@@ -534,6 +540,7 @@ extension SyncSettingsViewController: ScanOrPasteCodeViewModelDelegate {
         autoRestorePromptSource = nil
         dismissPresentedViewController()
         Pixel.fire(pixel: .syncSetupEndedAbandoned)
+        syncSetupExperimentPixels.fireSetupEndedAbandoned()
     }
 
     func gotoSettings() {
@@ -565,6 +572,7 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
     func controllerDidCreateSyncAccount() {
         let additionalParameters = source.map { ["source": $0] } ?? [:]
         Pixel.fire(pixel: .syncSignupConnect, withAdditionalParameters: additionalParameters, includedParameters: [.appVersion])
+        syncSetupExperimentPixels.fireSignupConnect()
         AutofillOnboardingExperimentPixelReporter().fireSyncEnabled(true)
         if useSimplifiedLayout {
             dismissVCAndShowDeviceSyncedToast()
@@ -580,6 +588,7 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
     }
     
     func controllerDidFinishTransmittingRecoveryKey() {
+        syncSetupExperimentPixels.fireSetupEndedSuccessful()
         dismissPresentedViewController()
     }
     
@@ -609,6 +618,7 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
     func controllerDidCompleteLogin(registeredDevices: [RegisteredDevice], isRecovery _: Bool, setupRole: SyncSetupRole) {
         mapDevices(registeredDevices)
         Pixel.fire(pixel: .syncLogin, includedParameters: [.appVersion])
+        syncSetupExperimentPixels.fireLogin()
         AutofillOnboardingExperimentPixelReporter().fireSyncEnabled(true)
         presentSyncCompletionAfterDelay()
         guard case .receiver(let syncSetupSource, let syncCodeSource) = setupRole else {
@@ -624,12 +634,27 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
             sendCodeParsingFailedPixel(setupRole: setupRole)
             await handleError(.unableToRecognizeCode, error: underlyingError, event: nil)
         case .failedToFetchPublicKey, .failedToTransmitExchangeRecoveryKey, .failedToFetchConnectRecoveryKey, .failedToLogIn, .failedToTransmitExchangeKey, .failedToFetchExchangeRecoveryKey, .failedToTransmitConnectRecoveryKey:
+            fireCodeHandlingFailedExperimentPixel(setupRole: setupRole)
             await handleError(.unableToSyncWithDevice, error: underlyingError, event: .syncLoginError)
         case .failedToCreateAccount:
             await handleError(.unableToSyncWithDevice, error: underlyingError, event: .syncSignupError)
         case .pollingForRecoveryKeyTimedOut:
             dismissPresentedViewController()
             handleRecoveryKeyPollingTimeout(setupRole: setupRole)
+        }
+
+        syncSetupExperimentPixels.fireSetupEndedAbandoned()
+    }
+
+    private func fireCodeHandlingFailedExperimentPixel(setupRole: SyncSetupRole) {
+        guard case .receiver(_, let codeSource) = setupRole else { return }
+        switch codeSource {
+        case .qrCode:
+            syncSetupExperimentPixels.fireBarcodeScannerFailed()
+        case .pastedCode:
+            syncSetupExperimentPixels.fireManualCodeEnteredFailed()
+        case .deepLink:
+            syncSetupExperimentPixels.fireDeepLinkFlowAbandoned()
         }
     }
 
@@ -639,8 +664,10 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         switch codeSource {
         case .qrCode:
             Pixel.fire(pixel: .syncSetupBarcodeScannerSuccess, withAdditionalParameters: parameters, includedParameters: [.appVersion])
+            syncSetupExperimentPixels.fireBarcodeScannerSuccess()
         case .pastedCode:
             Pixel.fire(pixel: .syncSetupManualCodeEnteredSuccess, withAdditionalParameters: parameters, includedParameters: [.appVersion])
+            syncSetupExperimentPixels.fireManualCodeEnteredSuccess()
         case .deepLink:
             break
         }
@@ -654,8 +681,10 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         switch codeSource {
         case .qrCode:
             Pixel.fire(pixel: .syncSetupBarcodeScannerFailed, includedParameters: [.appVersion])
+            syncSetupExperimentPixels.fireBarcodeScannerFailed()
         case .pastedCode:
             Pixel.fire(pixel: .syncSetupManualCodeEnteredFailed, includedParameters: [.appVersion])
+            syncSetupExperimentPixels.fireManualCodeEnteredFailed()
         case .deepLink:
             break
         }
@@ -667,9 +696,24 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         switch codeSource {
         case .pastedCode, .qrCode:
             Pixel.fire(pixel: .syncSetupEndedSuccessful, withAdditionalParameters: parameters, includedParameters: [.appVersion])
+            syncSetupExperimentPixels.fireSetupEndedSuccessful()
         case .deepLink:
             Pixel.fire(pixel: .syncSetupDeepLinkFlowSuccess, includedParameters: [.appVersion])
+            syncSetupExperimentPixels.fireDeepLinkFlowSuccess()
         }
+    }
+
+    func fireBarcodeCodeCopiedPixel(for code: String) {
+        guard let decoded = try? SyncCode.decodeBase64String(code) else { return }
+        let source: SyncSetupSource
+        if decoded.connect != nil {
+            source = .connect
+        } else if decoded.exchangeKey != nil {
+            source = .exchange
+        } else {
+            return
+        }
+        syncSetupExperimentPixels.fireBarcodeCodeCopied()
     }
 
     private func handleRecoveryKeyPollingTimeout(setupRole: SyncSetupRole) {
@@ -680,6 +724,7 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
             return
         }
         Pixel.fire(pixel: .syncSetupDeepLinkFlowTimeout, includedParameters: [.appVersion])
+        syncSetupExperimentPixels.fireDeepLinkTimeout()
     }
 }
 

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -713,6 +713,8 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         } else {
             return
         }
+        Pixel.fire(pixel: .syncSetupBarcodeCodeCopied,
+                   withAdditionalParameters: [PixelParameters.source: source.rawValue])
         syncSetupExperimentPixels.fireBarcodeCodeCopied()
     }
 

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -443,6 +443,7 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
         pairingInfo = nil
         Pixel.fire(pixel: .syncSetupDeepLinkFlowAbandoned, includedParameters: [.appVersion])
         syncSetupExperimentPixels.fireDeepLinkFlowAbandoned()
+        syncSetupExperimentPixels.fireSetupEndedAbandoned()
     }
 }
 
@@ -551,8 +552,17 @@ extension SyncSettingsViewController: ScanOrPasteCodeViewModelDelegate {
 }
 
 extension SyncSettingsViewController: SyncConnectionControllerDelegate {
+
+    enum SyncSetupSuccessOutcome {
+        case directEnable
+        case thisDeviceSyncEnabledViaConnect
+        case loginCompleted(setupRole: SyncSetupRole)
+    }
     
     func controllerDidCompleteAccountConnection(shouldShowSyncEnabled: Bool, setupSource: SyncSetupSource, codeSource: SyncCodeSource) {
+        if !shouldShowSyncEnabled {
+            handleSuccessfulSetupOutcome(.thisDeviceSyncEnabledViaConnect)
+        }
         sendSetupEndedSuccessfullyPixel(setupSource: setupSource, codeSource: codeSource)
         guard shouldShowSyncEnabled else { return }
         self.viewModel.$devices
@@ -573,6 +583,7 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         let additionalParameters = source.map { ["source": $0] } ?? [:]
         Pixel.fire(pixel: .syncSignupConnect, withAdditionalParameters: additionalParameters, includedParameters: [.appVersion])
         syncSetupExperimentPixels.fireSignupConnect()
+
         AutofillOnboardingExperimentPixelReporter().fireSyncEnabled(true)
         if useSimplifiedLayout {
             dismissVCAndShowDeviceSyncedToast()
@@ -588,7 +599,6 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
     }
     
     func controllerDidFinishTransmittingRecoveryKey() {
-        syncSetupExperimentPixels.fireSetupEndedSuccessful()
         dismissPresentedViewController()
     }
     
@@ -619,6 +629,7 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         mapDevices(registeredDevices)
         Pixel.fire(pixel: .syncLogin, includedParameters: [.appVersion])
         syncSetupExperimentPixels.fireLogin()
+        handleSuccessfulSetupOutcome(.loginCompleted(setupRole: setupRole))
         AutofillOnboardingExperimentPixelReporter().fireSyncEnabled(true)
         presentSyncCompletionAfterDelay()
         guard case .receiver(let syncSetupSource, let syncCodeSource) = setupRole else {
@@ -696,10 +707,26 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         switch codeSource {
         case .pastedCode, .qrCode:
             Pixel.fire(pixel: .syncSetupEndedSuccessful, withAdditionalParameters: parameters, includedParameters: [.appVersion])
-            syncSetupExperimentPixels.fireSetupEndedSuccessful()
         case .deepLink:
             Pixel.fire(pixel: .syncSetupDeepLinkFlowSuccess, includedParameters: [.appVersion])
             syncSetupExperimentPixels.fireDeepLinkFlowSuccess()
+        }
+    }
+
+    func handleSuccessfulSetupOutcome(_ outcome: SyncSetupSuccessOutcome) {
+        switch outcome {
+        case .directEnable, .thisDeviceSyncEnabledViaConnect:
+            syncSetupExperimentPixels.fireSetupEndedSuccessful()
+        case .loginCompleted(let setupRole):
+            switch setupRole {
+            case .sharer:
+                syncSetupExperimentPixels.fireSetupEndedSuccessful()
+            case .receiver(let setupSource, _):
+                guard setupSource == .exchange || setupSource == .recovery else {
+                    return
+                }
+                syncSetupExperimentPixels.fireSetupEndedSuccessful()
+            }
         }
     }
 

--- a/iOS/DuckDuckGo/SyncSetupExperimentPixels.swift
+++ b/iOS/DuckDuckGo/SyncSetupExperimentPixels.swift
@@ -1,0 +1,123 @@
+//
+//  SyncSetupExperimentPixels.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import BrowserServicesKit
+import Foundation
+import PixelExperimentKit
+import PixelKit
+import PrivacyConfig
+
+/// Instrumentation facade for the iOS Sync Setup Simplification A/B experiment.
+///
+protocol SyncSetupExperimentPixelFiring {
+
+    // Primary metrics
+    func fireSignupDirect()
+    func fireSignupConnect()
+    func fireLogin()
+
+    // Guardrail / secondary metrics
+    func fireSyncDisabled()
+    func fireSyncDisabledAndDeleted()
+
+    func fireBarcodeScreenShown()
+    func fireBarcodeScannerSuccess()
+    func fireBarcodeScannerFailed()
+    func fireBarcodeCodeCopied()
+
+    func fireManualCodeEntryScreenShown()
+    func fireManualCodeEnteredSuccess()
+    func fireManualCodeEnteredFailed()
+
+    func fireSetupEndedAbandoned()
+    func fireSetupEndedSuccessful()
+
+    func fireDeepLinkFlowStarted()
+    func fireDeepLinkFlowSuccess()
+    func fireDeepLinkFlowAbandoned()
+    func fireDeepLinkTimeout()
+}
+
+final class SyncSetupExperimentPixelReporter: SyncSetupExperimentPixelFiring {
+
+    private let subfeatureID: SubfeatureID = SyncSubfeature.simplifiedSyncSetupExperiment.rawValue
+
+    private enum Metric {
+        static let signupDirect = "signup_direct"
+        static let signupConnect = "signup_connect"
+        static let login = "login"
+
+        static let syncDisabled = "sync_disabled"
+        static let syncDisabledAndDeleted = "sync_disabled_and_deleted"
+
+        static let barcodeScreenShown = "barcode_screen_shown"
+        static let barcodeScannerSuccess = "barcode_scanner_success"
+        static let barcodeScannerFailed = "barcode_scanner_failed"
+        static let barcodeCodeCopied = "barcode_code_copied"
+
+        static let manualCodeEntryScreenShown = "manual_code_entry_screen_shown"
+        static let manualCodeEnteredSuccess = "manual_code_entered_success"
+        static let manualCodeEnteredFailed = "manual_code_entered_failed"
+
+        static let setupEndedAbandoned = "setup_ended_abandoned"
+        static let setupEndedSuccessful = "setup_ended_successful"
+
+        static let deepLinkFlowStarted = "deep_link_flow_started"
+        static let deepLinkFlowSuccess = "deep_link_flow_success"
+        static let deepLinkFlowAbandoned = "deep_link_flow_abandoned"
+        static let deepLinkTimeout = "deep_link_timeout"
+    }
+
+    private let window: ConversionWindow = 0...6
+
+    private func fire(_ metric: String) {
+        PixelKit.fireExperimentPixel(
+            for: subfeatureID,
+            metric: metric,
+            conversionWindowDays: window,
+            value: "1"
+        )
+    }
+
+    // MARK: Primary
+    func fireSignupDirect()  { fire(Metric.signupDirect) }
+    func fireSignupConnect() { fire(Metric.signupConnect) }
+    func fireLogin()         { fire(Metric.login) }
+
+    // MARK: Guardrail
+    func fireSyncDisabled()           { fire(Metric.syncDisabled) }
+    func fireSyncDisabledAndDeleted() { fire(Metric.syncDisabledAndDeleted) }
+
+    func fireBarcodeScreenShown()    { fire(Metric.barcodeScreenShown) }
+    func fireBarcodeScannerSuccess() { fire(Metric.barcodeScannerSuccess) }
+    func fireBarcodeScannerFailed()  { fire(Metric.barcodeScannerFailed) }
+    func fireBarcodeCodeCopied()     { fire(Metric.barcodeCodeCopied) }
+
+    func fireManualCodeEntryScreenShown() { fire(Metric.manualCodeEntryScreenShown) }
+    func fireManualCodeEnteredSuccess()   { fire(Metric.manualCodeEnteredSuccess) }
+    func fireManualCodeEnteredFailed()    { fire(Metric.manualCodeEnteredFailed) }
+
+    func fireSetupEndedAbandoned()  { fire(Metric.setupEndedAbandoned) }
+    func fireSetupEndedSuccessful() { fire(Metric.setupEndedSuccessful) }
+
+    func fireDeepLinkFlowStarted()   { fire(Metric.deepLinkFlowStarted) }
+    func fireDeepLinkFlowSuccess()   { fire(Metric.deepLinkFlowSuccess) }
+    func fireDeepLinkFlowAbandoned() { fire(Metric.deepLinkFlowAbandoned) }
+    func fireDeepLinkTimeout()       { fire(Metric.deepLinkTimeout) }
+}

--- a/iOS/DuckDuckGoTests/MockSyncSetupExperimentPixelFiring.swift
+++ b/iOS/DuckDuckGoTests/MockSyncSetupExperimentPixelFiring.swift
@@ -1,0 +1,48 @@
+//
+//  MockSyncSetupExperimentPixelFiring.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+@testable import DuckDuckGo
+
+final class MockSyncSetupExperimentPixelFiring: SyncSetupExperimentPixelFiring {
+    private(set) var firedMetrics: [String] = []
+
+    func fireSignupDirect()  { firedMetrics.append("signup_direct") }
+    func fireSignupConnect() { firedMetrics.append("signup_connect") }
+    func fireLogin()         { firedMetrics.append("login") }
+
+    func fireSyncDisabled()           { firedMetrics.append("sync_disabled") }
+    func fireSyncDisabledAndDeleted() { firedMetrics.append("sync_disabled_and_deleted") }
+
+    func fireBarcodeScreenShown()    { firedMetrics.append("barcode_screen_shown") }
+    func fireBarcodeScannerSuccess() { firedMetrics.append("barcode_scanner_success") }
+    func fireBarcodeScannerFailed()  { firedMetrics.append("barcode_scanner_failed") }
+    func fireBarcodeCodeCopied()     { firedMetrics.append("barcode_code_copied") }
+
+    func fireManualCodeEntryScreenShown() { firedMetrics.append("manual_code_entry_screen_shown") }
+    func fireManualCodeEnteredSuccess()   { firedMetrics.append("manual_code_entered_success") }
+    func fireManualCodeEnteredFailed()    { firedMetrics.append("manual_code_entered_failed") }
+
+    func fireSetupEndedAbandoned()  { firedMetrics.append("setup_ended_abandoned") }
+    func fireSetupEndedSuccessful() { firedMetrics.append("setup_ended_successful") }
+
+    func fireDeepLinkFlowStarted()   { firedMetrics.append("deep_link_flow_started") }
+    func fireDeepLinkFlowSuccess()   { firedMetrics.append("deep_link_flow_success") }
+    func fireDeepLinkFlowAbandoned() { firedMetrics.append("deep_link_flow_abandoned") }
+    func fireDeepLinkTimeout()       { firedMetrics.append("deep_link_timeout") }
+}

--- a/iOS/DuckDuckGoTests/SyncSettingsViewControllerErrorTests.swift
+++ b/iOS/DuckDuckGoTests/SyncSettingsViewControllerErrorTests.swift
@@ -34,6 +34,7 @@ final class SyncSettingsViewControllerErrorTests: XCTestCase {
     var errorHandler: CapturingSyncPausedStateManager!
     var ddgSyncing: MockDDGSyncing!
     var syncAutoRestoreHandler: MockSyncAutoRestoreHandler!
+    var syncSetupExperimentPixels: MockSyncSetupExperimentPixelFiring!
     var testRecoveryCode = "eyJyZWNvdmVyeSI6eyJ1c2VyX2lkIjoiMDZGODhFNzEtNDFBRS00RTUxLUE2UkRtRkEwOTcwMDE5QkYwIiwicHJpbWFyeV9rZXkiOiI1QTk3U3dsQVI5RjhZakJaU09FVXBzTktnSnJEYnE3aWxtUmxDZVBWazgwPSJ9fQ=="
 
     @MainActor
@@ -67,6 +68,7 @@ final class SyncSettingsViewControllerErrorTests: XCTestCase {
         let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.syncSeamlessAccountSwitching])
         syncAutoRestoreHandler = MockSyncAutoRestoreHandler()
         syncAutoRestoreHandler.isAutoRestoreFeatureEnabled = true
+        syncSetupExperimentPixels = MockSyncSetupExperimentPixelFiring()
         vc = SyncSettingsViewController(
             syncService: ddgSyncing,
             syncBookmarksAdapter: bookmarksAdapter,
@@ -74,7 +76,8 @@ final class SyncSettingsViewControllerErrorTests: XCTestCase {
             syncCreditCardsAdapter: creditCardsAdapter,
             syncPausedStateManager: errorHandler,
             featureFlagger: featureFlagger,
-            syncAutoRestoreHandler: syncAutoRestoreHandler
+            syncAutoRestoreHandler: syncAutoRestoreHandler,
+            syncSetupExperimentPixels: syncSetupExperimentPixels
         )
     }
 
@@ -83,6 +86,7 @@ final class SyncSettingsViewControllerErrorTests: XCTestCase {
         errorHandler = nil
         vc = nil
         syncAutoRestoreHandler = nil
+        syncSetupExperimentPixels = nil
         super.tearDown()
     }
 
@@ -357,6 +361,70 @@ final class SyncSettingsViewControllerErrorTests: XCTestCase {
         XCTAssertTrue(secondAttemptAllowed)
         XCTAssertEqual(ddgSyncing.disconnectedDeviceIDs, ["device-id", "device-id"])
         XCTAssertEqual(ddgSyncing.removePreservedSyncAccountCallCount, 2)
+    }
+
+    @MainActor
+    func testWhenControllerDidFinishTransmittingRecoveryKeyThenNoSuccessExperimentMetricIsFired() {
+        vc.controllerDidFinishTransmittingRecoveryKey()
+
+        XCTAssertFalse(syncSetupExperimentPixels.firedMetrics.contains("setup_ended_successful"))
+    }
+
+    @MainActor
+    func testWhenConnectReceiverWasNewlyEnabledThenSuccessExperimentMetricIsFired() {
+        vc.controllerDidCompleteAccountConnection(shouldShowSyncEnabled: false, setupSource: .connect, codeSource: .qrCode)
+
+        XCTAssertTrue(syncSetupExperimentPixels.firedMetrics.contains("setup_ended_successful"))
+    }
+
+    @MainActor
+    func testWhenControllerDidCreateSyncAccountThenSignupConnectIsFiredWithoutSuccess() {
+        vc.controllerDidCreateSyncAccount()
+
+        XCTAssertTrue(syncSetupExperimentPixels.firedMetrics.contains("signup_connect"))
+        XCTAssertFalse(syncSetupExperimentPixels.firedMetrics.contains("setup_ended_successful"))
+    }
+
+    @MainActor
+    func testWhenConnectReceiverWasAlreadyEnabledThenSuccessExperimentMetricIsNotFired() {
+        vc.controllerDidCompleteAccountConnection(shouldShowSyncEnabled: true, setupSource: .connect, codeSource: .qrCode)
+
+        XCTAssertFalse(syncSetupExperimentPixels.firedMetrics.contains("setup_ended_successful"))
+    }
+
+    @MainActor
+    func testWhenLoginCompletedAsSharerThenSuccessExperimentMetricIsFired() {
+        vc.handleSuccessfulSetupOutcome(.loginCompleted(setupRole: .sharer))
+
+        XCTAssertTrue(syncSetupExperimentPixels.firedMetrics.contains("setup_ended_successful"))
+    }
+
+    @MainActor
+    func testWhenLoginCompletedAsExchangeReceiverThenSuccessExperimentMetricIsFired() {
+        vc.handleSuccessfulSetupOutcome(.loginCompleted(setupRole: .receiver(.exchange, .qrCode)))
+
+        XCTAssertTrue(syncSetupExperimentPixels.firedMetrics.contains("setup_ended_successful"))
+    }
+
+    @MainActor
+    func testWhenLoginCompletedAsRecoveryReceiverThenSuccessExperimentMetricIsFired() {
+        vc.handleSuccessfulSetupOutcome(.loginCompleted(setupRole: .receiver(.recovery, .pastedCode)))
+
+        XCTAssertTrue(syncSetupExperimentPixels.firedMetrics.contains("setup_ended_successful"))
+    }
+
+    @MainActor
+    func testWhenLoginCompletedAsDeepLinkExchangeReceiverThenSuccessExperimentMetricIsFired() {
+        vc.handleSuccessfulSetupOutcome(.loginCompleted(setupRole: .receiver(.exchange, .deepLink)))
+
+        XCTAssertTrue(syncSetupExperimentPixels.firedMetrics.contains("setup_ended_successful"))
+    }
+
+    @MainActor
+    func testWhenLoginCompletedAsConnectReceiverThenSuccessExperimentMetricIsNotFired() {
+        vc.handleSuccessfulSetupOutcome(.loginCompleted(setupRole: .receiver(.connect, .qrCode)))
+
+        XCTAssertFalse(syncSetupExperimentPixels.firedMetrics.contains("setup_ended_successful"))
     }
 
     func x_test_syncCodeEntered_accountAlreadyExists_oneDevice_disconnectsThenLogsInAgain() async {

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/ScanOrPasteCodeViewModel.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/ScanOrPasteCodeViewModel.swift
@@ -39,7 +39,7 @@ public protocol ScanOrPasteCodeViewModelDelegate: AnyObject {
     func shareCode(_ code: String)
 
     func codeEntryScreenShown()
-    func codeCopied()
+    func codeCopied(_ code: String)
 }
 
 public class ScanOrPasteCodeViewModel: ObservableObject {
@@ -94,7 +94,7 @@ public class ScanOrPasteCodeViewModel: ObservableObject {
         guard showQRCodeModel.codeForDisplayOrPasting.isEmpty == false else { return }
         showQRCodeModel.copy()
         UINotificationFeedbackGenerator().notificationOccurred(.success)
-        delegate?.codeCopied()
+        delegate?.codeCopied(showQRCodeModel.codeForDisplayOrPasting)
     }
 
     @MainActor

--- a/iOS/PixelDefinitions/pixels/native_experiments.json5
+++ b/iOS/PixelDefinitions/pixels/native_experiments.json5
@@ -67,6 +67,83 @@
                     "enum": ["toggle-continue-pressed_search", "toggle-continue-pressed_ai", "fire-button-pressed"]
                 }
             }
+        },
+        "simplifiedSyncSetupExperiment": {
+            "cohorts": ["control", "treatment"],
+            "metrics": {
+                "signup_direct": {
+                    "description": "Fires when the user creates a new sync account directly (single-device setup).",
+                    "enum": ["1"]
+                },
+                "signup_connect": {
+                    "description": "Fires when the user creates a sync account by connecting to another device.",
+                    "enum": ["1"]
+                },
+                "login": {
+                    "description": "Fires when the user logs into an existing sync account via recovery code or pairing.",
+                    "enum": ["1"]
+                },
+                "sync_disabled": {
+                    "description": "Fires when the user disables sync.",
+                    "enum": ["1"]
+                },
+                "sync_disabled_and_deleted": {
+                    "description": "Fires when the user disables sync and deletes server data.",
+                    "enum": ["1"]
+                },
+                "barcode_screen_shown": {
+                    "description": "Fires when the QR/barcode screen is shown during setup.",
+                    "enum": ["1"]
+                },
+                "barcode_scanner_success": {
+                    "description": "Fires when the QR barcode is scanned successfully.",
+                    "enum": ["1"]
+                },
+                "barcode_scanner_failed": {
+                    "description": "Fires when the QR barcode fails to scan.",
+                    "enum": ["1"]
+                },
+                "barcode_code_copied": {
+                    "description": "Fires when the user copies the sync code from the barcode screen.",
+                    "enum": ["1"]
+                },
+                "manual_code_entry_screen_shown": {
+                    "description": "Fires when the manual code entry screen is shown.",
+                    "enum": ["1"]
+                },
+                "manual_code_entered_success": {
+                    "description": "Fires when the manually entered code is accepted.",
+                    "enum": ["1"]
+                },
+                "manual_code_entered_failed": {
+                    "description": "Fires when the manually entered code is rejected.",
+                    "enum": ["1"]
+                },
+                "setup_ended_abandoned": {
+                    "description": "Fires when the sync setup flow ends in abandonment.",
+                    "enum": ["1"]
+                },
+                "setup_ended_successful": {
+                    "description": "Fires when the sync setup flow ends successfully.",
+                    "enum": ["1"]
+                },
+                "deep_link_flow_started": {
+                    "description": "Fires when a sync deep link flow starts.",
+                    "enum": ["1"]
+                },
+                "deep_link_flow_success": {
+                    "description": "Fires when a sync deep link flow succeeds.",
+                    "enum": ["1"]
+                },
+                "deep_link_flow_abandoned": {
+                    "description": "Fires when a sync deep link flow is abandoned.",
+                    "enum": ["1"]
+                },
+                "deep_link_timeout": {
+                    "description": "Fires when a sync deep link flow times out.",
+                    "enum": ["1"]
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1214262848482010?focus=true
Tech Design URL:
CC:

### Description

This PR adds the experiment pixels required for the Simplified Sync Setup experiment.

### Testing Steps

I’m afraid there’s quite a bit of manual testing here! The part I’m most concerned with getting right is the various permutations of scanning another device’s QR code, and whether either device is already signed in, etc. I hope the below covers everything – I got Claude to help me put it together.

### Setup

- Run the app on two devices / simulators (one must be a device so you can scan QR codes), and set your remote config to `https://duckduckgo.github.io/privacy-configuration/pr-5037/v4/ios-config.json` so that you’ll be enrolled in the experiment when you visit Sync & Backup.
- If necessary, assign yourself to the `treatment` cohort via local override in debug settings.
- Confirm enrollment fired when you first visit Sync & Backup by looking for `experiment_enroll_simplifiedSyncSetupExperiment_<cohort>_…` in the Xcode debugger.

## Test matrix

### Scan-flow scenarios

**Scenario S1 — both signed out (connect flow)**

**Setup**: Device A signed out, Device B signed out.
**Action**: B scans A's QR.
**Result**: B creates a new sync account; A joins **B's** account.

| Device | Pixels fired |
|---|---|
| A | `barcode_screen_shown`, `login` |
| B | `barcode_scanner_success`, `signup_connect`, `setup_ended_successful` |

**Scenario S2 — A signed out, B signed in (connect flow)**

**Setup**: Device A signed out, Device B signed in.
**Action**: B scans A's QR.
**Result**: A joins B's existing account.

| Device | Pixels fired |
|---|---|
| A | `barcode_screen_shown`, `login` |
| B | `barcode_scanner_success`, `setup_ended_successful` |

**Scenario S3 — A signed in, B signed out (exchange flow)**

**Setup**: Device A signed in, Device B signed out.
**Action**: B scans A's QR.
**Result**: B joins **A's** account.

| Device | Pixels fired |
|---|---|
| A | `barcode_screen_shown`, `setup_ended_successful` |
| B | `barcode_scanner_success`, `login`, `setup_ended_successful` |


| # | Metric | How to fire it | Device |
|---|---|---|---|
| 1 | `signup_direct` | On a signed-out device: Settings → Sync & Backup, toggle on sync. Also fires `setup_ended_successful`. | Single device |
| 4 | `sync_disabled` | On a signed-in device: Settings → Sync & Backup, toggle off sync. | Single |
| 5 | `sync_disabled_and_deleted` | On a signed-in device: Sync settings → "Turn Off and Delete Server Data". | Single device |
| 6 | `barcode_screen_shown` | Open the scan-or-show-code view from any flow. | Whichever opens it |
| 7 | `barcode_scanner_success` | Run any of **S1 / S2 / S3** — fires on B in all three. | B |
| 8 | `barcode_scanner_failed` | (a) scan a malformed QR with the camera, or (b) scan a QR that fails downstream (e.g., expired/revoked). Also fires `setup_ended_abandoned`. | B |
| 9 | `barcode_code_copied` | From the show-code view, tap copy directly **or** Share → Copy to Pasteboard. | A |
| 10 | `manual_code_entry_screen_shown` | Open the "Enter code manually" screen. | Single device |
| 11 | `manual_code_entered_success` | Paste a valid code. Also fires `login` and `setup_ended_successful`. | Single device |
| 12 | `manual_code_entered_failed` | (a) paste a malformed code, or (b) paste a structurally-valid-but-invalid code that fails downstream. Also fires `setup_ended_abandoned`. | Single  device |
| 13 | `setup_ended_abandoned` | Any terminal failure: invalid code, downstream sync failure, account creation failure, polling timeout. Or cancel the barcode scanner screen. | Single device |
| 14 | `setup_ended_successful` | Triggered by various successful sync scenarios described above | Various |

I’ve added deep link pixels but I’m actually not 100% sure how these are triggered in practice. Verify the code, at the least!


### Notes

- I’ve added `setup_ended_abandoned` to fire on every failure path, not just user cancellation. Let me know if you think this should change.
- `signup_connect` and `deep_link_flow_success` not co-fire `setup_ended_successful`, unlike the other success paths. This mirrors existing instrumentation behaviour, but I’m not sure if we should also add those here.

### Impact and Risks

Low: Minor visual changes, small bug fixes, improvement to existing features

Low user risk, but could impact the experiment if incorrect.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: touches sync setup flow and delegate APIs to add new experiment instrumentation and tweak error/polling behavior, which could affect setup completion/error handling if misfired.
> 
> **Overview**
> Adds a new `SyncSetupExperimentPixelFiring`/`SyncSetupExperimentPixelReporter` and wires it through `SyncSettingsViewController` to emit **A/B experiment metrics** across key Sync setup paths (direct signup, connect signup, login, barcode/manual entry success/failure, deep-link outcomes, disable/delete, and setup end success/abandon).
> 
> Refactors copy/share handling to centralize “code copied” pixel logic and updates `ScanOrPasteCodeViewModelDelegate` to pass the copied code through `codeCopied(_:)`. Also tightens exchange-mode error handling by stopping polling and avoiding “finish transmitting” notifications when recovery-key transmission fails (with new test coverage), plus adds tests/mocks and registers the new experiment/metrics in `native_experiments.json5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4338d873535df661354346f1b46b2297eb611432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->