### PR TITLE
iOS: smooth UTI text slide and color crossfade across omnibar transition

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -165,7 +165,7 @@ class SwitchBarTextEntryView: UIView {
 
         placeholderLabel.font = textFont
         placeholderLabel.adjustsFontForContentSizeCategory = true
-        placeholderLabel.textColor = UIColor(designSystemColor: .textSecondary)
+        placeholderLabel.textColor = defaultPlaceholderColor
 
         // Truncate text in case it exceeds single line
         placeholderLabel.numberOfLines = 1
@@ -578,6 +578,9 @@ class SwitchBarTextEntryView: UIView {
         guard placeholderLabel.window != nil else { return nil }
         return placeholderLabel.convert(CGPoint.zero, to: nil).x
     }
+
+    /// Stable design-token color, immune to transient `textColor` changes from color crossfades.
+    var defaultPlaceholderColor: UIColor { UIColor(designSystemColor: .textSecondary) }
 
     // Two transient overlays composite directly over the parent background (the original label is
     // cleared) so a low-alpha source/target color isn't stacked atop the destination color, which

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -573,6 +573,71 @@ class SwitchBarTextEntryView: UIView {
         handler.updateCurrentText(text)
     }
 
+    /// Reflects the current transform; reset the shift to zero before reading the natural x.
+    var placeholderWindowX: CGFloat? {
+        guard placeholderLabel.window != nil else { return nil }
+        return placeholderLabel.convert(CGPoint.zero, to: nil).x
+    }
+
+    // Two transient overlays composite directly over the parent background (the original label is
+    // cleared) so a low-alpha source/target color isn't stacked atop the destination color, which
+    // would otherwise composite darker than either color alone.
+    func animatePlaceholderColorTransition(from: UIColor, to color: UIColor, duration: TimeInterval) {
+        let bounds = placeholderLabel.bounds
+        guard bounds.width > 0, bounds.height > 0, !(placeholderLabel.text ?? "").isEmpty else {
+            placeholderLabel.textColor = color
+            return
+        }
+        guard !from.isEqual(color) else {
+            placeholderLabel.textColor = color
+            return
+        }
+
+        placeholderLabel.textColor = .clear
+        let sourceOverlay = makePlaceholderColorOverlay(color: from, frame: bounds, alpha: 1)
+        let targetOverlay = makePlaceholderColorOverlay(color: color, frame: bounds, alpha: 0)
+        placeholderLabel.addSubview(sourceOverlay)
+        placeholderLabel.addSubview(targetOverlay)
+
+        UIView.animate(withDuration: duration, delay: 0, options: .curveEaseOut, animations: {
+            sourceOverlay.alpha = 0
+            targetOverlay.alpha = 1
+        }, completion: { [weak self] _ in
+            self?.placeholderLabel.textColor = color
+            sourceOverlay.removeFromSuperview()
+            targetOverlay.removeFromSuperview()
+        })
+    }
+
+    private func makePlaceholderColorOverlay(color: UIColor, frame: CGRect, alpha: CGFloat) -> UILabel {
+        let overlay = UILabel()
+        overlay.text = placeholderLabel.text
+        overlay.font = placeholderLabel.font
+        overlay.textColor = color
+        overlay.textAlignment = placeholderLabel.textAlignment
+        overlay.adjustsFontForContentSizeCategory = placeholderLabel.adjustsFontForContentSizeCategory
+        overlay.frame = frame
+        overlay.isUserInteractionEnabled = false
+        overlay.alpha = alpha
+        return overlay
+    }
+
+    func setTextHorizontalShift(_ shift: CGFloat) {
+        let transform = shift == 0 ? .identity : CGAffineTransform(translationX: shift, y: 0)
+        textView.transform = transform
+        placeholderLabel.transform = transform
+    }
+
+    @discardableResult
+    func alignPlaceholderHorizontally(toWindowX windowX: CGFloat) -> CGFloat {
+        setTextHorizontalShift(0)
+        guard placeholderLabel.window != nil else { return 0 }
+        let currentX = placeholderLabel.convert(CGPoint.zero, to: nil).x
+        let shift = windowX - currentX
+        setTextHorizontalShift(shift)
+        return shift
+    }
+
     private func disableAutoCorrectionAndSpellChecking() {
         textView.autocorrectionType = .no
         textView.spellCheckingType = .no

--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -214,9 +214,7 @@ class MainViewCoordinator {
         unifiedToggleInputContainer.layer.removeAllAnimations()
         navigationBarCollectionView.isUserInteractionEnabled = false
 
-        // Snap (not fade) on show — intentional asymmetry with dismiss. Both surfaces are
-        // full-density (placeholder + icons + toggle), so crossfading shows double-vision.
-        // Dismiss can fade because the UTI is shrinking + collapsing while it fades.
+        // Snap omnibar out, no fade — mirror of `finishUnifiedToggleInputOmnibarDismiss`.
         navigationBarCollectionView.alpha = 0
         unifiedToggleInputContainer.alpha = 1
         unifiedToggleInputContainer.isHidden = false
@@ -272,11 +270,12 @@ class MainViewCoordinator {
     // MARK: - Omnibar Editing Layout
 
     @MainActor
-    func hideUnifiedToggleInputOmnibar(completion: (() -> Void)? = nil) {
+    func hideUnifiedToggleInputOmnibar(additionalAnimations: (() -> Void)? = nil, completion: (() -> Void)? = nil) {
         omnibarDismissAnimator?.stopAnimation(true)
 
-        let animator = UIViewPropertyAnimator(duration: MainViewController.Constants.omnibarTransitionDuration, curve: .easeInOut) { [weak self] in
+        let animator = UIViewPropertyAnimator(duration: MainViewController.Constants.omnibarTransitionDuration(isBottom: addressBarPosition.isBottom), curve: .easeOut) { [weak self] in
             self?.animateUnifiedToggleInputOmnibarDismissLayout()
+            additionalAnimations?()
         }
         animator.addCompletion { [weak self] position in
             guard let self else { return }
@@ -290,15 +289,11 @@ class MainViewCoordinator {
         animator.startAnimation()
     }
 
-    /// Applies the dismiss-direction layout changes. Call inside an animation context
-    /// (UIView.animate or UIViewPropertyAnimator) — it includes a `layoutIfNeeded()` so the
-    /// constraint mutations interpolate.
+    /// Call inside an animation context — alpha swap is deferred to completion to avoid a crossfade gap.
     func animateUnifiedToggleInputOmnibarDismissLayout() {
         if addressBarPosition.isBottom {
             setNavBarContainerBottomToToolbar()
         }
-        navigationBarCollectionView.alpha = 1
-        unifiedToggleInputContainer.alpha = 0
         constraints.navigationBarContainerHeight.constant = standardNavigationBarContainerHeight
         superview.layoutIfNeeded()
     }
@@ -314,6 +309,8 @@ class MainViewCoordinator {
             unifiedToggleInputContainer.isHidden = false
             unifiedToggleInputContainer.alpha = 1
         } else {
+            // Snap omnibar in, no fade — crossfading would produce visible double-text mid-dismiss.
+            navigationBarCollectionView.alpha = 1
             unifiedToggleInputContainer.isHidden = true
             unifiedToggleInputContainer.alpha = 1
         }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -530,7 +530,7 @@ private extension MainViewController {
         coordinator.viewController.deactivateInput()
         let omnibarPlaceholderWindowX = currentOmnibarPlaceholderWindowX()
         let omnibarPlaceholderColor = currentOmnibarPlaceholderColor()
-        let utiPlaceholderColor = coordinator.viewController.placeholderTextColor
+        let utiPlaceholderColor = coordinator.viewController.defaultPlaceholderColor
         let duration = Constants.omnibarTransitionDuration(isBottom: coordinator.cardPosition.isBottom)
         UIView.animate(
             withDuration: duration,
@@ -550,7 +550,6 @@ private extension MainViewController {
                 self.viewCoordinator.unifiedInputContentContainer.isHidden = true
                 self.viewCoordinator.unifiedInputContentContainer.alpha = 1
                 coordinator.viewController.setTextHorizontalShift(0)
-                coordinator.viewController.placeholderTextColor = utiPlaceholderColor
                 coordinator.deactivateToOmnibar(resetView: false, animateDismiss: false)
                 coordinator.viewController.finalizeOmnibarEditingDismiss()
             }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -30,9 +30,10 @@ import UIKit
 extension MainViewController {
 
     enum Constants {
-        /// Single duration for both the show and dismiss omnibar-editing transitions.
-        /// Drives bar interior, content alpha, and container layout in lockstep.
-        static let omnibarTransitionDuration: TimeInterval = 0.25
+        // Bottom is longer to accommodate concurrent keyboard descent.
+        static func omnibarTransitionDuration(isBottom: Bool) -> TimeInterval {
+            isBottom ? 0.35 : 0.25
+        }
     }
 
     enum UnifiedInputChromeBackgroundState: String {
@@ -525,25 +526,43 @@ private extension MainViewController {
 
     func dismissUnifiedToggleInputToOmnibar(coordinator: UnifiedToggleInputCoordinator) {
         applyUnifiedInputChromeBackground(.standardChrome)
-        // Resign up-front so keyboard descent runs concurrent with bar collapse, not after.
+        // Resign up-front so the keyboard descent runs concurrent with the bar collapse.
         coordinator.viewController.deactivateInput()
+        let omnibarPlaceholderWindowX = currentOmnibarPlaceholderWindowX()
+        let omnibarPlaceholderColor = currentOmnibarPlaceholderColor()
+        let utiPlaceholderColor = coordinator.viewController.placeholderTextColor
+        let duration = Constants.omnibarTransitionDuration(isBottom: coordinator.cardPosition.isBottom)
         UIView.animate(
-            withDuration: Constants.omnibarTransitionDuration,
+            withDuration: duration,
             delay: 0,
-            options: .curveEaseInOut,
+            options: .curveEaseOut,
             animations: { [weak self] in
                 guard let self else { return }
                 coordinator.viewController.applyOmnibarEditingDismissPose()
                 self.viewCoordinator.animateUnifiedToggleInputOmnibarDismissLayout()
                 self.viewCoordinator.unifiedInputContentContainer.alpha = 0
+                if let omnibarPlaceholderWindowX {
+                    coordinator.viewController.alignPlaceholderHorizontally(toWindowX: omnibarPlaceholderWindowX)
+                }
             },
             completion: { [weak self] _ in
                 guard let self, let coordinator = self.unifiedToggleInputCoordinator else { return }
                 self.viewCoordinator.unifiedInputContentContainer.isHidden = true
                 self.viewCoordinator.unifiedInputContentContainer.alpha = 1
+                coordinator.viewController.setTextHorizontalShift(0)
+                coordinator.viewController.placeholderTextColor = utiPlaceholderColor
                 coordinator.deactivateToOmnibar(resetView: false, animateDismiss: false)
+                coordinator.viewController.finalizeOmnibarEditingDismiss()
             }
         )
+
+        if let omnibarPlaceholderColor {
+            coordinator.viewController.animatePlaceholderColorTransition(
+                from: utiPlaceholderColor,
+                to: omnibarPlaceholderColor,
+                duration: duration
+            )
+        }
     }
 
     func handleUnifiedToggleInputSearchSubmission(_ query: String) {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
@@ -103,7 +103,7 @@ private extension MainViewController {
 
         let omnibarPlaceholderWindowX = currentOmnibarPlaceholderWindowX()
         let omnibarPlaceholderColor = currentOmnibarPlaceholderColor()
-        let utiPlaceholderColor = coordinator.viewController.placeholderTextColor
+        let utiPlaceholderColor = coordinator.viewController.defaultPlaceholderColor
 
         viewCoordinator.showUnifiedToggleInputOmnibar(expandedHeight: height)
         viewCoordinator.suggestionTrayContainer.isHidden = true
@@ -147,18 +147,15 @@ private extension MainViewController {
 
     func handleHideOmnibarEditingIntent(animated: Bool) {
         let coordinator = unifiedToggleInputCoordinator
-        let utiPlaceholderColor = coordinator?.viewController.placeholderTextColor
         let onDismissed: () -> Void = { [weak coordinator] in
             coordinator?.viewController.setTextHorizontalShift(0)
-            if let utiPlaceholderColor {
-                coordinator?.viewController.placeholderTextColor = utiPlaceholderColor
-            }
             coordinator?.viewController.finalizeOmnibarEditingDismiss()
             coordinator?.clearText()
         }
         if animated {
             let omnibarPlaceholderWindowX = currentOmnibarPlaceholderWindowX()
             let omnibarPlaceholderColor = currentOmnibarPlaceholderColor()
+            let utiPlaceholderColor = coordinator?.viewController.defaultPlaceholderColor
             let duration = Constants.omnibarTransitionDuration(isBottom: viewCoordinator.addressBarPosition.isBottom)
             let slideUTIText: () -> Void = { [weak coordinator] in
                 guard let coordinator, let omnibarPlaceholderWindowX else { return }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
@@ -50,6 +50,20 @@ extension MainViewController {
         applyBottomOmnibarAnchor(state)
         viewCoordinator.navigationBarContainer.superview?.layoutIfNeeded()
     }
+
+    func currentOmnibarPlaceholderWindowX() -> CGFloat? {
+        guard let textField = viewCoordinator.omniBar.barView.textField,
+              textField.window != nil else { return nil }
+        let placeholderRect = textField.placeholderRect(forBounds: textField.bounds)
+        return textField.convert(placeholderRect.origin, to: nil).x
+    }
+
+    func currentOmnibarPlaceholderColor() -> UIColor? {
+        guard let textField = viewCoordinator.omniBar.barView.textField,
+              let attributed = textField.attributedPlaceholder,
+              attributed.length > 0 else { return nil }
+        return attributed.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? UIColor
+    }
 }
 
 private extension MainViewController {
@@ -87,16 +101,24 @@ private extension MainViewController {
     func handleShowOmnibarEditingIntent(height: CGFloat, pendingHeight: CGFloat?) {
         guard let coordinator = unifiedToggleInputCoordinator else { return }
 
-        // Set initial pose synchronously so the animate block grows from start to final height.
+        let omnibarPlaceholderWindowX = currentOmnibarPlaceholderWindowX()
+        let omnibarPlaceholderColor = currentOmnibarPlaceholderColor()
+        let utiPlaceholderColor = coordinator.viewController.placeholderTextColor
+
         viewCoordinator.showUnifiedToggleInputOmnibar(expandedHeight: height)
         viewCoordinator.suggestionTrayContainer.isHidden = true
         updateUnifiedInputContentVisibility(for: coordinator)
         viewCoordinator.unifiedInputContentContainer.alpha = 0
 
+        if let omnibarPlaceholderWindowX {
+            coordinator.viewController.alignPlaceholderHorizontally(toWindowX: omnibarPlaceholderWindowX)
+        }
+
+        let duration = Constants.omnibarTransitionDuration(isBottom: coordinator.cardPosition.isBottom)
         UIView.animate(
-            withDuration: Constants.omnibarTransitionDuration,
+            withDuration: duration,
             delay: 0,
-            options: .curveEaseInOut,
+            options: .curveEaseOut,
             animations: { [weak self] in
                 guard let self else { return }
                 coordinator.viewController.applyOmnibarEditingShowPose()
@@ -110,16 +132,46 @@ private extension MainViewController {
                 self.viewCoordinator.superview.layoutIfNeeded()
                 coordinator.pushContentInsets()
                 self.viewCoordinator.unifiedInputContentContainer.alpha = 1
+                coordinator.viewController.setTextHorizontalShift(0)
             }
         )
+
+        if let omnibarPlaceholderColor {
+            coordinator.viewController.animatePlaceholderColorTransition(
+                from: omnibarPlaceholderColor,
+                to: utiPlaceholderColor,
+                duration: duration
+            )
+        }
     }
 
     func handleHideOmnibarEditingIntent(animated: Bool) {
-        let onDismissed: () -> Void = { [weak self] in
-            self?.unifiedToggleInputCoordinator?.clearText()
+        let coordinator = unifiedToggleInputCoordinator
+        let utiPlaceholderColor = coordinator?.viewController.placeholderTextColor
+        let onDismissed: () -> Void = { [weak coordinator] in
+            coordinator?.viewController.setTextHorizontalShift(0)
+            if let utiPlaceholderColor {
+                coordinator?.viewController.placeholderTextColor = utiPlaceholderColor
+            }
+            coordinator?.viewController.finalizeOmnibarEditingDismiss()
+            coordinator?.clearText()
         }
         if animated {
-            viewCoordinator.hideUnifiedToggleInputOmnibar(completion: onDismissed)
+            let omnibarPlaceholderWindowX = currentOmnibarPlaceholderWindowX()
+            let omnibarPlaceholderColor = currentOmnibarPlaceholderColor()
+            let duration = Constants.omnibarTransitionDuration(isBottom: viewCoordinator.addressBarPosition.isBottom)
+            let slideUTIText: () -> Void = { [weak coordinator] in
+                guard let coordinator, let omnibarPlaceholderWindowX else { return }
+                coordinator.viewController.alignPlaceholderHorizontally(toWindowX: omnibarPlaceholderWindowX)
+            }
+            viewCoordinator.hideUnifiedToggleInputOmnibar(additionalAnimations: slideUTIText, completion: onDismissed)
+            if let coordinator, let omnibarPlaceholderColor, let utiPlaceholderColor {
+                coordinator.viewController.animatePlaceholderColorTransition(
+                    from: utiPlaceholderColor,
+                    to: omnibarPlaceholderColor,
+                    duration: duration
+                )
+            }
         } else {
             viewCoordinator.finishUnifiedToggleInputOmnibarDismiss()
             onDismissed()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -395,6 +395,8 @@ final class UnifiedToggleInputView: UIView {
 
     var placeholderWindowX: CGFloat? { textEntryView.placeholderWindowX }
 
+    var defaultPlaceholderColor: UIColor { textEntryView.defaultPlaceholderColor }
+
     var placeholderTextColor: UIColor {
         get { textEntryView.placeholderTextColor }
         set { textEntryView.placeholderTextColor = newValue }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -43,6 +43,8 @@ enum UnifiedToggleInputCardPosition {
     case top
     /// Top corners rounded, shadow upward (input at bottom of screen, default).
     case bottom
+
+    var isBottom: Bool { self == .bottom }
 }
 
 // MARK: - View
@@ -62,6 +64,9 @@ final class UnifiedToggleInputView: UIView {
         static let cardVerticalMargin: CGFloat = 8
         static let cardHorizontalMarginBottom: CGFloat = 12
         static let cardVerticalMarginBottom: CGFloat = 8
+        // Match the omnibar's small-top spacing so the dismiss snap lands on identical pill frames.
+        static let collapsedCardTopMarginBottom: CGFloat = 10
+        static let collapsedCardBottomMarginBottom: CGFloat = 6
         static let cardCornerRadiusExpanded: CGFloat = 24
         static let cardCornerRadiusCollapsed: CGFloat = 16
         static let toggleTopPadding: CGFloat = 8
@@ -388,6 +393,26 @@ final class UnifiedToggleInputView: UIView {
         textEntryView.selectAllText()
     }
 
+    var placeholderWindowX: CGFloat? { textEntryView.placeholderWindowX }
+
+    var placeholderTextColor: UIColor {
+        get { textEntryView.placeholderTextColor }
+        set { textEntryView.placeholderTextColor = newValue }
+    }
+
+    func animatePlaceholderColorTransition(from: UIColor, to color: UIColor, duration: TimeInterval) {
+        textEntryView.animatePlaceholderColorTransition(from: from, to: color, duration: duration)
+    }
+
+    func setTextHorizontalShift(_ shift: CGFloat) {
+        textEntryView.setTextHorizontalShift(shift)
+    }
+
+    @discardableResult
+    func alignPlaceholderHorizontally(toWindowX windowX: CGFloat) -> CGFloat {
+        textEntryView.alignPlaceholderHorizontally(toWindowX: windowX)
+    }
+
     func updateToggleEnabled(_ enabled: Bool) {
         guard enabled != isToggleEnabled else { return }
         isToggleEnabled = enabled
@@ -422,7 +447,7 @@ final class UnifiedToggleInputView: UIView {
         }
     }
 
-    func setExpanded(_ expanded: Bool, showToggle: Bool = true, animated: Bool) {
+    func setExpanded(_ expanded: Bool, showToggle: Bool = true, animated: Bool, updateShadow: Bool = true) {
         guard expanded != isExpanded else { return }
         isExpanded = expanded
         handler.isExpanded = expanded
@@ -447,17 +472,26 @@ final class UnifiedToggleInputView: UIView {
             hTrailingMargin = cardTrailingMargin
         }
 
-        let vMargin: CGFloat
+        let topMargin: CGFloat
+        let bottomMargin: CGFloat
         if expanded && !usesOmnibarMargins {
-            vMargin = (cardPosition == .bottom) ? Constants.cardVerticalMarginBottom : Constants.cardVerticalMargin
+            let expandedMargin = (cardPosition == .bottom) ? Constants.cardVerticalMarginBottom : Constants.cardVerticalMargin
+            topMargin = expandedMargin
+            bottomMargin = expandedMargin
+        } else if !expanded && cardPosition == .bottom {
+            topMargin = Constants.collapsedCardTopMarginBottom
+            bottomMargin = Constants.collapsedCardBottomMarginBottom
         } else {
-            vMargin = Constants.cardVerticalMargin
+            topMargin = Constants.cardVerticalMargin
+            bottomMargin = Constants.cardVerticalMargin
         }
 
         textEntryView.isExpandable = expanded
 
-        expandedShadowView.isHidden = !expanded
-        cardView.layer.shadowOpacity = expanded ? 0 : 1.0
+        if updateShadow {
+            expandedShadowView.isHidden = !expanded
+            cardView.layer.shadowOpacity = expanded ? 0 : 1.0
+        }
         cardCollapsedHeightConstraint.constant = Constants.collapsedCardHeight
         cardCollapsedHeightConstraint.isActive = !expanded
 
@@ -470,10 +504,10 @@ final class UnifiedToggleInputView: UIView {
         let expandedCornerRadius = effectiveToggleEnabled ? Constants.cardCornerRadiusExpanded : Constants.cardCornerRadiusCollapsed
         let changes = {
             self.cardView.layer.cornerRadius = expanded ? expandedCornerRadius : Constants.cardCornerRadiusCollapsed
-            self.cardTopConstraint.constant = vMargin
+            self.cardTopConstraint.constant = topMargin
             self.cardLeadingConstraint.constant = hLeadingMargin
             self.cardTrailingConstraint.constant = -hTrailingMargin
-            self.cardBottomConstraint.constant = -vMargin
+            self.cardBottomConstraint.constant = -bottomMargin
             self.toggleTopConstraint.constant = (expanded && effectiveToggleEnabled) ? Constants.toggleTopPadding : 0
             self.toggleHeightConstraint.constant = toggleHeight
             self.toggleTrailingConstraint.constant = reservesInlineDismissSpace
@@ -511,9 +545,7 @@ final class UnifiedToggleInputView: UIView {
         setExpanded(expanded, showToggle: false, animated: false)
     }
 
-    /// Pre-stages the bar to its starting pose for an omnibar-editing show animation.
     /// Top: slim card with toggle hidden. Bottom: collapsed bar.
-    /// Call BEFORE the UIView.animate that runs the show animation.
     func prepareForOmnibarEditingShow() {
         switch cardPosition {
         case .top:
@@ -524,8 +556,7 @@ final class UnifiedToggleInputView: UIView {
         }
     }
 
-    /// Applies the bar's active editing END pose. Designed to be called inside a UIView.animate
-    /// block so the property mutations animate.
+    /// Active editing pose. Call inside a UIView.animate block.
     func applyOmnibarEditingShowPose() {
         switch cardPosition {
         case .top:
@@ -537,8 +568,9 @@ final class UnifiedToggleInputView: UIView {
         }
     }
 
-    /// Applies the bar's inactive END pose (post-dismiss). Designed to be called inside a
-    /// UIView.animate block so the property mutations animate.
+    /// Inactive editing pose. Call inside a UIView.animate block.
+    /// Shadow swap is deferred to `finalizeOmnibarEditingDismiss` so the dominant expanded shadow
+    /// stays visible during collapse instead of snapping off mid-animation.
     func applyOmnibarEditingDismissPose() {
         switch cardPosition {
         case .top:
@@ -546,8 +578,16 @@ final class UnifiedToggleInputView: UIView {
             applyToggleHideChanges()
             layoutIfNeeded()
         case .bottom:
-            setExpanded(false, animated: false)
+            setExpanded(false, animated: false, updateShadow: false)
         }
+    }
+
+    /// Snap the shadow to its collapsed-pose state. Only bottom needs this — top dismiss never
+    /// alters the shadow during animation. Call after the UTI is hidden.
+    func finalizeOmnibarEditingDismiss() {
+        guard cardPosition.isBottom else { return }
+        expandedShadowView.isHidden = true
+        cardView.layer.shadowOpacity = 1.0
     }
 
     /// The property mutations that reveal the toggle within the omnibar-editing card.

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -261,6 +261,8 @@ final class UnifiedToggleInputViewController: UIViewController {
 
     var placeholderWindowX: CGFloat? { inputBarView.placeholderWindowX }
 
+    var defaultPlaceholderColor: UIColor { inputBarView.defaultPlaceholderColor }
+
     var placeholderTextColor: UIColor {
         get { inputBarView.placeholderTextColor }
         set { inputBarView.placeholderTextColor = newValue }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -235,19 +235,20 @@ final class UnifiedToggleInputViewController: UIViewController {
         inputBarView.setExpanded(expanded, animated: animated)
     }
 
-    /// See `UnifiedToggleInputView.prepareForOmnibarEditingShow`.
     func prepareForOmnibarEditingShow() {
         inputBarView.prepareForOmnibarEditingShow()
     }
 
-    /// See `UnifiedToggleInputView.applyOmnibarEditingShowPose`.
     func applyOmnibarEditingShowPose() {
         inputBarView.applyOmnibarEditingShowPose()
     }
 
-    /// See `UnifiedToggleInputView.applyOmnibarEditingDismissPose`.
     func applyOmnibarEditingDismissPose() {
         inputBarView.applyOmnibarEditingDismissPose()
+    }
+
+    func finalizeOmnibarEditingDismiss() {
+        inputBarView.finalizeOmnibarEditingDismiss()
     }
 
     func setInputMode(_ mode: TextEntryMode, animated: Bool) {
@@ -256,6 +257,26 @@ final class UnifiedToggleInputViewController: UIViewController {
 
     func selectAllText() {
         inputBarView.selectAllText()
+    }
+
+    var placeholderWindowX: CGFloat? { inputBarView.placeholderWindowX }
+
+    var placeholderTextColor: UIColor {
+        get { inputBarView.placeholderTextColor }
+        set { inputBarView.placeholderTextColor = newValue }
+    }
+
+    func animatePlaceholderColorTransition(from: UIColor, to color: UIColor, duration: TimeInterval) {
+        inputBarView.animatePlaceholderColorTransition(from: from, to: color, duration: duration)
+    }
+
+    func setTextHorizontalShift(_ shift: CGFloat) {
+        inputBarView.setTextHorizontalShift(shift)
+    }
+
+    @discardableResult
+    func alignPlaceholderHorizontally(toWindowX windowX: CGFloat) -> CGFloat {
+        inputBarView.alignPlaceholderHorizontally(toWindowX: windowX)
     }
 
     func updateToggleEnabled(_ enabled: Bool) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214344334837571
CC: @aataraxiaa 

### Description

Polishes the UTI ↔ omnibar transition. The placeholder text now slides horizontally between the two surfaces' text positions in lockstep with the bar's vertical motion (one diagonal motion instead of a bar grow/shrink + horizontal text jump), and its color crossfades from the omnibar's placeholder color to the UTI's natural color (and back).

Other tweaks needed to make the snap on each side land cleanly:
- Bottom transition uses 0.35s (top stays at 0.25s) so the slide isn't lost in the keyboard descent.
- Bottom collapsed pill margins now match the omnibar's `useSmallTopSpacing` (10/6) so the snap lands on identical pill frames.
- Shadow swap on bottom dismiss is deferred to completion so the dominant expanded shadow stays visible during collapse.
- UTI alpha no longer fades during dismiss; UTI/omnibar visibility swap happens in lockstep at completion (eliminates the visible double-text moment mid-dismiss).

### Testing Steps

1. Set address bar position to **bottom** in Settings.
2. Tap the address bar to open the UTI. Confirm the placeholder text slides diagonally from where the omnibar text was to its UTI position, with the color smoothly transitioning from the omnibar's placeholder color to the UTI's natural color.
3. Tap outside / dismiss the keyboard. Confirm the reverse: text slides diagonally back to the omnibar's spot with a smooth color crossfade. No "double text" or color flash mid-animation.
4. Toggle Search ↔ Duck.ai inside the UTI to exercise the mode-switch dismiss path. Confirm the same smooth slide + color crossfade.
5. Submit a query (return key) and confirm the dismiss animation looks right.
6. Repeat steps 2–5 with the toggle disabled in Settings.
7. Switch address bar position to **top** and re-run steps 2–5 — confirm no regressions, top transitions still look correct.
8. Try with typed text in the field (not just placeholder) to confirm typed text rides the slide too.
9. (Optional) Test on iPad and at largest accessibility text size (AX5) — visual sanity check.

### Impact and Risks

**Low.** Changes are scoped to the UTI ↔ omnibar editing transition's animation choreography (text slide, color crossfade, durations, shadow timing, collapsed pill margins). No new state, no new feature flags, no behavior changes outside the animation window. Worst-case visual regression would be a glitch in the transition itself, which is easy to spot.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only animation/layout changes around the UTI/omnibar transition; main risk is visual regressions (misaligned text, incorrect colors, or shadow/alpha timing) especially for bottom address bar and dynamic type.
> 
> **Overview**
> Improves the Unified Toggle Input (UTI) ↔ omnibar editing transition so the placeholder/typed text *slides horizontally* to match the other surface’s text position while the bar animates, and the placeholder color *crossfades* between omnibar and UTI colors.
> 
> This introduces new placeholder alignment/color-transition helpers in `SwitchBarTextEntryView` (and forwards them through `UnifiedToggleInputView`/`UnifiedToggleInputViewController`), adds omnibar placeholder position/color extraction in intent handling, and updates show/dismiss choreography to avoid crossfading the entire bars (snap alpha at completion instead). Bottom-position transitions are tuned with a longer duration, adjusted collapsed margins to match omnibar pill spacing, and deferred shadow swapping until dismiss completion to prevent mid-animation visual snaps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56645a3f6eae8884914ce1c54bf79da7efd5bfe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->