### PR TITLE
Add inline image support to TypingTextAnimation

### DIFF
--- a/SharedPackages/Onboarding/Sources/Onboarding/SwiftUIExtensions/TypingTextAnimation.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/SwiftUIExtensions/TypingTextAnimation.swift
@@ -19,6 +19,7 @@
 #if os(iOS)
 
 import SwiftUI
+import UIComponents
 
 // MARK: - Skip Environment Key
 
@@ -116,7 +117,7 @@ private final class TypingAnimationState: ObservableObject {
 ///   `TypingText` animations in the subtree (used for tap-to-skip).
 /// - When `accessibilityReduceMotion` is enabled, the full text appears immediately.
 public struct TypingText: View {
-    private let attributedText: AttributedString
+    private let attributedText: NSAttributedString
     private let startAnimating: Binding<Bool>
     private let onTypingFinished: (() -> Void)?
 
@@ -124,56 +125,56 @@ public struct TypingText: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.typingAnimationSkip) private var skipAnimation
 
-    public init(_ attributedText: AttributedString, startAnimating: Binding<Bool> = .constant(true), onTypingFinished: (() -> Void)? = nil) {
+    public init(_ attributedText: NSAttributedString, startAnimating: Binding<Bool> = .constant(true), onTypingFinished: (() -> Void)? = nil) {
         self.attributedText = attributedText
         self.startAnimating = startAnimating
         self.onTypingFinished = onTypingFinished
     }
 
     public init(_ text: String, startAnimating: Binding<Bool> = .constant(true), onTypingFinished: (() -> Void)? = nil) {
-        self.init(AttributedString(text), startAnimating: startAnimating, onTypingFinished: onTypingFinished)
+        self.init(NSAttributedString(string: text), startAnimating: startAnimating, onTypingFinished: onTypingFinished)
     }
 
-    /// Builds an `AttributedString` where the first `visibleCount` characters inherit
-    /// the environment's foreground style and the rest are transparent.
-    /// Because the full text is always rendered, line breaks never shift.
+    /// Builds a `Text` view where the first `visibleCount` characters are visible and the rest
+    /// are transparent. Uses `Text(attributedStringWithAttachments:)` so that inline image
+    /// attachments are handled the same way as in `AnimatableTypingText`: attachments in the
+    /// hidden portion are rendered as transparent placeholders that preserve layout.
     private var revealedText: Text {
         if state.isFinished {
-            return Text(attributedText)
+            return Text(attributedStringWithAttachments: attributedText)
         }
 
-        let splitIndex = attributedText.characters.index(attributedText.startIndex, offsetBy: state.visibleCount)
-        let visibleAttributedString = AttributedString(attributedText[..<splitIndex])
-        var hiddenAttributedString = AttributedString(attributedText[splitIndex...])
-        hiddenAttributedString.foregroundColor = .clear
-
-        return Text(visibleAttributedString) + Text(hiddenAttributedString)
+        let totalRange = NSRange(location: 0, length: attributedText.length)
+        let visibleRange = NSRange(location: 0, length: min(state.visibleCount, attributedText.length))
+        let visibleText = attributedText.applyingColor(.clear, to: totalRange)
+                                        .applyingColor(.label, to: visibleRange)
+        return Text(attributedStringWithAttachments: visibleText)
     }
 
     public var body: some View {
         revealedText
             .onChange(of: skipAnimation) { shouldSkip in
-                if shouldSkip { state.skip(totalCount: attributedText.characters.count, onFinished: onTypingFinished) }
+                if shouldSkip { state.skip(totalCount: attributedText.length, onFinished: onTypingFinished) }
             }
             .onChange(of: startAnimating.wrappedValue) { shouldAnimate in
                 if shouldAnimate {
                     if reduceMotion {
-                        state.skip(totalCount: attributedText.characters.count, onFinished: onTypingFinished)
+                        state.skip(totalCount: attributedText.length, onFinished: onTypingFinished)
                     } else {
-                        state.start(totalCount: attributedText.characters.count, onFinished: onTypingFinished)
+                        state.start(totalCount: attributedText.length, onFinished: onTypingFinished)
                     }
                 } else {
                     state.stop()
                 }
             }
             .onChange(of: reduceMotion) { shouldReduce in
-                if shouldReduce { state.skip(totalCount: attributedText.characters.count, onFinished: onTypingFinished) }
+                if shouldReduce { state.skip(totalCount: attributedText.length, onFinished: onTypingFinished) }
             }
             .onAppear {
                 if reduceMotion || skipAnimation {
-                    state.skip(totalCount: attributedText.characters.count, onFinished: onTypingFinished)
+                    state.skip(totalCount: attributedText.length, onFinished: onTypingFinished)
                 } else if startAnimating.wrappedValue {
-                    state.start(totalCount: attributedText.characters.count, onFinished: onTypingFinished)
+                    state.start(totalCount: attributedText.length, onFinished: onTypingFinished)
                 }
             }
             .onDisappear { state.stop() }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1214040804696193
Tech Design URL: N/A
CC: N/A

### Description

- In `TypingText` (`TypingTextAnimation.swift`), replace the `AttributedString` split + `Text(visible) + Text(hidden)` approach with `NSAttributedString` storage and `Text(attributedStringWithAttachments:)` rendering — the same pattern `AnimatableTypingText` uses after PR #3784.
- Add `import UIComponents` to access `Text(attributedStringWithAttachments:)`.

This ensures inline image attachments (`NSTextAttachment`) in the typed string are rendered via `InlineImageText`, which converts nil-image attachments to transparent size-preserving placeholders, so attachments in the hidden portion stay invisible until the cursor reaches them.

### Testing Steps

1. In `RebrandedOnboardingView+IntroDialogContent.swift`, add `import UIComponents` and `import DesignResourcesKitIcons`, then temporarily replace the `TypingText(content.title, ...)` call with the following to inject an inline image into the typed title:
```swift
let title = "\(content.message.split(separator: "\n").first!.replacingOccurrences(of: "puts", with: "[[intro_message_icon]]"))".attributedString(withPlaceholder: "[[intro_message_icon]]", replacedByImage: DesignSystemImages.Glyphs.Size16.aiChat, horizontalPadding: 40, verticalOffset: -1) ?? NSAttributedString(string: content.message)
TypingText(title, ...)
```
2. Run the rebranded onboarding on the iOS simulator — the Duck.ai icon must not appear until the cursor types past the attachment character.
3. Tap to skip mid-animation; the full text and icon should appear immediately.
4. Let the animation complete normally; verify the icon is visible at the end.

### Impact and Risks

**Impact Level: Low**

#### What could go wrong?

- `.applyingColor(.label, ...)` hardcodes the visible-text color, the same trade-off present in `AnimatableTypingText`. Callers setting a custom foreground color via `.foregroundColor` modifier may see it overridden during animation.

### Quality Considerations

- Change is scoped to `TypingTextAnimation.swift`; no other source files are affected.
- No privacy or security implications.
- `NSAttributedString` is stored once at init rather than converted on every animation tick.

### Notes to Reviewer

- Follow-up for the review comment on PR #3784: https://github.com/duckduckgo/apple-browsers/pull/3784/changes#r3062877661
- Pattern is identical to what PR #3784 applied to `AnimatableTypingText`: swap the renderer from `Text(AttributedString(...))` to `Text(attributedStringWithAttachments:)`.