### PR TITLE
iOS: defer UTI text clear to dismiss completion

### DIFF
--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -269,7 +269,7 @@ class MainViewCoordinator {
     // MARK: - Omnibar Editing Layout
 
     @MainActor
-    func hideUnifiedToggleInputOmnibar() {
+    func hideUnifiedToggleInputOmnibar(completion: (() -> Void)? = nil) {
         if addressBarPosition.isBottom {
             setNavBarContainerBottomToToolbar()
         }
@@ -285,6 +285,7 @@ class MainViewCoordinator {
             // Skip cleanup if the animation was superseded — otherwise it stomps fresh state from a concurrent show.
             guard position == .end else { return }
             self.finishUnifiedToggleInputOmnibarDismiss()
+            completion?()
         }
         omnibarDismissAnimator = animator
         animator.startAnimation()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
@@ -140,6 +140,8 @@ private extension MainViewController {
         unifiedToggleInputCoordinator?.viewController.view.backgroundColor = .clear
         viewCoordinator.hideUnifiedToggleInput()
         resetUnifiedInputContentAfterHide()
+        // Container is now hidden; clear text so it can't leak into the next session.
+        unifiedToggleInputCoordinator?.clearText()
     }
 
     func resetUnifiedInputContentAfterHide() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
@@ -123,10 +123,14 @@ private extension MainViewController {
     }
 
     func handleHideOmnibarEditingIntent(animated: Bool) {
+        let onDismissed: () -> Void = { [weak self] in
+            self?.unifiedToggleInputCoordinator?.clearText()
+        }
         if animated {
-            viewCoordinator.hideUnifiedToggleInputOmnibar()
+            viewCoordinator.hideUnifiedToggleInputOmnibar(completion: onDismissed)
         } else {
             viewCoordinator.finishUnifiedToggleInputOmnibarDismiss()
+            onDismissed()
         }
         resetUnifiedInputContentAfterHide()
         viewCoordinator.suggestionTrayContainer.backgroundColor = .clear

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
@@ -140,7 +140,7 @@ private extension MainViewController {
         unifiedToggleInputCoordinator?.viewController.view.backgroundColor = .clear
         viewCoordinator.hideUnifiedToggleInput()
         resetUnifiedInputContentAfterHide()
-        // Container is now hidden; clear text so it can't leak into the next session.
+        // Avoid leaking text into the next input session.
         unifiedToggleInputCoordinator?.clearText()
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -854,7 +854,6 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
         switch mode {
         case .search:
             if case .aiTab = displayState {
-                setText("")
                 hide()
             } else if isOmnibarSession {
                 deactivateToOmnibar()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -391,7 +391,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         displayState = .hidden
         cardPosition = .bottom
         isInputVisibleForKeyboard = true
-        setText("")
+        // Text clear is deferred to dismiss completion — avoids placeholder flash mid-collapse.
         resetToolsSelection()
         clearAttachments()
 
@@ -850,11 +850,11 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
 
     func unifiedToggleInputVC(_ vc: UnifiedToggleInputViewController, didSubmitText text: String, mode: TextEntryMode) {
         commitCurrentToggleState()
-        setText("")
 
         switch mode {
         case .search:
             if case .aiTab = displayState {
+                setText("")
                 hide()
             } else if isOmnibarSession {
                 deactivateToOmnibar()
@@ -875,6 +875,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
             if isOmnibarSession {
                 deactivateToOmnibar()
             } else {
+                setText("")
                 showCollapsed()
             }
             if let userScript = boundUserScript {
@@ -953,7 +954,10 @@ private extension UnifiedToggleInputCoordinator {
 
     func resetSessionState() {
         isNewChatPending = false
-        setText("")
+        // While the UTI is hidden, dismiss completion owns the visible text — clearing here would flash the placeholder.
+        if isActive {
+            setText("")
+        }
         aiChatStatus = .unknown
         aiChatInputBoxVisibility = .unknown
         attachmentUsage = nil

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -874,6 +874,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
             if isOmnibarSession {
                 deactivateToOmnibar()
             } else {
+                // showCollapsed has no dismiss hook; clear synchronously.
                 setText("")
                 showCollapsed()
             }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -372,7 +372,8 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         sut.deactivateToOmnibar()
 
         XCTAssertEqual(sut.displayState, .hidden)
-        XCTAssertEqual(sut.textState, .empty)
+        // Text is preserved through deactivate; the dismiss completion handler clears it after the animation.
+        XCTAssertEqual(sut.textState, .prefilledSelected)
         XCTAssertFalse(sut.isOmnibarSession)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214332089999847
CC: @aataraxiaa 

### Description

Fixes a brief flash of the empty-state placeholder ("Search or enter address" / "Ask anything privately") during the UTI omnibar dismiss animation.

The field's text was being cleared synchronously *before* the dismiss animation started, so the empty placeholder was exposed for the duration of the contraction. The clear is now deferred to the animation's completion handler, so the URL/query stays visible until the UTI is gone.

Three sites cleared text pre-dismiss:

- `UnifiedToggleInputCoordinator.deactivateToOmnibar()` — removed; relies on the deferred clear.
- `UnifiedToggleInputCoordinator.unifiedToggleInputVC(_:didSubmitText:)` — moved the unconditional pre-clear into the AI-tab/showCollapsed branches that don't go through the deferred path.
- `UnifiedToggleInputCoordinator.resetSessionState()` — guarded with `isActive` so navigation-triggered tab unbind/rebind during a dismiss-in-flight doesn't synchronously clear the still-visible field.

`MainViewCoordinator.hideUnifiedToggleInputOmnibar` gains an optional `completion:` closure so the intent handler can hook end-of-animation; `handleHideOmnibarEditingIntent` passes `coordinator.clearText()` as that completion.

Before:
https://github.com/user-attachments/assets/02365b72-a475-4f5a-ab91-2677a2b532ca
https://github.com/user-attachments/assets/205a5b9e-ba13-41d2-b78a-09345b05fcac

After:
https://github.com/user-attachments/assets/e12ea204-6160-4bd5-9aba-795f7cf83e09

### Testing Steps

Address bar position: **bottom**. Internal builds with **Slow Animations** enabled make the bug obvious; verify with slow anims first.

1. Open a real web page (e.g. `onet.pl`).
2. Tap the omnibar — UTI expands in Search mode, field shows the URL.
3. Tap the **X** dismiss button. Field should keep the URL visible the whole way through the dismiss animation. No empty-state placeholder flash.
4. Tap omnibar → type a search query → press **Enter**. No placeholder flash during the dismiss.
5. Repeat (4) on a webpage. Same: clean.
6. Tap omnibar → type → press the **clear (×)** inside the input. Field clears immediately (regression check — this path is unchanged).
7. On the AI tab, submit a prompt. UTI collapses to the chip; no regressions there.

### Impact and Risks

**Low** — UI polish for an animation that already works. No data, navigation, or persistence behavior is changed.

#### What could go wrong?

- *Stale text leaks into a fresh UTI session.* Investigated: the deferred `clearText()` runs on every animated and non-animated dismiss completion. The remaining synchronous `setText("")` calls in `didSubmitText` (AI-tab `hide()` / `showCollapsed()` paths) preserve the previous behavior for those flows. Tab-rebind paths still clear via `resetSessionState` when `isActive == true` (UTI visible).
- *Animation completion not firing.* The animator already filters `position == .end` before running cleanup, and `[weak self]` capture means a deallocated coordinator no-ops cleanly.

### Quality Considerations

`UnifiedToggleInputCoordinatorTests/test_deactivateToOmnibar_resetsState` previously asserted `textState == .empty` immediately after `deactivateToOmnibar`. That contract is no longer accurate — the test now asserts text is preserved (`.prefilledSelected`) through deactivate, with a comment pointing to the dismiss-completion handler that does the clear. 32 nearby coordinator tests (submit/dismiss/unbind/bind/modelChip/external-submission flows) run green.

### Notes to Reviewer

The asymmetric `setText("")` placements in `unifiedToggleInputVC(_:didSubmitText:)` (each non-omnibar branch clears synchronously, omnibar branches defer) is intentional — `hide()` and `showCollapsed()` use different intents that don't currently have a deferred-clear hook, and they weren't reported as flickering. Extending the deferred-clear pattern to those paths would be a separate, larger change.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/animation timing change that only alters when UTI text is cleared; main risk is stale text persisting briefly if dismiss completion doesn’t run in some edge case.
> 
> **Overview**
> Prevents a placeholder flash during Unified Toggle Input (UTI) omnibar dismiss by **deferring text clearing until the dismiss animation completes**, keeping the current URL/query visible through the collapse.
> 
> `MainViewCoordinator.hideUnifiedToggleInputOmnibar` now accepts an optional `completion` invoked after `finishUnifiedToggleInputOmnibarDismiss`, and the intent handler uses it to call `unifiedToggleInputCoordinator.clearText()` (also clearing text on non-animated dismiss and full `hide` to avoid leaking text into the next session). Coordinator logic no longer clears text synchronously on `deactivateToOmnibar`, adjusts `didSubmitText` to only clear immediately on non-omnibar collapse paths, and guards `resetSessionState` to avoid mid-dismiss placeholder flashes; tests are updated to reflect the new deferred-clear behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b6ea0ac41f5bb0a7bd3d8d3b18aaf80d1f2419e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->