### PR TITLE
Fix Tab Preview crash on zero-dimension snapshot

### DIFF
--- a/macOS/DuckDuckGo/TabPreview/TabPreviewViewController.swift
+++ b/macOS/DuckDuckGo/TabPreview/TabPreviewViewController.swift
@@ -165,7 +165,7 @@ final class TabPreviewViewController: NSViewController {
     }
 
     private func getHeight(for image: NSImage?) -> CGFloat {
-        guard let image else { return 0 }
+        guard let image, image.size.width > 0, image.size.height > 0 else { return 0 }
 
         let aspectRatio = image.size.width / image.size.height
         let width = TabPreviewWindowController.width


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214294661819890/task/1214334249145899

### Description

Fixes Sentry crash `APPLE-MACOS-BF8` (`SIGABRT TabPreviewViewController.display`).

`TabPreviewViewController.getHeight(for:)` computed `image.size.width / image.size.height` and then divided `TabPreviewWindowController.width` by that aspect ratio. When a snapshot has a zero width or zero height, the math produces NaN or +Inf, which was then assigned to `snapshotImageViewHeightConstraint.constant` — AppKit aborts with `NSInternalInconsistencyException: NSLayoutConstraint constant is not finite`.

The fix extends the existing `guard let image` to also require both dimensions to be `> 0`, falling back to height `0` (the same behavior as the existing no-snapshot branch).

### Testing Steps

1. Smoke test tab previews — hover over background tabs and confirm the preview popover renders correctly with the snapshot thumbnail.

### Impact and Risks

Low — defensive guard preventing a crash. User-visible behavior is unchanged for valid snapshots; for zero-dimension snapshots the preview now shows no thumbnail (height 0) instead of crashing.

#### What could go wrong?

- A snapshot pipeline regression that produces zero-dimension snapshots would silently render previews without thumbnails instead of being surfaced via the crash. This is an acceptable trade-off vs. a SIGABRT.

### Quality Considerations

- Edge cases covered: nil image, zero width, zero height, both zero.
- No performance impact (single extra comparison).
- No privacy/security implications.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk defensive change that prevents non-finite Auto Layout constraint constants when a tab snapshot has zero width/height; behavior is unchanged for valid images.
> 
> **Overview**
> Prevents a crash in macOS tab previews by making `TabPreviewViewController.getHeight(for:)` return `0` unless the snapshot image has *both* width and height greater than zero, avoiding NaN/+Inf constraint constants.
> 
> Zero-dimension snapshots now render with no thumbnail (height `0`) instead of aborting during Auto Layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a62efd94e6e106ee0eed39e3034cc2ed373dd02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->