### PR TITLE
iOS: Fix UTI content jump when toggling Search/Duck.ai mode

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -654,6 +654,8 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         daxLogoManager.setFireTabContentInsets(insets)
         guard swipeContainerManager?.containerViewController.additionalSafeAreaInsets != insets else { return }
         swipeContainerManager?.containerViewController.additionalSafeAreaInsets = insets
+        // layoutIfNeeded inside the active CATransaction so the inset change animates with the parent.
+        swipeContainerManager?.containerViewController.view.layoutIfNeeded()
     }
 
     @objc private func handleFloatingDismissTap() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -19,7 +19,6 @@
 
 import AIChat
 import Combine
-import os.log
 import Subscription
 import UIKit
 
@@ -453,12 +452,26 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         guard didModeChange || needsViewSync else { return }
 
         inputMode = effectiveMode
-        if needsViewSync {
-            viewController.setInputMode(effectiveMode, animated: animated)
+
+        // Wraps toolbar-height update + content-swap broadcast in one CATransaction so they animate
+        // together; otherwise the content snaps while the toolbar is still growing.
+        let applyModeChange = { [self] in
+            if needsViewSync {
+                viewController.setInputMode(effectiveMode, animated: animated)
+            }
+            if didModeChange {
+                modeChangeSubject.send(effectiveMode)
+            }
         }
-        if didModeChange {
-            modeChangeSubject.send(effectiveMode)
+
+        if animated {
+            UIView.animate(withDuration: 0.2, delay: 0, options: [.curveEaseInOut, .beginFromCurrentState]) {
+                applyModeChange()
+            }
+        } else {
+            applyModeChange()
         }
+
         updateToolbarAIVoiceChat()
         refreshToolsPresentation()
         if didModeChange, effectiveMode == .search {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -720,7 +720,7 @@ private extension UnifiedToggleInputView {
         toggleView.alpha = 0
         toggleView.onModeChanged = { [weak self] mode in
             guard let self else { return }
-            self.handler.setToggleState(mode)
+            // Intent only — coordinator is the single writer of handler.currentToggleState.
             self.delegate?.unifiedToggleInputViewDidChangeMode(self, mode: mode)
             if self.isExpanded {
                 self.textEntryView.becomeFirstResponder()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214332089999849?focus=true
CC: @aataraxiaa 

### Description

The toggle's `onModeChanged` callback wrote directly to `handler.currentToggleState`, which fired a Combine subscription via `.receive(on: DispatchQueue.main)` — delivering 33ms later on a separate runloop tick. Meanwhile the coordinator's `updateInputMode` saw `needsViewSync=false` and skipped the toolbar height animation entirely. Net result: the content swap fired synchronously at T+0ms while the UTI height animation started 33ms later — content visibly jumped under the still-animating toolbar.

The fix makes the coordinator the single writer of `handler.currentToggleState`:

- **`UnifiedToggleInputView.swift`** — toggle tap fires intent only via the delegate; no longer writes to the handler directly.
- **`UnifiedToggleInputCoordinator.updateInputMode`** — wraps `viewController.setInputMode` and `modeChangeSubject.send` in a single `UIView.animate(0.2)` block so toolbar height and content swap share one CATransaction.
- **`UnifiedInputContentContainerViewController.applyRequestedContentInset`** — adds `layoutIfNeeded()` on the swipe container after assigning `additionalSafeAreaInsets`, so the safe-area-driven layout pass runs inside the active animation block instead of snapping on the next runloop.

### Testing Steps

1. Open the app on an iPhone with the UTI feature enabled (Search/Duck.ai toggle visible in the address bar).
2. Tap the address bar to expand the UTI in editing state.
3. Toggle Search → Duck.ai. The UTI should grow to its Duck.ai height **and** the content underneath (Recent Chats / chat history) should slide into place in sync — no visible jump or gap below the UTI mid-animation.
4. Toggle Duck.ai → Search. The UTI should shrink **and** the content (Favorites grid, escape hatch card) should reflow in sync — no visible content snapping to its post-animation position before the UTI finishes shrinking.
5. Repeat with the address bar at the **top** position (Settings → Address Bar Position → Top) and confirm both directions still animate together.
6. On a Duck.ai chat tab (AI tab), toggle inside the UTI — content swap should be instant by design (`performWithoutAnimation`), but the UTI height should still animate cleanly.
7. Type some text in Search mode, toggle to Duck.ai and back — animation should still be smooth.
8. Cold-start the app, open UTI, first toggle — should animate cleanly with no first-time anomaly.

### Impact and Risks

**Low-Medium.**

The fix changes ownership of mode-state writes (toggle tap path) and wraps mode-change side effects in an animation block. Touches the central UTI mode-change path, so any mis-routing would be immediately user-visible.

Mitigations:
- 164 UTI unit tests pass (`UnifiedToggleInputCoordinatorTests` + `UnifiedInputContentContainerViewControllerTests`).
- All 5 manual scenarios verified on simulator: omnibar toggle (both directions), AI tab toggle, swipe-between-content, type-then-toggle, cold-start first toggle.
- The late Combine subscription on `handler.toggleStatePublisher` is intentionally kept (still drives toolbar updates for non-tap paths: swipe, fade-out, voice search). On the tap path it now fires after the synchronous wrap and is a visual no-op.

Risk areas not exercised by automated tests:
- Concurrent mode changes (e.g. tap while a programmatic mode change is in flight) — manual testing didn't surface issues but no automated coverage.
- Swipe/fade/voice-driven mode changes still go through the legacy path (`syncInputModeFromExternalSource` → late Combine subscription). Behavior unchanged from before this PR.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the central UTI mode-switch path and animation timing; mistakes would be immediately user-visible as layout/animation glitches, but the change is localized and UI-only.
> 
> **Overview**
> Fixes a visible content jump when switching between Search and Duck.ai by **making the coordinator the sole driver of mode changes** and ensuring related UI updates animate together.
> 
> Mode changes now wrap `setInputMode` and the `modeChangeSubject` broadcast in a single `UIView.animate` transaction, and safe-area inset updates in `UnifiedInputContentContainerViewController` force an in-transaction `layoutIfNeeded()` so the content reflows in sync. The toggle view no longer writes directly to `handler.currentToggleState`, sending intent to the delegate instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea3acf980576fc549392e3b4a508dd8ba3096afd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->