### PR TITLE
iOS: Increase Contextual Chat Native Submit Button Tap Area

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/iOS/Views/NativeInput/AIChatNativeInputView.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/iOS/Views/NativeInput/AIChatNativeInputView.swift
@@ -47,6 +47,7 @@ public final class AIChatNativeInputView: UIView {
         static let placeholderHorizontalOffset: CGFloat = 16
         static let placeholderTrailingSpacing: CGFloat = 8
         static let buttonSize: CGFloat = 40
+        static let minimumButtonHitSize: CGFloat = 44
         static let bottomBarHeight: CGFloat = 56
         static let bottomBarHorizontalPadding: CGFloat = 8
         static let cornerRadius: CGFloat = 16
@@ -164,6 +165,7 @@ public final class AIChatNativeInputView: UIView {
         let view = UIView()
         view.backgroundColor = .clear
         view.layer.cornerRadius = Constants.buttonSize / 2
+        view.isUserInteractionEnabled = false
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
@@ -172,6 +174,7 @@ public final class AIChatNativeInputView: UIView {
         let button = UIButton(type: .system)
         button.setImage(DesignSystemImages.Glyphs.Size24.arrowUp, for: .normal)
         button.tintColor = UIColor(designSystemColor: .accent)
+        button.accessibilityIdentifier = "AIChatNativeInputView.submitButton"
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(submitButtonTapped), for: .touchUpInside)
         button.isEnabled = false
@@ -285,7 +288,7 @@ private extension AIChatNativeInputView {
         mainContainer.addSubview(chipContainer)
         mainContainer.addSubview(bottomBar)
         bottomBar.addSubview(submitButtonContainer)
-        submitButtonContainer.addSubview(submitButton)
+        bottomBar.addSubview(submitButton)
 
         setupConstraints()
         updateButtonStates()
@@ -337,6 +340,8 @@ private extension AIChatNativeInputView {
 
             submitButton.centerXAnchor.constraint(equalTo: submitButtonContainer.centerXAnchor),
             submitButton.centerYAnchor.constraint(equalTo: submitButtonContainer.centerYAnchor),
+            submitButton.widthAnchor.constraint(equalToConstant: Constants.minimumButtonHitSize),
+            submitButton.heightAnchor.constraint(equalToConstant: Constants.minimumButtonHitSize),
         ])
     }
 

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatNativeInputViewTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatNativeInputViewTests.swift
@@ -131,6 +131,18 @@ final class AIChatNativeInputViewTests: XCTestCase {
         XCTAssertFalse(sut.isVoiceButtonEnabled)
     }
 
+    func testSubmitButtonUsesMinimumHitTarget() throws {
+        sut.frame = CGRect(x: 0, y: 0, width: 320, height: 160)
+        sut.text = "Hello"
+        sut.layoutIfNeeded()
+
+        let button = try XCTUnwrap(submitButton())
+        let frame = button.convert(button.bounds, to: sut)
+
+        XCTAssertEqual(frame.width, 44, accuracy: 0.5)
+        XCTAssertEqual(frame.height, 44, accuracy: 0.5)
+    }
+
     // MARK: - Context Chip Tests
 
     func testContextChipNotVisibleInitially() {
@@ -203,6 +215,20 @@ final class AIChatNativeInputViewTests: XCTestCase {
 
         // Then - second show is ignored while first is visible
         XCTAssertTrue(sut.isContextChipVisible)
+    }
+
+    private func submitButton() -> UIButton? {
+        buttons(in: sut).first { $0.accessibilityIdentifier == "AIChatNativeInputView.submitButton" }
+    }
+
+    private func buttons(in view: UIView) -> [UIButton] {
+        view.subviews.flatMap { subview -> [UIButton] in
+            var matches = buttons(in: subview)
+            if let button = subview as? UIButton {
+                matches.append(button)
+            }
+            return matches
+        }
     }
 }
 #endif


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1214281884864396?focus=true

### Description

Fixes the Duck.ai contextual sheet native submit button hit target by keeping the visible 40pt circle unchanged while centering a 44x44 `UIButton` over it. This makes the visible submit affordance reliably tappable without changing the button's visual appearance.

### Testing Steps
1. Open the contextual sheet, enter a prompt and tap submit (near the edge of the button if possible) -> Ensure the prompt is submitted.

### Impact and Risks
Low. This is a small native input layout fix for the Duck.ai contextual sheet submit button.

#### What could go wrong?
The submit button could become visually misaligned with the circular background. The regression test checks the control frame, and the implementation keeps the button centered on the existing 40pt visual circle.

### Quality Considerations
This change improves touch target accessibility while preserving existing colors, icon, and visual size. No privacy, performance, or data handling impact.

### Notes to Reviewer
The visible circle remains 40x40; only the transparent tappable `UIButton` frame is expanded to 44x44.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI layout/accessibility change plus a regression test; main risk is minor visual/alignment regressions around the submit button.
> 
> **Overview**
> Improves touch accessibility for the native AI Chat input submit action by keeping the 40pt circular background in `submitButtonContainer` while centering a transparent 44x44 `submitButton` over it (and disabling interaction on the container).
> 
> Adds a stable `accessibilityIdentifier` and a new unit test (`testSubmitButtonUsesMinimumHitTarget`) that locates the button via accessibility and asserts the 44x44 hit target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a3bceff54ab4ceaa0a85171218e5c7c5778bd76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->