### PR TITLE
Avoid showing Freemium DBP banner to subscribers during fast-path

### DIFF
--- a/macOS/DuckDuckGo/Freemium/DBP/FreemiumDBPFeature.swift
+++ b/macOS/DuckDuckGo/Freemium/DBP/FreemiumDBPFeature.swift
@@ -42,6 +42,9 @@ protocol FreemiumDBPFeature {
     /// Whether the feature flag is enabled in privacy config (synchronous, no async dependencies).
     var isFeatureFlagEnabled: Bool { get }
 
+    /// Availability ignoring only purchase capability — feature flag, auth, and storefront still apply.
+    var isAvailableIgnoringPurchaseCapability: Bool { get }
+
     /// Publishes updates to `isAvailable` when dependencies like privacy config or subscription status change.
     var isAvailablePublisher: AnyPublisher<Bool, Never> { get }
 
@@ -70,6 +73,10 @@ final class DefaultFreemiumDBPFeature: FreemiumDBPFeature {
     /// Synchronous — no async dependencies (unlike `isAvailable` which depends on product availability).
     var isFeatureFlagEnabled: Bool {
         featureFlagOverride ?? privacyConfigurationManager.freemiumIsEnabled
+    }
+
+    var isAvailableIgnoringPurchaseCapability: Bool {
+        isFeatureFlagEnabled && isNotACurrentUser && isUSAAppStorefront
     }
 
     /// Publishes `true` when feature availability changes.

--- a/macOS/DuckDuckGo/Freemium/DBP/FreemiumDBPPromotionViewCoordinator.swift
+++ b/macOS/DuckDuckGo/Freemium/DBP/FreemiumDBPPromotionViewCoordinator.swift
@@ -59,6 +59,11 @@ final class FreemiumDBPPromotionViewCoordinator: ObservableObject {
         freemiumDBPFeature.isFeatureFlagEnabled
     }
 
+    /// Whether the feature is available ignoring purchase capability. Used by the fast path while product availability settles.
+    var isFeatureAvailableIgnoringPurchaseCapability: Bool {
+        freemiumDBPFeature.isAvailableIgnoringPurchaseCapability
+    }
+
     /// The user state manager, which tracks the user's activation status and scan results.
     private var freemiumDBPUserStateManager: FreemiumDBPUserStateManager
 

--- a/macOS/DuckDuckGo/NewTabPage/Features/NewTabPageFreemiumDBPBannerProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NewTabPageFreemiumDBPBannerProvider.swift
@@ -118,7 +118,7 @@ final class FreemiumDBPPromoDelegate: PromoDelegate {
         // Fast-path: if the promo was shown within the last 7 days, consider
         // it eligible even before async product availability settles. This
         // avoids missing the NTP trigger on app restart during a display window.
-        guard coordinator.isFeatureFlagEnabled else { return false }
+        guard coordinator.isFeatureAvailableIgnoringPurchaseCapability else { return false }
         guard let lastShown = historyRecord?.lastShown else { return false }
         return dateProvider().timeIntervalSince(lastShown) < .days(7)
     }

--- a/macOS/UnitTests/Freemium/DBP/FreemiumDBPFeatureTests.swift
+++ b/macOS/UnitTests/Freemium/DBP/FreemiumDBPFeatureTests.swift
@@ -117,6 +117,45 @@ final class FreemiumDBPFeatureTests: XCTestCase {
         XCTAssertFalse(result)
     }
 
+    func testWhenOnlyPurchaseCapabilityIsUnavailable_thenFreemiumDBPIsAvailableIgnoringPurchaseCapability() throws {
+        // Given
+        mockPrivacyConfigurationManager.mockConfig.isSubfeatureEnabledCheck = { _, _ in true }
+        mockSubscriptionManager.hasAppStoreProductsAvailable = false
+        mockSubscriptionManager.resultTokenContainer = nil
+        mockSubscriptionManager.currentStorefrontRegion = .usa
+
+        sut = DefaultFreemiumDBPFeature(
+            privacyConfigurationManager: mockPrivacyConfigurationManager,
+            subscriptionManager: mockSubscriptionManager,
+            freemiumDBPUserStateManager: mockFreemiumDBPUserStateManagerManager,
+            featureDisabler: mockFeatureDisabler,
+            userDefaults: testUserDefaults
+        )
+
+        // Then
+        XCTAssertFalse(sut.isAvailable)
+        XCTAssertTrue(sut.isAvailableIgnoringPurchaseCapability)
+    }
+
+    func testWhenUserAlreadySubscribed_thenFreemiumDBPIsNotAvailableIgnoringPurchaseCapability() throws {
+        // Given
+        mockPrivacyConfigurationManager.mockConfig.isSubfeatureEnabledCheck = { _, _ in true }
+        mockSubscriptionManager.hasAppStoreProductsAvailable = false
+        mockSubscriptionManager.resultTokenContainer = OAuthTokensFactory.makeValidTokenContainerWithEntitlements()
+        mockSubscriptionManager.currentStorefrontRegion = .usa
+
+        sut = DefaultFreemiumDBPFeature(
+            privacyConfigurationManager: mockPrivacyConfigurationManager,
+            subscriptionManager: mockSubscriptionManager,
+            freemiumDBPUserStateManager: mockFreemiumDBPUserStateManagerManager,
+            featureDisabler: mockFeatureDisabler,
+            userDefaults: testUserDefaults
+        )
+
+        // Then
+        XCTAssertFalse(sut.isAvailableIgnoringPurchaseCapability)
+    }
+
     func testWhenUserDidNotActivate_thenOffboardingIsNotExecuted() {
         // Given
         mockFreemiumDBPUserStateManagerManager.didActivate = false

--- a/macOS/UnitTests/Freemium/DBP/FreemiumDBPPromoDelegateTests.swift
+++ b/macOS/UnitTests/Freemium/DBP/FreemiumDBPPromoDelegateTests.swift
@@ -72,6 +72,58 @@ final class FreemiumDBPPromoDelegateTests: XCTestCase {
         XCTAssertFalse(sut.isEligible)
     }
 
+    func testIsEligible_whenFeatureUnavailableOnlyBecausePurchaseAvailabilitySettles_andRecentlyShown() {
+        mockFeature.featureAvailable = false
+        mockFeature.mockIsAvailableIgnoringPurchaseCapability = true
+
+        coordinator = FreemiumDBPPromotionViewCoordinator(
+            freemiumDBPUserStateManager: mockUserStateManager,
+            freemiumDBPFeature: mockFeature,
+            freemiumDBPPresenter: MockFreemiumDBPPresenter(),
+            dataBrokerProtectionFreemiumPixelHandler: MockDataBrokerProtectionFreemiumPixelHandler(),
+            contextualOnboardingPublisher: Empty<Bool, Never>().eraseToAnyPublisher()
+        )
+
+        let provider = MockPromoHistoryProvider()
+        var record = PromoHistoryRecord(id: "freemium-dbp")
+        record.lastShown = Date().addingTimeInterval(-86_400)
+        provider.record = record
+
+        sut = FreemiumDBPPromoDelegate(
+            coordinator: coordinator,
+            historyProvider: provider,
+            promoId: "freemium-dbp"
+        )
+
+        XCTAssertTrue(sut.isEligible)
+    }
+
+    func testIsEligible_whenAuthGateBlocksFastPathEvenWithRecentLastShown() {
+        mockFeature.featureAvailable = false
+        mockFeature.mockIsAvailableIgnoringPurchaseCapability = false
+
+        coordinator = FreemiumDBPPromotionViewCoordinator(
+            freemiumDBPUserStateManager: mockUserStateManager,
+            freemiumDBPFeature: mockFeature,
+            freemiumDBPPresenter: MockFreemiumDBPPresenter(),
+            dataBrokerProtectionFreemiumPixelHandler: MockDataBrokerProtectionFreemiumPixelHandler(),
+            contextualOnboardingPublisher: Empty<Bool, Never>().eraseToAnyPublisher()
+        )
+
+        let provider = MockPromoHistoryProvider()
+        var record = PromoHistoryRecord(id: "freemium-dbp")
+        record.lastShown = Date().addingTimeInterval(-86_400)
+        provider.record = record
+
+        sut = FreemiumDBPPromoDelegate(
+            coordinator: coordinator,
+            historyProvider: provider,
+            promoId: "freemium-dbp"
+        )
+
+        XCTAssertFalse(sut.isEligible)
+    }
+
     // MARK: - Legacy dismissal (eligibility)
 
     func testIsEligible_falseForLegacyDismissal_whenPreScanBanner() {
@@ -274,4 +326,25 @@ final class FreemiumDBPPromoDelegateTests: XCTestCase {
         wait(for: [expectation], timeout: 2.0)
     }
 
+}
+
+private final class MockPromoHistoryProvider: PromoHistoryProviding {
+    private let subject: CurrentValueSubject<PromoHistoryRecord?, Never>
+
+    var record: PromoHistoryRecord? {
+        get { subject.value }
+        set { subject.send(newValue) }
+    }
+
+    init(record: PromoHistoryRecord? = nil) {
+        self.subject = CurrentValueSubject(record)
+    }
+
+    func historyPublisher(for promoId: String) -> AnyPublisher<PromoHistoryRecord?, Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    var allHistoryPublisher: AnyPublisher<[PromoHistoryRecord], Never> {
+        Empty().eraseToAnyPublisher()
+    }
 }

--- a/macOS/UnitTests/Menus/MoreOptionsMenuTests.swift
+++ b/macOS/UnitTests/Menus/MoreOptionsMenuTests.swift
@@ -989,6 +989,7 @@ final class MockFreemiumDBPFeature: FreemiumDBPFeature {
     var isAvailableSubject = PassthroughSubject<Bool, Never>()
 
     var mockFeatureFlagEnabled: Bool?
+    var mockIsAvailableIgnoringPurchaseCapability: Bool?
 
     var isFeatureFlagEnabled: Bool {
         mockFeatureFlagEnabled ?? featureAvailable
@@ -996,6 +997,10 @@ final class MockFreemiumDBPFeature: FreemiumDBPFeature {
 
     var isAvailable: Bool {
         featureAvailable
+    }
+
+    var isAvailableIgnoringPurchaseCapability: Bool {
+        mockIsAvailableIgnoringPurchaseCapability ?? featureAvailable
     }
 
     var isAvailablePublisher: AnyPublisher<Bool, Never> {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1214245122623050
Tech Design URL:
CC:

### Description

Fixes the Freemium DBP NTP banner fast-path eligibility bug introduced by promo queue integration (`2cb4f80e21` / #4187).

The regular eligibility path was already correct: `FreemiumDBPFeature.isAvailable` includes feature flag, auth/subscriber status, storefront, and purchase capability. The bug was only in the fast-path used during an active 7-day promo display window. That path was intended to bypass transient App Store product availability settling, but it only checked `isFeatureFlagEnabled`, so it also bypassed auth/subscriber and storefront gates, which lead to the banner showing up for subscribers.

#### Fix

Added `isAvailableIgnoringPurchaseCapability` to `FreemiumDBPFeature`. It reuses the existing synchronous eligibility gates:

```swift
isFeatureFlagEnabled && isNotACurrentUser && isUSAAppStorefront
```

### Testing Steps

(refer to steps in https://github.com/duckduckgo/apple-browsers/pull/4187)

1. Show the Freemium banner as a non-subscriber and let it become visible on the NTP.
2. Authenticate as a subscriber while still within the 7-day display window.
3. Open a fresh NTP. The banner should no longer appear.

### Impact and Risks

Medium. Affects whether authenticated/subscribed users see the Freemium DBP promo banner on the NTP fast-path. Only the fast-path changed, and it's more restrictive now.

#### What could go wrong?

N/A

### Quality Considerations

- No change to the publisher pipeline, so no risk of regressing reactive eligibility behavior.
- The new feature property is synchronous and side-effect free.
- No new pixels, no new persisted state.
- Added new tests to verify the changes

### Notes to Reviewer

The fast path is a workaround. IMO the ideal solution would be if the promo system could evaluate async eligibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eligibility logic for when the NTP Freemium DBP banner is shown, which can affect promo visibility in edge timing cases around product availability. Scope is limited and covered by added unit tests.
> 
> **Overview**
> Prevents the Freemium DBP New Tab Page promo fast-path from showing to subscribers/other ineligible users while App Store product availability is still settling.
> 
> This introduces `FreemiumDBPFeature.isAvailableIgnoringPurchaseCapability` (feature flag + auth/subscriber + storefront gates, excluding purchase capability) and switches the 7-day “recently shown” fast-path to use it instead of only `isFeatureFlagEnabled`, with coordinator plumbing and updated/new unit tests covering the fast-path and the new property.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3273afa99a01ff5aba3ced66a47e434ca5fd8f86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->