### PR TITLE
[executor] Add Ctrl+PgUp/PgDn keyboard shortcuts for tab navigation

### DIFF
--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -506,11 +506,15 @@ final class MainMenu: NSMenu {
                     .hidden()
                 NSMenuItem(title: "Show Previous Tab (Hidden)", action: #selector(MainViewController.showPreviousTab), keyEquivalent: [.option, .command, .left])
                     .hidden()
+                NSMenuItem(title: "Show Previous Tab (Hidden)", action: #selector(MainViewController.showPreviousTab), keyEquivalent: [.control, .pageUp])
+                    .hidden()
 
                 NSMenuItem(title: UserText.mainMenuWindowShowNextTab, action: #selector(MainViewController.showNextTab), keyEquivalent: [.control, .tab])
                 NSMenuItem(title: "Show Next Tab (Hidden)", action: #selector(MainViewController.showNextTab), keyEquivalent: [.command, .shift, "]"])
                     .hidden()
                 NSMenuItem(title: "Show Next Tab (Hidden)", action: #selector(MainViewController.showNextTab), keyEquivalent: [.option, .command, .right])
+                    .hidden()
+                NSMenuItem(title: "Show Next Tab (Hidden)", action: #selector(MainViewController.showNextTab), keyEquivalent: [.control, .pageDown])
                     .hidden()
 
                 NSMenuItem(title: "Show First Tab (Hidden)", action: #selector(MainViewController.showTab), keyEquivalent: "1")

--- a/macOS/LocalPackages/AppKitExtensions/Sources/AppKitExtensions/NSEventExtension.swift
+++ b/macOS/LocalPackages/AppKitExtensions/Sources/AppKitExtensions/NSEventExtension.swift
@@ -182,6 +182,8 @@ public enum KeyEquivalentElement: ExpressibleByStringLiteral, Hashable {
     public static let left = KeyEquivalentElement.charCode("\u{2190}")
     public static let right = KeyEquivalentElement.charCode("\u{2192}")
     public static let escape = KeyEquivalentElement.charCode("\u{1B}")
+    public static let pageUp = KeyEquivalentElement.charCode("\u{F72F}")
+    public static let pageDown = KeyEquivalentElement.charCode("\u{F72D}")
 
     public init(stringLiteral value: String) {
         self = .charCode(value)
@@ -196,6 +198,8 @@ extension NSEvent.KeyEquivalent: ExpressibleByStringLiteral, ExpressibleByUnicod
     public static let left: Self = [.left]
     public static let right: Self = [.right]
     public static let escape: Self = [.escape]
+    public static let pageUp: Self = [.pageUp]
+    public static let pageDown: Self = [.pageDown]
 
     public init(stringLiteral value: String) {
         self = [.charCode(value)]


### PR DESCRIPTION
## Summary

Add Ctrl+Page Up and Ctrl+Page Down as hidden keyboard shortcuts for navigating between tabs, matching the standard browser convention used by Firefox and Chrome.

This is complementary to the existing shortcuts:
- Ctrl+Tab / Ctrl+Shift+Tab (standard macOS)
- Cmd+Shift+[ / Cmd+Shift+] (macOS style)
- Opt+Cmd+Left / Opt+Cmd+Right (already present)

## Changes

- **NSEventExtension.swift**: Add `.pageUp` (`U+F72F`) and `.pageDown` (`U+F72D`) constants to `KeyEquivalentElement` and `NSEvent.KeyEquivalent` extensions
- **MainMenu.swift**: Add hidden `NSMenuItems` for `Ctrl+PgUp → showPreviousTab` and `Ctrl+PgDn → showNextTab`

## How to test

1. Open DuckDuckGo macOS browser with multiple tabs
2. Press Ctrl+Page Down — should move to the next tab
3. Press Ctrl+Page Up — should move to the previous tab
4. Verify wrapping behavior matches existing Ctrl+Tab

## Notes

Uses macOS special key Unicode values: Page Up = U+F72F, Page Down = U+F72D. Hidden menu items use the same `.hidden()` pattern as the other alternate shortcuts in MainMenu.swift.

Task: https://app.asana.com/0/0/1210067060365235