### PR TITLE
Fix web extensions not working in Fire Window on macOS

### DIFF
--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Loading/WebExtensionLoader.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Loading/WebExtensionLoader.swift
@@ -141,6 +141,7 @@ public final class WebExtensionLoader: WebExtensionLoading {
         }
 
         context.isInspectable = isInspectable
+        context.hasAccessToPrivateData = true
         return context
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203936086921904/task/1214355387212760?focus=true
Tech Design URL: N/A
CC:

### Description

- Set `hasAccessToPrivateData = true` on the `WKContentWorld` context in `WebExtensionLoader` to fix web extensions (e.g. YouTube ad blocking) not working in Fire Window on macOS.

### Testing Steps

1. Ensure Internal User mode is enabled
2. Go to Settings > YouTube Ad Blocking and enable the feature
3. Open a normal browser window
4. Navigate to YouTube and play a video — verify that ads are blocked
5. Open a Fire Window
6. Navigate to YouTube and play a video — verify that ads are also blocked in the Fire Window

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?

- Granting `hasAccessToPrivateData` broadly could allow extension content scripts to access data in private browsing contexts that was previously inaccessible. This is intentional — extensions need this access to function in Fire Windows.

### Quality Considerations

- This fix applies to all web extension contexts, not just YouTube ad blocking — any extension should now work correctly in Fire Windows.
- Privacy consideration: Fire Window is designed for ephemeral browsing. Extensions operating in Fire Windows will have the same access as in normal windows, but Fire Window data is still cleared on close.

### Notes to Reviewer

N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables `WKWebExtensionContext.hasAccessToPrivateData`, which changes extension behavior in private/Fire windows and could increase data exposure to extensions there. Code change is small and localized but touches privacy-sensitive behavior.
> 
> **Overview**
> Fixes web extensions failing to run in Fire/Private windows on macOS by setting `WKWebExtensionContext.hasAccessToPrivateData = true` when creating extension contexts in `WebExtensionLoader`.
> 
> This applies the private-data access flag to all loaded extensions, aligning their behavior between normal and Fire windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb07eeb76256df2136a224eba7c4f168c755994b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->