### PR TITLE
SFSpeechRecognizer disabled in simulator

### DIFF
--- a/iOS/DuckDuckGo/SpeechRecognizer.swift
+++ b/iOS/DuckDuckGo/SpeechRecognizer.swift
@@ -42,8 +42,11 @@ final class SpeechRecognizer: NSObject, SpeechRecognizerProtocol {
     override init() {
         operationQueue = OperationQueue()
         operationQueue.qualityOfService = .userInteractive
-        
+#if targetEnvironment(simulator)
+        speechRecognizer = nil
+#else
         speechRecognizer = SFSpeechRecognizer()
+#endif
         speechRecognizer?.queue = operationQueue
         
         super.init()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205842942115003/task/1214310773823103?focus=true
CC: @brindy @Bunn 

### Description



### Testing Steps
1. Start the ios app in simulator (iPad + iPhopne)
2. the app doesn't crash

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is compile-time gated to the iOS simulator and only affects speech recognition initialization/availability there.
> 
> **Overview**
> Disables `SFSpeechRecognizer` initialization when running in the iOS simulator (`#if targetEnvironment(simulator)`), leaving it `nil` and relying on existing optional handling.
> 
> This prevents simulator crashes and ensures availability checks/queue setup safely no-op in simulator builds while keeping device behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e565c97832db931d2450f90f34f41616f7f0ff5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->