### PR TITLE
[macOS] Fix tab bar crash on popup tab insert (APPLE-MACOS-BD7)

### DIFF
--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
@@ -505,10 +505,15 @@ final class TabCollectionViewModel: NSObject {
         }
 
         tabCollection.insert(tab, at: index.item)
+        // Notify the delegate before updating selection: setting `selectionIndex`
+        // publishes `selectedTabViewModel`, which can synchronously re-enter via
+        // `TabLazyLoader` → `materialize` → `replaceTab` → `didReplaceTabAt` and
+        // call `reloadItems` on the collection view while it still has the
+        // pre-insert item count, raising NSInternalInconsistencyException.
+        delegate?.tabCollectionViewModelDidInsert(self, at: index, selected: selected)
         if selected {
             select(at: index)
         }
-        delegate?.tabCollectionViewModelDidInsert(self, at: index, selected: selected)
     }
 
     func insert(_ tab: Tab, at index: TabIndex, selected: Bool = true) {

--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
@@ -442,11 +442,10 @@ final class TabCollectionViewModel: NSObject {
             NotificationCenter.default.post(name: HomePage.Models.newHomePageTabOpen, object: nil)
         }
         let insertionIndex = tabCollection.tabs.indices.index(before: tabCollection.tabs.endIndex)
+        // Notify the delegate before updating selection — see `insert(_:at:selected:)`.
+        delegate?.tabCollectionViewModelDidAppend(self, selected: selected)
         if selected {
             selectUnpinnedTab(at: insertionIndex, forceChange: forceChange)
-            delegate?.tabCollectionViewModelDidAppend(self, selected: true)
-        } else {
-            delegate?.tabCollectionViewModelDidAppend(self, selected: false)
         }
         return insertionIndex
     }
@@ -469,12 +468,12 @@ final class TabCollectionViewModel: NSObject {
         }
 
         tabCollection.append(tabs: tabs)
+        // Notify the delegate before updating selection — see `insert(_:at:selected:)`.
+        delegate?.tabCollectionViewModelDidMultipleChanges(self)
         if shouldSelectLastTab {
             let newSelectionIndex = tabCollection.tabs.count - 1
             selectUnpinnedTab(at: newSelectionIndex)
         }
-
-        delegate?.tabCollectionViewModelDidMultipleChanges(self)
     }
 
     func append(tabs: [Tab], andSelect shouldSelectLastTab: Bool) {

--- a/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests.swift
@@ -337,6 +337,31 @@ final class TabCollectionViewModelTests: XCTestCase {
         XCTAssert(tab === tabCollectionViewModel.tabViewModel(at: 2)?.tab)
     }
 
+    // Regression test for APPLE-MACOS-BD7: setting `selectionIndex` from inside
+    // `insert` publishes `selectedTabViewModel`, which can synchronously re-enter
+    // and call `reloadItems` on the collection view. The delegate must be
+    // notified of the insert before that publication so the collection view's
+    // item count stays in sync with the data source.
+    @MainActor
+    func testWhenInsertWithSelected_ThenDelegateIsNotifiedBeforeSelectionPublishes() {
+        let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
+        let delegate = TabCollectionViewModelDelegateMock()
+        tabCollectionViewModel.delegate = delegate
+
+        var didInsertCalledWhenSelectionPublished: Bool?
+        let cancellable = tabCollectionViewModel.$selectionIndex
+            .dropFirst()
+            .first()
+            .sink { _ in
+                didInsertCalledWhenSelectionPublished = delegate.didInsertCalled
+            }
+
+        tabCollectionViewModel.insert(Tab(), at: .unpinned(0), selected: true)
+
+        XCTAssertEqual(didInsertCalledWhenSelectionPublished, true)
+        cancellable.cancel()
+    }
+
     // MARK: - Insert or Append
 
     @MainActor

--- a/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests.swift
@@ -337,11 +337,11 @@ final class TabCollectionViewModelTests: XCTestCase {
         XCTAssert(tab === tabCollectionViewModel.tabViewModel(at: 2)?.tab)
     }
 
-    // Regression test for APPLE-MACOS-BD7: setting `selectionIndex` from inside
-    // `insert` publishes `selectedTabViewModel`, which can synchronously re-enter
-    // and call `reloadItems` on the collection view. The delegate must be
-    // notified of the insert before that publication so the collection view's
-    // item count stays in sync with the data source.
+    // Regression tests for APPLE-MACOS-BD7: setting `selectionIndex` from inside
+    // `insert`/`append` publishes `selectedTabViewModel`, which can synchronously
+    // re-enter and call `reloadItems` on the collection view. The delegate must
+    // be notified before that publication so the collection view's item count
+    // stays in sync with the data source.
     @MainActor
     func testWhenInsertWithSelected_ThenDelegateIsNotifiedBeforeSelectionPublishes() {
         let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
@@ -359,6 +359,46 @@ final class TabCollectionViewModelTests: XCTestCase {
         tabCollectionViewModel.insert(Tab(), at: .unpinned(0), selected: true)
 
         XCTAssertEqual(didInsertCalledWhenSelectionPublished, true)
+        cancellable.cancel()
+    }
+
+    @MainActor
+    func testWhenAppendWithSelected_ThenDelegateIsNotifiedBeforeSelectionPublishes() {
+        let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
+        let delegate = TabCollectionViewModelDelegateMock()
+        tabCollectionViewModel.delegate = delegate
+
+        var didAppendCalledWhenSelectionPublished: Bool?
+        let cancellable = tabCollectionViewModel.$selectionIndex
+            .dropFirst()
+            .first()
+            .sink { _ in
+                didAppendCalledWhenSelectionPublished = delegate.didAppendCalled
+            }
+
+        tabCollectionViewModel.append(tab: Tab(), selected: true)
+
+        XCTAssertEqual(didAppendCalledWhenSelectionPublished, true)
+        cancellable.cancel()
+    }
+
+    @MainActor
+    func testWhenAppendTabsWithSelectLast_ThenDelegateIsNotifiedBeforeSelectionPublishes() {
+        let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
+        let delegate = TabCollectionViewModelDelegateMock()
+        tabCollectionViewModel.delegate = delegate
+
+        var didMultipleChangesCalledWhenSelectionPublished: Bool?
+        let cancellable = tabCollectionViewModel.$selectionIndex
+            .dropFirst()
+            .first()
+            .sink { _ in
+                didMultipleChangesCalledWhenSelectionPublished = delegate.didMultipleChangesCalled
+            }
+
+        tabCollectionViewModel.append(tabs: [.loaded(Tab()), .loaded(Tab())], andSelect: true)
+
+        XCTAssertEqual(didMultipleChangesCalledWhenSelectionPublished, true)
         cancellable.cancel()
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214294661819890/task/1214265935091414?focus=true

### Description

Fixes APPLE-MACOS-BD7, an `NSInternalInconsistencyException` crash in `NSCollectionView` raised from `TabBarViewController.tabCollectionViewModel(_:didReplaceTabAt:)` when a WebKit popup creates a new tab.

Root cause: `TabCollectionViewModel.insert(_:at:selected:)` mutated the data source, then called `select(at:)`, then notified the delegate. Setting `selectionIndex` publishes `selectedTabViewModel`, which `TabLazyLoader` flat-maps to the new tab's `$isLoading` (Apr 9, #4227). For a freshly created popup tab `isLoading` is `false`, so `findAndReloadNextTab()` fires synchronously, materializes a different unloaded tab, and ends up calling `collectionView.reloadItems(at:)` while the collection view's item count is still the pre-insert value. NSCollectionView cannot reconcile the count diff with a reload-only update and throws.

The fix reorders the operations so the delegate is notified about the insert before any selection-driven publication can re-enter the collection view. The same vulnerable pattern existed in `append(tab:selected:)` and `append(tabs:andSelect:)`, so the second commit applies the same ordering there to prevent the same crash from showing up under different stacks. Regression tests assert the new ordering invariant for all three paths.

### Testing Steps

1. Verify that the latest UI Tests workflow run has passed tab-related test cases: https://github.com/duckduckgo/apple-browsers/actions/runs/24992237460
2. Run the new unit tests in `TabCollectionViewModelTests`:
   - `testWhenInsertWithSelected_ThenDelegateIsNotifiedBeforeSelectionPublishes`
   - `testWhenAppendWithSelected_ThenDelegateIsNotifiedBeforeSelectionPublishes`
   - `testWhenAppendTabsWithSelectLast_ThenDelegateIsNotifiedBeforeSelectionPublishes`
3. Smoke-test interactively: open ~50 tabs, then click a link with `target="_blank"` (e.g. `<a href="https://example.com" target="_blank">x</a>`) so WebKit opens it as a new tab. The popup should open and select without crashing. I also tested with https://webbrowsertools.com/popup-blocker/ and couldn't get the app to crash, but that was also the case with the current production version.

### Impact and Risks

Low. The change is a minimal reorder (and is contained to `TabCollectionViewModel`'s mutation methods).

#### What could go wrong?

- Subscribers that observe both `selectedTabViewModel` and the corresponding delegate callback now see the delegate callback first. None of the in-tree delegate methods read `selectionIndex`/`selectedTabViewModel`; they only touch the collection view UI, which is what we want to be in sync sooner.
- Visual selection in the tab bar is now applied (via `tabCollectionViewModelDidInsert`'s `selectItems`/`scrollToSelected`) immediately before the model selection updates. The two are still set in the same call frame, so user-perceived behavior is unchanged.

### Quality Considerations

- The fix is data-source-then-delegate-then-select, which mirrors how Apple's diffable data sources expect updates: the collection view's item count must always match the data source the moment any update method is called.
- Regression tests pin the ordering invariant via a `$selectionIndex` subscriber that records the delegate's call state at publication time, so any future code that puts selection back ahead of the delegate notification will fail the test.

### Notes to Reviewer

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reorders delegate callbacks vs. selection publication in core tab mutation paths, which could affect UI update sequencing for tab bar observers. Change is localized but touches selection/collection-view synchronization and could surface new ordering assumptions.
> 
> **Overview**
> Fixes a tab bar `NSCollectionView` crash by reordering operations in `TabCollectionViewModel` so delegate notifications for `insert`/`append` happen **before** any selection change publishes `selectedTabViewModel` (avoiding synchronous re-entrancy while the collection view still has the old item count).
> 
> Adds unit regression tests that subscribe to `$selectionIndex` and assert the delegate callbacks (`didInsert`/`didAppend`/`didMultipleChanges`) have already fired when selection is published.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 754bf3776a83ad97eb1540bdcae830b8ff0de13b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->