### PR TITLE
Run JS data clearing alongside native storage on fire button

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/HistoryCleaner/AIChatJSDataCleaner.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/HistoryCleaner/AIChatJSDataCleaner.swift
@@ -1,0 +1,265 @@
+//
+//  AIChatJSDataCleaner.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import BrowserServicesKit
+import os.log
+import PrivacyConfig
+import UserScript
+import WebKit
+
+/// Clears Duck.ai data held in the JS layer (localStorage, IndexedDB) by loading each
+/// Duck.ai domain in a headless WebView and invoking the content-scope-scripts
+/// `duck-ai-data-clearing` feature.
+public protocol AIChatJSDataCleaning {
+    @MainActor func clearJSData(chatID: String?) async -> Result<Void, Error>
+}
+
+public final class WebViewAIChatJSDataCleaner: AIChatJSDataCleaning {
+
+    enum CleanerError: Error {
+        case webViewNotInitialized
+        case scriptNotInitialized
+        case operationInProgress
+    }
+
+    private let featureFlagger: FeatureFlagger
+    private let privacyConfig: PrivacyConfigurationManaging
+    private let websiteDataStore: WKWebsiteDataStore
+
+    private var continuation: CheckedContinuation<Result<Void, Error>, Never>?
+    private var navigationContinuation: CheckedContinuation<Result<Void, Error>, Never>?
+    private var webView: WKWebView?
+    private var coordinator: Coordinator?
+    private var contentScopeUserScript: ContentScopeUserScript?
+    private var aiChatDataClearingUserScript: AIChatDataClearingUserScript?
+
+    public init(featureFlagger: FeatureFlagger,
+                privacyConfig: PrivacyConfigurationManaging,
+                websiteDataStore: WKWebsiteDataStore) {
+        self.featureFlagger = featureFlagger
+        self.privacyConfig = privacyConfig
+        self.websiteDataStore = websiteDataStore
+    }
+
+    @MainActor
+    public func clearJSData(chatID: String?) async -> Result<Void, Error> {
+        if let chatID {
+            Logger.aiChat.debug("WebViewAIChatJSDataCleaner: deleting chat \(chatID) from webView")
+        } else {
+            Logger.aiChat.debug("WebViewAIChatJSDataCleaner: deleting all chats from webView")
+        }
+
+        guard webView == nil else {
+            return .failure(CleanerError.operationInProgress)
+        }
+
+        return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+            Task { @MainActor in
+                await self.processAllDomains(chatID: chatID)
+            }
+        }
+    }
+
+    @MainActor
+    private func processAllDomains(chatID: String?) async {
+        do {
+            try setupWebView()
+            for domain in URL.aiChatDomains {
+                let navigationResult = await launchClearingWebView(requestURL: domain)
+
+                guard case .success = navigationResult else {
+                    finish(result: navigationResult)
+                    return
+                }
+
+                let clearingResult = await executeClearingScript(chatID: chatID)
+
+                guard case .success = clearingResult else {
+                    finish(result: clearingResult)
+                    return
+                }
+            }
+
+            finish(result: .success(()))
+        } catch {
+            finish(result: .failure(error))
+        }
+    }
+
+    @MainActor
+    private func setupWebView() throws {
+        let aiChatDataClearing = AIChatDataClearingUserScript()
+
+        let features = ContentScopeFeatureToggles(
+            emailProtection: false,
+            emailProtectionIncontextSignup: false,
+            credentialsAutofill: false,
+            identitiesAutofill: false,
+            creditCardsAutofill: false,
+            credentialsSaving: false,
+            passwordGeneration: false,
+            inlineIconCredentials: false,
+            thirdPartyCredentialsProvider: false,
+            unknownUsernameCategorization: false,
+            partialFormSaves: false,
+            passwordVariantCategorization: false,
+            inputFocusApi: false,
+            autocompleteAttributeSupport: false
+        )
+
+        let contentScopeProperties = ContentScopeProperties(
+            gpcEnabled: false,
+            sessionKey: UUID().uuidString,
+            messageSecret: UUID().uuidString,
+            isInternalUser: featureFlagger.internalUserDecider.isInternalUser,
+            featureToggles: features
+        )
+
+        let contentScope = try ContentScopeUserScript(
+            privacyConfig,
+            properties: contentScopeProperties,
+            scriptContext: .aiChatDataClearing,
+            allowedNonisolatedFeatures: [aiChatDataClearing.featureName],
+            privacyConfigurationJSONGenerator: nil
+        )
+        contentScope.registerSubfeature(delegate: aiChatDataClearing)
+
+        let userContentController = WKUserContentController()
+        userContentController.addUserScript(contentScope.makeWKUserScriptSync())
+        userContentController.addHandler(contentScope)
+
+        let configuration = WKWebViewConfiguration()
+        configuration.userContentController = userContentController
+        configuration.websiteDataStore = websiteDataStore
+
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        let coordinator = Coordinator(cleaner: self)
+        webView.navigationDelegate = coordinator
+
+        aiChatDataClearing.webView = webView
+        self.webView = webView
+        self.coordinator = coordinator
+        self.contentScopeUserScript = contentScope
+        self.aiChatDataClearingUserScript = aiChatDataClearing
+    }
+
+    @MainActor
+    private func launchClearingWebView(requestURL: URL) async -> Result<Void, Error> {
+        guard let webView = webView else {
+            return .failure(CleanerError.webViewNotInitialized)
+        }
+
+        return await withCheckedContinuation { continuation in
+            self.navigationContinuation = continuation
+
+            if #available(iOS 15.0, macOS 12.0, *) {
+                webView.loadSimulatedRequest(URLRequest(url: requestURL), responseHTML: "")
+            } else {
+                webView.loadHTMLString("", baseURL: requestURL)
+            }
+        }
+    }
+
+    @MainActor
+    private func completeNavigation(with result: Result<Void, Error>) {
+        navigationContinuation?.resume(returning: result)
+        navigationContinuation = nil
+    }
+
+    @MainActor
+    private func executeClearingScript(chatID: String?) async -> Result<Void, Error> {
+        guard let script = aiChatDataClearingUserScript else {
+            return .failure(CleanerError.scriptNotInitialized)
+        }
+
+        return await script.clearAIChatDataAsync(chatID: chatID, timeout: 5)
+    }
+
+    @MainActor
+    private func finish(result: Result<Void, Error>) {
+        tearDown()
+        continuation?.resume(returning: result)
+        continuation = nil
+    }
+
+    @MainActor
+    private func tearDown() {
+        webView?.stopLoading()
+        webView?.navigationDelegate = nil
+        webView = nil
+        coordinator = nil
+        aiChatDataClearingUserScript = nil
+        contentScopeUserScript = nil
+    }
+}
+
+// MARK: - Navigation Delegate
+extension WebViewAIChatJSDataCleaner {
+    private final class Coordinator: NSObject, WKNavigationDelegate {
+        weak var cleaner: WebViewAIChatJSDataCleaner?
+
+        init(cleaner: WebViewAIChatJSDataCleaner) {
+            self.cleaner = cleaner
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            cleaner?.completeNavigation(with: .success(()))
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            cleaner?.completeNavigation(with: .failure(error))
+        }
+
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            cleaner?.completeNavigation(with: .failure(error))
+        }
+    }
+}
+
+@MainActor
+extension WKUserContentController {
+
+    func addHandler(_ userScript: UserScript) {
+        for messageName in userScript.messageNames {
+            let contentWorld: WKContentWorld = userScript.getContentWorld()
+            if let handlerWithReply = userScript as? WKScriptMessageHandlerWithReply {
+                addScriptMessageHandler(handlerWithReply, contentWorld: contentWorld, name: messageName)
+            } else {
+                add(userScript, contentWorld: contentWorld, name: messageName)
+            }
+        }
+    }
+
+    func removeHandler(_ userScript: UserScript) {
+        userScript.messageNames.forEach {
+            let contentWorld: WKContentWorld = userScript.getContentWorld()
+            removeScriptMessageHandler(forName: $0, contentWorld: contentWorld)
+        }
+    }
+}
+
+extension URL {
+    static let duckAi = URL(string: "https://duck.ai")!
+    static let duckDuckGo = URL(string: "https://duckduckgo.com")!
+
+    static let aiChatDomains: [URL] = [
+        .duckDuckGo,
+        .duckAi
+    ]
+}

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/HistoryCleaner/HistoryCleaner.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/HistoryCleaner/HistoryCleaner.swift
@@ -28,53 +28,53 @@ public protocol HistoryCleaning {
 }
 
 public final class HistoryCleaner: HistoryCleaning {
-    private var continuation: CheckedContinuation<Result<Void, Error>, Never>?
-    private var navigationContinuation: CheckedContinuation<Result<Void, Error>, Never>?
-    private var webView: WKWebView?
-    private var coordinator: Coordinator?
-    private let featureFlagger: FeatureFlagger
-    private let privacyConfig: PrivacyConfigurationManaging
-    private let websiteDataStore: WKWebsiteDataStore
-    private var contentScopeUserScript: ContentScopeUserScript?
-    private var aiChatDataClearingUserScript: AIChatDataClearingUserScript?
     private let nativeStorageHandler: DuckAiNativeStorageHandling?
     private let featureFlagProvider: AIChatFeatureFlagProviding?
+    private let jsDataCleaner: AIChatJSDataCleaning
 
-    /// Creates a history cleaner that can clear data via native storage or a headless webview.
+    /// Creates a history cleaner that clears Duck.ai data from both native storage and the JS layer.
+    ///
     /// When `nativeStorageHandler` and `featureFlagProvider` are provided and the feature flag is enabled
-    /// with migration done, chats and files are deleted directly from local storage.
-    /// Otherwise the webview path is used.
+    /// with migration done, chats and files are deleted from native storage. The JS clearing path
+    /// (localStorage + IndexedDB) always runs, since JS-side data is kept in sync regardless of whether
+    /// native storage is in use — without it, fire button cleanup leaves traces behind.
     public init(featureFlagger: FeatureFlagger,
                 privacyConfig: PrivacyConfigurationManaging,
                 websiteDataStore: WKWebsiteDataStore? = nil,
                 nativeStorageHandler: DuckAiNativeStorageHandling? = nil,
-                featureFlagProvider: AIChatFeatureFlagProviding? = nil) {
-        self.featureFlagger = featureFlagger
-        self.privacyConfig = privacyConfig
-        self.websiteDataStore = websiteDataStore ?? .default()
+                featureFlagProvider: AIChatFeatureFlagProviding? = nil,
+                jsDataCleaner: AIChatJSDataCleaning? = nil) {
         self.nativeStorageHandler = nativeStorageHandler
         self.featureFlagProvider = featureFlagProvider
+        self.jsDataCleaner = jsDataCleaner ?? WebViewAIChatJSDataCleaner(
+            featureFlagger: featureFlagger,
+            privacyConfig: privacyConfig,
+            websiteDataStore: websiteDataStore ?? .default()
+        )
     }
 
     /// Clears all Duck.ai chat history (chats and files, not settings).
     @MainActor
     public func cleanAIChatHistory() async -> Result<Void, Error> {
-        if let result = clearLocalStorageIfAvailable(chatID: nil) {
-            return result
-        }
-        return await performWebViewDelete(chatID: nil)
+        return await performClear(chatID: nil)
     }
 
     /// Deletes a single Duck.ai chat.
     @MainActor
     public func deleteAIChat(chatID: String) async -> Result<Void, Error> {
-        if let result = clearLocalStorageIfAvailable(chatID: chatID) {
-            return result
-        }
-        return await performWebViewDelete(chatID: chatID)
+        return await performClear(chatID: chatID)
     }
 
-    // MARK: - Local Storage Path
+    @MainActor
+    private func performClear(chatID: String?) async -> Result<Void, Error> {
+        let nativeResult = clearLocalStorageIfAvailable(chatID: chatID)
+        let jsResult = await jsDataCleaner.clearJSData(chatID: chatID)
+
+        if case .failure = nativeResult {
+            return nativeResult ?? jsResult
+        }
+        return jsResult
+    }
 
     private func clearLocalStorageIfAvailable(chatID: String?) -> Result<Void, Error>? {
         guard let featureFlagProvider, featureFlagProvider.isNativeDataStorageEnabled(),
@@ -101,230 +101,4 @@ public final class HistoryCleaner: HistoryCleaning {
             return .failure(error)
         }
     }
-
-    // MARK: - WebView Path
-
-    @MainActor
-    private func performWebViewDelete(chatID: String?) async -> Result<Void, Error> {
-        if let chatID {
-            Logger.aiChat.debug("HistoryCleaner: deleting chat \(chatID) from webView")
-        } else {
-            Logger.aiChat.debug("HistoryCleaner: deleting all chats from webView")
-        }
-
-        guard webView == nil else {
-            return .failure(HistoryCleanerError.operationInProgress)
-        }
-
-        return await withCheckedContinuation { continuation in
-            self.continuation = continuation
-            Task { @MainActor in
-                await self.processAllDomains(chatID: chatID)
-            }
-        }
-    }
-
-    @MainActor
-    private func processAllDomains(chatID: String?) async {
-        do {
-            try setupWebView()
-            for domain in URL.aiChatDomains {
-                let navigationResult = await launchHistoryCleaningWebView(requestURL: domain)
-
-                guard case .success = navigationResult else {
-                    finish(result: navigationResult)
-                    return
-                }
-
-                let clearingResult = await executeClearingScript(chatID: chatID)
-
-                guard case .success = clearingResult else {
-                    finish(result: clearingResult)
-                    return
-                }
-            }
-
-            finish(result: .success(()))
-        } catch {
-            finish(result: .failure(error))
-        }
-    }
-
-    // MARK: - WebView Setup
-
-    @MainActor
-    private func setupWebView() throws {
-        let aiChatDataClearing = AIChatDataClearingUserScript()
-
-        let features = ContentScopeFeatureToggles(
-            emailProtection: false,
-            emailProtectionIncontextSignup: false,
-            credentialsAutofill: false,
-            identitiesAutofill: false,
-            creditCardsAutofill: false,
-            credentialsSaving: false,
-            passwordGeneration: false,
-            inlineIconCredentials: false,
-            thirdPartyCredentialsProvider: false,
-            unknownUsernameCategorization: false,
-            partialFormSaves: false,
-            passwordVariantCategorization: false,
-            inputFocusApi: false,
-            autocompleteAttributeSupport: false
-        )
-
-        let contentScopeProperties = ContentScopeProperties(
-            gpcEnabled: false,
-            sessionKey: UUID().uuidString,
-            messageSecret: UUID().uuidString,
-            isInternalUser: featureFlagger.internalUserDecider.isInternalUser,
-            featureToggles: features
-        )
-
-        let contentScope = try ContentScopeUserScript(
-            privacyConfig,
-            properties: contentScopeProperties,
-            scriptContext: .aiChatDataClearing,
-            allowedNonisolatedFeatures: [aiChatDataClearing.featureName],
-            privacyConfigurationJSONGenerator: nil
-        )
-        contentScope.registerSubfeature(delegate: aiChatDataClearing)
-
-        let userContentController = WKUserContentController()
-        userContentController.addUserScript(contentScope.makeWKUserScriptSync())
-        userContentController.addHandler(contentScope)
-
-        let configuration = WKWebViewConfiguration()
-        configuration.userContentController = userContentController
-        configuration.websiteDataStore = websiteDataStore
-
-        let webView = WKWebView(frame: .zero, configuration: configuration)
-        let coordinator = Coordinator(cleaner: self)
-        webView.navigationDelegate = coordinator
-
-        aiChatDataClearing.webView = webView
-        self.webView = webView
-        self.coordinator = coordinator
-        self.contentScopeUserScript = contentScope
-        self.aiChatDataClearingUserScript = aiChatDataClearing
-    }
-
-    // MARK: - Domain Navigation
-
-    @MainActor
-    private func launchHistoryCleaningWebView(requestURL: URL) async -> Result<Void, Error> {
-        guard let webView = webView else {
-            return .failure(HistoryCleanerError.webViewNotInitialized)
-        }
-
-        return await withCheckedContinuation { continuation in
-            self.navigationContinuation = continuation
-
-            if #available(iOS 15.0, macOS 12.0, *) {
-                webView.loadSimulatedRequest(URLRequest(url: requestURL), responseHTML: "")
-            } else {
-                webView.loadHTMLString("", baseURL: requestURL)
-            }
-        }
-    }
-
-    @MainActor
-    private func completeNavigation(with result: Result<Void, Error>) {
-        navigationContinuation?.resume(returning: result)
-        navigationContinuation = nil
-    }
-
-    // MARK: - Script Execution
-
-    @MainActor
-    private func executeClearingScript(chatID: String?) async -> Result<Void, Error> {
-        guard let script = aiChatDataClearingUserScript else {
-            return .failure(HistoryCleanerError.scriptNotInitialized)
-        }
-
-        return await script.clearAIChatDataAsync(chatID: chatID, timeout: 5)
-    }
-
-    // MARK: - Cleanup
-
-    @MainActor
-    private func finish(result: Result<Void, Error>) {
-        tearDownClearingWebView()
-        continuation?.resume(returning: result)
-        continuation = nil
-    }
-
-    @MainActor
-    private func tearDownClearingWebView() {
-        webView?.stopLoading()
-        webView?.navigationDelegate = nil
-        webView = nil
-        coordinator = nil
-        aiChatDataClearingUserScript = nil
-        contentScopeUserScript = nil
-    }
-}
-
-// MARK: - Errors
-extension HistoryCleaner {
-    enum HistoryCleanerError: Error {
-        case webViewNotInitialized
-        case scriptNotInitialized
-        case operationInProgress
-    }
-}
-
-// MARK: - Navigation Delegate
-extension HistoryCleaner {
-    private final class Coordinator: NSObject, WKNavigationDelegate {
-        weak var cleaner: HistoryCleaner?
-
-        init(cleaner: HistoryCleaner) {
-            self.cleaner = cleaner
-        }
-
-        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            cleaner?.completeNavigation(with: .success(()))
-        }
-
-        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-            cleaner?.completeNavigation(with: .failure(error))
-        }
-
-        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-            cleaner?.completeNavigation(with: .failure(error))
-        }
-    }
-}
-
-@MainActor
-extension WKUserContentController {
-
-    func addHandler(_ userScript: UserScript) {
-        for messageName in userScript.messageNames {
-            let contentWorld: WKContentWorld = userScript.getContentWorld()
-            if let handlerWithReply = userScript as? WKScriptMessageHandlerWithReply {
-                addScriptMessageHandler(handlerWithReply, contentWorld: contentWorld, name: messageName)
-            } else {
-                add(userScript, contentWorld: contentWorld, name: messageName)
-            }
-        }
-    }
-
-    func removeHandler(_ userScript: UserScript) {
-        userScript.messageNames.forEach {
-            let contentWorld: WKContentWorld = userScript.getContentWorld()
-            removeScriptMessageHandler(forName: $0, contentWorld: contentWorld)
-        }
-    }
-}
-
-extension URL {
-    static let duckAi = URL(string: "https://duck.ai")!
-    static let duckDuckGo = URL(string: "https://duckduckgo.com")!
-
-    static let aiChatDomains: [URL] = [
-        .duckDuckGo,
-        .duckAi
-    ]
 }

--- a/SharedPackages/AIChat/Tests/AIChatTests/HistoryCleanerTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/HistoryCleanerTests.swift
@@ -30,6 +30,7 @@ final class HistoryCleanerTests: XCTestCase {
     private var mockFlagProvider: MockAIChatFeatureFlagProvider!
     private var mockHandler: CallCountingStorageHandler!
     private var mockPrivacyConfig: MockPrivacyConfigurationManager!
+    private var mockJSCleaner: MockAIChatJSDataCleaner!
 
     override func setUp() {
         super.setUp()
@@ -37,6 +38,7 @@ final class HistoryCleanerTests: XCTestCase {
         mockFlagProvider = MockAIChatFeatureFlagProvider()
         mockHandler = CallCountingStorageHandler()
         mockPrivacyConfig = MockPrivacyConfigurationManager()
+        mockJSCleaner = MockAIChatJSDataCleaner()
     }
 
     override func tearDown() {
@@ -44,6 +46,7 @@ final class HistoryCleanerTests: XCTestCase {
         mockFlagProvider = nil
         mockHandler = nil
         mockPrivacyConfig = nil
+        mockJSCleaner = nil
         super.tearDown()
     }
 
@@ -56,7 +59,8 @@ final class HistoryCleanerTests: XCTestCase {
             privacyConfig: mockPrivacyConfig,
             websiteDataStore: .nonPersistent(),
             nativeStorageHandler: nativeStorageHandler,
-            featureFlagProvider: featureFlagProvider
+            featureFlagProvider: featureFlagProvider,
+            jsDataCleaner: mockJSCleaner
         )
     }
 
@@ -90,7 +94,7 @@ final class HistoryCleanerTests: XCTestCase {
         XCTAssertNotNil(try? result.get())
     }
 
-    func testWhenStorageFlagDisabledButAccessFlagEnabledThenCleanAIChatHistoryDoesNotUseLocalStorage() {
+    func testWhenStorageFlagDisabledButAccessFlagEnabledThenCleanAIChatHistoryDoesNotUseLocalStorage() async {
         // Regression guard for the pre-fix behavior: when only the access flag is on,
         // local storage must NOT be cleared.
         mockFlagProvider.isNativeDataStorageEnabledResult = false
@@ -98,34 +102,20 @@ final class HistoryCleanerTests: XCTestCase {
         mockHandler.stubbedIsMigrationDone = true
         let sut = makeSUT(nativeStorageHandler: mockHandler, featureFlagProvider: mockFlagProvider)
 
-        let deleteAllChatsNotCalled = expectation(description: "deleteAllChats should not be called")
-        deleteAllChatsNotCalled.isInverted = true
-        mockHandler.onDeleteAllChats = { deleteAllChatsNotCalled.fulfill() }
+        _ = await sut.cleanAIChatHistory()
 
-        let task = Task { _ = await sut.cleanAIChatHistory() }
-
-        wait(for: [deleteAllChatsNotCalled], timeout: 0.5)
         XCTAssertEqual(mockHandler.deleteAllChatsCallCount, 0)
         XCTAssertEqual(mockHandler.deleteAllFilesCallCount, 0)
-
-        task.cancel()
     }
 
-    func testWhenMigrationNotDoneThenCleanAIChatHistoryDoesNotUseLocalStorage() {
+    func testWhenMigrationNotDoneThenCleanAIChatHistoryDoesNotUseLocalStorage() async {
         mockFlagProvider.isNativeDataStorageEnabledResult = true
         mockHandler.stubbedIsMigrationDone = false
         let sut = makeSUT(nativeStorageHandler: mockHandler, featureFlagProvider: mockFlagProvider)
 
-        let deleteAllChatsNotCalled = expectation(description: "deleteAllChats should not be called")
-        deleteAllChatsNotCalled.isInverted = true
-        mockHandler.onDeleteAllChats = { deleteAllChatsNotCalled.fulfill() }
+        _ = await sut.cleanAIChatHistory()
 
-        let task = Task { _ = await sut.cleanAIChatHistory() }
-
-        wait(for: [deleteAllChatsNotCalled], timeout: 0.5)
         XCTAssertEqual(mockHandler.deleteAllChatsCallCount, 0)
-
-        task.cancel()
     }
 
     func testWhenHandlerThrowsOnDeleteAllChatsThenCleanAIChatHistoryReturnsFailure() async {
@@ -142,6 +132,59 @@ final class HistoryCleanerTests: XCTestCase {
         }
         XCTAssertEqual(error as NSError, expectedError)
         XCTAssertEqual(mockHandler.deleteAllFilesCallCount, 1, "Files should be cleared before chats")
+    }
+
+    // MARK: - JS data cleaner is also invoked when native storage is enabled
+
+    func testWhenStorageFlagEnabledAndMigrationDoneThenCleanAIChatHistoryAlsoClearsJSData() async {
+        // Without this, IndexedDB/localStorage on the JS side would leak data after the fire button is used.
+        mockFlagProvider.isNativeDataStorageEnabledResult = true
+        mockHandler.stubbedIsMigrationDone = true
+        let sut = makeSUT(nativeStorageHandler: mockHandler, featureFlagProvider: mockFlagProvider)
+
+        _ = await sut.cleanAIChatHistory()
+
+        XCTAssertEqual(mockJSCleaner.clearJSDataCalls, [nil])
+    }
+
+    func testWhenNoNativeHandlerProvidedThenCleanAIChatHistoryStillRunsJSCleaner() async {
+        let sut = makeSUT(nativeStorageHandler: nil, featureFlagProvider: nil)
+
+        _ = await sut.cleanAIChatHistory()
+
+        XCTAssertEqual(mockJSCleaner.clearJSDataCalls, [nil])
+    }
+
+    func testWhenNativeClearFailsThenJSCleanerStillRunsAndNativeErrorIsReturned() async {
+        mockFlagProvider.isNativeDataStorageEnabledResult = true
+        mockHandler.stubbedIsMigrationDone = true
+        let nativeError = NSError(domain: "native", code: 1)
+        mockHandler.stubbedDeleteAllChatsError = nativeError
+        let sut = makeSUT(nativeStorageHandler: mockHandler, featureFlagProvider: mockFlagProvider)
+
+        let result = await sut.cleanAIChatHistory()
+
+        XCTAssertEqual(mockJSCleaner.clearJSDataCalls, [nil], "JS cleanup must still run for best-effort cleanup")
+        guard case .failure(let error) = result else {
+            return XCTFail("Expected native failure to propagate, got \(result)")
+        }
+        XCTAssertEqual(error as NSError, nativeError)
+    }
+
+    func testWhenJSCleanerFailsAndNativeSucceedsThenJSFailureIsReturned() async {
+        mockFlagProvider.isNativeDataStorageEnabledResult = true
+        mockHandler.stubbedIsMigrationDone = true
+        let jsError = NSError(domain: "js", code: 7)
+        mockJSCleaner.stubbedResult = .failure(jsError)
+        let sut = makeSUT(nativeStorageHandler: mockHandler, featureFlagProvider: mockFlagProvider)
+
+        let result = await sut.cleanAIChatHistory()
+
+        XCTAssertEqual(mockHandler.deleteAllChatsCallCount, 1)
+        guard case .failure(let error) = result else {
+            return XCTFail("Expected JS failure to surface when native succeeded, got \(result)")
+        }
+        XCTAssertEqual(error as NSError, jsError)
     }
 
     // MARK: - deleteAIChat (single chat)
@@ -163,6 +206,7 @@ final class HistoryCleanerTests: XCTestCase {
         XCTAssertEqual(mockHandler.deletedChatIDs, ["target-chat"], "Only target chat should be deleted")
         XCTAssertEqual(mockHandler.deleteAllChatsCallCount, 0, "Bulk delete should not be called for single-chat delete")
         XCTAssertEqual(mockHandler.deleteAllFilesCallCount, 0, "Bulk file delete should not be called for single-chat delete")
+        XCTAssertEqual(mockJSCleaner.clearJSDataCalls, ["target-chat"])
     }
 
     func testWhenDeleteAIChatWithNoMatchingFilesThenOnlyChatIsDeleted() async {
@@ -194,28 +238,23 @@ final class HistoryCleanerTests: XCTestCase {
         }
         XCTAssertEqual(error as NSError, expectedError)
         XCTAssertTrue(mockHandler.deletedChatIDs.isEmpty, "Chat should not be deleted when file listing fails")
+        XCTAssertEqual(mockJSCleaner.clearJSDataCalls, ["target-chat"], "JS cleanup must still run when native fails")
     }
 
-    func testWhenStorageFlagDisabledButAccessFlagEnabledThenDeleteAIChatDoesNotUseLocalStorage() {
+    func testWhenStorageFlagDisabledButAccessFlagEnabledThenDeleteAIChatDoesNotUseLocalStorage() async {
         mockFlagProvider.isNativeDataStorageEnabledResult = false
         mockFlagProvider.isNativeDataAccessEnabledResult = true
         mockHandler.stubbedIsMigrationDone = true
         let sut = makeSUT(nativeStorageHandler: mockHandler, featureFlagProvider: mockFlagProvider)
 
-        let localPathNotUsed = expectation(description: "single-chat local delete should not run")
-        localPathNotUsed.isInverted = true
-        mockHandler.onDeleteChat = { _ in localPathNotUsed.fulfill() }
+        _ = await sut.deleteAIChat(chatID: "some-chat")
 
-        let task = Task { _ = await sut.deleteAIChat(chatID: "some-chat") }
-
-        wait(for: [localPathNotUsed], timeout: 0.5)
         XCTAssertTrue(mockHandler.deletedChatIDs.isEmpty)
-
-        task.cancel()
+        XCTAssertEqual(mockJSCleaner.clearJSDataCalls, ["some-chat"], "JS cleanup is the only path when native isn't applicable")
     }
 }
 
-// MARK: - Mock
+// MARK: - Mocks
 
 private final class CallCountingStorageHandler: DuckAiNativeStorageHandling {
 
@@ -223,9 +262,6 @@ private final class CallCountingStorageHandler: DuckAiNativeStorageHandling {
     var stubbedFiles: [DuckAiFileMetadata] = []
     var stubbedListFilesError: Error?
     var stubbedDeleteAllChatsError: Error?
-
-    var onDeleteAllChats: (() -> Void)?
-    var onDeleteChat: ((String) -> Void)?
 
     private(set) var deleteAllChatsCallCount = 0
     private(set) var deleteAllFilesCallCount = 0
@@ -249,12 +285,10 @@ private final class CallCountingStorageHandler: DuckAiNativeStorageHandling {
     func deleteChat(chatId: String) throws {
         deleteChatCallCount += 1
         deletedChatIDs.append(chatId)
-        onDeleteChat?(chatId)
     }
 
     func deleteAllChats() throws {
         deleteAllChatsCallCount += 1
-        onDeleteAllChats?()
         if let error = stubbedDeleteAllChatsError { throw error }
     }
 
@@ -280,4 +314,15 @@ private final class CallCountingStorageHandler: DuckAiNativeStorageHandling {
     func isMigrationDone() throws -> Bool { stubbedIsMigrationDone }
     func isMigrationDone(key: String) throws -> Bool { stubbedIsMigrationDone }
     func markMigrationDone(key: String) throws {}
+}
+
+private final class MockAIChatJSDataCleaner: AIChatJSDataCleaning {
+    var stubbedResult: Result<Void, Error> = .success(())
+    private(set) var clearJSDataCalls: [String?] = []
+
+    @MainActor
+    func clearJSData(chatID: String?) async -> Result<Void, Error> {
+        clearJSDataCalls.append(chatID)
+        return stubbedResult
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214365656065212?focus=true
Tech Design URL:
CC:

### Description
When the `duckAiNativeStorage` flag is on, the fire button cleared native storage but left IndexedDB and localStorage data behind because the JS layer is kept in sync regardless of the storage mode. `HistoryCleaner` now runs the c-s-s `duck-ai-data-clearing` script alongside the native clear via an injectable `AIChatJSDataCleaning`, so chats are wiped from both layers. The WebView/JS path was extracted into `WebViewAIChatJSDataCleaner` to make the combined behavior unit-testable.

### Testing Steps
1. Enable the `duckAiNativeStorage` feature flag, send a few Duck.ai chats, then tap the fire button — verify both native storage (GRDB / files on disk) and the page's IndexedDB / localStorage are empty afterwards.
2. With the flag off, repeat the fire button flow and confirm chats still clear via the JS path (no regression).
3. Run the AIChat test target — `HistoryCleanerTests` should pass (13 tests, including new combined-path coverage).

### Impact and Risks
Medium — touches privacy-sensitive cleanup; a regression here would leave residual chat data after fire button.

#### What could go wrong?
The JS path could fail (timeout, navigation error) and surface as a fire button failure even when native clearing succeeded; mitigated by still running native first and propagating the native error in preference when both run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Privacy-sensitive cleanup flow now runs an additional JS-layer wipe and changes error-propagation behavior; failures in the headless WebView/script path could cause fire-button cleanup to report failure even when native deletion succeeded.
> 
> **Overview**
> `HistoryCleaner` now **always** runs JS-layer data clearing (localStorage/IndexedDB) in addition to any native Duck.ai storage deletion, ensuring fire-button cleanup removes chat traces in both layers.
> 
> The previous embedded WebView/script logic was extracted into an injectable `AIChatJSDataCleaning` (`WebViewAIChatJSDataCleaner`), and unit tests were updated/added to cover combined native+JS execution and which error is surfaced when one side fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edeb36f0bef75f2a61d74d423b185d31b3acabe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->