### PR TITLE
iOS: Bug - Model picker opens at bottom showing locked models

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -822,7 +822,6 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         viewController.modelPickerMenu = modelStore.models.isEmpty ? nil : modelMenuFactory.makeMenu(
             models: modelStore.models,
             selectedId: selectedId,
-            isBottomAnchored: viewController.cardPosition == .bottom,
             hasActiveSubscription: modelStore.subscriptionState.hasActiveSubscription,
             advancedSectionTitle: modelStore.subscriptionState.hasActiveSubscription
                 ? UserText.aiChatAdvancedModelsSectionHeader

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputModelMenu.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputModelMenu.swift
@@ -39,12 +39,11 @@ struct UnifiedToggleInputModelMenu: Equatable {
     static func build(
         models: [AIChatModel],
         selectedId: String?,
-        isBottomAnchored: Bool,
         hasActiveSubscription: Bool,
         advancedSectionTitle: String,
         basicSectionTitle: String
     ) -> UnifiedToggleInputModelMenu {
-        var sections: [Section]
+        let sections: [Section]
 
         if hasActiveSubscription {
             sections = buildSubscribedSections(
@@ -59,10 +58,6 @@ struct UnifiedToggleInputModelMenu: Equatable {
                 selectedId: selectedId,
                 advancedSectionTitle: advancedSectionTitle
             )
-        }
-
-        if isBottomAnchored {
-            sections.reverse()
         }
 
         return UnifiedToggleInputModelMenu(sections: sections)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputModelMenuFactory.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputModelMenuFactory.swift
@@ -25,7 +25,6 @@ struct UnifiedToggleInputModelMenuFactory {
     func makeMenu(
         models: [AIChatModel],
         selectedId: String?,
-        isBottomAnchored: Bool,
         hasActiveSubscription: Bool,
         advancedSectionTitle: String,
         basicSectionTitle: String,
@@ -34,7 +33,6 @@ struct UnifiedToggleInputModelMenuFactory {
         let description = UnifiedToggleInputModelMenu.build(
             models: models,
             selectedId: selectedId,
-            isBottomAnchored: isBottomAnchored,
             hasActiveSubscription: hasActiveSubscription,
             advancedSectionTitle: advancedSectionTitle,
             basicSectionTitle: basicSectionTitle

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
@@ -199,6 +199,10 @@ final class UnifiedToggleInputToolbarView: UIView {
         config.cornerStyle = .capsule
 
         let button = UIButton(configuration: config)
+        button.accessibilityIdentifier = "AIChat.Toolbar.Button.ModelChip"
+        if #available(iOS 16.0, *) {
+            button.preferredMenuElementOrder = .fixed
+        }
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setContentHuggingPriority(.defaultLow, for: .horizontal)
         button.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -1439,6 +1439,17 @@ final class UnifiedToggleInputToolbarViewTests: XCTestCase {
         }
     }
 
+    func test_modelChipButton_usesFixedMenuElementOrder() {
+        let sut = UnifiedToggleInputToolbarView()
+
+        let modelChipButton = findButton(accessibilityIdentifier: "AIChat.Toolbar.Button.ModelChip", in: sut)
+
+        XCTAssertNotNil(modelChipButton)
+        if #available(iOS 16.0, *) {
+            XCTAssertEqual(modelChipButton?.preferredMenuElementOrder, .fixed)
+        }
+    }
+
     private func findButton(accessibilityLabel: String, in view: UIView) -> UIButton? {
         for subview in view.subviews {
             if let button = subview as? UIButton, button.accessibilityLabel == accessibilityLabel {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputModelMenuTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputModelMenuTests.swift
@@ -62,15 +62,6 @@ final class UnifiedToggleInputModelMenuTests: XCTestCase {
         XCTAssertEqual(menu.sections[1].items[0].modelId, "gpt-5")
     }
 
-    func test_freeUser_bottomAnchored_reversesSectionOrder() {
-        let menu = buildFreeMenu(models: [freeModel, premiumModel], selectedId: "gpt-4o-mini", isBottomAnchored: true)
-
-        XCTAssertEqual(menu.sections[0].title, "Advanced")
-        XCTAssertEqual(menu.sections[0].items[0].modelId, "gpt-5")
-        XCTAssertEqual(menu.sections[1].title, "")
-        XCTAssertEqual(menu.sections[1].items[0].modelId, "gpt-4o-mini")
-    }
-
     // MARK: - Free User: Item Properties
 
     func test_freeUser_accessibleItems_areNotDisabled() {
@@ -133,7 +124,6 @@ final class UnifiedToggleInputModelMenuTests: XCTestCase {
         let menu = UnifiedToggleInputModelMenu.build(
             models: [freeModel, premiumModel],
             selectedId: "",
-            isBottomAnchored: false,
             hasActiveSubscription: false,
             advancedSectionTitle: "Premium Models",
             basicSectionTitle: "Basic"
@@ -160,14 +150,6 @@ final class UnifiedToggleInputModelMenuTests: XCTestCase {
         let menu = buildSubscribedMenu(models: [subscribedPremium, freeModel], selectedId: "gpt-5")
 
         XCTAssertTrue(menu.sections.flatMap(\.items).allSatisfy { !$0.isDisabled })
-    }
-
-    func test_subscribedUser_bottomAnchored_reversesSections() {
-        let subscribedPremium = AIChatModel(id: "gpt-5", name: "GPT-5", provider: .openAI, supportsImageUpload: true, entityHasAccess: true, accessTier: ["plus", "pro"])
-        let menu = buildSubscribedMenu(models: [subscribedPremium, freeModel], selectedId: "gpt-5", isBottomAnchored: true)
-
-        XCTAssertEqual(menu.sections[0].title, "Basic")
-        XCTAssertEqual(menu.sections[1].title, "Advanced")
     }
 
     func test_subscribedUser_allBasicModels_singleSection() {
@@ -202,27 +184,101 @@ final class UnifiedToggleInputModelMenuTests: XCTestCase {
         XCTAssertTrue(advancedSection.items[0].isDisabled)
     }
 
+    // MARK: - Order Invariant (regression: items order independent from UI position)
+
+    func test_freeUser_premiumSection_preservesInputOrder() {
+        let sphynx = makeFakeModel(id: "acme-sphynx-5", name: "Acme Sphynx 5", accessTier: ["plus", "pro"], hasAccess: false)
+        let persian = makeFakeModel(id: "acme-persian-9", name: "Acme Persian 9", accessTier: ["plus", "pro"], hasAccess: false)
+        let burmese = makeFakeModel(id: "acme-burmese-11", name: "Acme Burmese 11", accessTier: ["plus", "pro"], hasAccess: false)
+
+        let menu = buildFreeMenu(models: [sphynx, persian, burmese], selectedId: "")
+
+        XCTAssertEqual(
+            menu.sections[1].items.map(\.modelId),
+            ["acme-sphynx-5", "acme-persian-9", "acme-burmese-11"]
+        )
+    }
+
+    func test_subscribedUser_advancedSection_preservesInputOrder() {
+        let sphynx = makeFakeModel(id: "acme-sphynx-5", name: "Acme Sphynx 5", accessTier: ["plus"], hasAccess: true)
+        let persian = makeFakeModel(id: "acme-persian-9", name: "Acme Persian 9", accessTier: ["plus"], hasAccess: true)
+        let burmese = makeFakeModel(id: "acme-burmese-11", name: "Acme Burmese 11", accessTier: ["plus"], hasAccess: true)
+
+        let menu = buildSubscribedMenu(models: [sphynx, persian, burmese], selectedId: "")
+
+        XCTAssertEqual(menu.sections[0].title, "Advanced")
+        XCTAssertEqual(
+            menu.sections[0].items.map(\.modelId),
+            ["acme-sphynx-5", "acme-persian-9", "acme-burmese-11"]
+        )
+    }
+
+    func test_subscribedUser_basicSection_preservesInputOrder() {
+        let ragdoll = makeFakeModel(id: "acme-ragdoll-7", name: "Acme Ragdoll 7", accessTier: ["free"], hasAccess: true)
+        let mainecoon = makeFakeModel(id: "acme-mainecoon-12", name: "Acme Maine Coon 12", accessTier: ["free"], hasAccess: true)
+        let bengal = makeFakeModel(id: "acme-bengal-3", name: "Acme Bengal 3", accessTier: ["free"], hasAccess: true)
+
+        let menu = buildSubscribedMenu(models: [ragdoll, mainecoon, bengal], selectedId: "")
+
+        XCTAssertEqual(menu.sections[0].title, "Basic")
+        XCTAssertEqual(
+            menu.sections[0].items.map(\.modelId),
+            ["acme-ragdoll-7", "acme-mainecoon-12", "acme-bengal-3"]
+        )
+    }
+
+    func test_subscribedUser_mixedInput_preservesOrderWithinEachSection() {
+        let sphynx = makeFakeModel(id: "acme-sphynx-5", name: "Acme Sphynx 5", accessTier: ["plus"], hasAccess: true)
+        let ragdoll = makeFakeModel(id: "acme-ragdoll-7", name: "Acme Ragdoll 7", accessTier: ["free"], hasAccess: true)
+        let persian = makeFakeModel(id: "acme-persian-9", name: "Acme Persian 9", accessTier: ["plus"], hasAccess: true)
+        let mainecoon = makeFakeModel(id: "acme-mainecoon-12", name: "Acme Maine Coon 12", accessTier: ["free"], hasAccess: true)
+
+        let menu = buildSubscribedMenu(models: [sphynx, ragdoll, persian, mainecoon], selectedId: "")
+
+        XCTAssertEqual(menu.sections[0].items.map(\.modelId), ["acme-sphynx-5", "acme-persian-9"])
+        XCTAssertEqual(menu.sections[1].items.map(\.modelId), ["acme-ragdoll-7", "acme-mainecoon-12"])
+    }
+
+    func test_build_isDeterministic_returnsIdenticalSectionsAcrossInvocations() {
+        let ragdoll = makeFakeModel(id: "acme-ragdoll-7", name: "Acme Ragdoll 7", accessTier: ["free"], hasAccess: true)
+        let sphynx = makeFakeModel(id: "acme-sphynx-5", name: "Acme Sphynx 5", accessTier: ["plus", "pro"], hasAccess: false)
+
+        let first = buildFreeMenu(models: [ragdoll, sphynx], selectedId: "acme-ragdoll-7")
+        let second = buildFreeMenu(models: [ragdoll, sphynx], selectedId: "acme-ragdoll-7")
+
+        XCTAssertEqual(first, second)
+    }
+
     // MARK: - Helpers
 
-    private func buildFreeMenu(models: [AIChatModel], selectedId: String, isBottomAnchored: Bool = false) -> UnifiedToggleInputModelMenu {
+    private func buildFreeMenu(models: [AIChatModel], selectedId: String) -> UnifiedToggleInputModelMenu {
         UnifiedToggleInputModelMenu.build(
             models: models,
             selectedId: selectedId,
-            isBottomAnchored: isBottomAnchored,
             hasActiveSubscription: false,
             advancedSectionTitle: "Advanced",
             basicSectionTitle: "Basic"
         )
     }
 
-    private func buildSubscribedMenu(models: [AIChatModel], selectedId: String, isBottomAnchored: Bool = false) -> UnifiedToggleInputModelMenu {
+    private func buildSubscribedMenu(models: [AIChatModel], selectedId: String) -> UnifiedToggleInputModelMenu {
         UnifiedToggleInputModelMenu.build(
             models: models,
             selectedId: selectedId,
-            isBottomAnchored: isBottomAnchored,
             hasActiveSubscription: true,
             advancedSectionTitle: "Advanced",
             basicSectionTitle: "Basic"
+        )
+    }
+
+    private func makeFakeModel(id: String, name: String, accessTier: [String], hasAccess: Bool) -> AIChatModel {
+        AIChatModel(
+            id: id,
+            name: name,
+            provider: .openAI,
+            supportsImageUpload: false,
+            entityHasAccess: hasAccess,
+            accessTier: accessTier
         )
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1211654189969294/task/1214153500938960?focus=true
Tech Design URL:
CC: @aataraxiaa 

### Description
Fixes a bug when in Duck.ai toggle model picker where items inside each section were rendered in reversed order whenever omnibar was bottom-anchored. When top-anchored, the order matched the backend; when bottom-anchored, order was flipped.

Root cause: `UIButton.preferredMenuElementOrder` defaults to `.automatic`, which makes UIKit reorder a `UIMenu`'s children. The Figma designs require a deterministic order regardless of anchor position, so the model chip button now opts into `.fixed` (mirroring what the [reasoning button](https://github.com/duckduckgo/apple-browsers/blob/153e0ed9607ae15d33fd0104895e74f8a21171b7/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift#L162-L174) in the same toolbar already does) - thus making it consistent.

[Figma designs](https://www.figma.com/design/QUTLfN2oPR6ivG1Jwsw3Mg/%F0%9F%93%B1-Phase-4--Full-Screen-Integration--iOS-?node-id=0-1&p=f&t=FxfUNg8KzF9lbW9D-0)


### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->

Enable `unifiedToggleInput` flag, restart the app.
Note: models are ordered by backend, so the ordering won’t be exactly the same as in Figma, but the main concept is to have free models on top and paid on bottom. Plus, no elements changing in each section.

1. Set ominbar position to top
2. Switch to Duck.ai
3. Tap on model picker, compare with Figma designs
4. Set ominbar position to bottom
5. Switch to Duck.ai
6. Tap on model picker, compare with Figma designs

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
7. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
**Impact: Low** — bug-fix only, no public API change. The only behavioral change is the model picker rendering its items in a deterministic order.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

- The `.fixed` setting is gated by `if #available(iOS 16.0, *)`, so on iOS 15 the button keeps the existing `.automatic` behavior — i.e. the status quo, not a regression.
- The removed `isBottomAnchored` parameter was only used by this single code path (model picker). The unrelated `cardPosition` property on the view controller is still used elsewhere in UTI for layout decisions and is untouched.
- All section/ordering logic is covered by an expanded unit-test suite — the previous tests asserting the now-removed reverse behavior were deleted, and replaced with regression tests asserting deterministic order across both free and subscribed user flows.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to the Duck.ai model picker menu ordering; no data, auth, or networking logic is affected. Main risk is minor menu presentation differences on iOS 16+ where `.preferredMenuElementOrder` is now forced to `.fixed`.
> 
> **Overview**
> Fixes the Duck.ai model picker menu showing models in a reversed/unstable order when the omnibar is bottom-anchored by making menu ordering *position-invariant*.
> 
> This removes the `isBottomAnchored`-driven section reversal from `UnifiedToggleInputModelMenu`/factory/coordinator wiring, and instead forces deterministic UIKit menu rendering by setting the model chip button’s `preferredMenuElementOrder` to `.fixed` (iOS 16+), matching the existing reasoning button behavior.
> 
> Tests are updated by deleting bottom-anchored reversal assertions and adding regression coverage that section/item order matches input order and stays deterministic across invocations, plus a toolbar test for the model chip button configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de5238fd2a50739bad68a3fe3e2e512f8a3d4dad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->