### PR TITLE
macOS VPN: Fix QUIC/UDP exclusions

### DIFF
--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Provider/TransparentProxyProvider.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Provider/TransparentProxyProvider.swift
@@ -195,14 +195,6 @@ open class TransparentProxyProvider: NETransparentProxyProvider {
                 NENetworkRule(destinationHost: NWHostEndpoint(hostname: "duckduckgo.com", port: "443"), protocol: .any))
         }
 
-        // Please note that excluding traffic from the proxy does not mean it will be excluded from the VPN.
-        // Traffic captured by the proxy can be excluded from the VPN, so excluding traffic from the proxy actually
-        // means this traffic will always be routed through the VPN.
-        networkSettings.excludedNetworkRules = [
-            // Ref: https://app.asana.com/0/1207603085593419/1209681033289804/f
-            NENetworkRule(destinationHost: NWHostEndpoint(hostname: "push.apple.com", port: ""), protocol: .UDP)
-        ]
-
         return networkSettings
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207603085593419/task/1209986428880880?focus=true

### Description

The macOS transparent proxy was excluding push.apple.com UDP traffic, which prevented UDP flows from reaching the proxy. This removes that exclusion so outbound UDP routes through the proxy as expected.

### Testing Steps
1. Start the VPN.
2. Visit https://browserleaks.com/quic.
3. Note the VPN IP shown by the site.
4. Exclude browserleaks.com from the VPN, reload, and confirm the site now shows your non-VPN IP — proving QUIC/UDP traffic is routed through the proxy when excluded.

### Impact and Risks

Low. UDP flow handling through the macOS transparent proxy was broken; this restores the intended behavior. No new risk surface — the change removes a rule that was preventing the proxy from working as designed.

#### What could go wrong?

Limited. The fix moves toward correctness rather than away from it.

### Quality Considerations

No automated test covers this codepath; verification is manual.

### Notes to Reviewer

The original exclusion referenced an internal Asana task. Please confirm removing it is acceptable, or whether the rule needs to remain in a different form that doesn't block other UDP flows.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transparent proxy network rules so `push.apple.com` UDP traffic is no longer bypassed; this can affect routing/behavior of Apple push/QUIC flows and should be validated on macOS VPN setups.
> 
> **Overview**
> Removes the `excludedNetworkRules` entry that previously excluded UDP traffic to `push.apple.com` from the macOS `NETransparentProxyNetworkSettings`.
> 
> As a result, outbound UDP (including push-related UDP flows) is now eligible to be captured by the transparent proxy under the existing included rules, restoring expected UDP routing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b553e4535596f9a602ef6f5515f46777627171f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->