### PR TITLE
[executor] Add SwiftLint rules: UITestCase + no app.launch() in UI tests

### DIFF
--- a/macOS/UITests/.swiftlint.yml
+++ b/macOS/UITests/.swiftlint.yml
@@ -14,3 +14,29 @@ disabled_rules:
 large_tuple:
   warning: 6
   error: 10
+
+custom_rules:
+  ui_test_must_subclass_uitestcase:
+    name: "UI test must subclass UITestCase"
+    # Match `class FooTests: XCTestCase` declarations in macOS UI tests.
+    # `UITestCase` itself is the only legitimate `: XCTestCase` subclass and is
+    # excluded below. New UI test classes must extend `UITestCase` so they get
+    # `XCUIApplication.setUp()` (UITEST_MODE env, swizzling, screenshot
+    # observer) for free; subclassing XCTestCase directly bypasses all of that.
+    regex: 'class\s+\w+\s*:\s*XCTestCase\b'
+    excluded: ".*Common/UITests\\.swift"
+    message: "UI tests must subclass UITestCase (defined in macOS/UITests/Common/UITests.swift), not XCTestCase. UITestCase wires up the project's launch + screenshot infrastructure."
+    severity: error
+
+  ui_test_no_app_launch:
+    name: "Avoid app.launch() in UI tests"
+    # Direct calls to `app.launch()` skip XCUIApplication.setUp(), which sets
+    # UITEST_MODE=1 and applies feature flags / launch arguments. The legitimate
+    # initial launch lives in XCUIApplicationExtension.setUp() (and the
+    # `relaunch()` helper there). For deliberate quit-and-relaunch flows
+    # (e.g. cmd-Q + launch), use a `// swiftlint:disable:next ui_test_no_app_launch`
+    # comment to acknowledge the intent.
+    regex: '\bapp\.launch\s*\(\s*\)'
+    excluded: ".*Common/XCUIApplicationExtension\\.swift"
+    message: "Don't call app.launch() directly. Use XCUIApplication.setUp() for initial launch (UITestCase does this) or app.relaunch() after terminate(). UITestCase already handles the first launch."
+    severity: error

--- a/macOS/UITests/Common/XCUIApplicationExtension.swift
+++ b/macOS/UITests/Common/XCUIApplicationExtension.swift
@@ -129,6 +129,15 @@ extension XCUIApplication {
         return app
     }
 
+    /// Terminate the app and re-launch it, preserving the configured
+    /// `launchEnvironment` and `launchArguments`. Use this in place of
+    /// `app.terminate(); app.launch()` so the `ui_test_no_app_launch`
+    /// SwiftLint rule remains effective in test code.
+    func relaunch() {
+        terminate()
+        launch()
+    }
+
     @nonobjc var path: String? {
         value(forKey: "path") as? String
     }

--- a/macOS/UITests/DownloadsUITests.swift
+++ b/macOS/UITests/DownloadsUITests.swift
@@ -321,7 +321,8 @@ class DownloadsUITests: UITestCase {
 
         // Quit and relaunch
         app.typeKey("q", modifierFlags: [.command])
-        app.launch()
+        // swiftlint:disable:next ui_test_no_app_launch
+        app.launch() // intentional: relaunch after cmd-Q (proper app quit, not terminate())
         _ = app.wait(for: .runningForeground, timeout: UITests.Timeouts.elementExistence)
         app.enforceSingleWindow()
         XCTAssertTrue(webView.popUpButtons["Customize"].waitForExistence(timeout: UITests.Timeouts.elementExistence))
@@ -375,7 +376,8 @@ class DownloadsUITests: UITestCase {
 
         // Quit and relaunch to restore session
         app.typeKey("q", modifierFlags: [.command])
-        app.launch()
+        // swiftlint:disable:next ui_test_no_app_launch
+        app.launch() // intentional: relaunch after cmd-Q (proper app quit, not terminate())
         _ = app.wait(for: .runningForeground, timeout: UITests.Timeouts.elementExistence)
 
         XCTAssertTrue(webView.staticTexts["Page loaded!"].waitForExistence(timeout: UITests.Timeouts.elementExistence))
@@ -610,7 +612,8 @@ class DownloadsUITests: UITestCase {
         // Restart app and verify the same file is listed
         app.typeKey("q", modifierFlags: [.command])
 
-        app.launch()
+        // swiftlint:disable:next ui_test_no_app_launch
+        app.launch() // intentional: relaunch after cmd-Q (proper app quit, not terminate())
         _=app.wait(for: .runningForeground, timeout: UITests.Timeouts.elementExistence)
         app.enforceSingleWindow()
         // wait for the New Tab page to load

--- a/macOS/UITests/FireWindowByDefaultTests.swift
+++ b/macOS/UITests/FireWindowByDefaultTests.swift
@@ -106,7 +106,8 @@ class FireWindowByDefaultTests: UITestCase {
 
         // Quit the application
         app.typeKey("q", modifierFlags: [.command])
-        app.launch()
+        // swiftlint:disable:next ui_test_no_app_launch
+        app.launch() // intentional: relaunch after cmd-Q (proper app quit, not terminate())
 
         _ = app.wait(for: .runningForeground, timeout: UITests.Timeouts.elementExistence)
 

--- a/macOS/UITests/FireWindowTests.swift
+++ b/macOS/UITests/FireWindowTests.swift
@@ -52,8 +52,7 @@ class FireWindowTests: UITestCase {
         app.openFireWindow()
         openThreeSitesOnFireWindow()
 
-        app.terminate()
-        app.launch()
+        app.relaunch()
 
         assertSitesOpenedInNormalWindowAreRestored()
         assertSitesOpenedOnFireWindowAreNotRestored()

--- a/macOS/UITests/PopupHandlingUITests.swift
+++ b/macOS/UITests/PopupHandlingUITests.swift
@@ -308,8 +308,7 @@ final class PopupHandlingUITests: UITestCase {
         popupWindow.buttons[XCUIIdentifierCloseWindow].click()
 
         // Restart app: Verify permission persists after restart
-        app.terminate()
-        app.launch()
+        app.relaunch()
 
         addressBarTextField = app.addressBar
         app.enforceSingleWindow()

--- a/macOS/UITests/PrintingTests.swift
+++ b/macOS/UITests/PrintingTests.swift
@@ -31,8 +31,7 @@ class PrintingTests: UITestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         continueAfterFailure = false
-        app = XCUIApplication()
-        app.launchEnvironment["UITEST_MODE"] = "1"
+        app = XCUIApplication.setUp()
 
         // Create PDF URL using the test server pattern
         let testPDFBundle = Bundle(for: type(of: self))
@@ -46,7 +45,6 @@ class PrintingTests: UITestCase {
         printDialog = app.sheets.containing(.button, identifier: "Print").firstMatch
         saveDialog = app.sheets.containing(.button, identifier: "Save").firstMatch
 
-        app.launch()
         app.enforceSingleWindow()
     }
 

--- a/macOS/UITests/PromoQueueUITests.swift
+++ b/macOS/UITests/PromoQueueUITests.swift
@@ -98,8 +98,7 @@ final class PromoQueueUITests: UITestCase {
         app.fireTestTrigger()
         XCTAssertTrue(app.alertA.waitForExistence(timeout: UITests.Timeouts.elementExistence))
 
-        app.terminate()
-        app.launch()
+        app.relaunch()
 
         XCTAssertTrue(app.alertA.waitForExistence(timeout: UITests.Timeouts.elementExistence), "test-promo-a should restore on relaunch (lastShown > lastDismissed)")
 

--- a/macOS/UITests/StateRestorationPromptTests.swift
+++ b/macOS/UITests/StateRestorationPromptTests.swift
@@ -63,8 +63,7 @@ class StateRestorationPromptTests: UITestCase {
 
         waitForSessionFileToBeUpdated(since: lastSaved)
 
-        app.terminate()
-        app.launch()
+        app.relaunch()
         app.openNewWindow()
 
         app.acceptSessionRestore()
@@ -102,8 +101,7 @@ class StateRestorationPromptTests: UITestCase {
 
         waitForSessionFileToBeUpdated(since: lastSaved)
 
-        app.terminate()
-        app.launch()
+        app.relaunch()
         app.openNewWindow()
 
         app.rejectSessionRestore()

--- a/macOS/UITests/StateRestorationTests.swift
+++ b/macOS/UITests/StateRestorationTests.swift
@@ -71,7 +71,8 @@ class StateRestorationTests: UITestCase {
         )
 
         app.typeKey("q", modifierFlags: [.command])
-        app.launch()
+        // swiftlint:disable:next ui_test_no_app_launch
+        app.launch() // intentional: relaunch after cmd-Q (proper app quit, not terminate())
 
         XCTAssertTrue(
             app.windows.webViews[secondPageTitle].waitForExistence(timeout: UITests.Timeouts.elementExistence),
@@ -106,8 +107,7 @@ class StateRestorationTests: UITestCase {
             "Site didn't load with the expected title in a reasonable timeframe."
         )
 
-        app.terminate()
-        app.launch()
+        app.relaunch()
 
         XCTAssertTrue(
             app.windows.webViews[secondPageTitle].waitForNonExistence(timeout: UITests.Timeouts.elementExistence),


### PR DESCRIPTION
## Task
Task/Issue URL: https://app.asana.com/0/0/1209477403052217

[Add swiftlint rule to use UITestCase and avoid app.launch](https://app.asana.com/0/0/1209477403052217)

## Root Cause
The project has a `UITestCase` base class (`macOS/UITests/Common/UITests.swift:136`) that wires up the test runtime — XCPointerEventPath swizzling, the screenshot-on-failure observer, and the initial `UITests.firstRun()` reset. The "real" launch path lives in `XCUIApplication.setUp(environment:featureFlags:arguments:)` (`macOS/UITests/Common/XCUIApplicationExtension.swift:114-130`), which sets `UITEST_MODE=1`, applies feature flags, and only then calls `app.launch()`.

Nothing was stopping a new UI test from subclassing `XCTestCase` directly (bypassing the observer + swizzling) or from calling `app.launch()` directly (bypassing `UITEST_MODE` and feature-flag env). The local `macOS/UITests/.swiftlint.yml` only carried `disabled_rules` and a `large_tuple` override.

## Fix Summary
Added two `custom_rules` to `macOS/UITests/.swiftlint.yml`:

- **`ui_test_must_subclass_uitestcase`** — fires on `class … : XCTestCase` declarations under `macOS/UITests/`. Excludes `Common/UITests.swift` where `UITestCase` itself legitimately extends `XCTestCase`.
- **`ui_test_no_app_launch`** — fires on `app.launch()` calls under `macOS/UITests/`. Excludes `Common/XCUIApplicationExtension.swift` where the canonical launch lives. Use `// swiftlint:disable:next ui_test_no_app_launch` for legitimate quit-and-relaunch flows.

Both rules are scoped — the nested `.swiftlint.yml` is auto-discovered by SwiftLint and only applies under `macOS/UITests/`, so unit / integration / BSK targets are unaffected.

Supporting changes:

- Added `XCUIApplication.relaunch()` helper for the common `terminate(); launch()` pattern. Tests now use `app.relaunch()` instead.
- `PrintingTests` rewired to `app = XCUIApplication.setUp()` instead of hand-rolling `UITEST_MODE` + a bare `app.launch()`.
- 5 `terminate(); launch()` pairs migrated to `relaunch()` (`FireWindowTests`, `PopupHandlingUITests`, `PromoQueueUITests`, `StateRestorationPromptTests` ×2, `StateRestorationTests`).
- 5 cmd-Q + launch sites tagged with `// swiftlint:disable:next ui_test_no_app_launch` and a one-line rationale (`DownloadsUITests` ×3, `FireWindowByDefaultTests`, `StateRestorationTests`). These intentionally use `app.launch()` to relaunch after a real `cmd-Q` (proper app quit, not `terminate()`).

## Testing
- SwiftLint: ✅ `mint run swiftlint lint --strict --quiet` clean across the full repo.
- Custom rule trigger verified: a synthetic `class BadUITests: XCTestCase { … app.launch() }` file under `macOS/UITests/` fires both rules with the expected error messages.
- Build: ✅ `xcodebuild build-for-testing -scheme "macOS UI Tests" -configuration Review` succeeded.
- Unit tests: not run (lint + UI-test target build only — change is enforcement + call-site refactors, no behaviour change).
- UI tests: not run locally; covered by CI.

## Self-review
- [x] Change matches root cause analysis
- [x] Scope limited to `macOS/UITests/` (no unrelated files)
- [x] Existing UI tests updated to comply
- [x] Privacy/security implications: none — lint config only
- [x] Disable-comment opt-out documented in YAML and used at every legitimate call site

## Notes for review
- The `excluded:` paths in the YAML use anchored regex (`.*Common/UITests\\.swift`) — SwiftLint's `excluded` is regex, not glob, so the `.swift` is escaped.
- Double-check that the `// swiftlint:disable:next` comments in cmd-Q + launch flows make sense to you. The argument is: those tests intentionally simulate a user quitting via menu (`cmd-Q`) and then re-launching, which exercises a different code path than `terminate()` would. They legitimately need a fresh `app.launch()` after the quit.

---
Generated by Executor — DRAFT until Alex flips to ready-for-review.
