### PR TITLE
[iOS] Fix back button navigation on external link open

### DIFF
--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -651,14 +651,7 @@ extension MainCoordinator: URLHandling {
                 controller.segueToSettingsSync(with: nil, pairingInfo: pairingInfo)
                 return true
             }
-            guard application.applicationState == .active, let currentTab = controller.currentTab else {
-                return false
-            }
-            // If app is in active state, treat this navigation as something initiated form the context of the current tab.
-            controller.tab(currentTab,
-                           didRequestNewTabForUrl: url,
-                           openedByPage: true,
-                           inheritingAttribution: nil)
+            return false
         }
         return true
     }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1214286391230053
Tech Design URL:
CC: @dus7 @hassaanelgarem @jaceklyp @ayoy 

### Description

### Testing Steps
1. Open a tab a navigate to any page (optionally, navigating from there)
2. Tap a link in an external app (Mail, Messages, etc.) that opens in DDG iOS browser
3. Browser opens to destination page (call this Page 1)
4. Click a link on Page 1 → navigate to Page 2
5. Tap Back → returns to Page 1
6. Back button should be disabled

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Change could create issues when handling external navigations into DDG iOS

### Quality Considerations
N/A

### Notes to Reviewer
Please focus on navigations initiated by external apps into DDG iOS

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes URL/deep-link routing for unrecognized schemes so they no longer open as a page-initiated navigation from the current tab, which could alter external-link behavior and back-stack state. Risk is limited in scope but impacts core navigation UX.
> 
> **Overview**
> Fixes external-link/back-button behavior by **stopping `handleAppDeepLink` from force-opening unknown URLs as a “page-opened” navigation on the current tab when the app is active**.
> 
> For URLs that aren’t a recognized app deep link (and aren’t intercepted as Sync pairing), the coordinator now returns `false` and lets the normal external URL handling path proceed instead of calling `tab(_:didRequestNewTabForUrl:openedByPage:)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0171474c2249d6c01ac8e647ff54abd66699c1a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->