### PR TITLE
[executor] Fix privacy dashboard not accessible on localhost

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -1017,7 +1017,6 @@ final class AddressBarButtonsViewController: NSViewController {
         let isNewTab = [.newtab].contains(tabViewModel.tab.content)
         let isHypertextUrl = url?.navigationalScheme?.isHypertextScheme == true && url?.isDuckPlayer == false
         let isEditingMode = controllerMode?.isEditing ?? false
-        let isLocalUrl = url?.isLocalURL ?? false
 
         // Privacy entry point button
         let isFlaggedAsMalicious = (tabViewModel.tab.privacyInfo?.malicousSiteThreatKind != .none)
@@ -1034,7 +1033,6 @@ final class AddressBarButtonsViewController: NSViewController {
         && isHypertextUrl
         && !tabViewModel.isShowingErrorPage
         && !hasPendingBarInput
-        && !isLocalUrl
         && !isAIChatPanelActive
 
         /// The `imageButton.image != nil` check is the gate that keeps the left icon out of `.editing(.text)` and


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207062650987868
Tech Design URL: N/A

### Description

Privacy dashboard button (shield icon) was hidden for all local URLs — including `localhost`, `127.0.0.1`, and `::1` — due to a `&& !isLocalUrl` condition in `updatePrivacyDashboardButton()` inside `AddressBarButtonsViewController.swift`.

This was introduced in #1456 to avoid showing the "insecure" icon for localhost. However it had an unintended consequence: the privacy dashboard is the **only** way to access the permissions settings and the "disable protections" toggle. So removing it entirely made it impossible for developers to manage permissions for local development servers.

Fix: remove the `isLocalUrl` variable and the `&& !isLocalUrl` condition from the `privacyDashboardButton.isShown` expression, so the privacy dashboard button shows on localhost and other local URLs.

The `isLocalURL` URL extension and its unit tests are left intact — they may be useful for other purposes.

### Testing Steps
1. Open a localhost URL (e.g. `http://localhost:3000`)
2. Verify the privacy dashboard shield icon appears in the address bar
3. Click the shield — the privacy dashboard should open
4. Verify the dashboard shows the permissions section and the protections toggle
5. Navigate to a regular public URL — privacy button still appears normally

### Impact and Risks
Low: Minor behaviour change, only affects localhost/private IP URLs. No effect on public sites.

#### What could go wrong?
The privacy dashboard on localhost may show minimal tracker data (no external trackers on local servers) — this is expected and acceptable. The shield icon will now appear but won't display a "red duck" for insecure localhost since the underlying URL is treated as secure elsewhere in the codebase.

### Quality Considerations
Two-line deletion. No new logic introduced. No tests need updating — the `isLocalURL` unit tests in `NavigationBarUrlExtensionsTests.swift` are unaffected (the property is retained).

### Notes to Reviewer
[executor] automated fix — removes the `!isLocalUrl` guard from privacy dashboard visibility. Regression reported in https://app.asana.com/0/0/1207062650987868.