### PR TITLE
Fix: Adds Pixels channel parameter

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/app_settings_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/app_settings_pixels.json5
@@ -19,14 +19,14 @@
         "owners": ["jleandroperez"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource", "themeChangeSource"]
+        "parameters": ["appVersion", "pixelSource", "channel", "themeChangeSource"]
     },
     "m_mac_settings_theme_name_changed": {
         "description": "Fired when Browser Theme Name setting is changed",
         "owners": ["jleandroperez"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource", "themeChangeSource", "themeName"]
+        "parameters": ["appVersion", "pixelSource", "channel", "themeChangeSource", "themeName"]
     },
     "m_mac_settings_add-to-dock_show-me-how-clicked": {
         "description": "Fired when Add to Dock Show Me How link in settings is clicked to open the demo video",

--- a/macOS/PixelDefinitions/pixels/definitions/autoplay_settings_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/autoplay_settings_pixels.json5
@@ -11,6 +11,6 @@
                 "enum": ["allow-all", "block-audio", "block-all"]
             }
         ],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/new_tab_page_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/new_tab_page_pixels.json5
@@ -77,7 +77,7 @@
         "owners": ["jleandroperez"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_new-tab-page_customizer_shown": {
         "description": "Fires when the user reveals the New Tab Page Customizer UI.",
@@ -87,6 +87,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "themePopoverWasOpen",
                 "type": "boolean",

--- a/macOS/PixelDefinitions/pixels/definitions/startup_metrics_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/startup_metrics_pixels.json5
@@ -8,6 +8,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "app_delegate_init",
                 "type": "string",

--- a/macOS/PixelDefinitions/pixels/definitions/theme_pixels.json
+++ b/macOS/PixelDefinitions/pixels/definitions/theme_pixels.json
@@ -5,6 +5,6 @@
         "owners": ["jleandroperez"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource", "themeName"]
+        "parameters": ["appVersion", "pixelSource", "channel", "themeName"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1214280226500138?focus=true
Tech Design URL:
CC:

### Description
This PR adds the (new) `channel` parameter to few Pixel definitions, so that the schema validator is green again:

- `m_mac_new-tab-page_customizer_hidden`
- `m_mac_new-tab-page_customizer_shown`
- `m_mac_settings_theme_appearance_changed`
- `m_mac_settings_theme_name_changed`
- `m_mac_startup_performance_metrics`
- `m_mac_theme_name_daily`
- `m_mac_autoplay_setting`

### Testing Steps
- [ ] Verify the Pixels CI validation step is green

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing really, this PR updates a few Pixel definition(s), so that they include the new `channel` parameter

### Quality Considerations
None

### Notes to Reviewer
Thanks in advance!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema-only change that updates analytics pixel definitions to include a new required `channel` parameter; no runtime logic is modified.
> 
> **Overview**
> Updates several macOS PixelDefinitions schemas to include the new `channel` parameter for existing pixels (theme settings, autoplay setting, new tab page customizer events, startup performance metrics, and daily theme name).
> 
> This aligns the definitions with the updated pixel schema/validator expectations so CI validation passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 821177451a8e3455d7d89e0e45bb152424c665db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->