### PR TITLE
iOS: Remove Customize Responses from UTI tools menu

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIToolsController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIToolsController.swift
@@ -75,7 +75,7 @@ final class UTIToolsController {
         return Presentation(
             isToolsButtonHidden: false,
             selectedTool: selectedTool,
-            toolsMenu: buildToolsMenu(displayState: displayState, modelStore: modelStore)
+            toolsMenu: buildToolsMenu(modelStore: modelStore)
         )
     }
 }
@@ -87,40 +87,27 @@ private extension UTIToolsController {
         return displayState != .hidden
     }
 
-    func buildToolsMenu(
-        displayState: UnifiedToggleInputDisplayState,
-        modelStore: UTIModelStore
-    ) -> UTIToolsMenu {
-        var items: [UTIToolsMenu.Item] = []
-
-        if case .aiTab = displayState {
-            items.append(.customizeResponses)
-        }
-
-        items.append(.webSearch(
-            isSelected: selectedTool == .webSearch,
-            isEnabled: modelStore.selectedModelSupports(tool: .webSearch)
-        ))
-
-        return UTIToolsMenu(items: items)
+    func buildToolsMenu(modelStore: UTIModelStore) -> UTIToolsMenu {
+        return UTIToolsMenu(items: [
+            .webSearch(
+                isSelected: selectedTool == .webSearch,
+                isEnabled: modelStore.selectedModelSupports(tool: .webSearch)
+            )
+        ])
     }
 }
 
 struct UTIToolsMenu {
 
     enum Item: Equatable {
-        case customizeResponses
         case webSearch(isSelected: Bool, isEnabled: Bool)
 
         enum Identifier {
-            case customizeResponses
             case webSearch
         }
 
         var identifier: Identifier {
             switch self {
-            case .customizeResponses:
-                return .customizeResponses
             case .webSearch:
                 return .webSearch
             }
@@ -141,13 +128,6 @@ struct UTIToolsMenuFactory {
 
     private func makeAction(_ item: UTIToolsMenu.Item, onSelect: @escaping (UTIToolsMenu.Item.Identifier) -> Void) -> UIAction {
         switch item {
-        case .customizeResponses:
-            return UIAction(
-                title: UserText.aiChatToolbarCustomizeResponsesMenuTitle,
-                image: DesignSystemImages.Glyphs.Size24.options
-            ) { _ in
-                onSelect(item.identifier)
-            }
         case let .webSearch(isSelected, isEnabled):
             return makeWebSearchAction(
                 isSelected: isSelected,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1090,8 +1090,6 @@ private extension UnifiedToggleInputCoordinator {
 
     func handleToolsMenuSelection(_ identifier: UTIToolsMenu.Item.Identifier) {
         switch identifier {
-        case .customizeResponses:
-            viewController.handler.customizeResponsesButtonTapped()
         case .webSearch:
             toolsController.toggleSelection(for: .webSearch, modelStore: modelStore)
             refreshToolsPresentation()

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -819,12 +819,12 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         XCTAssertEqual(sut.displayState, .aiTab(.collapsed))
     }
 
-    func test_toolsMenu_containsCustomizeResponsesAction_onAITab() {
+    func test_toolsMenu_doesNotContainCustomizeResponsesAction_onAITab() {
         sut.showExpanded()
 
         let actionTitles = toolsMenuActions().map(\.title)
 
-        XCTAssertTrue(actionTitles.contains(UserText.aiChatToolbarCustomizeResponsesMenuTitle))
+        XCTAssertFalse(actionTitles.contains(UserText.aiChatToolbarCustomizeResponsesMenuTitle))
     }
 
     func test_toolsMenu_doesNotContainCustomizeResponsesAction_inOmnibar() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214255034494690?focus=true
Tech Design URL:
CC:

### Description
Removes the "Customize Responses" entry (and its handler) from the AI-tab UTI tools menu, leaving only Web Search. Also fixes the AI-tab WKWebView bottom content/scroll-indicator insets so content is not obscured by the floating input bar when the keyboard is visible.

### Testing Steps
1. Open a Duck.ai tab, tap the tools button — verify only "Web Search" is shown (no "Customize Responses").

### Impact and Risks
Low

#### What could go wrong?
The new inset calculation could mis-size in an edge keyboard/toolbar configuration and leave a small gap or overlap at the bottom of the AI-tab webview.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI/menu change that only removes an action path; primary risk is unintended loss of access to Customize Responses if still expected elsewhere.
> 
> **Overview**
> Removes the AI-tab UTI tools-menu option for **Customize Responses**, leaving **Web Search** as the only tools-menu item.
> 
> This deletes the `.customizeResponses` menu item/identifier and its `UIAction`, simplifies menu construction to no longer depend on `displayState`, and removes the coordinator’s selection handler case for that menu item. Tests are updated to assert the Customize Responses action is absent even on the AI tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a787b89cd03cd15955e0c65daba00d442e9e9223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->