### PR TITLE
Switch remaining simplified sync strings to NSLocalizedString

### DIFF
--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -1250,7 +1250,7 @@ public struct UserText {
 
     // Simplified Sync
     public static let simplifiedSyncEnabledToast = NSLocalizedString("sync.simplified.enabled.toast", value: "Sync & Backup enabled", comment: "Toast message shown after sync is successfully enabled")
-    public static let simplifiedDeviceSyncedSuccessfullyToast = NotLocalizedString("sync.simplified.device-synced.toast", value: "Device synced successfully!", comment: "Toast message shown after sync is enabled by connecting with another device")
+    public static let simplifiedDeviceSyncedSuccessfullyToast = NSLocalizedString("sync.simplified.device-synced.toast", value: "Device synced successfully!", comment: "Toast message shown after sync is enabled by connecting with another device")
     public static let simplifiedSyncTurnOffTitle = NSLocalizedString("sync.simplified.turn.off.title", value: "Turn Off Sync & Backup?", comment: "Alert title when turning off sync")
     public static let simplifiedSyncTurnOffMessage = NSLocalizedString("sync.simplified.turn.off.message", value: "Your bookmarks and passwords on this device won't be affected.", comment: "Alert message when turning off sync")
     public static let simplifiedSyncTurnOffAction = NSLocalizedString("sync.simplified.turn.off.action", value: "Turn Off", comment: "Alert button to confirm turning off sync")

--- a/iOS/DuckDuckGo/bg.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/bg.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Кодът е копиран";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Устройството е синхронизирано успешно!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Функцията Sync & Backup е активирана";
 

--- a/iOS/DuckDuckGo/cs.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/cs.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Kód je zkopírovaný";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Zařízení se úspěšně synchronizovalo.";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sync & Backup zapnuto";
 

--- a/iOS/DuckDuckGo/da.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/da.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Kode kopieret";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Enheden er synkroniseret!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sync & Backup aktiveret";
 

--- a/iOS/DuckDuckGo/de.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/de.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Code kopiert";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Gerät erfolgreich synchronisiert!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sync & Backup aktiviert";
 

--- a/iOS/DuckDuckGo/el.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/el.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Ο κώδικας αντιγράφηκε";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Η συσκευή συγχρονίστηκε επιτυχώς!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Το Sync & Backup ενεργοποιήθηκε";
 

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -4021,6 +4021,9 @@ Take back control of your personal information with the browser designed for dat
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Code copied";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Device synced successfully!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sync & Backup enabled";
 

--- a/iOS/DuckDuckGo/es.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/es.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Código copiado";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "¡Dispositivo sincronizado correctamente!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sync & Backup activado";
 

--- a/iOS/DuckDuckGo/et.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/et.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Kood kopeeritud";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Seade sünkrooniti edukalt!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sync & Backup lubatud";
 

--- a/iOS/DuckDuckGo/fi.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fi.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Koodi kopioitu";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Laite synkronoitu onnistuneesti!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Synkronointi ja varmuuskopiointi käytössä";
 

--- a/iOS/DuckDuckGo/fr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fr.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Code copié";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "L'appareil a bien été synchronisé !";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sync & Backup activé";
 

--- a/iOS/DuckDuckGo/hr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hr.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Kôd je kopiran";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Uređaj je uspješno sinkroniziran!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sync & Backup je uključen";
 

--- a/iOS/DuckDuckGo/hu.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hu.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Kód másolva";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Az eszköz szinkronizálása sikeresen megtörtént!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sync & Backup engedélyezve";
 

--- a/iOS/DuckDuckGo/it.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/it.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Codice copiato";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Dispositivo sincronizzato correttamente!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sync & Backup abilitati";
 

--- a/iOS/DuckDuckGo/ja.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ja.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "コードがコピーされました";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "デバイスが正常に同期されました！";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sync & Backupが有効になりました";
 

--- a/iOS/DuckDuckGo/lt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lt.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Kodas nukopijuotas";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Įrenginys sėkmingai sinchronizuotas!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sinchronizavimas ir atsarginis kopijavimas įjungtas";
 

--- a/iOS/DuckDuckGo/lv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lv.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Kods nokopēts";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Ierīce veiksmīgi sinhronizēta!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sync & Backup iespējots";
 

--- a/iOS/DuckDuckGo/nb.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nb.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Koden er kopiert";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Enheten er synkronisert!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sync & Backup er aktivert";
 

--- a/iOS/DuckDuckGo/nl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nl.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Code gekopieerd";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Apparaat is gesynchroniseerd!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Synchronisatie en back-up ingeschakeld";
 

--- a/iOS/DuckDuckGo/pl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pl.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Kod skopiowany";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Urządzenie zostało pomyślnie zsynchronizowane.";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Synchronizacja i kopia zapasowa włączone";
 

--- a/iOS/DuckDuckGo/pt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pt.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Código copiado";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Dispositivo sincronizado com sucesso!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sincronização e cópia de segurança ativada";
 

--- a/iOS/DuckDuckGo/ro.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ro.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Cod copiat";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Dispozitivul a fost sincronizat!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sync & Backup activat";
 

--- a/iOS/DuckDuckGo/ru.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ru.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Код скопирован";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Устройство успешно синхронизировано!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sync & Backup включено";
 

--- a/iOS/DuckDuckGo/sk.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sk.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Kód bol skopírovaný";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Zariadenie bolo úspešne synchronizované!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sync & Backup je povolené";
 

--- a/iOS/DuckDuckGo/sl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sl.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Koda je kopirana";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Naprava je bila uspešno sinhronizirana";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Funkcija Sync & Backup je omogočena";
 

--- a/iOS/DuckDuckGo/sv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sv.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Kod kopierad";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Enheten har synkroniserats!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sync & Backup aktiverad";
 

--- a/iOS/DuckDuckGo/tr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/tr.lproj/Localizable.strings
@@ -4275,6 +4275,9 @@
 /* Toast message shown after copying sync code to clipboard */
 "sync.simplified.code.copied.toast" = "Kod kopyalandı";
 
+/* Toast message shown after sync is enabled by connecting with another device */
+"sync.simplified.device-synced.toast" = "Cihaz başarıyla senkronize edildi!";
+
 /* Toast message shown after sync is successfully enabled */
 "sync.simplified.enabled.toast" = "Sync & Backup etkin";
 

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/bg.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/bg.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Синхронизиране с друго устройство";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Не сега";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Синхронизиране на данните с друго устройство?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Зарежда икони от уебсайтове, които сте добавили в отметките. Изтеглянето на икони се разкрива във Вашата мрежа.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Отметки";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Използвайте едни и същи любими отметки на мобилни устройства и на компютър.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Свързване...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Запазете отметките и данните за автоматично попълване и ги синхронизирайте между устройствата с криптиране от край до край.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Използвайте този код, за да възстановите данните си, ако загубите достъп до това устройство. Данните в Sync & Backup не могат да бъдат възстановени след 18 месеца неактивност. [Научете повече](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "Приложение DuckDuckGo";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/cs.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/cs.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Synchronizovat s jiným zařízením";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Teď ne";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Synchronizovat data s jiným zařízením?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Načte ikony z webových stránek uložených do záložek. Stažené ikony jsou vidět ve tvé síti.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Záložky";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Používej stejné oblíbené záložky na mobilu i počítači.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Připojování...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Ukládej si záložky a data pro automatické vyplnění a synchronizuj je mezi svými zařízeními se šifrováním end-to-end.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Použij tento kód k případnému obnovení dat, pokud ztratíš přístup k tomuto zařízení. Data Sync & Backup nelze obnovit po 18 měsících nečinnosti. [Více informací](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "Aplikace DuckDuckGo";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/da.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/da.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Synkroniser en anden enhed";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Ikke nu";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Synkroniser dine data med en anden enhed?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Indlæser ikoner fra hjemmesider, du har bogmærket. Ikondownloads eksponeres for dit netværk.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Bogmærker";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Brug de samme favoritbogmærker på mobil og computer.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Forbinder...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Gem dine bogmærker og data til automatisk udfyldning, og synkroniser dem mellem dine enheder med end-to-end-kryptering.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Brug denne kode til at gendanne dine data, hvis du mister adgangen til denne enhed. Sync & Backup-data kan ikke gendannes efter 18 måneders inaktivitet. [Læs mere](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "DuckDuckGo-appen";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/de.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/de.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Anderes Gerät synchronisieren";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Jetzt nicht";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Möchtest du deine Daten mit einem anderen Gerät synchronisieren?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Lädt Symbole von Webseiten, die du als Lesezeichen gespeichert hast. Symbol-Downloads werden in deinem Netzwerk offengelegt.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Lesezeichen";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Verwende dieselben Lieblingslesezeichen auf dem Handy und auf dem Desktop.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Verbinden ...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Speichere deine Lesezeichen und Autofill-Daten und synchronisiere diese mit Ende-zu-Ende-Verschlüsselung zwischen deinen Geräten.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Verwende diesen Code, um deine Daten wiederherzustellen, wenn du den Zugriff auf dieses Gerät verlierst. Sync & Backup-Daten können nach 18 Monaten Inaktivität nicht wiederhergestellt werden. [Mehr erfahren](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "DuckDuckGo-App";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/el.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/el.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Συγχρονισμός άλλης συσκευής";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Όχι τώρα";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Θέλετε να συγχρονίσετε τα δεδομένα σας με άλλη συσκευή;";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Φορτώνει εικονίδια από ιστότοπους που έχετε προσθέσει σελιδοδείκτες. Οι λήψεις εικονιδίων αποκαλύπτονται στο δίκτυό σας.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Σελιδοδείκτες";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Χρησιμοποίησε τους ίδιους σελιδοδείκτες αγαπημένων σε κινητό και υπολογιστή.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Σύνδεση...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Αποθηκεύστε τους σελιδοδείκτες και τα δεδομένα αυτόματης συμπλήρωσης και συγχρονίστε τα μεταξύ των συσκευών σας με κρυπτογράφηση από άκρο σε άκρο.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Χρησιμοποιήστε αυτόν τον κωδικό ώστε να επαναφέρετε τα δεδομένα σας σε περίπτωση που χάσετε την πρόσβαση σε αυτήν τη συσκευή. Δεν είναι δυνατή η ανάκτηση δεδομένων Sync & Backup έπειτα από 18 μήνες αδράνειας. [Μάθετε περισσότερα](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "Εφαρμογή DuckDuckGo";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/en.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/en.lproj/Localizable.strings
@@ -322,11 +322,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Sync Another Device";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Not Now";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Sync your data with another device?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Loads icons from websites you've bookmarked. Icon downloads are exposed to your network.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Bookmarks";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Use the same favorite bookmarks on mobile and desktop.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Connecting...";
@@ -351,6 +360,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Save your bookmarks and autofill data, and sync them between your devices with end-to-end encryption.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Use this code to restore your data if you lose access to this device. Sync & Backup data can’t be recovered after 18 months of inactivity. [Learn More](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "DuckDuckGo App";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/es.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/es.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Sincronizar con otro dispositivo";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Ahora no";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "¿Sincronizar tus datos con otro dispositivo?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Carga iconos de los sitios web que has marcado como favoritos. Las descargas de iconos están expuestas a tu red.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Marcadores";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Usa los mismos marcadores favoritos en el móvil y el escritorio.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Conectando...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Guarda tus marcadores y datos de autocompletado y sincronízalos entre tus dispositivos con encriptación de extremo a extremo.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Usa este código para restaurar tus datos si pierdes el acceso a este dispositivo. Los datos de Sync & Backup no se pueden recuperar después de 18 meses de inactividad. [Más información](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "aplicación DuckDuckGo";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/et.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/et.lproj/Localizable.strings
@@ -374,7 +374,7 @@
 "sync.simplified.header.message.basic" = "Salvesta oma järjehoidjad ja automaatse täitmise andmed ning sünkrooni need oma seadmete vahel otspunktkrüpteerimise abil.";
 
 /* Sync settings data recovery section footer. %@ is replaced with the URL. */
-"sync.simplified.recovery.section.footer" = "Kasuta seda koodi oma andmete taastamiseks, kui kaotad juurdepääsu sellele seadmele. Funktsiooni Sync & Backup andmeid ei saa taastada pärast 18-kuulist mitteaktiivsust. [Learn More](%@)";
+"sync.simplified.recovery.section.footer" = "Kasuta seda koodi oma andmete taastamiseks, kui kaotad juurdepääsu sellele seadmele. Funktsiooni Sync & Backup andmeid ei saa taastada pärast 18-kuulist mitteaktiivsust. [Loe edasi](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "DuckDuckGo rakendus";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/et.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/et.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Sünkrooni teise seadmega";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Mitte praegu";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Kas sünkroonida oma andmed teise seadmega?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Laadib ikoonid veebisaitidelt, mille oled järjehoidjatesse lisanud. Ikoonide allalaadimine toimub sinu võrgus.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Järjehoidjad";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Kasuta samu lemmikuid järjehoidjaid nii mobiilis kui ka lauaarvutis.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Ühendamine...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Salvesta oma järjehoidjad ja automaatse täitmise andmed ning sünkrooni need oma seadmete vahel otspunktkrüpteerimise abil.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Kasuta seda koodi oma andmete taastamiseks, kui kaotad juurdepääsu sellele seadmele. Funktsiooni Sync & Backup andmeid ei saa taastada pärast 18-kuulist mitteaktiivsust. [Learn More](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "DuckDuckGo rakendus";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/fi.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/fi.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Synkronoi toinen laite";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Ei nyt";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Synkronoidaanko tietosi toisen laitteen kanssa?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Lataa kuvakkeet verkkosivustoista, jotka olet merkinnyt kirjanmerkkeihin. Kuvakelataukset näkyvät verkostollesi.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Kirjanmerkit";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Käytä samoja suosikkikirjanmerkkejä mobiililaitteessa ja tietokoneella.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Yhdistetään...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Tallenna kirjanmerkit ja automaattisen täytön tiedot ja synkronoi ne laitteidesi välillä päästä päähän -salauksella.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Käytä tätä koodia tietojesi palauttamiseen, jos menetät pääsyn tähän laitteeseen. Sync & Backup -tietoja ei voida palauttaa 18 kuukauden toimettomuuden jälkeen. [Lue lisää](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "DuckDuckGo-sovellus";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/fr.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/fr.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Synchronise un autre appareil";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Pas maintenant";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Synchroniser vos données avec un autre appareil ?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Charge les icônes des sites que vous avez enregistrés en signets. Les téléchargements d'icônes sont visibles sur votre réseau.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Signets";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Utilisez les mêmes signets favoris sur mobile et sur ordinateur.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Connexion en cours…";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Sauvegardez vos signets et vos données de remplissage automatique, et synchronisez-les entre vos appareils avec un cryptage de bout en bout.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Utilisez ce code pour rétablir vos données si vous perdez l'accès à cet appareil. Les données Sync & Backup ne peuvent pas être récupérées après 18 mois d'inactivité. [En savoir plus](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "l'application DuckDuckGo";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/hr.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/hr.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Sinkroniziraj drugi uređaj";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Ne sada";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Sinkronizirati vaše podatke s drugim uređajem?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Učitava ikone s web-mjesta koja ste označili. Preuzimanja ikona izložena su tvojoj mreži.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Knjižne oznake";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Koristi iste omiljene oznake na mobilnim uređajima i računalima.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Povezivanje u tijeku...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Spremi svoje knjižne oznake i podatke za automatsko popunjavanje te ih sinkroniziraj između uređaja pomoću end-to-end enkripcije.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Upotrijebi ovaj kôd za vraćanje podataka ako izgubiš pristup ovom uređaju. Podaci sinkronizacije i sigurnosne kopije (Sync & Backup) ne mogu se oporaviti nakon 18 (ili više) mjeseci neaktivnosti. [Saznaj više](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "Aplikacija DuckDuckGo";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/hu.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/hu.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Szinkronizálás másik eszközzel";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Most nem";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Szinkronizálod az adataidat egy másik eszközzel?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Betölti az ikonokat az általad könyvjelzővel megjelölt webhelyekről. Az ikonletöltések láthatók a hálózaton.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Könyvjelzők";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Használd ugyanazokat a kedvenc könyvjelzőket mobilon és asztali gépen.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Csatlakozás…";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Mentsd el a könyvjelzőidet és az automatikus kitöltési adataidat, és szinkronizáld őket az eszközeiden végpontok közötti titkosítással.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Ezzel a kóddal állíthatod vissza az adataidat, ha elveszíted a hozzáférést ehhez az eszközhöz. A Sync & Backup-adatok 18 hónapnyi inaktivitás után nem állíthatók vissza. [További részletek](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "DuckDuckGo alkalmazás";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/it.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/it.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Sincronizza un altro dispositivo";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Non adesso";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Sincronizzare i dati con un altro dispositivo?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Carica le icone dai siti web salvati. I download di icone sono esposti alla tua rete.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Segnalibri";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Usa gli stessi segnalibri preferiti su mobile e desktop.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Connessione in corso...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Salva i segnalibri e i dati di compilazione automatica, e sincronizzali tra i tuoi dispositivi con crittografia end-to-end.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Usa questo codice per ripristinare i tuoi dati se perdi l'accesso a questo dispositivo. I dati Sync & Backup non possono essere recuperati dopo 18 mesi di inattività. [Ulteriori informazioni](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "l'app DuckDuckGo";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/ja.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/ja.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "別のデバイスと同期";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "後で";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "他のデバイスとデータを同期しますか？";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "ブックマークしたウェブサイトからアイコンを取得します。アイコンのダウンロードはネットワークに公開されます。";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "ブックマーク";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "モバイルとデスクトップで同じお気に入りのブックマークを使用できます。";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "接続中...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "ブックマークや自動入力データを保存し、エンドツーエンドの暗号化でデバイス間で同期します。";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "このデバイスへのアクセスを失った場合は、このコードを使用してデータを復元してください。Sync & Backupのデータは18か月間アクティビティがないと復元できません。[詳細はこちら](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "DuckDuckGoアプリ";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/lt.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/lt.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Sinchronizuok kitą įrenginį";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Ne dabar";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Sinchronizuoti duomenis su kitu įrenginiu?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Įkelia piktogramas iš jūsų žymėse esančių svetainių. Piktogramų atsisiuntimai rodomi jūsų tinkle.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Žymės";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Tos pačios mėgstamiausių adresų žymės naudojamos mobiliajame telefone ir staliniame kompiuteryje.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Jungiamasi...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Išsaugok parankines bei automatinio pildymo duomenis ir sinchronizuok juos tarp savo įrenginių naudojant galutinį šifravimą.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Naudok šį kodą duomenims atkurti, jei prarasi prieigą prie šio įrenginio. Po 18 mėnesių neaktyvumo negalėsi atkurti „Sync & Backup“ duomenų. [Sužinoti daugiau](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "„DuckDuckGo“ programėlė";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/lv.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/lv.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Sinhronizēt citu ierīci";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Ne tagad";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Vai sinhronizēt datus ar citu ierīci?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Ielādē ikonas no vietnēm, kurām esi pievienojis grāmatzīmi. Ikonu lejupielādes ir atklātas tavam tīklam.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Grāmatzīmes";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Izmanto vienas un tās pašas izlases grāmatzīmes gan mobilajā ierīcē, gan galddatorā.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Savieno...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Saglabā savas grāmatzīmes un automātiskās aizpildes datus un sinhronizē tos starp ierīcēm, izmantojot pilnīgu šifrēšanu.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Izmanto šo kodu, lai atjaunotu datus, ja esi zaudējis piekļuvi šai ierīcei. Sync & Backup datus nevar atgūt pēc 18 mēnešu neaktivitātes. [Uzzināt vairāk](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "DuckDuckGo lietotne";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/nb.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/nb.lproj/Localizable.strings
@@ -374,7 +374,7 @@
 "sync.simplified.header.message.basic" = "Lagre bokmerkene og autofylldataene dine, og synkroniser dem på enhetene dine med ende-til-ende-kryptering.";
 
 /* Sync settings data recovery section footer. %@ is replaced with the URL. */
-"sync.simplified.recovery.section.footer" = "Bruk denne koden til å gjenopprette dataene dine hvis du mister tilgang til enheten. Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet. [Finn ut mer] (%@)";
+"sync.simplified.recovery.section.footer" = "Bruk denne koden til å gjenopprette dataene dine hvis du mister tilgang til enheten. Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet. [Finn ut mer](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "DuckDuckGo-app";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/nb.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/nb.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Synkroniser en annen enhet";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Ikke nå";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Vil du synkronisere dataene dine med en annen enhet?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Laster inn ikoner fra nettsteder du har bokmerket. Nedlasting av ikoner er synlig på nettverket du er tilkoblet.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Bokmerker";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Bruk de samme favorittbokmerkene på mobil og datamaskin.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Kobler til...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Lagre bokmerkene og autofylldataene dine, og synkroniser dem på enhetene dine med ende-til-ende-kryptering.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Bruk denne koden til å gjenopprette dataene dine hvis du mister tilgang til enheten. Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet. [Finn ut mer] (%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "DuckDuckGo-app";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/nl.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/nl.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Synchroniseer een ander apparaat";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Niet nu";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Synchroniseer je je data met een ander apparaat?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Laadt pictogrammen van websites die je als bladwijzer hebt opgeslagen. Pictogramdownloads worden weergegeven in je netwerk.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Bladwijzers";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Gebruik dezelfde favoriete bladwijzers op mobiel en desktop.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Er wordt verbinding gemaakt ...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Sla je bladwijzers en autofillgegevens op en synchroniseer ze tussen je apparaten met end-to-end versleuteling.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Gebruik deze code om je gegevens te herstellen als je de toegang tot dit apparaat verliest. Sync & Backup-gegevens kunnen niet worden hersteld na 18 maanden inactiviteit. [Meer informatie](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "DuckDuckGo-app";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/pl.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/pl.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Synchronizuj inne urządzenie";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Nie teraz";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Zsynchronizować dane z drugim urządzeniem?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Ładuje ikony ze stron dodanych do zakładek. Pobieranie ikon jest widoczne w Twojej sieci.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Zakładki";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Korzystaj z tych samych ulubionych zakładek na urządzeniach mobilnych i komputerach stacjonarnych.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Łączenie...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Zapisuj zakładki i dane autouzupełniania, a następnie synchronizuj je między urządzeniami z użyciem szyfrowania end-to-end.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Użyj tego kodu, aby przywrócić dane w przypadku utraty dostępu do tego urządzenia. Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności. [Dowiedz się więcej] (%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "aplikacji DuckDuckGo";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/pl.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/pl.lproj/Localizable.strings
@@ -374,7 +374,7 @@
 "sync.simplified.header.message.basic" = "Zapisuj zakładki i dane autouzupełniania, a następnie synchronizuj je między urządzeniami z użyciem szyfrowania end-to-end.";
 
 /* Sync settings data recovery section footer. %@ is replaced with the URL. */
-"sync.simplified.recovery.section.footer" = "Użyj tego kodu, aby przywrócić dane w przypadku utraty dostępu do tego urządzenia. Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności. [Dowiedz się więcej] (%@)";
+"sync.simplified.recovery.section.footer" = "Użyj tego kodu, aby przywrócić dane w przypadku utraty dostępu do tego urządzenia. Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności. [Dowiedz się więcej](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "aplikacji DuckDuckGo";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/pt.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/pt.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Sincronizar outro dispositivo";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Agora não";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Sincronizar os teus dados com outro dispositivo?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Carrega ícones de sites que guardaste nos marcadores. As transferências de ícones são expostas à tua rede.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Marcadores";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Usa os mesmos marcadores favoritos no telemóvel e no computador.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "A ligar…";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Guarda marcadores e dados de preenchimento automático, e sincroniza-os entre os teus dispositivos com encriptação ponto a ponto.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Usa este código para restaurar os teus dados caso percas o acesso a este dispositivo. Não é possível recuperar os dados de Sync & Backup após 18 meses de inatividade. [Sabe mais](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "aplicação DuckDuckGo";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/ro.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/ro.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Sincronizează un alt dispozitiv";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Nu acum";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Dorești să sincronizezi datele cu un alt dispozitiv?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Încarcă pictograme de pe site-urile pe care le-ai salvat la favorite. Descărcările de pictograme sunt expuse în rețeaua ta.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Semne de carte";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Folosește aceleași marcaje preferate pe mobil și pe desktop.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Se conectează...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Salvează marcajele și datele de completare automată și sincronizează-le între dispozitivele tale cu criptare de la un capăt la altul.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Folosește acest cod pentru a restaura datele dacă pierzi accesul la acest dispozitiv. Datele din Sync & Backup nu pot fi recuperate după 18 luni de inactivitate. [Află mai multe](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "Aplicația DuckDuckGo";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/ru.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/ru.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Синхронизировать другое устройство";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Не сейчас";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Синхронизировать данные с другим устройством?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Загружает значки с сайтов, которые вы добавили в закладки. Загрузки значков будут отображаться в вашей сети.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Закладки";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Использовать одни и те же избранные закладки на мобильном и ПК.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Выполняется подключение...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Сохраняйте закладки и данные автозаполнения и синхронизируйте их между устройствами с использованием сквозного шифрования.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Код поможет восстановить данные, если вы утратите доступ к этому устройству. Резервные копии Sync & Backup не восстанавливаются после 18 месяцев бездействия. [Подробнее](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "приложения DuckDuckGo";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/sk.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/sk.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Synchronizácia ďalšieho zariadenia";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Teraz nie";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Chceš synchronizovať dáta s iným zariadením?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Načíta ikony z webových stránok, ktoré si uložil/-a do záložiek. Stiahnuté ikony sú vystavené tvojej sieti.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Záložky";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Používaj tie isté obľúbené záložky na mobile aj v počítači.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Pripája sa...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Ulož si záložky a údaje automatického dopĺňania a synchronizuj ich medzi zariadeniami pomocou šifrovania typu end-to-end.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Použi tento kód na obnovenie údajov, ak stratíš prístup k tomuto zariadeniu. Údaje zo služby Sync & Backup nie je možné obnoviť po 18 mesiacoch nečinnosti. [Zisti viac](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "Aplikácia DuckDuckGo";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/sl.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/sl.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Sinhroniziraj drugo napravo";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Ne zdaj";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Želite podatke sinhronizirati z drugo napravo?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Naloži ikone spletnih mest, ki ste jih dodali med zaznamke. Prenosi ikon so izpostavljeni vašemu omrežju.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Zaznamki";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Uporabljajte iste priljubljene zaznamke v mobilnih napravah in namiznih računalnikih.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Povezovanje ...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Shranite zaznamke in podatke za samodejno izpolnjevanje ter jih sinhronizirajte med napravami s šifriranjem od začetka do konca.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "S to kodo obnovite podatke, če izgubite dostop do te naprave. Podatkov funkcije Sync & Backup ni mogoče obnoviti po 18 mesecih nedejavnosti. [Več informacij](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "Aplikacija DuckDuckGo";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/sv.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/sv.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Synkronisera en annan enhet";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Inte nu";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Synkronisera dina data med en annan enhet?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Läser in ikoner från webbplatser som du har bokmärkt. Ikonnedladdningar exponeras för ditt nätverk.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Bokmärken";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Använd samma favoritbokmärken på mobilen och datorn.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Ansluter …";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Spara dina bokmärken och data för automatisk ifyllning och synkronisera dem mellan dina enheter med end-to-end-kryptering.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Använd den här koden för att återställa dina data om du förlorar åtkomst till den här enheten. Sync & Backup-data kan inte återställas efter 18 månaders inaktivitet. [Läs mer](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "DuckDuckGo-app";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/tr.lproj/Localizable.strings
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Resources/tr.lproj/Localizable.strings
@@ -334,11 +334,20 @@
 /* Primary button to sync another device when sync is enabled */
 "sync.simplified.another.device.button" = "Başka Bir Cihazı Senkronize Et";
 
+/* Prompt secondary button */
+"sync.simplified.another.device.notnow" = "Şimdi Değil";
+
 /* Prompt title after enabling sync */
 "sync.simplified.another.device.title" = "Verileriniz başka bir cihazla senkronize edilsin mi?";
 
+/* Caption displayed on 'auto-download bookmarks icons' toggle. */
+"sync.simplified.bookmarks.section.fetch-favicons.caption" = "Yer imlerine eklediğiniz web sitelerinden simgeler yükler. İndirilen simgeler ağınıza açık olur.";
+
 /* Bookmarks section header in sync settings */
 "sync.simplified.bookmarks.section.header" = "Yer İmleri";
+
+/* Caption displayed on 'unify favorites' toggle. */
+"sync.simplified.bookmarks.section.unified-favorites.caption" = "Mobil ve masaüstü cihazlarda aynı favori yer imlerini kullanın.";
 
 /* Text shown next to toggle while sync is being set up */
 "sync.simplified.connecting" = "Bağlanıyor...";
@@ -363,6 +372,9 @@
 
 /* Description of the Sync & Backup feature */
 "sync.simplified.header.message.basic" = "Yer işaretlerinizi ve otomatik doldurma verilerinizi kaydedin ve cihazlarınız arasında uçtan uca şifreleme ile senkronize edin.";
+
+/* Sync settings data recovery section footer. %@ is replaced with the URL. */
+"sync.simplified.recovery.section.footer" = "Bu cihaza erişiminizi kaybettiğinizde verilerinizi kurtarmak için bu kodu kullanın. Sync & Backup verileri 18 ay kullanılmadıktan sonra kurtarılamaz. [Daha Fazla Bilgi](%@)";
 
 /* Part of instruction prompt referring to the DuckDuckGo app. */
 "sync.simplified.scan-or-view-code.app.name" = "DuckDuckGo Uygulaması";

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/Internal/UserText.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/Internal/UserText.swift
@@ -228,11 +228,11 @@ public struct UserText {
     static let simplifiedGetDesktopBrowserSubtitle = NSLocalizedString("sync.simplified.get.desktop.browser.subtitle", bundle: Bundle.module, value: "DuckDuckGo for Mac and Windows", comment: "Button subtitle to get the DuckDuckGo desktop browser")
     static let simplifiedSyncAnotherDeviceButton = NSLocalizedString("sync.simplified.another.device.button", bundle: Bundle.module, value: "Sync Another Device", comment: "Primary button to sync another device when sync is enabled")
     static let simplifiedBookmarksSectionHeader = NSLocalizedString("sync.simplified.bookmarks.section.header", bundle: Bundle.module, value: "Bookmarks", comment: "Bookmarks section header in sync settings")
-    static let simplifiedBookmarksUnifiedFavoritesCaption = NotLocalizedString("sync.simplified.bookmarks.section.unified-favorites.caption", bundle: Bundle.module, value: "Use the same favorite bookmarks on mobile and desktop.", comment: "Caption displayed on 'unify favorites' toggle.")
-    static let simplifiedBookmarksFetchFaviconsCaption = NotLocalizedString("sync.simplified.bookmarks.section.fetch-favicons.caption", bundle: Bundle.module, value: "Loads icons from websites you've bookmarked. Icon downloads are exposed to your network.", comment: "Caption displayed on 'auto-download bookmarks icons' toggle.")
+    static let simplifiedBookmarksUnifiedFavoritesCaption = NSLocalizedString("sync.simplified.bookmarks.section.unified-favorites.caption", bundle: Bundle.module, value: "Use the same favorite bookmarks on mobile and desktop.", comment: "Caption displayed on 'unify favorites' toggle.")
+    static let simplifiedBookmarksFetchFaviconsCaption = NSLocalizedString("sync.simplified.bookmarks.section.fetch-favicons.caption", bundle: Bundle.module, value: "Loads icons from websites you've bookmarked. Icon downloads are exposed to your network.", comment: "Caption displayed on 'auto-download bookmarks icons' toggle.")
     static let simplifiedDownloadRecoveryCodeButton = NSLocalizedString("sync.simplified.download.recovery.code.button", bundle: Bundle.module, value: "Download Recovery Code", comment: "Sync settings 'Download Recovery Code' button")
     static let simplifiedCopyRecoveryCodeButton = NSLocalizedString("sync.simplified.copy.recovery.code.button", bundle: Bundle.module, value: "Copy Recovery Code", comment: "Sync settings 'Copy Recovery Code' button")
-    static let simplifiedRecoverySectionFooterFormat = NotLocalizedString("sync.simplified.recovery.section.footer", bundle: Bundle.module, value: "Use this code to restore your data if you lose access to this device. Sync & Backup data can’t be recovered after 18 months of inactivity. [Learn More](%@)", comment: "Sync settings data recovery section footer. %@ is replaced with the URL.")
+    static let simplifiedRecoverySectionFooterFormat = NSLocalizedString("sync.simplified.recovery.section.footer", bundle: Bundle.module, value: "Use this code to restore your data if you lose access to this device. Sync & Backup data can’t be recovered after 18 months of inactivity. [Learn More](%@)", comment: "Sync settings data recovery section footer. %@ is replaced with the URL.")
     static let simplifiedDeleteSyncDataButton = NSLocalizedString("sync.simplified.delete.sync.data.button", bundle: Bundle.module, value: "Turn Off Sync and Delete Server Data", comment: "Sync settings action button title to turn off sync and delete server data")
 
     // Simplified Sync Toggle
@@ -241,7 +241,7 @@ public struct UserText {
     // Simplified Sync Another Device Prompt
     static let simplifiedSyncAnotherDeviceTitle = NSLocalizedString("sync.simplified.another.device.title", bundle: Bundle.module, value: "Sync your data with another device?", comment: "Prompt title after enabling sync")
     static let simplifiedSyncAnotherDeviceBody = NSLocalizedString("sync.simplified.another.device.body", bundle: Bundle.module, value: "Your bookmarks, autofill data, and Duck.ai chats are securely backed up. Now keep them in sync with your computer or tablet.", comment: "Prompt body text after enabling sync")
-    static let simplifiedSyncAnotherDeviceNotNow = NotLocalizedString("sync.simplified.another.device.notnow", bundle: Bundle.module, value: "Not Now", comment: "Prompt secondary button")
+    static let simplifiedSyncAnotherDeviceNotNow = NSLocalizedString("sync.simplified.another.device.notnow", bundle: Bundle.module, value: "Not Now", comment: "Prompt secondary button")
 
     // Simplified QR Scanning
     static let simplifiedScanTitle = NSLocalizedString("sync.simplified.scan-or-view-code.title", bundle: Bundle.module, value: "Sync Your Devices", comment: "Navigation title for simplified QR scanning screen")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214274533670107?focus=true
Tech Design URL:
CC:

### Description

A couple of non-localized strings for the simplified sync setup experiment slipped through between https://github.com/duckduckgo/apple-browsers/pull/4509 and https://github.com/duckduckgo/apple-browsers/pull/4574. This PR converts them to NSLocalizedString and will run a translation job.

### Testing Steps

1. Just review the changes! :) 

### Impact and Risks

Low: Minor visual changes, small bug fixes, improvement to existing features

Just string translations.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only switches a few simplified Sync UI strings from hardcoded/non-localized to localized resources, plus adds new translation entries.
> 
> **Overview**
> Ensures remaining Simplified Sync UI text is properly localized by replacing `NotLocalizedString` usages with `NSLocalizedString` (including the "device synced" toast and several Sync settings captions/buttons).
> 
> Adds the corresponding `Localizable.strings` keys across app and `SyncUI-iOS` resources for multiple locales, including new entries like `sync.simplified.device-synced.toast`, `sync.simplified.another.device.notnow`, bookmark toggle captions, and the recovery footer format string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c48dee2767f7eca10dcfaf169bf254a520e6407e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->