### PR TITLE
[Release PR] Check the VPN egress server dynamically during leak checks

### DIFF
--- a/SharedPackages/VPN/Sources/VPN/LeakCheck/LeakCheckModels.swift
+++ b/SharedPackages/VPN/Sources/VPN/LeakCheck/LeakCheckModels.swift
@@ -22,6 +22,7 @@ public enum LeakCheckTrigger: String, Codable {
     case tunnelStart = "tunnel_start"
     case reassert
     case periodic
+    case rekey
 }
 
 public struct LeakCheckEgressInfo: Equatable, Sendable {

--- a/SharedPackages/VPN/Sources/VPN/LeakCheck/VPNLeakCheckService.swift
+++ b/SharedPackages/VPN/Sources/VPN/LeakCheck/VPNLeakCheckService.swift
@@ -25,9 +25,10 @@ import PixelKit
 public actor VPNLeakCheckService {
 
     public typealias TunnelInterfaceProvider = @Sendable () async -> NWInterface?
+    public typealias EgressInfoProvider = @Sendable () async -> LeakCheckEgressInfo?
 
     private let configuration: LeakCheckConfiguration
-    private var egressInfo: LeakCheckEgressInfo
+    private let egressInfo: EgressInfoProvider
     private let tunnelInterface: TunnelInterfaceProvider
     private let httpClient: LeakCheckHTTPClient
     private let stunClient: LeakCheckSTUNClient
@@ -39,17 +40,19 @@ public actor VPNLeakCheckService {
     private var scheduledCheck: Task<Void, Never>?
     private var isStopped = false
 
-    /// The service resolves the tunnel `NWInterface` live at the start of every check via
-    /// `tunnelInterface`. This avoids caching a stale or nil interface from initialization time —
-    /// if the kernel hadn't yet published the utun device when the service was created, subsequent
-    /// checks will pick it up automatically.
+    /// The service resolves both the tunnel `NWInterface` and the egress info live at the start of
+    /// every check via `tunnelInterface` and `egressInfo`. This avoids caching stale values from
+    /// initialization time — for example, if a rekey has selected a different server underneath,
+    /// the next check picks up the new server automatically without anyone having to push an
+    /// update.
     ///
-    /// When `tunnelInterface` returns nil, the check is skipped entirely — no wide event is fired.
-    /// Running unpinned tests can't distinguish "tunnel is healthy" from "tunnel is leaking",
-    /// so the result would be meaningless either way.
+    /// When either provider returns nil, the check is skipped entirely — no wide event is fired.
+    /// Running without a tunnel-pinned interface, or without a reference IP to compare against,
+    /// can't distinguish "tunnel is healthy" from "tunnel is leaking", so the result would be
+    /// meaningless either way.
     public init(
         configuration: LeakCheckConfiguration = .default,
-        egressInfo: LeakCheckEgressInfo,
+        egressInfo: @escaping EgressInfoProvider,
         tunnelInterface: @escaping TunnelInterfaceProvider,
         httpClient: LeakCheckHTTPClient,
         stunClient: LeakCheckSTUNClient,
@@ -85,7 +88,7 @@ public actor VPNLeakCheckService {
     }
 
     /// Schedules a leak check that runs after the trigger's natural delay
-    /// (`tunnelStartDelay` for `.tunnelStart`, immediate for `.reassert`/`.periodic`).
+    /// (`tunnelStartDelay` for `.tunnelStart`, immediate for `.reassert`/`.periodic`/`.rekey`).
     ///
     /// The latest schedule wins: a pending scheduled check is cancelled and replaced. This collapses
     /// rapid bursts (e.g. manual start → reconnect) into a single check using the freshest trigger,
@@ -106,11 +109,6 @@ public actor VPNLeakCheckService {
             guard !Task.isCancelled else { return }
             await self?.runCheck(trigger: trigger)
         }
-    }
-
-    public func updateEgressInfo(_ newInfo: LeakCheckEgressInfo) {
-        Logger.networkProtectionIPLeakCheck.log("Updated egress info reference")
-        egressInfo = newInfo
     }
 
     public static func completeAllPendingFlows(wideEvent: WideEventManaging) {
@@ -136,8 +134,12 @@ public actor VPNLeakCheckService {
             Logger.networkProtectionIPLeakCheck.log("Skipping leak check — already in flight (trigger: \(trigger.rawValue, privacy: .public))")
             return
         }
+        // `.reassert` and `.rekey` both signal a tunnel path change (failure recovery /
+        // reconfiguration in the first case, server reselection in the second), so they bypass
+        // cooldown and always run — we want to validate the new path immediately.
         if !bypassCooldown,
            trigger != .reassert,
+           trigger != .rekey,
            let last = lastCompletionDate,
            Date().timeIntervalSince(last) < configuration.cooldown {
             Logger.networkProtectionIPLeakCheck.log("Skipping leak check — cooldown active (trigger: \(trigger.rawValue, privacy: .public))")
@@ -162,7 +164,10 @@ public actor VPNLeakCheckService {
 
         Logger.networkProtectionIPLeakCheck.log("🟢 Starting leak check (trigger: \(trigger.rawValue, privacy: .public))")
 
-        let egressInfoSnapshot = egressInfo
+        guard let egressInfoSnapshot = await egressInfo() else {
+            Logger.networkProtectionIPLeakCheck.log("🔴 Skipping leak check — egress info unavailable (trigger: \(trigger.rawValue, privacy: .public))")
+            return
+        }
         guard let tunnelInterfaceSnapshot = await tunnelInterface() else {
             Logger.networkProtectionIPLeakCheck.log("🔴 Skipping leak check — tunnel interface unavailable (trigger: \(trigger.rawValue, privacy: .public))")
             return

--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -313,18 +313,19 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
         providerEvents.fire(.rekeyAttempt(.begin))
 
-        let preRekeyEgress = await MainActor.run { self.currentEgressInfo() }
+        let preRekeyEgress = await currentEgressInfo()
 
         do {
             try await updateTunnelConfiguration(
                 updateMethod: .selectServer(currentServerSelectionMethod),
                 reassert: false,
                 regenerateKey: true)
-            let postRekeyEgress = await MainActor.run { self.currentEgressInfo() }
             // A rekey that landed back on the same server can't have changed the egress path, so
             // skip the leak check and let the periodic timer handle the routine validation. We
             // only force an immediate check when the server (or its IP) actually changed.
-            if preRekeyEgress != postRekeyEgress {
+            // If `postRekeyEgress` is nil the tunnel has dropped state out from under us; the
+            // service would skip the check anyway, so don't bother scheduling.
+            if let postRekeyEgress = await currentEgressInfo(), preRekeyEgress != postRekeyEgress {
                 await leakCheckService?.scheduleCheck(trigger: .rekey)
             }
             providerEvents.fire(.rekeyAttempt(.success))

--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -313,11 +313,20 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
         providerEvents.fire(.rekeyAttempt(.begin))
 
+        let preRekeyEgress = await MainActor.run { self.currentEgressInfo() }
+
         do {
             try await updateTunnelConfiguration(
                 updateMethod: .selectServer(currentServerSelectionMethod),
                 reassert: false,
                 regenerateKey: true)
+            let postRekeyEgress = await MainActor.run { self.currentEgressInfo() }
+            // A rekey that landed back on the same server can't have changed the egress path, so
+            // skip the leak check and let the periodic timer handle the routine validation. We
+            // only force an immediate check when the server (or its IP) actually changed.
+            if preRekeyEgress != postRekeyEgress {
+                await leakCheckService?.scheduleCheck(trigger: .rekey)
+            }
             providerEvents.fire(.rekeyAttempt(.success))
         } catch {
             providerEvents.fire(.rekeyAttempt(.failure(error)))
@@ -1240,12 +1249,6 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
     @MainActor
     private func scheduleLeakCheck(for startReason: AdapterStartReason) async {
-        guard let egressIP = lastSelectedServerInfo?.ipv4?.debugDescription,
-              let egressServerName = lastSelectedServerInfo?.name else {
-            return
-        }
-        let egressInfo = LeakCheckEgressInfo(ipAddress: egressIP, name: egressServerName)
-
         switch startReason {
         case .manual, .onDemand, .snoozeEnded:
             if leakCheckService == nil {
@@ -1254,7 +1257,9 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 let fallbackInterfaceName = adapter.interfaceName
                 let service = VPNLeakCheckService(
                     configuration: .default,
-                    egressInfo: egressInfo,
+                    egressInfo: { [weak self] in
+                        await self?.currentEgressInfo()
+                    },
                     tunnelInterface: { [weak self] in
                         await self?.resolveTunnelInterface(fallbackInterfaceName: fallbackInterfaceName)
                     },
@@ -1264,16 +1269,27 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 )
                 leakCheckService = service
                 await service.start()
-            } else {
-                await leakCheckService?.updateEgressInfo(egressInfo)
             }
             await leakCheckService?.scheduleCheck(trigger: .tunnelStart)
         case .reconnected:
-            await leakCheckService?.updateEgressInfo(egressInfo)
             await leakCheckService?.scheduleCheck(trigger: .reassert)
         case .wake:
             break
         }
+    }
+
+    /// Resolves the current egress info from `lastSelectedServerInfo` on the main actor. The leak
+    /// check service calls this at the start of every check so the reference IP stays in sync with
+    /// whichever server WireGuard is currently connected to — including changes made by `rekey()`,
+    /// `handleRestartAdapter()`, or any future code path that mutates `lastSelectedServer` without
+    /// going through `handleAdapterStarted`.
+    @MainActor
+    private func currentEgressInfo() -> LeakCheckEgressInfo? {
+        guard let info = lastSelectedServerInfo,
+              let ip = info.ipv4?.debugDescription else {
+            return nil
+        }
+        return LeakCheckEgressInfo(ipAddress: ip, name: info.name)
     }
 
     // MARK: - Monitors

--- a/SharedPackages/VPN/Tests/VPNTests/LeakCheck/VPNLeakCheckServiceTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/LeakCheck/VPNLeakCheckServiceTests.swift
@@ -404,6 +404,34 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         XCTAssertEqual(wideEvent.startedFlows.count, 2)
     }
 
+    func testCooldown_rekeyBypassesCooldown() async {
+        let http = MockLeakCheckHTTPClient(ipv4: "1.2.3.4", ipv6Error: URLError(.cannotFindHost))
+        let stun = MockLeakCheckSTUNClient(ipv4: "1.2.3.4", ipv6Error: URLError(.cannotFindHost))
+        let wideEvent = MockWideEventManager()
+        let config = LeakCheckConfiguration(
+            host: "leakcheck.netp.duckduckgo.com",
+            httpPort: 80, httpsPort: 443, stunPort: 3478,
+            httpTimeout: 10, stunTimeout: 5,
+            periodicInterval: 60 * 60,
+            cooldown: 60,
+            tunnelStartDelay: 0
+        )
+        let service = VPNLeakCheckService(
+            configuration: config,
+            egressInfo: makeEgressInfoProvider(),
+            tunnelInterface: { Self.systemInterface },
+            httpClient: http,
+            stunClient: stun,
+            wideEvent: wideEvent
+        )
+
+        await service.runCheck(trigger: .tunnelStart)
+        await service.runCheck(trigger: .rekey)
+
+        XCTAssertEqual(wideEvent.startedFlows.count, 2)
+        XCTAssertEqual(wideEvent.lastCompletedData?.trigger, .rekey)
+    }
+
     func testEgressIPChange_duringInflightCheck_usesSnapshot() async {
         let http = SlowMockHTTPClient(delaySeconds: 0.3, returnIP: "1.2.3.4")
         let stun = MockLeakCheckSTUNClient(ipv4: "1.2.3.4", ipv6Error: URLError(.cannotFindHost))

--- a/SharedPackages/VPN/Tests/VPNTests/LeakCheck/VPNLeakCheckServiceTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/LeakCheck/VPNLeakCheckServiceTests.swift
@@ -56,13 +56,18 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         LeakCheckEgressInfo(ipAddress: ip, name: name)
     }
 
+    private func makeEgressInfoProvider(ip: String = "1.2.3.4", name: String = "test-server") -> VPNLeakCheckService.EgressInfoProvider {
+        let info = LeakCheckEgressInfo(ipAddress: ip, name: name)
+        return { info }
+    }
+
     func testAllTestsMatchEgress_allSuccess() async throws {
         let http = MockLeakCheckHTTPClient(ipv4: "1.2.3.4", ipv6Error: URLError(.cannotFindHost))
         let stun = MockLeakCheckSTUNClient(ipv4: "1.2.3.4", ipv6Error: URLError(.cannotFindHost))
         let wideEvent = MockWideEventManager()
         let service = VPNLeakCheckService(
             configuration: .default,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -87,7 +92,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         let wideEvent = MockWideEventManager()
         let service = VPNLeakCheckService(
             configuration: .default,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -109,7 +114,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         let wideEvent = MockWideEventManager()
         let service = VPNLeakCheckService(
             configuration: .default,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -137,7 +142,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         let wideEvent = MockWideEventManager()
         let service = VPNLeakCheckService(
             configuration: .default,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -164,7 +169,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         let wideEvent = MockWideEventManager()
         let service = VPNLeakCheckService(
             configuration: .default,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -190,7 +195,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         let wideEvent = MockWideEventManager()
         let service = VPNLeakCheckService(
             configuration: .default,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -211,7 +216,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         let wideEvent = MockWideEventManager()
         let service = VPNLeakCheckService(
             configuration: .default,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -233,7 +238,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         let wideEvent = MockWideEventManager()
         let service = VPNLeakCheckService(
             configuration: .default,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -256,7 +261,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         let wideEvent = MockWideEventManager()
         let service = VPNLeakCheckService(
             configuration: .default,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -279,7 +284,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         let wideEvent = MockWideEventManager()
         let service = VPNLeakCheckService(
             configuration: .default,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -298,7 +303,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         let wideEvent = MockWideEventManager()
         let service = VPNLeakCheckService(
             configuration: .default,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -327,7 +332,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         )
         let service = VPNLeakCheckService(
             configuration: config,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -359,7 +364,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         )
         let service = VPNLeakCheckService(
             configuration: config,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -386,7 +391,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         )
         let service = VPNLeakCheckService(
             configuration: config,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -399,13 +404,14 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         XCTAssertEqual(wideEvent.startedFlows.count, 2)
     }
 
-    func testUpdateEgressIP_duringInflightCheck_usesSnapshot() async {
+    func testEgressIPChange_duringInflightCheck_usesSnapshot() async {
         let http = SlowMockHTTPClient(delaySeconds: 0.3, returnIP: "1.2.3.4")
         let stun = MockLeakCheckSTUNClient(ipv4: "1.2.3.4", ipv6Error: URLError(.cannotFindHost))
         let wideEvent = MockWideEventManager()
+        let box = MutableEgressInfoBox(makeEgressInfo())
         let service = VPNLeakCheckService(
             configuration: .default,
-            egressInfo: makeEgressInfo(),
+            egressInfo: { box.value },
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -414,26 +420,27 @@ final class VPNLeakCheckServiceTests: XCTestCase {
 
         async let checkTask: Void = service.runCheck(trigger: .tunnelStart)
         try? await Task.sleep(nanoseconds: 100_000_000)
-        await service.updateEgressInfo(makeEgressInfo(ip: "5.6.7.8"))
+        box.value = makeEgressInfo(ip: "5.6.7.8")
         _ = await checkTask
 
         XCTAssertEqual(wideEvent.lastCompletedData?.ipv4Http?.status, .success)
         XCTAssertEqual(wideEvent.lastCompletedData?.ipv4Https?.status, .success)
     }
 
-    func testUpdateEgressIP_changesComparison() async {
+    func testEgressIPChange_beforeCheck_changesComparison() async {
         let http = MockLeakCheckHTTPClient(ipv4: "5.6.7.8", ipv6Error: URLError(.cannotFindHost))
         let stun = MockLeakCheckSTUNClient(ipv4: "5.6.7.8", ipv6Error: URLError(.cannotFindHost))
         let wideEvent = MockWideEventManager()
+        let box = MutableEgressInfoBox(makeEgressInfo())
         let service = VPNLeakCheckService(
             configuration: .default,
-            egressInfo: makeEgressInfo(),
+            egressInfo: { box.value },
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
             wideEvent: wideEvent
         )
-        await service.updateEgressInfo(makeEgressInfo(ip: "5.6.7.8"))
+        box.value = makeEgressInfo(ip: "5.6.7.8")
         await service.runCheck(trigger: .reassert)
 
         XCTAssertEqual(wideEvent.lastCompletedData?.ipv4Http?.status, .success)
@@ -445,7 +452,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         let wideEvent = MockWideEventManagerWithPending()
         let service = VPNLeakCheckService(
             configuration: .default,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -466,7 +473,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         let wideEvent = MockWideEventManager()
         let service = VPNLeakCheckService(
             configuration: .default,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -494,7 +501,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         )
         let service = VPNLeakCheckService(
             configuration: config,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -516,7 +523,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         let wideEvent = MockWideEventManager()
         let service = VPNLeakCheckService(
             configuration: .default,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -544,7 +551,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         )
         let service = VPNLeakCheckService(
             configuration: config,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -574,7 +581,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         )
         let service = VPNLeakCheckService(
             configuration: config,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -596,7 +603,7 @@ final class VPNLeakCheckServiceTests: XCTestCase {
         let wideEvent = MockWideEventManager()
         let service = VPNLeakCheckService(
             configuration: .default,
-            egressInfo: makeEgressInfo(),
+            egressInfo: makeEgressInfoProvider(),
             tunnelInterface: { Self.systemInterface },
             httpClient: http,
             stunClient: stun,
@@ -658,6 +665,20 @@ final class MockWideEventManagerWithPending: WideEventManaging, @unchecked Senda
     func getFlowData<T: WideEventData>(_ type: T.Type, globalID: String) -> T? { nil }
     func getAllFlowData<T: WideEventData>(_ type: T.Type) -> [T] {
         return pending as? [T] ?? []
+    }
+}
+
+final class MutableEgressInfoBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value: LeakCheckEgressInfo?
+
+    init(_ initial: LeakCheckEgressInfo?) {
+        self._value = initial
+    }
+
+    var value: LeakCheckEgressInfo? {
+        get { lock.lock(); defer { lock.unlock() }; return _value }
+        set { lock.lock(); defer { lock.unlock() }; _value = newValue }
     }
 }
 

--- a/iOS/PixelDefinitions/wide_events/definitions/vpn-ip-leak-check.json5
+++ b/iOS/PixelDefinitions/wide_events/definitions/vpn-ip-leak-check.json5
@@ -14,7 +14,7 @@
                     "trigger": {
                         "type": "string",
                         "description": "What caused the leak check cycle to run",
-                        "enum": ["tunnel_start", "reassert", "periodic"]
+                        "enum": ["tunnel_start", "reassert", "periodic", "rekey"]
                     },
                     "status_reason": {
                         "type": "string",

--- a/iOS/PixelDefinitions/wide_events/generated_schemas/ios-vpn-ip-leak-check-1.0.0.json
+++ b/iOS/PixelDefinitions/wide_events/generated_schemas/ios-vpn-ip-leak-check-1.0.0.json
@@ -63,7 +63,7 @@
                                 "trigger": {
                                     "type": "string",
                                     "description": "What caused the leak check cycle to run",
-                                    "enum": ["tunnel_start", "reassert", "periodic"]
+                                    "enum": ["tunnel_start", "reassert", "periodic", "rekey"]
                                 },
                                 "status_reason": {
                                     "type": "string",

--- a/macOS/PixelDefinitions/wide_events/definitions/vpn-ip-leak-check.json5
+++ b/macOS/PixelDefinitions/wide_events/definitions/vpn-ip-leak-check.json5
@@ -14,7 +14,7 @@
                     "trigger": {
                         "type": "string",
                         "description": "What caused the leak check cycle to run",
-                        "enum": ["tunnel_start", "reassert", "periodic"]
+                        "enum": ["tunnel_start", "reassert", "periodic", "rekey"]
                     },
                     "status_reason": {
                         "type": "string",

--- a/macOS/PixelDefinitions/wide_events/generated_schemas/macos-vpn-ip-leak-check-1.0.0.json
+++ b/macOS/PixelDefinitions/wide_events/generated_schemas/macos-vpn-ip-leak-check-1.0.0.json
@@ -76,7 +76,7 @@
                                 "trigger": {
                                     "type": "string",
                                     "description": "What caused the leak check cycle to run",
-                                    "enum": ["tunnel_start", "reassert", "periodic"]
+                                    "enum": ["tunnel_start", "reassert", "periodic", "rekey"]
                                 },
                                 "status_reason": {
                                     "type": "string",


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214410332899564?focus=true
Tech Design URL:
CC:

### Description

This PR fixes the egress server check so that stale egress values cannot trigger a false-positive leak check.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Run the VPN
2. Trigger a rekey event
3. Check that the leak detection service runs and shows a success

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
4. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes leak-check scheduling and reference-IP selection in the VPN tunnel provider, which could affect when leak checks run and how results are classified. Logic is covered by updated tests but should be validated around rekey/reconnect edge cases.
> 
> **Overview**
> Leak checks now **resolve egress IP/server name dynamically at the start of each check** via an injected async provider, rather than caching and updating a stored `LeakCheckEgressInfo`, and will skip checks when either the tunnel interface or egress reference is unavailable.
> 
> Adds a new leak-check trigger, `rekey`, and updates cooldown logic so `.reassert` and `.rekey` bypass cooldown. `PacketTunnelProvider` now schedules an immediate leak check after `rekey()` *only when the egress server/IP actually changes*, and wide-event schemas/tests are updated to include the new trigger and the provider-based egress behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49de51b78d9fd264578e2b4f1cd839da9c6082d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->