### PR TITLE
[executor] Suppress update-available notification during onboarding

### DIFF
--- a/macOS/LocalPackages/AppUpdater/Sources/AppStoreAppUpdater/AppStoreUpdateController.swift
+++ b/macOS/LocalPackages/AppUpdater/Sources/AppStoreAppUpdater/AppStoreUpdateController.swift
@@ -131,11 +131,12 @@ extension UpdateControllerFactory: AppStoreUpdateControllerFactory {
          featureFlagger: FeatureFlagger? = nil,
          pixelFiring: PixelFiring? = nil,
          notificationPresenter: any UpdateNotificationPresenting,
+         releaseChecker: LatestReleaseChecker? = nil,
          isOnboardingFinished: @escaping () -> Bool = { true }) {
         self.updateCheckState = UpdateCheckState()
         self.updaterChecker = AppStoreUpdaterAvailabilityChecker()
         self.notificationPresenter = notificationPresenter
-        self.releaseChecker = LatestReleaseChecker()
+        self.releaseChecker = releaseChecker ?? LatestReleaseChecker()
         self.featureFlagger = featureFlagger ?? MockFeatureFlagger()
         self.pixelFiring = pixelFiring
         self.internalUserDecider = internalUserDecider ?? MockInternalUserDecider(isInternalUser: false)
@@ -227,7 +228,10 @@ extension UpdateControllerFactory: AppStoreUpdateControllerFactory {
                     let update = Update(releaseMetadata: releaseMetadata, isInstalled: false)
                     self.latestUpdate = update
                     self.hasPendingUpdate = true
-                    self.needsNotificationDot = true
+                    // Suppress the notification dot while onboarding is in progress to avoid
+                    // disrupting first-run UX. Subsequent automatic checks (on window-resign-key)
+                    // will set the dot once onboarding completes.
+                    self.needsNotificationDot = self.isOnboardingFinished()
 
                     Logger.updates.log("App Store update available: \(releaseMetadata.latestVersion)")
                     updateProgress = .updateCycleDone(.finishedWithNoError)

--- a/macOS/LocalPackages/AppUpdater/Sources/SparkleAppUpdater/SparkleUpdateController.swift
+++ b/macOS/LocalPackages/AppUpdater/Sources/SparkleAppUpdater/SparkleUpdateController.swift
@@ -368,7 +368,21 @@ public final class SparkleUpdateController: NSObject, SparkleUpdateControlling {
     // MARK: - Update Indicators (Dot + Notification + Menu Item)
 
     /// Shows update UI: blue dot, banner notification, and enables menu item visibility.
+    ///
+    /// Suppressed entirely while onboarding is in progress so the update flow doesn't
+    /// disrupt first-run UX. Sparkle re-checks every 30-60 minutes and the App's
+    /// progress publisher fires on each subsequent cycle, so indicators surface naturally
+    /// after onboarding completes — no explicit re-trigger required.
+    ///
+    /// When suppressed for onboarding, `pendingNotificationTask` is cleared so the next
+    /// `handleUpdateNotification` call (driven by the next Sparkle check) is free to
+    /// schedule a fresh notification rather than being short-circuited by the guard
+    /// against an already-fired task.
     private func showUpdateIndicators() {
+        guard isOnboardingFinished() else {
+            pendingNotificationTask = nil
+            return
+        }
         mustShowUpdateIndicators = true
         needsNotificationDot = true
         showUpdateNotificationIfNeeded(isOnboardingFinished: isOnboardingFinished)

--- a/macOS/LocalPackages/AppUpdater/Tests/AppStoreAppUpdaterTests/AppStoreUpdateControllerTests.swift
+++ b/macOS/LocalPackages/AppUpdater/Tests/AppStoreAppUpdaterTests/AppStoreUpdateControllerTests.swift
@@ -561,6 +561,107 @@ final class AppStoreUpdateControllerTests: XCTestCase {
             wait(for: [expectation], timeout: 1.0)
         }
     }
+
+    // MARK: - Onboarding Suppression Tests
+
+    /// Asana: https://app.asana.com/0/0/1208754999490080
+    /// Regression: clean install + onboarding showed the "update available" notification mid-flow.
+    /// The notification dot must be suppressed while onboarding is in progress.
+    func testUpdateAvailable_OnboardingFinished_SetsNotificationDot() async {
+        // Given — feature flag on, update available, onboarding finished
+        let controller = makeControllerForOnboardingTest(
+            remoteVersion: "999.0.0",
+            remoteBuild: 99999,
+            isOnboardingFinished: true
+        )
+
+        // When — automatic update check finds an update
+        await runUpdateCheckAndWait(on: controller)
+
+        // Then — pending update is recorded and notification dot is set
+        XCTAssertTrue(controller.hasPendingUpdate, "Pending update should be recorded")
+        XCTAssertTrue(controller.needsNotificationDot, "Notification dot should be set when onboarding is finished")
+    }
+
+    func testUpdateAvailable_OnboardingInProgress_SuppressesNotificationDot() async {
+        // Given — feature flag on, update available, onboarding NOT finished
+        let controller = makeControllerForOnboardingTest(
+            remoteVersion: "999.0.0",
+            remoteBuild: 99999,
+            isOnboardingFinished: false
+        )
+
+        // When — automatic update check finds an update
+        await runUpdateCheckAndWait(on: controller)
+
+        // Then — pending update is still recorded (so subsequent checks can surface the dot),
+        // but the notification dot is suppressed to avoid disrupting onboarding.
+        XCTAssertTrue(controller.hasPendingUpdate, "Pending update should still be recorded for later")
+        XCTAssertFalse(controller.needsNotificationDot, "Notification dot must be suppressed during onboarding")
+    }
+
+    // MARK: - Onboarding Suppression Test Helpers
+
+    private func makeControllerForOnboardingTest(
+        remoteVersion: String,
+        remoteBuild: Int,
+        isOnboardingFinished: Bool
+    ) -> AppStoreUpdateController {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+
+        MockURLProtocol.requestHandler = { request in
+            let json = """
+            {
+                "latest_appstore_version": {
+                    "latest_version": "\(remoteVersion)",
+                    "build_number": \(remoteBuild),
+                    "release_date": "2026-04-29T10:00:00Z",
+                    "is_critical": false
+                }
+            }
+            """
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, json.data(using: .utf8)!)
+        }
+
+        let mockFeatureFlagger = MockFeatureFlagger()
+        mockFeatureFlagger.enabledUpdateFeatureFlags = [.appStoreUpdateFlow]
+
+        return AppStoreUpdateController(
+            appStoreOpener: MockAppStoreOpener(),
+            featureFlagger: mockFeatureFlagger,
+            notificationPresenter: MockNotificationPresenter(),
+            releaseChecker: LatestReleaseChecker(
+                baseURL: "https://test.example.com/",
+                urlSession: session
+            ),
+            isOnboardingFinished: { isOnboardingFinished }
+        )
+    }
+
+    /// Triggers an automatic update check and waits until `hasPendingUpdate` becomes `true`,
+    /// using a publisher-driven expectation rather than arbitrary delays.
+    private func runUpdateCheckAndWait(on controller: AppStoreUpdateController) async {
+        let exp = expectation(description: "hasPendingUpdate becomes true")
+        let cancellable = controller.hasPendingUpdatePublisher
+            .filter { $0 }
+            .first()
+            .sink { _ in exp.fulfill() }
+
+        controller.checkForUpdateAutomatically()
+
+        await fulfillment(of: [exp], timeout: 5.0)
+        cancellable.cancel()
+        MockURLProtocol.requestHandler = nil
+    }
+
 }
 
 // MARK: - Mock Objects


### PR DESCRIPTION
## Task
[Delay "update available" notification during the onboarding](https://app.asana.com/0/0/1208754999490080)

## Root Cause
`AppStoreUpdateController` and `SparkleUpdateController` both set the in-menu
notification dot (and Sparkle's banner) the moment an update is detected,
without checking whether onboarding is still in progress. A clean install that
finds an update mid-onboarding therefore disrupts the first-run UX.

The shared `UpdateController.showUpdateNotificationIfNeeded(...)` helper
already gates the user-facing banner on `isOnboardingFinished()`, but the dot
itself and Sparkle's `showUpdateIndicators()` were not gated.

## Fix Summary
- **AppStoreUpdateController** (`AppStoreUpdateController.swift:233`): gate
  `needsNotificationDot` on `isOnboardingFinished()`. The window-resign-key
  publisher re-runs `checkForUpdateAutomatically()` and surfaces the dot once
  onboarding completes. The convenience init now also accepts a
  `releaseChecker:` for testability.
- **SparkleUpdateController** (`SparkleUpdateController.swift:376`):
  short-circuit `showUpdateIndicators()` when onboarding is in progress and
  clear `pendingNotificationTask` on the guarded path so the next Sparkle
  progress event can re-schedule the indicator. Sparkle's automatic 30–60-min
  re-checks then surface the indicator once onboarding finishes.

## Testing
- **Build**: ✅ `xcodebuild -workspace DuckDuckGo.xcworkspace -scheme "AppUpdater-Package"` succeeded
- **Build**: ✅ `xcodebuild -workspace DuckDuckGo.xcworkspace -scheme "macOS Browser"` succeeded
- **Unit tests**: ✅ AppUpdater-Package: 48/48 AppStoreAppUpdater + 34/34 AppUpdaterShared + SparkleAppUpdater suites passed, including two new regression tests:
  - `testUpdateAvailable_OnboardingFinished_SetsNotificationDot`
  - `testUpdateAvailable_OnboardingInProgress_SuppressesNotificationDot`
- **UI tests**: not required for this change (no UI surface added).

## Self-review
- [x] Change matches root cause analysis
- [x] Scope limited to affected files (AppUpdater package only)
- [x] Regression test added for the AppStore path; the Sparkle path is
      protected by the same one-line guard plus the `pendingNotificationTask`
      reset
- [x] Privacy/security implications checked — no new data flow

## Notes for review
- The Sparkle automatic-update path delays notifications by 2 hours
  (internal) or 2 days (external). The `pendingNotificationTask = nil` reset
  on the guarded path means that if onboarding is still in progress when the
  delayed task fires (extreme edge case), the next Sparkle progress event
  will schedule a fresh delayed notification rather than being silently
  blocked by the stale task reference.
- `AppStoreUpdateController` keeps `hasPendingUpdate = true` even when the
  dot is suppressed; this preserves Settings > About state and lets the next
  automatic check surface the dot.

---
Generated by Executor — DRAFT until Alex flips to ready-for-review.