### PR TITLE
Fix clear button appearing without fade on omnibar focus

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -43,6 +43,9 @@ class SwitchBarTextEntryView: UIView {
 
         // Increased buttons spacing
         static let additionalVerticalButtonsPadding: CGFloat = 6
+
+        // Matches UnifiedToggleInputView.Constants.animationDuration so icons ride the focus animation.
+        static let buttonStateAnimationDuration: TimeInterval = 0.25
     }
 
     private let handler: SwitchBarHandling
@@ -310,12 +313,15 @@ class SwitchBarTextEntryView: UIView {
         buttonsView.isAIVoiceChatEnabled = handler.isAIVoiceChatEnabled && handler.currentToggleState == .aiChat
 
         if newButtonState != currentButtonState {
-            // UIStackView animates `isHidden` changes that land inside an animation block;
-            // lay out `self` so `buttonsView`'s frame settles here, not on a later pass.
-            UIView.performWithoutAnimation {
-                currentButtonState = newButtonState
-                adjustTextViewContentInset()
-                layoutIfNeeded()
+            // Snapshot crossfade so icons fade in/out without UIStackView's `isHidden` jank.
+            UIView.transition(with: buttonsView,
+                              duration: Constants.buttonStateAnimationDuration,
+                              options: .transitionCrossDissolve) {
+                UIView.performWithoutAnimation {
+                    self.currentButtonState = newButtonState
+                    self.adjustTextViewContentInset()
+                    self.layoutIfNeeded()
+                }
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214332089999852?focus=true
CC: @aataraxiaa 

### Description

When the omnibar already contains text (e.g. the URL of the current page) and the user taps it to focus, the surrounding focus animation runs normally but the **clear (×) button pops in at full opacity** instead of fading with the rest of the UI.

Root cause: `SwitchBarTextEntryView.updateButtonState()` flipped the buttons' `isHidden` inside `UIView.performWithoutAnimation` to suppress UIStackView's built-in `isHidden` reveal animation (which produced layout jank). Since the publisher delivering the new button state fires asynchronously and is decoupled from `UnifiedToggleInputView.setExpanded`'s `UIView.animate` block, the icons had no fade source — neither their own animation nor an inherited one.

Fix: wrap the existing `performWithoutAnimation` block in `UIView.transition(with: buttonsView, options: .transitionCrossDissolve)`. UIKit takes a before/after snapshot of the buttons view and crossfades them, while the inner `performWithoutAnimation` still settles the layout instantly — so we get the fade without reintroducing the stack-view jank. Duration matches `UnifiedToggleInputView.Constants.animationDuration` (0.25s) so the icons ride the focus animation.

Before: (observe clear (x) button)
https://github.com/user-attachments/assets/a41f4117-8919-4f76-82fb-c245738b99ec

After:
https://github.com/user-attachments/assets/7d3242f9-6a27-4c96-a53a-4581645a3b7f

### Testing Steps

1. Open the app and navigate to any web page so the URL pre-fills the omnibar.
2. Without typing, tap the omnibar to focus it.
3. **Expected:** the clear (×) button fades in alongside the rest of the focus animation. **Before this fix:** it popped in at full opacity.
4. While focused with text, tap the clear button — the button should fade out as the field empties.
5. With an empty focused field, type a character — the clear button should fade in (rather than pop).
6. Repeat 1–3 with the omnibar in both top and bottom positions.

### Impact and Risks

Low — animation-only tweak. No change to button-state computation or layout logic; same buttons end up shown/hidden, just with a 250ms crossfade. Affects only the focused-omnibar (UnifiedToggleInput / SwitchBar) UI surface.

#### What could go wrong?

- **Animation queue stacking on rapid state changes:** if `updateButtonState()` fires again while the previous 250ms `UIView.transition` is still mid-animation, the second snapshot can stack on top. Mitigated upstream by `removeDuplicates()` on `currentButtonStatePublisher` — only genuine state changes propagate. Realistic user cadence (focus, type, clear) is well above 250ms; flagged for QA but not expected to be visible.
- **Crossfade affecting unrelated buttons:** transitions like `.voiceOnly → .clearOnly` crossfade the whole `buttonsView`. Buttons share the trailing position and are similar in size, so it reads as a clean swap rather than a mismatch.

### Quality Considerations

- Duration is set to match `UnifiedToggleInputView.Constants.animationDuration` (0.25s) so the icon crossfade is timed with the focus animation it's meant to ride along.
- The original anti-jank intent (`performWithoutAnimation` to suppress UIStackView's `isHidden` reveal) is preserved — it now lives *inside* the `UIView.transition` closure. Layout still settles instantly; only the snapshot crossfade runs.

### Notes to Reviewer

- The `// UIStackView animates ...` comment is replaced with a one-liner explaining the crossfade rationale; the WHY is now "snapshot crossfade so icons fade in/out without UIStackView's `isHidden` jank".
- No tests reference `SwitchBarTextEntryView` or the changed surface — none added. The change is animation-only with no logic delta, and was verified manually on iPhone 17 Pro simulator with slow animations enabled (focus path, clear-button tap, typing first character).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: button visibility updates now crossfade over 250ms, but state computation and layout outcomes are unchanged; main risk is minor animation artifacts if button state flips rapidly.
> 
> **Overview**
> Fixes the omnibar clear button (and other switch-bar icons) popping in at full opacity by **crossfading `SwitchBarButtonsView` state changes** in `SwitchBarTextEntryView.updateButtonState()`.
> 
> Adds a `0.25s` `buttonStateAnimationDuration` constant and wraps the existing `performWithoutAnimation` layout-settling block in `UIView.transition(..., .transitionCrossDissolve)` to keep UIStackView hide/show jank suppressed while matching the unified focus animation timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e339aca44408eb2537fccd85ffcab0e44deba10e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->