### PR TITLE
Pre-size applyingReplacements buffer to fix UserScripts OOM

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Common/Extensions/StringExtension.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Common/Extensions/StringExtension.swift
@@ -455,8 +455,12 @@ public extension String {
 
         let firstBytes = Set(keys.map { $0.utf8[0] })
 
+        // Output size can exceed template size when replacement values are
+        // larger than their placeholders; size the reservation accordingly
+        // to avoid repeated capacity doublings during append.
+        let estimatedSize = templateUTF8.count + keys.reduce(0) { $0 + $1.value.count }
         var result = [UInt8]()
-        result.reserveCapacity(templateUTF8.count)
+        result.reserveCapacity(estimatedSize)
 
         var i = 0
         while i < templateUTF8.count {

--- a/SharedPackages/BrowserServicesKit/Tests/CommonTests/Extensions/StringExtensionTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/CommonTests/Extensions/StringExtensionTests.swift
@@ -428,4 +428,14 @@ final class StringExtensionTests: XCTestCase {
         XCTAssertEqual(result, "world")
     }
 
+    func testApplyingReplacementsHandlesValueMuchLargerThanPlaceholder() {
+        let largeValue = String(repeating: "x", count: 1_100_000)
+        let template = "before $K$ after"
+        let result = template.applyingReplacements(["$K$": largeValue])
+
+        XCTAssertEqual(result.count, "before  after".count + largeValue.count)
+        XCTAssertTrue(result.hasPrefix("before "))
+        XCTAssertTrue(result.hasSuffix(" after"))
+    }
+
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200848783441532/task/1214310231037292

### Description

Fixes a memory pattern in `String.applyingReplacements` that contributed to OOM crashes during user-script construction (Sentry: `SIGABRT _ArrayBuffer._consumeAndCreateNew`, groups `APPLE-IOS-D6N7`, `D7RR`, `D8DG`).

The function builds the substituted output in a `[UInt8]` buffer and reserves capacity equal to the **template** length. ContentScope substitutions are highly asymmetric — `$CONTENT_SCOPE$` (15 bytes) is replaced with the privacy config (~1.1 MB) — so the output blows past the reservation immediately and grows through Swift's Array doubling, holding old + new buffers simultaneously per growth step. Per-tab peak transient memory is several MB, multiplied by the number of `WKWebView` × script-context combinations initializing concurrently. When the process can't service the next double, allocation aborts via `swift_abortAllocationFailure`.

Fix: pre-size the reservation to `templateUTF8.count + Σ value.count` — a tight upper bound for single-occurrence templates (which all current `loadJS` callers in ContentScope are). Eliminates capacity doublings for the typical case; multi-occurrence keys still grow but from a reasonable starting size rather than from the template length.

### Testing Steps

1. Run the BrowserServicesKit `CommonTests` suite; confirm `StringExtensionTests/testApplyingReplacements*` all pass, including the new `testApplyingReplacementsHandlesValueMuchLargerThanPlaceholder`.
2. Smoke test the iOS app on a low-memory device (e.g. iPhone SE / iPad with multiple Safari tabs forced into memory pressure):
   - Open 8–10 tabs across different sites
   - Confirm no SIGABRT during page loads
   - Browse normally on a few sites with content blocking active; confirm tracker blocking, autoconsent, and other ContentScope-driven features still work
3. (Optional) Profile in Instruments → Allocations on iOS while opening multiple tabs concurrently. Confirm transient peak memory during `UserContentController` init is reduced compared to a build without this change.

### Impact and Risks

**Low.**

The change is a pure capacity-reservation tweak inside `String.applyingReplacements`. Output is byte-identical to before — only the size of the initial buffer reservation differs. Existing unit tests cover correctness across single replacement, multiple replacements, repeated keys, empty dict, and empty key scenarios; a new test was added for the asymmetric large-value case that motivated the fix.

Worst case if the size estimate is wrong: the buffer either over-reserves (slightly higher one-time allocation, no growth) or under-reserves for multi-occurrence keys (some growth, but starting from a much larger base than today). Either way, behavior is no worse than current behavior.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only initial `Array` capacity reservation in `String.applyingReplacements`, with behavior expected to be output-identical; main risk is slightly higher one-time allocation size for large replacement values.
> 
> **Overview**
> Reduces transient allocations in `String.applyingReplacements` by reserving output buffer capacity based on the template size plus total replacement value sizes, avoiding repeated `Array` capacity doublings when substitutions are much larger than their placeholders.
> 
> Adds a regression test covering a very large replacement value to ensure correctness and guard against OOM-prone usage patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8c8b304cfc18e0906a61f17e625ccc925ae9ae2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->