### PR TITLE
Update macOS sync account deletion copy to match iOS

### DIFF
--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Resources/Localizable.xcstrings
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Resources/Localizable.xcstrings
@@ -5646,7 +5646,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Diese Geräte werden getrennt und deine synchronisierten Daten werden vom Server gelöscht."
+            "value" : "Dein Backup wird vom Server gelöscht. Alle Geräte werden von der Synchronisierung getrennt, es werden jedoch keine Daten von den Geräten gelöscht."
           }
         },
         "en" : {
@@ -5658,43 +5658,43 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Estos dispositivos se desdesconectarán y tus datos sincronizados se eliminarán del servidor."
+            "value" : "Tu copia de seguridad se eliminará del servidor. Todos los dispositivos se desconectarán de la sincronización, pero no se eliminará nada de ningún dispositivo."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ces appareils seront déconnectés et vos données synchronisées seront supprimées du serveur."
+            "value" : "Votre sauvegarde sera supprimée du serveur. Tous les appareils seront déconnectés de la synchronisation, mais rien ne sera supprimé sur aucun appareil."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Questi dispositivi saranno disconnessi e i dati sincronizzati saranno eliminati dal server."
+            "value" : "Il tuo backup verrà eliminato dal server. Tutti i dispositivi verranno disconnessi dalla sincronizzazione, ma nessun dato verrà eliminato da alcun dispositivo."
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "De verbinding met deze apparaten wordt verbroken en je gesynchroniseerde gegevens worden van de server verwijderd."
+            "value" : "Je back-up wordt verwijderd van de server. Alle apparaten worden losgekoppeld van de synchronisatie, maar er wordt niets van de apparaten verwijderd."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Te urządzenia zostaną odłączone, a zsynchronizowane dane usunięte z serwera."
+            "value" : "Twoja kopia zapasowa zostanie usunięta z serwera. Wszystkie urządzenia zostaną odłączone od synchronizacji, ale nic nie zostanie usunięte z żadnego urządzenia."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Estes dispositivos serão desconectados e os dados sincronizados serão eliminados do servidor."
+            "value" : "A tua cópia de segurança será eliminada do servidor. Todos os dispositivos serão desligados da sincronização, mas nada será eliminado dos dispositivos."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Привязка устройств будет отключена, а синхронизированные данные — удалены с сервера."
+            "value" : "Ваша резервная копия будет удалена с сервера. Все устройства будут отключены от синхронизации, но никакие данные с устройств удалены не будут."
           }
         }
       }

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Resources/Localizable.xcstrings
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Resources/Localizable.xcstrings
@@ -5652,7 +5652,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "These devices will be disconnected and your synced data will be deleted from the server."
+            "value" : "Your backup will be deleted from the server. All devices will be disconnected from sync, but nothing will be deleted from any device."
           }
         },
         "es" : {

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/internal/UserText.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/internal/UserText.swift
@@ -138,7 +138,7 @@ enum UserText {
 
     // Delete Account Dialog
     static let deleteAccountTitle = NSLocalizedString("prefrences.sync.delete-account.title", bundle: Bundle.module, value: "Delete server data?", comment: "Title for delete account confirmation pop up")
-    static let deleteAccountMessage = NSLocalizedString("prefrences.sync.delete-account.message", bundle: Bundle.module, value: "These devices will be disconnected and your synced data will be deleted from the server.", comment: "Message for delete account confirmation pop up")
+    static let deleteAccountMessage = NSLocalizedString("prefrences.sync.delete-account.message", bundle: Bundle.module, value: "Your backup will be deleted from the server. All devices will be disconnected from sync, but nothing will be deleted from any device.", comment: "Message for delete account confirmation pop up")
     static let deleteAccountButton = NSLocalizedString("prefrences.sync.delete-account.button", bundle: Bundle.module, value: "Delete Data", comment: "Label for delete account button")
 
     // Sync enabled options


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214394717672316
Tech Design URL:
CC:

### Description

This PR simply updates the macOS copy for deleting a sync account to match iOS, as per: https://app.asana.com/1/137249556945/project/1211264967278501/task/1213980425108387?focus=true

### Testing Steps

1. Review the copy in the code!
2. If you want to, run the app and head to Settings > Sync & Backup > “Turn off and delete server data”. Verify the copy there.

### Impact and Risks

Low: Minor visual changes, small bug fixes, improvement to existing features

Low, just a copy change!


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only localization/copy updates with no functional or data-handling logic changes.
> 
> **Overview**
> Updates the macOS Sync & Backup **delete account confirmation message** to clarify that only the server-side backup is deleted, devices are disconnected from sync, and **no local device data is removed**.
> 
> Applies the new wording across `Localizable.xcstrings` translations and the default string in `UserText.deleteAccountMessage` to match iOS copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31651fd125589ed9452ccf7f396bf012919a842b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->