### PR TITLE
fix css failing e2e test

### DIFF
--- a/.maestro/privacy_tests/11_content_scope_experiments_setup.yaml
+++ b/.maestro/privacy_tests/11_content_scope_experiments_setup.yaml
@@ -2,7 +2,7 @@ appId: com.duckduckgo.mobile.ios
 tags:
     - iphone
     - privacy
-name: 01_content_scope_experiments_setup
+name: 11_content_scope_experiments_setup
 
 ---
 
@@ -22,6 +22,8 @@ name: 01_content_scope_experiments_setup
     index: 0
 
 ##Override Privacy Config
+- scrollUntilVisible: 
+    element: "Configuration URLs"
 - tapOn: "Configuration URLs"
 - tapOn: "Privacy Config"
 - inputText: "https://privacy-test-pages.site/content-scope-scripts/infra/config/conditional-matching-experiments.json"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1214290970526973?focus=true
Tech Design URL:
CC:

### Description

### Testing Steps
Confirm CSS related tests have passed in this run: https://github.com/duckduckgo/apple-browsers/actions/runs/24994146155

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a Maestro E2E flow by renaming it and adding a scroll-to step to reduce flaky UI interaction failures.
> 
> **Overview**
> Updates the Maestro privacy test setup flow for content-scope experiments by renaming it to `11_content_scope_experiments_setup` and adding a `scrollUntilVisible` step before tapping **Configuration URLs** to prevent flaky failures when the option is off-screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 906788b970f6d9a9f0ee8a5a87ff828b4f32d665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->