### PR TITLE
iOS: Fix glitchy UTI toggle reveal animation

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
@@ -48,7 +48,6 @@ final class UnifiedToggleInputToggleView: UIView {
         let view = UIView()
         view.backgroundColor = UIColor(designSystemColor: .controlsRaisedBackdrop)
         view.layer.cornerRadius = Constants.cornerRadius
-        view.clipsToBounds = true
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
@@ -86,6 +85,8 @@ final class UnifiedToggleInputToggleView: UIView {
         stack.axis = .horizontal
         stack.distribution = .fillEqually
         stack.spacing = Constants.segmentSpacing
+        stack.layer.cornerRadius = Constants.cornerRadius - Constants.horizontalPadding
+        stack.clipsToBounds = true
         stack.translatesAutoresizingMaskIntoConstraints = false
         return stack
     }()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
@@ -28,7 +28,6 @@ final class UnifiedToggleInputToggleView: UIView {
 
     private enum Constants {
         static let height: CGFloat = 40
-        static let innerHeight: CGFloat = 36
         static let cornerRadius: CGFloat = 20
         static let innerCornerRadius: CGFloat = 18
         static let segmentSpacing: CGFloat = 2
@@ -49,6 +48,7 @@ final class UnifiedToggleInputToggleView: UIView {
         let view = UIView()
         view.backgroundColor = UIColor(designSystemColor: .controlsRaisedBackdrop)
         view.layer.cornerRadius = Constants.cornerRadius
+        view.clipsToBounds = true
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
@@ -154,7 +154,7 @@ final class UnifiedToggleInputToggleView: UIView {
 
             indicatorToDuckAI,
             indicator.topAnchor.constraint(equalTo: backgroundView.topAnchor, constant: Constants.horizontalPadding),
-            indicator.heightAnchor.constraint(equalToConstant: Constants.innerHeight),
+            indicator.bottomAnchor.constraint(equalTo: backgroundView.bottomAnchor, constant: -Constants.horizontalPadding),
             indicator.widthAnchor.constraint(equalTo: searchButton.widthAnchor),
         ])
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
@@ -154,8 +154,16 @@ final class UnifiedToggleInputToggleView: UIView {
             }(),
 
             indicatorToDuckAI,
-            indicator.topAnchor.constraint(equalTo: backgroundView.topAnchor, constant: Constants.horizontalPadding),
-            indicator.bottomAnchor.constraint(equalTo: backgroundView.bottomAnchor, constant: -Constants.horizontalPadding),
+            {
+                let topConstraint = indicator.topAnchor.constraint(equalTo: backgroundView.topAnchor, constant: Constants.horizontalPadding)
+                topConstraint.priority = .defaultHigh
+                return topConstraint
+            }(),
+            {
+                let bottomConstraint = indicator.bottomAnchor.constraint(equalTo: backgroundView.bottomAnchor, constant: -Constants.horizontalPadding)
+                bottomConstraint.priority = .defaultHigh
+                return bottomConstraint
+            }(),
             indicator.widthAnchor.constraint(equalTo: searchButton.widthAnchor),
         ])
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201392122292466/task/1214310402187034
Tech Design URL:
CC: @aataraxiaa 

### Description

When the UTI bar appears (e.g., on omnibar tap), the reveal animation looks out-of-sync: the white indicator pill behind the selected segment renders at full size while the gray toggle background is still mid-animation, and icon/text content reach full opacity before the outer frame catches up.

**Root cause:** the toggle's outer height animates 0→40pt while the inner indicator/content has fixed-size constraints, so they visibly render at their final size while the outer frame is still growing.

Before:
https://github.com/user-attachments/assets/c22a2676-b73b-459e-a57d-220c2b7145fe
<img width="388" height="108" alt="Zrzut ekranu 2026-04-27 o 14 28 41" src="https://github.com/user-attachments/assets/d84d73f5-2ce6-48c3-9ed6-714d5d07e40b" />

After:
https://github.com/user-attachments/assets/e3e442b2-8b51-43e0-86d1-f7ef705545f5

**Fix:**
- Pin the indicator to the background's bottom (instead of a fixed height) so it grows with the bg.
- Clip the rounded background so content reveals progressively as the bg grows.

### Testing Steps

1. Tap the omnibar so the UTI expands. The toggle row, indicator pill, and Search/Duck.ai labels should all grow together as a single unit (no "Search side already at full size" effect).
2. Toggle modes a few times to confirm the indicator slide animation still works.
3. Repeat with simulator slow animations enabled — the reveal should look coherent end-to-end.

### Impact and Risks

Low — touches only the internal layout of `UnifiedToggleInputToggleView`, no logic changes.

#### What could go wrong?

The `clipsToBounds = true` on the toggle background could in theory clip a future content that was meant to overflow (e.g. a badge or shadow). The current toggle has no such elements; the background already has a `cornerRadius`, so clipping was effectively expected.

### Notes to Reviewer

This is the first of two PRs splitting the "iOS Feedback: Glitchy toggle transitions" investigation. Companion PR for the mode-switch glitch on Duck.ai pages will follow.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only layout/constraint tweaks confined to `UnifiedToggleInputToggleView`; main risk is unintended clipping due to `clipsToBounds`.
> 
> **Overview**
> Improves the UTI segmented toggle reveal animation by removing the indicator’s fixed inner height and instead constraining it to the background’s top+bottom so it scales during height animations.
> 
> Adds rounded clipping on the segment `UIStackView` (corner radius + `clipsToBounds`) so button content reveals progressively with the container, avoiding the indicator/text appearing fully sized before the outer pill finishes expanding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d3de249980ddd7e371328d49c7894b36e0c742a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->