### PR TITLE
[iOS] Fix VPN widget intermittently failing to start the tunnel

### DIFF
--- a/iOS/LocalPackages/VPNiOS/Sources/VPNWidgetSupport/VPNWidgetTunnelController.swift
+++ b/iOS/LocalPackages/VPNiOS/Sources/VPNWidgetSupport/VPNWidgetTunnelController.swift
@@ -51,7 +51,9 @@ public struct VPNWidgetTunnelController: Sendable {
         }
 
         manager.isOnDemandEnabled = true
+        manager.isEnabled = true
         try await manager.saveToPreferences()
+        try await manager.loadFromPreferences()
         try manager.connection.startVPNTunnel()
 
         try await awaitUntilStatusIsNoLongerTransitioning(manager: manager)
@@ -65,6 +67,7 @@ public struct VPNWidgetTunnelController: Sendable {
 
         manager.isOnDemandEnabled = false
         try await manager.saveToPreferences()
+        try await manager.loadFromPreferences()
         manager.connection.stopVPNTunnel()
 
         try await awaitUntilStatusIsNoLongerTransitioning(manager: manager)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214320326497677

### Description

Fix the VPN widget intermittently failing to start the tunnel when the VPN configuration has been disabled by the system. The widget now re-enables the configuration as part of the start action.

### Testing Steps

1. Set up the DuckDuckGo VPN and confirm it connects.
2. Install or open another VPN app and connect to it. This disables the DuckDuckGo VPN configuration.
3. Without opening the DuckDuckGo app, tap the VPN widget on the home screen (or the Control Center toggle).
4. Confirm the DuckDuckGo VPN reliably transitions to connected.

### Impact and Risks

Low. Scope is limited to the widget's start and stop paths. Re-enabling the configuration on widget start matches what the in-app start path already does.

#### What could go wrong?

If the configuration was intentionally disabled by another flow, the widget will silently re-enable it. This matches existing in-app behavior.

### Quality Considerations

The widget runs in a short-lived extension where automated coverage is not feasible; verification is manual. Existing failure-mode pixels for widget connect/disconnect provide post-release monitoring of regressions.

### Notes to Reviewer

There is a secondary, defensive change that reloads the manager between save and the tunnel action. It's incidental, not the source of the fix; it just keeps the manager handle fresh.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, limited to the widget VPN start/stop flow; it mainly re-enables and reloads the saved `NETunnelProviderManager` before starting/stopping to avoid intermittent failures when the system has disabled the configuration.
> 
> **Overview**
> Fixes an intermittent widget start failure by **explicitly re-enabling** the VPN configuration (`manager.isEnabled = true`) before saving preferences and starting the tunnel.
> 
> Also **reloads the manager from preferences after saving** in both start and stop paths, keeping the manager state fresh before calling `startVPNTunnel()` / `stopVPNTunnel()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08290db6066ab6d20d89a2f03da89f9975cd2fe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->