### PR TITLE
Show NTP escape hatch only after idle (iOS)

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1470,8 +1470,9 @@ class MainViewController: UIViewController {
         return nil
     }
 
-    private func buildEscapeHatch() -> EscapeHatchModel? {
-        guard idleReturnEligibilityManager.isEligibleForNTPAfterIdle() else {
+    private func buildEscapeHatch(openedAfterIdle: Bool) -> EscapeHatchModel? {
+        guard openedAfterIdle,
+              idleReturnEligibilityManager.isEligibleForNTPAfterIdle() else {
             return nil
         }
         let currentTab = tabManager.currentTabsModel.currentTab
@@ -1547,7 +1548,7 @@ class MainViewController: UIViewController {
 
         newTabPageViewController = controller
 
-        let hatch = buildEscapeHatch()
+        let hatch = buildEscapeHatch(openedAfterIdle: openedAfterIdle)
         controller.setEscapeHatch(hatch)
         currentNTPEscapeHatch = hatch
         


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1214234567557847?focus=true

### Description

The NTP-after-idle escape hatch (the "Return to…" card on the New Tab Page) currently appears on every NTP — both idle-triggered and user-initiated — provided the feature flag, onboarding, and `.newTab` setting are satisfied.
he card now only builds for NTPs opened as a result of an idle-return.


### Testing Steps

1. Build and run on an iOS simulator (iPhone 16 used during development).
2. **User-initiated NTP**: open the app, tap "+" / new tab → the "Return to…" card must NOT appear.
3. **NTP after idle**: background the app, wait past the configured idle threshold (use the `idle-return-threshold-seconds-debug-override` debug knob to shorten), foreground the app → NTP shows the "Return to…" card; tapping it returns to the previous tab and fires `m_ntp_after_idle_return_to_page_tapped_after_idle`.
4. **Setting = Last Used Tab**: change After Inactivity setting to Last Used Tab → no NTP after idle is shown, card stays hidden (sanity check; unchanged behavior).
5. **Fire tab**: open a fire tab → card never shows.
6. **Omnibar editing state on user-initiated NTP**: tap into the address bar from a user-initiated NTP, including toggling between search and Duck.ai sides → no escape hatch on either pane.
7. **Omnibar editing state on NTP-after-idle**: tap into the address bar from an NTP-after-idle → escape hatch appears on both panes (preserved behavior).

### Impact and Risks

Low — visibility-only change for an existing UI element on a feature that's still gated behind a remote-config flag and a user setting. No data model, persistence, or networking change.

#### What could go wrong?

The `m_ntp_after_idle_return_to_page_tapped_user_initiated` pixel will go to zero by design — analytics dashboards that compare the two cohorts should expect this drop.

### Quality Considerations

No unit tests added. `buildEscapeHatch(...)` is a private method on `MainViewController`, which has no existing test harness; building one for a 1-line guard would be disproportionate. The change is covered by the manual testing steps above. Existing eligibility coverage in `IdleReturnEligibilityManagerTests` is unaffected.

### Notes to Reviewer

The change threads a single existing parameter through one already-private method. No public surface change, no behavior change for the after-idle path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-visibility gating change that only affects when the existing escape hatch model is created; no persistence/networking changes. Main risk is unintended hiding of the card if `openedAfterIdle` is incorrectly set by callers.
> 
> **Overview**
> The New Tab Page “Return to…” escape hatch is now **only built/shown for tabs opened after an idle return**. `MainViewController.buildEscapeHatch` now requires `openedAfterIdle` in addition to the existing eligibility checks, and `attachHomeScreen` passes its `openedAfterIdle` flag through so user-initiated NTPs get `nil` and no escape hatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ae766d67b3c781a64765322b5df441bb907968c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->