### PR TITLE
iOS: Fix UTI toggle labels overflowing pill during reveal

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
@@ -100,6 +100,9 @@ final class UnifiedToggleInputToggleView: UIView {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        // Clip subviews to bounds so labels don't protrude past the pill while the height
+        // constraint animates 0→40 during the reveal animation.
+        clipsToBounds = true
         setupUI()
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214344334837569
Tech Design URL:
CC: @aataraxiaa 

### Description

When focusing the UTI for the first time at the **top** address bar position, the segmented control's labels ("Search" / "Duck.ai") appeared at full intrinsic size while the pill was still mid-grow, leaving them overflowing the rounded container. Per-frame instrumentation confirmed the cause: `UnifiedToggleInputToggleView`'s internal `UIStackView` is pinned to its `backgroundView` at `.defaultHigh` priority (749) — the same priority as the segment buttons' compression resistance — so when the parent shrinks toward 0 the pin loses, and the stackView snaps to its intrinsic ~19 pt height while the rest of the toggle is still animating from 0.

The fix sets `clipsToBounds = true` on the toggle view so anything outside its animated bounds is hidden, mirroring the X close button's "small content inside a growing frame" visual semantic. The `.defaultHigh` priorities are intentionally preserved (they're how PR #4590 prevented "Unable to simultaneously satisfy constraints" warnings when the toggle collapses to height 0).

Before:
https://github.com/user-attachments/assets/2550b1eb-5aa1-4009-96af-68375c8b472a

After:
https://github.com/user-attachments/assets/9ec11c81-5c7c-4d30-aced-54262554c5f4

### Testing Steps

1. Open the app with **Address bar position: Top** (Settings → Address Bar → Top).
2. From a state where the UTI is hidden (e.g. fresh new tab), tap the omnibar to focus it for the first time.
3. Watch the appear animation: the segmented control with "Search" / "Duck.ai" labels should grow from 0 to full size with no labels protruding past the pill at any point.
4. Repeat with **slow animations** enabled (Simulator → Debug → Slow Animations) for a clearer view.
5. Confirm the X close button still scales correctly and the indicator (selected segment) drop shadow still reads cleanly at the resting state.
6. Confirm no "Unable to simultaneously satisfy constraints" warnings appear in the console when collapsing/expanding the UTI.

### Impact and Risks

Low — visual-only fix, three-line change in `UnifiedToggleInputToggleView.init(frame:)`.

#### What could go wrong?

The indicator's drop shadow (offset 0,2; radius 6) extends ~2-4 pt below the pill at full size. With `clipsToBounds = true` on the parent toggleView, that small overflow is now clipped. The shadow is still rendered for the dominant portion within the toggle's bounds; visual depth is preserved. If this turns out to be perceptible, follow-up options include moving the shadow rendering to the indicator's superview hierarchy or restructuring the clip boundary.

### Quality Considerations

- Constraint-priority structure is unchanged — no risk of recreating the AutoLayout conflict that PR #4590 prevented.
- No impact on hit testing (subviews remain within the toggle's bounds at full size; `clipsToBounds` only affects rendering).
- No performance impact.

### Notes to Reviewer

The investigation captured per-frame `presentation()` geometry via a CADisplayLink-based sampler around `animateToggleReveal` — that instrumentation has been stripped from this branch. Hard data showed `stackView` presentation height stuck at ~19.3 pt while `toggleView`/`backgroundView` animated from 0 to 40, confirming the priority-fallback hypothesis exactly.

Two alternative fix paths were considered and rejected:
- Bumping the stackView's vertical pins to `.required` would force the buttons to compress mid-animation (text clips through the middle of letterforms) and re-introduces the constraint conflict PR #4590 fixed.
- A `transform.scaleY` animation on the toggle gives true uniform scaling but introduces text rasterization blur and requires anchorPoint manipulation that interacts poorly with the existing height-constraint animation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change; it may slightly clip any subview effects (e.g., shadows) that extend outside the toggle’s bounds.
> 
> **Overview**
> Prevents `UnifiedToggleInputToggleView`’s segment labels from visually overflowing the pill during the reveal height animation by enabling `clipsToBounds` on the toggle view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1218bd6abfc1facd68f941d76100f943dc751d8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->