### PR TITLE
[executor] Add bookmarklet support for macOS browser

### DIFF
--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -648,6 +648,13 @@ protocol TabDelegate: ContentOverlayUserScriptDelegate {
         return self.setContent(.contentFromURL(url, source: source))
     }
 
+    /// Executes a bookmarklet (javascript: URL) in the current tab's web view context.
+    /// Bookmarklets must not be loaded as regular navigation targets — they run as JavaScript in the page context.
+    func executeBookmarklet(url: URL) {
+        guard let js = url.toDecodedBookmarklet() else { return }
+        webView.evaluateJavaScript(js, in: nil, in: .defaultClient)
+    }
+
     private func handleUrlDidChange() {
         if let url = webView.url {
             let content = TabContent.contentFromURL(url, source: .webViewUpdated)
@@ -1039,6 +1046,12 @@ protocol TabDelegate: ContentOverlayUserScriptDelegate {
         if case .settings = content, case .settings = webView.url.flatMap({ TabContent.contentFromURL($0, source: .ui) }) {
             // replace WebView URL without adding a new history item if switching settings panes
             webView.evaluateJavaScript("location.replace('\(url.absoluteString.escapedJavaScriptString())')", in: nil, in: .defaultClient)
+            return nil
+        }
+
+        // Execute bookmarklets in the current page context rather than navigating to them
+        if url.isBookmarklet() {
+            executeBookmarklet(url: url)
             return nil
         }
 

--- a/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
+++ b/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
@@ -219,10 +219,20 @@ extension WindowControllersManager {
     }
 
     /// Opens a bookmark in a tab, respecting the current modifier keys when deciding where to open the bookmark's URL.
+    /// Bookmarklets (javascript: URLs) are executed in the current tab's web view rather than loaded as navigation targets.
     func open(_ bookmark: Bookmark, target window: NSWindow? = nil, with event: NSEvent?) {
         guard let url = bookmark.urlObject else { return }
 
-        // Call updated openBookmark
+        // Bookmarklets must be executed in the current tab's context, not navigated to
+        if url.isBookmarklet() {
+            let eventWindowController = mainWindowController(for: window ?? event?.window)
+            let targetWindowController = eventWindowController ?? lastKeyMainWindowController
+            if let currentTab = targetWindowController?.mainViewController.tabCollectionViewModel.selectedTab {
+                currentTab.executeBookmarklet(url: url)
+                return
+            }
+        }
+
         open(url, source: .bookmark(isFavorite: bookmark.isFavorite), target: window, with: event)
     }
 


### PR DESCRIPTION
## Summary

When a user opens a Bookmark that is a bookmarklet (`javascript:` URL), execute it in the current tab's web view context instead of trying to navigate to it. This matches the existing iOS behavior.

## Changes

- **Tab.swift**: Added `executeBookmarklet(url:)` method that evaluates the decoded JavaScript in the page context using `.defaultClient` content world
- **Tab.swift**: Guard in `setContent` to intercept bookmarklet URLs before navigation and execute them inline
- **WindowControllersManager.swift**: Intercept bookmarklet URLs in `open(_:target:with:)` and route to `executeBookmarklet` on the selected tab

## How to test

1. Create a bookmark with URL: `javascript:alert('Hello from bookmarklet!')`
2. Click the bookmark from the bookmarks bar or menu
3. Verify the alert fires in the current tab instead of navigating to a blank/error page

## Notes

Uses existing `URL.isBookmarklet()` / `URL.toDecodedBookmarklet()` helpers from `BookmarkletExtensions.swift` (BSK). iOS already has equivalent logic in `TabViewController.executeBookmarklet(url:)`.

Task: https://app.asana.com/0/0/1211217619381277