### PR TITLE
Fix scriptlet path containment check failing on iOS devices

### DIFF
--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Scriptlets/Storage/ScriptletStore.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Scriptlets/Storage/ScriptletStore.swift
@@ -117,7 +117,7 @@ public final class ScriptletStore: ScriptletStoring {
 
             let relativeCachedPath = "\(extensionTypeRawValue)/\(safeVersion)/\(item.descriptor.name)"
             let scriptlet = Scriptlet(path: item.descriptor.name, relativeCachedPath: relativeCachedPath)
-            let file = tempDirectory.appendingPathComponent(item.descriptor.name)
+            let file = resolvedTempDirectory.appendingPathComponent(item.descriptor.name)
             try ScriptletPathSafety.ensureContained(file, within: resolvedTempDirectory, name: item.descriptor.name)
 
             let fileDirectory = file.deletingLastPathComponent()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200848783441532/task/1214381430847153
Tech Design URL: N/A
CC:

### Description

- Fix `ScriptletStore.save` using the unresolved `tempDirectory` URL to construct child file paths while passing the resolved `resolvedTempDirectory` as the containment base to `ScriptletPathSafety.ensureContained`, causing a path mismatch on iOS devices where `/var` is a symlink to `/private/var`
- Use `resolvedTempDirectory` consistently when constructing file paths so both the child and base URLs share the same canonical prefix

### Testing Steps
1. Build and run on a physical iOS device
2. Trigger a scriptlet update (e.g. by using custom privacy config with different version and forcing update from debug menu e.g. https://duckduckgo.github.io/privacy-configuration/pr-5059/v4/ios-config.json)
3. Verify scriptlets are saved successfully without `pathEscapesBase` errors in the logs

### Impact and Risks
**Impact Level: Medium**

#### What could go wrong?
- Low risk — the change only ensures the file URL is derived from the already-resolved base directory, which was the original intent

### Quality Considerations
- The `/var` → `/private/var` symlink is specific to iOS devices; simulators don't exhibit this mismatch, which is why the issue wasn't caught during development
- `ensureContained` remains fully functional as a path-traversal guard — only the input is corrected

### Notes to Reviewer
- One-line fix: `tempDirectory` → `resolvedTempDirectory` when constructing child file URLs
- The `resolvedTempDirectory` was already computed on line 110 but wasn't used for child path construction

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Very small change limited to temp file URL construction during scriptlet caching; behavior should only differ for symlinked temp paths (notably on iOS).
> 
> **Overview**
> Fixes `ScriptletStore.save` to build per-scriptlet temp file URLs from the *resolved* temp directory (`standardizedFileURL.resolvingSymlinksInPath()`), matching the base URL used by `ScriptletPathSafety.ensureContained`.
> 
> This prevents false `pathEscapesBase` containment failures on iOS devices where `/var` is a symlink to `/private/var` while keeping the same path-traversal protection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67720b1cf7d59639949a4c80db5e0fc6f22ae22d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->