### PR TITLE
[macOS] Add 1-click access to voice chat from omnibar surfaces

### DIFF
--- a/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DuckDuckGo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dccf3edc74b6a2f829159e0e69e38d3624e43a87b6b9fabfabfcfa068bac29b9",
+  "originHash" : "95fb5a94675710148596a938c5bf32ed8e030c544d72edbb7e3ce82176c07cf7",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "1e417da9e53e44c3d683b5d8d15837df80a3dd16",
-        "version" : "14.3.0"
+        "revision" : "311aa9498f17f7078a5e5d5e80fdcd928c3a6f7c",
+        "version" : "14.4.0"
       }
     },
     {

--- a/SharedPackages/AIChat/Package.resolved
+++ b/SharedPackages/AIChat/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "054b8c3e6c303924689ad07775e005504e7551634da3da25ede08fedc4ed4a7b",
+  "originHash" : "48971cf565b5895cc78a46f2d302829071d2dd6dbe6f92a852ebd47728e2e686",
   "pins" : [
     {
       "identity" : "content-scope-scripts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "56754c6e0fd58a76a78f2241b6e811d08cfbee84",
-        "version" : "13.37.0"
+        "revision" : "311aa9498f17f7078a5e5d5e80fdcd928c3a6f7c",
+        "version" : "14.4.0"
       }
     },
     {

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatScriptUserValues.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatScriptUserValues.swift
@@ -174,6 +174,9 @@ public struct AIChatNativeConfigValues: Codable {
 public struct AIChatNativePrompt: Codable, Equatable {
     /// Mode value for image generation prompts.
     public static let imageGenerationMode = "image-generation"
+    /// Mode value for voice-chat prompts. Duck.ai routes to the voice flow purely from this
+    /// mode in the handoff payload — no `?mode=voice` URL parameter is required.
+    public static let voiceMode = "voice-mode"
 
     public let platform: String
     public let tool: Tool?

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/Suggestions/AIChatSuggestion.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/Suggestions/AIChatSuggestion.swift
@@ -40,13 +40,20 @@ public struct AIChatSuggestion: Identifiable, Equatable, Hashable {
     /// Content of the first user message in the chat
     public let firstUserMessageContent: String?
 
+    /// The AI model the chat was conducted with (e.g. `"gpt-4o-mini"`, `"voice-mode"`,
+    /// `"image-generation"`). Nil when the data source doesn't carry a model — the Duck.ai
+    /// webview path (`getDuckAiChats`) doesn't include it today; the local-storage path does.
+    /// Drives the chat's icon classification via `kind`.
+    public let model: String?
+
     public init(
         id: String,
         title: String,
         isPinned: Bool,
         chatId: String,
         timestamp: Date? = nil,
-        firstUserMessageContent: String? = nil
+        firstUserMessageContent: String? = nil,
+        model: String? = nil
     ) {
         self.id = id
         self.title = Self.sanitize(title)
@@ -54,6 +61,41 @@ public struct AIChatSuggestion: Identifiable, Equatable, Hashable {
         self.chatId = chatId
         self.timestamp = timestamp
         self.firstUserMessageContent = firstUserMessageContent
+        self.model = model
+    }
+}
+
+// MARK: - Kind
+
+extension AIChatSuggestion {
+
+    /// Coarse classification of a chat used to pick a list-row icon. Derived from `model`
+    /// because the Duck.ai stored chat record persists the model used for the conversation.
+    public enum Kind: Equatable {
+        case voice
+        case image
+        case text
+    }
+
+    /// Returns the chat's kind based on its `model` string. Voice and image chats are matched
+    /// against the canonical mode tokens Duck.ai persists (`AIChatNativePrompt.voiceMode` and
+    /// `AIChatNativePrompt.imageGenerationMode`); everything else (including chats from data
+    /// sources that don't carry a model yet) is treated as a regular text chat.
+    public var kind: Kind {
+        Self.kind(forModel: model)
+    }
+
+    /// Pure helper kept separate from the property so the mapping is easy to test and tune as
+    /// new model identifiers ship from Duck.ai.
+    public static func kind(forModel model: String?) -> Kind {
+        guard let model, !model.isEmpty else { return .text }
+        if model.contains(AIChatNativePrompt.voiceMode) {
+            return .voice
+        }
+        if model.contains(AIChatNativePrompt.imageGenerationMode) {
+            return .image
+        }
+        return .text
     }
 
     /// Collapses any runs of whitespace (including newlines) into a single space and trims.

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/Suggestions/AIChatSuggestion.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/Suggestions/AIChatSuggestion.swift
@@ -86,16 +86,16 @@ extension AIChatSuggestion {
     }
 
     /// Pure helper kept separate from the property so the mapping is easy to test and tune as
-    /// new model identifiers ship from Duck.ai.
+    /// new model identifiers ship from Duck.ai. Uses exact equality so a future model name that
+    /// embeds the token (e.g. `"voice-mode-experimental-2"`) does not accidentally classify as
+    /// `.voice` — Duck.ai persists the canonical mode tokens unmodified.
     public static func kind(forModel model: String?) -> Kind {
         guard let model, !model.isEmpty else { return .text }
-        if model.contains(AIChatNativePrompt.voiceMode) {
-            return .voice
+        switch model {
+        case AIChatNativePrompt.voiceMode: return .voice
+        case AIChatNativePrompt.imageGenerationMode: return .image
+        default: return .text
         }
-        if model.contains(AIChatNativePrompt.imageGenerationMode) {
-            return .image
-        }
-        return .text
     }
 
     /// Collapses any runs of whitespace (including newlines) into a single space and trims.

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/Suggestions/AIChatSuggestionsUserScript.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/Suggestions/AIChatSuggestionsUserScript.swift
@@ -74,6 +74,10 @@ public final class AIChatSuggestionsUserScript: NSObject, Subfeature {
         let pinned: Bool?
         let lastEdit: String?  // ISO date string like "2026-01-19T11:48:10.903Z"
         let firstUserMessageContent: String?
+        /// AI model the chat was conducted with (e.g. `"voice-mode"`, `"image-generation"`,
+        /// `"gpt-4o-mini"`). Optional — if Duck.ai's `getDuckAiChats` response doesn't include
+        /// it on a given chat, this stays `nil` and the suggestion renders with the default icon.
+        let model: String?
 
         func toAIChatSuggestion() -> AIChatSuggestion {
             AIChatSuggestion(
@@ -82,7 +86,8 @@ public final class AIChatSuggestionsUserScript: NSObject, Subfeature {
                 isPinned: pinned ?? false,
                 chatId: chatId,
                 timestamp: AIChatSuggestion.parseISO8601Date(lastEdit),
-                firstUserMessageContent: firstUserMessageContent
+                firstUserMessageContent: firstUserMessageContent,
+                model: model
             )
         }
     }

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/Suggestions/LocalSuggestionsReader.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/Suggestions/LocalSuggestionsReader.swift
@@ -66,7 +66,8 @@ public final class LocalSuggestionsReader: SuggestionsReading {
                     isPinned: item.chat.pinned,
                     chatId: item.chat.chatId,
                     timestamp: AIChatSuggestion.parseISO8601Date(item.chat.lastEdit),
-                    firstUserMessageContent: item.firstUserMessageContent
+                    firstUserMessageContent: item.firstUserMessageContent,
+                    model: item.chat.model
                 )
             }
 

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatSuggestionTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatSuggestionTests.swift
@@ -262,4 +262,14 @@ final class AIChatSuggestionTests: XCTestCase {
         // A regular chat model doesn't match the voice/image tokens and falls through to .text.
         XCTAssertEqual(AIChatSuggestion.kind(forModel: "gpt-4o-mini"), .text)
     }
+
+    func testKind_WithModelEmbeddingVoiceTokenButNotEqual_ReturnsText() {
+        // Defensive — exact-equality matching prevents a future model whose name embeds the
+        // voice-mode token (e.g. an experimental variant) from being misclassified as `.voice`.
+        XCTAssertEqual(AIChatSuggestion.kind(forModel: "voice-mode-experimental-2"), .text)
+    }
+
+    func testKind_WithModelEmbeddingImageTokenButNotEqual_ReturnsText() {
+        XCTAssertEqual(AIChatSuggestion.kind(forModel: "image-generation-pro"), .text)
+    }
 }

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatSuggestionTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatSuggestionTests.swift
@@ -239,4 +239,27 @@ final class AIChatSuggestionTests: XCTestCase {
         // Then
         XCTAssertEqual(set.count, 2)
     }
+
+    // MARK: - Kind (model → chat type)
+
+    func testKind_WithVoiceModeModel_ReturnsVoice() {
+        XCTAssertEqual(AIChatSuggestion.kind(forModel: AIChatNativePrompt.voiceMode), .voice)
+    }
+
+    func testKind_WithImageGenerationModel_ReturnsImage() {
+        XCTAssertEqual(AIChatSuggestion.kind(forModel: AIChatNativePrompt.imageGenerationMode), .image)
+    }
+
+    func testKind_WithNilModel_ReturnsText() {
+        XCTAssertEqual(AIChatSuggestion.kind(forModel: nil), .text)
+    }
+
+    func testKind_WithEmptyModel_ReturnsText() {
+        XCTAssertEqual(AIChatSuggestion.kind(forModel: ""), .text)
+    }
+
+    func testKind_WithUnknownModel_ReturnsText() {
+        // A regular chat model doesn't match the voice/image tokens and falls through to .text.
+        XCTAssertEqual(AIChatSuggestion.kind(forModel: "gpt-4o-mini"), .text)
+    }
 }

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
         .package(url: "https://github.com/1024jp/GzipSwift.git", exact: "6.0.1"),
         .package(url: "https://github.com/vapor/jwt-kit.git", exact: "4.13.5"),
         .package(url: "https://github.com/pointfreeco/swift-clocks.git", exact: "1.0.6"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", exact: "14.3.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", exact: "14.4.0"),
         .package(path: "../URLPredictor"),
     ],
     targets: [

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -469,6 +469,9 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Enables the reasoning effort picker in the Duck.ai omnibar
     case omnibarReasoningEffort
 
+    /// Enables 1-click voice-chat access from the Duck.ai omnibar (mic icon shown when input is empty)
+    case omnibarVoiceChatAccess
+
     /// Enables querying AI Chat data directly from local storage instead of via webview
     case nativeDataAccess
 }

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -355,6 +355,8 @@
 		31521AC12CC013AD00248E6F /* AIChatMenuVisibilityConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31521ABF2CC013A400248E6F /* AIChatMenuVisibilityConfigurable.swift */; };
 		31521AC32CC01BC700248E6F /* AIChatTabOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31521AC22CC01BC300248E6F /* AIChatTabOpener.swift */; };
 		31521AC42CC01BC700248E6F /* AIChatTabOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31521AC22CC01BC300248E6F /* AIChatTabOpener.swift */; };
+		1A77VST00000000000000003 /* VoiceSessionTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A77VST00000000000000001 /* VoiceSessionTracker.swift */; };
+		1A77VST00000000000000004 /* VoiceSessionTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A77VST00000000000000001 /* VoiceSessionTracker.swift */; };
 		3154FD1428E6011A00909769 /* TabShadowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3154FD1328E6011A00909769 /* TabShadowView.swift */; };
 		3158B1492B0BF73000AF130C /* DBPHomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3192EC872A4DCF21001E97A5 /* DBPHomeViewController.swift */; };
 		3158B14A2B0BF74300AF130C /* DataBrokerProtectionDebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 316850712AF3AD58009A2828 /* DataBrokerProtectionDebugMenu.swift */; };
@@ -394,6 +396,8 @@
 		317307302CD2493900C492AB /* AutofillToolbarOnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3173072E2CD2493700C492AB /* AutofillToolbarOnboardingViewModel.swift */; };
 		317B39DA2ED9CBD1001B5600 /* AIChatOmnibarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317B39D92ED9CBD1001B5600 /* AIChatOmnibarControllerTests.swift */; };
 		317B39DB2ED9CBD1001B5600 /* AIChatOmnibarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317B39D92ED9CBD1001B5600 /* AIChatOmnibarControllerTests.swift */; };
+		1A77VST00000000000000005 /* VoiceSessionTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A77VST00000000000000002 /* VoiceSessionTrackerTests.swift */; };
+		1A77VST00000000000000006 /* VoiceSessionTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A77VST00000000000000002 /* VoiceSessionTrackerTests.swift */; };
 		3199AF6F2C80734A003AEBDC /* DuckPlayerOnboardingDecider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3199AF632C80734A003AEBDC /* DuckPlayerOnboardingDecider.swift */; };
 		3199AF702C80734A003AEBDC /* DuckPlayerOnboardingDecider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3199AF632C80734A003AEBDC /* DuckPlayerOnboardingDecider.swift */; };
 		319FCFF22CC81D54004F9288 /* AIChatRemoteSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319FCFF12CC81D54004F9288 /* AIChatRemoteSettings.swift */; };
@@ -4852,6 +4856,7 @@
 		3148727D2CC68F6200EEF89B /* AIChatTabExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabExtension.swift; sourceTree = "<group>"; };
 		31521ABF2CC013A400248E6F /* AIChatMenuVisibilityConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatMenuVisibilityConfigurable.swift; sourceTree = "<group>"; };
 		31521AC22CC01BC300248E6F /* AIChatTabOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabOpener.swift; sourceTree = "<group>"; };
+		1A77VST00000000000000001 /* VoiceSessionTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceSessionTracker.swift; sourceTree = "<group>"; };
 		3154FD1328E6011A00909769 /* TabShadowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabShadowView.swift; sourceTree = "<group>"; };
 		315AA06F28CA5CC800200030 /* YoutubePlayerNavigationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YoutubePlayerNavigationHandler.swift; sourceTree = "<group>"; };
 		3161D15C2DA02380008F59B5 /* AIChatPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatPixel.swift; sourceTree = "<group>"; };
@@ -4869,6 +4874,7 @@
 		3173072B2CD2490300C492AB /* AutofillToolbarOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillToolbarOnboardingView.swift; sourceTree = "<group>"; };
 		3173072E2CD2493700C492AB /* AutofillToolbarOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillToolbarOnboardingViewModel.swift; sourceTree = "<group>"; };
 		317B39D92ED9CBD1001B5600 /* AIChatOmnibarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatOmnibarControllerTests.swift; sourceTree = "<group>"; };
+		1A77VST00000000000000002 /* VoiceSessionTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceSessionTrackerTests.swift; sourceTree = "<group>"; };
 		3192EC872A4DCF21001E97A5 /* DBPHomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBPHomeViewController.swift; sourceTree = "<group>"; };
 		3199AF632C80734A003AEBDC /* DuckPlayerOnboardingDecider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DuckPlayerOnboardingDecider.swift; sourceTree = "<group>"; };
 		3199C6F82AF94F5B002A7BA1 /* DataBrokerProtectionFeatureDisabler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBrokerProtectionFeatureDisabler.swift; sourceTree = "<group>"; };
@@ -7597,6 +7603,7 @@
 				312E63962D9D821500806E2A /* AIChatURL.swift */,
 				319FCFF12CC81D54004F9288 /* AIChatRemoteSettings.swift */,
 				31521AC22CC01BC300248E6F /* AIChatTabOpener.swift */,
+				1A77VST00000000000000001 /* VoiceSessionTracker.swift */,
 				3135647A2D9EB8E800BF4B5D /* AIChatAddressBarPromptExtractor.swift */,
 				31521ABF2CC013A400248E6F /* AIChatMenuVisibilityConfigurable.swift */,
 				A3E61483DDA440CEAD33A5C5 /* AIChatDeleteChatsDialog.swift */,
@@ -7723,6 +7730,7 @@
 				3135647D2D9EBB9900BF4B5D /* AIChatAddressBarPromptExtractorTests.swift */,
 				31FBF2302CDD12FE00626C17 /* AIChatUserScriptTests.swift */,
 				317B39D92ED9CBD1001B5600 /* AIChatOmnibarControllerTests.swift */,
+				1A77VST00000000000000002 /* VoiceSessionTrackerTests.swift */,
 				31031EB62CC94C6C00684340 /* AIChatRemoteSettingsTests.swift */,
 				31F25EFE2CC3CA00002F9084 /* AIChatMenuConfigurationTests.swift */,
 				1E2A88792E2E477A00C29AC0 /* AIChatSessionStoreTests.swift */,
@@ -15214,6 +15222,7 @@
 				F18826812BBEB58100D9AC4F /* SubscriptionPixel.swift in Sources */,
 				BBC7BDA92D5B82BD0037A4AE /* DefaultBrowserAndDockPromptCoordinator.swift in Sources */,
 				31521AC42CC01BC700248E6F /* AIChatTabOpener.swift in Sources */,
+				1A77VST00000000000000004 /* VoiceSessionTracker.swift in Sources */,
 				3706FB88293F65D500E42796 /* PermissionAuthorizationQuery.swift in Sources */,
 				4B4D60C32A0C849100BCD287 /* EventMapping+NetworkProtectionError.swift in Sources */,
 				3706FB8A293F65D500E42796 /* BrowserTabSelectionDelegate.swift in Sources */,
@@ -16149,6 +16158,7 @@
 				3706FE3C293F661700E42796 /* FireproofDomainsStoreMock.swift in Sources */,
 				BBF17D212F7B4D33004AFCF4 /* AIChatMenuTests.swift in Sources */,
 				317B39DB2ED9CBD1001B5600 /* AIChatOmnibarControllerTests.swift in Sources */,
+				1A77VST00000000000000006 /* VoiceSessionTrackerTests.swift in Sources */,
 				56A054482C22536A007D8FAB /* CapturingOnboardingActionsManager.swift in Sources */,
 				3706FE3D293F661700E42796 /* DataEncryptionTests.swift in Sources */,
 				1D39F7292DCA2C9200F258F0 /* InitialWindowFrameProviderTests.swift in Sources */,
@@ -17388,6 +17398,7 @@
 				C1D3C5762E8ADB080086A2BD /* SyncIdentitiesAdapter.swift in Sources */,
 				C1B1CBE12BE1915100B6049C /* DataImportShortcutsViewModel.swift in Sources */,
 				31521AC32CC01BC700248E6F /* AIChatTabOpener.swift in Sources */,
+				1A77VST00000000000000003 /* VoiceSessionTracker.swift in Sources */,
 				EE72DCB32EAB73810052661B /* NewImportTypePickerView.swift in Sources */,
 				37B904712E2996FA00E5DAF7 /* AppVersionModel.swift in Sources */,
 				B6C0B23C26E87D900031CB7F /* NSAlert+ActiveDownloadsTermination.swift in Sources */,
@@ -18201,6 +18212,7 @@
 				BB0036612E426E9D0016DDEF /* ReportProblemFormViewModelTests.swift in Sources */,
 				1D04CA182F67FECE007AB0F3 /* PageContextMultipleContextsTests.swift in Sources */,
 				317B39DA2ED9CBD1001B5600 /* AIChatOmnibarControllerTests.swift in Sources */,
+				1A77VST00000000000000005 /* VoiceSessionTrackerTests.swift in Sources */,
 				CCAED35A2EB8E0C700C7368E /* MockDefaultBrowserAndDockPromptUserActivityProvider.swift in Sources */,
 				BB0036622E426E9D0016DDEF /* RequestNewFeatureViewModelTests.swift in Sources */,
 				CC6E897D2E5F08EA00F6BED0 /* SessionRestorePromptCoordinatorTests.swift in Sources */,

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b4cd7fe46a916ad3fd028a60b5d667a722aaedc3dd5414beb3f0a1cc4abb5867",
+  "originHash" : "f1e6042c22402049a868153f3c2ea92f9d9f7c5dd637295f828864bc216c70f5",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "1e417da9e53e44c3d683b5d8d15837df80a3dd16",
-        "version" : "14.3.0"
+        "revision" : "311aa9498f17f7078a5e5d5e80fdcd928c3a6f7c",
+        "version" : "14.4.0"
       }
     },
     {

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -337,21 +337,35 @@ final class AIChatOmnibarContainerViewController: NSViewController {
 
         NSAppearance.withAppAppearance {
             if enabled {
-                // Voice-chat mode uses the accent-alt palette (background + content-primary
-                // foreground) so the action reads as visually distinct from a standard submit.
                 if submitButtonMode == .voice {
-                    submitButton.layer?.backgroundColor = NSColor(designSystemColor: .accentAltPrimary).cgColor
+                    // Voice spec: icon stays at content-primary across all three states; only the
+                    // fill progresses through the accent-alt palette on hover and press.
+                    // `MouseOverButton` swaps the layer fill automatically based on these properties.
+                    submitButton.backgroundColor = NSColor(designSystemColor: .accentAltPrimary)
+                    submitButton.mouseOverColor = NSColor(designSystemColor: .accentAltSecondary)
+                    submitButton.mouseDownColor = NSColor(designSystemColor: .accentAltTertiary)
                     submitButton.normalTintColor = NSColor(designSystemColor: .accentAltContentPrimary)
-                    submitButton.mouseOverTintColor = NSColor(designSystemColor: .accentAltContentSecondary)
+                    submitButton.mouseOverTintColor = nil
+                    submitButton.mouseDownTintColor = nil
                 } else {
-                    submitButton.layer?.backgroundColor = NSColor(designSystemColor: .accentPrimary).cgColor
-                    submitButton.normalTintColor = .white
-                    submitButton.mouseOverTintColor = NSColor(designSystemColor: .buttonsPrimaryText).withAlphaComponent(0.8)
+                    // Submit spec: icon stays at accent/content-primary across all three states;
+                    // only the fill progresses through accent/primary → secondary → tertiary on
+                    // hover/press. `MouseOverButton` swaps the layer fill automatically based on
+                    // these properties.
+                    submitButton.backgroundColor = NSColor(designSystemColor: .accentPrimary)
+                    submitButton.mouseOverColor = NSColor(designSystemColor: .accentSecondary)
+                    submitButton.mouseDownColor = NSColor(designSystemColor: .accentTertiary)
+                    submitButton.normalTintColor = NSColor(designSystemColor: .accentContentPrimary)
+                    submitButton.mouseOverTintColor = nil
+                    submitButton.mouseDownTintColor = nil
                 }
             } else {
-                submitButton.layer?.backgroundColor = NSColor.clear.cgColor
+                submitButton.backgroundColor = nil
+                submitButton.mouseOverColor = nil
+                submitButton.mouseDownColor = nil
                 submitButton.normalTintColor = NSColor.secondaryLabelColor
                 submitButton.mouseOverTintColor = NSColor.secondaryLabelColor
+                submitButton.mouseDownTintColor = nil
             }
         }
     }
@@ -491,6 +505,9 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         submitButton.bezelStyle = .shadowlessSquare
         submitButton.isBordered = false
         submitButton.wantsLayer = true
+        // The `MouseOverButton`-managed hover/press sub-layer reads `cornerRadius` from this property
+        // when rendering its background — needed so the voice-chat fill renders rounded.
+        submitButton.cornerRadius = Constants.submitButtonCornerRadius
         submitButton.target = self
         submitButton.action = #selector(submitButtonClicked)
 

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -73,7 +73,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     private let shadowView = ShadowView()
     private let innerBorderView = ColorView(frame: .zero)
     private let containerView = HitTestableContainerView()
-    private let submitButton = MouseOverButton()
+    private let submitButton = AIChatSubmitButton()
     private let imageUploadButton = AIChatOmnibarToolButton()
     private let toolsButton = AIChatOmnibarToolButton()
     private let imageGenActiveButton = AIChatOmnibarToolButton()
@@ -167,11 +167,12 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         view.window?.makeFirstResponder(modelPickerButton)
     }
 
-    /// Advances focus to the next tool button after the given one, or to model picker, or back to text view.
+    /// Advances focus to the next tool button after the given one, or to model picker, then to the
+    /// voice-mode submit button (when active), and finally back to the text view.
     private func advanceFocusAfter(_ button: AIChatOmnibarToolButton) {
         let buttons = focusableToolButtons
         guard let index = buttons.firstIndex(of: button) else {
-            onToolButtonTabPressed?()
+            advanceFocusToVoiceSubmitOrText()
             return
         }
         // Find next visible button after current
@@ -179,9 +180,20 @@ final class AIChatOmnibarContainerViewController: NSViewController {
             view.window?.makeFirstResponder(nextButton)
             return
         }
-        // No more tool buttons — try model picker, then text view
+        // No more tool buttons — try model picker, then voice-mode submit button, then text view
         if isModelPickerButtonAvailableForFocus {
             makeModelPickerButtonFirstResponder()
+        } else {
+            advanceFocusToVoiceSubmitOrText()
+        }
+    }
+
+    /// Used as the final hop in the tab cycle. The voice-mode submit button is the only state in
+    /// which the submit button participates in keyboard navigation — submit mode skips it because
+    /// Enter on the textarea already handles submission.
+    private func advanceFocusToVoiceSubmitOrText() {
+        if submitButtonMode == .voice && submitButton.isEnabled {
+            view.window?.makeFirstResponder(submitButton)
         } else {
             onToolButtonTabPressed?()
         }
@@ -322,12 +334,16 @@ final class AIChatOmnibarContainerViewController: NSViewController {
             submitButton.image = DesignSystemImages.Glyphs.Size16.voice
             submitButton.toolTip = UserText.aiChatVoiceChatButtonTooltip
             submitButton.setAccessibilityLabel(UserText.aiChatVoiceChatButtonTooltip)
+            // Voice has no Enter-on-empty shortcut, so the button must be tab-reachable.
+            submitButton.refusesFirstResponder = false
             applySubmitButtonAppearance(enabled: true)
         } else {
             submitButtonMode = .submit
             submitButton.image = DesignSystemImages.Glyphs.Size12.arrowRight
             submitButton.toolTip = UserText.aiChatSendButtonTooltip
             submitButton.setAccessibilityLabel(UserText.aiChatSendButtonTooltip)
+            // Enter on the textarea handles submit; skip the button in tab order.
+            submitButton.refusesFirstResponder = true
             applySubmitButtonAppearance(enabled: hasText && !hasBlockingExcess)
         }
     }
@@ -510,6 +526,9 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         submitButton.cornerRadius = Constants.submitButtonCornerRadius
         submitButton.target = self
         submitButton.action = #selector(submitButtonClicked)
+        // Tab from the (voice-mode) submit button hands focus back to the textarea — same callback
+        // the model picker uses, so the loop closes consistently regardless of which button is last.
+        submitButton.onTabPressed = { [weak self] in self?.onToolButtonTabPressed?() }
 
         // Conservative initial state — arrow icon. `updateSubmitButtonState(for:)` fires
         // immediately on subscribe and swaps to voice mode if the flag is on and input is empty.
@@ -579,7 +598,9 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         modelPickerButton.modelName = persistedModelShortName
         modelPickerButton.toolTip = UserText.aiChatModelPickerButtonTooltip
         modelPickerButton.setAccessibilityLabel(UserText.aiChatModelPickerButtonTooltip)
-        modelPickerButton.onTabPressed = { [weak self] in self?.onToolButtonTabPressed?() }
+        // Tab from the model picker advances to the voice-mode submit button (when active), or
+        // falls back to the textarea if voice mode is off.
+        modelPickerButton.onTabPressed = { [weak self] in self?.advanceFocusToVoiceSubmitOrText() }
         containerView.addSubview(modelPickerButton)
 
         attachmentsContainerView.translatesAutoresizingMaskIntoConstraints = false
@@ -1264,5 +1285,53 @@ extension AIChatOmnibarContainerViewController: ThemeUpdateListening {
 
     func applyThemeStyle(theme: ThemeStyleProviding) {
         applyTheme(theme: theme)
+    }
+}
+
+// MARK: - AIChatSubmitButton
+
+/// Specialised submit button that participates in the omnibar's tab cycle when in voice
+/// mode. In submit mode the textarea's Enter handles submission, so the button is skipped
+/// in keyboard navigation; in voice mode there is no Enter shortcut on empty input, so users
+/// need to be able to Tab onto this button and press Enter/Space to start the voice session.
+///
+/// Mirrors the keyboard handling in `AIChatOmnibarToolButton`: Tab calls a callback (so the
+/// container VC can route focus back to the textarea), Enter/Space triggers the button's
+/// action via `NSButton`'s built-in behavior.
+final class AIChatSubmitButton: MouseOverButton {
+
+    /// Set by the container VC. When non-nil, `Tab` advances focus via this callback instead
+    /// of the default first-responder chain.
+    var onTabPressed: (() -> Void)?
+
+    override func keyDown(with event: NSEvent) {
+        switch event.keyCode {
+        case 48: // Tab
+            if let onTabPressed {
+                onTabPressed()
+            } else {
+                super.keyDown(with: event)
+            }
+        case 49, 36: // Space, Return — trigger the button's action manually.
+            // NSButton's default keyDown doesn't reliably fire the action when the button
+            // uses a custom layer-drawn appearance (`bezelStyle = .shadowlessSquare`, no border).
+            if isEnabled, let action, let target {
+                NSApp.sendAction(action, to: target, from: self)
+            }
+        default:
+            super.keyDown(with: event)
+        }
+    }
+
+    // The visible button is a rounded layer drawn by `MouseOverButton`'s hover tracking area.
+    // AppKit's default focus ring fits the image content, which makes it hug the icon instead
+    // of the rounded button frame. Overriding the mask + bounds makes the focus ring match the
+    // button's actual shape.
+    override var focusRingMaskBounds: NSRect {
+        bounds
+    }
+
+    override func drawFocusRingMask() {
+        NSBezierPath(roundedRect: bounds, xRadius: cornerRadius, yRadius: cornerRadius).fill()
     }
 }

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -113,6 +113,11 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     private var windowFrameObserver: AnyCancellable?
     private var viewBoundsObserver: AnyCancellable?
     private var imageGenModeCancellable: AnyCancellable?
+    /// KVO on the submit button's hover/press state — drives the layer fill through the
+    /// accent / accent-alt three-state palette. Direct-layer fill (rather than the
+    /// `MouseOverButton.backgroundColor` sub-layer) keeps the icon visible.
+    private var submitButtonMouseOverObservation: NSKeyValueObservation?
+    private var submitButtonMouseDownObservation: NSKeyValueObservation?
     private var toolsLeadingToUploadButton: NSLayoutConstraint?
     private var toolsLeadingToContainer: NSLayoutConstraint?
     private lazy var historyCleaner: HistoryCleaning = HistoryCleaner(
@@ -260,7 +265,20 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         subscribeToImageGenModeChanges()
         setupAttachmentsProvider()
         subscribeToModelUpdates()
+        observeSubmitButtonHoverState()
         applyThemeStyle()
+    }
+
+    /// Observe `MouseOverButton.isMouseOver` / `isMouseDown` so the submit button's fill
+    /// animates through `accent{,Alt}{Primary,Secondary,Tertiary}` on hover/press without
+    /// using the sub-layer-based `backgroundColor` property (which would obscure the icon).
+    private func observeSubmitButtonHoverState() {
+        submitButtonMouseOverObservation = submitButton.observe(\.isMouseOver, options: [.new]) { [weak self] _, _ in
+            self?.applySubmitButtonFill()
+        }
+        submitButtonMouseDownObservation = submitButton.observe(\.isMouseDown, options: [.new]) { [weak self] _, _ in
+            self?.applySubmitButtonFill()
+        }
     }
 
     override func viewDidLayout() {
@@ -350,39 +368,56 @@ final class AIChatOmnibarContainerViewController: NSViewController {
 
     private func applySubmitButtonAppearance(enabled: Bool) {
         submitButton.isEnabled = enabled
-
+        // Tints. Both modes keep the icon constant across hover/press; only the fill animates,
+        // so `mouseOverTintColor` / `mouseDownTintColor` stay nil.
         NSAppearance.withAppAppearance {
             if enabled {
                 if submitButtonMode == .voice {
-                    // Voice spec: icon stays at content-primary across all three states; only the
-                    // fill progresses through the accent-alt palette on hover and press.
-                    // `MouseOverButton` swaps the layer fill automatically based on these properties.
-                    submitButton.backgroundColor = NSColor(designSystemColor: .accentAltPrimary)
-                    submitButton.mouseOverColor = NSColor(designSystemColor: .accentAltSecondary)
-                    submitButton.mouseDownColor = NSColor(designSystemColor: .accentAltTertiary)
                     submitButton.normalTintColor = NSColor(designSystemColor: .accentAltContentPrimary)
-                    submitButton.mouseOverTintColor = nil
-                    submitButton.mouseDownTintColor = nil
                 } else {
-                    // Submit spec: icon stays at accent/content-primary across all three states;
-                    // only the fill progresses through accent/primary → secondary → tertiary on
-                    // hover/press. `MouseOverButton` swaps the layer fill automatically based on
-                    // these properties.
-                    submitButton.backgroundColor = NSColor(designSystemColor: .accentPrimary)
-                    submitButton.mouseOverColor = NSColor(designSystemColor: .accentSecondary)
-                    submitButton.mouseDownColor = NSColor(designSystemColor: .accentTertiary)
                     submitButton.normalTintColor = NSColor(designSystemColor: .accentContentPrimary)
-                    submitButton.mouseOverTintColor = nil
-                    submitButton.mouseDownTintColor = nil
                 }
             } else {
-                submitButton.backgroundColor = nil
-                submitButton.mouseOverColor = nil
-                submitButton.mouseDownColor = nil
                 submitButton.normalTintColor = NSColor.secondaryLabelColor
-                submitButton.mouseOverTintColor = NSColor.secondaryLabelColor
-                submitButton.mouseDownTintColor = nil
             }
+            submitButton.mouseOverTintColor = nil
+            submitButton.mouseDownTintColor = nil
+        }
+        // Fill. Driven via the view's main `layer.backgroundColor` directly so it renders BEHIND
+        // the NSButton image content. We deliberately do NOT use `MouseOverButton`'s
+        // `backgroundColor` property — that property drives a sub-layer added on top of the view's
+        // main layer, and CALayer sub-layers always render above the parent layer's contents,
+        // which would obscure the icon. The hover/press transitions are handled by KVO on
+        // `isMouseOver` / `isMouseDown` (see `observeSubmitButtonHoverState`).
+        applySubmitButtonFill()
+    }
+
+    /// Sets `submitButton.layer.backgroundColor` to the appropriate state-aware color. Called
+    /// from `applySubmitButtonAppearance(enabled:)` and from the KVO observers on the hover/press
+    /// dynamic properties. Disabled state and "submit mode while empty" both render no fill.
+    private func applySubmitButtonFill() {
+        let designSystemColor: DesignSystemColor?
+        if !submitButton.isEnabled {
+            designSystemColor = nil
+        } else if submitButtonMode == .voice {
+            if submitButton.isMouseDown {
+                designSystemColor = .accentAltTertiary
+            } else if submitButton.isMouseOver {
+                designSystemColor = .accentAltSecondary
+            } else {
+                designSystemColor = .accentAltPrimary
+            }
+        } else {
+            if submitButton.isMouseDown {
+                designSystemColor = .accentTertiary
+            } else if submitButton.isMouseOver {
+                designSystemColor = .accentSecondary
+            } else {
+                designSystemColor = .accentPrimary
+            }
+        }
+        NSAppearance.withAppAppearance {
+            submitButton.layer?.backgroundColor = designSystemColor.map { NSColor(designSystemColor: $0).cgColor } ?? NSColor.clear.cgColor
         }
     }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -19,6 +19,7 @@
 import Cocoa
 import QuartzCore
 import Combine
+import DesignResourcesKit
 import UniformTypeIdentifiers
 import DesignResourcesKitIcons
 import AIChat
@@ -293,14 +294,42 @@ final class AIChatOmnibarContainerViewController: NSViewController {
                 guard let self else { return }
                 self.updateToolButtonsVisibility(isEnabled: self.omnibarController.isOmnibarToolsEnabled)
                 self.updateImageUploadVisibility(supportsImageUpload: self.omnibarController.selectedModelSupportsImageUpload)
+                // Re-evaluate the submit button so voice mode is suppressed/restored when
+                // image-generation toggles (voice mode is hidden while image-gen is active).
+                self.updateSubmitButtonState(for: self.omnibarController.currentText)
             }
     }
+
+    /// What the submit button does on click. Driven by whether the input has text — empty
+    /// triggers a voice-chat tab open, otherwise the existing submit flow runs.
+    private enum SubmitButtonMode {
+        case submit
+        case voice
+    }
+
+    private var submitButtonMode: SubmitButtonMode = .submit
 
     private func updateSubmitButtonState(for text: String) {
         let hasText = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let canSendImages = omnibarController.isImageGenerationMode || omnibarController.selectedModelSupportsImageUpload
         let hasBlockingExcess = canSendImages && attachmentsContainerView.hasExcessAttachments
-        applySubmitButtonAppearance(enabled: hasText && !hasBlockingExcess)
+
+        // Voice-chat mode only kicks in when the input is empty, the feature flag is on, and we
+        // aren't in image-generation mode (where the button must keep its image-flow semantics).
+        // Otherwise the button keeps its original arrow/disabled-when-empty behavior.
+        if !hasText && omnibarController.isVoiceChatAccessEnabled && !omnibarController.isImageGenerationMode {
+            submitButtonMode = .voice
+            submitButton.image = DesignSystemImages.Glyphs.Size16.voice
+            submitButton.toolTip = UserText.aiChatVoiceChatButtonTooltip
+            submitButton.setAccessibilityLabel(UserText.aiChatVoiceChatButtonTooltip)
+            applySubmitButtonAppearance(enabled: true)
+        } else {
+            submitButtonMode = .submit
+            submitButton.image = DesignSystemImages.Glyphs.Size12.arrowRight
+            submitButton.toolTip = UserText.aiChatSendButtonTooltip
+            submitButton.setAccessibilityLabel(UserText.aiChatSendButtonTooltip)
+            applySubmitButtonAppearance(enabled: hasText && !hasBlockingExcess)
+        }
     }
 
     private func applySubmitButtonAppearance(enabled: Bool) {
@@ -308,9 +337,17 @@ final class AIChatOmnibarContainerViewController: NSViewController {
 
         NSAppearance.withAppAppearance {
             if enabled {
-                submitButton.layer?.backgroundColor = NSColor(designSystemColor: .accentPrimary).cgColor
-                submitButton.normalTintColor = .white
-                submitButton.mouseOverTintColor = NSColor(designSystemColor: .buttonsPrimaryText).withAlphaComponent(0.8)
+                // Voice-chat mode uses the accent-alt palette (background + content-primary
+                // foreground) so the action reads as visually distinct from a standard submit.
+                if submitButtonMode == .voice {
+                    submitButton.layer?.backgroundColor = NSColor(designSystemColor: .accentAltPrimary).cgColor
+                    submitButton.normalTintColor = NSColor(designSystemColor: .accentAltContentPrimary)
+                    submitButton.mouseOverTintColor = NSColor(designSystemColor: .accentAltContentSecondary)
+                } else {
+                    submitButton.layer?.backgroundColor = NSColor(designSystemColor: .accentPrimary).cgColor
+                    submitButton.normalTintColor = .white
+                    submitButton.mouseOverTintColor = NSColor(designSystemColor: .buttonsPrimaryText).withAlphaComponent(0.8)
+                }
             } else {
                 submitButton.layer?.backgroundColor = NSColor.clear.cgColor
                 submitButton.normalTintColor = NSColor.secondaryLabelColor
@@ -457,9 +494,12 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         submitButton.target = self
         submitButton.action = #selector(submitButtonClicked)
 
+        // Conservative initial state — arrow icon. `updateSubmitButtonState(for:)` fires
+        // immediately on subscribe and swaps to voice mode if the flag is on and input is empty.
         submitButton.image = DesignSystemImages.Glyphs.Size12.arrowRight
         submitButton.imagePosition = .imageOnly
         submitButton.toolTip = UserText.aiChatSendButtonTooltip
+        submitButton.setAccessibilityLabel(UserText.aiChatSendButtonTooltip)
         containerView.addSubview(submitButton)
 
         imageUploadButton.translatesAutoresizingMaskIntoConstraints = false
@@ -769,7 +809,12 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     }
 
     @objc private func submitButtonClicked() {
-        omnibarController.submit()
+        switch submitButtonMode {
+        case .submit:
+            omnibarController.submit()
+        case .voice:
+            omnibarController.openNewVoiceChat()
+        }
     }
 
     @objc private func toolsButtonClicked() {
@@ -1157,8 +1202,11 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         }
 
         submitButton.layer?.cornerRadius = Constants.submitButtonCornerRadius
-        // Colour is set dynamically by applySubmitButtonAppearance based on enabled state
-        applySubmitButtonAppearance(enabled: !omnibarController.currentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        // Colour is set dynamically by applySubmitButtonAppearance based on enabled state.
+        // Route through `updateSubmitButtonState(for:)` so voice mode is preserved on theme
+        // changes — calling `applySubmitButtonAppearance` directly with the legacy
+        // hasText-only enabled flag would re-disable the voice button on every theme refresh.
+        updateSubmitButtonState(for: omnibarController.currentText)
 
         let toolButtonTintColor = NSColor(designSystemColor: .textPrimary)
         toolsButton.tintColor = toolButtonTintColor

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -63,7 +63,6 @@ final class AIChatOmnibarController {
     private let suggestionsReader: AIChatSuggestionsReading?
     private let modelsService: AIChatModelsProviding
     private let subscriptionManager: any SubscriptionManager
-    private let aiChatURLProvider: () -> URL
     private var preferences: AIChatPreferencesPersisting
     private var cancellables = Set<AnyCancellable>()
     private var sharedTextStateCancellable: AnyCancellable?
@@ -161,8 +160,7 @@ final class AIChatOmnibarController {
         suggestionsReader: AIChatSuggestionsReading? = nil,
         preferences: AIChatPreferencesPersisting = AIChatPreferencesPersistor(),
         modelsService: AIChatModelsProviding = AIChatModelsService(),
-        subscriptionManager: any SubscriptionManager = Application.appDelegate.subscriptionManager,
-        aiChatURLProvider: @escaping () -> URL = { AIChatRemoteSettings().aiChatURL }
+        subscriptionManager: any SubscriptionManager = Application.appDelegate.subscriptionManager
     ) {
         self.aiChatTabOpener = aiChatTabOpener
         self.tabCollectionViewModel = tabCollectionViewModel
@@ -173,7 +171,6 @@ final class AIChatOmnibarController {
         self.preferences = preferences
         self.modelsService = modelsService
         self.subscriptionManager = subscriptionManager
-        self.aiChatURLProvider = aiChatURLProvider
         self.suggestionsViewModel = AIChatSuggestionsViewModel(
             maxSuggestions: suggestionsReader?.maxHistoryCount ?? AIChatSuggestionsViewModel.defaultMaxSuggestions
         )
@@ -183,10 +180,11 @@ final class AIChatOmnibarController {
     }
 
     /// Opens a new voice-chat tab from the AI chat omnibar. Mirrors the `Duck.ai → New Voice Chat`
-    /// menu action: a new selected tab loaded with the voice-mode URL.
+    /// menu action: opens a new selected Duck.ai tab and hands off `mode: voice-mode` via the prompt
+    /// handler (no `?mode=voice` URL param — Duck.ai routes purely on the prompt mode, same as
+    /// image generation).
     func openNewVoiceChat() {
-        let url = AIChatURLParameters.voiceModeURL(from: aiChatURLProvider())
-        aiChatTabOpener.openAIChatTab(with: .url(url), behavior: .newTab(selected: true))
+        aiChatTabOpener.openAIChatTab(with: .mode(AIChatNativePrompt.voiceMode), behavior: .newTab(selected: true))
         PixelKit.fire(AIChatPixel.aiChatNewVoiceChatOmnibarNative, frequency: .dailyAndStandard, includeAppVersionParameter: true)
     }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -179,12 +179,14 @@ final class AIChatOmnibarController {
         subscribeToTextChangesForSuggestions()
     }
 
-    /// Opens a new voice-chat tab from the AI chat omnibar. Mirrors the `Duck.ai → New Voice Chat`
-    /// menu action: opens a new selected Duck.ai tab and hands off `mode: voice-mode` via the prompt
-    /// handler (no `?mode=voice` URL param — Duck.ai routes purely on the prompt mode, same as
-    /// image generation).
+    /// Opens a new voice-chat tab from the AI chat omnibar. Focuses an existing voice session
+    /// in the same window if one is active; otherwise opens a new selected Duck.ai tab and hands
+    /// off `mode: voice-mode` via the prompt handler.
     func openNewVoiceChat() {
-        aiChatTabOpener.openAIChatTab(with: .mode(AIChatNativePrompt.voiceMode), behavior: .newTab(selected: true))
+        aiChatTabOpener.openVoiceSession(
+            inWindowOf: tabCollectionViewModel.selectedTab,
+            behavior: .newTab(selected: true)
+        )
         PixelKit.fire(AIChatPixel.aiChatNewVoiceChatOmnibarNative, frequency: .dailyAndStandard, includeAppVersionParameter: true)
     }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -63,6 +63,7 @@ final class AIChatOmnibarController {
     private let suggestionsReader: AIChatSuggestionsReading?
     private let modelsService: AIChatModelsProviding
     private let subscriptionManager: any SubscriptionManager
+    private let aiChatURLProvider: () -> URL
     private var preferences: AIChatPreferencesPersisting
     private var cancellables = Set<AnyCancellable>()
     private var sharedTextStateCancellable: AnyCancellable?
@@ -119,6 +120,12 @@ final class AIChatOmnibarController {
         featureFlagger.isFeatureOn(.aiChatOmnibarReasoningEffort)
     }
 
+    /// Whether 1-click voice-chat access in the omnibar is available. When disabled, the submit
+    /// button keeps its legacy "arrow / disabled when empty" behavior.
+    var isVoiceChatAccessEnabled: Bool {
+        featureFlagger.isFeatureOn(.aiChatOmnibarVoiceChatAccess)
+    }
+
     func toggleImageGenerationMode() {
         activeToolMode = isImageGenerationMode ? nil : .imageGeneration
     }
@@ -154,7 +161,8 @@ final class AIChatOmnibarController {
         suggestionsReader: AIChatSuggestionsReading? = nil,
         preferences: AIChatPreferencesPersisting = AIChatPreferencesPersistor(),
         modelsService: AIChatModelsProviding = AIChatModelsService(),
-        subscriptionManager: any SubscriptionManager = Application.appDelegate.subscriptionManager
+        subscriptionManager: any SubscriptionManager = Application.appDelegate.subscriptionManager,
+        aiChatURLProvider: @escaping () -> URL = { AIChatRemoteSettings().aiChatURL }
     ) {
         self.aiChatTabOpener = aiChatTabOpener
         self.tabCollectionViewModel = tabCollectionViewModel
@@ -165,12 +173,21 @@ final class AIChatOmnibarController {
         self.preferences = preferences
         self.modelsService = modelsService
         self.subscriptionManager = subscriptionManager
+        self.aiChatURLProvider = aiChatURLProvider
         self.suggestionsViewModel = AIChatSuggestionsViewModel(
             maxSuggestions: suggestionsReader?.maxHistoryCount ?? AIChatSuggestionsViewModel.defaultMaxSuggestions
         )
 
         subscribeToSelectedTabViewModel()
         subscribeToTextChangesForSuggestions()
+    }
+
+    /// Opens a new voice-chat tab from the AI chat omnibar. Mirrors the `Duck.ai → New Voice Chat`
+    /// menu action: a new selected tab loaded with the voice-mode URL.
+    func openNewVoiceChat() {
+        let url = AIChatURLParameters.voiceModeURL(from: aiChatURLProvider())
+        aiChatTabOpener.openAIChatTab(with: .url(url), behavior: .newTab(selected: true))
+        PixelKit.fire(AIChatPixel.aiChatNewVoiceChatOmnibarNative, frequency: .dailyAndStandard, includeAppVersionParameter: true)
     }
 
     private func subscribeToTextChangesForSuggestions() {

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -184,7 +184,7 @@ final class AIChatOmnibarController {
     /// off `mode: voice-mode` via the prompt handler.
     func openNewVoiceChat() {
         aiChatTabOpener.openVoiceSession(
-            inWindowOf: tabCollectionViewModel.selectedTab,
+            inSourceCollection: tabCollectionViewModel,
             behavior: .newTab(selected: true)
         )
         PixelKit.fire(AIChatPixel.aiChatNewVoiceChatOmnibarNative, frequency: .dailyAndStandard, includeAppVersionParameter: true)

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
@@ -300,6 +300,14 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
                 return true
             }
 
+            // Mirror the visible button state: when the input is empty and the voice-chat
+            // affordance is showing, Enter should activate voice rather than no-op via `submit()`.
+            let trimmed = omnibarController.currentText.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty && omnibarController.isVoiceChatAccessEnabled && !omnibarController.isImageGenerationMode {
+                omnibarController.openNewVoiceChat()
+                return true
+            }
+
             omnibarController.submit()
             return true
         } else if commandSelector == #selector(NSResponder.insertTab(_:)) {

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
@@ -300,14 +300,9 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
                 return true
             }
 
-            // Mirror the visible button state: when the input is empty and the voice-chat
-            // affordance is showing, Enter should activate voice rather than no-op via `submit()`.
-            let trimmed = omnibarController.currentText.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmed.isEmpty && omnibarController.isVoiceChatAccessEnabled && !omnibarController.isImageGenerationMode {
-                omnibarController.openNewVoiceChat()
-                return true
-            }
-
+            // Voice handoff requires an explicit click on the voice button. Enter on an empty
+            // input must not implicitly start a voice session — it stays a no-op via `submit()`,
+            // mirroring the legacy disabled-submit behavior.
             omnibarController.submit()
             return true
         } else if commandSelector == #selector(NSResponder.insertTab(_:)) {

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -225,6 +225,9 @@ enum AIChatPixel: PixelKitEvent {
     /// Event Trigger: User selects a reasoning effort from the native omnibar picker
     case aiChatAddressBarReasoningEffortSelected
 
+    /// Event Trigger: User opens a new voice Duck.ai chat from the native omnibar
+    case aiChatNewVoiceChatOmnibarNative
+
     // MARK: - Image Generation Mode
 
     /// Event Trigger: User activates image generation mode via the Tools menu
@@ -258,6 +261,9 @@ enum AIChatPixel: PixelKitEvent {
 
     /// Event Trigger: User taps "View all chats" from the New Tab Page omnibar
     case aiChatNtpViewAllChatsClicked
+
+    /// Event Trigger: User opens a new voice Duck.ai chat from the New Tab Page omnibar
+    case aiChatNewVoiceChatOmnibarNtp
 
     // MARK: - NTP Image Generation Mode
 
@@ -489,6 +495,8 @@ enum AIChatPixel: PixelKitEvent {
             return "aichat_addressbar_model_selected"
         case .aiChatAddressBarReasoningEffortSelected:
             return "aichat_addressbar_reasoning_effort_selected"
+        case .aiChatNewVoiceChatOmnibarNative:
+            return "aichat_new_voice_chat_omnibar_native"
         case .aiChatAddressBarImageGenerationActivated:
             return "aichat_addressbar_image_generation_activated"
         case .aiChatAddressBarImageGenerationDeactivated:
@@ -509,6 +517,8 @@ enum AIChatPixel: PixelKitEvent {
             return "aichat_ntp_reasoning_effort_selected"
         case .aiChatNtpViewAllChatsClicked:
             return "aichat_ntp_view_all_chats_clicked"
+        case .aiChatNewVoiceChatOmnibarNtp:
+            return "aichat_new_voice_chat_omnibar_ntp"
         case .aiChatNtpImageGenerationSubmitted:
             return "aichat_ntp_image_generation_submitted"
         case .aiChatNtpWebSearchSubmitted:
@@ -617,6 +627,7 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatNtpModelSelected,
                 .aiChatNtpReasoningEffortSelected,
                 .aiChatNtpViewAllChatsClicked,
+                .aiChatNewVoiceChatOmnibarNtp,
                 .aiChatNtpImageGenerationSubmitted,
                 .aiChatNtpWebSearchSubmitted,
                 .aiChatViewAllChatsClicked,
@@ -628,6 +639,7 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatOpenDuckAiMainMenu,
                 .aiChatNewChatMainMenu,
                 .aiChatNewVoiceChatMainMenu,
+                .aiChatNewVoiceChatOmnibarNative,
                 .aiChatNewImageChatMainMenu,
                 .aiChatRecentChatSelectedMainMenu,
                 .aiChatDeleteAllChatsMainMenu,
@@ -742,6 +754,7 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatNtpModelSelected,
                 .aiChatNtpReasoningEffortSelected,
                 .aiChatNtpViewAllChatsClicked,
+                .aiChatNewVoiceChatOmnibarNtp,
                 .aiChatNtpImageGenerationSubmitted,
                 .aiChatNtpWebSearchSubmitted,
                 .aiChatViewAllChatsClicked,
@@ -753,6 +766,7 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatOpenDuckAiMainMenu,
                 .aiChatNewChatMainMenu,
                 .aiChatNewVoiceChatMainMenu,
+                .aiChatNewVoiceChatOmnibarNative,
                 .aiChatNewImageChatMainMenu,
                 .aiChatRecentChatSelectedMainMenu,
                 .aiChatDeleteAllChatsMainMenu,

--- a/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
@@ -48,6 +48,12 @@ enum AIChatOpenTrigger {
     /// Opens an existing AI chat by its chat ID.
     /// - Parameter chatId: The unique identifier of the chat to open.
     case existingChat(chatId: String)
+
+    /// Opens a new AI chat session pre-set with a `mode` value in the prompt handoff.
+    /// Used for mode-driven entry points (e.g. voice) where there is no user query but Duck.ai
+    /// must route to a specific flow based on the mode — same mechanism image-generation submissions use.
+    /// - Parameter mode: The mode string forwarded in the native prompt payload (e.g. `AIChatNativePrompt.voiceMode`).
+    case mode(String)
 }
 
 /// Protocol defining the interface for opening AI chat tabs.
@@ -115,6 +121,11 @@ struct AIChatTabOpener: AIChatTabOpening {
         case .existingChat(let chatId):
             let chatURL = buildChatURL(for: chatId)
             aiChatTabManaging.openAIChat(chatURL, with: behavior, hasPrompt: false)
+
+        case .mode(let mode):
+            let prompt = AIChatNativePrompt.queryPrompt("", autoSubmit: false, mode: mode)
+            promptHandler.setData(prompt)
+            aiChatTabManaging.openAIChat(aiChatRemoteSettings.aiChatURL, with: behavior, hasPrompt: true)
         }
     }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import AIChat
+import OSLog
 
 /// Represents different triggers for opening an AI chat tab.
 ///
@@ -82,6 +83,22 @@ protocol AIChatTabOpening {
     /// - Parameter linkOpenBehavior: The `LinkOpenBehavior` determining where the new chat tab should open.
     @MainActor
     func openNewAIChat(in linkOpenBehavior: LinkOpenBehavior)
+
+    /// Opens a Duck.ai voice chat. If the same window already has a tab hosting an active voice
+    /// session (signalled by Duck.ai's `voiceSessionStarted` user-script message), focuses that
+    /// tab instead of opening a new one. Otherwise opens a fresh tab and hands off `mode: voice-mode`
+    /// via the prompt payload — same handoff mechanism image generation uses.
+    ///
+    /// On the focus-existing branch the prompt handler is intentionally NOT updated: the existing
+    /// voice tab keeps its in-progress state. Mirrors Windows-browser's `WillActivateExistingVoiceTab`
+    /// guard, which prevents a stale cached prompt from overriding the next real submission.
+    ///
+    /// - Parameters:
+    ///   - sourceTab: The tab the request originated from. Used to scope the lookup to the same
+    ///     window — voice in window A doesn't focus a voice tab in window B.
+    ///   - behavior: The `LinkOpenBehavior` used when opening a fresh voice tab.
+    @MainActor
+    func openVoiceSession(inWindowOf sourceTab: Tab?, behavior: LinkOpenBehavior)
 }
 
 struct AIChatTabOpener: AIChatTabOpening {
@@ -134,6 +151,14 @@ struct AIChatTabOpener: AIChatTabOpening {
         openAIChatTab(with: .newChat, behavior: linkOpenBehavior)
     }
 
+    @MainActor
+    func openVoiceSession(inWindowOf sourceTab: Tab?, behavior: LinkOpenBehavior) {
+        let didFocus = aiChatTabManaging.focusActiveVoiceSessionTab(inWindowOf: sourceTab)
+        Logger.aiChat.log("[VoiceSession.openVoiceSession] didFocus=\(didFocus, privacy: .public) — \(didFocus ? "skipping new-tab open" : "opening fresh voice tab", privacy: .public)")
+        if didFocus { return }
+        openAIChatTab(with: .mode(AIChatNativePrompt.voiceMode), behavior: behavior)
+    }
+
     // MARK: - Private Helpers
 
     @MainActor
@@ -169,6 +194,13 @@ protocol AIChatTabManaging {
 
     @MainActor
     func insertAIChatTab(with url: URL, restorationData: AIChatRestorationData)
+
+    /// If a tab in the same window as `sourceTab` currently hosts an active Duck.ai voice
+    /// session, focuses that window and selects the tab. Returns `true` on success so callers
+    /// can short-circuit before opening a new tab. Returns `false` when there's no active
+    /// voice tab in scope or no source-tab context.
+    @MainActor
+    func focusActiveVoiceSessionTab(inWindowOf sourceTab: Tab?) -> Bool
 }
 
 extension WindowControllersManager: AIChatTabManaging {
@@ -214,5 +246,28 @@ extension WindowControllersManager: AIChatTabManaging {
         let newAIChatTab = Tab(content: .url(url, source: .ui), burnerMode: tabCollectionViewModel.burnerMode)
         newAIChatTab.aiChat?.setAIChatRestorationData(restorationData)
         tabCollectionViewModel.insertOrAppend(tab: newAIChatTab, selected: true)
+    }
+
+    @MainActor
+    func focusActiveVoiceSessionTab(inWindowOf sourceTab: Tab?) -> Bool {
+        guard let target = voiceSessionTracker.findActiveVoiceTab(inWindowOf: sourceTab) else {
+            Logger.aiChat.log("[VoiceSession.focus] no active voice tab in source window")
+            return false
+        }
+        // Find the window controller hosting the target tab and select that tab. `AnyTab` is an
+        // enum, so we must pattern-match `.loaded` instead of attempting a class downcast.
+        for windowController in mainWindowControllers {
+            let tabCollectionViewModel = windowController.mainViewController.tabCollectionViewModel
+            guard let index = tabCollectionViewModel.indexInAllTabs(where: { anyTab in
+                if case .loaded(let tab) = anyTab { return tab === target }
+                return false
+            }) else { continue }
+            Logger.aiChat.log("[VoiceSession.focus] focusing tab id=\(ObjectIdentifier(target).hashValue, privacy: .public) at index=\(String(describing: index), privacy: .public)")
+            windowController.window?.makeKeyAndOrderFront(self)
+            tabCollectionViewModel.select(at: index)
+            return true
+        }
+        Logger.aiChat.log("[VoiceSession.focus] target tab id=\(ObjectIdentifier(target).hashValue, privacy: .public) NOT found in any window — stale entry?")
+        return false
     }
 }

--- a/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
@@ -18,7 +18,6 @@
 
 import Foundation
 import AIChat
-import OSLog
 
 /// Represents different triggers for opening an AI chat tab.
 ///
@@ -94,11 +93,14 @@ protocol AIChatTabOpening {
     /// guard, which prevents a stale cached prompt from overriding the next real submission.
     ///
     /// - Parameters:
-    ///   - sourceTab: The tab the request originated from. Used to scope the lookup to the same
-    ///     window — voice in window A doesn't focus a voice tab in window B.
+    ///   - sourceCollection: The `TabCollectionViewModel` of the window the request originated
+    ///     from. Used to scope the lookup to that window — voice in window A doesn't focus a
+    ///     voice tab in window B. Pass the user-facing window's TCVM rather than a tab so the
+    ///     scope is unambiguous when the source is a pinned tab (pinned tabs are shared across
+    ///     windows; a tab-only argument leaves the source-window ambiguous).
     ///   - behavior: The `LinkOpenBehavior` used when opening a fresh voice tab.
     @MainActor
-    func openVoiceSession(inWindowOf sourceTab: Tab?, behavior: LinkOpenBehavior)
+    func openVoiceSession(inSourceCollection sourceCollection: TabCollectionViewModel?, behavior: LinkOpenBehavior)
 }
 
 struct AIChatTabOpener: AIChatTabOpening {
@@ -152,10 +154,10 @@ struct AIChatTabOpener: AIChatTabOpening {
     }
 
     @MainActor
-    func openVoiceSession(inWindowOf sourceTab: Tab?, behavior: LinkOpenBehavior) {
-        let didFocus = aiChatTabManaging.focusActiveVoiceSessionTab(inWindowOf: sourceTab)
-        Logger.aiChat.log("[VoiceSession.openVoiceSession] didFocus=\(didFocus, privacy: .public) — \(didFocus ? "skipping new-tab open" : "opening fresh voice tab", privacy: .public)")
-        if didFocus { return }
+    func openVoiceSession(inSourceCollection sourceCollection: TabCollectionViewModel?, behavior: LinkOpenBehavior) {
+        if aiChatTabManaging.focusActiveVoiceSessionTab(inSourceCollection: sourceCollection) {
+            return
+        }
         openAIChatTab(with: .mode(AIChatNativePrompt.voiceMode), behavior: behavior)
     }
 
@@ -195,12 +197,12 @@ protocol AIChatTabManaging {
     @MainActor
     func insertAIChatTab(with url: URL, restorationData: AIChatRestorationData)
 
-    /// If a tab in the same window as `sourceTab` currently hosts an active Duck.ai voice
-    /// session, focuses that window and selects the tab. Returns `true` on success so callers
-    /// can short-circuit before opening a new tab. Returns `false` when there's no active
-    /// voice tab in scope or no source-tab context.
+    /// If a tab in `sourceCollection`'s window currently hosts an active Duck.ai voice session,
+    /// focuses that window and selects the tab. When the original session was hosted in a Duck.ai
+    /// sidebar, also surfaces the sidebar so the user lands on the in-progress voice UI.
+    /// Returns `true` on success so callers can short-circuit before opening a new tab.
     @MainActor
-    func focusActiveVoiceSessionTab(inWindowOf sourceTab: Tab?) -> Bool
+    func focusActiveVoiceSessionTab(inSourceCollection sourceCollection: TabCollectionViewModel?) -> Bool
 }
 
 extension WindowControllersManager: AIChatTabManaging {
@@ -249,9 +251,8 @@ extension WindowControllersManager: AIChatTabManaging {
     }
 
     @MainActor
-    func focusActiveVoiceSessionTab(inWindowOf sourceTab: Tab?) -> Bool {
-        guard let target = voiceSessionTracker.findActiveVoiceTab(inWindowOf: sourceTab) else {
-            Logger.aiChat.log("[VoiceSession.focus] no active voice tab in source window")
+    func focusActiveVoiceSessionTab(inSourceCollection sourceCollection: TabCollectionViewModel?) -> Bool {
+        guard let target = voiceSessionTracker.findActiveVoiceTab(in: sourceCollection) else {
             return false
         }
         // Find the window controller hosting the target tab and select that tab. `AnyTab` is an
@@ -262,12 +263,10 @@ extension WindowControllersManager: AIChatTabManaging {
                 if case .loaded(let tab) = anyTab { return tab === target }
                 return false
             }) else { continue }
-            Logger.aiChat.log("[VoiceSession.focus] focusing tab id=\(ObjectIdentifier(target).hashValue, privacy: .public) at index=\(String(describing: index), privacy: .public)")
             windowController.window?.makeKeyAndOrderFront(self)
             tabCollectionViewModel.select(at: index)
             return true
         }
-        Logger.aiChat.log("[VoiceSession.focus] target tab id=\(ObjectIdentifier(target).hashValue, privacy: .public) NOT found in any window — stale entry?")
         return false
     }
 }

--- a/macOS/DuckDuckGo/AIChat/Sidebar/AIChatCoordinator.swift
+++ b/macOS/DuckDuckGo/AIChat/Sidebar/AIChatCoordinator.swift
@@ -813,4 +813,3 @@ private extension AIChatCoordinator {
         pixelFiring?.fire(pixel, frequency: .dailyAndStandard)
     }
 }
-

--- a/macOS/DuckDuckGo/AIChat/Sidebar/AIChatCoordinator.swift
+++ b/macOS/DuckDuckGo/AIChat/Sidebar/AIChatCoordinator.swift
@@ -813,3 +813,4 @@ private extension AIChatCoordinator {
         pixelFiring?.fire(pixel, frequency: .dailyAndStandard)
     }
 }
+

--- a/macOS/DuckDuckGo/AIChat/Suggestions/AIChatSuggestionRowView.swift
+++ b/macOS/DuckDuckGo/AIChat/Suggestions/AIChatSuggestionRowView.swift
@@ -190,9 +190,22 @@ final class AIChatSuggestionRowView: NSView {
     private func configure(with suggestion: AIChatSuggestion) {
         titleLabel.stringValue = suggestion.title
 
-        let icon = suggestion.isPinned
-            ? DesignSystemImages.Glyphs.Size16.pin
-            : DesignSystemImages.Glyphs.Size16.chat
+        // Pinned chats override the kind-based icon. For non-pinned chats, the icon reflects
+        // the chat's kind — voice and image chats get their own glyphs (derived from the
+        // persisted model on the Duck.ai stored record), everything else uses the chat bubble.
+        let icon: NSImage
+        if suggestion.isPinned {
+            icon = DesignSystemImages.Glyphs.Size16.pin
+        } else {
+            switch suggestion.kind {
+            case .voice:
+                icon = DesignSystemImages.Glyphs.Size16.voice
+            case .image:
+                icon = DesignSystemImages.Glyphs.Size16.image
+            case .text:
+                icon = DesignSystemImages.Glyphs.Size16.chat
+            }
+        }
         iconImageView.image = icon
         iconImageView.contentTintColor = Constants.iconColor
     }

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
@@ -170,6 +170,10 @@ final class AIChatUserScript: NSObject, Subfeature {
             return handler.sendToSyncSettings
         case .setAIChatHistoryEnabled:
             return handler.setAIChatHistoryEnabled
+        case .voiceSessionStarted:
+            return handler.voiceSessionStarted
+        case .voiceSessionEnded:
+            return handler.voiceSessionEnded
         default:
             return nil
         }

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -80,6 +80,13 @@ protocol AIChatUserScriptHandling: AnyObject {
     func sendToSyncSettings(params: Any, message: UserScriptMessage) -> Encodable?
     func sendToSetupSync(params: Any, message: UserScriptMessage) -> Encodable?
     func setAIChatHistoryEnabled(params: Any, message: UserScriptMessage) -> Encodable?
+
+    /// Voice-session lifecycle messages from Duck.ai. Native rebroadcasts them as
+    /// `aiChatVoiceSessionStarted` / `aiChatVoiceSessionEnded` notifications carrying the
+    /// source `WKWebView` as `object`, so observers (`VoiceSessionTracker`) can map back
+    /// to the owning `Tab` and decide whether to focus it instead of opening a new one.
+    @MainActor func voiceSessionStarted(params: Any, message: UserScriptMessage) async -> Encodable?
+    @MainActor func voiceSessionEnded(params: Any, message: UserScriptMessage) async -> Encodable?
 }
 
 final class AIChatUserScriptHandler: AIChatUserScriptHandling {
@@ -616,6 +623,24 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
         }
 
         syncServiceProvider()?.setAIChatHistoryEnabled(enabled)
+        return nil
+    }
+
+    // MARK: - Voice Session
+
+    @MainActor
+    func voiceSessionStarted(params: Any, message: UserScriptMessage) async -> Encodable? {
+        let webViewID = message.messageWebView.map { ObjectIdentifier($0).hashValue } ?? 0
+        Logger.aiChat.log("[VoiceSession] started — webView id=\(webViewID, privacy: .public)")
+        notificationCenter.post(name: .aiChatVoiceSessionStarted, object: message.messageWebView)
+        return nil
+    }
+
+    @MainActor
+    func voiceSessionEnded(params: Any, message: UserScriptMessage) async -> Encodable? {
+        let webViewID = message.messageWebView.map { ObjectIdentifier($0).hashValue } ?? 0
+        Logger.aiChat.log("[VoiceSession] ended — webView id=\(webViewID, privacy: .public)")
+        notificationCenter.post(name: .aiChatVoiceSessionEnded, object: message.messageWebView)
         return nil
     }
 

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -630,16 +630,12 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
 
     @MainActor
     func voiceSessionStarted(params: Any, message: UserScriptMessage) async -> Encodable? {
-        let webViewID = message.messageWebView.map { ObjectIdentifier($0).hashValue } ?? 0
-        Logger.aiChat.log("[VoiceSession] started — webView id=\(webViewID, privacy: .public)")
         notificationCenter.post(name: .aiChatVoiceSessionStarted, object: message.messageWebView)
         return nil
     }
 
     @MainActor
     func voiceSessionEnded(params: Any, message: UserScriptMessage) async -> Encodable? {
-        let webViewID = message.messageWebView.map { ObjectIdentifier($0).hashValue } ?? 0
-        Logger.aiChat.log("[VoiceSession] ended — webView id=\(webViewID, privacy: .public)")
         notificationCenter.post(name: .aiChatVoiceSessionEnded, object: message.messageWebView)
         return nil
     }

--- a/macOS/DuckDuckGo/AIChat/VoiceSessionTracker.swift
+++ b/macOS/DuckDuckGo/AIChat/VoiceSessionTracker.swift
@@ -19,7 +19,6 @@
 import AIChat
 import AppKit
 import Foundation
-import OSLog
 import WebKit
 
 /// Tracks which `Tab`s currently host an active Duck.ai voice session.
@@ -30,9 +29,11 @@ import WebKit
 /// `WKWebView`; the tracker resolves that webView back to its owning `Tab` via
 /// `WindowControllersManagerProtocol.allTabCollectionViewModels`.
 ///
-/// Lookups are window-scoped (`findActiveVoiceTab(inWindowOf:)`), so opening a new voice chat
-/// in one window doesn't pull the user across to a voice tab in a different window — matching
-/// the Windows-browser behavior. Closed tabs auto-evict because the storage uses weak references.
+/// Lookups are window-scoped: callers pass the source `TabCollectionViewModel` (each window
+/// has its own), so opening a new voice chat in one window doesn't pull the user across to a
+/// voice tab in a different window — matching the Windows-browser behavior. Pinned tabs are
+/// shared across windows; a pinned voice tab is treated as visible from any source window.
+/// Closed tabs auto-evict because the storage uses weak references.
 @MainActor
 final class VoiceSessionTracker: NSObject {
 
@@ -57,108 +58,69 @@ final class VoiceSessionTracker: NSObject {
         notificationCenter.removeObserver(self)
     }
 
-    /// Returns any tracked active voice tab that lives in the same window as `sourceTab`.
-    /// Returns `nil` when no source is supplied (no window context available — better to
-    /// open a new tab than to focus an arbitrary one).
-    func findActiveVoiceTab(inWindowOf sourceTab: Tab?) -> Tab? {
-        let activeCount = activeTabs.count
-        Logger.aiChat.log("[VoiceSessionTracker] findActiveVoiceTab — sourceTab=\(sourceTab.map { ObjectIdentifier($0).hashValue } ?? 0, privacy: .public) activeCount=\(activeCount, privacy: .public)")
-        guard let sourceTab else {
-            Logger.aiChat.log("[VoiceSessionTracker] findActiveVoiceTab — no sourceTab, returning nil")
+    /// Returns any tracked active voice tab visible from `sourceCollection`'s window.
+    /// A candidate matches when it's an unpinned tab in `sourceCollection` (same window) or
+    /// when it's a pinned tab (pinned tabs are shared across all windows, so any source window
+    /// is allowed to focus a pinned voice tab). Returns `nil` when no source is supplied.
+    func findActiveVoiceTab(in sourceCollection: TabCollectionViewModel?) -> Tab? {
+        guard let sourceCollection else { return nil }
+        let unpinned = sourceCollection.unpinnedLoadedTabs
+        let pinned = sourceCollection.pinnedTabsCollection?.tabs.compactMap { anyTab -> Tab? in
+            if case .loaded(let tab) = anyTab { return tab }
             return nil
-        }
-        guard let manager = windowControllersManager else {
-            Logger.aiChat.log("[VoiceSessionTracker] findActiveVoiceTab — windowControllersManager nil")
-            return nil
-        }
-        guard let sourceCollection = tabCollectionViewModel(containing: sourceTab, in: manager) else {
-            Logger.aiChat.log("[VoiceSessionTracker] findActiveVoiceTab — sourceTab not found in any window's collection")
-            return nil
-        }
+        } ?? []
+
         for case let candidate as Tab in activeTabs.allObjects {
-            let candidateCollection = tabCollectionViewModel(containing: candidate, in: manager)
-            let candidateInSameWindow = candidateCollection === sourceCollection
-            Logger.aiChat.log("[VoiceSessionTracker]   candidate id=\(ObjectIdentifier(candidate).hashValue, privacy: .public) sameWindow=\(candidateInSameWindow, privacy: .public)")
-            if candidateInSameWindow {
-                Logger.aiChat.log("[VoiceSessionTracker] findActiveVoiceTab — match found")
+            if unpinned.contains(where: { $0 === candidate }) || pinned.contains(where: { $0 === candidate }) {
                 return candidate
             }
         }
-        Logger.aiChat.log("[VoiceSessionTracker] findActiveVoiceTab — no match in source window")
         return nil
     }
 
     @objc private func voiceSessionStarted(_ note: Notification) {
-        guard let webView = note.object as? WKWebView else {
-            Logger.aiChat.log("[VoiceSessionTracker] received `started` notification with non-WKWebView object=\(String(describing: note.object), privacy: .public)")
-            return
-        }
-        let webViewID = ObjectIdentifier(webView).hashValue
-        guard let tab = tab(for: webView) else {
-            Logger.aiChat.log("[VoiceSessionTracker] no Tab found for webView id=\(webViewID, privacy: .public) on `started` — known webViews=\(self.knownWebViewIDs(), privacy: .public)")
-            return
-        }
-        Logger.aiChat.log("[VoiceSessionTracker] tracking tab id=\(ObjectIdentifier(tab).hashValue, privacy: .public) webView=\(webViewID, privacy: .public) (active count → \(self.activeTabs.count + 1, privacy: .public))")
+        guard let webView = note.object as? WKWebView,
+              let tab = tab(for: webView) else { return }
         activeTabs.add(tab)
     }
 
     @objc private func voiceSessionEnded(_ note: Notification) {
-        guard let webView = note.object as? WKWebView else {
-            Logger.aiChat.log("[VoiceSessionTracker] received `ended` notification with non-WKWebView object=\(String(describing: note.object), privacy: .public)")
-            return
-        }
-        let webViewID = ObjectIdentifier(webView).hashValue
-        guard let tab = tab(for: webView) else {
-            Logger.aiChat.log("[VoiceSessionTracker] no Tab found for webView id=\(webViewID, privacy: .public) on `ended`")
-            return
-        }
-        Logger.aiChat.log("[VoiceSessionTracker] clearing tab id=\(ObjectIdentifier(tab).hashValue, privacy: .public) webView=\(webViewID, privacy: .public)")
+        guard let webView = note.object as? WKWebView,
+              let tab = tab(for: webView) else { return }
         activeTabs.remove(tab)
     }
 
+    /// Resolves a webView to its owning main-browser `Tab`, if any.
     private func tab(for webView: WKWebView) -> Tab? {
-        guard let manager = windowControllersManager else {
-            Logger.aiChat.log("[VoiceSessionTracker] tab(for:) — windowControllersManager is nil")
-            return nil
-        }
+        guard let manager = windowControllersManager else { return nil }
         for tabCollectionViewModel in manager.allTabCollectionViewModels {
-            if let tab = allTabs(in: tabCollectionViewModel).first(where: { $0.webView === webView }) {
+            for tab in allLoadedTabs(in: tabCollectionViewModel) where tab.webView === webView {
                 return tab
             }
         }
         return nil
     }
 
-    /// Diagnostic — comma-separated list of all currently-known tab webView identity hashes.
-    /// Used in logs when a `started` notification's webView can't be matched to a tab.
-    private func knownWebViewIDs() -> String {
-        guard let manager = windowControllersManager else { return "<nil mgr>" }
-        var ids: [Int] = []
-        for tcvm in manager.allTabCollectionViewModels {
-            for tab in allTabs(in: tcvm) {
-                ids.append(ObjectIdentifier(tab.webView).hashValue)
-            }
-        }
-        return ids.map(String.init).joined(separator: ",")
-    }
-
-    private func tabCollectionViewModel(containing tab: Tab, in manager: WindowControllersManagerProtocol) -> TabCollectionViewModel? {
-        manager.allTabCollectionViewModels.first(where: { tcvm in
-            allTabs(in: tcvm).contains(where: { $0 === tab })
-        })
-    }
-
     /// Concrete `Tab`s in both pinned and unpinned collections. `AnyTab` is an enum
     /// (`.loaded(Tab)` / `.unloaded(UnloadedTab)`) — only `.loaded` has a `WKWebView`, and
     /// voice sessions require a webview, so unloaded entries are skipped.
-    private func allTabs(in tabCollectionViewModel: TabCollectionViewModel) -> [Tab] {
-        var result: [Tab] = []
-        for anyTab in tabCollectionViewModel.tabs {
-            if case .loaded(let tab) = anyTab { result.append(tab) }
-        }
+    private func allLoadedTabs(in tabCollectionViewModel: TabCollectionViewModel) -> [Tab] {
+        var result = tabCollectionViewModel.unpinnedLoadedTabs
         for anyTab in tabCollectionViewModel.pinnedTabsCollection?.tabs ?? [] {
             if case .loaded(let tab) = anyTab { result.append(tab) }
         }
         return result
+    }
+}
+
+// MARK: - TabCollectionViewModel helpers
+
+private extension TabCollectionViewModel {
+    /// Unpinned tabs that have a materialized webview (excludes `.unloaded`).
+    var unpinnedLoadedTabs: [Tab] {
+        tabs.compactMap { anyTab in
+            if case .loaded(let tab) = anyTab { return tab }
+            return nil
+        }
     }
 }

--- a/macOS/DuckDuckGo/AIChat/VoiceSessionTracker.swift
+++ b/macOS/DuckDuckGo/AIChat/VoiceSessionTracker.swift
@@ -1,0 +1,164 @@
+//
+//  VoiceSessionTracker.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import AppKit
+import Foundation
+import OSLog
+import WebKit
+
+/// Tracks which `Tab`s currently host an active Duck.ai voice session.
+///
+/// Source of truth is the `aiChatVoiceSessionStarted` / `aiChatVoiceSessionEnded` user-script
+/// messages Duck.ai dispatches when a voice session actually begins/ends — independent of
+/// the URL, which Duck.ai may rewrite after load. Each notification's `object` is the source
+/// `WKWebView`; the tracker resolves that webView back to its owning `Tab` via
+/// `WindowControllersManagerProtocol.allTabCollectionViewModels`.
+///
+/// Lookups are window-scoped (`findActiveVoiceTab(inWindowOf:)`), so opening a new voice chat
+/// in one window doesn't pull the user across to a voice tab in a different window — matching
+/// the Windows-browser behavior. Closed tabs auto-evict because the storage uses weak references.
+@MainActor
+final class VoiceSessionTracker: NSObject {
+
+    /// Tabs with an active voice session. `NSHashTable.weakObjects()` keeps weak references —
+    /// closed tabs disappear without explicit cleanup, so we don't need to subscribe to a
+    /// "tab removed" event.
+    private let activeTabs: NSHashTable<Tab> = .weakObjects()
+
+    private let notificationCenter: NotificationCenter
+    private weak var windowControllersManager: WindowControllersManagerProtocol?
+
+    init(notificationCenter: NotificationCenter = .default,
+         windowControllersManager: WindowControllersManagerProtocol) {
+        self.notificationCenter = notificationCenter
+        self.windowControllersManager = windowControllersManager
+        super.init()
+        notificationCenter.addObserver(self, selector: #selector(voiceSessionStarted(_:)), name: .aiChatVoiceSessionStarted, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(voiceSessionEnded(_:)), name: .aiChatVoiceSessionEnded, object: nil)
+    }
+
+    deinit {
+        notificationCenter.removeObserver(self)
+    }
+
+    /// Returns any tracked active voice tab that lives in the same window as `sourceTab`.
+    /// Returns `nil` when no source is supplied (no window context available — better to
+    /// open a new tab than to focus an arbitrary one).
+    func findActiveVoiceTab(inWindowOf sourceTab: Tab?) -> Tab? {
+        let activeCount = activeTabs.count
+        Logger.aiChat.log("[VoiceSessionTracker] findActiveVoiceTab — sourceTab=\(sourceTab.map { ObjectIdentifier($0).hashValue } ?? 0, privacy: .public) activeCount=\(activeCount, privacy: .public)")
+        guard let sourceTab else {
+            Logger.aiChat.log("[VoiceSessionTracker] findActiveVoiceTab — no sourceTab, returning nil")
+            return nil
+        }
+        guard let manager = windowControllersManager else {
+            Logger.aiChat.log("[VoiceSessionTracker] findActiveVoiceTab — windowControllersManager nil")
+            return nil
+        }
+        guard let sourceCollection = tabCollectionViewModel(containing: sourceTab, in: manager) else {
+            Logger.aiChat.log("[VoiceSessionTracker] findActiveVoiceTab — sourceTab not found in any window's collection")
+            return nil
+        }
+        for case let candidate as Tab in activeTabs.allObjects {
+            let candidateCollection = tabCollectionViewModel(containing: candidate, in: manager)
+            let candidateInSameWindow = candidateCollection === sourceCollection
+            Logger.aiChat.log("[VoiceSessionTracker]   candidate id=\(ObjectIdentifier(candidate).hashValue, privacy: .public) sameWindow=\(candidateInSameWindow, privacy: .public)")
+            if candidateInSameWindow {
+                Logger.aiChat.log("[VoiceSessionTracker] findActiveVoiceTab — match found")
+                return candidate
+            }
+        }
+        Logger.aiChat.log("[VoiceSessionTracker] findActiveVoiceTab — no match in source window")
+        return nil
+    }
+
+    @objc private func voiceSessionStarted(_ note: Notification) {
+        guard let webView = note.object as? WKWebView else {
+            Logger.aiChat.log("[VoiceSessionTracker] received `started` notification with non-WKWebView object=\(String(describing: note.object), privacy: .public)")
+            return
+        }
+        let webViewID = ObjectIdentifier(webView).hashValue
+        guard let tab = tab(for: webView) else {
+            Logger.aiChat.log("[VoiceSessionTracker] no Tab found for webView id=\(webViewID, privacy: .public) on `started` — known webViews=\(self.knownWebViewIDs(), privacy: .public)")
+            return
+        }
+        Logger.aiChat.log("[VoiceSessionTracker] tracking tab id=\(ObjectIdentifier(tab).hashValue, privacy: .public) webView=\(webViewID, privacy: .public) (active count → \(self.activeTabs.count + 1, privacy: .public))")
+        activeTabs.add(tab)
+    }
+
+    @objc private func voiceSessionEnded(_ note: Notification) {
+        guard let webView = note.object as? WKWebView else {
+            Logger.aiChat.log("[VoiceSessionTracker] received `ended` notification with non-WKWebView object=\(String(describing: note.object), privacy: .public)")
+            return
+        }
+        let webViewID = ObjectIdentifier(webView).hashValue
+        guard let tab = tab(for: webView) else {
+            Logger.aiChat.log("[VoiceSessionTracker] no Tab found for webView id=\(webViewID, privacy: .public) on `ended`")
+            return
+        }
+        Logger.aiChat.log("[VoiceSessionTracker] clearing tab id=\(ObjectIdentifier(tab).hashValue, privacy: .public) webView=\(webViewID, privacy: .public)")
+        activeTabs.remove(tab)
+    }
+
+    private func tab(for webView: WKWebView) -> Tab? {
+        guard let manager = windowControllersManager else {
+            Logger.aiChat.log("[VoiceSessionTracker] tab(for:) — windowControllersManager is nil")
+            return nil
+        }
+        for tabCollectionViewModel in manager.allTabCollectionViewModels {
+            if let tab = allTabs(in: tabCollectionViewModel).first(where: { $0.webView === webView }) {
+                return tab
+            }
+        }
+        return nil
+    }
+
+    /// Diagnostic — comma-separated list of all currently-known tab webView identity hashes.
+    /// Used in logs when a `started` notification's webView can't be matched to a tab.
+    private func knownWebViewIDs() -> String {
+        guard let manager = windowControllersManager else { return "<nil mgr>" }
+        var ids: [Int] = []
+        for tcvm in manager.allTabCollectionViewModels {
+            for tab in allTabs(in: tcvm) {
+                ids.append(ObjectIdentifier(tab.webView).hashValue)
+            }
+        }
+        return ids.map(String.init).joined(separator: ",")
+    }
+
+    private func tabCollectionViewModel(containing tab: Tab, in manager: WindowControllersManagerProtocol) -> TabCollectionViewModel? {
+        manager.allTabCollectionViewModels.first(where: { tcvm in
+            allTabs(in: tcvm).contains(where: { $0 === tab })
+        })
+    }
+
+    /// Concrete `Tab`s in both pinned and unpinned collections. `AnyTab` is an enum
+    /// (`.loaded(Tab)` / `.unloaded(UnloadedTab)`) — only `.loaded` has a `WKWebView`, and
+    /// voice sessions require a webview, so unloaded entries are skipped.
+    private func allTabs(in tabCollectionViewModel: TabCollectionViewModel) -> [Tab] {
+        var result: [Tab] = []
+        for anyTab in tabCollectionViewModel.tabs {
+            if case .loaded(let tab) = anyTab { result.append(tab) }
+        }
+        for anyTab in tabCollectionViewModel.pinnedTabsCollection?.tabs ?? [] {
+            if case .loaded(let tab) = anyTab { result.append(tab) }
+        }
+        return result
+    }
+}

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -671,6 +671,7 @@ struct UserText {
 
 
     static let aiChatSendButtonTooltip = NSLocalizedString("aichat.send-button.tooltip", value: "Send", comment: "Tooltip for the send button in AI chat omnibar")
+    static let aiChatVoiceChatButtonTooltip = NSLocalizedString("aichat.voice-chat-button.tooltip", value: "Start a voice chat", comment: "Tooltip for the voice chat button shown in the AI chat omnibar when the input is empty")
     static let aiChatSearchToggleButtonTooltip = NSLocalizedString("aichat.search-toggle-button.tooltip", value: "Search the web", comment: "Tooltip for the search toggle button in AI chat omnibar")
     static let aiChatImageUploadButtonTooltip = NSLocalizedString("aichat.image-upload-button.tooltip", value: "Attach image", comment: "Tooltip for the image upload button in AI chat omnibar")
     static let aiChatToolsButtonLabel = NSLocalizedString("aichat.tools-button.label", value: "Tools", comment: "Label for the tools dropdown button in AI chat omnibar")

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -5005,10 +5005,58 @@
       "comment" : "Tooltip for the voice chat button shown in the AI chat omnibar when the input is empty",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprachchat starten"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Start a voice chat"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar chat de voz"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Démarre un chat vocal"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avvia una chat vocale"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Een spraakchat starten"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rozpocznij czat głosowy"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar um chat de voz"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Начать голосовой чат"
           }
         }
       }

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -5001,6 +5001,18 @@
         }
       }
     },
+    "aichat.voice-chat-button.tooltip" : {
+      "comment" : "Tooltip for the voice chat button shown in the AI chat omnibar when the input is empty",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Start a voice chat"
+          }
+        }
+      }
+    },
     "aichat.web-search-button.deactivate-tooltip" : {
       "comment" : "Tooltip for the web search button when web search mode is active",
       "extractionState" : "extracted_with_value",

--- a/macOS/DuckDuckGo/Menus/AIChatMenu.swift
+++ b/macOS/DuckDuckGo/Menus/AIChatMenu.swift
@@ -258,8 +258,7 @@ extension AIChatMenu.Actions {
                 tabOpener.openAIChatTab(with: .newChat, behavior: .newTab(selected: true))
             },
             openNewVoiceChat: {
-                let url = AIChatURLParameters.voiceModeURL(from: remoteSettings.aiChatURL)
-                tabOpener.openAIChatTab(with: .url(url), behavior: .newTab(selected: true))
+                tabOpener.openAIChatTab(with: .mode(AIChatNativePrompt.voiceMode), behavior: .newTab(selected: true))
             },
             openNewImageChat: {
                 let url = AIChatURLParameters.imageModeURL(from: remoteSettings.aiChatURL)

--- a/macOS/DuckDuckGo/Menus/AIChatMenu.swift
+++ b/macOS/DuckDuckGo/Menus/AIChatMenu.swift
@@ -267,9 +267,9 @@ extension AIChatMenu.Actions {
                 tabOpener.openAIChatTab(with: .newChat, behavior: .newTab(selected: true))
             },
             openNewVoiceChat: {
-                let sourceTab = windowControllersManager.lastKeyMainWindowController?
-                    .mainViewController.tabCollectionViewModel.selectedTab
-                tabOpener.openVoiceSession(inWindowOf: sourceTab, behavior: .newTab(selected: true))
+                let sourceCollection = windowControllersManager.lastKeyMainWindowController?
+                    .mainViewController.tabCollectionViewModel
+                tabOpener.openVoiceSession(inSourceCollection: sourceCollection, behavior: .newTab(selected: true))
             },
             openNewImageChat: {
                 let url = AIChatURLParameters.imageModeURL(from: remoteSettings.aiChatURL)

--- a/macOS/DuckDuckGo/Menus/AIChatMenu.swift
+++ b/macOS/DuckDuckGo/Menus/AIChatMenu.swift
@@ -62,14 +62,23 @@ final class AIChatMenu: NSMenu {
     }()
 
     private lazy var newVoiceChatItem: NSMenuItem = {
-        let item = NSMenuItem(title: UserText.aiChatMenuNewVoiceChat, action: #selector(newVoiceChatTapped), keyEquivalent: "")
+        // Shortcut on the main menu only — More Options popups don't bind global keys.
+        // ⌥⌘V groups with Open Duck.ai's ⌥⌘N under the same modifier family.
+        let item = NSMenuItem(title: UserText.aiChatMenuNewVoiceChat, action: #selector(newVoiceChatTapped), keyEquivalent: origin == .mainMenu ? "v" : "")
+        if origin == .mainMenu {
+            item.keyEquivalentModifierMask = [.option, .command]
+        }
         item.target = self
         item.image = origin == .moreOptionsMenu ? DesignSystemImages.Glyphs.Size16.voice : DesignSystemImages.Glyphs.Size12.voice
         return item
     }()
 
     private lazy var newImageChatItem: NSMenuItem = {
-        let item = NSMenuItem(title: UserText.aiChatMenuNewImageChat, action: #selector(newImageChatTapped), keyEquivalent: "")
+        // ⌥⌘G — G for "Generate" image; ⌥⌘I and ⌥⌘C are taken by Web Inspector / JS Console.
+        let item = NSMenuItem(title: UserText.aiChatMenuNewImageChat, action: #selector(newImageChatTapped), keyEquivalent: origin == .mainMenu ? "g" : "")
+        if origin == .mainMenu {
+            item.keyEquivalentModifierMask = [.option, .command]
+        }
         item.target = self
         item.image = origin == .moreOptionsMenu ? DesignSystemImages.Glyphs.Size16.images : DesignSystemImages.Glyphs.Size12.images
         return item
@@ -258,7 +267,9 @@ extension AIChatMenu.Actions {
                 tabOpener.openAIChatTab(with: .newChat, behavior: .newTab(selected: true))
             },
             openNewVoiceChat: {
-                tabOpener.openAIChatTab(with: .mode(AIChatNativePrompt.voiceMode), behavior: .newTab(selected: true))
+                let sourceTab = windowControllersManager.lastKeyMainWindowController?
+                    .mainViewController.tabCollectionViewModel.selectedTab
+                tabOpener.openVoiceSession(inWindowOf: sourceTab, behavior: .newTab(selected: true))
             },
             openNewImageChat: {
                 let url = AIChatURLParameters.imageModeURL(from: remoteSettings.aiChatURL)

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
@@ -155,9 +155,9 @@ final class NewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandling {
         // in-progress state, and pushing a stale prompt would override the user's next real
         // submission (matches the Windows-browser `WillActivateExistingVoiceTab` guard).
         if mode == AIChatNativePrompt.voiceMode {
-            let sourceTab = windowControllersManager.lastKeyMainWindowController?
-                .mainViewController.tabCollectionViewModel.selectedTab
-            tabOpener.openVoiceSession(inWindowOf: sourceTab, behavior: behavior)
+            let sourceCollection = windowControllersManager.lastKeyMainWindowController?
+                .mainViewController.tabCollectionViewModel
+            tabOpener.openVoiceSession(inSourceCollection: sourceCollection, behavior: behavior)
             return
         }
 

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
@@ -32,22 +32,19 @@ final class NewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandling {
     private let isShiftPressed: () -> Bool
     private let isCommandPressed: () -> Bool
     private let firePixel: (PixelKitEvent) -> Void
-    private let aiChatURLProvider: () -> URL
 
     init(promptHandler: AIChatPromptHandler = AIChatPromptHandler.shared,
          windowControllersManager: WindowControllersManagerProtocol & AIChatTabManaging,
          tabsPreferences: TabsPreferences,
          isShiftPressed: @escaping () -> Bool = { NSApp?.isShiftPressed ?? false },
          isCommandPressed: @escaping () -> Bool = { NSApp?.isCommandPressed ?? false },
-         firePixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0, frequency: .dailyAndStandard) },
-         aiChatURLProvider: @escaping () -> URL = { AIChatRemoteSettings().aiChatURL }) {
+         firePixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0, frequency: .dailyAndStandard) }) {
         self.promptHandler = promptHandler
         self.windowControllersManager = windowControllersManager
         self.tabsPreferences = tabsPreferences
         self.isShiftPressed = isShiftPressed
         self.isCommandPressed = isCommandPressed
         self.firePixel = firePixel
-        self.aiChatURLProvider = aiChatURLProvider
     }
 
     func submitSearch(_ term: String, target: NewTabPage.NewTabPageDataModel.OpenTarget) {
@@ -135,6 +132,8 @@ final class NewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandling {
 
         if mode == AIChatNativePrompt.imageGenerationMode {
             PixelKit.fire(AIChatPixel.aiChatNtpImageGenerationSubmitted, frequency: .dailyAndCount, includeAppVersionParameter: true)
+        } else if mode == AIChatNativePrompt.voiceMode {
+            PixelKit.fire(AIChatPixel.aiChatNewVoiceChatOmnibarNtp, frequency: .dailyAndStandard, includeAppVersionParameter: true)
         } else if toolChoice?.contains(AIChatRAGTool.webSearch.rawValue) == true {
             PixelKit.fire(AIChatPixel.aiChatNtpWebSearchSubmitted, frequency: .dailyAndCount, includeAppVersionParameter: true)
         }
@@ -197,17 +196,6 @@ final class NewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandling {
         }
 
         tabOpener.openNewAIChat(in: behavior)
-    }
-
-    @MainActor
-    func openNewVoiceChat() {
-        let tabOpener = AIChatTabOpener(
-            promptHandler: promptHandler,
-            aiChatTabManaging: windowControllersManager
-        )
-        let url = AIChatURLParameters.voiceModeURL(from: aiChatURLProvider())
-        tabOpener.openAIChatTab(with: .url(url), behavior: .newTab(selected: true))
-        PixelKit.fire(AIChatPixel.aiChatNewVoiceChatOmnibarNtp, frequency: .dailyAndStandard, includeAppVersionParameter: true)
     }
 
     private func linkOpenBehavior(for target: NewTabPageDataModel.OpenTarget, using tabsPreferences: TabsPreferences) -> LinkOpenBehavior {

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
@@ -32,19 +32,22 @@ final class NewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandling {
     private let isShiftPressed: () -> Bool
     private let isCommandPressed: () -> Bool
     private let firePixel: (PixelKitEvent) -> Void
+    private let aiChatURLProvider: () -> URL
 
     init(promptHandler: AIChatPromptHandler = AIChatPromptHandler.shared,
          windowControllersManager: WindowControllersManagerProtocol & AIChatTabManaging,
          tabsPreferences: TabsPreferences,
          isShiftPressed: @escaping () -> Bool = { NSApp?.isShiftPressed ?? false },
          isCommandPressed: @escaping () -> Bool = { NSApp?.isCommandPressed ?? false },
-         firePixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0, frequency: .dailyAndStandard) }) {
+         firePixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0, frequency: .dailyAndStandard) },
+         aiChatURLProvider: @escaping () -> URL = { AIChatRemoteSettings().aiChatURL }) {
         self.promptHandler = promptHandler
         self.windowControllersManager = windowControllersManager
         self.tabsPreferences = tabsPreferences
         self.isShiftPressed = isShiftPressed
         self.isCommandPressed = isCommandPressed
         self.firePixel = firePixel
+        self.aiChatURLProvider = aiChatURLProvider
     }
 
     func submitSearch(_ term: String, target: NewTabPage.NewTabPageDataModel.OpenTarget) {
@@ -194,6 +197,17 @@ final class NewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandling {
         }
 
         tabOpener.openNewAIChat(in: behavior)
+    }
+
+    @MainActor
+    func openNewVoiceChat() {
+        let tabOpener = AIChatTabOpener(
+            promptHandler: promptHandler,
+            aiChatTabManaging: windowControllersManager
+        )
+        let url = AIChatURLParameters.voiceModeURL(from: aiChatURLProvider())
+        tabOpener.openAIChatTab(with: .url(url), behavior: .newTab(selected: true))
+        PixelKit.fire(AIChatPixel.aiChatNewVoiceChatOmnibarNtp, frequency: .dailyAndStandard, includeAppVersionParameter: true)
     }
 
     private func linkOpenBehavior(for target: NewTabPageDataModel.OpenTarget, using tabsPreferences: TabsPreferences) -> LinkOpenBehavior {

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
@@ -149,6 +149,18 @@ final class NewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandling {
             behavior = .newTab(selected: isShiftPressed())
         }
 
+        // Voice handoff: focus an existing voice tab in the same window if one is active,
+        // otherwise open a fresh tab via `.mode(voiceMode)`. We must NOT fall through to
+        // `.query(chat)` + `setData(nativePrompt)` below — the existing voice tab keeps its
+        // in-progress state, and pushing a stale prompt would override the user's next real
+        // submission (matches the Windows-browser `WillActivateExistingVoiceTab` guard).
+        if mode == AIChatNativePrompt.voiceMode {
+            let sourceTab = windowControllersManager.lastKeyMainWindowController?
+                .mainViewController.tabCollectionViewModel.selectedTab
+            tabOpener.openVoiceSession(inWindowOf: sourceTab, behavior: behavior)
+            return
+        }
+
         tabOpener.openAIChatTab(with: .query(chat), behavior: behavior)
 
         // Re-set prompt after tab opener to include images, mode, tool choice, model selection,

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
@@ -232,6 +232,21 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
         featureFlagger.isFeatureOn(.aiChatNtpWebSearch)
     }
 
+    var isVoiceChatAccessEnabled: Bool {
+        featureFlagger.isFeatureOn(.aiChatOmnibarVoiceChatAccess)
+    }
+
+    /// Re-emits the current `isVoiceChatAccessEnabled` value whenever the feature-flagger reports
+    /// any change. The client uses this to push `omnibar_onConfigUpdate` so an open NTP swaps in
+    /// or out of voice-chat mode without a reload.
+    var isVoiceChatAccessEnabledPublisher: AnyPublisher<Bool, Never> {
+        featureFlagger.updatesPublisher
+            .compactMap { [weak self] in self?.isVoiceChatAccessEnabled }
+            .prepend(isVoiceChatAccessEnabled)
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
+
     var showCustomizePopover: Bool {
         get {
             // We no longer present the tooltip

--- a/macOS/DuckDuckGo/Windows/Model/WindowControllersManagerMock.swift
+++ b/macOS/DuckDuckGo/Windows/Model/WindowControllersManagerMock.swift
@@ -146,6 +146,19 @@ final class WindowControllersManagerMock: WindowControllersManagerProtocol, AICh
         insertAIChatTabCalls.append(InsertAIChatTabCall(url: url, payload: nil, restorationData: restorationData))
     }
 
+    /// Stubs `focusActiveVoiceSessionTab(inWindowOf:)` for tests. When `true`, the tab opener
+    /// short-circuits to "switch to existing tab" and skips opening a new one.
+    var focusActiveVoiceSessionTabResult: Bool = false
+    var focusActiveVoiceSessionTabCallCount: Int = 0
+    var lastFocusActiveVoiceSessionSourceTab: Tab?
+
+    @MainActor
+    func focusActiveVoiceSessionTab(inWindowOf sourceTab: Tab?) -> Bool {
+        focusActiveVoiceSessionTabCallCount += 1
+        lastFocusActiveVoiceSessionSourceTab = sourceTab
+        return focusActiveVoiceSessionTabResult
+    }
+
     var showTabCalls: [Tab.TabContent] = []
     struct OpenTabCall: Equatable {
         let tab: Tab

--- a/macOS/DuckDuckGo/Windows/Model/WindowControllersManagerMock.swift
+++ b/macOS/DuckDuckGo/Windows/Model/WindowControllersManagerMock.swift
@@ -146,16 +146,16 @@ final class WindowControllersManagerMock: WindowControllersManagerProtocol, AICh
         insertAIChatTabCalls.append(InsertAIChatTabCall(url: url, payload: nil, restorationData: restorationData))
     }
 
-    /// Stubs `focusActiveVoiceSessionTab(inWindowOf:)` for tests. When `true`, the tab opener
-    /// short-circuits to "switch to existing tab" and skips opening a new one.
+    /// Stubs `focusActiveVoiceSessionTab(inSourceCollection:)` for tests. When `true`, the tab
+    /// opener short-circuits to "switch to existing tab" and skips opening a new one.
     var focusActiveVoiceSessionTabResult: Bool = false
     var focusActiveVoiceSessionTabCallCount: Int = 0
-    var lastFocusActiveVoiceSessionSourceTab: Tab?
+    var lastFocusActiveVoiceSessionSourceCollection: TabCollectionViewModel?
 
     @MainActor
-    func focusActiveVoiceSessionTab(inWindowOf sourceTab: Tab?) -> Bool {
+    func focusActiveVoiceSessionTab(inSourceCollection sourceCollection: TabCollectionViewModel?) -> Bool {
         focusActiveVoiceSessionTabCallCount += 1
-        lastFocusActiveVoiceSessionSourceTab = sourceTab
+        lastFocusActiveVoiceSessionSourceCollection = sourceCollection
         return focusActiveVoiceSessionTabResult
     }
 

--- a/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
+++ b/macOS/DuckDuckGo/Windows/View/WindowControllersManager.swift
@@ -125,6 +125,11 @@ final class WindowControllersManager: WindowControllersManagerProtocol {
     /// `TabsPreferences` reference is needed to compute `shouldSwitchToNewTabWhenOpened`.
     weak var tabsPreferences: TabsPreferences?
 
+    /// Tracks which tabs currently host an active Duck.ai voice session, so voice entry points
+    /// can focus an existing tab instead of opening a new one. Lazy so the tracker can capture
+    /// `self` (the `WindowControllersManager` is its source of truth for tab membership).
+    private(set) lazy var voiceSessionTracker: VoiceSessionTracker = VoiceSessionTracker(windowControllersManager: self)
+
     var pinnedTabsManagerProvider: PinnedTabsManagerProviding
     private let subscriptionFeatureAvailability: SubscriptionFeatureAvailability
     private let internalUserDecider: InternalUserDecider

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -272,7 +272,7 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enables the reasoning effort picker in the Duck.ai omnibar
     case aiChatOmnibarReasoningEffort
 
-    /// Enables 1-click voice-chat access from the Duck.ai omnibar
+    /// https://app.asana.com/1/137249556945/project/1204006570077678/task/1214283076614743?focus=true
     case aiChatOmnibarVoiceChatAccess
 
     /// Enables attaching content from multiple open tabs to Duck.ai chat

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -272,6 +272,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enables the reasoning effort picker in the Duck.ai omnibar
     case aiChatOmnibarReasoningEffort
 
+    /// Enables 1-click voice-chat access from the Duck.ai omnibar
+    case aiChatOmnibarVoiceChatAccess
+
     /// Enables attaching content from multiple open tabs to Duck.ai chat
     case aiChatAttachMoreTabs
 
@@ -559,6 +562,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(AIChatSubfeature.omnibarWebSearch)), category: .duckAI)
         case .aiChatOmnibarReasoningEffort:
             Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(AIChatSubfeature.omnibarReasoningEffort)), category: .duckAI)
+        case .aiChatOmnibarVoiceChatAccess:
+            Config(defaultValue: .enabled, source: .remoteReleasable(.subfeature(AIChatSubfeature.omnibarVoiceChatAccess)), category: .duckAI)
         case .aiChatAttachMoreTabs:
             Config(source: .remoteReleasable(.subfeature(AIChatSubfeature.attachMoreTabs)), category: .duckAI)
         case .aiChatSidebarResizable:

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageDataModel+Omnibar.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageDataModel+Omnibar.swift
@@ -69,6 +69,10 @@ public extension NewTabPageDataModel {
         let enableAiChatTools: Bool?
         let enableImageGeneration: Bool?
         let enableWebSearch: Bool?
+        /// When true, the omnibar shows a 1-click voice-chat button. Driven by the native
+        /// `aiChatOmnibarVoiceChatAccess` feature flag and reactive over `omnibar_onConfigUpdate`
+        /// so the affordance appears/disappears without a page reload when the flag flips.
+        let enableVoiceChatAccess: Bool?
         let selectedModelId: String?
         let aiModelSections: [AIModelSection]?
         /// The user's persisted reasoning effort (e.g. `"none"`, `"low"`, `"medium"`). `nil` when

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarActionsHandling.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarActionsHandling.swift
@@ -39,9 +39,4 @@ public protocol NewTabPageOmnibarActionsHandling: AnyObject {
     @MainActor
     func viewAllAiChats(target: NewTabPageDataModel.OpenTarget)
 
-    /// Opens a new voice-chat tab from the NTP omnibar. Mirrors the `Duck.ai → New Voice Chat`
-    /// menu action.
-    @MainActor
-    func openNewVoiceChat()
-
 }

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarActionsHandling.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarActionsHandling.swift
@@ -39,4 +39,9 @@ public protocol NewTabPageOmnibarActionsHandling: AnyObject {
     @MainActor
     func viewAllAiChats(target: NewTabPageDataModel.OpenTarget)
 
+    /// Opens a new voice-chat tab from the NTP omnibar. Mirrors the `Duck.ai → New Voice Chat`
+    /// menu action.
+    @MainActor
+    func openNewVoiceChat()
+
 }

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
@@ -33,7 +33,6 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
         case getAiChats = "omnibar_getAiChats"
         case openAiChat = "omnibar_openAiChat"
         case viewAllAIChats = "omnibar_viewAllAIChats"
-        case openNewVoiceChat = "omnibar_openNewVoiceChat"
     }
 
     private let configProvider: NewTabPageOmnibarConfigProviding
@@ -91,8 +90,7 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             MessageName.submitChat.rawValue: { [weak self] in try await self?.submitChat(params: $0, original: $1) },
             MessageName.getAiChats.rawValue: { [weak self] in try await self?.getAiChats(params: $0, original: $1) },
             MessageName.openAiChat.rawValue: { [weak self] in try await self?.openAiChat(params: $0, original: $1) },
-            MessageName.viewAllAIChats.rawValue: { [weak self] in try await self?.viewAllAIChats(params: $0, original: $1) },
-            MessageName.openNewVoiceChat.rawValue: { [weak self] in try await self?.openNewVoiceChat(params: $0, original: $1) }
+            MessageName.viewAllAIChats.rawValue: { [weak self] in try await self?.viewAllAIChats(params: $0, original: $1) }
         ])
     }
 
@@ -289,15 +287,6 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             return nil
         }
         await actionHandler.viewAllAiChats(target: action.target)
-        return nil
-    }
-
-    /// Defensive flag gate: a stale page that holds an old config (or any forced caller) must not
-    /// bypass the rollout. Drop the message silently when the feature is off.
-    @MainActor
-    private func openNewVoiceChat(params: Any, original: WKScriptMessage) async throws -> Encodable? {
-        guard configProvider.isVoiceChatAccessEnabled else { return nil }
-        actionHandler.openNewVoiceChat()
         return nil
     }
 

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
@@ -33,6 +33,7 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
         case getAiChats = "omnibar_getAiChats"
         case openAiChat = "omnibar_openAiChat"
         case viewAllAIChats = "omnibar_viewAllAIChats"
+        case openNewVoiceChat = "omnibar_openNewVoiceChat"
     }
 
     private let configProvider: NewTabPageOmnibarConfigProviding
@@ -60,7 +61,8 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             configProvider.modePublisher.map { _ in () }.eraseToAnyPublisher(),
             configProvider.showViewAllAiChatsPublisher.map { _ in () }.eraseToAnyPublisher(),
             configProvider.selectedModelIdPublisher.map { _ in () }.eraseToAnyPublisher(),
-            configProvider.selectedReasoningEffortPublisher.map { _ in () }.eraseToAnyPublisher()
+            configProvider.selectedReasoningEffortPublisher.map { _ in () }.eraseToAnyPublisher(),
+            configProvider.isVoiceChatAccessEnabledPublisher.map { _ in () }.eraseToAnyPublisher()
         )
         .sink { [weak self] _ in
             Task { @MainActor in
@@ -89,7 +91,8 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             MessageName.submitChat.rawValue: { [weak self] in try await self?.submitChat(params: $0, original: $1) },
             MessageName.getAiChats.rawValue: { [weak self] in try await self?.getAiChats(params: $0, original: $1) },
             MessageName.openAiChat.rawValue: { [weak self] in try await self?.openAiChat(params: $0, original: $1) },
-            MessageName.viewAllAIChats.rawValue: { [weak self] in try await self?.viewAllAIChats(params: $0, original: $1) }
+            MessageName.viewAllAIChats.rawValue: { [weak self] in try await self?.viewAllAIChats(params: $0, original: $1) },
+            MessageName.openNewVoiceChat.rawValue: { [weak self] in try await self?.openNewVoiceChat(params: $0, original: $1) }
         ])
     }
 
@@ -106,6 +109,7 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             enableAiChatTools: configProvider.isAIChatToolsEnabled,
             enableImageGeneration: configProvider.isImageGenerationEnabled,
             enableWebSearch: configProvider.isWebSearchEnabled,
+            enableVoiceChatAccess: configProvider.isVoiceChatAccessEnabled,
             selectedModelId: configProvider.selectedModelId,
             aiModelSections: sectionsForWeb(aiModelSections),
             selectedReasoningEffort: configProvider.selectedReasoningEffort
@@ -177,6 +181,7 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             enableAiChatTools: configProvider.isAIChatToolsEnabled,
             enableImageGeneration: configProvider.isImageGenerationEnabled,
             enableWebSearch: configProvider.isWebSearchEnabled,
+            enableVoiceChatAccess: configProvider.isVoiceChatAccessEnabled,
             selectedModelId: configProvider.selectedModelId,
             aiModelSections: sectionsForWeb(modelsProvider?.lastFetchedSections),
             selectedReasoningEffort: configProvider.selectedReasoningEffort
@@ -284,6 +289,15 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             return nil
         }
         await actionHandler.viewAllAiChats(target: action.target)
+        return nil
+    }
+
+    /// Defensive flag gate: a stale page that holds an old config (or any forced caller) must not
+    /// bypass the rollout. Drop the message silently when the feature is off.
+    @MainActor
+    private func openNewVoiceChat(params: Any, original: WKScriptMessage) async throws -> Encodable? {
+        guard configProvider.isVoiceChatAccessEnabled else { return nil }
+        actionHandler.openNewVoiceChat()
         return nil
     }
 

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
@@ -43,6 +43,12 @@ public protocol NewTabPageOmnibarConfigProviding: AnyObject {
 
     var isWebSearchEnabled: Bool { get }
 
+    /// Whether the 1-click voice-chat affordance is currently enabled. Published so the client
+    /// can push an `omnibar_onConfigUpdate` when the underlying feature flag flips at runtime,
+    /// keeping an open NTP in sync without a reload.
+    var isVoiceChatAccessEnabled: Bool { get }
+    var isVoiceChatAccessEnabledPublisher: AnyPublisher<Bool, Never> { get }
+
     var selectedModelId: String? { get set }
     var selectedModelIdPublisher: AnyPublisher<String?, Never> { get }
 

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarActionsHandler.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarActionsHandler.swift
@@ -54,4 +54,11 @@ final class MockNewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandlin
     func viewAllAiChats(target: NewTabPage.NewTabPageDataModel.OpenTarget) {
 
     }
+
+    var openNewVoiceChatHandler: (() -> Void)?
+
+    @MainActor
+    func openNewVoiceChat() {
+        openNewVoiceChatHandler?()
+    }
 }

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarActionsHandler.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarActionsHandler.swift
@@ -54,11 +54,4 @@ final class MockNewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandlin
     func viewAllAiChats(target: NewTabPage.NewTabPageDataModel.OpenTarget) {
 
     }
-
-    var openNewVoiceChatHandler: (() -> Void)?
-
-    @MainActor
-    func openNewVoiceChat() {
-        openNewVoiceChatHandler?()
-    }
 }

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarConfigProvider.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarConfigProvider.swift
@@ -56,6 +56,15 @@ final class MockNewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProvidin
 
     var isWebSearchEnabled: Bool = false
 
+    @Published var isVoiceChatAccessEnabled: Bool = false
+
+    /// Mirrors the real `NewTabPageOmnibarConfigProvider.isVoiceChatAccessEnabledPublisher`
+    /// shape — emits the current value on subscribe (so `NewTabPageOmnibarClient.notifyConfigUpdated`
+    /// fires on init) and then de-duplicates subsequent flag flips.
+    var isVoiceChatAccessEnabledPublisher: AnyPublisher<Bool, Never> {
+        $isVoiceChatAccessEnabled.removeDuplicates().eraseToAnyPublisher()
+    }
+
     @Published var selectedModelId: String?
 
     var selectedModelIdPublisher: AnyPublisher<String?, Never> {

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
@@ -495,30 +495,6 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
         XCTAssertEqual(config.enableVoiceChatAccess, false)
     }
 
-    @MainActor
-    func testWhenOpenNewVoiceChatReceivedAndFlagEnabledThenActionHandlerIsCalled() async throws {
-        configProvider.isVoiceChatAccessEnabled = true
-        let expectation = expectation(description: "openNewVoiceChat invoked on action handler")
-        (actionHandler as? MockNewTabPageOmnibarActionsHandler)?.openNewVoiceChatHandler = {
-            expectation.fulfill()
-        }
-
-        try await messageHelper.handleMessageExpectingNilResponse(named: .openNewVoiceChat)
-        await fulfillment(of: [expectation], timeout: 1)
-    }
-
-    @MainActor
-    func testWhenOpenNewVoiceChatReceivedAndFlagDisabledThenMessageIsDropped() async throws {
-        configProvider.isVoiceChatAccessEnabled = false
-        var wasCalled = false
-        (actionHandler as? MockNewTabPageOmnibarActionsHandler)?.openNewVoiceChatHandler = {
-            wasCalled = true
-        }
-
-        try await messageHelper.handleMessageExpectingNilResponse(named: .openNewVoiceChat)
-
-        XCTAssertFalse(wasCalled, "Action handler must not be invoked when the feature flag is off")
-    }
 }
 
 private final class StubNewTabPageOmnibarModelsProvider: NewTabPageOmnibarModelsProviding {

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
@@ -71,7 +71,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
 
     @MainActor
     func testSetConfigUpdatesModeAndSettings() async throws {
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: false, showAiSetting: true, showCustomizePopover: true, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, selectedModelId: nil, aiModelSections: nil, selectedReasoningEffort: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: false, showAiSetting: true, showCustomizePopover: true, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableVoiceChatAccess: nil, selectedModelId: nil, aiModelSections: nil, selectedReasoningEffort: nil)
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
         XCTAssertEqual(configProvider.mode, .ai)
         XCTAssertEqual(configProvider.isAIChatShortcutEnabled, false)
@@ -80,7 +80,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
 
     @MainActor
     func testWhenSetConfigWithSelectedModelIdThenModelIdIsPersisted() async throws {
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, selectedModelId: "gpt-4o-mini", aiModelSections: nil, selectedReasoningEffort: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableVoiceChatAccess: nil, selectedModelId: "gpt-4o-mini", aiModelSections: nil, selectedReasoningEffort: nil)
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
         XCTAssertEqual(configProvider.selectedModelId, "gpt-4o-mini")
     }
@@ -93,7 +93,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
                 NewTabPageDataModel.AIModelItem(id: "maverick", name: "Maverick", shortName: "Maverick", isEnabled: true, supportsImageUpload: false, supportedTools: [])
             ])
         ]
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, selectedModelId: "maverick", aiModelSections: nil, selectedReasoningEffort: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableVoiceChatAccess: nil, selectedModelId: "maverick", aiModelSections: nil, selectedReasoningEffort: nil)
 
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
 
@@ -109,7 +109,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
                 NewTabPageDataModel.AIModelItem(id: "gpt-4o-mini", name: "GPT-4o mini", shortName: "G4m", isEnabled: true, supportsImageUpload: false, supportedTools: [])
             ])
         ]
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, selectedModelId: "brand-new-model", aiModelSections: nil, selectedReasoningEffort: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableVoiceChatAccess: nil, selectedModelId: "brand-new-model", aiModelSections: nil, selectedReasoningEffort: nil)
 
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
 
@@ -125,7 +125,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
         modelsProvider.lastFetchedSections = nil
 
         // When — web echoes back the same id (typical on launch)
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, selectedModelId: "gpt-4o-mini", aiModelSections: nil, selectedReasoningEffort: nil)
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableVoiceChatAccess: nil, selectedModelId: "gpt-4o-mini", aiModelSections: nil, selectedReasoningEffort: nil)
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
 
         // Then — cached short name is preserved (not wiped by a failed lookup)
@@ -207,7 +207,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
                                                  supportedReasoningEffort: ["none", "low", "medium"])
             ])
         ]
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, selectedModelId: "reasoning-model", aiModelSections: nil, selectedReasoningEffort: "low")
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableVoiceChatAccess: nil, selectedModelId: "reasoning-model", aiModelSections: nil, selectedReasoningEffort: "low")
 
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
 
@@ -226,7 +226,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
                                                  supportedReasoningEffort: ["low"])
             ])
         ]
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, selectedModelId: "limited-model", aiModelSections: nil, selectedReasoningEffort: "medium")
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableVoiceChatAccess: nil, selectedModelId: "limited-model", aiModelSections: nil, selectedReasoningEffort: "medium")
 
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
 
@@ -244,7 +244,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
                                                  supportedReasoningEffort: ["low"])
             ])
         ]
-        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, selectedModelId: "reasoning-model", aiModelSections: nil, selectedReasoningEffort: "low")
+        let newConfig = NewTabPageDataModel.OmnibarConfig(mode: .ai, enableAi: true, showAiSetting: nil, showCustomizePopover: nil, enableRecentAiChats: nil, showViewAllAiChats: nil, enableAiChatTools: nil, enableImageGeneration: nil, enableWebSearch: nil, enableVoiceChatAccess: nil, selectedModelId: "reasoning-model", aiModelSections: nil, selectedReasoningEffort: "low")
 
         try await messageHelper.handleMessageExpectingNilResponse(named: .setConfig, parameters: newConfig)
 
@@ -475,6 +475,50 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
         await fulfillment(of: [expectation], timeout: 1)
     }
 
+    // MARK: - voice chat access
+
+    @MainActor
+    func testWhenVoiceChatAccessEnabledThenGetConfigIncludesEnableVoiceChatAccessTrue() async throws {
+        configProvider.isVoiceChatAccessEnabled = true
+
+        let config: NewTabPageDataModel.OmnibarConfig = try await messageHelper.handleMessage(named: .getConfig)
+
+        XCTAssertEqual(config.enableVoiceChatAccess, true)
+    }
+
+    @MainActor
+    func testWhenVoiceChatAccessDisabledThenGetConfigIncludesEnableVoiceChatAccessFalse() async throws {
+        configProvider.isVoiceChatAccessEnabled = false
+
+        let config: NewTabPageDataModel.OmnibarConfig = try await messageHelper.handleMessage(named: .getConfig)
+
+        XCTAssertEqual(config.enableVoiceChatAccess, false)
+    }
+
+    @MainActor
+    func testWhenOpenNewVoiceChatReceivedAndFlagEnabledThenActionHandlerIsCalled() async throws {
+        configProvider.isVoiceChatAccessEnabled = true
+        let expectation = expectation(description: "openNewVoiceChat invoked on action handler")
+        (actionHandler as? MockNewTabPageOmnibarActionsHandler)?.openNewVoiceChatHandler = {
+            expectation.fulfill()
+        }
+
+        try await messageHelper.handleMessageExpectingNilResponse(named: .openNewVoiceChat)
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+
+    @MainActor
+    func testWhenOpenNewVoiceChatReceivedAndFlagDisabledThenMessageIsDropped() async throws {
+        configProvider.isVoiceChatAccessEnabled = false
+        var wasCalled = false
+        (actionHandler as? MockNewTabPageOmnibarActionsHandler)?.openNewVoiceChatHandler = {
+            wasCalled = true
+        }
+
+        try await messageHelper.handleMessageExpectingNilResponse(named: .openNewVoiceChat)
+
+        XCTAssertFalse(wasCalled, "Action handler must not be invoked when the feature flag is off")
+    }
 }
 
 private final class StubNewTabPageOmnibarModelsProvider: NewTabPageOmnibarModelsProviding {

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
@@ -128,6 +128,13 @@
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource"]
     },
+    "m_mac_aichat_new_voice_chat_omnibar_native": {
+        "description": "Fired when user opens a new Duck.ai voice chat from the native omnibar",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["daily_standard"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
     "m_mac_aichat_recent_chat_delete_button_clicked": {
         "description": "Fired when user clicks the delete button on a recent chat suggestion in the address bar",
         "owners": ["Bunn"],

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_ntp_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_ntp_pixels.json5
@@ -36,6 +36,13 @@
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource"]
     },
+    "m_mac_aichat_new_voice_chat_omnibar_ntp": {
+        "description": "Fired when user opens a new Duck.ai voice chat from the New Tab Page omnibar",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["daily_standard"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
     "m_mac_aichat_ntp_image_generation_submitted": {
         "description": "Fired when user submits a prompt while image generation mode is active on the New Tab Page",
         "owners": ["tomasstrba"],

--- a/macOS/UnitTests/AIChat/AIChatCoordinatorTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatCoordinatorTests.swift
@@ -1145,6 +1145,20 @@ class MockAIChatTabOpener: AIChatTabOpening {
         openMethodCalledExpectation = nil
     }
 
+    var openVoiceSessionCalled = false
+    var lastVoiceSessionSourceTab: Tab?
+    var lastVoiceSessionBehavior: LinkOpenBehavior?
+
+    @MainActor
+    func openVoiceSession(inWindowOf sourceTab: Tab?, behavior: LinkOpenBehavior) {
+        openVoiceSessionCalled = true
+        lastVoiceSessionSourceTab = sourceTab
+        lastVoiceSessionBehavior = behavior
+
+        openMethodCalledExpectation?.fulfill()
+        openMethodCalledExpectation = nil
+    }
+
     func reset() {
         openAIChatTabCalled = false
         lastTrigger = nil

--- a/macOS/UnitTests/AIChat/AIChatCoordinatorTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatCoordinatorTests.swift
@@ -1146,13 +1146,13 @@ class MockAIChatTabOpener: AIChatTabOpening {
     }
 
     var openVoiceSessionCalled = false
-    var lastVoiceSessionSourceTab: Tab?
+    var lastVoiceSessionSourceCollection: TabCollectionViewModel?
     var lastVoiceSessionBehavior: LinkOpenBehavior?
 
     @MainActor
-    func openVoiceSession(inWindowOf sourceTab: Tab?, behavior: LinkOpenBehavior) {
+    func openVoiceSession(inSourceCollection sourceCollection: TabCollectionViewModel?, behavior: LinkOpenBehavior) {
         openVoiceSessionCalled = true
-        lastVoiceSessionSourceTab = sourceTab
+        lastVoiceSessionSourceCollection = sourceCollection
         lastVoiceSessionBehavior = behavior
 
         openMethodCalledExpectation?.fulfill()

--- a/macOS/UnitTests/AIChat/AIChatCoordinatorTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatCoordinatorTests.swift
@@ -1128,6 +1128,8 @@ class MockAIChatTabOpener: AIChatTabOpening {
             lastRestorationData = data
         case .existingChat:
             break
+        case .mode:
+            break
         }
 
         openMethodCalledExpectation?.fulfill()

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -219,19 +219,14 @@ final class AIChatOmnibarControllerTests: XCTestCase {
 
     // MARK: - Voice Chat
 
-    func testOpenNewVoiceChat_OpensNewSelectedTabWithVoiceModeTrigger() {
+    func testOpenNewVoiceChat_DelegatesToOpenVoiceSessionWithNewSelectedTab() {
         // When
         controller.openNewVoiceChat()
 
-        // Then — tab opener invoked with the `.mode(voice)` trigger and a new selected tab.
-        // The mode is handed off via the prompt payload (Duck.ai routes on mode), not via a
-        // `?mode=voice` URL parameter — same handoff mechanism image-generation uses.
-        XCTAssertTrue(mockTabOpener.openAIChatTabCalled)
-        XCTAssertEqual(mockTabOpener.lastBehavior, .newTab(selected: true))
-        guard case .mode(let mode) = mockTabOpener.lastTrigger else {
-            return XCTFail("Expected .mode trigger, got \(String(describing: mockTabOpener.lastTrigger))")
-        }
-        XCTAssertEqual(mode, AIChatNativePrompt.voiceMode)
+        // Then — controller hands off to `openVoiceSession`, which encapsulates the
+        // "focus existing voice tab in the same window if active, otherwise open new" decision.
+        XCTAssertTrue(mockTabOpener.openVoiceSessionCalled)
+        XCTAssertEqual(mockTabOpener.lastVoiceSessionBehavior, .newTab(selected: true))
     }
 
     // MARK: - Text Update Tests

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -227,6 +227,7 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         // "focus existing voice tab in the same window if active, otherwise open new" decision.
         XCTAssertTrue(mockTabOpener.openVoiceSessionCalled)
         XCTAssertEqual(mockTabOpener.lastVoiceSessionBehavior, .newTab(selected: true))
+        XCTAssertTrue(mockTabOpener.lastVoiceSessionSourceCollection === tabCollectionViewModel)
     }
 
     // MARK: - Text Update Tests

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -219,28 +219,19 @@ final class AIChatOmnibarControllerTests: XCTestCase {
 
     // MARK: - Voice Chat
 
-    func testOpenNewVoiceChat_OpensTabWithVoiceModeURLInNewSelectedTab() {
-        // Given — a stubbed AI chat URL so the voice-mode transform is deterministic
-        let baseURL = URL(string: "https://duck.ai/")!
-        let voiceController = AIChatOmnibarController(
-            aiChatTabOpener: mockTabOpener,
-            tabCollectionViewModel: tabCollectionViewModel,
-            featureFlagger: featureFlagger,
-            searchPreferencesPersistor: searchPreferencesPersistor,
-            preferences: mockPreferences,
-            modelsService: mockModelsService,
-            subscriptionManager: mockSubscriptionManager,
-            aiChatURLProvider: { baseURL }
-        )
-
+    func testOpenNewVoiceChat_OpensNewSelectedTabWithVoiceModeTrigger() {
         // When
-        voiceController.openNewVoiceChat()
+        controller.openNewVoiceChat()
 
-        // Then — tab opener invoked with the voice-mode URL and a new selected tab behavior,
-        // matching the `Duck.ai → New Voice Chat` menu action.
+        // Then — tab opener invoked with the `.mode(voice)` trigger and a new selected tab.
+        // The mode is handed off via the prompt payload (Duck.ai routes on mode), not via a
+        // `?mode=voice` URL parameter — same handoff mechanism image-generation uses.
         XCTAssertTrue(mockTabOpener.openAIChatTabCalled)
-        XCTAssertEqual(mockTabOpener.lastURL, AIChatURLParameters.voiceModeURL(from: baseURL))
         XCTAssertEqual(mockTabOpener.lastBehavior, .newTab(selected: true))
+        guard case .mode(let mode) = mockTabOpener.lastTrigger else {
+            return XCTFail("Expected .mode trigger, got \(String(describing: mockTabOpener.lastTrigger))")
+        }
+        XCTAssertEqual(mode, AIChatNativePrompt.voiceMode)
     }
 
     // MARK: - Text Update Tests

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -217,6 +217,32 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         XCTAssertEqual(controller.currentText, "", "Current text should be cleared after submit")
     }
 
+    // MARK: - Voice Chat
+
+    func testOpenNewVoiceChat_OpensTabWithVoiceModeURLInNewSelectedTab() {
+        // Given — a stubbed AI chat URL so the voice-mode transform is deterministic
+        let baseURL = URL(string: "https://duck.ai/")!
+        let voiceController = AIChatOmnibarController(
+            aiChatTabOpener: mockTabOpener,
+            tabCollectionViewModel: tabCollectionViewModel,
+            featureFlagger: featureFlagger,
+            searchPreferencesPersistor: searchPreferencesPersistor,
+            preferences: mockPreferences,
+            modelsService: mockModelsService,
+            subscriptionManager: mockSubscriptionManager,
+            aiChatURLProvider: { baseURL }
+        )
+
+        // When
+        voiceController.openNewVoiceChat()
+
+        // Then — tab opener invoked with the voice-mode URL and a new selected tab behavior,
+        // matching the `Duck.ai → New Voice Chat` menu action.
+        XCTAssertTrue(mockTabOpener.openAIChatTabCalled)
+        XCTAssertEqual(mockTabOpener.lastURL, AIChatURLParameters.voiceModeURL(from: baseURL))
+        XCTAssertEqual(mockTabOpener.lastBehavior, .newTab(selected: true))
+    }
+
     // MARK: - Text Update Tests
 
     func testWhenTextIsUpdated_ThenCurrentTextReflectsChange() {

--- a/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
@@ -355,6 +355,14 @@ final class MockAIChatUserScriptHandler: AIChatUserScriptHandling {
         return nil
     }
 
+    func voiceSessionStarted(params: Any, message: any UserScriptMessage) async -> (any Encodable)? {
+        return nil
+    }
+
+    func voiceSessionEnded(params: Any, message: any UserScriptMessage) async -> (any Encodable)? {
+        return nil
+    }
+
     // Migration data mocks
     func storeMigrationData(params: Any, message: UserScriptMessage) -> Encodable? {
         didStoreMigrationData = true

--- a/macOS/UnitTests/AIChat/VoiceSessionTrackerTests.swift
+++ b/macOS/UnitTests/AIChat/VoiceSessionTrackerTests.swift
@@ -1,0 +1,160 @@
+//
+//  VoiceSessionTrackerTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import WebKit
+import XCTest
+@testable import DuckDuckGo_Privacy_Browser
+
+@MainActor
+final class VoiceSessionTrackerTests: XCTestCase {
+
+    /// Per-test private NotificationCenter so observers don't bleed across tests or
+    /// pick up notifications from app code running in the same process.
+    private var notificationCenter: NotificationCenter!
+    private var windowControllersManager: WindowControllersManagerMock!
+    private var tracker: VoiceSessionTracker!
+
+    override func setUp() {
+        super.setUp()
+        notificationCenter = NotificationCenter()
+        windowControllersManager = WindowControllersManagerMock()
+        tracker = VoiceSessionTracker(notificationCenter: notificationCenter,
+                                      windowControllersManager: windowControllersManager)
+    }
+
+    override func tearDown() {
+        tracker = nil
+        windowControllersManager = nil
+        notificationCenter = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Builds a `TabCollectionViewModel` containing the given tabs and registers it on the mock
+    /// manager so the tracker can resolve `webView → Tab` and run window-scope checks.
+    private func makeTabCollectionViewModel(with tabs: [Tab]) -> TabCollectionViewModel {
+        let tcvm = TabCollectionViewModel(
+            tabCollection: TabCollection(),
+            pinnedTabsManagerProvider: PinnedTabsManagerProvidingMock(),
+            tabsPreferences: TabsPreferences(
+                persistor: MockTabsPreferencesPersistor(),
+                windowControllersManager: WindowControllersManagerMock()
+            )
+        )
+        for tab in tabs { tcvm.append(tab: tab) }
+        return tcvm
+    }
+
+    // MARK: - Tracking
+
+    func testStartedNotification_TracksTabFromMatchingWebView() {
+        // Given a single window with one Duck.ai tab the manager knows about.
+        let tab = Tab(content: .none)
+        windowControllersManager.customAllTabCollectionViewModels = [makeTabCollectionViewModel(with: [tab])]
+
+        // When Duck.ai posts `voiceSessionStarted` carrying that tab's webView.
+        notificationCenter.post(name: .aiChatVoiceSessionStarted, object: tab.webView)
+
+        // Then querying with a source tab in the same window finds the tracked voice tab.
+        XCTAssertTrue(tracker.findActiveVoiceTab(inWindowOf: tab) === tab)
+    }
+
+    func testEndedNotification_UntracksPreviouslyTrackedTab() {
+        // Given a tab that was just marked active.
+        let tab = Tab(content: .none)
+        windowControllersManager.customAllTabCollectionViewModels = [makeTabCollectionViewModel(with: [tab])]
+        notificationCenter.post(name: .aiChatVoiceSessionStarted, object: tab.webView)
+        XCTAssertNotNil(tracker.findActiveVoiceTab(inWindowOf: tab))
+
+        // When the matching `voiceSessionEnded` arrives.
+        notificationCenter.post(name: .aiChatVoiceSessionEnded, object: tab.webView)
+
+        // Then the tab is no longer reported as active.
+        XCTAssertNil(tracker.findActiveVoiceTab(inWindowOf: tab))
+    }
+
+    func testStartedNotification_WithUnknownWebView_DoesNotTrackAnything() {
+        // Given a known tab in the manager but a stranger webView arrives via the notification
+        // (e.g. a sidebar webview the tracker isn't supposed to handle yet).
+        let tab = Tab(content: .none)
+        windowControllersManager.customAllTabCollectionViewModels = [makeTabCollectionViewModel(with: [tab])]
+        let strangerWebView = WKWebView()
+
+        // When
+        notificationCenter.post(name: .aiChatVoiceSessionStarted, object: strangerWebView)
+
+        // Then nothing is tracked.
+        XCTAssertNil(tracker.findActiveVoiceTab(inWindowOf: tab))
+    }
+
+    // MARK: - Window scoping
+
+    func testFindActiveVoiceTab_ReturnsNilWhenSourceTabIsNil() {
+        let tab = Tab(content: .none)
+        windowControllersManager.customAllTabCollectionViewModels = [makeTabCollectionViewModel(with: [tab])]
+        notificationCenter.post(name: .aiChatVoiceSessionStarted, object: tab.webView)
+
+        // No source-tab context → no window scope to check against → fall back to "open new".
+        XCTAssertNil(tracker.findActiveVoiceTab(inWindowOf: nil))
+    }
+
+    func testFindActiveVoiceTab_ReturnsNilWhenActiveTabIsInDifferentWindow() {
+        // Given two windows: voice tab is in window A, source tab in window B.
+        let voiceTab = Tab(content: .none)
+        let sourceTab = Tab(content: .none)
+        windowControllersManager.customAllTabCollectionViewModels = [
+            makeTabCollectionViewModel(with: [voiceTab]),
+            makeTabCollectionViewModel(with: [sourceTab])
+        ]
+        notificationCenter.post(name: .aiChatVoiceSessionStarted, object: voiceTab.webView)
+
+        // A voice tap originating in window B must not steal focus across windows.
+        XCTAssertNil(tracker.findActiveVoiceTab(inWindowOf: sourceTab))
+    }
+
+    func testFindActiveVoiceTab_FindsActiveTabInSameWindowAlongsideOtherTabs() {
+        // Given a window with two tabs, one of which has an active voice session.
+        let voiceTab = Tab(content: .none)
+        let neighbourTab = Tab(content: .none)
+        windowControllersManager.customAllTabCollectionViewModels = [
+            makeTabCollectionViewModel(with: [voiceTab, neighbourTab])
+        ]
+        notificationCenter.post(name: .aiChatVoiceSessionStarted, object: voiceTab.webView)
+
+        // Tapping voice from `neighbourTab` finds the existing voice tab in the same window.
+        XCTAssertTrue(tracker.findActiveVoiceTab(inWindowOf: neighbourTab) === voiceTab)
+    }
+
+    // MARK: - Stale ended notifications
+
+    func testEndedNotification_FromUnknownWebView_DoesNotEvictTrackedTab() {
+        // Given an active voice tab.
+        let tab = Tab(content: .none)
+        windowControllersManager.customAllTabCollectionViewModels = [makeTabCollectionViewModel(with: [tab])]
+        notificationCenter.post(name: .aiChatVoiceSessionStarted, object: tab.webView)
+        XCTAssertNotNil(tracker.findActiveVoiceTab(inWindowOf: tab))
+
+        // When a stray `voiceSessionEnded` arrives carrying some other webView.
+        notificationCenter.post(name: .aiChatVoiceSessionEnded, object: WKWebView())
+
+        // Then the tracked voice tab is still active.
+        XCTAssertTrue(tracker.findActiveVoiceTab(inWindowOf: tab) === tab)
+    }
+}

--- a/macOS/UnitTests/AIChat/VoiceSessionTrackerTests.swift
+++ b/macOS/UnitTests/AIChat/VoiceSessionTrackerTests.swift
@@ -200,4 +200,3 @@ final class VoiceSessionTrackerTests: XCTestCase {
         XCTAssertTrue(tracker.findActiveVoiceTab(in: tcvmA) === unpinnedVoiceInA)
     }
 }
-

--- a/macOS/UnitTests/AIChat/VoiceSessionTrackerTests.swift
+++ b/macOS/UnitTests/AIChat/VoiceSessionTrackerTests.swift
@@ -67,79 +67,80 @@ final class VoiceSessionTrackerTests: XCTestCase {
     func testStartedNotification_TracksTabFromMatchingWebView() {
         // Given a single window with one Duck.ai tab the manager knows about.
         let tab = Tab(content: .none)
-        windowControllersManager.customAllTabCollectionViewModels = [makeTabCollectionViewModel(with: [tab])]
+        let tcvm = makeTabCollectionViewModel(with: [tab])
+        windowControllersManager.customAllTabCollectionViewModels = [tcvm]
 
         // When Duck.ai posts `voiceSessionStarted` carrying that tab's webView.
         notificationCenter.post(name: .aiChatVoiceSessionStarted, object: tab.webView)
 
-        // Then querying with a source tab in the same window finds the tracked voice tab.
-        XCTAssertTrue(tracker.findActiveVoiceTab(inWindowOf: tab) === tab)
+        // Then the tracker finds the voice tab when queried with the source TCVM.
+        XCTAssertTrue(tracker.findActiveVoiceTab(in: tcvm) === tab)
     }
 
     func testEndedNotification_UntracksPreviouslyTrackedTab() {
         // Given a tab that was just marked active.
         let tab = Tab(content: .none)
-        windowControllersManager.customAllTabCollectionViewModels = [makeTabCollectionViewModel(with: [tab])]
+        let tcvm = makeTabCollectionViewModel(with: [tab])
+        windowControllersManager.customAllTabCollectionViewModels = [tcvm]
         notificationCenter.post(name: .aiChatVoiceSessionStarted, object: tab.webView)
-        XCTAssertNotNil(tracker.findActiveVoiceTab(inWindowOf: tab))
+        XCTAssertNotNil(tracker.findActiveVoiceTab(in: tcvm))
 
         // When the matching `voiceSessionEnded` arrives.
         notificationCenter.post(name: .aiChatVoiceSessionEnded, object: tab.webView)
 
         // Then the tab is no longer reported as active.
-        XCTAssertNil(tracker.findActiveVoiceTab(inWindowOf: tab))
+        XCTAssertNil(tracker.findActiveVoiceTab(in: tcvm))
     }
 
     func testStartedNotification_WithUnknownWebView_DoesNotTrackAnything() {
         // Given a known tab in the manager but a stranger webView arrives via the notification
-        // (e.g. a sidebar webview the tracker isn't supposed to handle yet).
+        // (e.g. a webview not associated with any browser tab or sidebar).
         let tab = Tab(content: .none)
-        windowControllersManager.customAllTabCollectionViewModels = [makeTabCollectionViewModel(with: [tab])]
+        let tcvm = makeTabCollectionViewModel(with: [tab])
+        windowControllersManager.customAllTabCollectionViewModels = [tcvm]
         let strangerWebView = WKWebView()
 
         // When
         notificationCenter.post(name: .aiChatVoiceSessionStarted, object: strangerWebView)
 
         // Then nothing is tracked.
-        XCTAssertNil(tracker.findActiveVoiceTab(inWindowOf: tab))
+        XCTAssertNil(tracker.findActiveVoiceTab(in: tcvm))
     }
 
     // MARK: - Window scoping
 
-    func testFindActiveVoiceTab_ReturnsNilWhenSourceTabIsNil() {
+    func testFindActiveVoiceTab_ReturnsNilWhenSourceCollectionIsNil() {
         let tab = Tab(content: .none)
         windowControllersManager.customAllTabCollectionViewModels = [makeTabCollectionViewModel(with: [tab])]
         notificationCenter.post(name: .aiChatVoiceSessionStarted, object: tab.webView)
 
-        // No source-tab context → no window scope to check against → fall back to "open new".
-        XCTAssertNil(tracker.findActiveVoiceTab(inWindowOf: nil))
+        // No source-window context → no scope to check against → fall back to "open new".
+        XCTAssertNil(tracker.findActiveVoiceTab(in: nil))
     }
 
     func testFindActiveVoiceTab_ReturnsNilWhenActiveTabIsInDifferentWindow() {
-        // Given two windows: voice tab is in window A, source tab in window B.
+        // Given two windows: voice tab is in window A, the request originates from window B.
         let voiceTab = Tab(content: .none)
         let sourceTab = Tab(content: .none)
-        windowControllersManager.customAllTabCollectionViewModels = [
-            makeTabCollectionViewModel(with: [voiceTab]),
-            makeTabCollectionViewModel(with: [sourceTab])
-        ]
+        let windowATCVM = makeTabCollectionViewModel(with: [voiceTab])
+        let windowBTCVM = makeTabCollectionViewModel(with: [sourceTab])
+        windowControllersManager.customAllTabCollectionViewModels = [windowATCVM, windowBTCVM]
         notificationCenter.post(name: .aiChatVoiceSessionStarted, object: voiceTab.webView)
 
         // A voice tap originating in window B must not steal focus across windows.
-        XCTAssertNil(tracker.findActiveVoiceTab(inWindowOf: sourceTab))
+        XCTAssertNil(tracker.findActiveVoiceTab(in: windowBTCVM))
     }
 
     func testFindActiveVoiceTab_FindsActiveTabInSameWindowAlongsideOtherTabs() {
         // Given a window with two tabs, one of which has an active voice session.
         let voiceTab = Tab(content: .none)
         let neighbourTab = Tab(content: .none)
-        windowControllersManager.customAllTabCollectionViewModels = [
-            makeTabCollectionViewModel(with: [voiceTab, neighbourTab])
-        ]
+        let tcvm = makeTabCollectionViewModel(with: [voiceTab, neighbourTab])
+        windowControllersManager.customAllTabCollectionViewModels = [tcvm]
         notificationCenter.post(name: .aiChatVoiceSessionStarted, object: voiceTab.webView)
 
-        // Tapping voice from `neighbourTab` finds the existing voice tab in the same window.
-        XCTAssertTrue(tracker.findActiveVoiceTab(inWindowOf: neighbourTab) === voiceTab)
+        // Tapping voice from anywhere in the same window finds the existing voice tab.
+        XCTAssertTrue(tracker.findActiveVoiceTab(in: tcvm) === voiceTab)
     }
 
     // MARK: - Stale ended notifications
@@ -147,14 +148,56 @@ final class VoiceSessionTrackerTests: XCTestCase {
     func testEndedNotification_FromUnknownWebView_DoesNotEvictTrackedTab() {
         // Given an active voice tab.
         let tab = Tab(content: .none)
-        windowControllersManager.customAllTabCollectionViewModels = [makeTabCollectionViewModel(with: [tab])]
+        let tcvm = makeTabCollectionViewModel(with: [tab])
+        windowControllersManager.customAllTabCollectionViewModels = [tcvm]
         notificationCenter.post(name: .aiChatVoiceSessionStarted, object: tab.webView)
-        XCTAssertNotNil(tracker.findActiveVoiceTab(inWindowOf: tab))
+        XCTAssertNotNil(tracker.findActiveVoiceTab(in: tcvm))
 
         // When a stray `voiceSessionEnded` arrives carrying some other webView.
         notificationCenter.post(name: .aiChatVoiceSessionEnded, object: WKWebView())
 
         // Then the tracked voice tab is still active.
-        XCTAssertTrue(tracker.findActiveVoiceTab(inWindowOf: tab) === tab)
+        XCTAssertTrue(tracker.findActiveVoiceTab(in: tcvm) === tab)
+    }
+
+    // MARK: - Pinned tabs (window-scope behaviour with the shared pinned collection)
+
+    /// A pinned voice tab is findable when the source window queries the tracker via a TCVM
+    /// whose pinned collection contains it. (In production the pinned collection is shared
+    /// across all windows via `PinnedTabsManagerProviding`, so this holds for every window;
+    /// in the test environment each TCVM has its own pinned collection, so we restrict the
+    /// assertion to the TCVM we know contains the tab.) Skipped when the test environment
+    /// doesn't expose a pinned tabs collection at all.
+    func testFindActiveVoiceTab_FindsPinnedActiveTabInSourceWindow() throws {
+        let unpinned = Tab(content: .none)
+        let tcvm = makeTabCollectionViewModel(with: [unpinned])
+        try XCTSkipIf(tcvm.pinnedTabsCollection == nil, "Pinned tabs collection unavailable in this test environment.")
+
+        let pinnedVoiceTab = Tab(content: .none)
+        tcvm.pinnedTabsCollection?.append(tab: pinnedVoiceTab)
+        windowControllersManager.customAllTabCollectionViewModels = [tcvm]
+        notificationCenter.post(name: .aiChatVoiceSessionStarted, object: pinnedVoiceTab.webView)
+
+        XCTAssertTrue(tracker.findActiveVoiceTab(in: tcvm) === pinnedVoiceTab)
+    }
+
+    /// Window-scope must hold even when the source window is queried via its TCVM but the source
+    /// tab is itself pinned. Previously the lookup keyed by `Tab`, and pinned tabs being shared
+    /// caused `tabCollectionViewModel(containing:)` to non-deterministically pick the first
+    /// window's TCVM — defeating the "voice in window B doesn't pull you to window A" promise
+    /// for the case where the active voice tab in window A was unpinned.
+    func testFindActiveVoiceTab_DoesNotMatchAcrossWindowsWhenActiveIsUnpinnedInWindowA() {
+        let unpinnedVoiceInA = Tab(content: .none)
+        let unpinnedInB = Tab(content: .none)
+        let tcvmA = makeTabCollectionViewModel(with: [unpinnedVoiceInA])
+        let tcvmB = makeTabCollectionViewModel(with: [unpinnedInB])
+        windowControllersManager.customAllTabCollectionViewModels = [tcvmA, tcvmB]
+        notificationCenter.post(name: .aiChatVoiceSessionStarted, object: unpinnedVoiceInA.webView)
+
+        // Voice request from window B must not focus window A's voice tab.
+        XCTAssertNil(tracker.findActiveVoiceTab(in: tcvmB))
+        // …but from window A it still does.
+        XCTAssertTrue(tracker.findActiveVoiceTab(in: tcvmA) === unpinnedVoiceInA)
     }
 }
+

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarAiChatsProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarAiChatsProviderTests.swift
@@ -259,7 +259,6 @@ private final class MockAIChatSuggestionsReader: AIChatSuggestionsReading {
 }
 
 private final class MockAiChatsConfigProvider: NewTabPageOmnibarConfigProviding {
-
     @MainActor var mode: NewTabPageDataModel.OmnibarMode = .ai
     private let modeSubject = PassthroughSubject<NewTabPageDataModel.OmnibarMode, Never>()
     var modePublisher: AnyPublisher<NewTabPageDataModel.OmnibarMode, Never> { modeSubject.eraseToAnyPublisher() }
@@ -283,6 +282,8 @@ private final class MockAiChatsConfigProvider: NewTabPageOmnibarConfigProviding 
     var isReasoningEffortEnabled: Bool = false
     var selectedReasoningEffort: String?
     var selectedReasoningEffortPublisher: AnyPublisher<String?, Never> { Just(nil).eraseToAnyPublisher() }
+    var isVoiceChatAccessEnabled: Bool = false
+    var isVoiceChatAccessEnabledPublisher: AnyPublisher<Bool, Never> { Just(false).eraseToAnyPublisher() }
 }
 
 private extension AIChatSuggestion {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1214283076614743?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1214283076614752?focus=true
CC:

### Description

Adds 1-click access to Duck.ai voice chat from native macOS surfaces (address-bar omnibar, NTP omnibar, main menu, more-options menu). When the chat input is empty and the feature flag is on, the submit button is replaced by a voice button; clicking it opens Duck.ai in a new tab and routes straight to voice mode.

The handoff piggy-backs on the existing `omnibar_submitChat` web→native message: the NTP voice button sends `{ chat: "", mode: "voice-mode", target }` and Duck.ai routes purely on the prompt mode — same mechanism image generation uses today. There is **no** dedicated bridge message and **no** `?mode=voice` URL parameter. Address-bar and menu paths use a new shared `AIChatOpenTrigger.mode(String)` case on `AIChatTabOpener` that opens Duck.ai and sets the prompt with the mode value.

The whole thing is gated end-to-end by `aiChatOmnibarVoiceChatAccess` (subfeature `omnibarVoiceChatAccess`) — a single shared flag controlling both surfaces. The NTP web app reads `enableVoiceChatAccess` from `OmnibarConfig` and reacts to flag flips at runtime via `omnibar_onConfigUpdate` (no reload needed).

iOS is intentionally untouched — it keeps using `voiceModeURL`.

### Screenshots / Demo

https://github.com/user-attachments/assets/631dc677-cf46-466e-8284-963ff0cd7c74

| Light mode      | Dark mode     |
| ------------- | ------------- |
|<img width="1624" height="1061" alt="Screenshot 2026-04-27 at 4 52 51 PM" src="https://github.com/user-attachments/assets/6d18e2ba-d3be-405a-b265-7045e1e92a96" />|<img width="1624" height="1061" alt="Screenshot 2026-04-27 at 4 53 00 PM" src="https://github.com/user-attachments/assets/f193d612-eb50-4d90-8230-ec1e7f76f5e4" />|

### Testing Steps

#### NTP omnibar (web)
1. Internal-only: enable `aiChatOmnibarVoiceChatAccess`. With the flag off, none of the steps below should produce a voice button anywhere — verify that first.
2. Open a new tab, switch to the **Duck.ai** tab in the omnibar. With the input empty, the submit arrow should be replaced by a voice waveform icon (aria-label: "Start voice chat").
3. Click the voice button → a new tab opens loading Duck.ai directly into voice mode.
4. Click the voice button with **Cmd** held → the new voice tab opens unselected; Cmd+Shift opens it selected; middle-click also opens in a new tab.
5. Type any character into the chat input → the voice button is replaced by the regular submit arrow. Clear the input → the voice button comes back.
6. Press **Enter** on an empty input → nothing happens (legacy disabled-submit behaviour, voice handoff requires an explicit click).
7. Activate image-generation mode (or attach an image) → the voice button is hidden even with the flag on.
8. While the NTP is open, toggle the feature flag remotely → the button should appear/disappear without a reload.

#### Address-bar omnibar (native)
9. Switch the address-bar omnibar to AI mode. With the input empty, the submit button is replaced by the voice button.
10. Click it → new tab loads Duck.ai voice mode (selected).
11. With the input empty, press **Enter** → no submission, no voice (matches NTP).
12. Switch into image-generation mode → voice button hidden.

#### Main menu / More Options menu
13. **Duck.ai → New Voice Chat** in the main menu opens a new selected tab in voice mode.
14. Same item in the More Options menu does the same.

#### Pixels
15. Trigger voice from each surface and verify the corresponding pixel fires (one per surface, daily+standard frequency):
    - `aichat_new_voice_chat_omnibar_native` (address bar)
    - `aichat_new_voice_chat_omnibar_ntp` (NTP)

### Impact and Risks

**Low.** Net-additive feature gated end-to-end behind `aiChatOmnibarVoiceChatAccess`. Disabling the flag returns the omnibar to today's submit-only behavior with no UI surface and no inbound voice routing. No data model changes, no migrations, no privacy surface.

#### What could go wrong?

- **Duck.ai rejects `mode: "voice-mode"`** → user sees a regular Duck.ai chat instead of voice. The fallback is a normal chat session, not a broken state.
- **iOS regression** → `AIChatURLParameters.voiceModeURL` / `voiceModeValue` were intentionally kept in the shared package because iOS still consumes them; iOS code path is unchanged.
- **Image-gen / web-search mode race** → voice button is gated on `!imageGenerationActive && !hasAttachedImages` so it can't co-exist with conflicting submission states. Toggling between modes was manually exercised.

### Quality Considerations

- **Edge cases** covered: feature flag off, input non-empty, input has only whitespace, image-gen active, image attached, web-search active, Cmd/Shift/middle-click modifiers, runtime flag flip, new-window vs new-tab behavior, unit tests + integration tests on the web side.
- **Performance**: zero added work on the hot paths — the flag check is a single `Bool` read and the voice button only conditionally renders. Reactive flag updates use the existing `featureFlagger.updatesPublisher` + `removeDuplicates` pipeline already used by other config fields.
- **Monitoring**: four new pixels (one per entry point) at `dailyAndStandard` frequency for adoption tracking. Definitions live in `aichat_addressbar_pixels.json5` and `aichat_ntp_pixels.json5`; new Swift cases are wired through `AIChatPixel.swift`.
- **Documentation**: tech design and revision (post-AL1 feedback) attached on the Asana task. Schema docs in content-scope-scripts updated (`omnibar.md`).
- **Privacy / Security**: no new data collection, no new web→native message surface (we removed `omnibar_openNewVoiceChat` and reused the existing `omnibar_submitChat` enum). Pixel parameters are aggregate counts only.

### Notes to Reviewer

- The mode-based handoff is a deliberate revision of the original tech design (which had a dedicated `omnibar_openNewVoiceChat` notify and a `?mode=voice` URL param). AL1's feedback in the design comments pushed us to reuse `omnibar_submitChat` mode, mirroring image-generation. The original design + revision are both linked on the Asana task.
- Three independent code-review passes (composer-2, gpt-5.3-codex-high, gemini-3.1-pro) returned no high-confidence findings on this branch.


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches omnibar UI behavior, keyboard focus handling, and tab-opening logic (including cross-window tab selection) plus adds new user-script-driven state tracking; issues could manifest as incorrect focus/tab routing or broken submission affordances when the flag is enabled.
> 
> **Overview**
> **Adds 1-click Duck.ai voice chat access across macOS surfaces (address-bar omnibar, NTP omnibar, and menus) behind the new `aiChatOmnibarVoiceChatAccess` / `omnibarVoiceChatAccess` flag.** When the input is empty (and not in image-generation), the submit button switches to a mic icon; clicking opens Duck.ai using a new mode-based prompt handoff (`mode: "voice-mode"`) and fires new adoption pixels.
> 
> Introduces a new `AIChatOpenTrigger.mode(String)` and `AIChatTabOpener.openVoiceSession(...)` flow that **focuses an existing active voice tab in the same window** before opening a new one, powered by a new `VoiceSessionTracker` that listens for Duck.ai user-script voice session start/end notifications. NTP omnibar config now includes `enableVoiceChatAccess` and publishes runtime updates to swap the UI without reload; recent chat suggestions also gain optional `model` and a `kind` classification to show voice/image-specific icons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a09e4d0ac6b5d1c6b26142989358f4728aa196bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->