### PR TITLE
Tracker test scaffolding

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentScopeScript/TrackerProtectionEventMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentScopeScript/TrackerProtectionEventMapper.swift
@@ -170,12 +170,20 @@ public struct TrackerProtectionEventMapper {
 
     /// Multi-TDS classification loop.
     ///
+    /// Mirrors the legacy `ContentBlockerRulesUserScript.userContentController(_:didReceive:)`
+    /// pipeline exactly so the C-S-S-driven classification is observationally identical to
+    /// the WKScriptMessage-driven one. Any divergence here is a behavior regression.
+    ///
     /// 1. Try each supplementary TDS (CTL, ad-attribution) with ad-click vendor.
     ///    If any returns blocked, use it immediately.
     /// 2. Fall back to the main TDS without vendor.
-    /// 3. Main result overwrites non-blocked supplementary candidates (by design).
-    ///    This is correct because the splitter removes attribution trackers from main TDS,
-    ///    so main returns nil for those URLs and the supplementary candidate survives.
+    /// 3. Main result unconditionally overwrites non-blocked supplementary candidates.
+    ///    This matches legacy semantics. It is safe in practice because the splitters
+    ///    (`AdClickAttributionRulesSplitter`, `ClickToLoadRulesSplitter`) remove the
+    ///    supplementary trackers from the main TDS, so main returns nil for those URLs
+    ///    and the supplementary candidate survives. If the splitter contract were ever
+    ///    weakened, both the legacy script and this mapper would change behavior in
+    ///    lockstep — see the parity regression tests in `TrackerProtectionEventMapperTests`.
     private func classifyUrl(_ urlString: String,
                              pageUrlString: String,
                              resourceType: String,

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerReferenceTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockerReferenceTests.swift
@@ -16,198 +16,271 @@
 //  limitations under the License.
 //
 
-// Tests are disabled on iOS due to WKWebView stability issues on the iOS 17.5+ simulator.
 #if os(macOS)
 
-import XCTest
-import os.log
-import WebKit
 import BrowserServicesKit
-import TrackerRadarKit
 import Common
+import ContentBlocking
+import Foundation
+import os.log
+import TrackerRadarKit
+import WebKit
+import XCTest
 
-class ContentBlockerReferenceTests: XCTestCase {
+/// Data-driven tracker-protection reference tests exercising the full production path:
+///   WKWebView → WKContentRuleList → ContentScopeUserScript → TrackerProtectionSubfeature
+///   → TrackerProtectionEventMapper → DetectedRequest assertions
+///
+/// The fixture data uses `.test` TLD domains. Because `.test` is not in the Public Suffix
+/// List, `TLD.eTLDplus1` returns nil for those hosts, breaking same-site / same-entity
+/// semantics. To preserve faithful PSL behavior the fixtures are normalized at load time:
+/// every `.test` occurrence is replaced with `.site`. Using `.site` instead of `.org`
+/// avoids HSTS-preloaded domains (e.g. `random.org`) that WebKit upgrades to HTTPS,
+/// breaking the loopback proxy tunnel. This preserves all domain relationships
+/// (same-host, subdomain, cross-site, entity affiliation) while ensuring real eTLD+1
+/// resolution. Normalized names may appear in failure messages.
+@available(macOS 14.0, iOS 17.0, *)
+@MainActor
+final class ContentBlockerReferenceTests: XCTestCase {
 
-    let schemeHandler = TestSchemeHandler()
-    let userScriptDelegateMock = MockRulesUserScriptDelegate()
-    let navigationDelegateMock = MockNavigationDelegate()
-    let tld = TLD()
+    private let tld = TLD()
 
-    var webView: WKWebView!
-    var tds: TrackerData!
-    var tests = [RefTests.Test]()
+    func testDomainMatching() async throws {
+        let loader = JsonTestDataLoader()
 
-    func setupWebViewForUserScripTests(trackerData: TrackerData,
-                                       userScriptDelegate: ContentBlockerRulesUserScriptDelegate,
-                                       schemeHandler: TestSchemeHandler,
-                                       completion: @escaping (WKWebView) -> Void) {
+        let tdsRaw = String(
+            data: loader.fromJsonFile(
+                "Resources/privacy-reference-tests/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json"
+            ),
+            encoding: .utf8
+        )!
+        let testsRaw = String(
+            data: loader.fromJsonFile(
+                "Resources/privacy-reference-tests/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json"
+            ),
+            encoding: .utf8
+        )!
 
-        WebKitTestHelper.prepareContentBlockingRules(trackerData: trackerData,
-                                                     exceptions: [],
-                                                     tempUnprotected: [],
-                                                     trackerExceptions: []) { rules in
-            guard let rules = rules else {
-                XCTFail("Rules were not compiled properly")
-                return
+        // .test → .site normalization for PSL-faithful execution.
+        // .site is preferred over .org to avoid HSTS-preloaded domains like random.org.
+        let tdsNormalized = tdsRaw.replacingOccurrences(of: ".test", with: ".site")
+        let testsNormalized = testsRaw.replacingOccurrences(of: ".test", with: ".site")
+
+        let tds = try JSONDecoder().decode(TrackerData.self, from: Data(tdsNormalized.utf8))
+        let refTests = try JSONDecoder().decode(RefTests.self, from: Data(testsNormalized.utf8))
+        let tests = refTests.domainTests.tests
+
+        // Keep original names for failure messages.
+        let originalNames = try JSONDecoder()
+            .decode(RefTests.self, from: loader.fromJsonFile(
+                "Resources/privacy-reference-tests/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json"
+            ))
+            .domainTests.tests.map(\.name)
+
+        // useDefaultDataStore works around a macOS 26 WebKit crash triggered by
+        // large WKContentRuleLists + WKUserScript + nonPersistent proxy configuration.
+        let harness = try await WebViewTestHarness.create(
+            trackerDataJSON: tdsNormalized, useDefaultDataStore: true
+        )
+        defer {
+            harness.proxy.stop()
+            harness.webView.configuration.websiteDataStore.proxyConfigurations = []
+        }
+
+        var executed = 0
+        var skipped = 0
+
+        for (index, test) in tests.enumerated() {
+            let name = index < originalNames.count ? originalNames[index] : test.name
+
+            if test.exceptPlatforms?.contains("ios-browser") == true {
+                os_log("!!SKIPPING: %s", name)
+                skipped += 1
+                continue
             }
 
-            let configuration = WKWebViewConfiguration()
-            configuration.setURLSchemeHandler(schemeHandler, forURLScheme: schemeHandler.scheme)
+            os_log("TEST [%d]: %s", index, name)
 
-            let webView = WKWebView(frame: .init(origin: .zero, size: .init(width: 500, height: 1000)),
-                                 configuration: configuration)
-            webView.navigationDelegate = self.navigationDelegateMock
+            harness.proxy.clearReceivedRequests()
+            harness.delegate.reset()
+            await harness.clearWebKitCaches()
 
-            let privacyConfig = WebKitTestHelper.preparePrivacyConfig(locallyUnprotected: [],
-                                                                      tempUnprotected: [],
-                                                                      trackerAllowlist: [:],
-                                                                      contentBlockingEnabled: true,
-                                                                      exceptions: [])
+            // --- URL construction (mirrors old appendPathComponent approach) ---
 
-            do {
-                let config = try DefaultContentBlockerUserScriptConfig(privacyConfiguration: privacyConfig,
-                                                                       trackerData: trackerData,
-                                                                       ctlTrackerData: nil,
-                                                                       tld: self.tld)
+            let httpRequestURL = test.requestURL
+                .replacingOccurrences(of: "https://", with: "http://")
 
-                let userScript = ContentBlockerRulesUserScript(configuration: config)
-                userScript.delegate = userScriptDelegate
-
-                for messageName in userScript.messageNames {
-                    configuration.userContentController.add(userScript, name: messageName)
-                }
-
-                configuration.userContentController.addUserScript(WKUserScript(source: userScript.source,
-                                                                               injectionTime: .atDocumentStart,
-                                                                               forMainFrameOnly: false))
-                configuration.userContentController.add(rules)
-
-                completion(webView)
-            } catch {
-                XCTFail("Failed to initialize DefaultContentBlockerUserScriptConfig: \(error)")
+            guard let siteURL = URL(string: test.siteURL
+                    .replacingOccurrences(of: "https://", with: "http://")),
+                  let requestBaseURL = URL(string: httpRequestURL) else {
+                XCTFail("\(name): invalid fixture URL")
+                continue
             }
-        }
-    }
 
-    func testDomainMatching() throws {
+            let pageHost = siteURL.host!
+            let pagePath = "/iter-\(index)/index.html"
 
-        let data = JsonTestDataLoader()
-        let trackerJSON = data.fromJsonFile("Resources/privacy-reference-tests/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json")
-        let testJSON = data.fromJsonFile("Resources/privacy-reference-tests/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json")
-
-        tds = try JSONDecoder().decode(TrackerData.self, from: trackerJSON)
-
-        let refTests = try JSONDecoder().decode(RefTests.self, from: testJSON)
-        tests = refTests.domainTests.tests
-
-        let testsExecuted = expectation(description: "tests executed")
-        testsExecuted.expectedFulfillmentCount = tests.count
-
-        setupWebViewForUserScripTests(trackerData: tds,
-                                      userScriptDelegate: userScriptDelegateMock,
-                                      schemeHandler: schemeHandler) { webView in
-            self.webView = webView
-
-            self.popTestAndExecute(onTestExecuted: testsExecuted)
-        }
-
-        waitForExpectations(timeout: 30, handler: nil)
-    }
-
-    private func popTestAndExecute(onTestExecuted: XCTestExpectation) {
-
-        guard let test = tests.popLast() else {
-            return
-        }
-
-        let skip = test.exceptPlatforms?.contains("ios-browser")
-        if skip == true {
-            os_log("!!SKIPPING TEST: %s", test.name)
-            onTestExecuted.fulfill()
-            DispatchQueue.main.async {
-                self.popTestAndExecute(onTestExecuted: onTestExecuted)
+            let resourceURL: URL
+            let resourceTag: String
+            switch test.requestType {
+            case "image":
+                resourceURL = requestBaseURL.appendingPathComponent("1.png")
+                resourceTag = "<img src=\"\(resourceURL.absoluteString)\">"
+            case "script":
+                resourceURL = requestBaseURL.appendingPathComponent("1.js")
+                // Dynamic creation avoids a macOS 26 WebKit crash triggered by
+                // static <script src> + large WKContentRuleList + WKUserScript.
+                resourceTag = """
+                    <script>
+                    var s = document.createElement('script');
+                    s.src = '\(resourceURL.absoluteString)';
+                    document.body.appendChild(s);
+                    </script>
+                    """
+            default:
+                XCTFail("\(name): unsupported requestType '\(test.requestType)'")
+                continue
             }
-            return
-        }
 
-        os_log("TEST: %s", test.name)
+            let resourceHost = resourceURL.host!
+            let resourceURLString = resourceURL.absoluteString
+            var resourceProxyPath = resourceURL.path
+            if let q = resourceURL.query { resourceProxyPath += "?\(q)" }
 
-        let siteURL = URL(string: test.siteURL.appending("/index.html").testSchemeNormalized)!
-        let requestURL = URL(string: test.requestURL.testSchemeNormalized)!
+            let html = """
+                <!DOCTYPE html>
+                <html>
+                <body>
+                <h1>Test Page</h1>
+                \(resourceTag)
+                </body>
+                </html>
+                """
 
-        let resource: MockWebsite.EmbeddedResource
-        if test.requestType == "image" {
-            resource = MockWebsite.EmbeddedResource(type: .image,
-                                                    url: requestURL.appendingPathComponent("1.png"))
-        } else if test.requestType == "script" {
-            resource = MockWebsite.EmbeddedResource(type: .script,
-                                                    url: requestURL.appendingPathComponent("1.js"))
-        } else {
-            XCTFail("Unknown request type: \(test.requestType) in test \(test.name)")
-            return
-        }
+            let resourceMime = test.requestType == "image"
+                ? "image/png" : "application/javascript"
+            harness.registerContent(host: pageHost, path: pagePath, body: html)
+            harness.registerContent(
+                host: resourceHost, path: resourceProxyPath,
+                body: "/* resource */", mimeType: resourceMime
+            )
 
-        let mockWebsite = MockWebsite(resources: [resource])
+            let obsExp = harness.expectObservation(of: resourceURLString, testCase: self)
 
-        schemeHandler.reset()
-        schemeHandler.requestHandlers[siteURL] = { _ in
-            return mockWebsite.htmlRepresentation.data(using: .utf8)!
-        }
+            try await harness.load(URL(string: "http://\(pageHost)\(pagePath)")!)
+            await fulfillment(of: [obsExp], timeout: 10)
 
-        userScriptDelegateMock.reset()
+            // --- Classify scenario for assertion template selection ---
 
-        os_log("Loading %s ...", siteURL.absoluteString)
-        let request = URLRequest(url: siteURL)
-        WKWebsiteDataStore.default().removeData(ofTypes: [WKWebsiteDataTypeDiskCache,
-                                                          WKWebsiteDataTypeMemoryCache],
-                                                modifiedSince: Date(timeIntervalSince1970: 0),
-                                                completionHandler: {
-            self.webView.load(request)
-        })
+            let isSameEntity: Bool = {
+                guard let pageEntity = tds.findEntity(forHost: pageHost),
+                      let trackerOwner = tds.findTracker(forUrl: httpRequestURL)?.owner,
+                      pageEntity.displayName == trackerOwner.name else { return false }
+                return true
+            }()
 
-        navigationDelegateMock.onDidFinishNavigation = {
-            os_log("Website loaded")
+            let isSameSite: Bool = {
+                guard let p = tld.eTLDplus1(pageHost),
+                      let r = tld.eTLDplus1(resourceHost) else { return false }
+                return p == r
+            }()
+
+            let blockedCount = harness.delegate.detectedTrackers.count
+            let allowedCount = harness.delegate.detectedThirdPartyRequests.count
+
+            // --- Apply approved assertion template ---
+
             if test.expectAction == "block" {
-                // Only website request
-                XCTAssertEqual(self.schemeHandler.handledRequests.count, 1)
-                // Only resource request
-                XCTAssertEqual(self.userScriptDelegateMock.detectedTrackers.count, 1)
+                // Template A: Blocked Third-Party
+                XCTAssertTrue(
+                    harness.proxyDidReceive(host: pageHost, path: pagePath),
+                    "\(name): page must reach proxy")
+                XCTAssertFalse(
+                    harness.proxyDidReceive(host: resourceHost, path: resourceProxyPath),
+                    "\(name): blocked resource must NOT reach proxy")
+                XCTAssertEqual(blockedCount, 1,
+                    "\(name): expected exactly 1 blocked DetectedRequest")
+                XCTAssertTrue(
+                    harness.delegate.detectedTrackers.first?.isBlocked == true,
+                    "\(name): DetectedRequest must be blocked")
+                XCTAssertEqual(allowedCount, 0,
+                    "\(name): expected 0 allowed entries for blocked resource")
 
-                if let tracker = self.userScriptDelegateMock.detectedTrackers.first {
-                    XCTAssert(tracker.isBlocked)
-                } else {
-                    XCTFail("Expected to detect tracker for test \(test.name)")
-                }
             } else if test.expectAction == "ignore" {
-                // Website request & resource request
-                XCTAssertEqual(self.schemeHandler.handledRequests.count, 2)
+                XCTAssertTrue(
+                    harness.proxyDidReceive(host: pageHost, path: pagePath),
+                    "\(name): page must reach proxy")
+                XCTAssertTrue(
+                    harness.proxyDidReceive(host: resourceHost, path: resourceProxyPath),
+                    "\(name): allowed resource must reach proxy")
 
-                if let pageEntity = self.tds.findEntity(forHost: siteURL.host!),
-                   let trackerOwner = self.tds.findTracker(forUrl: requestURL.absoluteString)?.owner,
-                   pageEntity.displayName == trackerOwner.name {
+                if isSameEntity && isSameSite {
+                    // Template C: Same-Entity Same-Site — No Event
+                    // Same-site observation is silently dropped by the native pipeline.
+                    XCTAssertEqual(blockedCount, 0,
+                        "\(name): same-entity same-site must not be blocked")
+                    XCTAssertEqual(allowedCount, 0,
+                        "\(name): same-entity same-site must be silently dropped")
 
-                    // Nothing to detect - tracker and website have the same entity
+                } else if isSameEntity {
+                    // Template D: Same-Entity Cross-Site — Allowed First-Party
+                    // Old enforced contract: the resource was allowed to load.
+                    // New stronger assertion: resource loads, is not blocked, and
+                    // is classified as .allowed(reason: .ownedByFirstParty).
+                    XCTAssertEqual(blockedCount, 0,
+                        "\(name): same-entity cross-site must not be blocked")
+                    XCTAssertEqual(allowedCount, 1,
+                        "\(name): same-entity cross-site must produce exactly 1 allowed event")
+                    XCTAssertEqual(
+                        harness.delegate.detectedThirdPartyRequests.first?.state,
+                        .allowed(reason: .ownedByFirstParty),
+                        "\(name): must be classified as ownedByFirstParty")
+
                 } else {
-                    XCTAssertEqual(self.userScriptDelegateMock.detectedTrackers.count, 1)
-
-                    if let tracker = self.userScriptDelegateMock.detectedTrackers.first {
-                        XCTAssertFalse(tracker.isBlocked)
-                    } else {
-                        XCTFail("Expected to detect tracker for test \(test.name)")
-                    }
+                    // Template B: Allowed Known Tracker
+                    XCTAssertEqual(blockedCount, 0,
+                        "\(name): allowed tracker must not be blocked")
+                    XCTAssertEqual(allowedCount, 1,
+                        "\(name): expected exactly 1 allowed DetectedRequest")
+                    XCTAssertFalse(
+                        harness.delegate.detectedThirdPartyRequests.first?.isBlocked == true,
+                        "\(name): DetectedRequest must NOT be blocked")
                 }
 
             } else {
-                // Website request & resource request
-                XCTAssertEqual(self.schemeHandler.handledRequests.count, 2)
-                XCTAssertEqual(self.userScriptDelegateMock.detectedTrackers.count, 0)
+                // expectAction == nil: resource is not a known tracker.
+                XCTAssertTrue(
+                    harness.proxyDidReceive(host: pageHost, path: pagePath),
+                    "\(name): page must reach proxy")
+                XCTAssertTrue(
+                    harness.proxyDidReceive(host: resourceHost, path: resourceProxyPath),
+                    "\(name): non-tracker resource must reach proxy")
+                XCTAssertEqual(blockedCount, 0,
+                    "\(name): non-tracker must not be blocked")
+
+                if isSameSite {
+                    // Template E: Non-Tracker Same-Site — No Event
+                    XCTAssertEqual(allowedCount, 0,
+                        "\(name): same-site non-tracker must be silently dropped")
+                } else {
+                    // Template F: Non-Tracker Cross-Site
+                    XCTAssertGreaterThan(allowedCount, 0,
+                        "\(name): cross-site non-tracker must produce at least one allowed event")
+                    for entry in harness.delegate.detectedThirdPartyRequests {
+                        XCTAssertEqual(
+                            entry.state, .allowed(reason: .otherThirdPartyRequest),
+                            "\(name): cross-site non-tracker must be .otherThirdPartyRequest")
+                    }
+                }
             }
 
-            onTestExecuted.fulfill()
-            DispatchQueue.main.async {
-                self.popTestAndExecute(onTestExecuted: onTestExecuted)
-            }
+            executed += 1
         }
+
+        os_log("Domain matching tests: %d executed, %d skipped, %d total",
+               executed, skipped, tests.count)
+        XCTAssertEqual(executed + skipped, tests.count,
+                       "All scenarios must be executed or explicitly skipped")
     }
 }
 

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockingDatasetContractTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/ContentBlockingDatasetContractTests.swift
@@ -1,0 +1,100 @@
+//
+//  ContentBlockingDatasetContractTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+@testable import BrowserServicesKit
+import PrivacyConfigTestsUtils
+import TrackerRadarKit
+import XCTest
+
+/// Structural assertions enforcing the content-blocking dataset contract:
+/// - Full TDS is used exclusively for native classification (Rules.trackerData).
+/// - Surrogate-filtered TDS is the only tracker data passed to JavaScript (Rules.encodedTrackerData).
+/// - These are separate datasets with separate consumers and must never be collapsed.
+class ContentBlockingDatasetContractTests: XCTestCase {
+
+    // MARK: - Dataset split contract
+
+    func testWhenRulesAreCompiledThenEncodedTrackerDataContainsOnlySurrogates() throws {
+        let tds = Self.tdsWithMixedTrackers
+        let surrogateTDS = ContentBlockerRulesManager.extractSurrogates(from: tds)
+
+        XCTAssertGreaterThan(tds.trackers.count, surrogateTDS.trackers.count,
+                             "Full TDS should have more trackers than surrogate-filtered TDS")
+
+        for (domain, tracker) in surrogateTDS.trackers {
+            let hasSurrogate = tracker.rules?.contains(where: { $0.surrogate != nil }) ?? false
+            XCTAssertTrue(hasSurrogate,
+                          "Surrogate-filtered TDS should only contain trackers with surrogate rules, but \(domain) has none")
+        }
+    }
+
+    func testWhenExtractSurrogatesCalledThenEntitiesAndDomainsAreFiltered() {
+        let tds = Self.tdsWithMixedTrackers
+        let surrogateTDS = ContentBlockerRulesManager.extractSurrogates(from: tds)
+
+        XCTAssertNotNil(surrogateTDS.domains["surrogatetracker.com"],
+                        "Domain for surrogate tracker should be in filtered TDS")
+    }
+
+    // MARK: - Fixtures
+
+    static let tdsWithMixedTrackers: TrackerData = {
+        let surrogateTracker = KnownTracker(
+            domain: "surrogatetracker.com",
+            defaultAction: .block,
+            owner: KnownTracker.Owner(name: "SurrogateOwner", displayName: "Surrogate Owner", ownedBy: nil),
+            prevalence: 0.1,
+            subdomains: nil,
+            categories: nil,
+            rules: [
+                KnownTracker.Rule(rule: "surrogatetracker\\.com/script\\.js",
+                                  surrogate: "script.js",
+                                  action: nil,
+                                  options: nil,
+                                  exceptions: nil)
+            ])
+
+        let nonSurrogateTracker = KnownTracker(
+            domain: "nonsurrogate.com",
+            defaultAction: .block,
+            owner: KnownTracker.Owner(name: "NonSurrogateOwner", displayName: "Non Surrogate Owner", ownedBy: nil),
+            prevalence: 0.05,
+            subdomains: nil,
+            categories: nil,
+            rules: nil)
+
+        return TrackerData(
+            trackers: [
+                "surrogatetracker.com": surrogateTracker,
+                "nonsurrogate.com": nonSurrogateTracker
+            ],
+            entities: [
+                "SurrogateOwner": Entity(displayName: "Surrogate Owner",
+                                         domains: ["surrogatetracker.com"],
+                                         prevalence: 0.1),
+                "NonSurrogateOwner": Entity(displayName: "Non Surrogate Owner",
+                                            domains: ["nonsurrogate.com"],
+                                            prevalence: 0.05)
+            ],
+            domains: [
+                "surrogatetracker.com": "SurrogateOwner",
+                "nonsurrogate.com": "NonSurrogateOwner"
+            ],
+            cnames: nil)
+    }()
+}

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/LegacyUserScriptTestHelpers.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/LegacyUserScriptTestHelpers.swift
@@ -1,0 +1,152 @@
+//
+//  LegacyUserScriptTestHelpers.swift
+//
+//  Copyright © 2021 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+// Test helpers for the legacy `ContentBlockerRulesUserScript` and
+// `SurrogatesUserScript` pipelines. Retained alongside the new
+// `TrackerProtectionSubfeature` test scaffolding until the legacy userscripts
+// (and their reference/unit tests) are removed in the cleanup commit, at which
+// point this file is deleted in one go.
+
+import BrowserServicesKit
+import Common
+import ContentBlocking
+import Foundation
+import PrivacyConfig
+import PrivacyConfigTestsUtils
+import TrackerRadarKit
+import WebKit
+import XCTest
+
+final class MockRulesUserScriptDelegate: NSObject, ContentBlockerRulesUserScriptDelegate {
+
+    var shouldProcessTrackers = true
+    var shouldProcessCTLTrackers = true
+    var onTrackerDetected: ((DetectedRequest) -> Void)?
+    var detectedTrackers = Set<DetectedRequest>()
+    var onThirdPartyRequestDetected: ((DetectedRequest) -> Void)?
+    var detectedThirdPartyRequests = Set<DetectedRequest>()
+
+    func reset() {
+        detectedTrackers.removeAll()
+    }
+
+    func contentBlockerRulesUserScriptShouldProcessTrackers(_ script: ContentBlockerRulesUserScript) -> Bool {
+        return shouldProcessTrackers
+    }
+
+    func contentBlockerRulesUserScriptShouldProcessCTLTrackers(_ script: ContentBlockerRulesUserScript) -> Bool {
+        return shouldProcessCTLTrackers
+    }
+
+    func contentBlockerRulesUserScript(_ script: ContentBlockerRulesUserScript,
+                                       detectedTracker tracker: DetectedRequest) {
+        detectedTrackers.insert(tracker)
+        onTrackerDetected?(tracker)
+    }
+
+    func contentBlockerRulesUserScript(_ script: ContentBlockerRulesUserScript,
+                                       detectedThirdPartyRequest request: DetectedRequest) {
+        detectedThirdPartyRequests.insert(request)
+        onThirdPartyRequestDetected?(request)
+    }
+}
+
+final class MockSurrogatesUserScriptDelegate: NSObject, SurrogatesUserScriptDelegate {
+
+    var shouldProcessTrackers = true
+    var shouldProcessCTLTrackers = false
+
+    var onSurrogateDetected: ((DetectedRequest, String) -> Void)?
+    var detectedSurrogates = Set<DetectedRequest>()
+
+    func reset() {
+        detectedSurrogates.removeAll()
+    }
+
+    func surrogatesUserScriptShouldProcessTrackers(_ script: SurrogatesUserScript) -> Bool {
+        return shouldProcessTrackers
+    }
+
+    func surrogatesUserScriptShouldProcessCTLTrackers(_ script: SurrogatesUserScript) -> Bool {
+        shouldProcessCTLTrackers
+    }
+
+    func surrogatesUserScript(_ script: SurrogatesUserScript,
+                              detectedTracker tracker: DetectedRequest,
+                              withSurrogate host: String) {
+        detectedSurrogates.insert(tracker)
+        onSurrogateDetected?(tracker, host)
+    }
+}
+
+final class TestSchemeContentBlockerUserScriptConfig: ContentBlockerUserScriptConfig {
+
+    public let privacyConfiguration: PrivacyConfiguration
+    public let trackerData: TrackerData?
+    public let ctlTrackerData: TrackerData?
+    public let tld: TLD
+
+    public private(set) var source: String
+
+    public init(privacyConfiguration: PrivacyConfiguration,
+                trackerData: TrackerData?,
+                ctlTrackerData: TrackerData?,
+                tld: TLD) throws {
+        self.privacyConfiguration = privacyConfiguration
+        self.trackerData = trackerData
+        self.ctlTrackerData = ctlTrackerData
+        self.tld = tld
+
+        // UserScripts contain TrackerAllowlist rules in form of regular expressions - we need to ensure test scheme is matched instead of http/https
+        let orginalSource = try ContentBlockerRulesUserScript.generateSource(privacyConfiguration: privacyConfiguration)
+        source = orginalSource.replacingOccurrences(of: "http", with: "test")
+    }
+}
+
+public class TestSchemeSurrogatesUserScriptConfig: SurrogatesUserScriptConfig {
+
+    public let privacyConfig: PrivacyConfiguration
+    public let surrogates: String
+    public let trackerData: TrackerData?
+    public let encodedSurrogateTrackerData: String?
+    public let tld: TLD
+
+    public let source: String
+
+    public init(privacyConfig: PrivacyConfiguration,
+                surrogates: String,
+                trackerData: TrackerData?,
+                encodedSurrogateTrackerData: String?,
+                tld: TLD,
+                isDebugBuild: Bool) throws {
+
+        self.privacyConfig = privacyConfig
+        self.surrogates = surrogates
+        self.trackerData = trackerData
+        self.encodedSurrogateTrackerData = encodedSurrogateTrackerData
+        self.tld = tld
+
+        // UserScripts contain TrackerAllowlist rules in form of regular expressions - we need to ensure test scheme is matched instead of http/https
+        let orginalSource = try SurrogatesUserScript.generateSource(privacyConfiguration: privacyConfig,
+                                                                surrogates: surrogates,
+                                                                encodedSurrogateTrackerData: encodedSurrogateTrackerData,
+                                                                isDebugBuild: isDebugBuild)
+
+        source = orginalSource.replacingOccurrences(of: "http", with: "test")
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/TrackerAllowlistReferenceTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/TrackerAllowlistReferenceTests.swift
@@ -21,199 +21,202 @@
 
 import BrowserServicesKit
 import Common
+import ContentBlocking
+import Foundation
 import os.log
 import PrivacyConfig
 import TrackerRadarKit
 import WebKit
 import XCTest
 
-struct AllowlistTests: Decodable {
+/// Data-driven tracker-allowlist reference tests exercising the full production path:
+///   WKWebView → WKContentRuleList → ContentScopeUserScript → TrackerProtectionSubfeature
+///   → TrackerProtectionEventMapper → DetectedRequest assertions
+///
+/// All fixture domains are `.com` and do not require PSL normalization.
+@available(macOS 14.0, iOS 17.0, *)
+@MainActor
+final class TrackerAllowlistReferenceTests: XCTestCase {
 
-    struct Test: Decodable {
-
+    private struct AllowlistTest: Decodable {
         let description: String
         let site: String
         let request: String
         let isAllowlisted: Bool
-
+        let exceptPlatforms: [String]?
     }
 
-    let domainTests: [Test]
-}
+    func testDomainAllowlist() async throws {
+        let loader = JsonTestDataLoader()
 
-class TrackerAllowlistReferenceTests: XCTestCase {
+        let tdsData = loader.fromJsonFile(
+            "Resources/privacy-reference-tests/tracker-radar-tests/TR-domain-matching/tracker_allowlist_tds_reference.json"
+        )
+        let tdsJSON = String(data: tdsData, encoding: .utf8)!
+        let trackerData = try JSONDecoder().decode(TrackerData.self, from: tdsData)
 
-    let schemeHandler = TestSchemeHandler()
-    let userScriptDelegateMock = MockRulesUserScriptDelegate()
-    let navigationDelegateMock = MockNavigationDelegate()
-    let tld = TLD()
+        let allowlistData = loader.fromJsonFile(
+            "Resources/privacy-reference-tests/tracker-radar-tests/TR-domain-matching/tracker_allowlist_reference.json"
+        )
 
-    var webView: WKWebView!
-    var tds: TrackerData!
-    var tests = [AllowlistTests.Test]()
-    var mockWebsite: MockWebsite!
+        let allowlistJson = try JSONSerialization.jsonObject(with: allowlistData) as! [String: Any]
+        let allowlist = PrivacyConfigurationData.TrackerAllowlist(
+            json: ["state": "enabled", "settings": ["allowlistedTrackers": allowlistJson]]
+        )!
 
-    func setupWebView(trackerData: TrackerData,
-                      userScriptDelegate: ContentBlockerRulesUserScriptDelegate,
-                      trackerAllowlist: PrivacyConfigurationData.TrackerAllowlistData,
-                      schemeHandler: TestSchemeHandler,
-                      completion: @escaping (WKWebView) -> Void) {
+        let tests = try JSONDecoder().decode(
+            [AllowlistTest].self,
+            from: loader.fromJsonFile(
+                "Resources/privacy-reference-tests/tracker-radar-tests/TR-domain-matching/tracker_allowlist_matching_tests.json"
+            )
+        )
 
-        let exceptions = DefaultContentBlockerRulesExceptionsSource.transform(allowList: trackerAllowlist)
+        let harness = try await WebViewTestHarness.create(
+            trackerDataJSON: tdsJSON,
+            trackerAllowlist: allowlist.entries,
+            useDefaultDataStore: true
+        )
+        defer {
+            harness.proxy.stop()
+            harness.webView.configuration.websiteDataStore.proxyConfigurations = []
+        }
 
-        WebKitTestHelper.prepareContentBlockingRules(trackerData: trackerData,
-                                                     exceptions: [],
-                                                     tempUnprotected: [],
-                                                     trackerExceptions: exceptions) { rules in
-            guard let rules = rules else {
-                XCTFail("Rules were not compiled properly")
-                return
+        var executed = 0
+        var skipped = 0
+        var allowedReasons = [String]()
+
+        for (index, test) in tests.enumerated() {
+            if test.exceptPlatforms?.contains("ios-browser") == true {
+                os_log("!!SKIPPING: %s", test.description)
+                skipped += 1
+                continue
             }
 
-            let configuration = WKWebViewConfiguration()
-            configuration.setURLSchemeHandler(schemeHandler, forURLScheme: schemeHandler.scheme)
+            os_log("TEST [%d]: %s", index, test.description)
 
-            let webView = WKWebView(frame: .init(origin: .zero, size: .init(width: 500, height: 1000)),
-                                 configuration: configuration)
-            webView.navigationDelegate = self.navigationDelegateMock
+            harness.proxy.clearReceivedRequests()
+            harness.delegate.reset()
+            await harness.clearWebKitCaches()
 
-            let privacyConfig = WebKitTestHelper.preparePrivacyConfig(locallyUnprotected: [],
-                                                                      tempUnprotected: [],
-                                                                      trackerAllowlist: trackerAllowlist,
-                                                                      contentBlockingEnabled: true,
-                                                                      exceptions: [])
+            // --- URL construction ---
 
-            do {
-                let config = try TestSchemeContentBlockerUserScriptConfig(privacyConfiguration: privacyConfig,
-                                                                          trackerData: trackerData,
-                                                                          ctlTrackerData: nil,
-                                                                          tld: self.tld)
+            let siteURLString = test.site.replacingOccurrences(of: "https://", with: "http://")
+            let requestURLString = test.request.replacingOccurrences(of: "https://", with: "http://")
 
-                let userScript = ContentBlockerRulesUserScript(configuration: config)
-                userScript.delegate = userScriptDelegate
-
-                for messageName in userScript.messageNames {
-                    configuration.userContentController.add(userScript, name: messageName)
-                }
-
-                configuration.userContentController.addUserScript(WKUserScript(source: userScript.source,
-                                                                               injectionTime: .atDocumentStart,
-                                                                               forMainFrameOnly: false))
-                configuration.userContentController.add(rules)
-
-                completion(webView)
-            } catch {
-                XCTFail("Failed to initialize TestSchemeContentBlockerUserScriptConfig: \(error)")
+            guard var siteURL = URL(string: siteURLString),
+                  let requestURL = URL(string: requestURLString) else {
+                XCTFail("\(test.description): invalid fixture URL")
+                continue
             }
-        }
-    }
 
-    func testDomainAllowlist() throws {
+            // Fixture sites are bare hosts (e.g. `https://example.com`); give them an
+            // explicit document path so the proxy registration key matches what
+            // WebKit requests. `appendingPathComponent` normalizes any trailing
+            // slash so we never end up with `//index.html`.
+            if siteURL.path.isEmpty || siteURL.path == "/" {
+                siteURL = siteURL.appendingPathComponent("index.html")
+            }
 
-        let data = JsonTestDataLoader()
-        let trackerJSON = data.fromJsonFile("Resources/privacy-reference-tests/tracker-radar-tests/TR-domain-matching/tracker_allowlist_tds_reference.json")
-        let testJSON = data.fromJsonFile("Resources/privacy-reference-tests/tracker-radar-tests/TR-domain-matching/tracker_allowlist_matching_tests.json")
+            let pageHost = siteURL.host!
+            let pagePath = siteURL.path
 
-        let allowlistReference = data.fromJsonFile("Resources/privacy-reference-tests/tracker-radar-tests/TR-domain-matching/tracker_allowlist_reference.json")
+            let resourceHost = requestURL.host!
+            var resourceProxyPath = requestURL.path
+            if let q = requestURL.query { resourceProxyPath += "?\(q)" }
 
-        tds = try JSONDecoder().decode(TrackerData.self, from: trackerJSON)
+            // Dynamic script creation avoids a macOS 26 WebKit crash with
+            // static <script src> + large WKContentRuleList + WKUserScript.
+            let html = """
+                <!DOCTYPE html>
+                <html><body>
+                <script>
+                var s = document.createElement('script');
+                s.src = '\(requestURL.absoluteString)';
+                document.body.appendChild(s);
+                </script>
+                </body></html>
+                """
 
-        let allowlistJson = try? JSONSerialization.jsonObject(with: allowlistReference, options: []) as? [String: Any]
+            harness.registerContent(host: pageHost, path: pagePath, body: html)
+            harness.registerContent(
+                host: resourceHost, path: resourceProxyPath,
+                body: "/* resource */", mimeType: "application/javascript"
+            )
 
-        let allowlist = PrivacyConfigurationData.TrackerAllowlist(json: ["state": "enabled", "settings": ["allowlistedTrackers": allowlistJson]])!
+            let obsExp = harness.expectObservation(of: requestURL.absoluteString, testCase: self)
 
-        let refTests = try JSONDecoder().decode(Array<AllowlistTests.Test>.self, from: testJSON)
-        tests = refTests
+            try await harness.load(siteURL)
+            await fulfillment(of: [obsExp], timeout: 10)
 
-        let testsExecuted = expectation(description: "tests executed")
-        testsExecuted.expectedFulfillmentCount = tests.count
+            let blockedCount = harness.delegate.detectedTrackers.count
+            let allowedCount = harness.delegate.detectedThirdPartyRequests.count
 
-        setupWebView(trackerData: tds,
-                     userScriptDelegate: userScriptDelegateMock,
-                     trackerAllowlist: allowlist.entries,
-                     schemeHandler: schemeHandler) { webView in
-            self.webView = webView
+            // --- Assertions ---
 
-            self.popTestAndExecute(onTestExecuted: testsExecuted)
-        }
-
-        waitForExpectations(timeout: 30, handler: nil)
-    }
-
-    private func popTestAndExecute(onTestExecuted: XCTestExpectation) {
-
-        guard let test = tests.popLast() else {
-            return
-        }
-
-        os_log("TEST: %s", test.description)
-
-        var siteURL = URL(string: test.site.testSchemeNormalized)!
-        if siteURL.absoluteString.hasSuffix(".com") {
-            siteURL = siteURL.appendingPathComponent("index.html")
-        }
-        let requestURL = URL(string: test.request.testSchemeNormalized)!
-
-        let resource = MockWebsite.EmbeddedResource(type: .script,
-                                                    url: requestURL)
-
-        mockWebsite = MockWebsite(resources: [resource])
-
-        schemeHandler.reset()
-        schemeHandler.requestHandlers[siteURL] = { _ in
-            return self.mockWebsite.htmlRepresentation.data(using: .utf8)!
-        }
-
-        userScriptDelegateMock.reset()
-
-        os_log("Loading %s ...", siteURL.absoluteString)
-        let request = URLRequest(url: siteURL)
-
-        WKWebsiteDataStore.default().removeData(ofTypes: [WKWebsiteDataTypeDiskCache,
-                                                          WKWebsiteDataTypeMemoryCache,
-                                                          WKWebsiteDataTypeOfflineWebApplicationCache],
-                                                modifiedSince: Date(timeIntervalSince1970: 0),
-                                                completionHandler: {
-            self.webView.load(request)
-        })
-
-        navigationDelegateMock.onDidFinishNavigation = {
-            os_log("Website loaded")
             if !test.isAllowlisted {
-                // Only website request
-                XCTAssertEqual(self.schemeHandler.handledRequests.count, 1)
-                // Only resource request
-                XCTAssertEqual(self.userScriptDelegateMock.detectedTrackers.count, 1)
+                // Blocked: content rules prevent the request from reaching the proxy.
+                XCTAssertTrue(
+                    harness.proxyDidReceive(host: pageHost, path: pagePath),
+                    "\(test.description): page must reach proxy")
+                XCTAssertFalse(
+                    harness.proxyDidReceive(host: resourceHost, path: resourceProxyPath),
+                    "\(test.description): blocked resource must NOT reach proxy")
+                XCTAssertEqual(blockedCount, 1,
+                    "\(test.description): expected exactly 1 blocked DetectedRequest")
+                XCTAssertTrue(
+                    harness.delegate.detectedTrackers.first?.isBlocked == true,
+                    "\(test.description): DetectedRequest must be blocked")
+                XCTAssertEqual(allowedCount, 0,
+                    "\(test.description): expected 0 allowed events for blocked resource")
 
-                if let tracker = self.userScriptDelegateMock.detectedTrackers.first {
-                    XCTAssert(tracker.isBlocked)
-                } else {
-                    XCTFail("Expected to detect tracker for test \(test.description)")
-                }
             } else {
-                // Website request & resource request
-                XCTAssertEqual(self.schemeHandler.handledRequests.count, 2)
+                // Allowlisted: content rule exception lets the request through.
+                XCTAssertTrue(
+                    harness.proxyDidReceive(host: pageHost, path: pagePath),
+                    "\(test.description): page must reach proxy")
+                XCTAssertTrue(
+                    harness.proxyDidReceive(host: resourceHost, path: resourceProxyPath),
+                    "\(test.description): allowlisted resource must reach proxy")
+                XCTAssertEqual(blockedCount, 0,
+                    "\(test.description): allowlisted resource must not be blocked")
 
-                if let pageEntity = self.tds.findEntity(forHost: siteURL.host!),
-                   let trackerOwner = self.tds.findTracker(forUrl: requestURL.absoluteString)?.owner,
-                   pageEntity.displayName == trackerOwner.name {
+                // Same-entity (page and tracker share an owner) is suppressed by the
+                // mapper: same-site observations classify to nil and `makeThirdPartyRequest`
+                // also returns nil. Mirrors legacy behavior — assert only the proxy/page
+                // path in that case. This guards against fixture drift where an entry
+                // could later pair page + tracker under a single entity.
+                let pageEntity = trackerData.findEntity(forHost: pageHost)
+                let trackerOwner = trackerData.findTracker(forUrl: requestURL.absoluteString)?.owner
+                let isSameEntity = pageEntity != nil
+                    && trackerOwner != nil
+                    && pageEntity?.displayName == trackerOwner?.name
 
-                    // Nothing to detect - tracker and website have the same entity
+                if isSameEntity {
+                    os_log("Skipping detection assertions (same-entity): %s", test.description)
                 } else {
-                    XCTAssertEqual(self.userScriptDelegateMock.detectedTrackers.count, 1)
+                    XCTAssertEqual(allowedCount, 1,
+                        "\(test.description): expected exactly 1 allowed DetectedRequest")
+                    XCTAssertFalse(
+                        harness.delegate.detectedThirdPartyRequests.first?.isBlocked == true,
+                        "\(test.description): DetectedRequest must NOT be blocked")
 
-                    if let tracker = self.userScriptDelegateMock.detectedTrackers.first {
-                        XCTAssertFalse(tracker.isBlocked)
-                    } else {
-                        XCTFail("Expected to detect tracker for test \(test.description)")
+                    if let state = harness.delegate.detectedThirdPartyRequests.first?.state {
+                        allowedReasons.append("\(test.description) → \(state)")
                     }
                 }
             }
 
-            onTestExecuted.fulfill()
-            DispatchQueue.main.async {
-                self.popTestAndExecute(onTestExecuted: onTestExecuted)
-            }
+            executed += 1
+        }
+
+        os_log("Allowlist tests: %d executed, %d skipped, %d total",
+               executed, skipped, tests.count)
+        XCTAssertEqual(executed + skipped, tests.count,
+                       "All scenarios must be executed or explicitly skipped")
+
+        // Log observed allowed reasons for post-run analysis.
+        for entry in allowedReasons {
+            os_log("ALLOWED REASON: %s", entry)
         }
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/TrackerProtectionBundledSurrogatesSmokeTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/TrackerProtectionBundledSurrogatesSmokeTests.swift
@@ -1,0 +1,291 @@
+//
+//  TrackerProtectionBundledSurrogatesSmokeTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+// Apple-side smoke tests proving real bundled surrogates work end-to-end
+// through the new production path:
+//
+//   WKWebView → WKContentRuleList → ContentScopeUserScript →
+//   TrackerProtectionSubfeature → native surrogate event → page-side JS effect
+//
+// This is NOT a migration of legacy SurrogatesReferenceTests or
+// SurrogatesUserScriptTests. Those remain deferred because they depend on
+// custom test surrogates not present in the bundled surrogates-generated.js.
+//
+// Surrogate names and expected page-side effects are sourced from the C-S-S
+// integration test suite (tracker-protection.spec.js / tracker-data-fixtures.js).
+
+#if os(macOS)
+
+import BrowserServicesKit
+import TrackerRadarKit
+import WebKit
+import XCTest
+
+@available(macOS 14.0, iOS 17.0, *)
+final class TrackerProtectionBundledSurrogatesSmokeTests: XCTestCase {
+
+    // Synthetic TDS referencing real bundled surrogate names.
+    // Surrogate names sourced from makeTrackerDataGoogle() in C-S-S integration fixtures.
+    //
+    // Uses proxy-safe tracker domains (not HSTS-preloaded) so the unprotected
+    // negative test can observe the request reaching the proxy over plain HTTP.
+    // The surrogate names are what matter — they must match bundled surrogates.
+    private static let tdsJSON = """
+    {
+      "trackers": {
+        "analytics-tracker.org": {
+          "domain": "analytics-tracker.org",
+          "default": "block",
+          "owner": { "name": "Analytics Corp", "displayName": "Analytics Corp" },
+          "rules": [
+            { "rule": "analytics-tracker\\\\.org.*/analytics\\\\.js", "surrogate": "analytics.js" }
+          ]
+        },
+        "adservices-tracker.org": {
+          "domain": "adservices-tracker.org",
+          "default": "block",
+          "owner": { "name": "Ads Corp", "displayName": "Ads Corp" },
+          "rules": [
+            { "rule": "adservices-tracker\\\\.org.*/tag/js/gpt\\\\.js", "surrogate": "gpt.js" }
+          ]
+        }
+      },
+      "entities": {
+        "Analytics Corp": {
+          "domains": ["analytics-tracker.org"],
+          "displayName": "Analytics Corp",
+          "prevalence": 0.5
+        },
+        "Ads Corp": {
+          "domains": ["adservices-tracker.org"],
+          "displayName": "Ads Corp",
+          "prevalence": 0.5
+        }
+      },
+      "domains": {
+        "analytics-tracker.org": "Analytics Corp",
+        "adservices-tracker.org": "Ads Corp"
+      },
+      "cnames": {}
+    }
+    """
+
+    // MARK: - Test 1: Bundled surrogate injects and executes
+
+    @MainActor
+    func testBundledSurrogateInjectsAndExecutes() async throws {
+        let harness = try await WebViewTestHarness.create(trackerDataJSON: Self.tdsJSON)
+        defer { harness.proxy.stop() }
+
+        let trackerHost = "analytics-tracker.org"
+        let trackerPath = "/analytics.js"
+        let port = harness.proxy.port
+
+        let pageHTML = """
+        <html><body>
+        <script>
+        var s = document.createElement('script');
+        s.src = 'http://\(trackerHost):\(port)\(trackerPath)';
+        document.body.appendChild(s);
+        </script>
+        </body></html>
+        """
+
+        harness.registerContent(host: "page.example.com", path: "/index.html", body: pageHTML)
+        harness.registerContent(host: trackerHost, path: trackerPath, body: "/* blocked */")
+
+        let trackerURL = "http://\(trackerHost):\(port)\(trackerPath)"
+        let exp = harness.expectObservation(of: trackerURL, testCase: self)
+        // Both resourceObserved and surrogateInjected fire for this URL.
+        exp.expectedFulfillmentCount = 2
+
+        try await harness.load(host: "page.example.com")
+        await fulfillment(of: [exp], timeout: 10)
+
+        // Layer 1: content rules blocked the tracker — proxy never received it
+        XCTAssertFalse(
+            harness.proxyDidReceive(host: trackerHost, path: trackerPath),
+            "Content rules should block the tracker request")
+
+        // Layer 2: native surrogate event was captured
+        XCTAssertEqual(
+            harness.delegate.detectedSurrogates.count, 1,
+            "Exactly one surrogate injection expected")
+        if let (detected, host) = harness.delegate.detectedSurrogates.first {
+            XCTAssertTrue(detected.isBlocked, "Surrogate replaces a blocked tracker")
+            XCTAssertEqual(host, trackerHost)
+        }
+
+        // Layer 3: bundled surrogate JS actually executed — analytics.js defines window.ga
+        let gaIsDefined = try await harness.evaluateJS(
+            "typeof window.ga === 'function'") as? Bool
+        XCTAssertEqual(gaIsDefined, true, "analytics.js surrogate should define window.ga")
+    }
+
+    // MARK: - Test 2: Integrity attribute prevents surrogate injection
+
+    @MainActor
+    func testIntegrityAttributePreventsSurrogateInjection() async throws {
+        let harness = try await WebViewTestHarness.create(trackerDataJSON: Self.tdsJSON)
+        defer { harness.proxy.stop() }
+
+        let trackerHost = "analytics-tracker.org"
+        let trackerPath = "/analytics.js"
+        let port = harness.proxy.port
+
+        let pageHTML = """
+        <html><body>
+        <script>
+        var s = document.createElement('script');
+        s.integrity = 'sha512-fakehash';
+        s.crossOrigin = 'anonymous';
+        s.src = 'http://\(trackerHost):\(port)\(trackerPath)';
+        document.body.appendChild(s);
+        </script>
+        </body></html>
+        """
+
+        harness.registerContent(host: "page.example.com", path: "/index.html", body: pageHTML)
+        harness.registerContent(host: trackerHost, path: trackerPath, body: "/* blocked */")
+
+        let trackerURL = "http://\(trackerHost):\(port)\(trackerPath)"
+        // Only resourceObserved fires (no surrogateInjected due to integrity).
+        let exp = harness.expectObservation(of: trackerURL, testCase: self)
+
+        try await harness.load(host: "page.example.com")
+        await fulfillment(of: [exp], timeout: 10)
+
+        // Content rules still block the tracker
+        XCTAssertFalse(
+            harness.proxyDidReceive(host: trackerHost, path: trackerPath),
+            "Content rules should block the tracker request")
+
+        // No surrogate injection due to integrity attribute
+        XCTAssertEqual(
+            harness.delegate.detectedSurrogates.count, 0,
+            "Integrity attribute should prevent surrogate injection")
+
+        // Page should NOT have the surrogate's global
+        let gaIsDefined = try await harness.evaluateJS(
+            "typeof window.ga === 'function'") as? Bool
+        XCTAssertNotEqual(gaIsDefined, true, "No surrogate should have executed")
+    }
+
+    // MARK: - Test 3: Exception-listed domain — no blocking, no surrogate
+
+    @MainActor
+    func testExceptionListedDomainPreventsBlocking() async throws {
+        let harness = try await WebViewTestHarness.create(
+            trackerDataJSON: Self.tdsJSON,
+            exceptions: ["page.example.com"])
+        defer { harness.proxy.stop() }
+
+        let trackerHost = "analytics-tracker.org"
+        let trackerPath = "/pixel.js"
+        let port = harness.proxy.port
+
+        let pageHTML = """
+        <html><body>
+        <script>
+        var s = document.createElement('script');
+        s.src = 'http://\(trackerHost):\(port)\(trackerPath)';
+        document.body.appendChild(s);
+        </script>
+        </body></html>
+        """
+
+        harness.registerContent(host: "page.example.com", path: "/index.html", body: pageHTML)
+        harness.registerContent(host: trackerHost, path: trackerPath,
+                                body: "window.__trackerLoaded = true;")
+
+        let trackerURL = "http://\(trackerHost):\(port)\(trackerPath)"
+        let exp = harness.expectObservation(of: trackerURL, testCase: self)
+
+        try await harness.load(host: "page.example.com")
+        await fulfillment(of: [exp], timeout: 10)
+
+        // Request reached proxy — not blocked because page is exception-listed
+        XCTAssertTrue(
+            harness.proxyDidReceive(host: trackerHost, path: trackerPath),
+            "Tracker request should reach proxy when page is exception-listed")
+
+        // No surrogate injection
+        XCTAssertEqual(
+            harness.delegate.detectedSurrogates.count, 0,
+            "No surrogate on unprotected domain")
+
+        // Surrogate global should NOT exist (the actual tracker script loaded instead)
+        let gaIsDefined = try await harness.evaluateJS(
+            "typeof window.ga === 'function'") as? Bool
+        XCTAssertNotEqual(gaIsDefined, true,
+                          "analytics.js surrogate should not have executed")
+    }
+
+    // MARK: - Test 4: Second bundled surrogate (gpt.js) injects and executes
+
+    @MainActor
+    func testSecondBundledSurrogateGptInjectsAndExecutes() async throws {
+        let harness = try await WebViewTestHarness.create(trackerDataJSON: Self.tdsJSON)
+        defer { harness.proxy.stop() }
+
+        let trackerHost = "adservices-tracker.org"
+        let trackerPath = "/tag/js/gpt.js"
+        let port = harness.proxy.port
+
+        let pageHTML = """
+        <html><body>
+        <script>
+        var s = document.createElement('script');
+        s.src = 'http://\(trackerHost):\(port)\(trackerPath)';
+        document.body.appendChild(s);
+        </script>
+        </body></html>
+        """
+
+        harness.registerContent(host: "page.example.com", path: "/index.html", body: pageHTML)
+        harness.registerContent(host: trackerHost, path: trackerPath, body: "/* blocked */")
+
+        let trackerURL = "http://\(trackerHost):\(port)\(trackerPath)"
+        let exp = harness.expectObservation(of: trackerURL, testCase: self)
+        exp.expectedFulfillmentCount = 2
+
+        try await harness.load(host: "page.example.com")
+        await fulfillment(of: [exp], timeout: 10)
+
+        XCTAssertFalse(
+            harness.proxyDidReceive(host: trackerHost, path: trackerPath),
+            "Content rules should block the tracker request")
+
+        XCTAssertEqual(
+            harness.delegate.detectedSurrogates.count, 1,
+            "Exactly one surrogate injection expected")
+        if let (detected, host) = harness.delegate.detectedSurrogates.first {
+            XCTAssertTrue(detected.isBlocked)
+            XCTAssertEqual(host, trackerHost)
+        }
+
+        // gpt.js surrogate defines window.googletag as an object
+        let googletagIsDefined = try await harness.evaluateJS(
+            "typeof window.googletag === 'object'") as? Bool
+        XCTAssertEqual(googletagIsDefined, true,
+                       "gpt.js surrogate should define window.googletag")
+    }
+
+}
+
+#endif

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/TrackerProtectionClickToLoadSmokeTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/TrackerProtectionClickToLoadSmokeTests.swift
@@ -1,0 +1,399 @@
+//
+//  TrackerProtectionClickToLoadSmokeTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+// Replacement Apple-side CTL smoke suite proving the new production path
+// handles Click-to-Load *gating and reporting* semantics correctly:
+//
+//   WKWebView → WKContentRuleList (split: nonCTL + optional CTL)
+//   → ContentScopeUserScript → TrackerProtectionSubfeature
+//   → TrackerProtectionEventMapper (with split supplementary TDS)
+//   → final DetectedRequest assertions
+//
+// SCOPE
+// These tests focus on CTL-specific *transport* and *classification* behavior:
+//   - CTL-active:   request blocked, classified as blocked in detectedTrackers
+//   - CTL-inactive: request allowed, classified as non-blocked in
+//                   detectedThirdPartyRequests with .ruleException
+//   - non-CTL rule: still blocked regardless of CTL state
+//
+// Surrogate *injection* for CTL rules (fb-sdk.js) is NOT asserted here.
+// When the CTL split-TDS setup compiles two WKContentRuleList instances,
+// a pre-existing WebKit memory bug ("freed pointer was not the last
+// allocation") can crash the process during surrogate execution. General
+// bundled-surrogate injection is already covered by the separate
+// TrackerProtectionBundledSurrogatesSmokeTests suite, which uses a single
+// rule list and is not affected by this crash.
+//
+// This is NOT a literal migration of legacy ClickToLoadBlockingTests.swift.
+// It uses the approved proxy-based harness with ClickToLoadRulesSplitter.
+//
+// Synthetic tracker domains (fb-tracker.org) are used to avoid HSTS/proxy
+// interference from real public domains. The `.*` regex segments in the TDS
+// fixture accommodate proxy-port-bearing test URLs.
+
+#if os(macOS)
+
+import BrowserServicesKit
+import TrackerRadarKit
+import WebKit
+import XCTest
+
+@available(macOS 14.0, iOS 17.0, *)
+final class TrackerProtectionClickToLoadSmokeTests: XCTestCase {
+
+    // MARK: - TDS Fixture
+
+    // Synthetic tracker with both CTL and non-CTL rules. The `.*` between
+    // domain and path accommodates proxy-port-bearing test URLs.
+    // Rules reference real bundled surrogate names (fb-sdk.js).
+    static let tdsJSON = """
+    {
+      "trackers": {
+        "fb-tracker.org": {
+          "domain": "fb-tracker.org",
+          "owner": { "name": "FB Tracker Inc", "displayName": "FB Tracker" },
+          "default": "ignore",
+          "rules": [
+            {
+              "rule": "fb-tracker\\\\.org.*/sdk\\\\.js",
+              "surrogate": "fb-sdk.js",
+              "action": "block-ctl-fb"
+            },
+            {
+              "rule": "fb-tracker\\\\.org.*/events\\\\.js"
+            },
+            {
+              "rule": "fb-tracker\\\\.org",
+              "action": "block-ctl-fb"
+            }
+          ]
+        }
+      },
+      "entities": {
+        "FB Tracker Inc": {
+          "domains": ["fb-tracker.org"],
+          "displayName": "FB Tracker",
+          "prevalence": 0.5
+        }
+      },
+      "domains": {
+        "fb-tracker.org": "FB Tracker Inc"
+      }
+    }
+    """
+
+    // MARK: - Harness Factory
+
+    /// Builds a test harness modeling the real CTL architecture:
+    /// - C-S-S receives the full (merged) TDS so it can match CTL rules
+    /// - native mapper receives split TDS via ClickToLoadRulesSplitter
+    /// - content rules are compiled separately for nonCTL and CTL splits
+    /// - CTL content rules and supplementary TDS are included only when ctlEnabled
+    ///
+    /// The config sets both `trackerProtection.settings.ctlEnabled` and
+    /// `features.clickToLoad.state` for compatibility with the pre-built
+    /// C-S-S bundle, which reads CTL state from the latter path.
+    @MainActor
+    private func makeHarness(ctlEnabled: Bool) async throws -> WebViewTestHarness {
+        let fullTDS = try JSONDecoder().decode(TrackerData.self, from: Data(Self.tdsJSON.utf8))
+        let dataSet = TrackerDataManager.DataSet(tds: fullTDS, etag: "test")
+        let ruleList = ContentBlockerRulesList(
+            name: "TrackerDataSet", trackerData: nil, fallbackTrackerData: dataSet)
+        let splits = try XCTUnwrap(ClickToLoadRulesSplitter(rulesList: ruleList).split())
+
+        let privacyConfig = WebViewTestConfig.preparePrivacyConfig()
+        let configJSON = try WebViewTestConfig.makeConfig(ctlEnabled: ctlEnabled)
+        let manager = WebViewTestConfig.makeManager(configJSON: configJSON, privacyConfig: privacyConfig)
+
+        let supplementary: [TrackerData] = ctlEnabled
+            ? [splits.withBlockCTL.fallbackTrackerData.tds]
+            : []
+
+        let proxy = TestLoopbackProxy()
+        try await proxy.start()
+
+        let harness = try WebViewTestHarness(
+            trackerData: splits.withoutBlockCTL.fallbackTrackerData.tds,
+            supplementaryTrackerData: supplementary,
+            cssTrackerData: fullTDS,
+            privacyConfigManager: manager,
+            proxy: proxy)
+
+        // Always install non-CTL content rules
+        try await harness.compileAndInstallRules(
+            trackerData: splits.withoutBlockCTL.fallbackTrackerData.tds,
+            exceptions: [], tempUnprotected: [], trackerExceptions: [])
+
+        // Install CTL content rules only when CTL is active
+        if ctlEnabled {
+            try await harness.compileAndInstallRules(
+                trackerData: splits.withBlockCTL.fallbackTrackerData.tds,
+                exceptions: [], tempUnprotected: [], trackerExceptions: [])
+        }
+
+        return harness
+    }
+
+    // MARK: - Test 1: CTL-active, catch-all rule → blocked
+
+    @MainActor
+    func testCTLActiveCatchAllRuleIsBlocked() async throws {
+        let harness = try await makeHarness(ctlEnabled: true)
+        defer { harness.proxy.stop() }
+
+        let trackerHost = "fb-tracker.org"
+        let trackerPath = "/some.js"
+        let port = harness.proxy.port
+
+        let pageHTML = """
+        <html><body>
+        <script>
+        var s = document.createElement('script');
+        s.src = 'http://\(trackerHost):\(port)\(trackerPath)';
+        document.body.appendChild(s);
+        </script>
+        </body></html>
+        """
+
+        harness.registerContent(host: "page.example.com", path: "/index.html", body: pageHTML)
+        harness.registerContent(host: trackerHost, path: trackerPath, body: "/* catch-all */")
+
+        let trackerURL = "http://\(trackerHost):\(port)\(trackerPath)"
+        let exp = harness.expectObservation(of: trackerURL, testCase: self)
+
+        try await harness.load(host: "page.example.com")
+        await fulfillment(of: [exp], timeout: 10)
+
+        XCTAssertFalse(
+            harness.proxyDidReceive(host: trackerHost, path: trackerPath),
+            "CTL catch-all request must be blocked by content rules")
+
+        let blocked = harness.delegate.detectedTrackers.filter { $0.url == trackerURL }
+        XCTAssertEqual(blocked.count, 1, "Exactly 1 blocked event expected")
+        XCTAssertTrue(blocked.first?.isBlocked == true)
+
+        let allowed = harness.delegate.detectedThirdPartyRequests.filter { $0.url == trackerURL }
+        XCTAssertEqual(allowed.count, 0, "Zero non-blocked events expected")
+    }
+
+    // MARK: - Test 2: CTL-inactive, catch-all rule → allowed, non-blocked event
+
+    @MainActor
+    func testCTLInactiveCatchAllRuleIsAllowedAndReported() async throws {
+        let harness = try await makeHarness(ctlEnabled: false)
+        defer { harness.proxy.stop() }
+
+        let trackerHost = "fb-tracker.org"
+        let trackerPath = "/some.js"
+        let port = harness.proxy.port
+
+        let pageHTML = """
+        <html><body>
+        <script>
+        var s = document.createElement('script');
+        s.src = 'http://\(trackerHost):\(port)\(trackerPath)';
+        document.body.appendChild(s);
+        </script>
+        </body></html>
+        """
+
+        harness.registerContent(host: "page.example.com", path: "/index.html", body: pageHTML)
+        harness.registerContent(host: trackerHost, path: trackerPath, body: "/* allowed */")
+
+        let trackerURL = "http://\(trackerHost):\(port)\(trackerPath)"
+        let exp = harness.expectObservation(of: trackerURL, testCase: self)
+
+        try await harness.load(host: "page.example.com")
+        await fulfillment(of: [exp], timeout: 10)
+
+        XCTAssertTrue(
+            harness.proxyDidReceive(host: trackerHost, path: trackerPath),
+            "CTL-inactive request must reach proxy")
+
+        let blocked = harness.delegate.detectedTrackers.filter { $0.url == trackerURL }
+        XCTAssertEqual(blocked.count, 0, "Zero blocked events expected when CTL inactive")
+
+        let allowed = harness.delegate.detectedThirdPartyRequests.filter { $0.url == trackerURL }
+        XCTAssertEqual(allowed.count, 1, "Exactly 1 non-blocked event expected")
+        XCTAssertFalse(allowed.first?.isBlocked == true)
+        if case .allowed(reason: .ruleException) = allowed.first?.state {} else {
+            XCTFail("Expected .ruleException for CTL-inactive ignore-default tracker, got \(String(describing: allowed.first?.state))")
+        }
+
+        XCTAssertEqual(harness.delegate.detectedSurrogates.count, 0,
+                        "No surrogate events when CTL inactive")
+    }
+
+    // MARK: - Test 3: CTL-active, SDK/surrogate rule → blocked
+
+    // This test verifies the CTL blocking/classification contract for an SDK
+    // rule that also carries a surrogate declaration. Surrogate *injection* is
+    // intentionally suppressed here via an integrity attribute on the script
+    // element: with two compiled WKContentRuleList instances (nonCTL + CTL),
+    // a pre-existing WebKit memory bug crashes the process when the fb-sdk.js
+    // surrogate executes. The integrity attribute causes C-S-S to skip
+    // surrogate loading while still classifying the request as blocked.
+    // General bundled-surrogate injection is already proven by
+    // TrackerProtectionBundledSurrogatesSmokeTests.
+
+    @MainActor
+    func testCTLActiveSDKRuleIsBlocked() async throws {
+        let harness = try await makeHarness(ctlEnabled: true)
+        defer { harness.proxy.stop() }
+
+        let trackerHost = "fb-tracker.org"
+        let trackerPath = "/sdk.js"
+        let port = harness.proxy.port
+
+        // integrity attribute prevents C-S-S from injecting the fb-sdk.js
+        // surrogate, avoiding the WebKit crash while keeping the
+        // transport/classification contract intact.
+        let pageHTML = """
+        <html><body>
+        <script>
+        var s = document.createElement('script');
+        s.integrity = 'sha256-suppress-surrogate';
+        s.src = 'http://\(trackerHost):\(port)\(trackerPath)';
+        document.body.appendChild(s);
+        </script>
+        </body></html>
+        """
+
+        harness.registerContent(host: "page.example.com", path: "/index.html", body: pageHTML)
+        harness.registerContent(host: trackerHost, path: trackerPath, body: "/* blocked SDK */")
+
+        let trackerURL = "http://\(trackerHost):\(port)\(trackerPath)"
+        let exp = harness.expectObservation(of: trackerURL, testCase: self)
+
+        try await harness.load(host: "page.example.com")
+        await fulfillment(of: [exp], timeout: 10)
+
+        XCTAssertFalse(
+            harness.proxyDidReceive(host: trackerHost, path: trackerPath),
+            "CTL SDK request must be blocked by content rules")
+
+        let blocked = harness.delegate.detectedTrackers.filter { $0.url == trackerURL }
+        XCTAssertEqual(blocked.count, 1, "Exactly 1 blocked event expected for SDK")
+        XCTAssertTrue(blocked.first?.isBlocked == true)
+
+        let allowed = harness.delegate.detectedThirdPartyRequests.filter { $0.url == trackerURL }
+        XCTAssertEqual(allowed.count, 0, "Zero non-blocked events expected for SDK")
+    }
+
+    // MARK: - Test 4: CTL-inactive, SDK/surrogate rule → allowed, no surrogate
+
+    @MainActor
+    func testCTLInactiveSDKRuleIsAllowedNoSurrogate() async throws {
+        let harness = try await makeHarness(ctlEnabled: false)
+        defer { harness.proxy.stop() }
+
+        let trackerHost = "fb-tracker.org"
+        let trackerPath = "/sdk.js"
+        let port = harness.proxy.port
+
+        let pageHTML = """
+        <html><body>
+        <script>
+        var s = document.createElement('script');
+        s.src = 'http://\(trackerHost):\(port)\(trackerPath)';
+        document.body.appendChild(s);
+        </script>
+        </body></html>
+        """
+
+        harness.registerContent(host: "page.example.com", path: "/index.html", body: pageHTML)
+        harness.registerContent(host: trackerHost, path: trackerPath, body: "window.__sdkLoaded = true;")
+
+        let trackerURL = "http://\(trackerHost):\(port)\(trackerPath)"
+        let exp = harness.expectObservation(of: trackerURL, testCase: self)
+
+        try await harness.load(host: "page.example.com")
+        await fulfillment(of: [exp], timeout: 10)
+
+        XCTAssertTrue(
+            harness.proxyDidReceive(host: trackerHost, path: trackerPath),
+            "CTL-inactive SDK request must reach proxy")
+
+        let blocked = harness.delegate.detectedTrackers.filter { $0.url == trackerURL }
+        XCTAssertEqual(blocked.count, 0, "Zero blocked events when CTL inactive")
+
+        let allowed = harness.delegate.detectedThirdPartyRequests.filter { $0.url == trackerURL }
+        XCTAssertEqual(allowed.count, 1, "Exactly 1 non-blocked event expected")
+        XCTAssertFalse(allowed.first?.isBlocked == true)
+        if case .allowed(reason: .ruleException) = allowed.first?.state {} else {
+            XCTFail("Expected .ruleException for CTL-inactive SDK, got \(String(describing: allowed.first?.state))")
+        }
+
+        XCTAssertEqual(harness.delegate.detectedSurrogates.count, 0,
+                        "No surrogate when CTL inactive")
+
+        // The real SDK script loaded, not the surrogate
+        let sdkLoaded = try await harness.evaluateJS(
+            "window.__sdkLoaded === true") as? Bool
+        XCTAssertEqual(sdkLoaded, true, "Actual SDK script should have loaded")
+
+        // Surrogate-specific global should NOT exist
+        let fbDefined = try await harness.evaluateJS(
+            "typeof window.FB !== 'undefined'") as? Bool
+        XCTAssertNotEqual(fbDefined, true, "Surrogate window.FB should NOT exist")
+    }
+
+    // MARK: - Test 5: Non-CTL control rule, CTL inactive → still blocked
+
+    @MainActor
+    func testNonCTLRuleStillBlockedWhenCTLInactive() async throws {
+        let harness = try await makeHarness(ctlEnabled: false)
+        defer { harness.proxy.stop() }
+
+        let trackerHost = "fb-tracker.org"
+        let trackerPath = "/events.js"
+        let port = harness.proxy.port
+
+        let pageHTML = """
+        <html><body>
+        <script>
+        var s = document.createElement('script');
+        s.src = 'http://\(trackerHost):\(port)\(trackerPath)';
+        document.body.appendChild(s);
+        </script>
+        </body></html>
+        """
+
+        harness.registerContent(host: "page.example.com", path: "/index.html", body: pageHTML)
+        harness.registerContent(host: trackerHost, path: trackerPath, body: "/* events */")
+
+        let trackerURL = "http://\(trackerHost):\(port)\(trackerPath)"
+        let exp = harness.expectObservation(of: trackerURL, testCase: self)
+
+        try await harness.load(host: "page.example.com")
+        await fulfillment(of: [exp], timeout: 10)
+
+        XCTAssertFalse(
+            harness.proxyDidReceive(host: trackerHost, path: trackerPath),
+            "Non-CTL rule must still be blocked regardless of CTL state")
+
+        let blocked = harness.delegate.detectedTrackers.filter { $0.url == trackerURL }
+        XCTAssertEqual(blocked.count, 1, "Exactly 1 blocked event expected for non-CTL rule")
+        XCTAssertTrue(blocked.first?.isBlocked == true)
+
+        let allowed = harness.delegate.detectedThirdPartyRequests.filter { $0.url == trackerURL }
+        XCTAssertEqual(allowed.count, 0, "Zero non-blocked events for non-CTL blocked rule")
+    }
+}
+
+#endif

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/WebViewTestHelper.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/WebViewTestHelper.swift
@@ -20,143 +20,744 @@ import BrowserServicesKit
 import Common
 import ContentBlocking
 import Foundation
+import Network
 import PrivacyConfig
 import PrivacyConfigTestsUtils
 import TrackerRadarKit
+import UserScript
 import WebKit
 import XCTest
 
-final class MockNavigationDelegate: NSObject, WKNavigationDelegate {
+// ╔══════════════════════════════════════════════════════════════════════════════╗
+// ║  NEW PROXY-BASED TEST INFRASTRUCTURE (macOS 14+ / iOS 17+)                ║
+// ║                                                                            ║
+// ║  Uses WKWebsiteDataStore.proxyConfigurations with a loopback CONNECT       ║
+// ║  proxy and real PSL-listed domains for faithful eTLD+1 semantics.          ║
+// ╚══════════════════════════════════════════════════════════════════════════════╝
 
-    var onDidFinishNavigation: (() -> Void)?
+// MARK: - TestTrackerProtectionDelegate
 
-    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        XCTFail("Could to navigate to test site")
+/// Collects DetectedRequest objects produced by the real TrackerProtectionEventMapper.
+/// This is the ONLY test-double in the full stack. Everything else is real production code.
+@MainActor
+final class TestTrackerProtectionDelegate: NSObject, TrackerProtectionSubfeatureDelegate {
+
+    private(set) var detectedTrackers: [DetectedRequest] = []
+    private(set) var detectedThirdPartyRequests: [DetectedRequest] = []
+    private(set) var detectedSurrogates: [(DetectedRequest, String)] = []
+
+    /// Keyed by resource URL string. Fulfilled when C-S-S observes the resource
+    /// (regardless of whether a DetectedRequest is produced or the observation
+    /// is silently dropped as same-site).
+    var expectations: [String: XCTestExpectation] = [:]
+
+    private let eventMapper: TrackerProtectionEventMapper
+
+    init(eventMapper: TrackerProtectionEventMapper) {
+        self.eventMapper = eventMapper
+        super.init()
     }
-
-    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        onDidFinishNavigation?()
-    }
-}
-
-final class MockRulesUserScriptDelegate: NSObject, ContentBlockerRulesUserScriptDelegate {
-
-    var shouldProcessTrackers = true
-    var shouldProcessCTLTrackers = true
-    var onTrackerDetected: ((DetectedRequest) -> Void)?
-    var detectedTrackers = Set<DetectedRequest>()
-    var onThirdPartyRequestDetected: ((DetectedRequest) -> Void)?
-    var detectedThirdPartyRequests = Set<DetectedRequest>()
 
     func reset() {
         detectedTrackers.removeAll()
-    }
-
-    func contentBlockerRulesUserScriptShouldProcessTrackers(_ script: ContentBlockerRulesUserScript) -> Bool {
-        return shouldProcessTrackers
-    }
-
-    func contentBlockerRulesUserScriptShouldProcessCTLTrackers(_ script: ContentBlockerRulesUserScript) -> Bool {
-        return shouldProcessCTLTrackers
-    }
-
-    func contentBlockerRulesUserScript(_ script: ContentBlockerRulesUserScript,
-                                       detectedTracker tracker: DetectedRequest) {
-        detectedTrackers.insert(tracker)
-        onTrackerDetected?(tracker)
-    }
-
-    func contentBlockerRulesUserScript(_ script: ContentBlockerRulesUserScript,
-                                       detectedThirdPartyRequest request: DetectedRequest) {
-        detectedThirdPartyRequests.insert(request)
-        onThirdPartyRequestDetected?(request)
-    }
-}
-
-final class MockSurrogatesUserScriptDelegate: NSObject, SurrogatesUserScriptDelegate {
-
-    var shouldProcessTrackers = true
-    var shouldProcessCTLTrackers = false
-
-    var onSurrogateDetected: ((DetectedRequest, String) -> Void)?
-    var detectedSurrogates = Set<DetectedRequest>()
-
-    func reset() {
+        detectedThirdPartyRequests.removeAll()
         detectedSurrogates.removeAll()
+        expectations.removeAll()
     }
 
-    func surrogatesUserScriptShouldProcessTrackers(_ script: SurrogatesUserScript) -> Bool {
-        return shouldProcessTrackers
+    // MARK: - TrackerProtectionSubfeatureDelegate
+
+    func trackerProtectionShouldProcessTrackers(_ subfeature: TrackerProtectionSubfeature) -> Bool {
+        return true
     }
 
-    func surrogatesUserScriptShouldProcessCTLTrackers(_ script: SurrogatesUserScript) -> Bool {
-        shouldProcessCTLTrackers
+    func trackerProtection(_ subfeature: TrackerProtectionSubfeature,
+                           didObserveResource observation: TrackerProtectionSubfeature.ResourceObservation) {
+        let vendor = subfeature.currentAdClickAttributionVendor
+
+        if let detected = eventMapper.classifyResource(observation, adClickAttributionVendor: vendor) {
+            if detected.state == .blocked {
+                detectedTrackers.append(detected)
+            } else {
+                // Mapper guarantees same-site observations are filtered upstream
+                // (see `classifyResource` / `makeThirdPartyRequest`), so any
+                // non-blocked classification here is a real cross-site allow.
+                detectedThirdPartyRequests.append(detected)
+            }
+        } else if let thirdParty = eventMapper.makeThirdPartyRequest(from: observation) {
+            detectedThirdPartyRequests.append(thirdParty)
+        }
+
+        fulfillExpectation(for: observation.url)
     }
 
-    func surrogatesUserScript(_ script: SurrogatesUserScript,
-                              detectedTracker tracker: DetectedRequest,
-                              withSurrogate host: String) {
-        detectedSurrogates.insert(tracker)
-        onSurrogateDetected?(tracker, host)
+    func trackerProtection(_ subfeature: TrackerProtectionSubfeature,
+                           didInjectSurrogate surrogate: TrackerProtectionSubfeature.SurrogateInjection) {
+        let vendor = subfeature.currentAdClickAttributionVendor
+
+        if let detected = eventMapper.classifySurrogate(surrogate, adClickAttributionVendor: vendor),
+           let host = eventMapper.surrogateHost(from: surrogate) {
+            detectedSurrogates.append((detected, host))
+        }
+
+        fulfillExpectation(for: surrogate.url)
+    }
+
+    private func fulfillExpectation(for urlString: String) {
+        if let expectation = expectations[urlString] {
+            expectation.fulfill()
+        }
+    }
+}
+
+// MARK: - TestLoopbackProxy
+
+/// Minimal HTTP CONNECT proxy bound to 127.0.0.1 for use with
+/// `WKWebsiteDataStore.proxyConfigurations`. Routes traffic by Host header
+/// and serves registered canned responses.
+///
+/// WKWebView sends `CONNECT host:port HTTP/1.1` through this proxy; the proxy
+/// responds 200 and then relays HTTP request/response pairs over the tunnel.
+/// The tunnel is kept alive for same-host sub-resource reuse.
+@available(macOS 14.0, iOS 17.0, *)
+final class TestLoopbackProxy: @unchecked Sendable {
+
+    private var listener: NWListener?
+    private let queue = DispatchQueue(label: "TestLoopbackProxy")
+    private(set) var port: UInt16 = 0
+
+    private let lock = NSLock()
+    private var _received: [(host: String, path: String)] = []
+    private var _content: [String: Data] = [:]
+
+    /// Register a canned response for a given host + path combination.
+    func registerContent(host: String, path: String, body: String, mimeType: String = "text/html") {
+        let resolvedMime: String
+        if path.hasSuffix(".js") {
+            resolvedMime = "application/javascript"
+        } else if path.hasSuffix(".png") || path.hasSuffix(".gif") {
+            resolvedMime = "image/png"
+        } else {
+            resolvedMime = mimeType
+        }
+        let bodyData = body.data(using: .utf8)!
+        let header = "HTTP/1.1 200 OK\r\nContent-Type: \(resolvedMime)\r\nContent-Length: \(bodyData.count)\r\nAccess-Control-Allow-Origin: *\r\nConnection: keep-alive\r\n\r\n"
+        var full = header.data(using: .utf8)!
+        full.append(bodyData)
+        lock.withLock { _content["\(host)\(path)"] = full }
+    }
+
+    func start() async throws {
+        let params = NWParameters.tcp
+        params.requiredLocalEndpoint = .hostPort(host: .ipv4(.loopback), port: .any)
+        let l = try NWListener(using: params)
+        self.listener = l
+
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            var resumed = false
+            l.stateUpdateHandler = { [weak self] state in
+                guard !resumed else { return }
+                switch state {
+                case .ready:
+                    resumed = true
+                    self?.port = l.port?.rawValue ?? 0
+                    cont.resume()
+                case .failed(let error):
+                    resumed = true
+                    cont.resume(throwing: error)
+                default: break
+                }
+            }
+            l.newConnectionHandler = { [weak self] conn in
+                self?.handleConnection(conn)
+            }
+            l.start(queue: queue)
+        }
+    }
+
+    func stop() {
+        listener?.cancel()
+        listener = nil
+    }
+
+    /// Clear the recorded request log (call between test iterations).
+    func clearReceivedRequests() {
+        lock.withLock { _received.removeAll() }
+    }
+
+    /// All requests the proxy has received, in order.
+    func receivedRequests() -> [(host: String, path: String)] {
+        lock.withLock { _received }
+    }
+
+    /// Whether the proxy received a request for the given host + path.
+    func didReceive(host: String, path: String) -> Bool {
+        lock.withLock { _received.contains { $0.host == host && $0.path == path } }
+    }
+
+    // MARK: - Connection handling
+
+    private func handleConnection(_ conn: NWConnection) {
+        conn.start(queue: queue)
+        conn.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, _, _ in
+            guard let self, let data, let text = String(data: data, encoding: .utf8) else {
+                conn.cancel(); return
+            }
+            let lines = text.components(separatedBy: "\r\n")
+            guard let reqLine = lines.first else { conn.cancel(); return }
+            let parts = reqLine.components(separatedBy: " ")
+            guard parts.count >= 2 else { conn.cancel(); return }
+
+            if parts[0] == "CONNECT" {
+                self.handleConnect(conn: conn, target: parts[1])
+            } else {
+                self.handleForwardProxy(conn: conn, fullURL: parts[1])
+            }
+        }
+    }
+
+    private func handleConnect(conn: NWConnection, target: String) {
+        let targetHost = target.components(separatedBy: ":").first ?? target
+        let established = "HTTP/1.1 200 Connection Established\r\n\r\n".data(using: .utf8)!
+
+        conn.send(content: established, completion: .contentProcessed { [weak self] _ in
+            self?.readTunnelRequest(conn: conn, defaultHost: targetHost)
+        })
+    }
+
+    private func readTunnelRequest(conn: NWConnection, defaultHost: String) {
+        conn.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, _, _ in
+            guard let self, let data, !data.isEmpty, let text = String(data: data, encoding: .utf8) else {
+                conn.cancel(); return
+            }
+            let lines = text.components(separatedBy: "\r\n")
+            guard let reqLine = lines.first else { conn.cancel(); return }
+            let reqParts = reqLine.components(separatedBy: " ")
+            guard reqParts.count >= 2 else { conn.cancel(); return }
+
+            let path = reqParts[1]
+            let host = lines.first(where: { $0.lowercased().hasPrefix("host:") })
+                .map { String($0.dropFirst(5)).trimmingCharacters(in: .whitespaces) }
+                .map { $0.components(separatedBy: ":").first ?? $0 }
+                ?? defaultHost
+
+            self.lock.withLock { self._received.append((host: host, path: path)) }
+            self.serveKeepAlive(conn: conn, host: host, path: path, defaultHost: defaultHost)
+        }
+    }
+
+    private func handleForwardProxy(conn: NWConnection, fullURL: String) {
+        guard let url = URL(string: fullURL) else { conn.cancel(); return }
+        let host = url.host ?? ""
+        let path = url.path.isEmpty ? "/" : url.path
+
+        lock.withLock { _received.append((host: host, path: path)) }
+        let key = "\(host)\(path)"
+        let resp: Data = lock.withLock {
+            _content[key] ?? notFoundResponse
+        }
+        conn.send(content: resp, completion: .contentProcessed { _ in conn.cancel() })
+    }
+
+    private func serveKeepAlive(conn: NWConnection, host: String, path: String, defaultHost: String) {
+        let key = "\(host)\(path)"
+        let resp: Data = lock.withLock { _content[key] ?? notFoundResponse }
+        conn.send(content: resp, completion: .contentProcessed { [weak self] _ in
+            self?.readTunnelRequest(conn: conn, defaultHost: defaultHost)
+        })
+    }
+
+    private var notFoundResponse: Data {
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n".data(using: .utf8)!
     }
 }
 
-final class TestSchemeContentBlockerUserScriptConfig: ContentBlockerUserScriptConfig {
+// MARK: - HarnessNavigationDelegate
 
-    public let privacyConfiguration: PrivacyConfiguration
-    public let trackerData: TrackerData?
-    public let ctlTrackerData: TrackerData?
-    public let tld: TLD
+@MainActor
+private final class HarnessNavigationDelegate: NSObject, WKNavigationDelegate {
 
-    public private(set) var source: String
+    var onDidFinish: (() -> Void)?
+    var onDidFail: ((Error) -> Void)?
 
-    public init(privacyConfiguration: PrivacyConfiguration,
-                trackerData: TrackerData?,
-                ctlTrackerData: TrackerData?,
-                tld: TLD) throws {
-        self.privacyConfiguration = privacyConfiguration
-        self.trackerData = trackerData
-        self.ctlTrackerData = ctlTrackerData
-        self.tld = tld
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        let callback = onDidFinish
+        onDidFinish = nil
+        onDidFail = nil
+        callback?()
+    }
 
-        // UserScripts contain TrackerAllowlist rules in form of regular expressions - we need to ensure test scheme is matched instead of http/https
-        let orginalSource = try ContentBlockerRulesUserScript.generateSource(privacyConfiguration: privacyConfiguration)
-        source = orginalSource.replacingOccurrences(of: "http", with: "test")
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        let callback = onDidFail
+        onDidFinish = nil
+        onDidFail = nil
+        callback?(error)
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        let callback = onDidFail
+        onDidFinish = nil
+        onDidFail = nil
+        callback?(error)
     }
 }
 
-public class TestSchemeSurrogatesUserScriptConfig: SurrogatesUserScriptConfig {
+// MARK: - TestPrivacyConfigurationJSONGenerator
 
-    public let privacyConfig: PrivacyConfiguration
-    public let surrogates: String
-    public let trackerData: TrackerData?
-    public let encodedSurrogateTrackerData: String?
-    public let tld: TLD
-
-    public let source: String
-
-    public init(privacyConfig: PrivacyConfiguration,
-                surrogates: String,
-                trackerData: TrackerData?,
-                encodedSurrogateTrackerData: String?,
-                tld: TLD,
-                isDebugBuild: Bool) throws {
-
-        self.privacyConfig = privacyConfig
-        self.surrogates = surrogates
-        self.trackerData = trackerData
-        self.encodedSurrogateTrackerData = encodedSurrogateTrackerData
-        self.tld = tld
-
-        // UserScripts contain TrackerAllowlist rules in form of regular expressions - we need to ensure test scheme is matched instead of http/https
-        let orginalSource = try SurrogatesUserScript.generateSource(privacyConfiguration: privacyConfig,
-                                                                surrogates: surrogates,
-                                                                encodedSurrogateTrackerData: encodedSurrogateTrackerData,
-                                                                isDebugBuild: isDebugBuild)
-
-        source = orginalSource.replacingOccurrences(of: "http", with: "test")
+private struct TestPrivacyConfigurationJSONGenerator: CustomisedPrivacyConfigurationJSONGenerating {
+    let privacyConfigManager: PrivacyConfigurationManaging
+    var privacyConfiguration: Data? {
+        privacyConfigManager.currentConfig
     }
 }
+
+// MARK: - WebViewTestHarness
+
+/// Bundles the full ContentScopeUserScript + TrackerProtectionSubfeature + EventMapper
+/// test stack with a real WKWebView routed through a loopback CONNECT proxy.
+///
+/// Uses `WKWebsiteDataStore.proxyConfigurations` so that real PSL-listed domain
+/// names (e.g. `page.example.com`, `tracker.example.org`) resolve through the
+/// local proxy instead of the internet.  This preserves production-like eTLD+1
+/// and same-site semantics without modifying `/etc/hosts` or production code.
+@available(macOS 14.0, iOS 17.0, *)
+@MainActor
+final class WebViewTestHarness: NSObject {
+
+    let webView: WKWebView
+    let proxy: TestLoopbackProxy
+    let delegate: TestTrackerProtectionDelegate
+
+    private let contentScopeUserScript: ContentScopeUserScript
+    private let trackerProtectionSubfeature: TrackerProtectionSubfeature
+    private let eventMapper: TrackerProtectionEventMapper
+    private let navigationDelegate: HarnessNavigationDelegate
+
+    /// Creates a fully-wired test harness.
+    ///
+    /// Note: this init only configures the EventMapper, ContentScopeUserScript, and
+    /// WKWebView. WKContentRuleList compilation/installation is a separate step —
+    /// callers must invoke `compileAndInstallRules(...)` to install rule lists. The
+    /// WKContentRuleList side of the pipeline therefore takes its tracker allowlist
+    /// (`trackerExceptions`) and unprotected/exception domains from that call, not
+    /// from this init. The `create(...)` factory wires both ends together.
+    ///
+    /// - Parameters:
+    ///   - trackerData: TDS used for native classification (EventMapper mainTrackerData)
+    ///     and, unless `cssTrackerData` is provided, also for C-S-S injection.
+    ///   - supplementaryTrackerData: Additional TDS arrays for the mapper's multi-TDS loop
+    ///     (e.g. CTL split TDS when CTL is active). Defaults to empty.
+    ///   - cssTrackerData: If provided, C-S-S receives this TDS instead of `trackerData`.
+    ///     Use when C-S-S needs the full/merged TDS while the mapper receives a split subset.
+    ///   - privacyConfigManager: Provides the JSON injected into C-S-S at runtime.
+    ///   - temporaryUnprotectedDomains: Domains temporarily unprotected (EventMapper).
+    ///   - userUnprotectedDomains: Domains user-unprotected (EventMapper).
+    ///   - contentBlockingEnabled: Whether content blocking is logically enabled in the EventMapper.
+    ///   - trackerAllowlist: Tracker allowlist passed to the EventMapper for native
+    ///     allowlist override (parity with WKContentRuleList allowlist matching).
+    ///   - proxy: A started `TestLoopbackProxy` instance.
+    ///   - useDefaultDataStore: When `true`, uses `WKWebsiteDataStore.default()` instead
+    ///     of `.nonPersistent()`. Required as a workaround for a macOS 26 WebKit crash
+    ///     triggered by large WKContentRuleLists + WKUserScript + nonPersistent proxy
+    ///     configuration.
+    init(trackerData: TrackerData,
+         supplementaryTrackerData: [TrackerData] = [],
+         cssTrackerData: TrackerData? = nil,
+         privacyConfigManager: PrivacyConfigurationManaging,
+         temporaryUnprotectedDomains: [String] = [],
+         userUnprotectedDomains: [String] = [],
+         contentBlockingEnabled: Bool = true,
+         trackerAllowlist: PrivacyConfigurationData.TrackerAllowlistData = [:],
+         proxy: TestLoopbackProxy,
+         useDefaultDataStore: Bool = false) throws {
+
+        self.proxy = proxy
+
+        let tld = TLD()
+        navigationDelegate = HarnessNavigationDelegate()
+
+        eventMapper = TrackerProtectionEventMapper(
+            tld: tld,
+            mainTrackerData: trackerData,
+            supplementaryTrackerData: supplementaryTrackerData,
+            unprotectedSites: userUnprotectedDomains,
+            tempList: temporaryUnprotectedDomains,
+            contentBlockingEnabled: contentBlockingEnabled,
+            trackerAllowlist: trackerAllowlist
+        )
+
+        delegate = TestTrackerProtectionDelegate(eventMapper: eventMapper)
+
+        trackerProtectionSubfeature = TrackerProtectionSubfeature()
+        trackerProtectionSubfeature.delegate = delegate
+
+        let properties = ContentScopeProperties(
+            gpcEnabled: false,
+            sessionKey: UUID().uuidString,
+            messageSecret: UUID().uuidString,
+            featureToggles: .allTogglesOn
+        )
+
+        contentScopeUserScript = try ContentScopeUserScript(
+            privacyConfigManager,
+            properties: properties,
+            scriptContext: .contentScope(surrogateTrackerData: ContentBlockerRulesManager.extractSurrogates(from: cssTrackerData ?? trackerData)),
+            allowedNonisolatedFeatures: [TrackerProtectionSubfeature.featureNameValue],
+            privacyConfigurationJSONGenerator: TestPrivacyConfigurationJSONGenerator(
+                privacyConfigManager: privacyConfigManager
+            )
+        )
+        contentScopeUserScript.registerSubfeature(delegate: trackerProtectionSubfeature)
+
+        let configuration = WKWebViewConfiguration()
+
+        let proxyEndpoint = NWEndpoint.hostPort(
+            host: .ipv4(.loopback),
+            port: NWEndpoint.Port(rawValue: proxy.port)!
+        )
+        if useDefaultDataStore {
+            let dataStore = WKWebsiteDataStore.default()
+            dataStore.proxyConfigurations = [ProxyConfiguration(httpCONNECTProxy: proxyEndpoint)]
+            configuration.websiteDataStore = dataStore
+        } else {
+            let dataStore = WKWebsiteDataStore.nonPersistent()
+            dataStore.proxyConfigurations = [ProxyConfiguration(httpCONNECTProxy: proxyEndpoint)]
+            configuration.websiteDataStore = dataStore
+        }
+
+        let ucc = configuration.userContentController
+        ucc.addUserScript(contentScopeUserScript.makeWKUserScriptSync())
+        for messageName in contentScopeUserScript.messageNames {
+            ucc.addScriptMessageHandler(
+                contentScopeUserScript,
+                contentWorld: contentScopeUserScript.getContentWorld(),
+                name: messageName
+            )
+        }
+
+        webView = WKWebView(
+            frame: .init(origin: .zero, size: .init(width: 500, height: 1000)),
+            configuration: configuration
+        )
+        webView.navigationDelegate = navigationDelegate
+
+        super.init()
+    }
+
+    // MARK: - Content Rule List
+
+    /// Compiles a WKContentRuleList from tracker data and adds it to the web view.
+    /// No scheme replacement — rules naturally match http:// URLs.
+    func compileAndInstallRules(trackerData: TrackerData,
+                                exceptions: [String],
+                                tempUnprotected: [String],
+                                trackerExceptions: [TrackerException]) async throws {
+        let rules = ContentBlockerRulesBuilder(trackerData: trackerData)
+            .buildRules(withExceptions: exceptions,
+                        andTemporaryUnprotectedDomains: tempUnprotected,
+                        andTrackerAllowlist: trackerExceptions)
+
+        let data = try JSONEncoder().encode(rules)
+        let ruleList = String(data: data, encoding: .utf8)!
+
+        let compiled = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<WKContentRuleList, Error>) in
+            WKContentRuleListStore.default().compileContentRuleList(
+                forIdentifier: "harness-\(UUID().uuidString)",
+                encodedContentRuleList: ruleList
+            ) { list, error in
+                if let list {
+                    cont.resume(returning: list)
+                } else {
+                    cont.resume(throwing: error ?? NSError(domain: "WebViewTestHarness", code: -1,
+                                                            userInfo: [NSLocalizedDescriptionKey: "Failed to compile content rule list"]))
+                }
+            }
+        }
+        webView.configuration.userContentController.add(compiled)
+    }
+
+    // MARK: - Content Registration
+
+    /// Register a page or resource on the proxy, keyed by host + path.
+    func registerContent(host: String, path: String, body: String, mimeType: String = "text/html") {
+        proxy.registerContent(host: host, path: path, body: body, mimeType: mimeType)
+    }
+
+    // MARK: - Page Loading
+
+    /// Loads a URL through the proxy and waits for navigation to finish.
+    func load(_ url: URL) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            navigationDelegate.onDidFinish = { cont.resume() }
+            navigationDelegate.onDidFail = { cont.resume(throwing: $0) }
+            webView.load(URLRequest(url: url))
+        }
+    }
+
+    /// Convenience: loads `http://host/path`.
+    func load(host: String, path: String = "/index.html") async throws {
+        try await load(URL(string: "http://\(host)\(path)")!)
+    }
+
+    /// Loads an HTML string with a base URL and waits for navigation to finish.
+    func loadHTMLString(_ html: String, baseURL: URL) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            navigationDelegate.onDidFinish = { cont.resume() }
+            navigationDelegate.onDidFail = { cont.resume(throwing: $0) }
+            webView.loadHTMLString(html, baseURL: baseURL)
+        }
+    }
+
+    // MARK: - Observation Helpers
+
+    /// Creates an expectation fulfilled when C-S-S observes a resource at `urlString`.
+    /// The expectation fires regardless of whether a DetectedRequest is produced.
+    func expectObservation(of urlString: String, testCase: XCTestCase) -> XCTestExpectation {
+        let exp = testCase.expectation(description: "C-S-S observes \(urlString)")
+        delegate.expectations[urlString] = exp
+        return exp
+    }
+
+    /// Whether the proxy received a request for the given host + path.
+    func proxyDidReceive(host: String, path: String) -> Bool {
+        proxy.didReceive(host: host, path: path)
+    }
+
+    /// Clears WebKit caches on the data store. Call between test iterations
+    /// when using the default (persistent) data store to avoid stale pages.
+    func clearWebKitCaches() async {
+        await webView.configuration.websiteDataStore.removeData(
+            ofTypes: Set([WKWebsiteDataTypeDiskCache, WKWebsiteDataTypeMemoryCache]),
+            modifiedSince: Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    // MARK: - JavaScript Evaluation
+
+    /// Evaluate JavaScript in the harness's web view, disambiguating the WebKit vs
+    /// Common `evaluateJavaScript` overloads.
+    func evaluateJS(_ script: String) async throws -> Any? {
+        try await withCheckedThrowingContinuation { cont in
+            webView.evaluateJavaScript(script) { result, error in
+                if let error { cont.resume(throwing: error) } else { cont.resume(returning: result) }
+            }
+        }
+    }
+}
+
+// MARK: - WebViewTestHarness Convenience Factory
+
+@available(macOS 14.0, iOS 17.0, *)
+extension WebViewTestHarness {
+
+    /// High-level factory: creates a started proxy, builds all config objects,
+    /// compiles content rules, and returns a ready-to-use harness.
+    static func create(
+        trackerDataJSON: String,
+        locallyUnprotected: [String] = [],
+        tempUnprotected: [String] = [],
+        trackerAllowlist: [String: [PrivacyConfigurationData.TrackerAllowlist.Entry]] = [:],
+        contentBlockingEnabled: Bool = true,
+        exceptions: [String] = [],
+        useDefaultDataStore: Bool = false
+    ) async throws -> WebViewTestHarness {
+        let trackerData = try JSONDecoder().decode(TrackerData.self, from: Data(trackerDataJSON.utf8))
+
+        let privacyConfig = WebViewTestConfig.preparePrivacyConfig(
+            locallyUnprotected: locallyUnprotected,
+            tempUnprotected: tempUnprotected,
+            trackerAllowlist: trackerAllowlist,
+            contentBlockingEnabled: contentBlockingEnabled,
+            exceptions: exceptions
+        )
+
+        var cssAllowlist: [String: [[String: Any]]] = [:]
+        for (domain, entries) in trackerAllowlist {
+            cssAllowlist[domain] = entries.map { entry in
+                ["rule": entry.rule, "domains": entry.domains] as [String: Any]
+            }
+        }
+
+        let configJSON = try WebViewTestConfig.makeConfig(
+            trackerProtectionEnabled: true,
+            contentBlockingEnabled: contentBlockingEnabled,
+            trackerAllowlist: cssAllowlist,
+            tempUnprotectedDomains: tempUnprotected
+        )
+
+        let manager = WebViewTestConfig.makeManager(configJSON: configJSON, privacyConfig: privacyConfig)
+
+        var combinedTempUnprotected = privacyConfig.tempUnprotectedDomains.filter { !$0.trimmingWhitespace().isEmpty }
+        combinedTempUnprotected.append(contentsOf: privacyConfig.exceptionsList(forFeature: .contentBlocking))
+
+        let trackerExceptions = DefaultContentBlockerRulesExceptionsSource.transform(
+            allowList: privacyConfig.trackerAllowlist.entries
+        )
+
+        let proxy = TestLoopbackProxy()
+        try await proxy.start()
+
+        let harness = try WebViewTestHarness(
+            trackerData: trackerData,
+            privacyConfigManager: manager,
+            temporaryUnprotectedDomains: combinedTempUnprotected,
+            userUnprotectedDomains: privacyConfig.userUnprotectedDomains,
+            contentBlockingEnabled: contentBlockingEnabled,
+            trackerAllowlist: trackerAllowlist,
+            proxy: proxy,
+            useDefaultDataStore: useDefaultDataStore
+        )
+
+        try await harness.compileAndInstallRules(
+            trackerData: trackerData,
+            exceptions: privacyConfig.userUnprotectedDomains,
+            tempUnprotected: combinedTempUnprotected,
+            trackerExceptions: trackerExceptions
+        )
+
+        return harness
+    }
+}
+
+// MARK: - Config Builder Helpers
+
+enum WebViewTestConfig {
+
+    /// Builds a full remote-config-shaped JSON Data matching the structure C-S-S expects.
+    static func makeConfig(
+        trackerProtectionEnabled: Bool = true,
+        contentBlockingEnabled: Bool = true,
+        surrogateInjectionEnabled: Bool = true,
+        ctlEnabled: Bool = false,
+        trackerAllowlist: [String: [[String: Any]]] = [:],
+        unprotectedDomains: [String] = [],
+        tempUnprotectedDomains: [String] = [],
+        userUnprotectedDomains: [String] = [],
+        trackerProtectionExceptions: [[String: String]] = []
+    ) throws -> Data {
+
+        let exceptions = trackerProtectionExceptions.map { entry -> [String: String] in
+            var result = [String: String]()
+            if let domain = entry["domain"] { result["domain"] = domain }
+            if let reason = entry["reason"] { result["reason"] = reason }
+            return result
+        }
+
+        let settings: [String: Any] = [
+            "blockingEnabled": contentBlockingEnabled,
+            "ctlEnabled": ctlEnabled,
+            "surrogateInjectionEnabled": surrogateInjectionEnabled,
+            "allowlist": trackerAllowlist,
+            "tempUnprotectedDomains": tempUnprotectedDomains,
+            "userUnprotectedDomains": userUnprotectedDomains
+        ]
+
+        let trackerProtectionFeature: [String: Any] = [
+            "state": trackerProtectionEnabled ? "enabled" : "disabled",
+            "exceptions": exceptions,
+            "settings": settings
+        ]
+
+        let contentBlockingFeature: [String: Any] = [
+            "state": contentBlockingEnabled ? "enabled" : "disabled",
+            "exceptions": [] as [[String: String]]
+        ]
+
+        // C-S-S compiled bundle reads the allowlist from
+        // bundledConfig.features.trackerAllowlist.settings.allowlistedTrackers
+        // using the native format: { domain: { rules: [{rule, domains}] } }
+        var allowlistedTrackers = [String: [String: Any]]()
+        for (domain, entries) in trackerAllowlist {
+            allowlistedTrackers[domain] = ["rules": entries]
+        }
+        let trackerAllowlistFeature: [String: Any] = [
+            "state": trackerAllowlist.isEmpty ? "disabled" : "enabled",
+            "exceptions": [] as [[String: String]],
+            "settings": ["allowlistedTrackers": allowlistedTrackers]
+        ]
+
+        var features: [String: Any] = [
+            "trackerProtection": trackerProtectionFeature,
+            "contentBlocking": contentBlockingFeature
+        ]
+        if !trackerAllowlist.isEmpty {
+            features["trackerAllowlist"] = trackerAllowlistFeature
+        }
+        // The pre-built C-S-S bundle determines _ctlEnabled from
+        // `features.clickToLoad.state` (via _isStateEnabled), while the local
+        // submodule source reads `trackerProtection.settings.ctlEnabled`.
+        // Both paths must be set so tests work with either bundle version.
+        if ctlEnabled {
+            features["clickToLoad"] = [
+                "state": "enabled",
+                "exceptions": [] as [[String: String]]
+            ] as [String: Any]
+        }
+
+        let config: [String: Any] = [
+            "version": 1,
+            "features": features,
+            "unprotectedTemporary": unprotectedDomains.map { ["domain": $0] }
+        ]
+
+        return try JSONSerialization.data(withJSONObject: config, options: [])
+    }
+
+    /// Creates a PrivacyConfiguration for WKContentRuleList compilation and EventMapper.
+    static func preparePrivacyConfig(
+        locallyUnprotected: [String] = [],
+        tempUnprotected: [String] = [],
+        trackerAllowlist: [String: [PrivacyConfigurationData.TrackerAllowlist.Entry]] = [:],
+        contentBlockingEnabled: Bool = true,
+        exceptions: [String] = []
+    ) -> PrivacyConfiguration {
+        let contentBlockingExceptions = exceptions.map { PrivacyConfigurationData.ExceptionEntry(domain: $0, reason: nil) }
+        let contentBlockingStatus = contentBlockingEnabled ? "enabled" : "disabled"
+        let features = [
+            PrivacyFeature.contentBlocking.rawValue: PrivacyConfigurationData.PrivacyFeature(
+                state: contentBlockingStatus,
+                exceptions: contentBlockingExceptions
+            )
+        ]
+        let unprotectedTemporary = tempUnprotected.map { PrivacyConfigurationData.ExceptionEntry(domain: $0, reason: nil) }
+        let privacyData = PrivacyConfigurationData(
+            features: features,
+            unprotectedTemporary: unprotectedTemporary,
+            trackerAllowlist: trackerAllowlist
+        )
+
+        let localProtection = MockDomainsProtectionStore()
+        localProtection.unprotectedDomains = Set(locallyUnprotected)
+
+        return AppPrivacyConfiguration(
+            data: privacyData,
+            identifier: "",
+            localProtection: localProtection,
+            internalUserDecider: MockInternalUserDecider()
+        )
+    }
+
+    /// Creates a MockPrivacyConfigurationManager wired with config JSON and PrivacyConfiguration.
+    static func makeManager(
+        configJSON: Data,
+        privacyConfig: PrivacyConfiguration
+    ) -> MockPrivacyConfigurationManager {
+        let manager = MockPrivacyConfigurationManager(privacyConfig: privacyConfig)
+        manager.currentConfigString = String(data: configJSON, encoding: .utf8) ?? "{}"
+        return manager
+    }
+}
+
+// ╔══════════════════════════════════════════════════════════════════════════════╗
+// ║  LEGACY HELPERS — PRESERVED FOR UNMIGRATED TESTS                           ║
+// ║                                                                            ║
+// ║  The types below are used by tests that still rely on the old              ║
+// ║  ContentBlockerRulesUserScript / SurrogatesUserScript / test:// pipeline.  ║
+// ║  Do NOT use them in new or migrated tests.                                 ║
+// ║  Remove once all dependent tests have been migrated.                       ║
+// ╚══════════════════════════════════════════════════════════════════════════════╝
+
+// MARK: - LEGACY -- WebKitTestHelper
 
 final class WebKitTestHelper {
 
@@ -204,17 +805,32 @@ final class WebKitTestHelper {
         let data = (try? JSONEncoder().encode(rules))!
         var ruleList = String(data: data, encoding: .utf8)!
 
-        // Replace https scheme regexp with test
         ruleList = ruleList.replacingOccurrences(of: "https", with: "test", options: [], range: nil)
 
         WKContentRuleListStore.default().compileContentRuleList(forIdentifier: identifier, encodedContentRuleList: ruleList) { list, _ in
-
             DispatchQueue.main.async {
                 completion(list)
             }
         }
     }
 }
+
+// MARK: - LEGACY -- MockNavigationDelegate
+
+final class MockNavigationDelegate: NSObject, WKNavigationDelegate {
+
+    var onDidFinishNavigation: (() -> Void)?
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        XCTFail("Could to navigate to test site")
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        onDidFinishNavigation?()
+    }
+}
+
+// MARK: - MockExperimentCohortsManager
 
 class MockExperimentCohortsManager: ExperimentCohortsManaging {
     func resolveCohort(for experiment: ExperimentSubfeature, allowCohortAssignment: Bool) -> CohortID? {

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentScopeScript/TrackerProtectionEventMapperTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentScopeScript/TrackerProtectionEventMapperTests.swift
@@ -564,6 +564,130 @@ final class TrackerProtectionEventMapperTests: XCTestCase {
         XCTAssertTrue(result!.isBlocked, "Non-CTL tracker must remain blocked when CTL TDS is excluded")
     }
 
+    // MARK: - Multi-TDS Loop Parity with Legacy ContentBlockerRulesUserScript
+    //
+    // These pin the documented contract of `classifyUrl`'s multi-TDS loop so any future
+    // refactor that diverges from `ContentBlockerRulesUserScript.userContentController(_:didReceive:)`
+    // fails loudly. The legacy script's behavior is the source of truth.
+
+    /// When the supplementary TDS yields a non-blocked candidate (e.g. CTL-inactive
+    /// `.allowed(reason: .ruleException)`) and the main TDS is empty for that URL, the
+    /// supplementary candidate must survive — matching legacy semantics where the main
+    /// resolver's `nil` result does not overwrite `detectedTracker`.
+    func testSupplementaryNonBlockedCandidateSurvivesWhenMainTDSReturnsNil() {
+        // Supplementary TDS contains facebook.net with default-ignore — yields a
+        // non-blocked candidate. Main TDS contains only tracker.com so it returns nil
+        // for facebook.net (mirrors splitter contract: supplementary trackers are
+        // removed from main).
+        let supplementary = makeCtlTDS()
+        let mapper = TrackerProtectionEventMapper(
+            tld: tld,
+            mainTrackerData: makeTestTDS(),
+            supplementaryTrackerData: [supplementary],
+            unprotectedSites: [],
+            tempList: [],
+            contentBlockingEnabled: true,
+            trackerAllowlist: [:])
+
+        // facebook.net/some.js does not match the CTL `sdk.js` rule, so the supplementary
+        // resolver returns a non-blocked candidate (ignore-default + no matching rule).
+        let observation = TrackerProtectionSubfeature.ResourceObservation(
+            url: "https://connect.facebook.net/some-other.js",
+            resourceType: "script",
+            potentiallyBlocked: false,
+            pageUrl: "https://example.com")
+
+        let result = mapper.classifyResource(observation)
+
+        XCTAssertNotNil(result, "Supplementary non-blocked candidate must survive when main TDS returns nil")
+        XCTAssertFalse(result!.isBlocked, "Candidate from supplementary TDS must remain non-blocked")
+        XCTAssertEqual(result?.eTLDplus1, "facebook.net",
+                       "Returned candidate must be the supplementary TDS's classification")
+    }
+
+    /// When BOTH the supplementary and main TDSes classify the same URL, the main TDS
+    /// result wins. This matches legacy `ContentBlockerRulesUserScript` line 180:
+    /// `detectedTracker = tracker` (unconditional overwrite). The splitter contract makes
+    /// this branch unreachable in practice, but we pin the semantics so the mapper and
+    /// the legacy script can never silently diverge.
+    func testMainTDSResultOverwritesSupplementaryNonBlockedCandidate() {
+        // Both TDSes recognise tracker.com. Supplementary classifies it as ignore-default
+        // (non-blocked). Main classifies it as block-default. Legacy semantics: main wins.
+        let supplementaryTracker = KnownTracker(
+            domain: "tracker.com",
+            defaultAction: .ignore,
+            owner: KnownTracker.Owner(name: "Supplementary Inc", displayName: "Supplementary", ownedBy: nil),
+            prevalence: 0.1, subdomains: nil, categories: nil, rules: nil)
+        let supplementaryTDS = TrackerData(
+            trackers: ["tracker.com": supplementaryTracker],
+            entities: ["Supplementary Inc": Entity(displayName: "Supplementary",
+                                                   domains: ["tracker.com"], prevalence: 0.1)],
+            domains: ["tracker.com": "Supplementary Inc"],
+            cnames: nil)
+
+        let mapper = TrackerProtectionEventMapper(
+            tld: tld,
+            mainTrackerData: makeTestTDS(), // tracker.com defaultAction = .block
+            supplementaryTrackerData: [supplementaryTDS],
+            unprotectedSites: [],
+            tempList: [],
+            contentBlockingEnabled: true,
+            trackerAllowlist: [:])
+
+        let observation = TrackerProtectionSubfeature.ResourceObservation(
+            url: "https://tracker.com/pixel.js",
+            resourceType: "script",
+            potentiallyBlocked: true,
+            pageUrl: "https://example.com")
+        let result = mapper.classifyResource(observation)
+
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result!.isBlocked,
+                      "Main TDS result must overwrite supplementary candidate (legacy parity)")
+        XCTAssertEqual(result?.entityName, "Tracker Inc",
+                       "Returned classification must come from main TDS, not supplementary")
+    }
+
+    /// Supplementary blocked result must short-circuit the loop — main TDS is never consulted.
+    /// Mirrors legacy `ContentBlockerRulesUserScript` lines 161–164: `if tracker.isBlocked { return }`.
+    func testSupplementaryBlockedResultShortCircuitsMainTDS() {
+        // Main TDS would classify tracker.com as blocked too, but the supplementary
+        // matches first and short-circuits. We use a sentinel entity name to verify
+        // which TDS produced the result.
+        let supplementaryBlocking = KnownTracker(
+            domain: "tracker.com",
+            defaultAction: .block,
+            owner: KnownTracker.Owner(name: "Supplementary Sentinel", displayName: "Sup", ownedBy: nil),
+            prevalence: 0.1, subdomains: nil, categories: nil, rules: nil)
+        let supplementaryTDS = TrackerData(
+            trackers: ["tracker.com": supplementaryBlocking],
+            entities: ["Supplementary Sentinel": Entity(displayName: "Sup",
+                                                        domains: ["tracker.com"], prevalence: 0.1)],
+            domains: ["tracker.com": "Supplementary Sentinel"],
+            cnames: nil)
+
+        let mapper = TrackerProtectionEventMapper(
+            tld: tld,
+            mainTrackerData: makeTestTDS(),
+            supplementaryTrackerData: [supplementaryTDS],
+            unprotectedSites: [],
+            tempList: [],
+            contentBlockingEnabled: true,
+            trackerAllowlist: [:])
+
+        let observation = TrackerProtectionSubfeature.ResourceObservation(
+            url: "https://tracker.com/pixel.js",
+            resourceType: "script",
+            potentiallyBlocked: true,
+            pageUrl: "https://example.com")
+        let result = mapper.classifyResource(observation)
+
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result!.isBlocked)
+        XCTAssertEqual(result?.entityName, "Sup",
+                       "Supplementary blocked result must short-circuit; main TDS must not run")
+    }
+
     // MARK: - CTL-Inactive Parity (authentic split-TDS validation)
     // Uses ClickToLoadRulesSplitter with a facebook.net CTL fixture (macOS-only).
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214229888151734?focus=true
Tech Design URL:
CC:

### Description

This adds the test cases for coverage of the number one in the stack. Again, this is prep for three and four prs as we move over.

Stack:
1. https://github.com/duckduckgo/apple-browsers/pull/4639
2. https://github.com/duckduckgo/apple-browsers/pull/4640
3. https://github.com/duckduckgo/apple-browsers/pull/4641
4. https://github.com/duckduckgo/apple-browsers/pull/4642
5. https://github.com/duckduckgo/apple-browsers/pull/4538


### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1.
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large test-scaffolding overhaul that adds a loopback CONNECT proxy + WKWebView harness and rewrites reference tests, which could introduce CI flakiness/crashes (notably WebKit workarounds) despite minimal production-code impact.
> 
> **Overview**
> Adds a new macOS/iOS(17+) **proxy-based `WKWebView` test harness** (`TestLoopbackProxy`, `WebViewTestHarness`, `TestTrackerProtectionDelegate`) that exercises the full production path from `WKContentRuleList` + `ContentScopeUserScript` through `TrackerProtectionEventMapper`, while keeping legacy `test://` helpers segregated.
> 
> Migrates the tracker-protection **domain matching** and **tracker allowlist** reference tests to this harness (including `.test`→`.site` fixture normalization and WebKit crash workarounds), and adds new suites: **dataset split contract** tests (surrogate-only JS dataset), **bundled surrogate** end-to-end smoke tests, and **Click-to-Load** gating/classification smoke tests using split rule lists.
> 
> Documents and pins `TrackerProtectionEventMapper.classifyUrl` multi-TDS loop semantics to match the legacy userscript, and adds parity regression unit tests to prevent future divergence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf07dff57fd417de31fc3e23db67d01c88f6c975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->