### PR TITLE
[macOS] Attempt to fix a rare test suite crash

### DIFF
--- a/macOS/UnitTests/HomePage/HomePageSettingsModelTests.swift
+++ b/macOS/UnitTests/HomePage/HomePageSettingsModelTests.swift
@@ -62,6 +62,7 @@ final class NewTabPageCustomizationModelTests: XCTestCase {
         )
     }
 
+    @MainActor
     override func tearDown() async throws {
         try? FileManager.default.removeItem(at: storageLocation)
         appearancePreferences = nil


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1214377060963383?focus=true
Tech Design URL:
CC:

### Description

This PR attempt to fix a threading issue with the test suite, where we have two threads mutating the same property:

```
Thread 9 (com.apple.root.user-initiated-qos.cooperative, faulting):
#00  libobjc            objc_class::realizeIfNeeded()      ← EXC_BAD_ACCESS
#01  libobjc            objc_destructInstance
#02  libswiftCore       swift_deallocClassInstance
#03  libswiftCore       _swift_release_dealloc
#04  libswiftCore       RefCounts::doDecrementSlow<…PerformDeinit…>
#05  Unit Tests App     NewTabPageCustomizationModelTests.tearDown()
…    @isolated(any) async thunks (no actor) → completeTaskWithClosure

Thread 0 (main, runnable in parallel):
#00–04  Combine          HandleEvents.Inner.cancel → AnyCancellable.cancel
#05     Combine          AnyCancellable.__deallocating_deinit
#06–07  libswiftCore     _swift_release_dealloc
#08     DDG App Store    outlined destroy of AnyCancellable?
#09     DDG App Store    NewTabPageCustomizationModel.deinit          ← also in deinit
#10     DDG App Store    NewTabPageCustomizationModel.__deallocating_deinit
#11–12  libswiftCore     _swift_release_dealloc
#13     DDG App Store    closure #1 in NewTabPageCustomizationModel.subscribeToUserBackgroundImages()
#14–15  Combine          HandleEvents.Inner.receive
#16     Combine          closure #1 in Publishers.ReceiveOn.Inner.receive
#17–22  libdispatch      _dispatch_main_queue_drain
```

To fix this I'm moving `tearDown` to the main actor (the `setUp` function is already doing the same).

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Check that CI is green
2. Use "Run Repeatedly" to stress test the suite locally

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adjusts actor isolation for teardown; low blast radius, with the main risk being masking a real concurrency issue rather than fixing it.
> 
> **Overview**
> Marks `NewTabPageCustomizationModelTests`’s `tearDown()` as `@MainActor`, aligning cleanup with the already-main-actor `setUp()`.
> 
> This aims to prevent rare test-suite crashes caused by teardown/deinit work happening off the main thread while Combine/UI-related resources are being released.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3082d2b9a670da2dd77b429cfbceb3630e352abb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->