### PR TITLE
[macOS] Add formSubmittedDate to PIR native↔web contract

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/UIWeb/DBPUICommunicationModel.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/UIWeb/DBPUICommunicationModel.swift
@@ -256,11 +256,12 @@ public struct DBPUIDataBrokerProfileMatch: Codable {
     public let relatives: [String]
     public let foundDate: Double
     public let optOutSubmittedDate: Double?
+    public let formSubmittedDate: Double?
     public let estimatedRemovalDate: Double?
     public let removedDate: Double?
     public let hasMatchingRecordOnParentBroker: Bool
 
-    public init(id: Int64?, dataBroker: DBPUIDataBroker, name: String, addresses: [DBPUIUserProfileAddress], alternativeNames: [String], relatives: [String], foundDate: Double, optOutSubmittedDate: Double? = nil, estimatedRemovalDate: Double? = nil, removedDate: Double? = nil, hasMatchingRecordOnParentBroker: Bool) {
+    public init(id: Int64?, dataBroker: DBPUIDataBroker, name: String, addresses: [DBPUIUserProfileAddress], alternativeNames: [String], relatives: [String], foundDate: Double, optOutSubmittedDate: Double? = nil, formSubmittedDate: Double? = nil, estimatedRemovalDate: Double? = nil, removedDate: Double? = nil, hasMatchingRecordOnParentBroker: Bool) {
         self.id = id
         self.dataBroker = dataBroker
         self.name = name
@@ -269,6 +270,7 @@ public struct DBPUIDataBrokerProfileMatch: Codable {
         self.relatives = relatives
         self.foundDate = foundDate
         self.optOutSubmittedDate = optOutSubmittedDate
+        self.formSubmittedDate = formSubmittedDate
         self.estimatedRemovalDate = estimatedRemovalDate
         self.removedDate = removedDate
         self.hasMatchingRecordOnParentBroker = hasMatchingRecordOnParentBroker
@@ -308,10 +310,19 @@ extension DBPUIDataBrokerProfileMatch {
         }
         let estimatedRemovalDate = Calendar.current.date(byAdding: .day, value: 14, to: optOutSubmittedDate ?? foundDate)
 
-        // Check for any matching records on the parent broker
-        let hasFoundParentMatch = parentBrokerOptOutJobData?.contains { parentOptOut in
+        // Strict-match parent lookup: still used for `hasMatchingRecordOnParentBroker`. We do *not*
+        // use this matcher for the `formSubmittedDate` fallback — see TD note [5]: the strict
+        // matcher rejected nearly every real-world child↔parent pairing because brokers scrape
+        // names with different middle-name granularity and age inconsistently.
+        let matchingParentOptOut = parentBrokerOptOutJobData?.first { parentOptOut in
             extractedProfile.doesMatchExtractedProfile(parentOptOut.extractedProfile)
-        } ?? false
+        }
+
+        // Broker-level fallback for child brokers (TD note [5]): every child record is downstream
+        // of the parent, so any submission we made to the parent is a removal request that may
+        // clear this record. Most recent so the value reflects the latest activity.
+        let formSubmittedDate = Self.formSubmittedDate(in: optOutJobData.historyEvents)
+            ?? parentBrokerOptOutJobData.flatMap { Self.mostRecentSubmission(across: $0) }
 
         self.init(id: extractedProfile.id,
                   dataBroker: dataBroker,
@@ -321,9 +332,36 @@ extension DBPUIDataBrokerProfileMatch {
                   relatives: extractedProfile.relatives ?? [String](),
                   foundDate: foundDate.timeIntervalSince1970,
                   optOutSubmittedDate: optOutSubmittedDate?.timeIntervalSince1970,
+                  formSubmittedDate: formSubmittedDate?.timeIntervalSince1970,
                   estimatedRemovalDate: estimatedRemovalDate?.timeIntervalSince1970,
                   removedDate: extractedProfile.removedDate?.timeIntervalSince1970,
-                  hasMatchingRecordOnParentBroker: hasFoundParentMatch)
+                  hasMatchingRecordOnParentBroker: matchingParentOptOut != nil)
+    }
+
+    /// Derives the moment the form-submission action against the broker successfully completed,
+    /// from history events already loaded on the read path. For brokers requiring email confirmation
+    /// this is the first `.optOutSubmittedAndAwaitingEmailConfirmation` event; otherwise the first
+    /// `.optOutRequested` event, which is logged at form submission for non-email brokers and
+    /// after email confirmation for email brokers (in which case the email-confirmation event,
+    /// logged earlier, is what we actually want).
+    private static func formSubmittedDate(in historyEvents: [HistoryEvent]) -> Date? {
+        if let firstEmailConfirmation = historyEvents
+            .filter({ $0.type == .optOutSubmittedAndAwaitingEmailConfirmation })
+            .min(by: { $0.date < $1.date }) {
+            return firstEmailConfirmation.date
+        }
+        return historyEvents
+            .filter { $0.type == .optOutRequested }
+            .min(by: { $0.date < $1.date })?.date
+    }
+
+    /// The most recent `formSubmittedDate` derivation across the given opt-out jobs, regardless of
+    /// whether their extracted profiles match anything. Used for the child→parent broker-level
+    /// fallback.
+    private static func mostRecentSubmission(across jobs: [OptOutJobData]) -> Date? {
+        jobs.lazy
+            .compactMap { formSubmittedDate(in: $0.historyEvents) }
+            .max()
     }
 
     /// Generates an array of `DBPUIDataBrokerProfileMatch` objects from the provided query data.

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/DBPUICommunicationModelTests.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/DBPUICommunicationModelTests.swift
@@ -229,6 +229,240 @@ final class DBPUICommunicationModelTests: XCTestCase {
         XCTAssertTrue(profileMatch.hasMatchingRecordOnParentBroker)
     }
 
+    // MARK: - formSubmittedDate derivation
+
+    func testProfileMatchInit_whenBrokerHasOptOutRequestedEvent_thenFormSubmittedDateIsThatEventDate() {
+
+        // Given
+        let extractedProfile = ExtractedProfile.mockWithoutRemovedDate
+        let optOutRequestedDate = Calendar.current.date(byAdding: .day, value: -3, to: Date.now)!
+        let historyEvents = [
+            HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutRequested, date: optOutRequestedDate)
+        ]
+        let optOut = OptOutJobData.mock(with: extractedProfile,
+                                        historyEvents: historyEvents,
+                                        createdDate: Date.now,
+                                        submittedSuccessfullyDate: nil)
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: optOut,
+                                                       dataBroker: makeUIBroker(),
+                                                       parentBrokerOptOutJobData: nil)
+
+        // Then
+        XCTAssertEqual(profileMatch.formSubmittedDate, optOutRequestedDate.timeIntervalSince1970)
+    }
+
+    func testProfileMatchInit_whenBrokerHasEmailConfirmationEvent_thenFormSubmittedDateIsThatEventDate() {
+
+        // Given
+        let extractedProfile = ExtractedProfile.mockWithoutRemovedDate
+        let formSubmittedAtDate = Calendar.current.date(byAdding: .day, value: -5, to: Date.now)!
+        let emailConfirmedDate = Calendar.current.date(byAdding: .day, value: -2, to: Date.now)!
+        let historyEvents = [
+            HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutSubmittedAndAwaitingEmailConfirmation, date: formSubmittedAtDate),
+            HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutRequested, date: emailConfirmedDate)
+        ]
+        let optOut = OptOutJobData.mock(with: extractedProfile,
+                                        historyEvents: historyEvents,
+                                        createdDate: Date.now,
+                                        submittedSuccessfullyDate: emailConfirmedDate)
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: optOut,
+                                                       dataBroker: makeUIBroker(),
+                                                       parentBrokerOptOutJobData: nil)
+
+        // Then
+        XCTAssertEqual(profileMatch.formSubmittedDate, formSubmittedAtDate.timeIntervalSince1970)
+        XCTAssertEqual(profileMatch.optOutSubmittedDate, emailConfirmedDate.timeIntervalSince1970)
+    }
+
+    func testProfileMatchInit_whenMultipleSubmissionEventsExist_thenFormSubmittedDateIsTheFirstOne() {
+
+        // Given
+        let extractedProfile = ExtractedProfile.mockWithoutRemovedDate
+        let firstAttempt = Calendar.current.date(byAdding: .day, value: -10, to: Date.now)!
+        let secondAttempt = Calendar.current.date(byAdding: .day, value: -5, to: Date.now)!
+        let historyEvents = [
+            HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutRequested, date: secondAttempt),
+            HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutRequested, date: firstAttempt)
+        ]
+        let optOut = OptOutJobData.mock(with: extractedProfile,
+                                        historyEvents: historyEvents,
+                                        createdDate: Date.now,
+                                        submittedSuccessfullyDate: nil)
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: optOut,
+                                                       dataBroker: makeUIBroker(),
+                                                       parentBrokerOptOutJobData: nil)
+
+        // Then
+        XCTAssertEqual(profileMatch.formSubmittedDate, firstAttempt.timeIntervalSince1970)
+    }
+
+    func testProfileMatchInit_whenNoSubmissionEvents_thenFormSubmittedDateIsNil() {
+
+        // Given
+        let extractedProfile = ExtractedProfile.mockWithoutRemovedDate
+        let historyEvents = [
+            HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .matchesFound(count: 1), date: Date.now)
+        ]
+        let optOut = OptOutJobData.mock(with: extractedProfile,
+                                        historyEvents: historyEvents,
+                                        createdDate: Date.now,
+                                        submittedSuccessfullyDate: nil)
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: optOut,
+                                                       dataBroker: makeUIBroker(),
+                                                       parentBrokerOptOutJobData: nil)
+
+        // Then
+        XCTAssertNil(profileMatch.formSubmittedDate)
+    }
+
+    func testProfileMatchInit_whenChildBrokerHasNoOwnSubmissionEventsButParentDoes_thenFormSubmittedDateFallsBackToParent() {
+
+        // Given — child has no submission events of its own (its opt-out is skipped at runtime),
+        // parent ran the opt-out and has the submission event.
+        let extractedProfile = ExtractedProfile.mockWithName("Steve Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+        let parentProfile = ExtractedProfile.mockWithName("Steve Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+
+        let parentSubmissionDate = Calendar.current.date(byAdding: .day, value: -4, to: Date.now)!
+        let parentEvents = [
+            HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutRequested, date: parentSubmissionDate)
+        ]
+
+        let childOptOut = OptOutJobData.mock(with: extractedProfile, historyEvents: [])
+        let parentOptOut = OptOutJobData.mock(with: parentProfile, historyEvents: parentEvents)
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: childOptOut,
+                                                       dataBroker: makeUIBroker(parentURL: "parent.com"),
+                                                       parentBrokerOptOutJobData: [parentOptOut])
+
+        // Then
+        XCTAssertEqual(profileMatch.formSubmittedDate, parentSubmissionDate.timeIntervalSince1970)
+    }
+
+    func testProfileMatchInit_whenChildBrokerHasNoOwnSubmissionEventsAndParentMatchHasNone_thenFormSubmittedDateIsNil() {
+
+        // Given
+        let extractedProfile = ExtractedProfile.mockWithName("Steve Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+        let parentProfile = ExtractedProfile.mockWithName("Steve Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+
+        let childOptOut = OptOutJobData.mock(with: extractedProfile, historyEvents: [])
+        let parentOptOut = OptOutJobData.mock(with: parentProfile, historyEvents: [])
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: childOptOut,
+                                                       dataBroker: makeUIBroker(parentURL: "parent.com"),
+                                                       parentBrokerOptOutJobData: [parentOptOut])
+
+        // Then
+        XCTAssertNil(profileMatch.formSubmittedDate)
+    }
+
+    func testProfileMatchInit_whenChildHasOwnSubmissionEventAndParentAlsoHasOne_thenFormSubmittedDatePrefersChild() {
+
+        // Given — defensive: if a child somehow has its own submission event (e.g. a future change
+        // changes the parentSiteOptOut behavior), the child's own value should win.
+        let extractedProfile = ExtractedProfile.mockWithName("Steve Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+        let parentProfile = ExtractedProfile.mockWithName("Steve Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+
+        let childSubmission = Calendar.current.date(byAdding: .day, value: -2, to: Date.now)!
+        let parentSubmission = Calendar.current.date(byAdding: .day, value: -10, to: Date.now)!
+
+        let childOptOut = OptOutJobData.mock(with: extractedProfile,
+                                             historyEvents: [HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutRequested, date: childSubmission)])
+        let parentOptOut = OptOutJobData.mock(with: parentProfile,
+                                              historyEvents: [HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutRequested, date: parentSubmission)])
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: childOptOut,
+                                                       dataBroker: makeUIBroker(parentURL: "parent.com"),
+                                                       parentBrokerOptOutJobData: [parentOptOut])
+
+        // Then
+        XCTAssertEqual(profileMatch.formSubmittedDate, childSubmission.timeIntervalSince1970)
+    }
+
+    func testProfileMatchInit_whenChildHasNoSubmissionEventsAndParentMatchIsNotAnExactMatch_thenFormSubmittedDateStillUsesParentSubmission() {
+
+        // Given — broker-level fallback: every child broker record is structurally downstream of
+        // the parent, so any parent submission is a removal request that may clear this record.
+        // The strict matcher is reserved for `hasMatchingRecordOnParentBroker`.
+        let extractedProfile = ExtractedProfile.mockWithName("Steve Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+        let parentProfileNonmatching = ExtractedProfile.mockWithName("Jamie Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+
+        let parentSubmission = Calendar.current.date(byAdding: .day, value: -4, to: Date.now)!
+        let childOptOut = OptOutJobData.mock(with: extractedProfile, historyEvents: [])
+        let parentOptOut = OptOutJobData.mock(with: parentProfileNonmatching,
+                                              historyEvents: [HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutRequested, date: parentSubmission)])
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: childOptOut,
+                                                       dataBroker: makeUIBroker(parentURL: "parent.com"),
+                                                       parentBrokerOptOutJobData: [parentOptOut])
+
+        // Then
+        XCTAssertEqual(profileMatch.formSubmittedDate, parentSubmission.timeIntervalSince1970)
+        // Strict matcher still rejects, so the parent-broker-duplicate signal stays false.
+        XCTAssertFalse(profileMatch.hasMatchingRecordOnParentBroker)
+    }
+
+    func testProfileMatchInit_whenMultipleParentJobsHaveSubmissions_thenChildUsesMostRecent() {
+
+        // Given — three parent opt-outs, two with submissions on different dates, one without.
+        // The fallback should pick the most recent submission, regardless of which extracted
+        // profile it belongs to.
+        let extractedProfile = ExtractedProfile.mockWithName("Steve Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+        let parentA = ExtractedProfile.mockWithName("Adam P Smith", age: "46", addresses: [AddressCityState(city: "San Diego", state: "CA")])
+        let parentB = ExtractedProfile.mockWithName("Adam M Smith", age: "48", addresses: [AddressCityState(city: "San Diego", state: "CA")])
+        let parentC = ExtractedProfile.mockWithName("Adam O Smith", age: "50", addresses: [AddressCityState(city: "San Diego", state: "CA")])
+
+        let oldSubmission = Calendar.current.date(byAdding: .day, value: -10, to: Date.now)!
+        let recentSubmission = Calendar.current.date(byAdding: .day, value: -2, to: Date.now)!
+
+        let childOptOut = OptOutJobData.mock(with: extractedProfile, historyEvents: [])
+        let parentOptOutA = OptOutJobData.mock(with: parentA,
+                                               historyEvents: [HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutRequested, date: oldSubmission)])
+        let parentOptOutB = OptOutJobData.mock(with: parentB,
+                                               historyEvents: [HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutSubmittedAndAwaitingEmailConfirmation, date: recentSubmission)])
+        let parentOptOutC = OptOutJobData.mock(with: parentC, historyEvents: [])
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: childOptOut,
+                                                       dataBroker: makeUIBroker(parentURL: "parent.com"),
+                                                       parentBrokerOptOutJobData: [parentOptOutA, parentOptOutB, parentOptOutC])
+
+        // Then
+        XCTAssertEqual(profileMatch.formSubmittedDate, recentSubmission.timeIntervalSince1970)
+    }
+
+    func testProfileMatchInit_whenAllParentJobsAreFailures_thenFormSubmittedDateIsNil() {
+
+        // Given — parent has opt-outs but none reached a submission event (e.g. Spokeo's
+        // error(actionFailed) loops). Broker-level fallback should resolve to nil, not paper over
+        // the failure.
+        let extractedProfile = ExtractedProfile.mockWithName("Steve Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+        let parentProfile = ExtractedProfile.mockWithName("Adam P Smith", age: "46", addresses: [AddressCityState(city: "San Diego", state: "CA")])
+
+        let childOptOut = OptOutJobData.mock(with: extractedProfile, historyEvents: [])
+        let parentOptOut = OptOutJobData.mock(with: parentProfile,
+                                              historyEvents: [HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutStarted, date: Date.now)])
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: childOptOut,
+                                                       dataBroker: makeUIBroker(parentURL: "parent.com"),
+                                                       parentBrokerOptOutJobData: [parentOptOut])
+
+        // Then
+        XCTAssertNil(profileMatch.formSubmittedDate)
+    }
+
     // MARK: - `profileMatches` Broker OptOut URL & Name tests
 
     func testProfileMatches_optOutUrlAndBrokerNameForChildBroker() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1214253991604416/f/
Tech Design URL: https://app.asana.com/1/137249556945/project/1209121419454298/task/1214328412449852

### Description

Adds `formSubmittedDate` to `DBPUIDataBrokerProfileMatch` so the web dashboard can count what *we* did (form-submission) rather than what brokers did (acknowledged the submission). Today the activity-card numerator uses `optOutSubmittedDate`, which for the ~50/61 email-confirming brokers represents broker acknowledgment — leaving the count stuck whenever email confirmation rates are low. The new field surfaces the form-submission moment directly.

Implementation:
- `formSubmittedDate` is derived at read time in `DBPUIDataBrokerProfileMatch.init(optOutJobData:dataBroker:parentBrokerOptOutJobData:)` from history events that are already loaded with each `OptOutJobData`. No new column, no DB migration, no extra DB queries.
- Email-confirming brokers: first `.optOutSubmittedAndAwaitingEmailConfirmation` event.
- Non-email brokers: first `.optOutRequested` event (which is logged at form submission for them).
- Set once at the first successful form submission. Set on every match regardless of broker type.
- `optOutSubmittedDate` is unchanged in name, semantics, and population. Pixels, the macOS estimated-removal-date, and the confirmation-scan scheduler all keep their current inputs.

Child brokers (`optOutType: parentSiteOptOut`) skip their own opt-out execution at runtime and inherit from the parent. Implementation propagates the most recent `formSubmittedDate` from *any* opt-out on the parent broker — see TD note [5] for why broker-level rather than strict-record-match: in real-world data the strict matcher (`doesMatchExtractedProfile`) rejected nearly every child↔parent pair because brokers scrape names with different middle-name granularity and age inconsistently. `hasMatchingRecordOnParentBroker` keeps using the strict matcher (different question — "is this a duplicate of a parent record?" — where false positives matter more).

iOS shares `DataBrokerProtectionCore` so picks this up automatically.

### Testing Steps
1. Run `DBPUICommunicationModelTests` — 19 tests pass, 10 of them new for `formSubmittedDate`.
2. With the matching web change deployed: open a fresh scan with at least one email-confirming broker (Spokeo is the canonical case). After the broker reaches `optOutSubmittedAndAwaitingEmailConfirmation`, the activity card should flip from "Preparing to send removal requests" to "Submitting requests to remove records / N of M removal requests submitted" — without waiting for email confirmation.
3. Confirm that brokers with `parentSiteOptOut` get `formSubmittedDate` populated whenever their parent broker has reached form submission for any of its records.

### Impact and Risks
**Low.** The change is additive (one new optional field on the wire) and read-only — no schema, no persistence, no backfill, no behavioral change to opt-out execution. Existing consumers of `optOutSubmittedDate` are unaffected.

#### What could go wrong?
- **Web on older clients**: Web reads `formSubmittedDate ?? optOutSubmittedDate`, so older native clients keep working unchanged.
- **Mirror sites**: handled implicitly — they already share the parent broker's `OptOutJobData`, so the form-submission events are right there in their own history events.
- **Stranded child opt-outs** (parent broker had no scan match → no parent opt-out jobs to inherit from): not addressed here, separate concern.

### Quality Considerations

- **Privacy**: no new user data is collected, retained, or transmitted. `formSubmittedDate` is a timestamp already captured internally and now exposed only on the existing native↔WebView contract. Not persisted by web, not included in any pixel.
- **Performance**: read-time derivation operates on data the existing read path already loads (`historyEvents` are eager-fetched on `OptOutJobData`). Parent broker lookup is O(1) against the broker-URL→query-data dict every platform already builds; the per-child scan over the parent's opt-outs is bounded by the small number of records a user has on a single broker.
- **Tests**: per-broker-type unit tests (email-confirming and non-email) and parent-value derivation for child brokers (broker-level fallback, most-recent semantics, all-failures → nil, child has own value → wins, etc.).

### Notes to Reviewer

- This is the macOS/iOS slice of the cross-platform TD. Web ships first; Android and Windows are separate PRs.
- Code comment in `DBPUIDataBrokerProfileMatch.init` references TD note [5] for the broker-level fallback rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)