### PR TITLE
Fix omnibar stuck in Duck.ai mode after disabling AI Features

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandler.swift
@@ -32,6 +32,13 @@ public enum TextEntryMode: String, CaseIterable {
     case aiChat
 }
 
+extension TextEntryMode {
+    /// Returns the mode the omnibar should actually display, falling back to `.search` when the AI search-input feature is unavailable.
+    func displayed(isAIChatSearchInputEnabled: Bool) -> TextEntryMode {
+        isAIChatSearchInputEnabled ? self : .search
+    }
+}
+
 // MARK: - SwitchBarHandling Protocol
 protocol SwitchBarHandling: AnyObject {
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2057,6 +2057,10 @@ class MainViewController: UIViewController {
         omniBarTabSwitcherButton?.isFireMode = isFireMode
     }
 
+    private func displayedTextEntryMode(for tab: Tab) -> TextEntryMode {
+        tab.preferredTextEntryMode.displayed(isAIChatSearchInputEnabled: aiChatSettings.isAIChatSearchInputUserSettingsEnabled)
+    }
+
     func refreshOmniBar() {
         updateOmniBarLoadingState()
         viewCoordinator.omniBar.refreshFireMode(fireMode: isCurrentTabFireTab())
@@ -2068,7 +2072,7 @@ class MainViewController: UIViewController {
             // Clear Dax Easter Egg logo when no tab is active
             viewCoordinator.omniBar.setDaxEasterEggLogoURL(nil)
             if let tabModel = tabManager.currentTabsModel.currentTab {
-                viewCoordinator.omniBar.setSelectedTextEntryMode(tabModel.preferredTextEntryMode)
+                viewCoordinator.omniBar.setSelectedTextEntryMode(displayedTextEntryMode(for: tabModel))
             }
             updateBrowsingMenuHeaderDataSource()
             if let tab = currentTab {
@@ -2101,7 +2105,7 @@ class MainViewController: UIViewController {
             viewCoordinator.omniBar.enterAIChatMode()
         } else {
             viewCoordinator.omniBar.startBrowsing()
-            viewCoordinator.omniBar.setSelectedTextEntryMode(tab.tabModel.preferredTextEntryMode)
+            viewCoordinator.omniBar.setSelectedTextEntryMode(displayedTextEntryMode(for: tab.tabModel))
         }
 
         restorePostFireAddressBarPickerIfNeeded()
@@ -4048,8 +4052,8 @@ extension MainViewController: OmniBarDelegate {
         // Restore the tab's committed mode — the user may have toggled without submitting.
         // Safe on iPhone: the experimental editing state prevents textFieldDidEndEditing from
         // firing (text field never becomes first responder during that flow).
-        if let tabMode = tabManager.currentTabsModel.currentTab?.preferredTextEntryMode {
-            viewCoordinator.omniBar.setSelectedTextEntryMode(tabMode)
+        if let tab = tabManager.currentTabsModel.currentTab {
+            viewCoordinator.omniBar.setSelectedTextEntryMode(displayedTextEntryMode(for: tab))
         }
     }
 
@@ -4274,7 +4278,7 @@ extension MainViewController: OmniBarDelegate {
     }
 
     func preferredTextEntryModeForCurrentTab() -> TextEntryMode? {
-        tabManager.currentTabsModel.currentTab?.preferredTextEntryMode
+        tabManager.currentTabsModel.currentTab.map { displayedTextEntryMode(for: $0) }
     }
 
     /// Saves the current omnibar toggle state to the tab on submission,

--- a/iOS/DuckDuckGo/TabManager.swift
+++ b/iOS/DuckDuckGo/TabManager.swift
@@ -247,11 +247,10 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
         registerForNotifications()
     }
 
-    /// Resolves the preferred text entry mode for a newly created tab based on the user's default omnibar mode setting.
     private func resolvedTextEntryMode() -> TextEntryMode {
-        aiChatSettings.defaultOmnibarMode.resolvedTextEntryMode {
-            toggleModeStorage.restore()
-        }
+        aiChatSettings.defaultOmnibarMode
+            .resolvedTextEntryMode { toggleModeStorage.restore() }
+            .displayed(isAIChatSearchInputEnabled: aiChatSettings.isAIChatSearchInputUserSettingsEnabled)
     }
 
     func setWebExtensionManager(_ manager: WebExtensionManaging?) {

--- a/iOS/DuckDuckGoTests/ToggleMode/DefaultTogglePositionTests.swift
+++ b/iOS/DuckDuckGoTests/ToggleMode/DefaultTogglePositionTests.swift
@@ -23,6 +23,24 @@ import PersistenceTestingUtils
 @testable import Core
 @testable import DuckDuckGo
 
+// MARK: - TextEntryMode Display Gating
+
+final class TextEntryModeDisplayTests: XCTestCase {
+
+    func testAIChatFallsBackToSearchWhenSearchInputDisabled() {
+        XCTAssertEqual(TextEntryMode.aiChat.displayed(isAIChatSearchInputEnabled: false), .search)
+    }
+
+    func testAIChatPreservedWhenSearchInputEnabled() {
+        XCTAssertEqual(TextEntryMode.aiChat.displayed(isAIChatSearchInputEnabled: true), .aiChat)
+    }
+
+    func testSearchAlwaysPreserved() {
+        XCTAssertEqual(TextEntryMode.search.displayed(isAIChatSearchInputEnabled: true), .search)
+        XCTAssertEqual(TextEntryMode.search.displayed(isAIChatSearchInputEnabled: false), .search)
+    }
+}
+
 // MARK: - DefaultOmnibarMode Resolution
 
 final class DefaultOmnibarModeResolutionTests: XCTestCase {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1214373977763784?focus=true
Tech Design URL:
CC:

### Description

When the user disabled the "AI Features" master toggle (or the "Search Input" sub-toggle) while a tab's `Tab.preferredTextEntryMode` was `.aiChat`, the omnibar stayed in Duck.ai mode and kept showing the "Ask anything privately" placeholder. With "Toggle Position = Last Used" the user had no way back to Search without re-enabling AI Features.

The omnibar mode was being read directly from the per-tab stored value with no awareness of whether the AI search-input feature was currently usable. The existing `aiChatSettingsChanged` observer already calls `refreshOmniBar()`, but the refresh was blindly re-applying the stale `.aiChat`.

Introduces `TextEntryMode.displayed(isAIChatSearchInputEnabled:)` as the canonical predicate. The persisted per-tab preference and global last-used value are intentionally preserved, so re-enabling AI Features restores the user's prior preference automatically.

The predicate is applied at:
- `TabManager.resolvedTextEntryMode()` — gates new-tab creation
- `MainViewController.refreshOmniBar()` (×2) — gates display on tab switch / settings change
- `MainViewController.onDidEndEditing()` — gates restoration after editing
- `MainViewController.preferredTextEntryModeForCurrentTab()` — `OmniBarDelegate` impl read by `DefaultOmniBarViewController`

### Testing Steps

1. Settings → AI Features → enable the master toggle.
2. Same screen → enable "Search Input" sub-toggle, set "Toggle Position" → "Last Used".
3. On a tab, flip the omnibar toggle to Duck.ai (so `.aiChat` is persisted as last-used and the tab is in Duck.ai mode).
4. Settings → AI Features → disable the master toggle.
5. Expected: the currently visible tab — and any other tab that was in Duck.ai — now show "Search or enter address" instead of "Ask anything privately".
6. Re-enable the master toggle → previously-Duck.ai tabs return to Duck.ai mode (preserved preference).

### Impact and Risks

Low. Affects only the omnibar's *displayed* mode for tabs whose stored `preferredTextEntryMode` is `.aiChat` while the AI search-input feature is unavailable. No data loss; persisted state is preserved.

#### What could go wrong?

- A tab created while AI is disabled gets `.search` baked in. Standard commit flow updates the stored preference if the user later enters Duck.ai mode — same as today.
- Background tabs heal lazily on activation; anything that drives the omnibar must go through the gate. Direct readers of `tab.preferredTextEntryMode` (e.g. `commitToggleMode`) intentionally remain ungated — they are write-side and need the raw stored value.

### Quality Considerations

New regression tests in `TextEntryModeDisplayTests` cover the predicate directly. All existing `DefaultTogglePositionTests` and `AIChatSettingsTests` continue to pass (24/24).

### Notes to Reviewer

`TextEntryMode.displayed(isAIChatSearchInputEnabled:)` is the single source of truth — any new omnibar consumer that reads `tab.preferredTextEntryMode` should call it. The predicate uses `isAIChatSearchInputUserSettingsEnabled` (composite: master toggle ∧ search-input toggle ∧ `experimentalAddressBar` flag), which is the actual prerequisite for the toggle UI being shown in the first place.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI state/display logic only; it gates the shown omnibar mode based on an existing feature toggle while leaving persisted preferences untouched.
> 
> **Overview**
> Prevents the omnibar from getting stuck displaying Duck.ai mode when AI Search Input is disabled by introducing `TextEntryMode.displayed(isAIChatSearchInputEnabled:)`, which forces a `.search` display fallback while preserving the stored per-tab/last-used preference.
> 
> The new gating is applied when resolving new-tab default mode (`TabManager.resolvedTextEntryMode`) and when restoring/refreshing omnibar state in `MainViewController` (tab switches, settings-driven `refreshOmniBar`, end-editing restore, and delegate reads). Adds unit coverage for the display-gating behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2fa1925d99076c34d5494e7cee528159755dd8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->