### PR TITLE
Add post-idle session wide pixel (iOS)

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -115,6 +115,8 @@
 		275A9E842551836ECC9E6873 /* UnifiedToggleInputModelMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC9145E578E99B3052757F /* UnifiedToggleInputModelMenuTests.swift */; };
 		286810A915227B119AC60831 /* DefaultTogglePositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8AD06BCB81EA991F22DD66 /* DefaultTogglePositionTests.swift */; };
 		2CCD716C578642B8BC760D55 /* NTPAfterIdleInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0742FD8DD5F46AB8243103F /* NTPAfterIdleInstrumentation.swift */; };
+		D1A2B3C4E5F60001AABB0001 /* PostIdleSessionWideEventData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F60001AABB0002 /* PostIdleSessionWideEventData.swift */; };
+		D1A2B3C4E5F60001AABB0005 /* PostIdleSessionInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F60001AABB0006 /* PostIdleSessionInstrumentation.swift */; };
 		2DC3FC65C6D9DA634426672D /* AutofillNoAuthAvailableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC3FBD62FBAF21E87610FA8 /* AutofillNoAuthAvailableView.swift */; };
 		3105BCF12DF214A000EB755E /* AIChatPixelMetricHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3105BCF02DF214A000EB755E /* AIChatPixelMetricHandler.swift */; };
 		3105BCF52DF2154800EB755E /* AIChatPixelMetricHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3105BCF32DF2154800EB755E /* AIChatPixelMetricHandlerTests.swift */; };
@@ -1638,6 +1640,8 @@
 		9FFDA83F2DFA907A007923F7 /* MockPictureInPictureController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FFDA83E2DFA9073007923F7 /* MockPictureInPictureController.swift */; };
 		A06E1D600618608596891F29 /* AIChatRecentChatsPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0B70EF2418A35A5D863506 /* AIChatRecentChatsPopupViewController.swift */; };
 		A1B2C3D4E5F60001AABB0001 /* NTPAfterIdleInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001AABB0002 /* NTPAfterIdleInstrumentationTests.swift */; };
+		D1A2B3C4E5F60001AABB0003 /* PostIdleSessionWideEventDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F60001AABB0004 /* PostIdleSessionWideEventDataTests.swift */; };
+		D1A2B3C4E5F60001AABB0007 /* PostIdleSessionInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F60001AABB0008 /* PostIdleSessionInstrumentationTests.swift */; };
 		A1B2C3D4E5F60002A1B2C3D4 /* UnifiedInputContentContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001A1B2C3D4 /* UnifiedInputContentContainerViewController.swift */; };
 		A1B2C3D52F7F111100ABCDEF /* SaveRecoveryKeyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42F7F111100ABCDEF /* SaveRecoveryKeyViewModelTests.swift */; };
 		A1B2C3D72F7F111100ABCDEF /* SyncSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D62F7F111100ABCDEF /* SyncSettingsViewModelTests.swift */; };
@@ -4172,6 +4176,8 @@
 		A1B2C3D42F7F111100ABCDEF /* SaveRecoveryKeyViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SaveRecoveryKeyViewModelTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001A1B2C3D4 /* UnifiedInputContentContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedInputContentContainerViewController.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001AABB0002 /* NTPAfterIdleInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPAfterIdleInstrumentationTests.swift; sourceTree = "<group>"; };
+		D1A2B3C4E5F60001AABB0004 /* PostIdleSessionWideEventDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostIdleSessionWideEventDataTests.swift; sourceTree = "<group>"; };
+		D1A2B3C4E5F60001AABB0008 /* PostIdleSessionInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostIdleSessionInstrumentationTests.swift; sourceTree = "<group>"; };
 		A1B2C3D62F7F111100ABCDEF /* SyncSettingsViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncSettingsViewModelTests.swift; sourceTree = "<group>"; };
 		A1D1C0E62F8CB3A400B1D001 /* DataImportUserActivityHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataImportUserActivityHandler.swift; sourceTree = "<group>"; };
 		A6C36CDBF1DD7FBC036F9067 /* DarkReaderFeatureSettingsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DarkReaderFeatureSettingsTests.swift; sourceTree = "<group>"; };
@@ -4754,6 +4760,8 @@
 		DA0001042F3D000100000002 /* DarkReaderFeatureSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkReaderFeatureSettings.swift; sourceTree = "<group>"; };
 		DD503EBD506182525F5E8107 /* RebrandedOnboardingView+Landing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "RebrandedOnboardingView+Landing.swift"; sourceTree = "<group>"; };
 		E0742FD8DD5F46AB8243103F /* NTPAfterIdleInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPAfterIdleInstrumentation.swift; sourceTree = "<group>"; };
+		D1A2B3C4E5F60001AABB0002 /* PostIdleSessionWideEventData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostIdleSessionWideEventData.swift; sourceTree = "<group>"; };
+		D1A2B3C4E5F60001AABB0006 /* PostIdleSessionInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostIdleSessionInstrumentation.swift; sourceTree = "<group>"; };
 		E29382A31F7E094527FD807C /* IPadTabChatHistoryCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadTabChatHistoryCoordinator.swift; sourceTree = "<group>"; };
 		E7971E90992B46FABF42A908 /* AIChatContextualWebViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualWebViewControllerTests.swift; sourceTree = "<group>"; };
 		EA39B7E1268A1A35000C62CD /* privacy-reference-tests */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = folder; name = "privacy-reference-tests"; path = "../SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Resources/privacy-reference-tests"; sourceTree = SOURCE_ROOT; };
@@ -9539,6 +9547,8 @@
 				CBAD0F3A2D02EE5B006267B8 /* IdleReturnCohort.swift */,
 				CBAD0F2C2D02EE4F006267B8 /* IdleReturnEligibilityManager.swift */,
 				E0742FD8DD5F46AB8243103F /* NTPAfterIdleInstrumentation.swift */,
+				D1A2B3C4E5F60001AABB0002 /* PostIdleSessionWideEventData.swift */,
+				D1A2B3C4E5F60001AABB0006 /* PostIdleSessionInstrumentation.swift */,
 				CBAD0F242D02EE48006267B8 /* LastBackgroundDateStore.swift */,
 				CBAD0EF72CFE1D14006267B8 /* AppStates */,
 			);
@@ -10391,6 +10401,8 @@
 				9770D4AF2F7B000200293610 /* VoiceSessionStateManagerTests.swift */,
 				9770D4B12F7B000300293610 /* VoiceEntryPointPixelTests.swift */,
 				A1B2C3D4E5F60001AABB0002 /* NTPAfterIdleInstrumentationTests.swift */,
+				D1A2B3C4E5F60001AABB0004 /* PostIdleSessionWideEventDataTests.swift */,
+				D1A2B3C4E5F60001AABB0008 /* PostIdleSessionInstrumentationTests.swift */,
 				CBAD0F302D02EE50006267B8 /* IdleReturnEligibilityManagerTests.swift */,
 				CBAD0F322D02EE50006267B8 /* AfterInactivityEffectiveOptionResolverTests.swift */,
 				3192F4572E6F1E5500FC2A95 /* LaunchSourceManagerTests.swift */,
@@ -12039,6 +12051,8 @@
 				80A09D522F6B854400AACDEE /* URLCacheFireWorker.swift in Sources */,
 				CBAD0F2D2D02EE50006267B8 /* IdleReturnEligibilityManager.swift in Sources */,
 				2CCD716C578642B8BC760D55 /* NTPAfterIdleInstrumentation.swift in Sources */,
+				D1A2B3C4E5F60001AABB0001 /* PostIdleSessionWideEventData.swift in Sources */,
+				D1A2B3C4E5F60001AABB0005 /* PostIdleSessionInstrumentation.swift in Sources */,
 				CBAD0F252D02EE49006267B8 /* LastBackgroundDateStore.swift in Sources */,
 				CB3C788A2D06D3A700A7E4ED /* Background.swift in Sources */,
 				C1AD33342DBAD1DD003B80A4 /* SaveCreditCardViewController.swift in Sources */,
@@ -13056,6 +13070,8 @@
 				9770D4AE2F7B000200293610 /* VoiceSessionStateManagerTests.swift in Sources */,
 				9770D4B02F7B000300293610 /* VoiceEntryPointPixelTests.swift in Sources */,
 				A1B2C3D4E5F60001AABB0001 /* NTPAfterIdleInstrumentationTests.swift in Sources */,
+				D1A2B3C4E5F60001AABB0003 /* PostIdleSessionWideEventDataTests.swift in Sources */,
+				D1A2B3C4E5F60001AABB0007 /* PostIdleSessionInstrumentationTests.swift in Sources */,
 				CBAD0F312D02EE50006267B8 /* IdleReturnEligibilityManagerTests.swift in Sources */,
 				CBAD0F332D02EE50006267B8 /* AfterInactivityEffectiveOptionResolverTests.swift in Sources */,
 				8590CB632684F10F0089F6BF /* ContentBlockerProtectionStoreTests.swift in Sources */,

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
@@ -87,11 +87,7 @@ struct Foreground: ForegroundHandling {
             privacyConfigurationManager: appDependencies.services.contentBlockingService.common.privacyConfigurationManager,
             isStillOnboarding: { daxDialogsManager.isStillOnboarding() }
         )
-        let idleReturnEvaluator = IdleReturnEvaluator(
-            featureFlagger: appDependencies.featureFlagger,
-            privacyConfigurationManager: appDependencies.services.contentBlockingService.common.privacyConfigurationManager,
-            idleReturnEligibilityManager: idleReturnEligibilityManager
-        )
+        let idleReturnEvaluator = IdleReturnEvaluator(eligibilityManager: idleReturnEligibilityManager)
         launchActionHandler = LaunchActionHandler(
             urlHandler: appDependencies.mainCoordinator,
             shortcutItemHandler: appDependencies.mainCoordinator,

--- a/iOS/DuckDuckGo/AppLifecycle/IdleReturnEligibilityManager.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/IdleReturnEligibilityManager.swift
@@ -23,8 +23,19 @@ import Persistence
 import PrivacyConfig
 
 protocol IdleReturnEligibilityManaging {
+    /// Is the after-idle feature turned on and ready for this user, regardless
+    /// of which treatment (NTP / LUT) their setting selects? Gates everything
+    /// — narrow pixel firing, NTP UI, and launch-time evaluation.
+    func isFeatureAvailable() -> Bool
+
+    /// Should NTP-specific UI/pixels treat this user as in scope?
+    /// Equivalent to `isFeatureAvailable() && effectiveAfterInactivityOption() == .newTab`.
     func isEligibleForNTPAfterIdle() -> Bool
+
+    /// The user's effective After-Inactivity choice (New Tab vs Last Used Tab).
     func effectiveAfterInactivityOption() -> AfterInactivityOption
+
+    /// How many seconds of inactivity before the feature engages.
     func idleThresholdSeconds() -> Int
 }
 
@@ -65,13 +76,16 @@ final class IdleReturnEligibilityManager: IdleReturnEligibilityManaging {
         self.isStillOnboarding = isStillOnboarding
     }
 
-    /// Gates NTP-after-idle on linear onboarding completion and contextual
-    /// onboarding not actively showing NTP dialogs.
-    func isEligibleForNTPAfterIdle() -> Bool {
+    /// Feature flag on and the user has finished both linear and contextual
+    /// onboarding. Independent of which treatment the user picked.
+    func isFeatureAvailable() -> Bool {
         tutorialSettings.hasSeenOnboarding
             && !isStillOnboarding()
             && featureFlagger.isFeatureOn(.showNTPAfterIdleReturn)
-            && effectiveAfterInactivityOption() == .newTab
+    }
+
+    func isEligibleForNTPAfterIdle() -> Bool {
+        isFeatureAvailable() && effectiveAfterInactivityOption() == .newTab
     }
 
     func effectiveAfterInactivityOption() -> AfterInactivityOption {

--- a/iOS/DuckDuckGo/AppLifecycle/IdleReturnEligibilityManager.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/IdleReturnEligibilityManager.swift
@@ -23,19 +23,15 @@ import Persistence
 import PrivacyConfig
 
 protocol IdleReturnEligibilityManaging {
-    /// Is the after-idle feature turned on and ready for this user, regardless
-    /// of which treatment (NTP / LUT) their setting selects? Gates everything
-    /// — narrow pixel firing, NTP UI, and launch-time evaluation.
+    /// True when the feature flag is on and onboarding is complete, regardless
+    /// of which treatment (NTP / LUT) the user's setting selects.
     func isFeatureAvailable() -> Bool
 
-    /// Should NTP-specific UI/pixels treat this user as in scope?
-    /// Equivalent to `isFeatureAvailable() && effectiveAfterInactivityOption() == .newTab`.
+    /// `isFeatureAvailable() && effectiveAfterInactivityOption() == .newTab`.
     func isEligibleForNTPAfterIdle() -> Bool
 
-    /// The user's effective After-Inactivity choice (New Tab vs Last Used Tab).
     func effectiveAfterInactivityOption() -> AfterInactivityOption
 
-    /// How many seconds of inactivity before the feature engages.
     func idleThresholdSeconds() -> Int
 }
 
@@ -76,8 +72,6 @@ final class IdleReturnEligibilityManager: IdleReturnEligibilityManaging {
         self.isStillOnboarding = isStillOnboarding
     }
 
-    /// Feature flag on and the user has finished both linear and contextual
-    /// onboarding. Independent of which treatment the user picked.
     func isFeatureAvailable() -> Bool {
         tutorialSettings.hasSeenOnboarding
             && !isStillOnboarding()

--- a/iOS/DuckDuckGo/AppLifecycle/IdleReturnEvaluator.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/IdleReturnEvaluator.swift
@@ -24,6 +24,10 @@ import PrivacyConfig
 
 protocol IdleReturnEvaluating {
     func shouldShowNTPAfterIdle(lastBackgroundDate: Date?) -> Bool
+
+    /// Whether the idle threshold was exceeded since the last background — independent
+    /// of whether the user's setting will surface NTP-after-idle or LUT-after-idle.
+    func idleThresholdPassed(lastBackgroundDate: Date?) -> Bool
 }
 
 /// Key namespace for idle-return NTP debug overrides (typed storage, no dotted keys).
@@ -105,6 +109,17 @@ final class IdleReturnEvaluator: IdleReturnEvaluating {
             return false
         }
         guard idleReturnEligibilityManager?.isEligibleForNTPAfterIdle() ?? true else {
+            return false
+        }
+        let thresholdSeconds = idleThresholdSeconds()
+        return Date().timeIntervalSince(lastBackgroundDate) >= Double(thresholdSeconds)
+    }
+
+    func idleThresholdPassed(lastBackgroundDate: Date?) -> Bool {
+        guard featureFlagger.isFeatureOn(.showNTPAfterIdleReturn) else {
+            return false
+        }
+        guard let lastBackgroundDate else {
             return false
         }
         let thresholdSeconds = idleThresholdSeconds()

--- a/iOS/DuckDuckGo/AppLifecycle/IdleReturnEvaluator.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/IdleReturnEvaluator.swift
@@ -28,10 +28,7 @@ enum IdleReturnTreatment {
 }
 
 protocol IdleReturnEvaluating {
-    /// Whether the user returned after an idle period
     func didReturnAfterIdle(lastBackgroundDate: Date?) -> Bool
-
-    /// The treatment to apply on an idle return.
     func treatmentForIdleReturn() -> IdleReturnTreatment
 }
 
@@ -88,11 +85,6 @@ struct IdleReturnThresholdResolver {
     }
 }
 
-/// Launch-time decision-maker. Composes pieces of `IdleReturnEligibilityManaging`
-/// to answer questions about a specific launch (did the user just return after
-/// idle? what should we show them?). All "is the feature available / what's the
-/// user's setting / what's the threshold" questions live on the eligibility
-/// manager — this type does not duplicate those checks.
 final class IdleReturnEvaluator: IdleReturnEvaluating {
 
     private let eligibilityManager: IdleReturnEligibilityManaging

--- a/iOS/DuckDuckGo/AppLifecycle/IdleReturnEvaluator.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/IdleReturnEvaluator.swift
@@ -28,12 +28,10 @@ enum IdleReturnTreatment {
 }
 
 protocol IdleReturnEvaluating {
-    /// Whether the user returned after an idle period — feature flag and threshold only.
-    /// Independent of which treatment will be applied.
+    /// Whether the user returned after an idle period
     func didReturnAfterIdle(lastBackgroundDate: Date?) -> Bool
 
-    /// The treatment to apply on an idle return. Eligibility (onboarding state,
-    /// user's "After Inactivity" setting) selects between cases. Defaults to `.lut`.
+    /// The treatment to apply on an idle return.
     func treatmentForIdleReturn() -> IdleReturnTreatment
 }
 
@@ -48,6 +46,12 @@ struct IdleReturnDebugOverridesKeys: StoringKeys {
 }
 
 struct IdleReturnThresholdResolver {
+
+    enum Constants {
+        static let idleThresholdSecondsSettingKey = "idleThresholdSeconds"
+        static let defaultIdleThresholdSeconds = 300 // 5 minutes
+        static let subfeature: any PrivacySubfeature = iOSBrowserConfigSubfeature.showNTPAfterIdleReturn
+    }
 
     private let debugOverridesStorage: (any KeyedStoring<IdleReturnDebugOverridesKeys>)?
     private let privacyConfigurationManager: PrivacyConfigurationManaging
@@ -67,70 +71,51 @@ struct IdleReturnThresholdResolver {
         if let overrideSeconds: Int = debugOverridesStorage?.thresholdSecondsOverride, overrideSeconds > 0 {
             return overrideSeconds
         }
-        let constants = IdleReturnEvaluator.IdleReturnEvaluatorConstants.self
-        guard let settings = privacyConfigurationManager.privacyConfig.settings(for: constants.subfeature),
+        guard let settings = privacyConfigurationManager.privacyConfig.settings(for: Constants.subfeature),
               let jsonData = settings.data(using: .utf8) else {
-            return IdleReturnEvaluator.IdleReturnEvaluatorConstants.defaultIdleThresholdSeconds
+            return Constants.defaultIdleThresholdSeconds
         }
         do {
             if let settingsDict = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
-               let value = settingsDict[IdleReturnEvaluator.IdleReturnEvaluatorConstants.idleThresholdSecondsSettingKey] as? NSNumber,
+               let value = settingsDict[Constants.idleThresholdSecondsSettingKey] as? NSNumber,
                value.intValue >= 0 {
                 return value.intValue
             }
         } catch {
             Logger.general.debug("Idle return NTP idleThresholdSeconds parse failed: \(error.localizedDescription)")
         }
-        return IdleReturnEvaluator.IdleReturnEvaluatorConstants.defaultIdleThresholdSeconds
+        return Constants.defaultIdleThresholdSeconds
     }
 }
 
+/// Launch-time decision-maker. Composes pieces of `IdleReturnEligibilityManaging`
+/// to answer questions about a specific launch (did the user just return after
+/// idle? what should we show them?). All "is the feature available / what's the
+/// user's setting / what's the threshold" questions live on the eligibility
+/// manager — this type does not duplicate those checks.
 final class IdleReturnEvaluator: IdleReturnEvaluating {
 
-    enum IdleReturnEvaluatorConstants {
-        static let idleThresholdSecondsSettingKey = "idleThresholdSeconds"
-        static let defaultIdleThresholdSeconds = 300 // 5 minutes
-        static let subfeature: any PrivacySubfeature = iOSBrowserConfigSubfeature.showNTPAfterIdleReturn
-    }
+    private let eligibilityManager: IdleReturnEligibilityManaging
 
-    private let featureFlagger: FeatureFlagger
-    private let privacyConfigurationManager: PrivacyConfigurationManaging
-    private let debugOverridesStorage: any KeyedStoring<IdleReturnDebugOverridesKeys>
-    private let idleReturnEligibilityManager: IdleReturnEligibilityManaging?
-
-    init(featureFlagger: FeatureFlagger,
-         privacyConfigurationManager: PrivacyConfigurationManaging,
-         debugOverridesStorage: (any KeyedStoring<IdleReturnDebugOverridesKeys>)? = nil,
-         idleReturnEligibilityManager: IdleReturnEligibilityManaging? = nil) {
-        self.featureFlagger = featureFlagger
-        self.privacyConfigurationManager = privacyConfigurationManager
-        self.debugOverridesStorage = if let debugOverridesStorage { debugOverridesStorage } else { UserDefaults.app.keyedStoring() }
-        self.idleReturnEligibilityManager = idleReturnEligibilityManager
+    init(eligibilityManager: IdleReturnEligibilityManaging) {
+        self.eligibilityManager = eligibilityManager
     }
 
     func didReturnAfterIdle(lastBackgroundDate: Date?) -> Bool {
-        guard featureFlagger.isFeatureOn(.showNTPAfterIdleReturn) else {
+        guard eligibilityManager.isFeatureAvailable(),
+              let lastBackgroundDate else {
             return false
         }
-        guard let lastBackgroundDate else {
-            return false
-        }
-        let thresholdSeconds = idleThresholdSeconds()
+        let thresholdSeconds = eligibilityManager.idleThresholdSeconds()
         return Date().timeIntervalSince(lastBackgroundDate) >= Double(thresholdSeconds)
     }
 
     func treatmentForIdleReturn() -> IdleReturnTreatment {
-        if idleReturnEligibilityManager?.isEligibleForNTPAfterIdle() ?? true {
+        switch eligibilityManager.effectiveAfterInactivityOption() {
+        case .newTab:
             return .ntp
+        case .lastUsedTab:
+            return .lut
         }
-        return .lut
-    }
-
-    private func idleThresholdSeconds() -> Int {
-        let resolver = IdleReturnThresholdResolver(
-            privacyConfigurationManager: privacyConfigurationManager,
-            debugOverridesStorage: debugOverridesStorage
-        )
-        return resolver.thresholdSeconds()
     }
 }

--- a/iOS/DuckDuckGo/AppLifecycle/IdleReturnEvaluator.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/IdleReturnEvaluator.swift
@@ -22,12 +22,19 @@ import Core
 import Persistence
 import PrivacyConfig
 
-protocol IdleReturnEvaluating {
-    func shouldShowNTPAfterIdle(lastBackgroundDate: Date?) -> Bool
+enum IdleReturnTreatment {
+    case ntp
+    case lut
+}
 
-    /// Whether the idle threshold was exceeded since the last background — independent
-    /// of whether the user's setting will surface NTP-after-idle or LUT-after-idle.
-    func idleThresholdPassed(lastBackgroundDate: Date?) -> Bool
+protocol IdleReturnEvaluating {
+    /// Whether the user returned after an idle period — feature flag and threshold only.
+    /// Independent of which treatment will be applied.
+    func didReturnAfterIdle(lastBackgroundDate: Date?) -> Bool
+
+    /// The treatment to apply on an idle return. Eligibility (onboarding state,
+    /// user's "After Inactivity" setting) selects between cases. Defaults to `.lut`.
+    func treatmentForIdleReturn() -> IdleReturnTreatment
 }
 
 /// Key namespace for idle-return NTP debug overrides (typed storage, no dotted keys).
@@ -101,29 +108,22 @@ final class IdleReturnEvaluator: IdleReturnEvaluating {
         self.idleReturnEligibilityManager = idleReturnEligibilityManager
     }
 
-    func shouldShowNTPAfterIdle(lastBackgroundDate: Date?) -> Bool {
+    func didReturnAfterIdle(lastBackgroundDate: Date?) -> Bool {
         guard featureFlagger.isFeatureOn(.showNTPAfterIdleReturn) else {
             return false
         }
         guard let lastBackgroundDate else {
-            return false
-        }
-        guard idleReturnEligibilityManager?.isEligibleForNTPAfterIdle() ?? true else {
             return false
         }
         let thresholdSeconds = idleThresholdSeconds()
         return Date().timeIntervalSince(lastBackgroundDate) >= Double(thresholdSeconds)
     }
 
-    func idleThresholdPassed(lastBackgroundDate: Date?) -> Bool {
-        guard featureFlagger.isFeatureOn(.showNTPAfterIdleReturn) else {
-            return false
+    func treatmentForIdleReturn() -> IdleReturnTreatment {
+        if idleReturnEligibilityManager?.isEligibleForNTPAfterIdle() ?? true {
+            return .ntp
         }
-        guard let lastBackgroundDate else {
-            return false
-        }
-        let thresholdSeconds = idleThresholdSeconds()
-        return Date().timeIntervalSince(lastBackgroundDate) >= Double(thresholdSeconds)
+        return .lut
     }
 
     private func idleThresholdSeconds() -> Int {

--- a/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
@@ -1,0 +1,143 @@
+//
+//  PostIdleSessionInstrumentation.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import PixelKit
+
+/// Session-scoped hooks for the post-idle wide-event pixel.
+///
+/// The caller decides which surface to fire (based on the user's After Inactivity
+/// setting) and is responsible for any per-surface eligibility gating. The
+/// instrumentation itself trusts the caller. Only one session may be in flight
+/// at a time; calling `sessionStarted` while another session is active cancels
+/// the previous one.
+protocol PostIdleSessionInstrumentation: AnyObject {
+
+    /// The post-idle surface (NTP or LUT) was displayed.
+    func sessionStarted(surface: PostIdleSessionWideEventData.Surface)
+
+    /// User scrolled or activated an in-page link. Idempotent within a session.
+    func pageEngaged()
+
+    /// User toggled between search and Duck.ai.
+    func toggleUsed()
+
+    /// User pressed back / cancel from the post-idle surface.
+    func backPressed()
+
+    /// Terminal user action ended the session (bar used, return-to-page, etc.).
+    func sessionEnded(reason: PostIdleSessionWideEventData.StatusReason)
+
+    /// App was backgrounded with a session still active. Completes as CANCELLED.
+    func sessionCancelledByBackground()
+}
+
+final class DefaultPostIdleSessionInstrumentation: PostIdleSessionInstrumentation {
+
+    private let wideEvent: WideEventManaging
+    private let dateProvider: () -> Date
+    private var activeSessionID: String?
+
+    init(wideEvent: WideEventManaging,
+         dateProvider: @escaping () -> Date = { Date() }) {
+        self.wideEvent = wideEvent
+        self.dateProvider = dateProvider
+    }
+
+    func sessionStarted(surface: PostIdleSessionWideEventData.Surface) {
+        // If a session is already active, cancel it before starting a new one.
+        // Quick background-foreground cycles over the idle threshold can trigger
+        // this; the previous session is reported as CANCELLED so we don't lose it.
+        if activeSessionID != nil {
+            sessionCancelledByBackground()
+        }
+
+        let data = PostIdleSessionWideEventData(surface: surface, startedAt: dateProvider())
+        activeSessionID = data.globalData.id
+        wideEvent.startFlow(data)
+    }
+
+    func pageEngaged() {
+        updateActiveSession { data in
+            data.pageEngaged = true
+            markFirstInteractionIfNeeded(&data)
+        }
+    }
+
+    func toggleUsed() {
+        updateActiveSession { data in
+            data.toggleUsed = true
+            markFirstInteractionIfNeeded(&data)
+        }
+    }
+
+    func backPressed() {
+        updateActiveSession { data in
+            data.backPressed = true
+            markFirstInteractionIfNeeded(&data)
+        }
+    }
+
+    func sessionEnded(reason: PostIdleSessionWideEventData.StatusReason) {
+        guard let globalID = activeSessionID,
+              let data = wideEvent.getFlowData(PostIdleSessionWideEventData.self, globalID: globalID) else {
+            activeSessionID = nil
+            return
+        }
+
+        let now = dateProvider()
+        data.statusReason = reason
+        data.sessionInterval.end = now
+        markFirstInteractionIfNeeded(on: data, at: now)
+
+        wideEvent.completeFlow(data, status: .success(reason: reason.rawValue), onComplete: { _, _ in })
+        activeSessionID = nil
+    }
+
+    func sessionCancelledByBackground() {
+        guard let globalID = activeSessionID,
+              let data = wideEvent.getFlowData(PostIdleSessionWideEventData.self, globalID: globalID) else {
+            activeSessionID = nil
+            return
+        }
+
+        data.statusReason = .appBackgrounded
+        data.sessionInterval.end = dateProvider()
+
+        wideEvent.completeFlow(data, status: .cancelled, onComplete: { _, _ in })
+        activeSessionID = nil
+    }
+
+    // MARK: - Helpers
+
+    private func updateActiveSession(_ mutate: (inout PostIdleSessionWideEventData) -> Void) {
+        guard let globalID = activeSessionID else { return }
+        wideEvent.updateFlow(globalID: globalID, update: mutate)
+    }
+
+    private func markFirstInteractionIfNeeded(_ data: inout PostIdleSessionWideEventData) {
+        guard data.firstInteractionInterval.end == nil else { return }
+        data.firstInteractionInterval.end = dateProvider()
+    }
+
+    private func markFirstInteractionIfNeeded(on data: PostIdleSessionWideEventData, at date: Date) {
+        guard data.firstInteractionInterval.end == nil else { return }
+        data.firstInteractionInterval.end = date
+    }
+}

--- a/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
@@ -53,6 +53,10 @@ final class DefaultPostIdleSessionInstrumentation: PostIdleSessionInstrumentatio
     private let wideEvent: WideEventManaging
     private let dateProvider: () -> Date
     private var activeSessionID: String?
+    /// Latches `pageEngaged` once per session so we don't hit `updateFlow`
+    /// (synchronous disk I/O) on every scroll tick — the page-engaged signal
+    /// is monotonic, the storage round-trip is wasted after the first call.
+    private var pageEngagedSent = false
 
     init(wideEvent: WideEventManaging,
          dateProvider: @escaping () -> Date = { Date() }) {
@@ -70,10 +74,13 @@ final class DefaultPostIdleSessionInstrumentation: PostIdleSessionInstrumentatio
 
         let data = PostIdleSessionWideEventData(surface: surface, startedAt: dateProvider())
         activeSessionID = data.globalData.id
+        pageEngagedSent = false
         wideEvent.startFlow(data)
     }
 
     func pageEngaged() {
+        guard !pageEngagedSent else { return }
+        pageEngagedSent = true
         updateActiveSession { data in
             data.pageEngaged = true
             markFirstInteractionIfNeeded(&data)

--- a/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
@@ -53,9 +53,7 @@ final class DefaultPostIdleSessionInstrumentation: PostIdleSessionInstrumentatio
     private let wideEvent: WideEventManaging
     private let dateProvider: () -> Date
     private var activeSessionID: String?
-    /// Latches `pageEngaged` once per session so we don't hit `updateFlow`
-    /// (synchronous disk I/O) on every scroll tick — the page-engaged signal
-    /// is monotonic, the storage round-trip is wasted after the first call.
+    /// Skips `updateFlow` (synchronous disk I/O) on every scroll tick after the first.
     private var pageEngagedSent = false
 
     init(wideEvent: WideEventManaging,

--- a/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
@@ -81,21 +81,21 @@ final class DefaultPostIdleSessionInstrumentation: PostIdleSessionInstrumentatio
         pageEngagedSent = true
         updateActiveSession { data in
             data.pageEngaged = true
-            markFirstInteractionIfNeeded(&data)
+            markFirstInteractionIfNeeded(on: data, at: dateProvider())
         }
     }
 
     func toggleUsed() {
         updateActiveSession { data in
             data.toggleUsed = true
-            markFirstInteractionIfNeeded(&data)
+            markFirstInteractionIfNeeded(on: data, at: dateProvider())
         }
     }
 
     func backPressed() {
         updateActiveSession { data in
             data.backPressed = true
-            markFirstInteractionIfNeeded(&data)
+            markFirstInteractionIfNeeded(on: data, at: dateProvider())
         }
     }
 
@@ -134,11 +134,6 @@ final class DefaultPostIdleSessionInstrumentation: PostIdleSessionInstrumentatio
     private func updateActiveSession(_ mutate: (inout PostIdleSessionWideEventData) -> Void) {
         guard let globalID = activeSessionID else { return }
         wideEvent.updateFlow(globalID: globalID, update: mutate)
-    }
-
-    private func markFirstInteractionIfNeeded(_ data: inout PostIdleSessionWideEventData) {
-        guard data.firstInteractionInterval.end == nil else { return }
-        data.firstInteractionInterval.end = dateProvider()
     }
 
     private func markFirstInteractionIfNeeded(on data: PostIdleSessionWideEventData, at date: Date) {

--- a/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionWideEventData.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionWideEventData.swift
@@ -1,0 +1,125 @@
+//
+//  PostIdleSessionWideEventData.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Common
+import PixelKit
+
+/// Wide-event payload for the post-idle session pixel
+/// (`m_ios_wide_post_idle_session`). Captures the full journey of an
+/// NTP-after-idle or LUT-after-idle session.
+final class PostIdleSessionWideEventData: WideEventData {
+
+    static let metadata = WideEventMetadata(
+        pixelName: "post_idle_session",
+        featureName: "post_idle_session",
+        mobileMetaType: "ios-post-idle-session",
+        // API requires both; only mobileMetaType is read on iOS.
+        desktopMetaType: "macos-post-idle-session",
+        version: "1.0.0"
+    )
+
+    enum Surface: String, Codable, CaseIterable {
+        case ntp
+        case lut
+    }
+
+    enum StatusReason: String, Codable, CaseIterable {
+        case barUsed = "bar_used"
+        case returnToPageTapped = "return_to_page_tapped"
+        case tabSwitcherSelected = "tab_switcher_selected"
+        case appBackgrounded = "app_backgrounded"
+        case favoriteSelected = "favorite_selected"
+        case chatSelected = "chat_selected"
+    }
+
+    var globalData: WideEventGlobalData
+    var contextData: WideEventContextData
+    var appData: WideEventAppData
+    var errorData: WideEventErrorData?
+
+    var surface: Surface
+    var statusReason: StatusReason?
+    var sessionInterval: WideEvent.MeasuredInterval
+    var firstInteractionInterval: WideEvent.MeasuredInterval
+    var pageEngaged: Bool
+    var toggleUsed: Bool
+    var backPressed: Bool
+
+    init(surface: Surface,
+         startedAt: Date = Date(),
+         statusReason: StatusReason? = nil,
+         pageEngaged: Bool = false,
+         toggleUsed: Bool = false,
+         backPressed: Bool = false,
+         contextData: WideEventContextData = WideEventContextData(),
+         appData: WideEventAppData = WideEventAppData(),
+         globalData: WideEventGlobalData = WideEventGlobalData()) {
+        self.surface = surface
+        self.statusReason = statusReason
+        self.sessionInterval = WideEvent.MeasuredInterval(start: startedAt)
+        self.firstInteractionInterval = WideEvent.MeasuredInterval(start: startedAt)
+        self.pageEngaged = pageEngaged
+        self.toggleUsed = toggleUsed
+        self.backPressed = backPressed
+        self.contextData = contextData
+        self.appData = appData
+        self.globalData = globalData
+    }
+
+    /// Any pending flow on relaunch is by definition orphaned: the normal
+    /// background path completes flows as CANCELLED, and a successful
+    /// terminal action removes them. So if we still see one at app launch
+    /// the app died mid-session — complete immediately as UNKNOWN.
+    func completionDecision(for trigger: WideEventCompletionTrigger) async -> WideEventCompletionDecision {
+        switch trigger {
+        case .appLaunch:
+            return .complete(.unknown(reason: Self.appRelaunchedReason))
+        }
+    }
+
+    static let appRelaunchedReason = "app_relaunched"
+}
+
+extension PostIdleSessionWideEventData {
+
+    func jsonParameters() -> [String: Encodable] {
+        Dictionary(compacting: [
+            (WideEventParameter.PostIdleSessionFeature.surface, surface.rawValue),
+            (WideEventParameter.Feature.statusReason, statusReason?.rawValue),
+            (WideEventParameter.PostIdleSessionFeature.sessionDurationMs, sessionInterval.durationMilliseconds),
+            (WideEventParameter.PostIdleSessionFeature.timeToFirstInteractionMs, firstInteractionInterval.durationMilliseconds),
+            (WideEventParameter.PostIdleSessionFeature.pageEngaged, pageEngaged),
+            (WideEventParameter.PostIdleSessionFeature.toggleUsed, toggleUsed),
+            (WideEventParameter.PostIdleSessionFeature.backPressed, backPressed),
+        ])
+    }
+}
+
+extension WideEventParameter {
+
+    enum PostIdleSessionFeature {
+        static let surface = "feature.data.ext.surface"
+        static let sessionDurationMs = "feature.data.ext.session_duration_ms"
+        static let timeToFirstInteractionMs = "feature.data.ext.time_to_first_interaction_ms"
+        static let pageEngaged = "feature.data.ext.page_engaged"
+        static let toggleUsed = "feature.data.ext.toggle_used"
+        static let backPressed = "feature.data.ext.back_pressed"
+    }
+}

--- a/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionWideEventData.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionWideEventData.swift
@@ -90,11 +90,11 @@ final class PostIdleSessionWideEventData: WideEventData {
     func completionDecision(for trigger: WideEventCompletionTrigger) async -> WideEventCompletionDecision {
         switch trigger {
         case .appLaunch:
-            return .complete(.unknown(reason: Self.appRelaunchedReason))
+            return .complete(.unknown(reason: Self.appTerminatedReason))
         }
     }
 
-    static let appRelaunchedReason = "app_relaunched"
+    static let appTerminatedReason = "app_terminated"
 }
 
 extension PostIdleSessionWideEventData {

--- a/iOS/DuckDuckGo/AppServices/WideEventService.swift
+++ b/iOS/DuckDuckGo/AppServices/WideEventService.swift
@@ -49,6 +49,7 @@ actor WideEventService {
         await processCompletion(VPNConnectionWideEventData.self, trigger: trigger)
         await processSubscriptionPurchaseCompletion(trigger: trigger)
         await processCompletion(DataImportWideEventData.self, trigger: trigger)
+        await processCompletion(PostIdleSessionWideEventData.self, trigger: trigger)
 
         isProcessing = false
     }

--- a/iOS/DuckDuckGo/BrowserChromeManager.swift
+++ b/iOS/DuckDuckGo/BrowserChromeManager.swift
@@ -49,7 +49,9 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
             animator.delegate = delegate
         }
     }
-    
+
+    var onUserScrolled: (() -> Void)?
+
     private let animator = BarsAnimator()
     
     private var observation: NSKeyValueObservation?
@@ -82,8 +84,9 @@ class BrowserChromeManager: NSObject, UIScrollViewDelegate {
         
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         guard !scrollView.isZooming else { return }
-        
+
         guard scrollView.isDragging else { return }
+        onUserScrolled?()
         guard canHideBars(for: scrollView) else {
             if animator.barsState != .revealed {
                 animator.revealBars(animated: true)

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1470,8 +1470,9 @@ class MainViewController: UIViewController {
         return nil
     }
 
-    private func buildEscapeHatch() -> EscapeHatchModel? {
-        guard idleReturnEligibilityManager.isEligibleForNTPAfterIdle() else {
+    private func buildEscapeHatch(openedAfterIdle: Bool) -> EscapeHatchModel? {
+        guard openedAfterIdle,
+              idleReturnEligibilityManager.isEligibleForNTPAfterIdle() else {
             return nil
         }
         let currentTab = tabManager.currentTabsModel.currentTab
@@ -1547,7 +1548,7 @@ class MainViewController: UIViewController {
 
         newTabPageViewController = controller
 
-        let hatch = buildEscapeHatch()
+        let hatch = buildEscapeHatch(openedAfterIdle: openedAfterIdle)
         controller.setEscapeHatch(hatch)
         currentNTPEscapeHatch = hatch
         

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3857,17 +3857,20 @@ extension MainViewController: OmniBarDelegate {
             PixelParameters.browsingMode: tabManager.currentBrowsingMode.pixelParamValue
         ])
         guard !experimentDuckAIFireOnboardingFlow.controlsLocked else { return }
+        postIdleSessionInstrumentation.sessionEnded(reason: .tabSwitcherSelected)
         performCancel()
         newTab()
     }
 
     private func newFireTabLongPressMenuAction() {
+        postIdleSessionInstrumentation.sessionEnded(reason: .tabSwitcherSelected)
         tabManager.setBrowsingMode(.fire, source: .longPressTabsIcon)
         performCancel()
         newTab()
     }
 
     private func newNormalTabLongPressMenuAction() {
+        postIdleSessionInstrumentation.sessionEnded(reason: .tabSwitcherSelected)
         tabManager.setBrowsingMode(.normal, source: .longPressTabsIcon)
         performCancel()
         newTab()

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1593,10 +1593,7 @@ class MainViewController: UIViewController {
         // about to shown to the user.
         if presentedViewController == nil || presentedViewController?.isBeingDismissed == true {
             fireNewTabPixels()
-            ntpAfterIdleInstrumentation.ntpShown(afterIdle: openedAfterIdle)
-            if openedAfterIdle {
-                postIdleSessionInstrumentation.sessionStarted(surface: .ntp)
-            }
+            fireNTPShownInstrumentation(openedAfterIdle: openedAfterIdle)
         }
 
         if isNewTab && allowingKeyboard && KeyboardSettings().onNewTab {
@@ -1604,6 +1601,13 @@ class MainViewController: UIViewController {
         }
 
         syncService.scheduler.requestSyncImmediately()
+    }
+
+    private func fireNTPShownInstrumentation(openedAfterIdle: Bool) {
+        ntpAfterIdleInstrumentation.ntpShown(afterIdle: openedAfterIdle)
+        if openedAfterIdle {
+            postIdleSessionInstrumentation.sessionStarted(surface: .ntp)
+        }
     }
 
     func fireNewTabPixels() {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -181,6 +181,7 @@ class MainViewController: UIViewController {
     let featureFlagger: FeatureFlagger
     let idleReturnEligibilityManager: IdleReturnEligibilityManaging
     let ntpAfterIdleInstrumentation: NTPAfterIdleInstrumentation
+    let postIdleSessionInstrumentation: PostIdleSessionInstrumentation
     let syncAutoRestoreHandler: SyncAutoRestoreHandling
     private let lastActiveTabStore: LastActiveTabStoring
     let fireModeCapability: FireModeCapable
@@ -462,6 +463,7 @@ class MainViewController: UIViewController {
         self.idleReturnEligibilityManager = idleReturnEligibilityManager
         self.lastActiveTabStore = lastActiveTabStore
         self.ntpAfterIdleInstrumentation = DefaultNTPAfterIdleInstrumentation(eligibilityManager: idleReturnEligibilityManager)
+        self.postIdleSessionInstrumentation = DefaultPostIdleSessionInstrumentation(wideEvent: AppDependencyProvider.shared.wideEvent)
         self.syncAutoRestoreHandler = syncAutoRestoreHandler
         self.fireproofing = fireproofing
         self.favicons = favicons
@@ -605,6 +607,9 @@ class MainViewController: UIViewController {
         
         chromeManager = BrowserChromeManager()
         chromeManager.delegate = self
+        chromeManager.onUserScrolled = { [weak self] in
+            self?.postIdleSessionInstrumentation.pageEngaged()
+        }
         initTabButton()
         initBookmarksButton()
         setUpUnifiedToggleInputIfNeeded()
@@ -1109,6 +1114,7 @@ class MainViewController: UIViewController {
         if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {
             ntpAfterIdleInstrumentation.appBackgroundedFromNTP(afterIdle: tab.openedAfterIdle)
         }
+        postIdleSessionInstrumentation.sessionCancelledByBackground()
 
         /// Resign the web view's first responder when backgrounding with the tab switcher
         /// visible. The tab switcher uses .overCurrentContext so the WKWebView stays in the
@@ -1588,6 +1594,9 @@ class MainViewController: UIViewController {
         if presentedViewController == nil || presentedViewController?.isBeingDismissed == true {
             fireNewTabPixels()
             ntpAfterIdleInstrumentation.ntpShown(afterIdle: openedAfterIdle)
+            if openedAfterIdle {
+                postIdleSessionInstrumentation.sessionStarted(surface: .ntp)
+            }
         }
 
         if isNewTab && allowingKeyboard && KeyboardSettings().onNewTab {
@@ -1865,6 +1874,7 @@ class MainViewController: UIViewController {
         if currentTab.tabModel.link == nil {
             ntpAfterIdleInstrumentation.barUsedFromNTP(afterIdle: currentTab.tabModel.openedAfterIdle)
         }
+        postIdleSessionInstrumentation.sessionEnded(reason: .barUsed)
         prepareTabForRequest {
             currentTab.load(
                 query,
@@ -3358,6 +3368,7 @@ extension MainViewController: BrowserChromeDelegate {
             return
         }
 
+        postIdleSessionInstrumentation.sessionEnded(reason: .favoriteSelected)
         newTabPageViewController?.chromeDelegate = nil
         dismissOmniBar()
         favicons.loadFavicon(forDomain: url.host, intoCache: .fireproof, fromCache: .tabs)
@@ -3374,6 +3385,7 @@ extension MainViewController: BrowserChromeDelegate {
         if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {
             ntpAfterIdleInstrumentation.barUsedFromNTP(afterIdle: tab.openedAfterIdle)
         }
+        postIdleSessionInstrumentation.sessionEnded(reason: .barUsed)
         newTabPageViewController?.chromeDelegate = nil
         dismissOmniBar()
         viewCoordinator.omniBar.cancel()
@@ -3819,6 +3831,7 @@ extension MainViewController: OmniBarDelegate {
         if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {
             ntpAfterIdleInstrumentation.backButtonUsedFromNTP(afterIdle: tab.openedAfterIdle)
         }
+        postIdleSessionInstrumentation.backPressed()
         performCancel()
     }
 
@@ -4153,6 +4166,7 @@ extension MainViewController: OmniBarDelegate {
         if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {
             ntpAfterIdleInstrumentation.backButtonUsedFromNTP(afterIdle: tab.openedAfterIdle)
         }
+        postIdleSessionInstrumentation.backPressed()
     }
 
     /// Delegate method called when the AI Chat left button is tapped
@@ -4202,6 +4216,7 @@ extension MainViewController: OmniBarDelegate {
         }
         let wasAfterIdle = currentTab?.openedAfterIdle ?? false
         ntpAfterIdleInstrumentation.returnToPageTapped(afterIdle: wasAfterIdle)
+        postIdleSessionInstrumentation.sessionEnded(reason: .returnToPageTapped)
         viewCoordinator.omniBar.endEditing()
         if let currentTab {
             closeTab(currentTab)
@@ -4213,6 +4228,7 @@ extension MainViewController: OmniBarDelegate {
         if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {
             ntpAfterIdleInstrumentation.toggleUsedFromNTP(afterIdle: tab.openedAfterIdle)
         }
+        postIdleSessionInstrumentation.toggleUsed()
         iPadAIChatQuery = currentIPadAIQuery()
         guard iPadTabChatHistoryCoordinator.isInstalled else { return }
         if isModeToggleInAIChatMode {
@@ -4366,6 +4382,7 @@ extension MainViewController: NewTabPageControllerDelegate {
         guard tab !== currentTab else { return }
         let wasAfterIdle = currentTab?.openedAfterIdle ?? false
         ntpAfterIdleInstrumentation.returnToPageTapped(afterIdle: wasAfterIdle)
+        postIdleSessionInstrumentation.sessionEnded(reason: .returnToPageTapped)
         if let currentTab {
             closeTab(currentTab)
         }
@@ -4394,6 +4411,10 @@ extension MainViewController: TabDelegate {
 
     func tabDidRequestFireMode(tab: TabViewController) {
         navigateToFireMode(source: .menuPromotion)
+    }
+
+    func tabDidEngageWithPage(_ tab: TabViewController) {
+        postIdleSessionInstrumentation.pageEngaged()
     }
 
     var isAIChatEnabled: Bool {
@@ -4969,6 +4990,7 @@ extension MainViewController: TabSwitcherButtonDelegate {
         if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {
             ntpAfterIdleInstrumentation.tabSwitcherSelectedFromNTP(afterIdle: tab.openedAfterIdle)
         }
+        postIdleSessionInstrumentation.sessionEnded(reason: .tabSwitcherSelected)
         tabManager.currentTabsModel.currentTab?.openedAfterIdle = false
         hideNotificationBarIfBrokenSitePromptShown()
         updatePreviewForCurrentTab {
@@ -5951,6 +5973,7 @@ extension MainViewController {
 extension MainViewController: AIChatHistoryManagerDelegate {
 
     func aiChatHistoryManager(_ manager: AIChatHistoryManager, didSelectChatURL url: URL) {
+        postIdleSessionInstrumentation.sessionEnded(reason: .chatSelected)
         onChatHistorySelected(url: url)
     }
 }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3448,6 +3448,7 @@ extension MainViewController: OmniBarDelegate {
     }
 
     func onChatHistorySelected(url: URL) {
+        postIdleSessionInstrumentation.sessionEnded(reason: .chatSelected)
         loadUrlInNewTab(url, inheritedAttribution: nil)
     }
 
@@ -5973,7 +5974,6 @@ extension MainViewController {
 extension MainViewController: AIChatHistoryManagerDelegate {
 
     func aiChatHistoryManager(_ manager: AIChatHistoryManager, didSelectChatURL url: URL) {
-        postIdleSessionInstrumentation.sessionEnded(reason: .chatSelected)
         onChatHistorySelected(url: url)
     }
 }

--- a/iOS/DuckDuckGo/TabDelegate.swift
+++ b/iOS/DuckDuckGo/TabDelegate.swift
@@ -119,6 +119,9 @@ protocol TabDelegate: AnyObject {
     func closeFindInPage(tab: TabViewController)
 
     func tabContentProcessDidTerminate(tab: TabViewController)
+
+    /// User activated an in-page link in this tab.
+    func tabDidEngageWithPage(_ tab: TabViewController)
     
     func tabDidRequestFireButtonPulse(tab: TabViewController)
 

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -2428,6 +2428,10 @@ extension TabViewController: WKNavigationDelegate {
     private func decidePolicyFor(navigationAction: WKNavigationAction, completion: @escaping (WKNavigationActionPolicy) -> Void) {
         let allowPolicy = determineAllowPolicy()
 
+        if navigationAction.navigationType == .linkActivated {
+            delegate?.tabDidEngageWithPage(self)
+        }
+
         let tld = storageCache.tld
         
         // If WKNavigationAction requests to shouldPerformDownload prepare for handling it in decidePolicyFor:navigationResponse:

--- a/iOS/DuckDuckGo/UICoordination/LaunchActionHandler.swift
+++ b/iOS/DuckDuckGo/UICoordination/LaunchActionHandler.swift
@@ -45,6 +45,7 @@ enum LaunchAction {
 @MainActor
 protocol IdleReturnLaunchDelegate: AnyObject {
     func showNewTabPageAfterIdleReturn()
+    func markLastUsedTabAsResumedAfterIdle()
 }
 
 @MainActor
@@ -100,6 +101,9 @@ final class LaunchActionHandler: LaunchActionHandling {
             if idleReturnEvaluator.shouldShowNTPAfterIdle(lastBackgroundDate: lastBackgroundDate) {
                 idleReturnDelegate?.showNewTabPageAfterIdleReturn()
             } else {
+                if idleReturnEvaluator.idleThresholdPassed(lastBackgroundDate: lastBackgroundDate) {
+                    idleReturnDelegate?.markLastUsedTabAsResumedAfterIdle()
+                }
                 keyboardPresenter.showKeyboardOnLaunch(lastBackgroundDate: isFirstForeground ? nil : lastBackgroundDate)
             }
         }

--- a/iOS/DuckDuckGo/UICoordination/LaunchActionHandler.swift
+++ b/iOS/DuckDuckGo/UICoordination/LaunchActionHandler.swift
@@ -98,14 +98,16 @@ final class LaunchActionHandler: LaunchActionHandling {
             userActivityHandler.handleUserActivity(userActivity)
         case .standardLaunch(let lastBackgroundDate, let isFirstForeground):
             launchSourceManager.setSource(.standard)
-            if idleReturnEvaluator.shouldShowNTPAfterIdle(lastBackgroundDate: lastBackgroundDate) {
-                idleReturnDelegate?.showNewTabPageAfterIdleReturn()
-            } else {
-                if idleReturnEvaluator.idleThresholdPassed(lastBackgroundDate: lastBackgroundDate) {
+            if idleReturnEvaluator.didReturnAfterIdle(lastBackgroundDate: lastBackgroundDate) {
+                switch idleReturnEvaluator.treatmentForIdleReturn() {
+                case .ntp:
+                    idleReturnDelegate?.showNewTabPageAfterIdleReturn()
+                    return
+                case .lut:
                     idleReturnDelegate?.markLastUsedTabAsResumedAfterIdle()
                 }
-                keyboardPresenter.showKeyboardOnLaunch(lastBackgroundDate: isFirstForeground ? nil : lastBackgroundDate)
             }
+            keyboardPresenter.showKeyboardOnLaunch(lastBackgroundDate: isFirstForeground ? nil : lastBackgroundDate)
         }
     }
     

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -758,6 +758,10 @@ extension MainCoordinator: IdleReturnLaunchDelegate {
         }
     }
 
+    func markLastUsedTabAsResumedAfterIdle() {
+        controller.postIdleSessionInstrumentation.sessionStarted(surface: .lut)
+    }
+
 }
 
 // MARK: - SystemSettingsPiPTutorialPresenting

--- a/iOS/DuckDuckGoTests/IdleReturnEligibilityManagerTests.swift
+++ b/iOS/DuckDuckGoTests/IdleReturnEligibilityManagerTests.swift
@@ -69,13 +69,13 @@ struct IdleReturnEligibilityManagerTests {
         )
     }
 
-    @Test("isFeatureAvailable is true when flag is on and onboarding is complete", .timeLimit(.minutes(1)))
+    @Test("isFeatureAvailable is true when flag is on and onboarding is complete")
     func isFeatureAvailableTrueWhenAllPreconditionsMet() {
         let manager = makeManager(featureOn: true, hasSeenOnboarding: true, isStillOnboarding: false)
         #expect(manager.isFeatureAvailable())
     }
 
-    @Test("isFeatureAvailable is independent of effective After-Inactivity option", .timeLimit(.minutes(1)))
+    @Test("isFeatureAvailable is independent of effective After-Inactivity option")
     func isFeatureAvailableIgnoresEffectiveOption() {
         let managerNewTab = makeManager(featureOn: true, effectiveOption: .newTab)
         let managerLastUsed = makeManager(featureOn: true, effectiveOption: .lastUsedTab)
@@ -83,61 +83,61 @@ struct IdleReturnEligibilityManagerTests {
         #expect(managerLastUsed.isFeatureAvailable())
     }
 
-    @Test("isFeatureAvailable is false when feature flag is off", .timeLimit(.minutes(1)))
+    @Test("isFeatureAvailable is false when feature flag is off")
     func isFeatureAvailableFalseWhenFlagOff() {
         let manager = makeManager(featureOn: false)
         #expect(!manager.isFeatureAvailable())
     }
 
-    @Test("isFeatureAvailable is false when linear onboarding has not been seen", .timeLimit(.minutes(1)))
+    @Test("isFeatureAvailable is false when linear onboarding has not been seen")
     func isFeatureAvailableFalseWhenOnboardingNotSeen() {
         let manager = makeManager(featureOn: true, hasSeenOnboarding: false)
         #expect(!manager.isFeatureAvailable())
     }
 
-    @Test("isFeatureAvailable is false when contextual onboarding still active", .timeLimit(.minutes(1)))
+    @Test("isFeatureAvailable is false when contextual onboarding still active")
     func isFeatureAvailableFalseWhenContextualOnboardingActive() {
         let manager = makeManager(featureOn: true, isStillOnboarding: true)
         #expect(!manager.isFeatureAvailable())
     }
 
-    @Test("When all conditions met then isEligibleForNTPAfterIdle returns true", .timeLimit(.minutes(1)))
+    @Test("When all conditions met then isEligibleForNTPAfterIdle returns true")
     func whenAllConditionsMetThenIsEligibleReturnsTrue() {
         let manager = makeManager(featureOn: true, effectiveOption: .newTab)
         #expect(manager.isEligibleForNTPAfterIdle())
     }
 
-    @Test("When feature is off then isEligibleForNTPAfterIdle returns false", .timeLimit(.minutes(1)))
+    @Test("When feature is off then isEligibleForNTPAfterIdle returns false")
     func whenFeatureOffThenIsEligibleReturnsFalse() {
         let manager = makeManager(featureOn: false, effectiveOption: .newTab)
         #expect(!manager.isEligibleForNTPAfterIdle())
     }
 
-    @Test("When effective option is Last Used Tab then isEligibleForNTPAfterIdle returns false", .timeLimit(.minutes(1)))
+    @Test("When effective option is Last Used Tab then isEligibleForNTPAfterIdle returns false")
     func whenEffectiveOptionIsLastUsedTabThenIsEligibleReturnsFalse() {
         let manager = makeManager(featureOn: true, effectiveOption: .lastUsedTab)
         #expect(!manager.isEligibleForNTPAfterIdle())
     }
 
-    @Test("When linear onboarding has not been seen then isEligibleForNTPAfterIdle returns false", .timeLimit(.minutes(1)))
+    @Test("When linear onboarding has not been seen then isEligibleForNTPAfterIdle returns false")
     func whenLinearOnboardingNotSeenThenIsEligibleReturnsFalse() {
         let manager = makeManager(featureOn: true, effectiveOption: .newTab, hasSeenOnboarding: false)
         #expect(!manager.isEligibleForNTPAfterIdle())
     }
 
-    @Test("When contextual onboarding is still active then isEligibleForNTPAfterIdle returns false", .timeLimit(.minutes(1)))
+    @Test("When contextual onboarding is still active then isEligibleForNTPAfterIdle returns false")
     func whenContextualOnboardingActiveReturnsFalse() {
         let manager = makeManager(featureOn: true, effectiveOption: .newTab, isStillOnboarding: true)
         #expect(!manager.isEligibleForNTPAfterIdle())
     }
 
-    @Test("When contextual onboarding is done then isEligibleForNTPAfterIdle returns true", .timeLimit(.minutes(1)))
+    @Test("When contextual onboarding is done then isEligibleForNTPAfterIdle returns true")
     func whenContextualOnboardingDoneReturnsTrue() {
         let manager = makeManager(featureOn: true, effectiveOption: .newTab, isStillOnboarding: false)
         #expect(manager.isEligibleForNTPAfterIdle())
     }
 
-    @Test("effectiveAfterInactivityOption returns value from resolver", .timeLimit(.minutes(1)))
+    @Test("effectiveAfterInactivityOption returns value from resolver")
     func effectiveAfterInactivityOptionReturnsValueFromResolver() {
         let managerNewTab = makeManager(effectiveOption: .newTab)
         #expect(managerNewTab.effectiveAfterInactivityOption() == .newTab)
@@ -146,7 +146,7 @@ struct IdleReturnEligibilityManagerTests {
         #expect(managerLastUsed.effectiveAfterInactivityOption() == .lastUsedTab)
     }
 
-    @Test("idleThresholdSeconds returns value from threshold resolver", .timeLimit(.minutes(1)))
+    @Test("idleThresholdSeconds returns value from threshold resolver")
     func idleThresholdSecondsReturnsValueFromThresholdResolver() {
         let manager = makeManager(thresholdSeconds: 120)
         #expect(manager.idleThresholdSeconds() == 120)

--- a/iOS/DuckDuckGoTests/IdleReturnEligibilityManagerTests.swift
+++ b/iOS/DuckDuckGoTests/IdleReturnEligibilityManagerTests.swift
@@ -69,43 +69,75 @@ struct IdleReturnEligibilityManagerTests {
         )
     }
 
-    @Test("When all conditions met then isEligibleForNTPAfterIdle returns true")
+    @Test("isFeatureAvailable is true when flag is on and onboarding is complete", .timeLimit(.minutes(1)))
+    func isFeatureAvailableTrueWhenAllPreconditionsMet() {
+        let manager = makeManager(featureOn: true, hasSeenOnboarding: true, isStillOnboarding: false)
+        #expect(manager.isFeatureAvailable())
+    }
+
+    @Test("isFeatureAvailable is independent of effective After-Inactivity option", .timeLimit(.minutes(1)))
+    func isFeatureAvailableIgnoresEffectiveOption() {
+        let managerNewTab = makeManager(featureOn: true, effectiveOption: .newTab)
+        let managerLastUsed = makeManager(featureOn: true, effectiveOption: .lastUsedTab)
+        #expect(managerNewTab.isFeatureAvailable())
+        #expect(managerLastUsed.isFeatureAvailable())
+    }
+
+    @Test("isFeatureAvailable is false when feature flag is off", .timeLimit(.minutes(1)))
+    func isFeatureAvailableFalseWhenFlagOff() {
+        let manager = makeManager(featureOn: false)
+        #expect(!manager.isFeatureAvailable())
+    }
+
+    @Test("isFeatureAvailable is false when linear onboarding has not been seen", .timeLimit(.minutes(1)))
+    func isFeatureAvailableFalseWhenOnboardingNotSeen() {
+        let manager = makeManager(featureOn: true, hasSeenOnboarding: false)
+        #expect(!manager.isFeatureAvailable())
+    }
+
+    @Test("isFeatureAvailable is false when contextual onboarding still active", .timeLimit(.minutes(1)))
+    func isFeatureAvailableFalseWhenContextualOnboardingActive() {
+        let manager = makeManager(featureOn: true, isStillOnboarding: true)
+        #expect(!manager.isFeatureAvailable())
+    }
+
+    @Test("When all conditions met then isEligibleForNTPAfterIdle returns true", .timeLimit(.minutes(1)))
     func whenAllConditionsMetThenIsEligibleReturnsTrue() {
         let manager = makeManager(featureOn: true, effectiveOption: .newTab)
         #expect(manager.isEligibleForNTPAfterIdle())
     }
 
-    @Test("When feature is off then isEligibleForNTPAfterIdle returns false")
+    @Test("When feature is off then isEligibleForNTPAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenFeatureOffThenIsEligibleReturnsFalse() {
         let manager = makeManager(featureOn: false, effectiveOption: .newTab)
         #expect(!manager.isEligibleForNTPAfterIdle())
     }
 
-    @Test("When effective option is Last Used Tab then isEligibleForNTPAfterIdle returns false")
+    @Test("When effective option is Last Used Tab then isEligibleForNTPAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenEffectiveOptionIsLastUsedTabThenIsEligibleReturnsFalse() {
         let manager = makeManager(featureOn: true, effectiveOption: .lastUsedTab)
         #expect(!manager.isEligibleForNTPAfterIdle())
     }
 
-    @Test("When linear onboarding has not been seen then isEligibleForNTPAfterIdle returns false")
+    @Test("When linear onboarding has not been seen then isEligibleForNTPAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenLinearOnboardingNotSeenThenIsEligibleReturnsFalse() {
         let manager = makeManager(featureOn: true, effectiveOption: .newTab, hasSeenOnboarding: false)
         #expect(!manager.isEligibleForNTPAfterIdle())
     }
 
-    @Test("When contextual onboarding is still active then isEligibleForNTPAfterIdle returns false")
+    @Test("When contextual onboarding is still active then isEligibleForNTPAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenContextualOnboardingActiveReturnsFalse() {
         let manager = makeManager(featureOn: true, effectiveOption: .newTab, isStillOnboarding: true)
         #expect(!manager.isEligibleForNTPAfterIdle())
     }
 
-    @Test("When contextual onboarding is done then isEligibleForNTPAfterIdle returns true")
+    @Test("When contextual onboarding is done then isEligibleForNTPAfterIdle returns true", .timeLimit(.minutes(1)))
     func whenContextualOnboardingDoneReturnsTrue() {
         let manager = makeManager(featureOn: true, effectiveOption: .newTab, isStillOnboarding: false)
         #expect(manager.isEligibleForNTPAfterIdle())
     }
 
-    @Test("effectiveAfterInactivityOption returns value from resolver")
+    @Test("effectiveAfterInactivityOption returns value from resolver", .timeLimit(.minutes(1)))
     func effectiveAfterInactivityOptionReturnsValueFromResolver() {
         let managerNewTab = makeManager(effectiveOption: .newTab)
         #expect(managerNewTab.effectiveAfterInactivityOption() == .newTab)
@@ -114,7 +146,7 @@ struct IdleReturnEligibilityManagerTests {
         #expect(managerLastUsed.effectiveAfterInactivityOption() == .lastUsedTab)
     }
 
-    @Test("idleThresholdSeconds returns value from threshold resolver")
+    @Test("idleThresholdSeconds returns value from threshold resolver", .timeLimit(.minutes(1)))
     func idleThresholdSecondsReturnsValueFromThresholdResolver() {
         let manager = makeManager(thresholdSeconds: 120)
         #expect(manager.idleThresholdSeconds() == 120)

--- a/iOS/DuckDuckGoTests/IdleReturnEligibilityManagerTests.swift
+++ b/iOS/DuckDuckGoTests/IdleReturnEligibilityManagerTests.swift
@@ -69,12 +69,14 @@ struct IdleReturnEligibilityManagerTests {
         )
     }
 
+    @available(iOS 16, *)
     @Test("isFeatureAvailable is true when flag is on and onboarding is complete", .timeLimit(.minutes(1)))
     func isFeatureAvailableTrueWhenAllPreconditionsMet() {
         let manager = makeManager(featureOn: true, hasSeenOnboarding: true, isStillOnboarding: false)
         #expect(manager.isFeatureAvailable())
     }
 
+    @available(iOS 16, *)
     @Test("isFeatureAvailable is independent of effective After-Inactivity option", .timeLimit(.minutes(1)))
     func isFeatureAvailableIgnoresEffectiveOption() {
         let managerNewTab = makeManager(featureOn: true, effectiveOption: .newTab)
@@ -83,60 +85,70 @@ struct IdleReturnEligibilityManagerTests {
         #expect(managerLastUsed.isFeatureAvailable())
     }
 
+    @available(iOS 16, *)
     @Test("isFeatureAvailable is false when feature flag is off", .timeLimit(.minutes(1)))
     func isFeatureAvailableFalseWhenFlagOff() {
         let manager = makeManager(featureOn: false)
         #expect(!manager.isFeatureAvailable())
     }
 
+    @available(iOS 16, *)
     @Test("isFeatureAvailable is false when linear onboarding has not been seen", .timeLimit(.minutes(1)))
     func isFeatureAvailableFalseWhenOnboardingNotSeen() {
         let manager = makeManager(featureOn: true, hasSeenOnboarding: false)
         #expect(!manager.isFeatureAvailable())
     }
 
+    @available(iOS 16, *)
     @Test("isFeatureAvailable is false when contextual onboarding still active", .timeLimit(.minutes(1)))
     func isFeatureAvailableFalseWhenContextualOnboardingActive() {
         let manager = makeManager(featureOn: true, isStillOnboarding: true)
         #expect(!manager.isFeatureAvailable())
     }
 
+    @available(iOS 16, *)
     @Test("When all conditions met then isEligibleForNTPAfterIdle returns true", .timeLimit(.minutes(1)))
     func whenAllConditionsMetThenIsEligibleReturnsTrue() {
         let manager = makeManager(featureOn: true, effectiveOption: .newTab)
         #expect(manager.isEligibleForNTPAfterIdle())
     }
 
+    @available(iOS 16, *)
     @Test("When feature is off then isEligibleForNTPAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenFeatureOffThenIsEligibleReturnsFalse() {
         let manager = makeManager(featureOn: false, effectiveOption: .newTab)
         #expect(!manager.isEligibleForNTPAfterIdle())
     }
 
+    @available(iOS 16, *)
     @Test("When effective option is Last Used Tab then isEligibleForNTPAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenEffectiveOptionIsLastUsedTabThenIsEligibleReturnsFalse() {
         let manager = makeManager(featureOn: true, effectiveOption: .lastUsedTab)
         #expect(!manager.isEligibleForNTPAfterIdle())
     }
 
+    @available(iOS 16, *)
     @Test("When linear onboarding has not been seen then isEligibleForNTPAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenLinearOnboardingNotSeenThenIsEligibleReturnsFalse() {
         let manager = makeManager(featureOn: true, effectiveOption: .newTab, hasSeenOnboarding: false)
         #expect(!manager.isEligibleForNTPAfterIdle())
     }
 
+    @available(iOS 16, *)
     @Test("When contextual onboarding is still active then isEligibleForNTPAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenContextualOnboardingActiveReturnsFalse() {
         let manager = makeManager(featureOn: true, effectiveOption: .newTab, isStillOnboarding: true)
         #expect(!manager.isEligibleForNTPAfterIdle())
     }
 
+    @available(iOS 16, *)
     @Test("When contextual onboarding is done then isEligibleForNTPAfterIdle returns true", .timeLimit(.minutes(1)))
     func whenContextualOnboardingDoneReturnsTrue() {
         let manager = makeManager(featureOn: true, effectiveOption: .newTab, isStillOnboarding: false)
         #expect(manager.isEligibleForNTPAfterIdle())
     }
 
+    @available(iOS 16, *)
     @Test("effectiveAfterInactivityOption returns value from resolver", .timeLimit(.minutes(1)))
     func effectiveAfterInactivityOptionReturnsValueFromResolver() {
         let managerNewTab = makeManager(effectiveOption: .newTab)
@@ -146,6 +158,7 @@ struct IdleReturnEligibilityManagerTests {
         #expect(managerLastUsed.effectiveAfterInactivityOption() == .lastUsedTab)
     }
 
+    @available(iOS 16, *)
     @Test("idleThresholdSeconds returns value from threshold resolver", .timeLimit(.minutes(1)))
     func idleThresholdSecondsReturnsValueFromThresholdResolver() {
         let manager = makeManager(thresholdSeconds: 120)

--- a/iOS/DuckDuckGoTests/IdleReturnEligibilityManagerTests.swift
+++ b/iOS/DuckDuckGoTests/IdleReturnEligibilityManagerTests.swift
@@ -69,13 +69,13 @@ struct IdleReturnEligibilityManagerTests {
         )
     }
 
-    @Test("isFeatureAvailable is true when flag is on and onboarding is complete")
+    @Test("isFeatureAvailable is true when flag is on and onboarding is complete", .timeLimit(.minutes(1)))
     func isFeatureAvailableTrueWhenAllPreconditionsMet() {
         let manager = makeManager(featureOn: true, hasSeenOnboarding: true, isStillOnboarding: false)
         #expect(manager.isFeatureAvailable())
     }
 
-    @Test("isFeatureAvailable is independent of effective After-Inactivity option")
+    @Test("isFeatureAvailable is independent of effective After-Inactivity option", .timeLimit(.minutes(1)))
     func isFeatureAvailableIgnoresEffectiveOption() {
         let managerNewTab = makeManager(featureOn: true, effectiveOption: .newTab)
         let managerLastUsed = makeManager(featureOn: true, effectiveOption: .lastUsedTab)
@@ -83,61 +83,61 @@ struct IdleReturnEligibilityManagerTests {
         #expect(managerLastUsed.isFeatureAvailable())
     }
 
-    @Test("isFeatureAvailable is false when feature flag is off")
+    @Test("isFeatureAvailable is false when feature flag is off", .timeLimit(.minutes(1)))
     func isFeatureAvailableFalseWhenFlagOff() {
         let manager = makeManager(featureOn: false)
         #expect(!manager.isFeatureAvailable())
     }
 
-    @Test("isFeatureAvailable is false when linear onboarding has not been seen")
+    @Test("isFeatureAvailable is false when linear onboarding has not been seen", .timeLimit(.minutes(1)))
     func isFeatureAvailableFalseWhenOnboardingNotSeen() {
         let manager = makeManager(featureOn: true, hasSeenOnboarding: false)
         #expect(!manager.isFeatureAvailable())
     }
 
-    @Test("isFeatureAvailable is false when contextual onboarding still active")
+    @Test("isFeatureAvailable is false when contextual onboarding still active", .timeLimit(.minutes(1)))
     func isFeatureAvailableFalseWhenContextualOnboardingActive() {
         let manager = makeManager(featureOn: true, isStillOnboarding: true)
         #expect(!manager.isFeatureAvailable())
     }
 
-    @Test("When all conditions met then isEligibleForNTPAfterIdle returns true")
+    @Test("When all conditions met then isEligibleForNTPAfterIdle returns true", .timeLimit(.minutes(1)))
     func whenAllConditionsMetThenIsEligibleReturnsTrue() {
         let manager = makeManager(featureOn: true, effectiveOption: .newTab)
         #expect(manager.isEligibleForNTPAfterIdle())
     }
 
-    @Test("When feature is off then isEligibleForNTPAfterIdle returns false")
+    @Test("When feature is off then isEligibleForNTPAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenFeatureOffThenIsEligibleReturnsFalse() {
         let manager = makeManager(featureOn: false, effectiveOption: .newTab)
         #expect(!manager.isEligibleForNTPAfterIdle())
     }
 
-    @Test("When effective option is Last Used Tab then isEligibleForNTPAfterIdle returns false")
+    @Test("When effective option is Last Used Tab then isEligibleForNTPAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenEffectiveOptionIsLastUsedTabThenIsEligibleReturnsFalse() {
         let manager = makeManager(featureOn: true, effectiveOption: .lastUsedTab)
         #expect(!manager.isEligibleForNTPAfterIdle())
     }
 
-    @Test("When linear onboarding has not been seen then isEligibleForNTPAfterIdle returns false")
+    @Test("When linear onboarding has not been seen then isEligibleForNTPAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenLinearOnboardingNotSeenThenIsEligibleReturnsFalse() {
         let manager = makeManager(featureOn: true, effectiveOption: .newTab, hasSeenOnboarding: false)
         #expect(!manager.isEligibleForNTPAfterIdle())
     }
 
-    @Test("When contextual onboarding is still active then isEligibleForNTPAfterIdle returns false")
+    @Test("When contextual onboarding is still active then isEligibleForNTPAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenContextualOnboardingActiveReturnsFalse() {
         let manager = makeManager(featureOn: true, effectiveOption: .newTab, isStillOnboarding: true)
         #expect(!manager.isEligibleForNTPAfterIdle())
     }
 
-    @Test("When contextual onboarding is done then isEligibleForNTPAfterIdle returns true")
+    @Test("When contextual onboarding is done then isEligibleForNTPAfterIdle returns true", .timeLimit(.minutes(1)))
     func whenContextualOnboardingDoneReturnsTrue() {
         let manager = makeManager(featureOn: true, effectiveOption: .newTab, isStillOnboarding: false)
         #expect(manager.isEligibleForNTPAfterIdle())
     }
 
-    @Test("effectiveAfterInactivityOption returns value from resolver")
+    @Test("effectiveAfterInactivityOption returns value from resolver", .timeLimit(.minutes(1)))
     func effectiveAfterInactivityOptionReturnsValueFromResolver() {
         let managerNewTab = makeManager(effectiveOption: .newTab)
         #expect(managerNewTab.effectiveAfterInactivityOption() == .newTab)
@@ -146,7 +146,7 @@ struct IdleReturnEligibilityManagerTests {
         #expect(managerLastUsed.effectiveAfterInactivityOption() == .lastUsedTab)
     }
 
-    @Test("idleThresholdSeconds returns value from threshold resolver")
+    @Test("idleThresholdSeconds returns value from threshold resolver", .timeLimit(.minutes(1)))
     func idleThresholdSecondsReturnsValueFromThresholdResolver() {
         let manager = makeManager(thresholdSeconds: 120)
         #expect(manager.idleThresholdSeconds() == 120)

--- a/iOS/DuckDuckGoTests/IdleReturnEvaluatorTests.swift
+++ b/iOS/DuckDuckGoTests/IdleReturnEvaluatorTests.swift
@@ -24,9 +24,14 @@ import PrivacyConfig
 @testable import DuckDuckGo
 
 final class MockIdleReturnEligibilityManager: IdleReturnEligibilityManaging {
+    var isFeatureAvailableResult = true
     var isEligibleForNTPAfterIdleResult = true
     var effectiveAfterInactivityOptionResult: AfterInactivityOption = .newTab
     var idleThresholdSecondsResult = 300
+
+    func isFeatureAvailable() -> Bool {
+        isFeatureAvailableResult
+    }
 
     func isEligibleForNTPAfterIdle() -> Bool {
         isEligibleForNTPAfterIdleResult
@@ -44,103 +49,61 @@ final class MockIdleReturnEligibilityManager: IdleReturnEligibilityManaging {
 @MainActor
 final class IdleReturnEvaluatorTests {
 
-    func makeEvaluator(
-        featureOn: Bool = true,
-        settingsJSON: String? = "{\"idleThresholdSeconds\": 60}",
-        eligibilityManager: IdleReturnEligibilityManaging? = nil
-    ) -> IdleReturnEvaluator {
-        let mockConfig = MockPrivacyConfiguration()
-        mockConfig.subfeatureSettings = settingsJSON
-        let mockManager = MockPrivacyConfigurationManager()
-        mockManager.privacyConfig = mockConfig
-        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: featureOn ? [.showNTPAfterIdleReturn] : [])
-        return IdleReturnEvaluator(
-            featureFlagger: featureFlagger,
-            privacyConfigurationManager: mockManager,
-            idleReturnEligibilityManager: eligibilityManager
-        )
+    private func makeEligibility(
+        featureAvailable: Bool = true,
+        thresholdSeconds: Int = 60,
+        effectiveOption: AfterInactivityOption = .newTab
+    ) -> MockIdleReturnEligibilityManager {
+        let mock = MockIdleReturnEligibilityManager()
+        mock.isFeatureAvailableResult = featureAvailable
+        mock.idleThresholdSecondsResult = thresholdSeconds
+        mock.effectiveAfterInactivityOptionResult = effectiveOption
+        return mock
     }
 
-    @Test("When feature is off then didReturnAfterIdle returns false")
-    func whenFeatureOffThenReturnsFalse() {
-        let evaluator = makeEvaluator(featureOn: false)
+    @Test("When feature is unavailable then didReturnAfterIdle returns false", .timeLimit(.minutes(1)))
+    func whenFeatureUnavailableThenReturnsFalse() {
+        let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(featureAvailable: false))
         let date = Date().addingTimeInterval(-61)
         #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: date))
     }
 
-    @Test("When lastBackgroundDate is nil then didReturnAfterIdle returns false")
+    @Test("When lastBackgroundDate is nil then didReturnAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenLastBackgroundDateNilThenReturnsFalse() {
-        let evaluator = makeEvaluator()
+        let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility())
         #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: nil))
     }
 
-    @Test("When under threshold then didReturnAfterIdle returns false")
+    @Test("When under threshold then didReturnAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenUnderThresholdThenReturnsFalse() {
-        let evaluator = makeEvaluator(settingsJSON: "{\"idleThresholdSeconds\": 120}")
-        let oneHourAgo = Date().addingTimeInterval(-110)
-        #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: oneHourAgo))
+        let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(thresholdSeconds: 120))
+        let underThreshold = Date().addingTimeInterval(-110)
+        #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: underThreshold))
     }
 
-    @Test("When over threshold then didReturnAfterIdle returns true")
+    @Test("When over threshold then didReturnAfterIdle returns true", .timeLimit(.minutes(1)))
     func whenOverThresholdThenReturnsTrue() {
-        let evaluator = makeEvaluator(settingsJSON: "{\"idleThresholdSeconds\": 120}")
-        let twoHoursAgo = Date().addingTimeInterval(-121)
-        #expect(evaluator.didReturnAfterIdle(lastBackgroundDate: twoHoursAgo))
+        let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(thresholdSeconds: 120))
+        let overThreshold = Date().addingTimeInterval(-121)
+        #expect(evaluator.didReturnAfterIdle(lastBackgroundDate: overThreshold))
     }
 
-    @Test("When at exactly threshold then didReturnAfterIdle returns true")
+    @Test("When at exactly threshold then didReturnAfterIdle returns true", .timeLimit(.minutes(1)))
     func whenAtThresholdThenReturnsTrue() {
-        let evaluator = makeEvaluator(settingsJSON: "{\"idleThresholdSeconds\": 120}")
-        let oneMinuteAgo = Date().addingTimeInterval(-120)
-        #expect(evaluator.didReturnAfterIdle(lastBackgroundDate: oneMinuteAgo))
+        let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(thresholdSeconds: 120))
+        let atThreshold = Date().addingTimeInterval(-120)
+        #expect(evaluator.didReturnAfterIdle(lastBackgroundDate: atThreshold))
     }
 
-    @Test("When settings missing then uses default threshold and returns true for 300+s idle")
-    func whenSettingsMissingThenUsesDefaultThreshold() {
-        let evaluator = makeEvaluator(settingsJSON: nil)
-        let fiveMinutesAgo = Date().addingTimeInterval(-300)
-        #expect(evaluator.didReturnAfterIdle(lastBackgroundDate: fiveMinutesAgo))
-        let justUnderFiveMinutes = Date().addingTimeInterval(-299)
-        #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: justUnderFiveMinutes))
-    }
-
-    @Test("When settings invalid JSON then uses default threshold")
-    func whenSettingsInvalidThenUsesDefaultThreshold() {
-        let evaluator = makeEvaluator(settingsJSON: "not json")
-        let fiveMinutesAgo = Date().addingTimeInterval(-300)
-        #expect(evaluator.didReturnAfterIdle(lastBackgroundDate: fiveMinutesAgo))
-        let justUnderFiveMinutes = Date().addingTimeInterval(-299)
-        #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: justUnderFiveMinutes))
-    }
-
-    @Test("When idleThresholdSeconds missing in settings then uses default")
-    func whenIdleThresholdSecondsMissingThenUsesDefault() {
-        let evaluator = makeEvaluator(settingsJSON: "{}")
-        let fiveMinutesAgo = Date().addingTimeInterval(-300)
-        #expect(evaluator.didReturnAfterIdle(lastBackgroundDate: fiveMinutesAgo))
-        let justUnderFiveMinutes = Date().addingTimeInterval(-299)
-        #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: justUnderFiveMinutes))
-    }
-
-    @Test("When eligibility manager returns true then treatmentForIdleReturn is .ntp")
-    func whenEligibleThenTreatmentIsNTP() {
-        let mockEligibility = MockIdleReturnEligibilityManager()
-        mockEligibility.isEligibleForNTPAfterIdleResult = true
-        let evaluator = makeEvaluator(eligibilityManager: mockEligibility)
+    @Test("When effective option is .newTab then treatmentForIdleReturn is .ntp", .timeLimit(.minutes(1)))
+    func whenEffectiveOptionIsNewTabThenTreatmentIsNTP() {
+        let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(effectiveOption: .newTab))
         #expect(evaluator.treatmentForIdleReturn() == .ntp)
     }
 
-    @Test("When eligibility manager returns false then treatmentForIdleReturn is .lut")
-    func whenNotEligibleThenTreatmentIsLUT() {
-        let mockEligibility = MockIdleReturnEligibilityManager()
-        mockEligibility.isEligibleForNTPAfterIdleResult = false
-        let evaluator = makeEvaluator(eligibilityManager: mockEligibility)
+    @Test("When effective option is .lastUsedTab then treatmentForIdleReturn is .lut", .timeLimit(.minutes(1)))
+    func whenEffectiveOptionIsLastUsedTabThenTreatmentIsLUT() {
+        let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(effectiveOption: .lastUsedTab))
         #expect(evaluator.treatmentForIdleReturn() == .lut)
-    }
-
-    @Test("When no eligibility manager provided then treatmentForIdleReturn defaults to .ntp")
-    func whenNoEligibilityManagerThenTreatmentIsNTP() {
-        let evaluator = makeEvaluator(eligibilityManager: nil)
-        #expect(evaluator.treatmentForIdleReturn() == .ntp)
     }
 }

--- a/iOS/DuckDuckGoTests/IdleReturnEvaluatorTests.swift
+++ b/iOS/DuckDuckGoTests/IdleReturnEvaluatorTests.swift
@@ -61,47 +61,47 @@ final class IdleReturnEvaluatorTests {
         return mock
     }
 
-    @Test("When feature is unavailable then didReturnAfterIdle returns false")
+    @Test("When feature is unavailable then didReturnAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenFeatureUnavailableThenReturnsFalse() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(featureAvailable: false))
         let date = Date().addingTimeInterval(-61)
         #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: date))
     }
 
-    @Test("When lastBackgroundDate is nil then didReturnAfterIdle returns false")
+    @Test("When lastBackgroundDate is nil then didReturnAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenLastBackgroundDateNilThenReturnsFalse() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility())
         #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: nil))
     }
 
-    @Test("When under threshold then didReturnAfterIdle returns false")
+    @Test("When under threshold then didReturnAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenUnderThresholdThenReturnsFalse() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(thresholdSeconds: 120))
         let underThreshold = Date().addingTimeInterval(-110)
         #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: underThreshold))
     }
 
-    @Test("When over threshold then didReturnAfterIdle returns true")
+    @Test("When over threshold then didReturnAfterIdle returns true", .timeLimit(.minutes(1)))
     func whenOverThresholdThenReturnsTrue() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(thresholdSeconds: 120))
         let overThreshold = Date().addingTimeInterval(-121)
         #expect(evaluator.didReturnAfterIdle(lastBackgroundDate: overThreshold))
     }
 
-    @Test("When at exactly threshold then didReturnAfterIdle returns true")
+    @Test("When at exactly threshold then didReturnAfterIdle returns true", .timeLimit(.minutes(1)))
     func whenAtThresholdThenReturnsTrue() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(thresholdSeconds: 120))
         let atThreshold = Date().addingTimeInterval(-120)
         #expect(evaluator.didReturnAfterIdle(lastBackgroundDate: atThreshold))
     }
 
-    @Test("When effective option is .newTab then treatmentForIdleReturn is .ntp")
+    @Test("When effective option is .newTab then treatmentForIdleReturn is .ntp", .timeLimit(.minutes(1)))
     func whenEffectiveOptionIsNewTabThenTreatmentIsNTP() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(effectiveOption: .newTab))
         #expect(evaluator.treatmentForIdleReturn() == .ntp)
     }
 
-    @Test("When effective option is .lastUsedTab then treatmentForIdleReturn is .lut")
+    @Test("When effective option is .lastUsedTab then treatmentForIdleReturn is .lut", .timeLimit(.minutes(1)))
     func whenEffectiveOptionIsLastUsedTabThenTreatmentIsLUT() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(effectiveOption: .lastUsedTab))
         #expect(evaluator.treatmentForIdleReturn() == .lut)

--- a/iOS/DuckDuckGoTests/IdleReturnEvaluatorTests.swift
+++ b/iOS/DuckDuckGoTests/IdleReturnEvaluatorTests.swift
@@ -61,6 +61,7 @@ final class IdleReturnEvaluatorTests {
         return mock
     }
 
+    @available(iOS 16, *)
     @Test("When feature is unavailable then didReturnAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenFeatureUnavailableThenReturnsFalse() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(featureAvailable: false))
@@ -68,12 +69,14 @@ final class IdleReturnEvaluatorTests {
         #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: date))
     }
 
+    @available(iOS 16, *)
     @Test("When lastBackgroundDate is nil then didReturnAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenLastBackgroundDateNilThenReturnsFalse() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility())
         #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: nil))
     }
 
+    @available(iOS 16, *)
     @Test("When under threshold then didReturnAfterIdle returns false", .timeLimit(.minutes(1)))
     func whenUnderThresholdThenReturnsFalse() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(thresholdSeconds: 120))
@@ -81,6 +84,7 @@ final class IdleReturnEvaluatorTests {
         #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: underThreshold))
     }
 
+    @available(iOS 16, *)
     @Test("When over threshold then didReturnAfterIdle returns true", .timeLimit(.minutes(1)))
     func whenOverThresholdThenReturnsTrue() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(thresholdSeconds: 120))
@@ -88,6 +92,7 @@ final class IdleReturnEvaluatorTests {
         #expect(evaluator.didReturnAfterIdle(lastBackgroundDate: overThreshold))
     }
 
+    @available(iOS 16, *)
     @Test("When at exactly threshold then didReturnAfterIdle returns true", .timeLimit(.minutes(1)))
     func whenAtThresholdThenReturnsTrue() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(thresholdSeconds: 120))
@@ -95,12 +100,14 @@ final class IdleReturnEvaluatorTests {
         #expect(evaluator.didReturnAfterIdle(lastBackgroundDate: atThreshold))
     }
 
+    @available(iOS 16, *)
     @Test("When effective option is .newTab then treatmentForIdleReturn is .ntp", .timeLimit(.minutes(1)))
     func whenEffectiveOptionIsNewTabThenTreatmentIsNTP() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(effectiveOption: .newTab))
         #expect(evaluator.treatmentForIdleReturn() == .ntp)
     }
 
+    @available(iOS 16, *)
     @Test("When effective option is .lastUsedTab then treatmentForIdleReturn is .lut", .timeLimit(.minutes(1)))
     func whenEffectiveOptionIsLastUsedTabThenTreatmentIsLUT() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(effectiveOption: .lastUsedTab))

--- a/iOS/DuckDuckGoTests/IdleReturnEvaluatorTests.swift
+++ b/iOS/DuckDuckGoTests/IdleReturnEvaluatorTests.swift
@@ -61,47 +61,47 @@ final class IdleReturnEvaluatorTests {
         return mock
     }
 
-    @Test("When feature is unavailable then didReturnAfterIdle returns false", .timeLimit(.minutes(1)))
+    @Test("When feature is unavailable then didReturnAfterIdle returns false")
     func whenFeatureUnavailableThenReturnsFalse() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(featureAvailable: false))
         let date = Date().addingTimeInterval(-61)
         #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: date))
     }
 
-    @Test("When lastBackgroundDate is nil then didReturnAfterIdle returns false", .timeLimit(.minutes(1)))
+    @Test("When lastBackgroundDate is nil then didReturnAfterIdle returns false")
     func whenLastBackgroundDateNilThenReturnsFalse() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility())
         #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: nil))
     }
 
-    @Test("When under threshold then didReturnAfterIdle returns false", .timeLimit(.minutes(1)))
+    @Test("When under threshold then didReturnAfterIdle returns false")
     func whenUnderThresholdThenReturnsFalse() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(thresholdSeconds: 120))
         let underThreshold = Date().addingTimeInterval(-110)
         #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: underThreshold))
     }
 
-    @Test("When over threshold then didReturnAfterIdle returns true", .timeLimit(.minutes(1)))
+    @Test("When over threshold then didReturnAfterIdle returns true")
     func whenOverThresholdThenReturnsTrue() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(thresholdSeconds: 120))
         let overThreshold = Date().addingTimeInterval(-121)
         #expect(evaluator.didReturnAfterIdle(lastBackgroundDate: overThreshold))
     }
 
-    @Test("When at exactly threshold then didReturnAfterIdle returns true", .timeLimit(.minutes(1)))
+    @Test("When at exactly threshold then didReturnAfterIdle returns true")
     func whenAtThresholdThenReturnsTrue() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(thresholdSeconds: 120))
         let atThreshold = Date().addingTimeInterval(-120)
         #expect(evaluator.didReturnAfterIdle(lastBackgroundDate: atThreshold))
     }
 
-    @Test("When effective option is .newTab then treatmentForIdleReturn is .ntp", .timeLimit(.minutes(1)))
+    @Test("When effective option is .newTab then treatmentForIdleReturn is .ntp")
     func whenEffectiveOptionIsNewTabThenTreatmentIsNTP() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(effectiveOption: .newTab))
         #expect(evaluator.treatmentForIdleReturn() == .ntp)
     }
 
-    @Test("When effective option is .lastUsedTab then treatmentForIdleReturn is .lut", .timeLimit(.minutes(1)))
+    @Test("When effective option is .lastUsedTab then treatmentForIdleReturn is .lut")
     func whenEffectiveOptionIsLastUsedTabThenTreatmentIsLUT() {
         let evaluator = IdleReturnEvaluator(eligibilityManager: makeEligibility(effectiveOption: .lastUsedTab))
         #expect(evaluator.treatmentForIdleReturn() == .lut)

--- a/iOS/DuckDuckGoTests/IdleReturnEvaluatorTests.swift
+++ b/iOS/DuckDuckGoTests/IdleReturnEvaluatorTests.swift
@@ -61,73 +61,86 @@ final class IdleReturnEvaluatorTests {
         )
     }
 
-    @Test("When feature is off then shouldShowNTPAfterIdle returns false")
+    @Test("When feature is off then didReturnAfterIdle returns false")
     func whenFeatureOffThenReturnsFalse() {
         let evaluator = makeEvaluator(featureOn: false)
         let date = Date().addingTimeInterval(-61)
-        #expect(!evaluator.shouldShowNTPAfterIdle(lastBackgroundDate: date))
+        #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: date))
     }
 
-    @Test("When lastBackgroundDate is nil then shouldShowNTPAfterIdle returns false")
+    @Test("When lastBackgroundDate is nil then didReturnAfterIdle returns false")
     func whenLastBackgroundDateNilThenReturnsFalse() {
         let evaluator = makeEvaluator()
-        #expect(!evaluator.shouldShowNTPAfterIdle(lastBackgroundDate: nil))
+        #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: nil))
     }
 
-    @Test("When under threshold then shouldShowNTPAfterIdle returns false")
+    @Test("When under threshold then didReturnAfterIdle returns false")
     func whenUnderThresholdThenReturnsFalse() {
         let evaluator = makeEvaluator(settingsJSON: "{\"idleThresholdSeconds\": 120}")
         let oneHourAgo = Date().addingTimeInterval(-110)
-        #expect(!evaluator.shouldShowNTPAfterIdle(lastBackgroundDate: oneHourAgo))
+        #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: oneHourAgo))
     }
 
-    @Test("When over threshold then shouldShowNTPAfterIdle returns true")
+    @Test("When over threshold then didReturnAfterIdle returns true")
     func whenOverThresholdThenReturnsTrue() {
         let evaluator = makeEvaluator(settingsJSON: "{\"idleThresholdSeconds\": 120}")
         let twoHoursAgo = Date().addingTimeInterval(-121)
-        #expect(evaluator.shouldShowNTPAfterIdle(lastBackgroundDate: twoHoursAgo))
+        #expect(evaluator.didReturnAfterIdle(lastBackgroundDate: twoHoursAgo))
     }
 
-    @Test("When at exactly threshold then shouldShowNTPAfterIdle returns true")
+    @Test("When at exactly threshold then didReturnAfterIdle returns true")
     func whenAtThresholdThenReturnsTrue() {
         let evaluator = makeEvaluator(settingsJSON: "{\"idleThresholdSeconds\": 120}")
         let oneMinuteAgo = Date().addingTimeInterval(-120)
-        #expect(evaluator.shouldShowNTPAfterIdle(lastBackgroundDate: oneMinuteAgo))
+        #expect(evaluator.didReturnAfterIdle(lastBackgroundDate: oneMinuteAgo))
     }
 
     @Test("When settings missing then uses default threshold and returns true for 300+s idle")
     func whenSettingsMissingThenUsesDefaultThreshold() {
         let evaluator = makeEvaluator(settingsJSON: nil)
         let fiveMinutesAgo = Date().addingTimeInterval(-300)
-        #expect(evaluator.shouldShowNTPAfterIdle(lastBackgroundDate: fiveMinutesAgo))
+        #expect(evaluator.didReturnAfterIdle(lastBackgroundDate: fiveMinutesAgo))
         let justUnderFiveMinutes = Date().addingTimeInterval(-299)
-        #expect(!evaluator.shouldShowNTPAfterIdle(lastBackgroundDate: justUnderFiveMinutes))
+        #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: justUnderFiveMinutes))
     }
 
     @Test("When settings invalid JSON then uses default threshold")
     func whenSettingsInvalidThenUsesDefaultThreshold() {
         let evaluator = makeEvaluator(settingsJSON: "not json")
         let fiveMinutesAgo = Date().addingTimeInterval(-300)
-        #expect(evaluator.shouldShowNTPAfterIdle(lastBackgroundDate: fiveMinutesAgo))
+        #expect(evaluator.didReturnAfterIdle(lastBackgroundDate: fiveMinutesAgo))
         let justUnderFiveMinutes = Date().addingTimeInterval(-299)
-        #expect(!evaluator.shouldShowNTPAfterIdle(lastBackgroundDate: justUnderFiveMinutes))
-    }
-
-    @Test("When eligibility manager returns false then shouldShowNTPAfterIdle returns false even when over threshold")
-    func whenEligibilityManagerReturnsFalseThenReturnsFalse() {
-        let mockEligibility = MockIdleReturnEligibilityManager()
-        mockEligibility.isEligibleForNTPAfterIdleResult = false
-        let evaluator = makeEvaluator(settingsJSON: "{\"idleThresholdSeconds\": 60}", eligibilityManager: mockEligibility)
-        let twoMinutesAgo = Date().addingTimeInterval(-121)
-        #expect(!evaluator.shouldShowNTPAfterIdle(lastBackgroundDate: twoMinutesAgo))
+        #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: justUnderFiveMinutes))
     }
 
     @Test("When idleThresholdSeconds missing in settings then uses default")
     func whenIdleThresholdSecondsMissingThenUsesDefault() {
         let evaluator = makeEvaluator(settingsJSON: "{}")
         let fiveMinutesAgo = Date().addingTimeInterval(-300)
-        #expect(evaluator.shouldShowNTPAfterIdle(lastBackgroundDate: fiveMinutesAgo))
+        #expect(evaluator.didReturnAfterIdle(lastBackgroundDate: fiveMinutesAgo))
         let justUnderFiveMinutes = Date().addingTimeInterval(-299)
-        #expect(!evaluator.shouldShowNTPAfterIdle(lastBackgroundDate: justUnderFiveMinutes))
+        #expect(!evaluator.didReturnAfterIdle(lastBackgroundDate: justUnderFiveMinutes))
+    }
+
+    @Test("When eligibility manager returns true then treatmentForIdleReturn is .ntp")
+    func whenEligibleThenTreatmentIsNTP() {
+        let mockEligibility = MockIdleReturnEligibilityManager()
+        mockEligibility.isEligibleForNTPAfterIdleResult = true
+        let evaluator = makeEvaluator(eligibilityManager: mockEligibility)
+        #expect(evaluator.treatmentForIdleReturn() == .ntp)
+    }
+
+    @Test("When eligibility manager returns false then treatmentForIdleReturn is .lut")
+    func whenNotEligibleThenTreatmentIsLUT() {
+        let mockEligibility = MockIdleReturnEligibilityManager()
+        mockEligibility.isEligibleForNTPAfterIdleResult = false
+        let evaluator = makeEvaluator(eligibilityManager: mockEligibility)
+        #expect(evaluator.treatmentForIdleReturn() == .lut)
+    }
+
+    @Test("When no eligibility manager provided then treatmentForIdleReturn defaults to .ntp")
+    func whenNoEligibilityManagerThenTreatmentIsNTP() {
+        let evaluator = makeEvaluator(eligibilityManager: nil)
+        #expect(evaluator.treatmentForIdleReturn() == .ntp)
     }
 }

--- a/iOS/DuckDuckGoTests/LaunchActionHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/LaunchActionHandlerTests.swift
@@ -168,7 +168,7 @@ final class LaunchActionHandlerTests {
     }
 
     @available(iOS 16, *)
-    @Test("Handle user activity when LaunchAction is .handleUserActivity")
+    @Test("Handle user activity when LaunchAction is .handleUserActivity", .timeLimit(.minutes(1)))
     func handleUserActivity() {
         let userActivity = NSUserActivity(activityType: "BEBrowserDataExchangeImportActivity")
         let action = LaunchAction.handleUserActivity(userActivity)
@@ -335,7 +335,7 @@ final class LaunchActionHandlerTests {
 
     // MARK: - Idle return
 
-    @Test("When idle return with NTP treatment then showNewTabPageAfterIdleReturn is called and keyboard is not")
+    @Test("When idle return with NTP treatment then showNewTabPageAfterIdleReturn is called and keyboard is not", .timeLimit(.minutes(1)))
     func whenIdleReturnNTPTreatmentThenIdleReturnHandlerIsCalled() {
         let date = Date()
         idleReturnEvaluator.didReturnAfterIdleResult = true
@@ -350,7 +350,7 @@ final class LaunchActionHandlerTests {
         #expect(!keyboardPresenter.showKeyboardOnLaunchCalled)
     }
 
-    @Test("When idle return with LUT treatment then markLastUsedTabAsResumedAfterIdle is called and keyboard shows")
+    @Test("When idle return with LUT treatment then markLastUsedTabAsResumedAfterIdle is called and keyboard shows", .timeLimit(.minutes(1)))
     func whenIdleReturnLUTTreatmentThenLUTHandlerIsCalled() {
         let date = Date()
         idleReturnEvaluator.didReturnAfterIdleResult = true
@@ -367,7 +367,7 @@ final class LaunchActionHandlerTests {
         #expect(keyboardPresenter.lastBackgroundDate == date)
     }
 
-    @Test("When no idle return then showKeyboardOnLaunch is called and neither delegate is called")
+    @Test("When no idle return then showKeyboardOnLaunch is called and neither delegate is called", .timeLimit(.minutes(1)))
     func whenNoIdleReturnThenKeyboardIsCalled() {
         let date = Date()
         idleReturnEvaluator.didReturnAfterIdleResult = false
@@ -383,7 +383,7 @@ final class LaunchActionHandlerTests {
         #expect(keyboardPresenter.lastBackgroundDate == date)
     }
 
-    @Test("When isFirstForeground is true then keyboard presenter receives nil so keyboard shows on cold start")
+    @Test("When isFirstForeground is true then keyboard presenter receives nil so keyboard shows on cold start", .timeLimit(.minutes(1)))
     func whenFirstForegroundThenKeyboardReceivesNil() {
         let date = Date()
         idleReturnEvaluator.didReturnAfterIdleResult = false

--- a/iOS/DuckDuckGoTests/LaunchActionHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/LaunchActionHandlerTests.swift
@@ -335,6 +335,7 @@ final class LaunchActionHandlerTests {
 
     // MARK: - Idle return
 
+    @available(iOS 16, *)
     @Test("When idle return with NTP treatment then showNewTabPageAfterIdleReturn is called and keyboard is not", .timeLimit(.minutes(1)))
     func whenIdleReturnNTPTreatmentThenIdleReturnHandlerIsCalled() {
         let date = Date()
@@ -350,6 +351,7 @@ final class LaunchActionHandlerTests {
         #expect(!keyboardPresenter.showKeyboardOnLaunchCalled)
     }
 
+    @available(iOS 16, *)
     @Test("When idle return with LUT treatment then markLastUsedTabAsResumedAfterIdle is called and keyboard shows", .timeLimit(.minutes(1)))
     func whenIdleReturnLUTTreatmentThenLUTHandlerIsCalled() {
         let date = Date()
@@ -367,6 +369,7 @@ final class LaunchActionHandlerTests {
         #expect(keyboardPresenter.lastBackgroundDate == date)
     }
 
+    @available(iOS 16, *)
     @Test("When no idle return then showKeyboardOnLaunch is called and neither delegate is called", .timeLimit(.minutes(1)))
     func whenNoIdleReturnThenKeyboardIsCalled() {
         let date = Date()
@@ -383,6 +386,7 @@ final class LaunchActionHandlerTests {
         #expect(keyboardPresenter.lastBackgroundDate == date)
     }
 
+    @available(iOS 16, *)
     @Test("When isFirstForeground is true then keyboard presenter receives nil so keyboard shows on cold start", .timeLimit(.minutes(1)))
     func whenFirstForegroundThenKeyboardReceivesNil() {
         let date = Date()

--- a/iOS/DuckDuckGoTests/LaunchActionHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/LaunchActionHandlerTests.swift
@@ -80,20 +80,30 @@ final class MockKeyboardPresenter: KeyboardPresenting {
 
 final class MockIdleReturnEvaluator: IdleReturnEvaluating {
     var shouldShowNTPAfterIdleResult = false
+    var idleThresholdPassedResult = false
     var lastLastBackgroundDate: Date?
 
     func shouldShowNTPAfterIdle(lastBackgroundDate: Date?) -> Bool {
         lastLastBackgroundDate = lastBackgroundDate
         return shouldShowNTPAfterIdleResult
     }
+
+    func idleThresholdPassed(lastBackgroundDate: Date?) -> Bool {
+        return idleThresholdPassedResult
+    }
 }
 
 @MainActor
 final class MockIdleReturnLaunchDelegate: IdleReturnLaunchDelegate {
     var showNewTabPageAfterIdleReturnCalled = false
+    var markLastUsedTabAsResumedAfterIdleCalled = false
 
     func showNewTabPageAfterIdleReturn() {
         showNewTabPageAfterIdleReturnCalled = true
+    }
+
+    func markLastUsedTabAsResumedAfterIdle() {
+        markLastUsedTabAsResumedAfterIdleCalled = true
     }
 }
 

--- a/iOS/DuckDuckGoTests/LaunchActionHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/LaunchActionHandlerTests.swift
@@ -335,7 +335,7 @@ final class LaunchActionHandlerTests {
 
     // MARK: - Idle return
 
-    @Test("When idle return with NTP treatment then showNewTabPageAfterIdleReturn is called and keyboard is not")
+    @Test("When idle return with NTP treatment then showNewTabPageAfterIdleReturn is called and keyboard is not", .timeLimit(.minutes(1)))
     func whenIdleReturnNTPTreatmentThenIdleReturnHandlerIsCalled() {
         let date = Date()
         idleReturnEvaluator.didReturnAfterIdleResult = true
@@ -350,7 +350,7 @@ final class LaunchActionHandlerTests {
         #expect(!keyboardPresenter.showKeyboardOnLaunchCalled)
     }
 
-    @Test("When idle return with LUT treatment then markLastUsedTabAsResumedAfterIdle is called and keyboard shows")
+    @Test("When idle return with LUT treatment then markLastUsedTabAsResumedAfterIdle is called and keyboard shows", .timeLimit(.minutes(1)))
     func whenIdleReturnLUTTreatmentThenLUTHandlerIsCalled() {
         let date = Date()
         idleReturnEvaluator.didReturnAfterIdleResult = true
@@ -367,7 +367,7 @@ final class LaunchActionHandlerTests {
         #expect(keyboardPresenter.lastBackgroundDate == date)
     }
 
-    @Test("When no idle return then showKeyboardOnLaunch is called and neither delegate is called")
+    @Test("When no idle return then showKeyboardOnLaunch is called and neither delegate is called", .timeLimit(.minutes(1)))
     func whenNoIdleReturnThenKeyboardIsCalled() {
         let date = Date()
         idleReturnEvaluator.didReturnAfterIdleResult = false
@@ -383,7 +383,7 @@ final class LaunchActionHandlerTests {
         #expect(keyboardPresenter.lastBackgroundDate == date)
     }
 
-    @Test("When isFirstForeground is true then keyboard presenter receives nil so keyboard shows on cold start")
+    @Test("When isFirstForeground is true then keyboard presenter receives nil so keyboard shows on cold start", .timeLimit(.minutes(1)))
     func whenFirstForegroundThenKeyboardReceivesNil() {
         let date = Date()
         idleReturnEvaluator.didReturnAfterIdleResult = false

--- a/iOS/DuckDuckGoTests/LaunchActionHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/LaunchActionHandlerTests.swift
@@ -168,7 +168,7 @@ final class LaunchActionHandlerTests {
     }
 
     @available(iOS 16, *)
-    @Test("Handle user activity when LaunchAction is .handleUserActivity", .timeLimit(.minutes(1)))
+    @Test("Handle user activity when LaunchAction is .handleUserActivity")
     func handleUserActivity() {
         let userActivity = NSUserActivity(activityType: "BEBrowserDataExchangeImportActivity")
         let action = LaunchAction.handleUserActivity(userActivity)
@@ -335,7 +335,7 @@ final class LaunchActionHandlerTests {
 
     // MARK: - Idle return
 
-    @Test("When idle return with NTP treatment then showNewTabPageAfterIdleReturn is called and keyboard is not", .timeLimit(.minutes(1)))
+    @Test("When idle return with NTP treatment then showNewTabPageAfterIdleReturn is called and keyboard is not")
     func whenIdleReturnNTPTreatmentThenIdleReturnHandlerIsCalled() {
         let date = Date()
         idleReturnEvaluator.didReturnAfterIdleResult = true
@@ -350,7 +350,7 @@ final class LaunchActionHandlerTests {
         #expect(!keyboardPresenter.showKeyboardOnLaunchCalled)
     }
 
-    @Test("When idle return with LUT treatment then markLastUsedTabAsResumedAfterIdle is called and keyboard shows", .timeLimit(.minutes(1)))
+    @Test("When idle return with LUT treatment then markLastUsedTabAsResumedAfterIdle is called and keyboard shows")
     func whenIdleReturnLUTTreatmentThenLUTHandlerIsCalled() {
         let date = Date()
         idleReturnEvaluator.didReturnAfterIdleResult = true
@@ -367,7 +367,7 @@ final class LaunchActionHandlerTests {
         #expect(keyboardPresenter.lastBackgroundDate == date)
     }
 
-    @Test("When no idle return then showKeyboardOnLaunch is called and neither delegate is called", .timeLimit(.minutes(1)))
+    @Test("When no idle return then showKeyboardOnLaunch is called and neither delegate is called")
     func whenNoIdleReturnThenKeyboardIsCalled() {
         let date = Date()
         idleReturnEvaluator.didReturnAfterIdleResult = false
@@ -383,7 +383,7 @@ final class LaunchActionHandlerTests {
         #expect(keyboardPresenter.lastBackgroundDate == date)
     }
 
-    @Test("When isFirstForeground is true then keyboard presenter receives nil so keyboard shows on cold start", .timeLimit(.minutes(1)))
+    @Test("When isFirstForeground is true then keyboard presenter receives nil so keyboard shows on cold start")
     func whenFirstForegroundThenKeyboardReceivesNil() {
         let date = Date()
         idleReturnEvaluator.didReturnAfterIdleResult = false

--- a/iOS/DuckDuckGoTests/LaunchActionHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/LaunchActionHandlerTests.swift
@@ -79,17 +79,17 @@ final class MockKeyboardPresenter: KeyboardPresenting {
 }
 
 final class MockIdleReturnEvaluator: IdleReturnEvaluating {
-    var shouldShowNTPAfterIdleResult = false
-    var idleThresholdPassedResult = false
+    var didReturnAfterIdleResult = false
+    var treatmentForIdleReturnResult: IdleReturnTreatment = .ntp
     var lastLastBackgroundDate: Date?
 
-    func shouldShowNTPAfterIdle(lastBackgroundDate: Date?) -> Bool {
+    func didReturnAfterIdle(lastBackgroundDate: Date?) -> Bool {
         lastLastBackgroundDate = lastBackgroundDate
-        return shouldShowNTPAfterIdleResult
+        return didReturnAfterIdleResult
     }
 
-    func idleThresholdPassed(lastBackgroundDate: Date?) -> Bool {
-        return idleThresholdPassedResult
+    func treatmentForIdleReturn() -> IdleReturnTreatment {
+        return treatmentForIdleReturnResult
     }
 }
 
@@ -333,31 +333,52 @@ final class LaunchActionHandlerTests {
         }
     }
 
-    // MARK: - Idle return NTP
+    // MARK: - Idle return
 
-    @Test("When idle evaluator returns true then showNewTabPageAfterIdleReturn is called and keyboard is not")
-    func whenIdleEvaluatorReturnsTrueThenIdleReturnHandlerIsCalled() {
+    @Test("When idle return with NTP treatment then showNewTabPageAfterIdleReturn is called and keyboard is not")
+    func whenIdleReturnNTPTreatmentThenIdleReturnHandlerIsCalled() {
         let date = Date()
-        idleReturnEvaluator.shouldShowNTPAfterIdleResult = true
+        idleReturnEvaluator.didReturnAfterIdleResult = true
+        idleReturnEvaluator.treatmentForIdleReturnResult = .ntp
         idleReturnDelegate.showNewTabPageAfterIdleReturnCalled = false
         keyboardPresenter.showKeyboardOnLaunchCalled = false
 
         launchActionHandler.handleLaunchAction(.standardLaunch(lastBackgroundDate: date, isFirstForeground: false))
 
         #expect(idleReturnDelegate.showNewTabPageAfterIdleReturnCalled)
+        #expect(!idleReturnDelegate.markLastUsedTabAsResumedAfterIdleCalled)
         #expect(!keyboardPresenter.showKeyboardOnLaunchCalled)
     }
 
-    @Test("When idle evaluator returns false then showKeyboardOnLaunch is called and idle return handler is not")
-    func whenIdleEvaluatorReturnsFalseThenKeyboardIsCalled() {
+    @Test("When idle return with LUT treatment then markLastUsedTabAsResumedAfterIdle is called and keyboard shows")
+    func whenIdleReturnLUTTreatmentThenLUTHandlerIsCalled() {
         let date = Date()
-        idleReturnEvaluator.shouldShowNTPAfterIdleResult = false
+        idleReturnEvaluator.didReturnAfterIdleResult = true
+        idleReturnEvaluator.treatmentForIdleReturnResult = .lut
+        idleReturnDelegate.markLastUsedTabAsResumedAfterIdleCalled = false
         idleReturnDelegate.showNewTabPageAfterIdleReturnCalled = false
         keyboardPresenter.showKeyboardOnLaunchCalled = false
 
         launchActionHandler.handleLaunchAction(.standardLaunch(lastBackgroundDate: date, isFirstForeground: false))
 
+        #expect(idleReturnDelegate.markLastUsedTabAsResumedAfterIdleCalled)
         #expect(!idleReturnDelegate.showNewTabPageAfterIdleReturnCalled)
+        #expect(keyboardPresenter.showKeyboardOnLaunchCalled)
+        #expect(keyboardPresenter.lastBackgroundDate == date)
+    }
+
+    @Test("When no idle return then showKeyboardOnLaunch is called and neither delegate is called")
+    func whenNoIdleReturnThenKeyboardIsCalled() {
+        let date = Date()
+        idleReturnEvaluator.didReturnAfterIdleResult = false
+        idleReturnDelegate.showNewTabPageAfterIdleReturnCalled = false
+        idleReturnDelegate.markLastUsedTabAsResumedAfterIdleCalled = false
+        keyboardPresenter.showKeyboardOnLaunchCalled = false
+
+        launchActionHandler.handleLaunchAction(.standardLaunch(lastBackgroundDate: date, isFirstForeground: false))
+
+        #expect(!idleReturnDelegate.showNewTabPageAfterIdleReturnCalled)
+        #expect(!idleReturnDelegate.markLastUsedTabAsResumedAfterIdleCalled)
         #expect(keyboardPresenter.showKeyboardOnLaunchCalled)
         #expect(keyboardPresenter.lastBackgroundDate == date)
     }
@@ -365,7 +386,7 @@ final class LaunchActionHandlerTests {
     @Test("When isFirstForeground is true then keyboard presenter receives nil so keyboard shows on cold start")
     func whenFirstForegroundThenKeyboardReceivesNil() {
         let date = Date()
-        idleReturnEvaluator.shouldShowNTPAfterIdleResult = false
+        idleReturnEvaluator.didReturnAfterIdleResult = false
         keyboardPresenter.showKeyboardOnLaunchCalled = false
 
         launchActionHandler.handleLaunchAction(.standardLaunch(lastBackgroundDate: date, isFirstForeground: true))

--- a/iOS/DuckDuckGoTests/PostIdleSessionInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/PostIdleSessionInstrumentationTests.swift
@@ -54,21 +54,21 @@ struct PostIdleSessionInstrumentationTests {
 
     // MARK: - No active session
 
-    @Test("When no active session then sessionEnded is a no-op")
+    @Test("When no active session then sessionEnded is a no-op", .timeLimit(.minutes(1)))
     func sessionEndedWithoutActiveSessionIsNoop() {
         let (sut, wideEvent, _) = makeSUT()
         sut.sessionEnded(reason: .barUsed)
         #expect(wideEvent.completions.isEmpty)
     }
 
-    @Test("When no active session then sessionCancelledByBackground is a no-op")
+    @Test("When no active session then sessionCancelledByBackground is a no-op", .timeLimit(.minutes(1)))
     func sessionCancelledWithoutActiveSessionIsNoop() {
         let (sut, wideEvent, _) = makeSUT()
         sut.sessionCancelledByBackground()
         #expect(wideEvent.completions.isEmpty)
     }
 
-    @Test("When no active session then non-terminal updates are no-ops")
+    @Test("When no active session then non-terminal updates are no-ops", .timeLimit(.minutes(1)))
     func nonTerminalUpdatesWithoutActiveSessionAreNoop() {
         let (sut, wideEvent, _) = makeSUT()
         sut.pageEngaged()
@@ -79,7 +79,7 @@ struct PostIdleSessionInstrumentationTests {
 
     // MARK: - sessionStarted
 
-    @Test("When sessionStarted with ntp then a flow is started with surface=ntp")
+    @Test("When sessionStarted with ntp then a flow is started with surface=ntp", .timeLimit(.minutes(1)))
     func sessionStartedNtpStartsFlow() {
         let (sut, wideEvent, _) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -87,7 +87,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(started?.surface == .ntp)
     }
 
-    @Test("When sessionStarted with lut then a flow is started with surface=lut")
+    @Test("When sessionStarted with lut then a flow is started with surface=lut", .timeLimit(.minutes(1)))
     func sessionStartedLutStartsFlow() {
         let (sut, wideEvent, _) = makeSUT()
         sut.sessionStarted(surface: .lut)
@@ -95,7 +95,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(started?.surface == .lut)
     }
 
-    @Test("Restarting cancels the previous active session")
+    @Test("Restarting cancels the previous active session", .timeLimit(.minutes(1)))
     func restartingSessionCancelsPrevious() {
         let (sut, wideEvent, clock) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -116,7 +116,7 @@ struct PostIdleSessionInstrumentationTests {
 
     // MARK: - Non-terminal updates
 
-    @Test("pageEngaged sets pageEngaged=true and marks first interaction")
+    @Test("pageEngaged sets pageEngaged=true and marks first interaction", .timeLimit(.minutes(1)))
     func pageEngagedSetsFlagsAndFirstInteraction() {
         let (sut, wideEvent, clock) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -128,7 +128,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(last?.firstInteractionInterval.end == clock.now)
     }
 
-    @Test("toggleUsed sets toggleUsed=true")
+    @Test("toggleUsed sets toggleUsed=true", .timeLimit(.minutes(1)))
     func toggleUsedSetsFlag() {
         let (sut, wideEvent, _) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -137,7 +137,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(last?.toggleUsed == true)
     }
 
-    @Test("backPressed sets backPressed=true")
+    @Test("backPressed sets backPressed=true", .timeLimit(.minutes(1)))
     func backPressedSetsFlag() {
         let (sut, wideEvent, _) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -146,7 +146,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(last?.backPressed == true)
     }
 
-    @Test("First interaction is only set once across multiple updates")
+    @Test("First interaction is only set once across multiple updates", .timeLimit(.minutes(1)))
     func firstInteractionMarkedOnlyOnce() {
         let (sut, wideEvent, clock) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -164,7 +164,7 @@ struct PostIdleSessionInstrumentationTests {
 
     // MARK: - Terminal events
 
-    @Test("sessionEnded completes flow as success with given reason")
+    @Test("sessionEnded completes flow as success with given reason", .timeLimit(.minutes(1)))
     func sessionEndedCompletesAsSuccess() {
         let (sut, wideEvent, clock) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -184,7 +184,7 @@ struct PostIdleSessionInstrumentationTests {
         }
     }
 
-    @Test("sessionEnded sets first interaction if not yet set")
+    @Test("sessionEnded sets first interaction if not yet set", .timeLimit(.minutes(1)))
     func sessionEndedMarksFirstInteractionIfNotSet() {
         let (sut, wideEvent, clock) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -197,7 +197,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(completion.0.firstInteractionInterval.end == clock.now)
     }
 
-    @Test("sessionEnded preserves prior first-interaction timestamp")
+    @Test("sessionEnded preserves prior first-interaction timestamp", .timeLimit(.minutes(1)))
     func sessionEndedPreservesEarlierFirstInteraction() {
         let (sut, wideEvent, clock) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -213,7 +213,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(completion.0.firstInteractionInterval.end == firstStamp)
     }
 
-    @Test("sessionEnded clears the active session")
+    @Test("sessionEnded clears the active session", .timeLimit(.minutes(1)))
     func sessionEndedClearsActiveSession() {
         let (sut, wideEvent, _) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -226,7 +226,7 @@ struct PostIdleSessionInstrumentationTests {
 
     // MARK: - Cancellation
 
-    @Test("sessionCancelledByBackground completes as cancelled with app_backgrounded")
+    @Test("sessionCancelledByBackground completes as cancelled with app_backgrounded", .timeLimit(.minutes(1)))
     func sessionCancelledCompletesAsCancelled() {
         let (sut, wideEvent, clock) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -244,7 +244,7 @@ struct PostIdleSessionInstrumentationTests {
         }
     }
 
-    @Test("sessionCancelledByBackground clears the active session")
+    @Test("sessionCancelledByBackground clears the active session", .timeLimit(.minutes(1)))
     func sessionCancelledClearsActiveSession() {
         let (sut, wideEvent, _) = makeSUT()
         sut.sessionStarted(surface: .ntp)

--- a/iOS/DuckDuckGoTests/PostIdleSessionInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/PostIdleSessionInstrumentationTests.swift
@@ -1,0 +1,255 @@
+//
+//  PostIdleSessionInstrumentationTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Testing
+import PixelKit
+import PixelKitTestingUtilities
+@testable import DuckDuckGo
+
+@Suite("Post Idle Session Instrumentation")
+struct PostIdleSessionInstrumentationTests {
+
+    private final class MockClock {
+        var now: Date
+        init(_ start: Date = Date(timeIntervalSince1970: 1_700_000_000)) { self.now = start }
+        func advance(by seconds: TimeInterval) { now = now.addingTimeInterval(seconds) }
+    }
+
+    private func makeSUT() -> (DefaultPostIdleSessionInstrumentation, WideEventMock, MockClock) {
+        let wideEvent = WideEventMock()
+        let clock = MockClock()
+        let sut = DefaultPostIdleSessionInstrumentation(
+            wideEvent: wideEvent,
+            dateProvider: { clock.now }
+        )
+        return (sut, wideEvent, clock)
+    }
+
+    private func startedData(_ wideEvent: WideEventMock) -> PostIdleSessionWideEventData? {
+        wideEvent.started.compactMap { $0 as? PostIdleSessionWideEventData }.last
+    }
+
+    private func lastCompletion(_ wideEvent: WideEventMock) -> (PostIdleSessionWideEventData, WideEventStatus)? {
+        guard let last = wideEvent.completions.last,
+              let data = last.0 as? PostIdleSessionWideEventData else { return nil }
+        return (data, last.1)
+    }
+
+    // MARK: - No active session
+
+    @Test("When no active session then sessionEnded is a no-op")
+    func sessionEndedWithoutActiveSessionIsNoop() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionEnded(reason: .barUsed)
+        #expect(wideEvent.completions.isEmpty)
+    }
+
+    @Test("When no active session then sessionCancelledByBackground is a no-op")
+    func sessionCancelledWithoutActiveSessionIsNoop() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionCancelledByBackground()
+        #expect(wideEvent.completions.isEmpty)
+    }
+
+    @Test("When no active session then non-terminal updates are no-ops")
+    func nonTerminalUpdatesWithoutActiveSessionAreNoop() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.pageEngaged()
+        sut.toggleUsed()
+        sut.backPressed()
+        #expect(wideEvent.updates.isEmpty)
+    }
+
+    // MARK: - sessionStarted
+
+    @Test("When sessionStarted with ntp then a flow is started with surface=ntp")
+    func sessionStartedNtpStartsFlow() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionStarted(surface: .ntp)
+        let started = startedData(wideEvent)
+        #expect(started?.surface == .ntp)
+    }
+
+    @Test("When sessionStarted with lut then a flow is started with surface=lut")
+    func sessionStartedLutStartsFlow() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionStarted(surface: .lut)
+        let started = startedData(wideEvent)
+        #expect(started?.surface == .lut)
+    }
+
+    @Test("Restarting cancels the previous active session")
+    func restartingSessionCancelsPrevious() {
+        let (sut, wideEvent, clock) = makeSUT()
+        sut.sessionStarted(surface: .ntp)
+        clock.advance(by: 1)
+        sut.sessionStarted(surface: .ntp)
+
+        guard let cancelled = wideEvent.completions.first,
+              let data = cancelled.0 as? PostIdleSessionWideEventData else {
+            Issue.record("Expected a cancelled completion")
+            return
+        }
+        #expect(data.statusReason == .appBackgrounded)
+        if case .cancelled = cancelled.1 {} else {
+            Issue.record("Expected .cancelled status, got \(cancelled.1)")
+        }
+        #expect(wideEvent.started.count == 2)
+    }
+
+    // MARK: - Non-terminal updates
+
+    @Test("pageEngaged sets pageEngaged=true and marks first interaction")
+    func pageEngagedSetsFlagsAndFirstInteraction() {
+        let (sut, wideEvent, clock) = makeSUT()
+        sut.sessionStarted(surface: .ntp)
+        clock.advance(by: 0.5)
+        sut.pageEngaged()
+
+        let last = wideEvent.updates.compactMap { $0 as? PostIdleSessionWideEventData }.last
+        #expect(last?.pageEngaged == true)
+        #expect(last?.firstInteractionInterval.end == clock.now)
+    }
+
+    @Test("toggleUsed sets toggleUsed=true")
+    func toggleUsedSetsFlag() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionStarted(surface: .ntp)
+        sut.toggleUsed()
+        let last = wideEvent.updates.compactMap { $0 as? PostIdleSessionWideEventData }.last
+        #expect(last?.toggleUsed == true)
+    }
+
+    @Test("backPressed sets backPressed=true")
+    func backPressedSetsFlag() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionStarted(surface: .ntp)
+        sut.backPressed()
+        let last = wideEvent.updates.compactMap { $0 as? PostIdleSessionWideEventData }.last
+        #expect(last?.backPressed == true)
+    }
+
+    @Test("First interaction is only set once across multiple updates")
+    func firstInteractionMarkedOnlyOnce() {
+        let (sut, wideEvent, clock) = makeSUT()
+        sut.sessionStarted(surface: .ntp)
+
+        clock.advance(by: 0.5)
+        let firstStamp = clock.now
+        sut.pageEngaged()
+
+        clock.advance(by: 1.0)
+        sut.toggleUsed()
+
+        let last = wideEvent.updates.compactMap { $0 as? PostIdleSessionWideEventData }.last
+        #expect(last?.firstInteractionInterval.end == firstStamp)
+    }
+
+    // MARK: - Terminal events
+
+    @Test("sessionEnded completes flow as success with given reason")
+    func sessionEndedCompletesAsSuccess() {
+        let (sut, wideEvent, clock) = makeSUT()
+        sut.sessionStarted(surface: .ntp)
+        clock.advance(by: 2)
+        sut.sessionEnded(reason: .barUsed)
+
+        guard let completion = lastCompletion(wideEvent) else {
+            Issue.record("Expected a completion")
+            return
+        }
+        #expect(completion.0.statusReason == .barUsed)
+        #expect(completion.0.sessionInterval.end == clock.now)
+        if case .success(let reason) = completion.1 {
+            #expect(reason == "bar_used")
+        } else {
+            Issue.record("Expected .success status, got \(completion.1)")
+        }
+    }
+
+    @Test("sessionEnded sets first interaction if not yet set")
+    func sessionEndedMarksFirstInteractionIfNotSet() {
+        let (sut, wideEvent, clock) = makeSUT()
+        sut.sessionStarted(surface: .ntp)
+        clock.advance(by: 1.5)
+        sut.sessionEnded(reason: .barUsed)
+        guard let completion = lastCompletion(wideEvent) else {
+            Issue.record("Expected a completion")
+            return
+        }
+        #expect(completion.0.firstInteractionInterval.end == clock.now)
+    }
+
+    @Test("sessionEnded preserves prior first-interaction timestamp")
+    func sessionEndedPreservesEarlierFirstInteraction() {
+        let (sut, wideEvent, clock) = makeSUT()
+        sut.sessionStarted(surface: .ntp)
+        clock.advance(by: 0.5)
+        let firstStamp = clock.now
+        sut.pageEngaged()
+        clock.advance(by: 2)
+        sut.sessionEnded(reason: .barUsed)
+        guard let completion = lastCompletion(wideEvent) else {
+            Issue.record("Expected a completion")
+            return
+        }
+        #expect(completion.0.firstInteractionInterval.end == firstStamp)
+    }
+
+    @Test("sessionEnded clears the active session")
+    func sessionEndedClearsActiveSession() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionStarted(surface: .ntp)
+        sut.sessionEnded(reason: .barUsed)
+        // Subsequent signals should be no-ops.
+        sut.pageEngaged()
+        sut.sessionEnded(reason: .returnToPageTapped)
+        #expect(wideEvent.completions.count == 1)
+    }
+
+    // MARK: - Cancellation
+
+    @Test("sessionCancelledByBackground completes as cancelled with app_backgrounded")
+    func sessionCancelledCompletesAsCancelled() {
+        let (sut, wideEvent, clock) = makeSUT()
+        sut.sessionStarted(surface: .ntp)
+        clock.advance(by: 3)
+        sut.sessionCancelledByBackground()
+
+        guard let completion = lastCompletion(wideEvent) else {
+            Issue.record("Expected a completion")
+            return
+        }
+        #expect(completion.0.statusReason == .appBackgrounded)
+        #expect(completion.0.sessionInterval.end == clock.now)
+        if case .cancelled = completion.1 {} else {
+            Issue.record("Expected .cancelled status, got \(completion.1)")
+        }
+    }
+
+    @Test("sessionCancelledByBackground clears the active session")
+    func sessionCancelledClearsActiveSession() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionStarted(surface: .ntp)
+        sut.sessionCancelledByBackground()
+        sut.sessionCancelledByBackground()
+        #expect(wideEvent.completions.count == 1)
+    }
+}

--- a/iOS/DuckDuckGoTests/PostIdleSessionInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/PostIdleSessionInstrumentationTests.swift
@@ -54,6 +54,7 @@ struct PostIdleSessionInstrumentationTests {
 
     // MARK: - No active session
 
+    @available(iOS 16, *)
     @Test("When no active session then sessionEnded is a no-op", .timeLimit(.minutes(1)))
     func sessionEndedWithoutActiveSessionIsNoop() {
         let (sut, wideEvent, _) = makeSUT()
@@ -61,6 +62,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(wideEvent.completions.isEmpty)
     }
 
+    @available(iOS 16, *)
     @Test("When no active session then sessionCancelledByBackground is a no-op", .timeLimit(.minutes(1)))
     func sessionCancelledWithoutActiveSessionIsNoop() {
         let (sut, wideEvent, _) = makeSUT()
@@ -68,6 +70,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(wideEvent.completions.isEmpty)
     }
 
+    @available(iOS 16, *)
     @Test("When no active session then non-terminal updates are no-ops", .timeLimit(.minutes(1)))
     func nonTerminalUpdatesWithoutActiveSessionAreNoop() {
         let (sut, wideEvent, _) = makeSUT()
@@ -79,6 +82,7 @@ struct PostIdleSessionInstrumentationTests {
 
     // MARK: - sessionStarted
 
+    @available(iOS 16, *)
     @Test("When sessionStarted with ntp then a flow is started with surface=ntp", .timeLimit(.minutes(1)))
     func sessionStartedNtpStartsFlow() {
         let (sut, wideEvent, _) = makeSUT()
@@ -87,6 +91,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(started?.surface == .ntp)
     }
 
+    @available(iOS 16, *)
     @Test("When sessionStarted with lut then a flow is started with surface=lut", .timeLimit(.minutes(1)))
     func sessionStartedLutStartsFlow() {
         let (sut, wideEvent, _) = makeSUT()
@@ -95,6 +100,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(started?.surface == .lut)
     }
 
+    @available(iOS 16, *)
     @Test("Restarting cancels the previous active session", .timeLimit(.minutes(1)))
     func restartingSessionCancelsPrevious() {
         let (sut, wideEvent, clock) = makeSUT()
@@ -116,6 +122,7 @@ struct PostIdleSessionInstrumentationTests {
 
     // MARK: - Non-terminal updates
 
+    @available(iOS 16, *)
     @Test("pageEngaged sets pageEngaged=true and marks first interaction", .timeLimit(.minutes(1)))
     func pageEngagedSetsFlagsAndFirstInteraction() {
         let (sut, wideEvent, clock) = makeSUT()
@@ -128,6 +135,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(last?.firstInteractionInterval.end == clock.now)
     }
 
+    @available(iOS 16, *)
     @Test("toggleUsed sets toggleUsed=true", .timeLimit(.minutes(1)))
     func toggleUsedSetsFlag() {
         let (sut, wideEvent, _) = makeSUT()
@@ -137,6 +145,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(last?.toggleUsed == true)
     }
 
+    @available(iOS 16, *)
     @Test("backPressed sets backPressed=true", .timeLimit(.minutes(1)))
     func backPressedSetsFlag() {
         let (sut, wideEvent, _) = makeSUT()
@@ -146,6 +155,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(last?.backPressed == true)
     }
 
+    @available(iOS 16, *)
     @Test("First interaction is only set once across multiple updates", .timeLimit(.minutes(1)))
     func firstInteractionMarkedOnlyOnce() {
         let (sut, wideEvent, clock) = makeSUT()
@@ -164,6 +174,7 @@ struct PostIdleSessionInstrumentationTests {
 
     // MARK: - Terminal events
 
+    @available(iOS 16, *)
     @Test("sessionEnded completes flow as success with given reason", .timeLimit(.minutes(1)))
     func sessionEndedCompletesAsSuccess() {
         let (sut, wideEvent, clock) = makeSUT()
@@ -184,6 +195,7 @@ struct PostIdleSessionInstrumentationTests {
         }
     }
 
+    @available(iOS 16, *)
     @Test("sessionEnded sets first interaction if not yet set", .timeLimit(.minutes(1)))
     func sessionEndedMarksFirstInteractionIfNotSet() {
         let (sut, wideEvent, clock) = makeSUT()
@@ -197,6 +209,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(completion.0.firstInteractionInterval.end == clock.now)
     }
 
+    @available(iOS 16, *)
     @Test("sessionEnded preserves prior first-interaction timestamp", .timeLimit(.minutes(1)))
     func sessionEndedPreservesEarlierFirstInteraction() {
         let (sut, wideEvent, clock) = makeSUT()
@@ -213,6 +226,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(completion.0.firstInteractionInterval.end == firstStamp)
     }
 
+    @available(iOS 16, *)
     @Test("sessionEnded clears the active session", .timeLimit(.minutes(1)))
     func sessionEndedClearsActiveSession() {
         let (sut, wideEvent, _) = makeSUT()
@@ -226,6 +240,7 @@ struct PostIdleSessionInstrumentationTests {
 
     // MARK: - Cancellation
 
+    @available(iOS 16, *)
     @Test("sessionCancelledByBackground completes as cancelled with app_backgrounded", .timeLimit(.minutes(1)))
     func sessionCancelledCompletesAsCancelled() {
         let (sut, wideEvent, clock) = makeSUT()
@@ -244,6 +259,7 @@ struct PostIdleSessionInstrumentationTests {
         }
     }
 
+    @available(iOS 16, *)
     @Test("sessionCancelledByBackground clears the active session", .timeLimit(.minutes(1)))
     func sessionCancelledClearsActiveSession() {
         let (sut, wideEvent, _) = makeSUT()

--- a/iOS/DuckDuckGoTests/PostIdleSessionInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/PostIdleSessionInstrumentationTests.swift
@@ -54,21 +54,21 @@ struct PostIdleSessionInstrumentationTests {
 
     // MARK: - No active session
 
-    @Test("When no active session then sessionEnded is a no-op", .timeLimit(.minutes(1)))
+    @Test("When no active session then sessionEnded is a no-op")
     func sessionEndedWithoutActiveSessionIsNoop() {
         let (sut, wideEvent, _) = makeSUT()
         sut.sessionEnded(reason: .barUsed)
         #expect(wideEvent.completions.isEmpty)
     }
 
-    @Test("When no active session then sessionCancelledByBackground is a no-op", .timeLimit(.minutes(1)))
+    @Test("When no active session then sessionCancelledByBackground is a no-op")
     func sessionCancelledWithoutActiveSessionIsNoop() {
         let (sut, wideEvent, _) = makeSUT()
         sut.sessionCancelledByBackground()
         #expect(wideEvent.completions.isEmpty)
     }
 
-    @Test("When no active session then non-terminal updates are no-ops", .timeLimit(.minutes(1)))
+    @Test("When no active session then non-terminal updates are no-ops")
     func nonTerminalUpdatesWithoutActiveSessionAreNoop() {
         let (sut, wideEvent, _) = makeSUT()
         sut.pageEngaged()
@@ -79,7 +79,7 @@ struct PostIdleSessionInstrumentationTests {
 
     // MARK: - sessionStarted
 
-    @Test("When sessionStarted with ntp then a flow is started with surface=ntp", .timeLimit(.minutes(1)))
+    @Test("When sessionStarted with ntp then a flow is started with surface=ntp")
     func sessionStartedNtpStartsFlow() {
         let (sut, wideEvent, _) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -87,7 +87,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(started?.surface == .ntp)
     }
 
-    @Test("When sessionStarted with lut then a flow is started with surface=lut", .timeLimit(.minutes(1)))
+    @Test("When sessionStarted with lut then a flow is started with surface=lut")
     func sessionStartedLutStartsFlow() {
         let (sut, wideEvent, _) = makeSUT()
         sut.sessionStarted(surface: .lut)
@@ -95,7 +95,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(started?.surface == .lut)
     }
 
-    @Test("Restarting cancels the previous active session", .timeLimit(.minutes(1)))
+    @Test("Restarting cancels the previous active session")
     func restartingSessionCancelsPrevious() {
         let (sut, wideEvent, clock) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -116,7 +116,7 @@ struct PostIdleSessionInstrumentationTests {
 
     // MARK: - Non-terminal updates
 
-    @Test("pageEngaged sets pageEngaged=true and marks first interaction", .timeLimit(.minutes(1)))
+    @Test("pageEngaged sets pageEngaged=true and marks first interaction")
     func pageEngagedSetsFlagsAndFirstInteraction() {
         let (sut, wideEvent, clock) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -128,7 +128,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(last?.firstInteractionInterval.end == clock.now)
     }
 
-    @Test("toggleUsed sets toggleUsed=true", .timeLimit(.minutes(1)))
+    @Test("toggleUsed sets toggleUsed=true")
     func toggleUsedSetsFlag() {
         let (sut, wideEvent, _) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -137,7 +137,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(last?.toggleUsed == true)
     }
 
-    @Test("backPressed sets backPressed=true", .timeLimit(.minutes(1)))
+    @Test("backPressed sets backPressed=true")
     func backPressedSetsFlag() {
         let (sut, wideEvent, _) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -146,7 +146,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(last?.backPressed == true)
     }
 
-    @Test("First interaction is only set once across multiple updates", .timeLimit(.minutes(1)))
+    @Test("First interaction is only set once across multiple updates")
     func firstInteractionMarkedOnlyOnce() {
         let (sut, wideEvent, clock) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -164,7 +164,7 @@ struct PostIdleSessionInstrumentationTests {
 
     // MARK: - Terminal events
 
-    @Test("sessionEnded completes flow as success with given reason", .timeLimit(.minutes(1)))
+    @Test("sessionEnded completes flow as success with given reason")
     func sessionEndedCompletesAsSuccess() {
         let (sut, wideEvent, clock) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -184,7 +184,7 @@ struct PostIdleSessionInstrumentationTests {
         }
     }
 
-    @Test("sessionEnded sets first interaction if not yet set", .timeLimit(.minutes(1)))
+    @Test("sessionEnded sets first interaction if not yet set")
     func sessionEndedMarksFirstInteractionIfNotSet() {
         let (sut, wideEvent, clock) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -197,7 +197,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(completion.0.firstInteractionInterval.end == clock.now)
     }
 
-    @Test("sessionEnded preserves prior first-interaction timestamp", .timeLimit(.minutes(1)))
+    @Test("sessionEnded preserves prior first-interaction timestamp")
     func sessionEndedPreservesEarlierFirstInteraction() {
         let (sut, wideEvent, clock) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -213,7 +213,7 @@ struct PostIdleSessionInstrumentationTests {
         #expect(completion.0.firstInteractionInterval.end == firstStamp)
     }
 
-    @Test("sessionEnded clears the active session", .timeLimit(.minutes(1)))
+    @Test("sessionEnded clears the active session")
     func sessionEndedClearsActiveSession() {
         let (sut, wideEvent, _) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -226,7 +226,7 @@ struct PostIdleSessionInstrumentationTests {
 
     // MARK: - Cancellation
 
-    @Test("sessionCancelledByBackground completes as cancelled with app_backgrounded", .timeLimit(.minutes(1)))
+    @Test("sessionCancelledByBackground completes as cancelled with app_backgrounded")
     func sessionCancelledCompletesAsCancelled() {
         let (sut, wideEvent, clock) = makeSUT()
         sut.sessionStarted(surface: .ntp)
@@ -244,7 +244,7 @@ struct PostIdleSessionInstrumentationTests {
         }
     }
 
-    @Test("sessionCancelledByBackground clears the active session", .timeLimit(.minutes(1)))
+    @Test("sessionCancelledByBackground clears the active session")
     func sessionCancelledClearsActiveSession() {
         let (sut, wideEvent, _) = makeSUT()
         sut.sessionStarted(surface: .ntp)

--- a/iOS/DuckDuckGoTests/PostIdleSessionWideEventDataTests.swift
+++ b/iOS/DuckDuckGoTests/PostIdleSessionWideEventDataTests.swift
@@ -1,0 +1,198 @@
+//
+//  PostIdleSessionWideEventDataTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Testing
+import PixelKit
+@testable import DuckDuckGo
+
+@Suite("Post Idle Session Wide Event Data")
+struct PostIdleSessionWideEventDataTests {
+
+    // MARK: - Metadata
+
+    @Test("Metadata exposes expected pixel and feature names")
+    func metadataExposesExpectedNames() {
+        #expect(PostIdleSessionWideEventData.metadata.pixelName == "post_idle_session")
+        #expect(PostIdleSessionWideEventData.metadata.featureName == "post_idle_session")
+        #expect(PostIdleSessionWideEventData.metadata.type == "ios-post-idle-session")
+        #expect(PostIdleSessionWideEventData.metadata.version == "1.0.0")
+    }
+
+    // MARK: - jsonParameters
+
+    @Test("Default flow produces surface-only parameters and no status reason")
+    func defaultFlowProducesSurfaceOnly() {
+        let data = PostIdleSessionWideEventData(surface: .ntp)
+        let params = data.jsonParameters()
+
+        #expect(params["feature.data.ext.surface"] as? String == "ntp")
+        #expect(params["feature.data.ext.status_reason"] == nil)
+        #expect(params["feature.data.ext.session_duration_ms"] == nil)
+        #expect(params["feature.data.ext.time_to_first_interaction_ms"] == nil)
+        #expect(params["feature.data.ext.page_engaged"] as? Bool == false)
+        #expect(params["feature.data.ext.toggle_used"] as? Bool == false)
+        #expect(params["feature.data.ext.back_pressed"] as? Bool == false)
+    }
+
+    @Test("Bar used reason emits status_reason")
+    func barUsedReasonEmitsStatusReason() {
+        let data = PostIdleSessionWideEventData(surface: .ntp)
+        data.statusReason = .barUsed
+        #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "bar_used")
+    }
+
+    @Test("Return-to-page reason emits status_reason")
+    func returnToPageReasonEmitsStatusReason() {
+        let data = PostIdleSessionWideEventData(surface: .ntp)
+        data.statusReason = .returnToPageTapped
+        #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "return_to_page_tapped")
+    }
+
+    @Test("Tab switcher reason emits status_reason")
+    func tabSwitcherReasonEmitsStatusReason() {
+        let data = PostIdleSessionWideEventData(surface: .ntp)
+        data.statusReason = .tabSwitcherSelected
+        #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "tab_switcher_selected")
+    }
+
+    @Test("App backgrounded reason emits status_reason")
+    func appBackgroundedReasonEmitsStatusReason() {
+        let data = PostIdleSessionWideEventData(surface: .ntp)
+        data.statusReason = .appBackgrounded
+        #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "app_backgrounded")
+    }
+
+    @Test("Favorite selected reason emits status_reason")
+    func favoriteSelectedReasonEmitsStatusReason() {
+        let data = PostIdleSessionWideEventData(surface: .ntp)
+        data.statusReason = .favoriteSelected
+        #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "favorite_selected")
+    }
+
+    @Test("Chat selected reason emits status_reason")
+    func chatSelectedReasonEmitsStatusReason() {
+        let data = PostIdleSessionWideEventData(surface: .ntp)
+        data.statusReason = .chatSelected
+        #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "chat_selected")
+    }
+
+    @Test("LUT surface emits lut")
+    func lutSurfaceEmitsLut() {
+        let data = PostIdleSessionWideEventData(surface: .lut)
+        #expect(data.jsonParameters()["feature.data.ext.surface"] as? String == "lut")
+    }
+
+    @Test("Boolean flags propagate when set")
+    func booleanFlagsPropagateWhenSet() {
+        let data = PostIdleSessionWideEventData(surface: .ntp,
+                                                pageEngaged: true,
+                                                toggleUsed: true,
+                                                backPressed: true)
+        let params = data.jsonParameters()
+        #expect(params["feature.data.ext.page_engaged"] as? Bool == true)
+        #expect(params["feature.data.ext.toggle_used"] as? Bool == true)
+        #expect(params["feature.data.ext.back_pressed"] as? Bool == true)
+    }
+
+    // MARK: - Durations
+
+    @Test("Session duration is computed in ms when sessionInterval is closed")
+    func sessionDurationIsComputedInMs() {
+        let start = Date()
+        let data = PostIdleSessionWideEventData(surface: .ntp, startedAt: start)
+        data.sessionInterval.end = start.addingTimeInterval(2.5) // 2500ms
+
+        let params = data.jsonParameters()
+        #expect(params["feature.data.ext.session_duration_ms"] as? Int == 2500)
+    }
+
+    @Test("First interaction duration is computed in ms when interval is closed")
+    func firstInteractionDurationIsComputedInMs() {
+        let start = Date()
+        let data = PostIdleSessionWideEventData(surface: .ntp, startedAt: start)
+        data.firstInteractionInterval.end = start.addingTimeInterval(0.5) // 500ms (exactly representable in float)
+
+        let params = data.jsonParameters()
+        #expect(params["feature.data.ext.time_to_first_interaction_ms"] as? Int == 500)
+    }
+
+    @Test("Both intervals share the same start by default")
+    func bothIntervalsShareSameStart() {
+        let start = Date()
+        let data = PostIdleSessionWideEventData(surface: .ntp, startedAt: start)
+        #expect(data.sessionInterval.start == start)
+        #expect(data.firstInteractionInterval.start == start)
+    }
+
+    // MARK: - Completion decision
+
+    @Test("App launch trigger always completes as UNKNOWN with app_relaunched reason")
+    func appLaunchAlwaysCompletesAsUnknownAppRelaunched() async {
+        let data = PostIdleSessionWideEventData(surface: .ntp)
+        let decision = await data.completionDecision(for: .appLaunch)
+
+        if case .complete(.unknown(let reason)) = decision {
+            #expect(reason == PostIdleSessionWideEventData.appRelaunchedReason)
+            #expect(reason == "app_relaunched")
+        } else {
+            Issue.record("Expected .complete(.unknown(reason:)), got \(decision)")
+        }
+    }
+
+    @Test("App launch trigger completes orphan with all surface variants")
+    func appLaunchCompletesAllSurfaceVariants() async {
+        for surface in PostIdleSessionWideEventData.Surface.allCases {
+            let data = PostIdleSessionWideEventData(surface: surface)
+            let decision = await data.completionDecision(for: .appLaunch)
+            if case .complete = decision {
+                // ok
+            } else {
+                Issue.record("Expected .complete for surface \(surface), got \(decision)")
+            }
+        }
+    }
+
+    // MARK: - Codable
+
+    @Test("Round-trips through JSONEncoder/Decoder preserves all fields")
+    func codableRoundTripPreservesAllFields() throws {
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        let original = PostIdleSessionWideEventData(surface: .lut, startedAt: start)
+        original.statusReason = .returnToPageTapped
+        original.sessionInterval.end = start.addingTimeInterval(5)
+        original.firstInteractionInterval.end = start.addingTimeInterval(1)
+        original.pageEngaged = true
+        original.toggleUsed = true
+        original.backPressed = true
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(PostIdleSessionWideEventData.self, from: encoded)
+
+        #expect(decoded.surface == .lut)
+        #expect(decoded.statusReason == .returnToPageTapped)
+        #expect(decoded.sessionInterval.start == start)
+        #expect(decoded.sessionInterval.end == start.addingTimeInterval(5))
+        #expect(decoded.firstInteractionInterval.start == start)
+        #expect(decoded.firstInteractionInterval.end == start.addingTimeInterval(1))
+        #expect(decoded.pageEngaged == true)
+        #expect(decoded.toggleUsed == true)
+        #expect(decoded.backPressed == true)
+    }
+}

--- a/iOS/DuckDuckGoTests/PostIdleSessionWideEventDataTests.swift
+++ b/iOS/DuckDuckGoTests/PostIdleSessionWideEventDataTests.swift
@@ -27,7 +27,7 @@ struct PostIdleSessionWideEventDataTests {
 
     // MARK: - Metadata
 
-    @Test("Metadata exposes expected pixel and feature names")
+    @Test("Metadata exposes expected pixel and feature names", .timeLimit(.minutes(1)))
     func metadataExposesExpectedNames() {
         #expect(PostIdleSessionWideEventData.metadata.pixelName == "post_idle_session")
         #expect(PostIdleSessionWideEventData.metadata.featureName == "post_idle_session")
@@ -37,7 +37,7 @@ struct PostIdleSessionWideEventDataTests {
 
     // MARK: - jsonParameters
 
-    @Test("Default flow produces surface-only parameters and no status reason")
+    @Test("Default flow produces surface-only parameters and no status reason", .timeLimit(.minutes(1)))
     func defaultFlowProducesSurfaceOnly() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
         let params = data.jsonParameters()
@@ -51,55 +51,55 @@ struct PostIdleSessionWideEventDataTests {
         #expect(params["feature.data.ext.back_pressed"] as? Bool == false)
     }
 
-    @Test("Bar used reason emits status_reason")
+    @Test("Bar used reason emits status_reason", .timeLimit(.minutes(1)))
     func barUsedReasonEmitsStatusReason() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
         data.statusReason = .barUsed
         #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "bar_used")
     }
 
-    @Test("Return-to-page reason emits status_reason")
+    @Test("Return-to-page reason emits status_reason", .timeLimit(.minutes(1)))
     func returnToPageReasonEmitsStatusReason() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
         data.statusReason = .returnToPageTapped
         #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "return_to_page_tapped")
     }
 
-    @Test("Tab switcher reason emits status_reason")
+    @Test("Tab switcher reason emits status_reason", .timeLimit(.minutes(1)))
     func tabSwitcherReasonEmitsStatusReason() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
         data.statusReason = .tabSwitcherSelected
         #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "tab_switcher_selected")
     }
 
-    @Test("App backgrounded reason emits status_reason")
+    @Test("App backgrounded reason emits status_reason", .timeLimit(.minutes(1)))
     func appBackgroundedReasonEmitsStatusReason() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
         data.statusReason = .appBackgrounded
         #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "app_backgrounded")
     }
 
-    @Test("Favorite selected reason emits status_reason")
+    @Test("Favorite selected reason emits status_reason", .timeLimit(.minutes(1)))
     func favoriteSelectedReasonEmitsStatusReason() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
         data.statusReason = .favoriteSelected
         #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "favorite_selected")
     }
 
-    @Test("Chat selected reason emits status_reason")
+    @Test("Chat selected reason emits status_reason", .timeLimit(.minutes(1)))
     func chatSelectedReasonEmitsStatusReason() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
         data.statusReason = .chatSelected
         #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "chat_selected")
     }
 
-    @Test("LUT surface emits lut")
+    @Test("LUT surface emits lut", .timeLimit(.minutes(1)))
     func lutSurfaceEmitsLut() {
         let data = PostIdleSessionWideEventData(surface: .lut)
         #expect(data.jsonParameters()["feature.data.ext.surface"] as? String == "lut")
     }
 
-    @Test("Boolean flags propagate when set")
+    @Test("Boolean flags propagate when set", .timeLimit(.minutes(1)))
     func booleanFlagsPropagateWhenSet() {
         let data = PostIdleSessionWideEventData(surface: .ntp,
                                                 pageEngaged: true,
@@ -113,7 +113,7 @@ struct PostIdleSessionWideEventDataTests {
 
     // MARK: - Durations
 
-    @Test("Session duration is computed in ms when sessionInterval is closed")
+    @Test("Session duration is computed in ms when sessionInterval is closed", .timeLimit(.minutes(1)))
     func sessionDurationIsComputedInMs() {
         let start = Date()
         let data = PostIdleSessionWideEventData(surface: .ntp, startedAt: start)
@@ -123,7 +123,7 @@ struct PostIdleSessionWideEventDataTests {
         #expect(params["feature.data.ext.session_duration_ms"] as? Int == 2500)
     }
 
-    @Test("First interaction duration is computed in ms when interval is closed")
+    @Test("First interaction duration is computed in ms when interval is closed", .timeLimit(.minutes(1)))
     func firstInteractionDurationIsComputedInMs() {
         let start = Date()
         let data = PostIdleSessionWideEventData(surface: .ntp, startedAt: start)
@@ -133,7 +133,7 @@ struct PostIdleSessionWideEventDataTests {
         #expect(params["feature.data.ext.time_to_first_interaction_ms"] as? Int == 500)
     }
 
-    @Test("Both intervals share the same start by default")
+    @Test("Both intervals share the same start by default", .timeLimit(.minutes(1)))
     func bothIntervalsShareSameStart() {
         let start = Date()
         let data = PostIdleSessionWideEventData(surface: .ntp, startedAt: start)
@@ -143,7 +143,7 @@ struct PostIdleSessionWideEventDataTests {
 
     // MARK: - Completion decision
 
-    @Test("App launch trigger always completes as UNKNOWN with app_terminated reason")
+    @Test("App launch trigger always completes as UNKNOWN with app_terminated reason", .timeLimit(.minutes(1)))
     func appLaunchAlwaysCompletesAsUnknownAppTerminated() async {
         let data = PostIdleSessionWideEventData(surface: .ntp)
         let decision = await data.completionDecision(for: .appLaunch)
@@ -156,7 +156,7 @@ struct PostIdleSessionWideEventDataTests {
         }
     }
 
-    @Test("App launch trigger completes orphan with all surface variants")
+    @Test("App launch trigger completes orphan with all surface variants", .timeLimit(.minutes(1)))
     func appLaunchCompletesAllSurfaceVariants() async {
         for surface in PostIdleSessionWideEventData.Surface.allCases {
             let data = PostIdleSessionWideEventData(surface: surface)
@@ -171,7 +171,7 @@ struct PostIdleSessionWideEventDataTests {
 
     // MARK: - Codable
 
-    @Test("Round-trips through JSONEncoder/Decoder preserves all fields")
+    @Test("Round-trips through JSONEncoder/Decoder preserves all fields", .timeLimit(.minutes(1)))
     func codableRoundTripPreservesAllFields() throws {
         let start = Date(timeIntervalSince1970: 1_700_000_000)
         let original = PostIdleSessionWideEventData(surface: .lut, startedAt: start)

--- a/iOS/DuckDuckGoTests/PostIdleSessionWideEventDataTests.swift
+++ b/iOS/DuckDuckGoTests/PostIdleSessionWideEventDataTests.swift
@@ -27,6 +27,7 @@ struct PostIdleSessionWideEventDataTests {
 
     // MARK: - Metadata
 
+    @available(iOS 16, *)
     @Test("Metadata exposes expected pixel and feature names", .timeLimit(.minutes(1)))
     func metadataExposesExpectedNames() {
         #expect(PostIdleSessionWideEventData.metadata.pixelName == "post_idle_session")
@@ -37,6 +38,7 @@ struct PostIdleSessionWideEventDataTests {
 
     // MARK: - jsonParameters
 
+    @available(iOS 16, *)
     @Test("Default flow produces surface-only parameters and no status reason", .timeLimit(.minutes(1)))
     func defaultFlowProducesSurfaceOnly() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
@@ -51,6 +53,7 @@ struct PostIdleSessionWideEventDataTests {
         #expect(params["feature.data.ext.back_pressed"] as? Bool == false)
     }
 
+    @available(iOS 16, *)
     @Test("Bar used reason emits status_reason", .timeLimit(.minutes(1)))
     func barUsedReasonEmitsStatusReason() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
@@ -58,6 +61,7 @@ struct PostIdleSessionWideEventDataTests {
         #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "bar_used")
     }
 
+    @available(iOS 16, *)
     @Test("Return-to-page reason emits status_reason", .timeLimit(.minutes(1)))
     func returnToPageReasonEmitsStatusReason() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
@@ -65,6 +69,7 @@ struct PostIdleSessionWideEventDataTests {
         #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "return_to_page_tapped")
     }
 
+    @available(iOS 16, *)
     @Test("Tab switcher reason emits status_reason", .timeLimit(.minutes(1)))
     func tabSwitcherReasonEmitsStatusReason() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
@@ -72,6 +77,7 @@ struct PostIdleSessionWideEventDataTests {
         #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "tab_switcher_selected")
     }
 
+    @available(iOS 16, *)
     @Test("App backgrounded reason emits status_reason", .timeLimit(.minutes(1)))
     func appBackgroundedReasonEmitsStatusReason() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
@@ -79,6 +85,7 @@ struct PostIdleSessionWideEventDataTests {
         #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "app_backgrounded")
     }
 
+    @available(iOS 16, *)
     @Test("Favorite selected reason emits status_reason", .timeLimit(.minutes(1)))
     func favoriteSelectedReasonEmitsStatusReason() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
@@ -86,6 +93,7 @@ struct PostIdleSessionWideEventDataTests {
         #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "favorite_selected")
     }
 
+    @available(iOS 16, *)
     @Test("Chat selected reason emits status_reason", .timeLimit(.minutes(1)))
     func chatSelectedReasonEmitsStatusReason() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
@@ -93,12 +101,14 @@ struct PostIdleSessionWideEventDataTests {
         #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "chat_selected")
     }
 
+    @available(iOS 16, *)
     @Test("LUT surface emits lut", .timeLimit(.minutes(1)))
     func lutSurfaceEmitsLut() {
         let data = PostIdleSessionWideEventData(surface: .lut)
         #expect(data.jsonParameters()["feature.data.ext.surface"] as? String == "lut")
     }
 
+    @available(iOS 16, *)
     @Test("Boolean flags propagate when set", .timeLimit(.minutes(1)))
     func booleanFlagsPropagateWhenSet() {
         let data = PostIdleSessionWideEventData(surface: .ntp,
@@ -113,6 +123,7 @@ struct PostIdleSessionWideEventDataTests {
 
     // MARK: - Durations
 
+    @available(iOS 16, *)
     @Test("Session duration is computed in ms when sessionInterval is closed", .timeLimit(.minutes(1)))
     func sessionDurationIsComputedInMs() {
         let start = Date()
@@ -123,6 +134,7 @@ struct PostIdleSessionWideEventDataTests {
         #expect(params["feature.data.ext.session_duration_ms"] as? Int == 2500)
     }
 
+    @available(iOS 16, *)
     @Test("First interaction duration is computed in ms when interval is closed", .timeLimit(.minutes(1)))
     func firstInteractionDurationIsComputedInMs() {
         let start = Date()
@@ -133,6 +145,7 @@ struct PostIdleSessionWideEventDataTests {
         #expect(params["feature.data.ext.time_to_first_interaction_ms"] as? Int == 500)
     }
 
+    @available(iOS 16, *)
     @Test("Both intervals share the same start by default", .timeLimit(.minutes(1)))
     func bothIntervalsShareSameStart() {
         let start = Date()
@@ -143,6 +156,7 @@ struct PostIdleSessionWideEventDataTests {
 
     // MARK: - Completion decision
 
+    @available(iOS 16, *)
     @Test("App launch trigger always completes as UNKNOWN with app_terminated reason", .timeLimit(.minutes(1)))
     func appLaunchAlwaysCompletesAsUnknownAppTerminated() async {
         let data = PostIdleSessionWideEventData(surface: .ntp)
@@ -156,6 +170,7 @@ struct PostIdleSessionWideEventDataTests {
         }
     }
 
+    @available(iOS 16, *)
     @Test("App launch trigger completes orphan with all surface variants", .timeLimit(.minutes(1)))
     func appLaunchCompletesAllSurfaceVariants() async {
         for surface in PostIdleSessionWideEventData.Surface.allCases {
@@ -171,6 +186,7 @@ struct PostIdleSessionWideEventDataTests {
 
     // MARK: - Codable
 
+    @available(iOS 16, *)
     @Test("Round-trips through JSONEncoder/Decoder preserves all fields", .timeLimit(.minutes(1)))
     func codableRoundTripPreservesAllFields() throws {
         let start = Date(timeIntervalSince1970: 1_700_000_000)

--- a/iOS/DuckDuckGoTests/PostIdleSessionWideEventDataTests.swift
+++ b/iOS/DuckDuckGoTests/PostIdleSessionWideEventDataTests.swift
@@ -27,7 +27,7 @@ struct PostIdleSessionWideEventDataTests {
 
     // MARK: - Metadata
 
-    @Test("Metadata exposes expected pixel and feature names", .timeLimit(.minutes(1)))
+    @Test("Metadata exposes expected pixel and feature names")
     func metadataExposesExpectedNames() {
         #expect(PostIdleSessionWideEventData.metadata.pixelName == "post_idle_session")
         #expect(PostIdleSessionWideEventData.metadata.featureName == "post_idle_session")
@@ -37,7 +37,7 @@ struct PostIdleSessionWideEventDataTests {
 
     // MARK: - jsonParameters
 
-    @Test("Default flow produces surface-only parameters and no status reason", .timeLimit(.minutes(1)))
+    @Test("Default flow produces surface-only parameters and no status reason")
     func defaultFlowProducesSurfaceOnly() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
         let params = data.jsonParameters()
@@ -51,55 +51,55 @@ struct PostIdleSessionWideEventDataTests {
         #expect(params["feature.data.ext.back_pressed"] as? Bool == false)
     }
 
-    @Test("Bar used reason emits status_reason", .timeLimit(.minutes(1)))
+    @Test("Bar used reason emits status_reason")
     func barUsedReasonEmitsStatusReason() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
         data.statusReason = .barUsed
         #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "bar_used")
     }
 
-    @Test("Return-to-page reason emits status_reason", .timeLimit(.minutes(1)))
+    @Test("Return-to-page reason emits status_reason")
     func returnToPageReasonEmitsStatusReason() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
         data.statusReason = .returnToPageTapped
         #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "return_to_page_tapped")
     }
 
-    @Test("Tab switcher reason emits status_reason", .timeLimit(.minutes(1)))
+    @Test("Tab switcher reason emits status_reason")
     func tabSwitcherReasonEmitsStatusReason() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
         data.statusReason = .tabSwitcherSelected
         #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "tab_switcher_selected")
     }
 
-    @Test("App backgrounded reason emits status_reason", .timeLimit(.minutes(1)))
+    @Test("App backgrounded reason emits status_reason")
     func appBackgroundedReasonEmitsStatusReason() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
         data.statusReason = .appBackgrounded
         #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "app_backgrounded")
     }
 
-    @Test("Favorite selected reason emits status_reason", .timeLimit(.minutes(1)))
+    @Test("Favorite selected reason emits status_reason")
     func favoriteSelectedReasonEmitsStatusReason() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
         data.statusReason = .favoriteSelected
         #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "favorite_selected")
     }
 
-    @Test("Chat selected reason emits status_reason", .timeLimit(.minutes(1)))
+    @Test("Chat selected reason emits status_reason")
     func chatSelectedReasonEmitsStatusReason() {
         let data = PostIdleSessionWideEventData(surface: .ntp)
         data.statusReason = .chatSelected
         #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == "chat_selected")
     }
 
-    @Test("LUT surface emits lut", .timeLimit(.minutes(1)))
+    @Test("LUT surface emits lut")
     func lutSurfaceEmitsLut() {
         let data = PostIdleSessionWideEventData(surface: .lut)
         #expect(data.jsonParameters()["feature.data.ext.surface"] as? String == "lut")
     }
 
-    @Test("Boolean flags propagate when set", .timeLimit(.minutes(1)))
+    @Test("Boolean flags propagate when set")
     func booleanFlagsPropagateWhenSet() {
         let data = PostIdleSessionWideEventData(surface: .ntp,
                                                 pageEngaged: true,
@@ -113,7 +113,7 @@ struct PostIdleSessionWideEventDataTests {
 
     // MARK: - Durations
 
-    @Test("Session duration is computed in ms when sessionInterval is closed", .timeLimit(.minutes(1)))
+    @Test("Session duration is computed in ms when sessionInterval is closed")
     func sessionDurationIsComputedInMs() {
         let start = Date()
         let data = PostIdleSessionWideEventData(surface: .ntp, startedAt: start)
@@ -123,7 +123,7 @@ struct PostIdleSessionWideEventDataTests {
         #expect(params["feature.data.ext.session_duration_ms"] as? Int == 2500)
     }
 
-    @Test("First interaction duration is computed in ms when interval is closed", .timeLimit(.minutes(1)))
+    @Test("First interaction duration is computed in ms when interval is closed")
     func firstInteractionDurationIsComputedInMs() {
         let start = Date()
         let data = PostIdleSessionWideEventData(surface: .ntp, startedAt: start)
@@ -133,7 +133,7 @@ struct PostIdleSessionWideEventDataTests {
         #expect(params["feature.data.ext.time_to_first_interaction_ms"] as? Int == 500)
     }
 
-    @Test("Both intervals share the same start by default", .timeLimit(.minutes(1)))
+    @Test("Both intervals share the same start by default")
     func bothIntervalsShareSameStart() {
         let start = Date()
         let data = PostIdleSessionWideEventData(surface: .ntp, startedAt: start)
@@ -143,7 +143,7 @@ struct PostIdleSessionWideEventDataTests {
 
     // MARK: - Completion decision
 
-    @Test("App launch trigger always completes as UNKNOWN with app_terminated reason", .timeLimit(.minutes(1)))
+    @Test("App launch trigger always completes as UNKNOWN with app_terminated reason")
     func appLaunchAlwaysCompletesAsUnknownAppTerminated() async {
         let data = PostIdleSessionWideEventData(surface: .ntp)
         let decision = await data.completionDecision(for: .appLaunch)
@@ -156,7 +156,7 @@ struct PostIdleSessionWideEventDataTests {
         }
     }
 
-    @Test("App launch trigger completes orphan with all surface variants", .timeLimit(.minutes(1)))
+    @Test("App launch trigger completes orphan with all surface variants")
     func appLaunchCompletesAllSurfaceVariants() async {
         for surface in PostIdleSessionWideEventData.Surface.allCases {
             let data = PostIdleSessionWideEventData(surface: surface)
@@ -171,7 +171,7 @@ struct PostIdleSessionWideEventDataTests {
 
     // MARK: - Codable
 
-    @Test("Round-trips through JSONEncoder/Decoder preserves all fields", .timeLimit(.minutes(1)))
+    @Test("Round-trips through JSONEncoder/Decoder preserves all fields")
     func codableRoundTripPreservesAllFields() throws {
         let start = Date(timeIntervalSince1970: 1_700_000_000)
         let original = PostIdleSessionWideEventData(surface: .lut, startedAt: start)

--- a/iOS/DuckDuckGoTests/PostIdleSessionWideEventDataTests.swift
+++ b/iOS/DuckDuckGoTests/PostIdleSessionWideEventDataTests.swift
@@ -143,14 +143,14 @@ struct PostIdleSessionWideEventDataTests {
 
     // MARK: - Completion decision
 
-    @Test("App launch trigger always completes as UNKNOWN with app_relaunched reason")
-    func appLaunchAlwaysCompletesAsUnknownAppRelaunched() async {
+    @Test("App launch trigger always completes as UNKNOWN with app_terminated reason")
+    func appLaunchAlwaysCompletesAsUnknownAppTerminated() async {
         let data = PostIdleSessionWideEventData(surface: .ntp)
         let decision = await data.completionDecision(for: .appLaunch)
 
         if case .complete(.unknown(let reason)) = decision {
-            #expect(reason == PostIdleSessionWideEventData.appRelaunchedReason)
-            #expect(reason == "app_relaunched")
+            #expect(reason == PostIdleSessionWideEventData.appTerminatedReason)
+            #expect(reason == "app_terminated")
         } else {
             Issue.record("Expected .complete(.unknown(reason:)), got \(decision)")
         }

--- a/iOS/PixelDefinitions/pixels/definitions/post_idle_session_wide_event.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/post_idle_session_wide_event.json5
@@ -57,7 +57,7 @@
                     "app_backgrounded",
                     "favorite_selected",
                     "chat_selected",
-                    "app_relaunched"
+                    "app_terminated"
                 ]
             },
             {

--- a/iOS/PixelDefinitions/pixels/definitions/post_idle_session_wide_event.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/post_idle_session_wide_event.json5
@@ -1,0 +1,90 @@
+{
+    // Defined in https://app.asana.com/1/137249556945/project/1204186595873227/task/1214156660588025
+    "m_ios_wide_post_idle_session": {
+        "description": "Wide pixel sent at the end of a post-idle session on iOS (NTP-after-idle or LUT-after-idle).",
+        "owners": ["SabrinaTardio"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            // Standard wide event parameters
+            "appVersion",
+            "wideEventAppName",
+            "wideEventAppVersion",
+            "wideEventPlatform",
+            "wideEventType",
+            "wideEventFormFactor",
+            "wideEventSampleRate",
+            "wideEventIsFirstDailyOccurrence",
+            "wideEventFeatureStatus",
+            "wideEventErrorDomain",
+            "wideEventErrorCode",
+            "wideEventErrorDescription",
+            "wideEventUnderlyingErrorDomain",
+            "wideEventUnderlyingErrorCode",
+            "wideEventMetaVersion",
+
+            // Wide event type identifier
+            {
+                "key": "meta.type",
+                "type": "string",
+                "description": "Wide event type identifier",
+                "enum": ["ios-post-idle-session"]
+            },
+
+            // Feature identifier
+            {
+                "key": "feature.name",
+                "type": "string",
+                "description": "Feature identifier for this wide pixel",
+                "enum": ["post_idle_session"]
+            },
+
+            // Feature data
+            {
+                "key": "feature.data.ext.surface",
+                "type": "string",
+                "description": "Which post-idle surface was shown",
+                "enum": ["ntp", "lut"]
+            },
+            {
+                "key": "feature.data.ext.status_reason",
+                "type": "string",
+                "description": "Reason the session ended",
+                "enum": [
+                    "bar_used",
+                    "return_to_page_tapped",
+                    "tab_switcher_selected",
+                    "app_backgrounded",
+                    "favorite_selected",
+                    "chat_selected",
+                    "app_relaunched"
+                ]
+            },
+            {
+                "key": "feature.data.ext.session_duration_ms",
+                "type": "integer",
+                "description": "Duration from surface shown to session end (in ms)."
+            },
+            {
+                "key": "feature.data.ext.time_to_first_interaction_ms",
+                "type": "integer",
+                "description": "Duration from surface shown to first user interaction or terminal action (in ms)."
+            },
+            {
+                "key": "feature.data.ext.page_engaged",
+                "type": "boolean",
+                "description": "Whether the user scrolled or activated an in-page link during the session."
+            },
+            {
+                "key": "feature.data.ext.toggle_used",
+                "type": "boolean",
+                "description": "Whether the user toggled between search and Duck.ai during the session."
+            },
+            {
+                "key": "feature.data.ext.back_pressed",
+                "type": "boolean",
+                "description": "Whether the user pressed back/cancel during the session."
+            }
+        ]
+    }
+}

--- a/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
+++ b/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
@@ -39,6 +39,7 @@ import AIChatTestingUtilities
 // swiftlint:disable force_try
 
 private final class MockIdleReturnEligibilityManagerForMainVC: IdleReturnEligibilityManaging {
+    func isFeatureAvailable() -> Bool { false }
     func isEligibleForNTPAfterIdle() -> Bool { false }
     func effectiveAfterInactivityOption() -> AfterInactivityOption { .lastUsedTab }
     func idleThresholdSeconds() -> Int { 60 }

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
@@ -110,6 +110,8 @@ final class MockTabDelegate: TabDelegate {
 
     func tabContentProcessDidTerminate(tab: DuckDuckGo.TabViewController) {}
 
+    func tabDidEngageWithPage(_ tab: DuckDuckGo.TabViewController) {}
+
     func tabDidRequestFireButtonPulse(tab: DuckDuckGo.TabViewController) {
         didRequestFireButtonPulseCalled = true
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1214234567557845?focus=true

### Description

Adds a session-scoped wide-event pixel `m_ios_wide_post_idle_session` that captures the full post-idle session journey on both surfaces (NTP-after-idle and LUT-after-idle), so engagement across cohorts can be compared and a full-rollout decision made. Stacked on top of #4581 (escape-hatch gating).

The narrow `m_ntp_after_idle_*` pixels are unchanged; the wide pixel is additive.

**What's tracked**
- `surface`: `ntp` | `lut`
- `status` + `status_reason`:
  - `SUCCESS`: `bar_used`, `return_to_page_tapped`, `tab_switcher_selected`, `favorite_selected`, `chat_selected`
  - `CANCELLED`: `app_backgrounded`
  - `UNKNOWN`: `app_terminated` (orphan recovery for force-quit / crash mid-session)
- `session_duration_ms`, `time_to_first_interaction_ms`
- `page_engaged` (scroll or in-page link click), `toggle_used` (search ↔ Duck.ai), `back_pressed`

**Notable additions**
- New code path for **LUT-after-idle**: `IdleReturnEvaluator` is split into `didReturnAfterIdle` (threshold check) and `treatmentForIdleReturn` (NTP vs LUT). When the user's "After Inactivity" setting is `.lastUsedTab`, `LaunchActionHandler` dispatches a new `markLastUsedTabAsResumedAfterIdle` delegate call to start the LUT session.
- Page-engagement signals: scroll wired through `BrowserChromeManager` → `TabDelegate.tabDidEngageWithPage`; `linkActivated` navigation hooked in `TabViewController`.
- Wide-pixel JSON5 definition with the standard wide-event suffix/parameter set.

### Testing Steps

1. Build the app
2. Set the idle threshold low via `idle-return-threshold-seconds-debug-override` (e.g. 3s).

**NTP-after-idle** (After Inactivity = New Tab)

3. **bar_used** — background, foreground onto NTP, type a query → `surface=ntp`, `status_reason=bar_used`.
4. **return_to_page_tapped** — same start, tap the "Return to…" card → `status_reason=return_to_page_tapped`.
5. **favorite_selected** — same start, tap a favorite → `status_reason=favorite_selected`.
6. **chat_selected** — same start, toggle to Duck.ai, select a chat from history → `status_reason=chat_selected`.
7. **tab_switcher_selected** — same start, open the tab switcher → `status_reason=tab_switcher_selected`.
8. **app_backgrounded** — same start, immediately background → `status=CANCELLED`, `status_reason=app_backgrounded`.
9. **non-terminal flags** — same start, scroll favorites, toggle to Duck.ai, tap back, then submit a search → `page_engaged=true`, `toggle_used=true`, `back_pressed=true`, `status_reason=bar_used`.

**LUT-after-idle** (After Inactivity = Last Used Tab)

10. **bar_used** — background, foreground (previous tab restored, no NTP), tap the address bar and submit a query → `surface=lut`, `status_reason=bar_used`.
11. **chat_selected** — same start, open the omnibar, select a chat from history → `status_reason=chat_selected`.
12. **tab_switcher_selected** — same start, open the tab switcher → `status_reason=tab_switcher_selected`.
13. **app_backgrounded** — same start, immediately background → `status=CANCELLED`, `status_reason=app_backgrounded`.
14. **non-terminal flags** — same start, scroll the page (or tap an in-page link), toggle to Duck.ai, tap back, then submit a search → `page_engaged=true`, `toggle_used=true`, `back_pressed=true`, `status_reason=bar_used`.

**Other**

15. **Orphan recovery** — start a session, force-quit mid-session, relaunch → `status=UNKNOWN`, `reason=app_terminated`.
16. **No false positives** — open user-initiated NTP (no idle resume), interact normally → no wide pixel fires.
17. Run `cd iOS && npm run validate-pixel-defs` → passes.

### Impact and Risks

**Low** — telemetry-only addition. No user-visible behavior changes; existing narrow pixels are untouched. The new LUT detection path adds a delegate hook that is currently a no-op aside from session start.

#### What could go wrong?

- **Orphan recovery firing spuriously.** Any pending flow on launch is closed as `UNKNOWN(app_terminated)`. If `completeFlow(.cancelled)` doesn't finish before iOS suspends the process on background, a stale flow could remain on disk and report UNKNOWN on the next launch. Mitigated by completing on `applicationDidEnterBackground` (within the ~5s window).
- **Pixel double-firing on tab switcher / chat selection.** Hooks are placed at the convergence points (`onChatHistorySelected`, the single tab-switcher entry) so each terminal action fires exactly once across all caller paths. `activeSessionID` is cleared on every terminal/cancel call so subsequent signals are no-ops.
- **Sample rate.** `1.0` per spec — full volume, but only for sessions that pass the eligibility gate (feature flag + onboarding + setting), and only on idle-return launches.

### Quality Considerations

- **Edge cases**: rapid background ↔ foreground over the threshold; user lands on NTP without an idle return (no pixel fires); session active when app is killed (orphan recovery).
- **Privacy/security**: no PII or URL content captured; all fields are categorical or numeric.
- **Tests**: unit coverage for `PostIdleSessionWideEventData` parameter shape, `DefaultPostIdleSessionInstrumentation` start/update/complete sequencing, the refactored `IdleReturnEvaluator` API, and the new LUT branch in `LaunchActionHandler`.

### Notes to Reviewer

- The `IdleReturnEvaluator` refactor (`didReturnAfterIdle` + `treatmentForIdleReturn`) replaces the previous `shouldShowNTPAfterIdle()` API. Existing call sites are migrated; `treatmentForIdleReturn` is designed to extend cleanly if more idle-return treatments are added later.
- `WideEventService` registration is one line — the framework handles persistence, sampling, and flow lifecycle.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches app-launch idle-return decision flow and hooks multiple UI interaction points to start/end/update a new wide-event session; mistakes could cause incorrect launch behavior or double/missed telemetry events.
> 
> **Overview**
> Adds a new **session-scoped wide-event pixel** (`post_idle_session` / `m_ios_wide_post_idle_session`) to track post-idle journeys across both *NTP-after-idle* and *Last Used Tab-after-idle* surfaces, including duration, first-interaction timing, and engagement flags.
> 
> Refactors idle-return evaluation to separate **idle detection** (`didReturnAfterIdle`) from **treatment selection** (`treatmentForIdleReturn`), and updates `LaunchActionHandler` to either show NTP or mark LUT resumed after idle via a new delegate call.
> 
> Wires new instrumentation throughout the app lifecycle/UI: starts sessions on idle-return NTP/LUT, updates flags on scroll/link activation and toggle/back usage, ends sessions on terminal actions (bar used, return-to-page, tab switcher, favorite/chat selection), cancels on background, and registers orphan completion on app launch via `WideEventService`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e4ae053cd5f5d4e9873bdd4177a6f1b0a2e4945. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->