### PR TITLE
UTI: fix frozen screen after dismissing input view

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
@@ -143,7 +143,6 @@ private extension MainViewController {
         viewCoordinator.hideUnifiedInputContent()
         unifiedToggleInputCoordinator?.contentViewController.setContentInset(top: 0, bottom: 0)
         hideSuggestionTray()
-        viewCoordinator.suggestionTrayContainer.isHidden = false
     }
 
     func applyBottomOmnibarVisibility(_ state: UnifiedToggleInputDisplayState.OmnibarState) {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210947754188321/task/1213869176100877?focus=true
Tech Design URL:
CC:

### Description
Removes a redundant `viewCoordinator.suggestionTrayContainer.isHidden = false` reset at the end of `resetUnifiedInputContentAfterHide()` in `MainViewController+UnifiedToggleInputIntentHandling.swift`.

That single line undoes the `hideSuggestionTray()` call that sits above, leaving `SuggestionTrayContainer` — a fullscreen `UIView` constrained 1:1 to the main `contentContainer`, with `isUserInteractionEnabled = true` and a clear background — sitting on top of `NewTabPageViewController.view`. Because the container is transparent, the bug is invisible to the eye but the overlay swallows every touch on the NTP. After dismissing the omnibar keyboard via the X button, favorites, the escape hatch, and scrolling all become non-interactive.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->

#### Setup
1. Enable the UTI feature flag
2. (Optional) Add at least 2 favorites so there is something to tap on the New Tab Page.

#### Scenario 1 
1. Open a new tab. NTP is shown
2. Tap the omnibar (search field). Expect:
   - The UTI bar expands and shows the Search/Duck.ai toggle plus an X button.
   - The keyboard appears.
3. Tap the **X button** in the UTI bar to dismiss
4. Try to interact with the NTP:
   - Tap a favorite icon — expected: it opens. Before the fix: the tap is silently swallowed.
   - Long-press a favorite icon — expected: context menu appears (Edit / Delete). Before the fix: nothing happens.
   - Tap a "Return to..." card if visible — expected: returns to that tab. Before the fix: nothing.
   - Try to scroll the favorites grid — expected: scroll works. Before the fix: NTP feels frozen.

#### Scenario 2
1. Open a new tab.
2. Tap the omnibar — UTI bar expands with the Search/Duck.ai toggle and the keyboard.
3. Tap the "[Duck.ai](http://duck.ai/)" toggle — switches to AI mode.
4. Tap the "Search" toggle — switches back to Search mode.
5. Tap the **X button** to dismiss.
6. Repeat all four NTP interaction tests from Scenario A. All should work.

#### Sanity check — suggestions still render (no regression)
1. Open a new tab, UTI should be already expanded
2. Type "duck" — verify the suggestions list appears as before.
3. Tap a suggestion — verify it triggers the search.

#### Theme color check (no regression in `SiteThemeColorManager`)
1. Set address bar to bottom
2. Navigate to a site with a custom theme color (e.g. [github.com](http://github.com/)).
3. Note the status bar / address bar background reflects the site's theme color (should be dark when visiting [github.com](http://github.com/)).
4. Tap the omnibar, then tap the X to dismiss.
5. Verify the bar still reflects the site theme
6. Bonus: tap omnibar → submit a search (duck) → verify the loaded page's theme color is applied (light on our SERP)
7. Note: with the top address bar position, the omnibar stays white. This is consistent with UTI-OFF / production behavior, not a regression of this fix.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Medium impact. The bug makes the NTP completely non-interactive after a common user action (focus omnibar + dismiss with X), forcing an app restart. The fix is a single-line deletion that reverses a regression introduced in a recent refactor (https://github.com/duckduckgo/apple-browsers/pull/4399)

Risk is low. The replaced behavior is fully covered by the preceding `hideSuggestionTray()` call (defined in `MainViewController.swift:2371`), which already sets `suggestionTrayContainer.isHidden = true` and clears the suggestion tray view controller. 

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
- **Theme color regression in `SiteThemeColorManager`** — `SiteThemeColorManager.swift:127` reads `suggestionTrayContainer.isHidden` as a proxy for "user is editing". With the fix, this reader observes `isHidden = true` after dismiss (instead of `false`), so it now applies the site theme color when expected instead of resetting it. Verified manually across three theme-color scenarios on [github.com](http://github.com/): passive view, focus → X, and toggle AI → Search → X. All expected.

- **Suggestions disappear / fail to show on next omnibar focus** — verified in the suggestions sanity check above. Suggestions render normally on subsequent edits.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk single-line UI state fix that removes an incorrect visibility reset which could leave a full-screen transparent view intercepting touches after dismissing the omnibar.
> 
> **Overview**
> Prevents the New Tab Page from becoming non-interactive after dismissing Unified Toggle Input by **removing a redundant `suggestionTrayContainer.isHidden = false` reset** in `resetUnifiedInputContentAfterHide()`.
> 
> After this change, `hideSuggestionTray()` is no longer immediately undone, so the suggestion tray container stays hidden instead of remaining as a transparent, touch-blocking overlay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66165dd824c4dc90ffe0cb79eb97a95899c239ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->