### PR TITLE
iOS: Fix glitchy UTI mode switch on Duck.ai pages

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1224,13 +1224,13 @@ class MainViewController: UIViewController {
 
         let coordinator = unifiedToggleInputCoordinator
         let isAITabCollapsed = coordinator?.displayState == .aiTab(.collapsed)
-        let isBottomExpandedUTIKeyboardAnchored = (coordinator?.isOmnibarSession == true || coordinator?.isAITabExpanded == true)
+        let isBottomExpandedUTIKeyboardAnchored = coordinator?.isInputEditing == true
             && coordinator?.cardPosition == .bottom
             && viewCoordinator.isNavigationBarContainerBottomKeyboardBased
 
         let baseInputHeight: CGFloat
-        if let coordinator, coordinator.isAITabExpanded || coordinator.isOmnibarSession {
-            baseInputHeight = coordinator.omnibarEditingHeight()
+        if let coordinator, coordinator.isInputEditing {
+            baseInputHeight = coordinator.editingHeight()
         } else {
             baseInputHeight = omniBarHeight
         }
@@ -2203,7 +2203,7 @@ class MainViewController: UIViewController {
             }
 
             ViewHighlighter.updatePositions()
-            self.recomputeOmnibarEditingHeightIfNeeded()
+            self.recomputeNavigationBarContainerHeightIfNeeded()
         }
 
         hideNotificationBarIfBrokenSitePromptShown()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -137,12 +137,12 @@ extension MainViewController {
         }
     }
 
-    func recomputeOmnibarEditingHeightIfNeeded() {
+    func recomputeNavigationBarContainerHeightIfNeeded() {
         guard let coordinator = unifiedToggleInputCoordinator,
-              coordinator.isOmnibarSession else {
+              coordinator.isInputEditing else {
             return
         }
-        let height = coordinator.omnibarEditingHeight()
+        let height = coordinator.editingHeight()
         guard viewCoordinator.constraints.navigationBarContainerHeight.constant != height else { return }
         viewCoordinator.constraints.navigationBarContainerHeight.constant = height
         viewCoordinator.navigationBarContainer.superview?.layoutIfNeeded()
@@ -195,7 +195,7 @@ private extension MainViewController {
         coordinator.attachmentsChangePublisher
             .sink { [weak self] in
                 guard let self, let coordinator = unifiedToggleInputCoordinator else { return }
-                if coordinator.isAITabExpanded || coordinator.isOmnibarSession {
+                if coordinator.isInputEditing {
                     adjustUI(withKeyboardFrame: latestKeyboardFrame, in: 0.2, animationCurve: .curveEaseInOut)
                 }
             }
@@ -608,11 +608,7 @@ extension MainViewController: UnifiedToggleInputDelegate {
     }
 
     func unifiedToggleInputDidChangeHeight() {
-        if unifiedToggleInputCoordinator?.isOmnibarSession == true {
-            recomputeOmnibarEditingHeightIfNeeded()
-        } else {
-            unifiedToggleInputCoordinator?.pushContentInsets()
-        }
+        recomputeNavigationBarContainerHeightIfNeeded()
     }
 }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
@@ -150,12 +150,12 @@ private extension MainViewController {
         guard let coordinator = unifiedToggleInputCoordinator,
               coordinator.cardPosition == .bottom,
               viewCoordinator.addressBarPosition.isBottom else {
-            recomputeOmnibarEditingHeightIfNeeded()
+            recomputeNavigationBarContainerHeightIfNeeded()
             return
         }
         applyBottomOmnibarAnchor(state)
         viewCoordinator.navigationBarContainer.superview?.layoutIfNeeded()
-        recomputeOmnibarEditingHeightIfNeeded()
+        recomputeNavigationBarContainerHeightIfNeeded()
     }
 
     func applyBottomOmnibarAnchor(_ state: UnifiedToggleInputDisplayState.OmnibarState) {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -141,6 +141,10 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         displayState == .aiTab(.expanded)
     }
 
+    var isInputEditing: Bool {
+        isOmnibarSession || isAITabExpanded
+    }
+
     var isActive: Bool {
         displayState != .hidden
     }
@@ -350,17 +354,17 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         }
 
         contentViewController.setDismissButtonVisible(renderState.isFloatingDismissVisible)
-        let expandedHeight = omnibarEditingHeight()
+        let expandedHeight = editingHeight()
 
         if cardPosition == .top && isToggleEnabled {
             viewController.setExpanded(false, animated: false)
             viewController.setExpandedWithToggleHidden(true)
-            let toggleHiddenHeight = omnibarEditingHeight()
+            let toggleHiddenHeight = editingHeight()
             intentSubject.send(.showOmnibarEditing(expandedHeight: toggleHiddenHeight, pendingExpandedHeight: expandedHeight))
         } else if cardPosition == .top {
             viewController.setExpanded(false, animated: false)
             viewController.setExpandedWithToggleHidden(true)
-            let omnibarMatchingHeight = omnibarEditingHeight()
+            let omnibarMatchingHeight = editingHeight()
             intentSubject.send(.showOmnibarEditing(expandedHeight: omnibarMatchingHeight))
         } else {
             intentSubject.send(.showOmnibarEditing(expandedHeight: expandedHeight))
@@ -422,7 +426,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         viewController.animateToggleReveal(additionalAnimations: additionalAnimations)
     }
 
-    func omnibarEditingHeight() -> CGFloat {
+    func editingHeight() -> CGFloat {
         let screenWidth = viewController.view.window?.bounds.width ?? viewController.view.bounds.width
         let height = viewController.view.systemLayoutSizeFitting(
             CGSize(width: screenWidth, height: UIView.layoutFittingCompressedSize.height),
@@ -486,6 +490,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     }
 
     func updateOmnibarInputVisibility(_ isInputVisible: Bool) {
+        guard isInputVisibleForKeyboard != isInputVisible else { return }
         isInputVisibleForKeyboard = isInputVisible
         let isAITabSearch = displayState == .aiTab(.expanded) && inputMode == .search
 
@@ -506,11 +511,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         case (.omnibar(.active), true):
             cancelTopOmnibarKeyboardPresentationFallback()
             isAwaitingTopOmnibarKeyboardPresentation = false
-        case (.aiTab(.expanded), false) where isAITabSearch:
-            let renderState = computeRenderState()
-            viewController.apply(renderState.viewConfig, animated: false)
-            contentViewController.setDismissButtonVisible(renderState.isFloatingDismissVisible)
-        case (.aiTab(.expanded), true) where isAITabSearch:
+        case (.aiTab(.expanded), _) where isAITabSearch:
             let renderState = computeRenderState()
             viewController.apply(renderState.viewConfig, animated: false)
             contentViewController.setDismissButtonVisible(renderState.isFloatingDismissVisible)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201392122292466/task/1214310645361410
Tech Design URL:
CC: @aataraxiaa 

### Description

On a Duck.ai page with UTI at the bottom, switching modes was glitchy in two ways:

- **Duck.ai → Search:** the toolbar (paperclip / model / send) disappeared instantly with no animation, and the UTI lost its keyboard anchor briefly — looked like a jump rather than a smooth shrink.
- **Search → Duck.ai:** the UTI's y-position jumped up immediately, then the toolbar grew in with animation — a two-step visual instead of one fluid motion.

The equivalent transition on the new tab page (omnibar) was already smooth, so the fix is targeted at the AI-tab-expanded path.

**Root causes**
1. `updateOmnibarInputVisibility` on the coordinator was called redundantly during AI-tab mode changes (the keyboard was already visible). For `(.aiTab(.expanded), true) where isAITabSearch` it then synchronously called `apply(animated: false)`, which snapped the toolbar height to 0 with no animation.
2. The AI-tab-expanded path was missing a counterpart to the omnibar's `recomputeOmnibarEditingHeightIfNeeded` hook — so when the toolbar finished animating, the outer `navigationBarContainerHeight` wasn't re-synced inside the active animation block. The container's resize was instead driven by a spurious `keyboardWillChangeFrame(duration: 0)` event that snapped instead of animating.

Before:
https://github.com/user-attachments/assets/2f8cdd9d-164a-482e-beb6-ad15eb78c45c

After:
https://github.com/user-attachments/assets/5c1ad31a-8ada-41a1-a263-0cff64577c05

**Fix**
- Add a no-op guard at the top of `updateOmnibarInputVisibility` so identical visibility values short-circuit before any work.
- Generalise `recomputeOmnibarEditingHeightIfNeeded` into a single `recomputeNavigationBarContainerHeightIfNeeded` that fires for both omnibar editing and AI-tab expanded states. It's called from `unifiedToggleInputDidChangeHeight` inside the toolbar's `UIView.animate` block, so the container resize animates alongside the toolbar.

Minor cleanups along the way: collapsed two identical `(.aiTab(.expanded), _) where isAITabSearch` switch arms; renamed the now-misleading `omnibarEditingHeight()` → `editingHeight()`; introduced `coordinator.isInputEditing` for the `isOmnibarSession || isAITabExpanded` predicate that was duplicated across four call sites.

### Testing Steps

1. On a Duck.ai page (anything that puts the placeholder in the "Ask a follow-up question" state), with the UTI at the bottom, tap into the input.
2. Tap **Search** → toolbar should fade out smoothly while the UTI shrinks; UTI stays anchored to the keyboard.
4. Tap **Duck.ai** → toolbar should grow in smoothly while the UTI grows upward as a single motion (no upward jump followed by a separate enlarge).
5. Repeat the toggling several times to confirm both directions are stable.
6. Smoke test: omnibar editing on the new tab page should still feel the same as before (Search ↔ Duck.ai). Rotation should still work (the new generalised helper now also fires from the rotation post-layout hook for AI-tab states).

### Impact and Risks

Low — touches the layout/sizing path for the UTI navigation bar container. UTI unit tests (200 tests) all pass. Manually verified both the bug repro and the broader omnibar/rotation flows on iPhone 17 Pro simulator with slow animations enabled.

#### What could go wrong?

- The `recomputeNavigationBarContainerHeightIfNeeded` predicate now matches both `isOmnibarSession || isAITabExpanded` instead of just omnibar — three pre-existing call sites (post-rotation hook, omnibar visibility transitions) will now also recompute for AI-tab-expanded states. That's the intended new behaviour, but worth a careful eye in code review.
- The `omnibarEditingHeight()` → `editingHeight()` rename is mechanical (5 call sites in the same file plus one external) but is the kind of change that benefits from a quick search-and-replace verification.

### Notes to Reviewer

This is the second of two PRs splitting the "iOS Feedback: Glitchy toggle transitions" investigation. The companion PR (toggle reveal animation) is independent — they touch disjoint files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout change that mostly refactors height/keyboard-anchoring logic for Unified Toggle Input; primary risk is unintended navigation bar container sizing regressions across omnibar vs AI-tab states.
> 
> **Overview**
> Improves Unified Toggle Input (UTI) mode-switch animations on Duck.ai pages by **preventing redundant keyboard visibility updates** and ensuring the outer `navigationBarContainerHeight` recomputes whenever the input is actively editing (omnibar session *or* expanded AI tab).
> 
> This generalizes the omnibar-only height recomputation into `recomputeNavigationBarContainerHeightIfNeeded`, updates call sites to use a new `coordinator.isInputEditing` predicate, and renames `omnibarEditingHeight()` to `editingHeight()` to match the broader behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 901a28aed6130c8d3567bc007ab70a805448c361. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->