### PR TITLE
[Debug] Trigger VPN leak check on demand from debug menu

### DIFF
--- a/SharedPackages/VPN/Sources/VPN/LeakCheck/VPNLeakCheckService.swift
+++ b/SharedPackages/VPN/Sources/VPN/LeakCheck/VPNLeakCheckService.swift
@@ -127,7 +127,7 @@ public actor VPNLeakCheckService {
         }
     }
 
-    public func runCheck(trigger: LeakCheckTrigger) async {
+    public func runCheck(trigger: LeakCheckTrigger, bypassCooldown: Bool = false) async {
         guard !isStopped else {
             Logger.networkProtectionIPLeakCheck.log("Skipping leak check — service stopped (trigger: \(trigger.rawValue, privacy: .public))")
             return
@@ -136,7 +136,8 @@ public actor VPNLeakCheckService {
             Logger.networkProtectionIPLeakCheck.log("Skipping leak check — already in flight (trigger: \(trigger.rawValue, privacy: .public))")
             return
         }
-        if trigger != .reassert,
+        if !bypassCooldown,
+           trigger != .reassert,
            let last = lastCompletionDate,
            Date().timeIntervalSince(last) < configuration.cooldown {
             Logger.networkProtectionIPLeakCheck.log("Skipping leak check — cooldown active (trigger: \(trigger.rawValue, privacy: .public))")

--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelMessageHandler.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelMessageHandler.swift
@@ -42,6 +42,10 @@ protocol SnoozeManaging: AnyObject {
     @MainActor func cancelSnooze() async
 }
 
+protocol LeakCheckControlling: AnyObject {
+    @MainActor func triggerLeakCheckFromDebugMenu() async
+}
+
 // MARK: - PacketTunnelMessageHandler
 
 @MainActor
@@ -60,6 +64,7 @@ final class PacketTunnelMessageHandler {
     private weak var tunnelState: (any TunnelStateProviding)?
     private weak var tunnelLifecycle: (any TunnelLifecycleManaging)?
     private weak var snoozeManager: (any SnoozeManaging)?
+    private weak var leakCheckController: (any LeakCheckControlling)?
 
     init(keyStore: NetworkProtectionKeyStore,
          keyExpirationTester: KeyExpirationTesting,
@@ -72,7 +77,8 @@ final class PacketTunnelMessageHandler {
          debugEvents: EventMapping<NetworkProtectionError>,
          tunnelState: any TunnelStateProviding,
          tunnelLifecycle: any TunnelLifecycleManaging,
-         snoozeManager: any SnoozeManaging) {
+         snoozeManager: any SnoozeManaging,
+         leakCheckController: any LeakCheckControlling) {
 
         self.keyStore = keyStore
         self.keyExpirationTester = keyExpirationTester
@@ -86,6 +92,7 @@ final class PacketTunnelMessageHandler {
         self.tunnelState = tunnelState
         self.tunnelLifecycle = tunnelLifecycle
         self.snoozeManager = snoozeManager
+        self.leakCheckController = leakCheckController
     }
 
     // MARK: - Message Routing
@@ -196,6 +203,11 @@ final class PacketTunnelMessageHandler {
         case .createLogSnapshot:
             if #available(macOS 12.0, iOS 15.0, *) {
                 handleCreateLogSnapshot(completionHandler: completionHandler)
+            }
+        case .triggerLeakCheck:
+            Task { [weak self] in
+                await self?.leakCheckController?.triggerLeakCheckFromDebugMenu()
+                completionHandler?(nil)
             }
         }
     }

--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -1798,7 +1798,7 @@ extension PacketTunnelProvider: SnoozeManaging {
 extension PacketTunnelProvider: LeakCheckControlling {
     func triggerLeakCheckFromDebugMenu() async {
         Logger.networkProtectionIPLeakCheck.log("Debug-triggered leak check requested")
-        await leakCheckService?.runCheck(trigger: .periodic)
+        await leakCheckService?.runCheck(trigger: .periodic, bypassCooldown: true)
     }
 }
 

--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -533,7 +533,8 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
             debugEvents: self.debugEvents,
             tunnelState: self,
             tunnelLifecycle: self,
-            snoozeManager: self
+            snoozeManager: self,
+            leakCheckController: self
         )
 
         Logger.networkProtectionMemory.log("[+] PacketTunnelProvider initialized")
@@ -1792,6 +1793,13 @@ extension PacketTunnelProvider: TunnelLifecycleManaging {
 extension PacketTunnelProvider: SnoozeManaging {
     // startSnooze(duration:) — already internal @MainActor
     // cancelSnooze() — already internal @MainActor
+}
+
+extension PacketTunnelProvider: LeakCheckControlling {
+    func triggerLeakCheckFromDebugMenu() async {
+        Logger.networkProtectionIPLeakCheck.log("Debug-triggered leak check requested")
+        await leakCheckService?.runCheck(trigger: .periodic)
+    }
 }
 
 // MARK: - Error Description Helper

--- a/SharedPackages/VPN/Tests/VPNTests/Mocks/MockLeakCheckController.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/Mocks/MockLeakCheckController.swift
@@ -1,7 +1,7 @@
 //
-//  ExtensionRequest.swift
+//  MockLeakCheckController.swift
 //
-//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -17,21 +17,14 @@
 //
 
 import Foundation
+@testable import VPN
 
-public enum VPNCommand: Codable {
-    case expireRegistrationKey
-    case removeSystemExtension
-    case removeVPNConfiguration
-    case sendTestNotification
-    case restartAdapter
-    case uninstallVPN(showNotification: Bool)
-    case simulateSubscriptionExpirationInTunnel
-    case quitAgent
-    case createLogSnapshot
-    case triggerLeakCheck
-}
+@MainActor
+final class MockLeakCheckController: LeakCheckControlling {
 
-public enum ExtensionRequest: Codable {
-    case changeTunnelSetting(_ change: VPNSettings.Change)
-    case command(_ command: VPNCommand)
+    private(set) var triggerLeakCheckFromDebugMenuCalled = false
+
+    func triggerLeakCheckFromDebugMenu() async {
+        triggerLeakCheckFromDebugMenuCalled = true
+    }
 }

--- a/SharedPackages/VPN/Tests/VPNTests/PacketTunnelMessageHandlerTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/PacketTunnelMessageHandlerTests.swift
@@ -126,6 +126,7 @@ final class PacketTunnelMessageHandlerTests: XCTestCase {
     private var tunnelState: MockTunnelStateProvider!
     private var tunnelLifecycle: MockTunnelLifecycleManager!
     private var snoozeManager: MockSnoozeManager!
+    private var leakCheckController: MockLeakCheckController!
     private var handler: PacketTunnelMessageHandler!
 
     override func setUp() {
@@ -149,6 +150,7 @@ final class PacketTunnelMessageHandlerTests: XCTestCase {
         tunnelState = MockTunnelStateProvider()
         tunnelLifecycle = MockTunnelLifecycleManager()
         snoozeManager = MockSnoozeManager()
+        leakCheckController = MockLeakCheckController()
 
         handler = PacketTunnelMessageHandler(
             keyStore: keyStore,
@@ -162,12 +164,14 @@ final class PacketTunnelMessageHandlerTests: XCTestCase {
             debugEvents: debugEvents,
             tunnelState: tunnelState,
             tunnelLifecycle: tunnelLifecycle,
-            snoozeManager: snoozeManager
+            snoozeManager: snoozeManager,
+            leakCheckController: leakCheckController
         )
     }
 
     override func tearDown() {
         handler = nil
+        leakCheckController = nil
         snoozeManager = nil
         tunnelLifecycle = nil
         tunnelState = nil

--- a/iOS/DuckDuckGo/NetworkProtectionDebugUtilities.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionDebugUtilities.swift
@@ -56,6 +56,16 @@ final class NetworkProtectionDebugUtilities {
         try? await activeSession.sendProviderRequest(.command(.simulateSubscriptionExpirationInTunnel))
     }
 
+    // MARK: - Leak Check
+
+    func triggerLeakCheck() async {
+        guard let activeSession = await AppDependencyProvider.shared.networkProtectionTunnelController.activeSession() else {
+            return
+        }
+
+        try? await activeSession.sendProviderRequest(.command(.triggerLeakCheck))
+    }
+
     // MARK: - Failure Simulation
 
     func triggerSimulation(_ option: NetworkProtectionSimulationOption) async {

--- a/iOS/DuckDuckGo/NetworkProtectionDebugViewController.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionDebugViewController.swift
@@ -87,6 +87,7 @@ final class NetworkProtectionDebugViewController: UITableViewController {
         case startSnooze
         case createLogSnapshot
         case viewLogSnapshots
+        case triggerLeakCheck
     }
 
     enum NetworkPathRows: Int, CaseIterable {
@@ -398,6 +399,8 @@ final class NetworkProtectionDebugViewController: UITableViewController {
             cell.textLabel?.text = "Create Log Snapshot"
         case .viewLogSnapshots:
             cell.textLabel?.text = "View Log Snapshots"
+        case .triggerLeakCheck:
+            cell.textLabel?.text = "Trigger VPN Leak Check Now"
         case .none:
             break
         }
@@ -442,6 +445,10 @@ final class NetworkProtectionDebugViewController: UITableViewController {
             }
         case .viewLogSnapshots:
             showLogSnapshotsViewer()
+        case .triggerLeakCheck:
+            Task {
+                await NetworkProtectionDebugUtilities().triggerLeakCheck()
+            }
         case .none:
             break
         }

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDebugMenu.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDebugMenu.swift
@@ -133,6 +133,9 @@ final class NetworkProtectionDebugMenu: NSMenu {
             NSMenuItem(title: "Send Test Notification", action: #selector(NetworkProtectionDebugMenu.sendTestNotification))
                 .targetting(self)
 
+            NSMenuItem(title: "Trigger VPN Leak Check Now", action: #selector(NetworkProtectionDebugMenu.triggerLeakCheck))
+                .targetting(self)
+
             NSMenuItem(title: "Log Feedback Metadata to Console", action: #selector(NetworkProtectionDebugMenu.logFeedbackMetadataToConsole))
                 .targetting(self)
 
@@ -289,6 +292,16 @@ final class NetworkProtectionDebugMenu: NSMenu {
         Task { @MainActor in
             do {
                 try await debugUtilities.simulateSubscriptionExpirationInTunnel()
+            } catch {
+                await NSAlert(error: error).runModal()
+            }
+        }
+    }
+
+    @objc func triggerLeakCheck(_ sender: Any?) {
+        Task { @MainActor in
+            do {
+                try await debugUtilities.triggerLeakCheck()
             } catch {
                 await NSAlert(error: error).runModal()
             }

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDebugUtilities.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDebugUtilities.swift
@@ -71,6 +71,10 @@ final class NetworkProtectionDebugUtilities {
         try await ipcClient.command(.restartAdapter)
     }
 
+    func triggerLeakCheck() async throws {
+        try await ipcClient.command(.triggerLeakCheck)
+    }
+
     func resetAllState(keepAuthToken: Bool) async throws {
         try await vpnUninstaller.uninstall(
             removeSystemExtension: true,

--- a/macOS/DuckDuckGoVPN/TunnelControllerIPCService.swift
+++ b/macOS/DuckDuckGoVPN/TunnelControllerIPCService.swift
@@ -258,6 +258,9 @@ extension TunnelControllerIPCService: XPCServerInterface {
             quitAgent()
         case .createLogSnapshot:
             assertionFailure("Unsupported on macOS")
+        case .triggerLeakCheck:
+            // Intentional no-op: handled by the extension
+            break
         }
     }
 


### PR DESCRIPTION
## Summary

Adds a debug menu entry on iOS and macOS that triggers a VPN leak check immediately, bypassing the natural triggers (tunnel start delay, reasserts, 4h periodic). Targets the VPN leak detection feature in #4508 — without this, leak detection can only be observed via natural triggers, which makes manual QA on real devices slow and the leak path hard to validate.

Wires a new `VPNCommand.triggerLeakCheck` through the existing app→NE IPC, dispatched via a new `LeakCheckControlling` protocol on `PacketTunnelProvider`, which calls into the existing `VPNLeakCheckService`.

## Test plan

- [ ] On iOS: open Settings → VPN → Debug → tap "Trigger VPN Leak Check Now". Confirm a leak check fires (Console: `subsystem == DuckDuckGo, category == VPN-IP-Leak-Check`).
- [ ] On macOS: VPN → Debug menu → "Trigger VPN Leak Check Now". Same Console check.
- [ ] Verify behavior with and without the tunnel connected (no-op when disconnected; immediate check when connected).
- [ ] Existing message handler tests still pass.

## Follow-ups (out of scope here)

A second debug option to simulate a real leak by removing tunnel-interface pinning from a chosen probe (e.g. "IPv4 HTTP only") was discussed but deferred. With this PR you can validate the no-leak path end-to-end on demand; the simulate-leak option remains TODO.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new app→extension IPC command that can invoke the leak-check service and bypass its cooldown; mistakes could cause unexpected checks or IPC incompatibilities, but the path is debug-oriented and largely additive.
> 
> **Overview**
> Adds an on-demand *debug* action to trigger the VPN leak check immediately from iOS and macOS debug UIs.
> 
> This introduces a new `VPNCommand.triggerLeakCheck` routed through the existing app→extension messaging, adds a `LeakCheckControlling` hook on `PacketTunnelProvider` to execute the check, and extends `VPNLeakCheckService.runCheck` with a `bypassCooldown` option so the debug trigger can ignore normal throttling.
> 
> Updates unit-test wiring with a `MockLeakCheckController` and adjusts `PacketTunnelMessageHandler` initialization/handling to dispatch the new command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23a331c9e0c946f57b32ce9f0844a23458d7e87e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->