### PR TITLE
Gate supportsNativeStorage on native storage bridge availability

### DIFF
--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -128,6 +128,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     private let aichatContextualModeFeature: AIChatContextualModeFeatureProviding
     private var contextualModePixelHandler: AIChatContextualModePixelFiring?
     private let keyValueStore: KeyValueStoring
+    private let isNativeStorageBridgeAvailable: Bool
 
     /// Set externally via `AIChatContentHandler.setup()`.
     var displayMode: AIChatDisplayMode?
@@ -146,7 +147,8 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
          keyValueStore: KeyValueStoring = UserDefaults(suiteName: Global.appConfigurationGroupName) ?? UserDefaults(),
          promptHandler: any AIChatConsumableDataHandling = AIChatPromptHandler.shared,
          aichatFullModeFeature: AIChatFullModeFeatureProviding = AIChatFullModeFeature(),
-         aichatContextualModeFeature: AIChatContextualModeFeatureProviding = AIChatContextualModeFeature()) {
+         aichatContextualModeFeature: AIChatContextualModeFeatureProviding = AIChatContextualModeFeature(),
+         isNativeStorageBridgeAvailable: Bool = false) {
         self.experimentalAIChatManager = experimentalAIChatManager
         self.syncHandler = syncHandler
         self.featureFlagger = featureFlagger
@@ -154,6 +156,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
         self.promptHandler = promptHandler
         self.aichatFullModeFeature = aichatFullModeFeature
         self.aichatContextualModeFeature = aichatContextualModeFeature
+        self.isNativeStorageBridgeAvailable = isNativeStorageBridgeAvailable
         setUpSyncStatusObserver()
     }
 
@@ -274,7 +277,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
             supportsOpenAIChatLink: defaults.supportsOpenAIChatLink,
             supportsAIChatSync: featureFlagger.isFeatureOn(.aiChatSync) && !fireMode,
             supportsMultipleContexts: supportsContextualMode && featureFlagger.isFeatureOn(.multiplePageContexts),
-            supportsNativeStorage: featureFlagger.isFeatureOn(.aiChatNativeStorage)
+            supportsNativeStorage: featureFlagger.isFeatureOn(.aiChatNativeStorage) && isNativeStorageBridgeAvailable
         )
     }
 

--- a/iOS/DuckDuckGo/UserScripts.swift
+++ b/iOS/DuckDuckGo/UserScripts.swift
@@ -100,17 +100,19 @@ final class UserScripts: UserScriptsProvider {
             webExtensionAvailability: sourceProvider.webExtensionAvailability
         )
 
+        let isNativeStorageBridgeAvailable = featureFlagger.isFeatureOn(.aiChatNativeStorage) && duckAiNativeStorageHandler != nil
         let experimentalManager: ExperimentalAIChatManager = .init(featureFlagger: featureFlagger)
         let aiChatSettings = AIChatSettings()
         let aiChatScriptHandler = AIChatUserScriptHandler(experimentalAIChatManager: experimentalManager,
                                                           syncHandler: AIChatSyncHandler(sync: sourceProvider.sync,
                                                                                          httpRequestErrorHandler: sourceProvider.syncErrorHandler.handleAiChatsError),
-                                                          featureFlagger: featureFlagger)
+                                                          featureFlagger: featureFlagger,
+                                                          isNativeStorageBridgeAvailable: isNativeStorageBridgeAvailable)
         aiChatUserScript = AIChatUserScript(handler: aiChatScriptHandler,
                                             debugSettings: aiChatDebugSettings)
         serpSettingsUserScript = SERPSettingsUserScript(serpSettingsProviding: SERPSettingsProvider(aiChatProvider: aiChatSettings, featureFlagger: featureFlagger))
 
-        if featureFlagger.isFeatureOn(.aiChatNativeStorage),
+        if isNativeStorageBridgeAvailable,
            let duckAiNativeStorageHandler {
             var originRules: [HostnameMatchingRule] = [
                 .exactOrSubdomain(hostname: "duck.ai"),

--- a/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -51,15 +51,7 @@ class AIChatUserScriptHandlerTests: XCTestCase {
         mockUserDefaults = UserDefaults(suiteName: mockSuiteName)
         mockUserDefaults.removePersistentDomain(forName: mockSuiteName)
 
-        let experimentalAIChatManager = ExperimentalAIChatManager(featureFlagger: mockFeatureFlagger, userDefaults: mockUserDefaults)
-        aiChatUserScriptHandler = AIChatUserScriptHandler(
-            experimentalAIChatManager: experimentalAIChatManager,
-            syncHandler: mockAIChatSyncHandler,
-            featureFlagger: mockFeatureFlagger,
-            keyValueStore: mockUserDefaults,
-            aichatFullModeFeature: mockAIChatFullModeFeature,
-            aichatContextualModeFeature: mockAIChatContextualModeFeature
-        )
+        aiChatUserScriptHandler = makeAIChatUserScriptHandler()
         aiChatUserScriptHandler.setPayloadHandler(mockPayloadHandler)
     }
 
@@ -71,6 +63,19 @@ class AIChatUserScriptHandlerTests: XCTestCase {
         mockAIChatFullModeFeature = nil
         mockAIChatContextualModeFeature = nil
         super.tearDown()
+    }
+
+    private func makeAIChatUserScriptHandler(isNativeStorageBridgeAvailable: Bool = false) -> AIChatUserScriptHandler {
+        let experimentalAIChatManager = ExperimentalAIChatManager(featureFlagger: mockFeatureFlagger, userDefaults: mockUserDefaults)
+        return AIChatUserScriptHandler(
+            experimentalAIChatManager: experimentalAIChatManager,
+            syncHandler: mockAIChatSyncHandler,
+            featureFlagger: mockFeatureFlagger,
+            keyValueStore: mockUserDefaults,
+            aichatFullModeFeature: mockAIChatFullModeFeature,
+            aichatContextualModeFeature: mockAIChatContextualModeFeature,
+            isNativeStorageBridgeAvailable: isNativeStorageBridgeAvailable
+        )
     }
 
     func testGetAIChatNativeConfigValues() {
@@ -88,9 +93,10 @@ class AIChatUserScriptHandlerTests: XCTestCase {
         XCTAssertEqual(configValues?.supportsAIChatSync, false)
     }
     
-    func testWhenNativeStorageFeatureIsOnAndNotInFireModeThenSupportsNativeStorageIsTrue() {
+    func testWhenNativeStorageFeatureIsOnAndBridgeIsAvailableAndNotInFireModeThenSupportsNativeStorageIsTrue() {
         // Given
         mockFeatureFlagger.enabledFeatureFlags = [.aiChatNativeStorage]
+        aiChatUserScriptHandler = makeAIChatUserScriptHandler(isNativeStorageBridgeAvailable: true)
         aiChatUserScriptHandler.isFireModeProvider = { false }
 
         // When
@@ -100,9 +106,10 @@ class AIChatUserScriptHandlerTests: XCTestCase {
         XCTAssertEqual(configValues?.supportsNativeStorage, true)
     }
 
-    func testWhenNativeStorageFeatureIsOnAndInFireModeThenSupportsNativeStorageIsTrue() {
+    func testWhenNativeStorageFeatureIsOnAndBridgeIsAvailableAndInFireModeThenSupportsNativeStorageIsTrue() {
         // Given
         mockFeatureFlagger.enabledFeatureFlags = [.aiChatNativeStorage]
+        aiChatUserScriptHandler = makeAIChatUserScriptHandler(isNativeStorageBridgeAvailable: true)
         aiChatUserScriptHandler.isFireModeProvider = { true }
 
         // When
@@ -110,6 +117,31 @@ class AIChatUserScriptHandlerTests: XCTestCase {
 
         // Then
         XCTAssertEqual(configValues?.supportsNativeStorage, true)
+    }
+
+    func testWhenNativeStorageFeatureIsOnAndBridgeIsUnavailableThenSupportsNativeStorageIsFalse() {
+        // Given
+        mockFeatureFlagger.enabledFeatureFlags = [.aiChatNativeStorage]
+        aiChatUserScriptHandler.isFireModeProvider = { false }
+
+        // When
+        let configValues = aiChatUserScriptHandler.getAIChatNativeConfigValues(params: [], message: MockUserScriptMessage(name: "test", body: [:])) as? AIChatNativeConfigValues
+
+        // Then
+        XCTAssertEqual(configValues?.supportsNativeStorage, false)
+    }
+
+    func testWhenNativeStorageFeatureIsOffAndBridgeIsAvailableThenSupportsNativeStorageIsFalse() {
+        // Given
+        mockFeatureFlagger.enabledFeatureFlags = []
+        aiChatUserScriptHandler = makeAIChatUserScriptHandler(isNativeStorageBridgeAvailable: true)
+        aiChatUserScriptHandler.isFireModeProvider = { false }
+
+        // When
+        let configValues = aiChatUserScriptHandler.getAIChatNativeConfigValues(params: [], message: MockUserScriptMessage(name: "test", body: [:])) as? AIChatNativeConfigValues
+
+        // Then
+        XCTAssertEqual(configValues?.supportsNativeStorage, false)
     }
 
     func testWhenNativeStorageFeatureIsOffAndNotInFireModeThenSupportsNativeStorageIsFalse() {

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
@@ -40,17 +40,20 @@ final class AIChatMessageHandler: AIChatMessageHandling {
     private let payloadHandler: AIChatPayloadHandler
     private let chatRestorationDataHandler: AIChatRestorationDataHandler
     private let pageContextHandler: AIChatPageContextHandler
+    private let isNativeStorageBridgeAvailable: Bool
 
     init(featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger,
          promptHandler: any AIChatConsumableDataHandling = AIChatPromptHandler.shared,
          payloadHandler: AIChatPayloadHandler = AIChatPayloadHandler(),
          chatRestorationDataHandler: AIChatRestorationDataHandler = AIChatRestorationDataHandler(),
-         pageContextHandler: AIChatPageContextHandler = AIChatPageContextHandler()) {
+         pageContextHandler: AIChatPageContextHandler = AIChatPageContextHandler(),
+         isNativeStorageBridgeAvailable: Bool = false) {
         self.featureFlagger = featureFlagger
         self.promptHandler = promptHandler
         self.payloadHandler = payloadHandler
         self.chatRestorationDataHandler = chatRestorationDataHandler
         self.pageContextHandler = pageContextHandler
+        self.isNativeStorageBridgeAvailable = isNativeStorageBridgeAvailable
     }
 
     func getDataForMessageType(_ type: AIChatMessageType) -> Encodable? {
@@ -103,7 +106,7 @@ extension AIChatMessageHandler {
             supportsAIChatSync: featureFlagger.isFeatureOn(.aiChatSync) && !isFireWindow,
             supportsMultipleContexts: featureFlagger.isFeatureOn(.aiChatPageContext) && featureFlagger.isFeatureOn(.aiChatMultiplePageContexts),
             supportsTabPicker: featureFlagger.isFeatureOn(.aiChatPageContext) && featureFlagger.isFeatureOn(.aiChatAttachMoreTabs),
-            supportsNativeStorage: featureFlagger.isFeatureOn(.aiChatNativeStorage)
+            supportsNativeStorage: featureFlagger.isFeatureOn(.aiChatNativeStorage) && isNativeStorageBridgeAvailable
         )
     }
 

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -75,8 +75,14 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
         clickToLoadScript = ClickToLoadUserScript()
         contentBlockerRulesScript = ContentBlockerRulesUserScript(configuration: sourceProvider.contentBlockerRulesConfig!)
         surrogatesScript = SurrogatesUserScript(configuration: sourceProvider.surrogatesConfig!)
+        let isNativeStorageBridgeAvailable = sourceProvider.featureFlagger.isFeatureOn(.aiChatNativeStorage) && duckAiNativeStorageHandler != nil
+        let aiChatMessageHandler = AIChatMessageHandler(
+            featureFlagger: sourceProvider.featureFlagger,
+            isNativeStorageBridgeAvailable: isNativeStorageBridgeAvailable
+        )
         let aiChatHandler = AIChatUserScriptHandler(
             storage: DefaultAIChatPreferencesStorage(),
+            messageHandling: aiChatMessageHandler,
             windowControllersManager: sourceProvider.windowControllersManager,
             pixelFiring: PixelKit.shared,
             statisticsLoader: StatisticsLoader.shared,
@@ -96,7 +102,7 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
         )
         serpSettingsUserScript = SERPSettingsUserScript(serpSettingsProviding: SERPSettingsProvider())
 
-        if sourceProvider.featureFlagger.isFeatureOn(.aiChatNativeStorage),
+        if isNativeStorageBridgeAvailable,
            let duckAiNativeStorageHandler {
             var originRules: [HostnameMatchingRule] = [
                 .exactOrSubdomain(hostname: "duck.ai"),

--- a/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -889,23 +889,46 @@ struct AIChatUserScriptHandlerTests {
     }
 
     @available(iOS 16, macOS 13, *)
-    @Test("When aiChatNativeStorage is enabled and not a fire window, supportsNativeStorage is true", .timeLimit(.minutes(1)))
-    func testWhenAIChatNativeStorageEnabledAndNotFireWindowThenSupportsNativeStorageIsTrue() {
+    @Test("When aiChatNativeStorage is enabled and bridge is available, supportsNativeStorage is true", .timeLimit(.minutes(1)))
+    func testWhenAIChatNativeStorageEnabledAndBridgeAvailableThenSupportsNativeStorageIsTrue() {
         let featureFlagger = makeFeatureFlagger(aiChatNativeStorageEnabled: true)
         let handler = AIChatMessageHandler(featureFlagger: featureFlagger,
-                                           promptHandler: AIChatPromptHandler.shared)
+                                           promptHandler: AIChatPromptHandler.shared,
+                                           isNativeStorageBridgeAvailable: true)
 
         #expect(handler.getNativeConfigValues(isFireWindow: false).supportsNativeStorage == true)
     }
 
     @available(iOS 16, macOS 13, *)
-    @Test("When aiChatNativeStorage is enabled and is a fire window, supportsNativeStorage is true", .timeLimit(.minutes(1)))
-    func testWhenAIChatNativeStorageEnabledAndFireWindowThenSupportsNativeStorageIsTrue() {
+    @Test("When aiChatNativeStorage is enabled and bridge is available in a fire window, supportsNativeStorage is true", .timeLimit(.minutes(1)))
+    func testWhenAIChatNativeStorageEnabledAndBridgeAvailableInFireWindowThenSupportsNativeStorageIsTrue() {
+        let featureFlagger = makeFeatureFlagger(aiChatNativeStorageEnabled: true)
+        let handler = AIChatMessageHandler(featureFlagger: featureFlagger,
+                                           promptHandler: AIChatPromptHandler.shared,
+                                           isNativeStorageBridgeAvailable: true)
+
+        #expect(handler.getNativeConfigValues(isFireWindow: true).supportsNativeStorage == true)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("When aiChatNativeStorage is enabled but bridge is unavailable, supportsNativeStorage is false", .timeLimit(.minutes(1)))
+    func testWhenAIChatNativeStorageEnabledAndBridgeUnavailableThenSupportsNativeStorageIsFalse() {
         let featureFlagger = makeFeatureFlagger(aiChatNativeStorageEnabled: true)
         let handler = AIChatMessageHandler(featureFlagger: featureFlagger,
                                            promptHandler: AIChatPromptHandler.shared)
 
-        #expect(handler.getNativeConfigValues(isFireWindow: true).supportsNativeStorage == true)
+        #expect(handler.getNativeConfigValues(isFireWindow: false).supportsNativeStorage == false)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("When aiChatNativeStorage is disabled but bridge is available, supportsNativeStorage is false", .timeLimit(.minutes(1)))
+    func testWhenAIChatNativeStorageDisabledAndBridgeAvailableThenSupportsNativeStorageIsFalse() {
+        let featureFlagger = makeFeatureFlagger(aiChatNativeStorageEnabled: false)
+        let handler = AIChatMessageHandler(featureFlagger: featureFlagger,
+                                           promptHandler: AIChatPromptHandler.shared,
+                                           isNativeStorageBridgeAvailable: true)
+
+        #expect(handler.getNativeConfigValues(isFireWindow: false).supportsNativeStorage == false)
     }
 }
 // swiftlint:enable inclusive_language


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214392952784988?focus=true
Tech Design URL:
CC:

### Description
The AI Chat user script previously reported `supportsNativeStorage=true` to the JS whenever the `aiChatNativeStorage` feature flag was on, even on call sites where no native storage handler was wired up. This change threads an `isNativeStorageBridgeAvailable` flag through the iOS and macOS message/user-script handlers so the JS only sees `supportsNativeStorage=true` when both the flag is on and the native bridge actually exists. Tests cover all four flag/bridge combinations on both platforms.

### Testing Steps
Both iOS and macOS

1. Run the browser, disable the feature flag for aiChatNativeStorage if enabled
2. Force close the browser
3. Open it again, at this point it's all indexDB. 
4. Open duck.ai, check if getAIChatNativeConfigValues returns false as it should
6. Change the FF (aiChatNativeStorage) during runtime to true
7. Open duck.ai, check if getAIChatNativeConfigValues returns false as it should (The bridge is only setup during startup so it should return false here)
8. Restart the app
9. Open duck.ai, check if getAIChatNativeConfigValues returns true as it should
10. Change the feature flag to off
11. Open duck.ai, check if getAIChatNativeConfigValues returns false as it should since the flag is false even though the bridge was setup

### Impact and Risks
Low

#### What could go wrong?
A call site that should advertise native storage isn't passing the new flag and silently falls back to `false`, but the only production call sites have been updated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit df60eec29f5cfa57e1a06b5f616b84c25d7481fe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->