### PR TITLE
[iOS] Unified Input: toggle-off UI fixes + Duck.ai shortcut button

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarButtonsView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarButtonsView.swift
@@ -28,23 +28,27 @@ enum SwitchBarButtonState {
     case voiceAndSearchGoTo
     case stopGeneratingOnly
     case stopGeneratingAndSearchGoTo
+    case aiChatShortcutOnly
+    case voiceAndAIChatShortcut
 
     var showsClearButton: Bool {
         switch self {
         case .clearOnly:
             return true
         case .noButtons, .voiceOnly, .searchGoToOnly, .voiceAndSearchGoTo,
-             .stopGeneratingOnly, .stopGeneratingAndSearchGoTo:
+             .stopGeneratingOnly, .stopGeneratingAndSearchGoTo,
+             .aiChatShortcutOnly, .voiceAndAIChatShortcut:
             return false
         }
     }
 
     var showsVoiceButton: Bool {
         switch self {
-        case .voiceOnly, .voiceAndSearchGoTo:
+        case .voiceOnly, .voiceAndSearchGoTo, .voiceAndAIChatShortcut:
             return true
         case .noButtons, .clearOnly, .searchGoToOnly,
-             .stopGeneratingOnly, .stopGeneratingAndSearchGoTo:
+             .stopGeneratingOnly, .stopGeneratingAndSearchGoTo,
+             .aiChatShortcutOnly:
             return false
         }
     }
@@ -53,16 +57,18 @@ enum SwitchBarButtonState {
         switch self {
         case .searchGoToOnly, .voiceAndSearchGoTo, .stopGeneratingAndSearchGoTo:
             return true
-        case .noButtons, .clearOnly, .voiceOnly, .stopGeneratingOnly:
+        case .noButtons, .clearOnly, .voiceOnly, .stopGeneratingOnly,
+             .aiChatShortcutOnly, .voiceAndAIChatShortcut:
             return false
         }
     }
 
     var showsSeparator: Bool {
         switch self {
-        case .voiceAndSearchGoTo, .stopGeneratingAndSearchGoTo:
+        case .voiceAndSearchGoTo, .stopGeneratingAndSearchGoTo, .voiceAndAIChatShortcut:
             return true
-        case .noButtons, .clearOnly, .voiceOnly, .searchGoToOnly, .stopGeneratingOnly:
+        case .noButtons, .clearOnly, .voiceOnly, .searchGoToOnly, .stopGeneratingOnly,
+             .aiChatShortcutOnly:
             return false
         }
     }
@@ -71,7 +77,18 @@ enum SwitchBarButtonState {
         switch self {
         case .stopGeneratingOnly, .stopGeneratingAndSearchGoTo:
             return true
-        case .noButtons, .clearOnly, .voiceOnly, .searchGoToOnly, .voiceAndSearchGoTo:
+        case .noButtons, .clearOnly, .voiceOnly, .searchGoToOnly, .voiceAndSearchGoTo,
+             .aiChatShortcutOnly, .voiceAndAIChatShortcut:
+            return false
+        }
+    }
+
+    var showsAIChatShortcutButton: Bool {
+        switch self {
+        case .aiChatShortcutOnly, .voiceAndAIChatShortcut:
+            return true
+        case .noButtons, .clearOnly, .voiceOnly, .searchGoToOnly, .voiceAndSearchGoTo,
+             .stopGeneratingOnly, .stopGeneratingAndSearchGoTo:
             return false
         }
     }
@@ -81,7 +98,8 @@ enum SwitchBarButtonState {
         case .noButtons:
             return false
         case .clearOnly, .voiceOnly, .searchGoToOnly, .voiceAndSearchGoTo,
-             .stopGeneratingOnly, .stopGeneratingAndSearchGoTo:
+             .stopGeneratingOnly, .stopGeneratingAndSearchGoTo,
+             .aiChatShortcutOnly, .voiceAndAIChatShortcut:
             return true
         }
     }
@@ -104,6 +122,7 @@ class SwitchBarButtonsView: UIView {
     var onVoiceTapped: (() -> Void)?
     var onSearchGoToTapped: (() -> Void)?
     var onStopGeneratingTapped: (() -> Void)?
+    var onAIChatShortcutTapped: (() -> Void)?
 
     private let stack = UIStackView()
     private let clearButton = BrowserChromeButton(.secondary)
@@ -124,6 +143,7 @@ class SwitchBarButtonsView: UIView {
         return view
     }()
     private let voiceButton = BrowserChromeButton(.primary)
+    private let aiChatShortcutButton = BrowserChromeButton(.primary)
     private let separatorView = UIView()
     private let searchGoToButton = BrowserChromeButton(.primary)
 
@@ -166,6 +186,7 @@ class SwitchBarButtonsView: UIView {
         stack.addArrangedSubview(stopGeneratingButton)
         stack.addArrangedSubview(voiceButton)
         stack.addArrangedSubview(separatorView)
+        stack.addArrangedSubview(aiChatShortcutButton)
         stack.addArrangedSubview(searchGoToButton)
     }
 
@@ -190,6 +211,9 @@ class SwitchBarButtonsView: UIView {
             voiceButton.widthAnchor.constraint(equalToConstant: Constants.buttonSize),
             voiceButton.heightAnchor.constraint(equalToConstant: Constants.buttonSize),
 
+            aiChatShortcutButton.widthAnchor.constraint(equalToConstant: Constants.buttonSize),
+            aiChatShortcutButton.heightAnchor.constraint(equalToConstant: Constants.buttonSize),
+
             separatorView.widthAnchor.constraint(equalToConstant: Constants.separatorWidth),
             separatorView.heightAnchor.constraint(equalToConstant: Constants.separatorHeight),
 
@@ -206,6 +230,9 @@ class SwitchBarButtonsView: UIView {
 
         voiceButton.setImage(DesignSystemImages.Glyphs.Size24.microphone)
         voiceButton.addAction(UIAction { [weak self] _ in self?.onVoiceTapped?() }, for: .touchUpInside)
+
+        aiChatShortcutButton.setImage(DesignSystemImages.Glyphs.Size24.aiChat)
+        aiChatShortcutButton.addAction(UIAction { [weak self] _ in self?.onAIChatShortcutTapped?() }, for: .touchUpInside)
 
         separatorView.backgroundColor = UIColor(designSystemColor: .decorationPrimary)
 
@@ -226,6 +253,10 @@ class SwitchBarButtonsView: UIView {
         voiceButton.accessibilityIdentifier = "\(Constants.accessibilityPrefix).Button.VoiceSearch"
         voiceButton.accessibilityTraits = .button
 
+        aiChatShortcutButton.accessibilityLabel = UserText.duckAiFeatureName
+        aiChatShortcutButton.accessibilityIdentifier = "\(Constants.accessibilityPrefix).Button.AIChat"
+        aiChatShortcutButton.accessibilityTraits = .button
+
         searchGoToButton.accessibilityLabel = "Search"
         searchGoToButton.accessibilityIdentifier = "\(Constants.accessibilityPrefix).Button.SearchGoTo"
         searchGoToButton.accessibilityTraits = .button
@@ -235,6 +266,7 @@ class SwitchBarButtonsView: UIView {
         clearButton.isHidden = !buttonState.showsClearButton
         stopGeneratingButton.isHidden = !buttonState.showsStopGeneratingButton
         voiceButton.isHidden = !buttonState.showsVoiceButton
+        aiChatShortcutButton.isHidden = !buttonState.showsAIChatShortcutButton
         separatorView.isHidden = !buttonState.showsSeparator
         searchGoToButton.isHidden = !buttonState.showsSearchGoToButton
     }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarButtonsView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarButtonsView.swift
@@ -30,10 +30,11 @@ enum SwitchBarButtonState {
     case stopGeneratingAndSearchGoTo
     case aiChatShortcutOnly
     case voiceAndAIChatShortcut
+    case clearAndAIChatShortcut
 
     var showsClearButton: Bool {
         switch self {
-        case .clearOnly:
+        case .clearOnly, .clearAndAIChatShortcut:
             return true
         case .noButtons, .voiceOnly, .searchGoToOnly, .voiceAndSearchGoTo,
              .stopGeneratingOnly, .stopGeneratingAndSearchGoTo,
@@ -48,7 +49,7 @@ enum SwitchBarButtonState {
             return true
         case .noButtons, .clearOnly, .searchGoToOnly,
              .stopGeneratingOnly, .stopGeneratingAndSearchGoTo,
-             .aiChatShortcutOnly:
+             .aiChatShortcutOnly, .clearAndAIChatShortcut:
             return false
         }
     }
@@ -58,14 +59,14 @@ enum SwitchBarButtonState {
         case .searchGoToOnly, .voiceAndSearchGoTo, .stopGeneratingAndSearchGoTo:
             return true
         case .noButtons, .clearOnly, .voiceOnly, .stopGeneratingOnly,
-             .aiChatShortcutOnly, .voiceAndAIChatShortcut:
+             .aiChatShortcutOnly, .voiceAndAIChatShortcut, .clearAndAIChatShortcut:
             return false
         }
     }
 
     var showsSeparator: Bool {
         switch self {
-        case .voiceAndSearchGoTo, .stopGeneratingAndSearchGoTo, .voiceAndAIChatShortcut:
+        case .voiceAndSearchGoTo, .stopGeneratingAndSearchGoTo, .voiceAndAIChatShortcut, .clearAndAIChatShortcut:
             return true
         case .noButtons, .clearOnly, .voiceOnly, .searchGoToOnly, .stopGeneratingOnly,
              .aiChatShortcutOnly:
@@ -78,14 +79,14 @@ enum SwitchBarButtonState {
         case .stopGeneratingOnly, .stopGeneratingAndSearchGoTo:
             return true
         case .noButtons, .clearOnly, .voiceOnly, .searchGoToOnly, .voiceAndSearchGoTo,
-             .aiChatShortcutOnly, .voiceAndAIChatShortcut:
+             .aiChatShortcutOnly, .voiceAndAIChatShortcut, .clearAndAIChatShortcut:
             return false
         }
     }
 
     var showsAIChatShortcutButton: Bool {
         switch self {
-        case .aiChatShortcutOnly, .voiceAndAIChatShortcut:
+        case .aiChatShortcutOnly, .voiceAndAIChatShortcut, .clearAndAIChatShortcut:
             return true
         case .noButtons, .clearOnly, .voiceOnly, .searchGoToOnly, .voiceAndSearchGoTo,
              .stopGeneratingOnly, .stopGeneratingAndSearchGoTo:
@@ -99,7 +100,7 @@ enum SwitchBarButtonState {
             return false
         case .clearOnly, .voiceOnly, .searchGoToOnly, .voiceAndSearchGoTo,
              .stopGeneratingOnly, .stopGeneratingAndSearchGoTo,
-             .aiChatShortcutOnly, .voiceAndAIChatShortcut:
+             .aiChatShortcutOnly, .voiceAndAIChatShortcut, .clearAndAIChatShortcut:
             return true
         }
     }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -106,6 +106,7 @@ class SwitchBarTextEntryView: UIView {
     }
 
     var onTextInputActivated: (() -> Void)?
+    var onAIChatShortcutTapped: (() -> Void)?
 
     var isExpandable: Bool = false {
         didSet {
@@ -229,6 +230,10 @@ class SwitchBarTextEntryView: UIView {
 
         buttonsView.onStopGeneratingTapped = { [weak self] in
             self?.handler.stopGeneratingButtonTapped()
+        }
+
+        buttonsView.onAIChatShortcutTapped = { [weak self] in
+            self?.onAIChatShortcutTapped?()
         }
     }
 

--- a/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
@@ -209,7 +209,15 @@ final class DefaultOmniBarSearchView: UIView {
         DefaultOmniBarView.setUpCommonProperties(for: aiChatButton)
 
         isModeToggleHidden = true
-        trailingItemsContainer.setCustomSpacing(8, after: separatorView)
+        // The unified input lays out its trailing buttons with no extra gap after the
+        // separator and uses `decorationPrimary` for the divider line, so we drop the
+        // omnibar's 8pt gap and switch the divider color to match — keeping the mic
+        // position and separator appearance aligned across the focus transition.
+        if UnifiedToggleInputFeature().isAvailable {
+            separatorView.lineColor = UIColor(designSystemColor: .decorationPrimary)
+        } else {
+            trailingItemsContainer.setCustomSpacing(8, after: separatorView)
+        }
 
         reloadButton.setImage(DesignSystemImages.Glyphs.Size24.reload)
         DefaultOmniBarView.setUpCommonProperties(for: reloadButton)

--- a/iOS/DuckDuckGo/URLSeparatorView.swift
+++ b/iOS/DuckDuckGo/URLSeparatorView.swift
@@ -24,6 +24,11 @@ final class URLSeparatorView: UIView {
 
     private let lineView = UIView()
 
+    var lineColor: UIColor? {
+        get { lineView.backgroundColor }
+        set { lineView.backgroundColor = newValue }
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -54,6 +54,7 @@ extension MainViewController {
         coordinator.delegate = self
         coordinator.updateVoiceSearchAvailability(voiceSearchHelper.isVoiceSearchEnabled)
         coordinator.updateAIVoiceChatAvailability(voiceShortcutFeature.isAvailable)
+        coordinator.updateAIChatShortcutAvailability(aiChatAddressBarExperience.shouldShowDuckAIAddressBarButton)
         coordinator.onAnimatedDismissToOmnibar = { [weak self] in
             guard let self, let coordinator = self.unifiedToggleInputCoordinator else { return }
             self.dismissUnifiedToggleInputToOmnibar(coordinator: coordinator)
@@ -618,6 +619,10 @@ extension MainViewController: UnifiedToggleInputDelegate {
         } else {
             handleVoiceSearchOpenRequest(preferredTarget: mode == .aiChat ? .AIChat : .SERP)
         }
+    }
+
+    func unifiedToggleInputDidRequestAIChat() {
+        onAIChatPressed()
     }
 
     func unifiedToggleInputDidChangeHeight() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -278,6 +278,7 @@ private extension MainViewController {
                 let enabled = self.aiChatSettings.isAIChatSearchInputUserSettingsEnabled
                 coordinator.updateToggleEnabled(enabled)
                 coordinator.contentViewController.isSwipeEnabled = enabled
+                coordinator.updateAIChatShortcutAvailability(self.aiChatAddressBarExperience.shouldShowDuckAIAddressBarButton)
             }
             .store(in: &unifiedToggleInputCancellables)
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIRenderState.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIRenderState.swift
@@ -44,12 +44,11 @@ struct UTIRenderState: Equatable {
         )
     }
 
-    /// The inline dismiss (X inside the card's top row) takes over when the expanded card is
-    /// anchored at the top with the Search/Duck.ai toggle enabled. When the toggle setting is
-    /// disabled, the card has no top row to host the X, so the floating dismiss in the content
-    /// container is used instead.
+    /// The inline dismiss (X inside the card) takes over whenever the expanded card is
+    /// anchored at the top. With the toggle enabled it sits in the toggle row; with the
+    /// toggle disabled it sits in the field row alongside the inline buttons.
     var isInlineDismissActive: Bool {
-        cardPosition == .top && isExpanded && isToggleEnabled
+        cardPosition == .top && isExpanded
     }
 
     var isFloatingDismissVisible: Bool {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -562,6 +562,10 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         viewController.isVoiceSearchAvailable = enabled
     }
 
+    func updateAIChatShortcutAvailability(_ available: Bool) {
+        viewController.handler.isAIChatShortcutAvailable = available
+    }
+
     func updateIsFireTab(_ isFireTab: Bool) {
         guard viewController.handler.isFireTab != isFireTab else { return }
         viewController.handler.isFireTab = isFireTab
@@ -987,6 +991,10 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
         // The inline X dismisses the same way the floating X does — forward to the
         // content container's shared handler so both controls route through one path.
         contentViewController.onDismissRequested?()
+    }
+
+    func unifiedToggleInputVCDidTapAIChatShortcut(_ vc: UnifiedToggleInputViewController) {
+        delegate?.unifiedToggleInputDidRequestAIChat()
     }
 }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputDelegate.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputDelegate.swift
@@ -24,6 +24,7 @@ protocol UnifiedToggleInputDelegate: AnyObject {
     func unifiedToggleInputDidSubmitPrompt(_ prompt: String, modelId: String?, tools: [AIChatRAGTool]?, reasoningEffort: AIChatReasoningEffort?, images: [AIChatNativePrompt.NativePromptImage]?)
     func unifiedToggleInputDidSubmitQuery(_ query: String)
     func unifiedToggleInputDidRequestVoiceSearch()
+    func unifiedToggleInputDidRequestAIChat()
     func unifiedToggleInputDidChangeHeight()
     func unifiedToggleInputDidCommitMode(_ mode: TextEntryMode)
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
@@ -89,6 +89,13 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
         }
     }
 
+    var isAIChatShortcutAvailable: Bool = false {
+        didSet {
+            guard isAIChatShortcutAvailable != oldValue else { return }
+            updateButtonState()
+        }
+    }
+
     // MARK: - SwitchBarHandling — Publishers
 
     var currentTextPublisher: AnyPublisher<String, Never> {
@@ -143,9 +150,13 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
 
     // MARK: - Initialization
 
-    init(isVoiceSearchEnabled: Bool, isToggleEnabled: Bool = true, isFireTab: Bool = false) {
+    init(isVoiceSearchEnabled: Bool,
+         isToggleEnabled: Bool = true,
+         isAIChatShortcutAvailable: Bool = false,
+         isFireTab: Bool = false) {
         self.isVoiceSearchEnabled = isVoiceSearchEnabled
         self.isToggleEnabled = isToggleEnabled
+        self.isAIChatShortcutAvailable = isAIChatShortcutAvailable
         self.isFireTab = isFireTab
         updateButtonState()
     }
@@ -215,6 +226,8 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
             nextButtonState = .clearOnly
         } else if !isToggleEnabled && currentToggleState == .aiChat && !isExpanded {
             nextButtonState = voiceAvailable ? .voiceAndSearchGoTo : .searchGoToOnly
+        } else if !isToggleEnabled && currentToggleState == .search && isAIChatShortcutAvailable {
+            nextButtonState = voiceAvailable ? .voiceAndAIChatShortcut : .aiChatShortcutOnly
         } else if voiceAvailable {
             nextButtonState = .voiceOnly
         } else {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
@@ -222,6 +222,8 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
             nextButtonState = .stopGeneratingAndSearchGoTo
         } else if isGenerating && !isExpanded && currentToggleState == .aiChat {
             nextButtonState = .stopGeneratingOnly
+        } else if !currentText.isEmpty && !isToggleEnabled && currentToggleState == .search && isAIChatShortcutAvailable {
+            nextButtonState = .clearAndAIChatShortcut
         } else if !currentText.isEmpty {
             nextButtonState = .clearOnly
         } else if !isToggleEnabled && currentToggleState == .aiChat && !isExpanded {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -212,6 +212,7 @@ final class UnifiedToggleInputView: UIView {
     var onAttachTapped: (() -> Void)?
     var onAttachmentRemoved: ((UUID) -> Void)?
     var onInlineDismissTapped: (() -> Void)?
+    var onAIChatShortcutTapped: (() -> Void)?
 
     // MARK: - Attachment API
 
@@ -842,6 +843,10 @@ private extension UnifiedToggleInputView {
         textEntryView.onTextInputActivated = { [weak self] in
             guard let self, !self.isExpanded else { return }
             self.delegate?.unifiedToggleInputViewDidTapWhileCollapsed(self)
+        }
+
+        textEntryView.onAIChatShortcutTapped = { [weak self] in
+            self?.onAIChatShortcutTapped?()
         }
 
         setupConstraints()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -74,7 +74,7 @@ final class UnifiedToggleInputView: UIView {
         static let toggleHeight: CGFloat = 40
         static let toggleHorizontalPadding: CGFloat = 8
         static let animationDuration: TimeInterval = 0.25
-        static let toggleDisabledSearchTopPadding: CGFloat = 10
+        static let toggleDisabledSearchTopPadding: CGFloat = 6
         static let toolbarHeight: CGFloat = 56
         static let expandedBorderWidth: CGFloat = 0.5
         static let inlineDismissSize: CGFloat = 40
@@ -452,7 +452,7 @@ final class UnifiedToggleInputView: UIView {
             inputTopConstraint.constant = Constants.toggleBottomPadding
             toolbarBottomConstraint.constant = 0
         } else {
-            let usePadding = mode == .search && cardPosition == .bottom
+            let usePadding = mode == .search
             let padding = usePadding ? Constants.toggleDisabledSearchTopPadding : 0
             inputTopConstraint.constant = padding
             toolbarBottomConstraint.constant = -padding
@@ -518,7 +518,7 @@ final class UnifiedToggleInputView: UIView {
         cardView.layer.borderWidth = showToolbar ? Constants.expandedBorderWidth : 0
         cardView.layer.borderColor = showToolbar ? expandedBorderColor : UIColor.clear.cgColor
 
-        let expandedCornerRadius = effectiveToggleEnabled ? Constants.cardCornerRadiusExpanded : Constants.cardCornerRadiusCollapsed
+        let expandedCornerRadius = Constants.cardCornerRadiusExpanded
         let changes = {
             self.cardView.layer.cornerRadius = expanded ? expandedCornerRadius : Constants.cardCornerRadiusCollapsed
             self.cardTopConstraint.constant = topMargin
@@ -530,7 +530,7 @@ final class UnifiedToggleInputView: UIView {
             self.toggleTrailingConstraint.constant = reservesInlineDismissSpace
                 ? Constants.toggleTrailingWithInlineDismiss
                 : -Constants.toggleHorizontalPadding
-            let toggleDisabledSearchPadding = expanded && !self.isToggleEnabled && showToggle && self.handler.currentToggleState == .search && self.cardPosition == .bottom
+            let toggleDisabledSearchPadding = expanded && !self.isToggleEnabled && self.handler.currentToggleState == .search
             self.inputTopConstraint.constant = expanded && effectiveToggleEnabled ? Constants.toggleBottomPadding : (toggleDisabledSearchPadding ? Constants.toggleDisabledSearchTopPadding : 0)
             self.toolbarBottomConstraint.constant = toggleDisabledSearchPadding ? -Constants.toggleDisabledSearchTopPadding : 0
             self.toggleView.alpha = (expanded && effectiveToggleEnabled) ? 1 : 0

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -80,12 +80,18 @@ final class UnifiedToggleInputView: UIView {
         static let inlineDismissSize: CGFloat = 40
         static let inlineDismissTrailingPadding: CGFloat = 8
         static let toggleInlineDismissSpacing: CGFloat = 6
-        /// Carves room for the floating X at `.top` when the toggle is disabled.
-        static let cardTrailingMarginWithFloatingDismiss: CGFloat = 68
+        /// Spacing between the inline dismiss button and the field's trailing edge when the
+        /// dismiss shares the field row (toggle disabled, top position).
+        static let fieldRowInlineDismissSpacing: CGFloat = 4
 
         /// Trailing constant for the toggle when the inline dismiss button shares the top row.
         static var toggleTrailingWithInlineDismiss: CGFloat {
             -(inlineDismissTrailingPadding + inlineDismissSize + toggleInlineDismissSpacing)
+        }
+
+        /// Trailing constant for the text entry field when the inline dismiss shares the field row.
+        static var textEntryViewTrailingWithInlineDismiss: CGFloat {
+            -(inlineDismissTrailingPadding + inlineDismissSize + fieldRowInlineDismissSpacing)
         }
 
         static let allCorners: CACornerMask = [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
@@ -310,7 +316,10 @@ final class UnifiedToggleInputView: UIView {
     private var toggleTrailingConstraint: NSLayoutConstraint!
     private var toggleHeightConstraint: NSLayoutConstraint!
     private var inlineDismissHeightConstraint: NSLayoutConstraint!
+    private var inlineDismissTopConstraint: NSLayoutConstraint!
+    private var inlineDismissCenterYConstraint: NSLayoutConstraint!
     private var inputTopConstraint: NSLayoutConstraint!
+    private var textEntryViewTrailingConstraint: NSLayoutConstraint!
     private var toolbarBottomConstraint: NSLayoutConstraint!
     private var attachmentsStripHeightConstraint: NSLayoutConstraint!
     private var toolbarHeightConstraint: NSLayoutConstraint!
@@ -464,6 +473,11 @@ final class UnifiedToggleInputView: UIView {
         // with the toggle via `applyToggleRevealChanges` rather than snapping in on activation.
         let reservesInlineDismissSpace = expanded && cardPosition == .top
         let showInlineDismiss = reservesInlineDismissSpace && effectiveToggleEnabled
+        // When the toggle is disabled by the user but the card is anchored at the top, the X
+        // moves into the field row alongside the inline trailing buttons. Keyed on
+        // `isToggleEnabled` (not `effectiveToggleEnabled`) so the dismiss stays hidden during
+        // the toggle-on activation transient where `showToggle` is briefly `false`.
+        let showFieldRowInlineDismiss = expanded && cardPosition == .top && !isToggleEnabled
 
         let hLeadingMargin: CGFloat
         let hTrailingMargin: CGFloat
@@ -520,7 +534,9 @@ final class UnifiedToggleInputView: UIView {
             self.inputTopConstraint.constant = expanded && effectiveToggleEnabled ? Constants.toggleBottomPadding : (toggleDisabledSearchPadding ? Constants.toggleDisabledSearchTopPadding : 0)
             self.toolbarBottomConstraint.constant = toggleDisabledSearchPadding ? -Constants.toggleDisabledSearchTopPadding : 0
             self.toggleView.alpha = (expanded && effectiveToggleEnabled) ? 1 : 0
-            self.applyInlineDismissVisibility(showInlineDismiss)
+            self.applyInlineDismissVerticalAnchor(useFieldRowAnchor: showFieldRowInlineDismiss)
+            self.applyInlineDismissVisibility(showInlineDismiss || showFieldRowInlineDismiss)
+            self.applyTextEntryViewTrailingInset(showFieldRowInlineDismiss: showFieldRowInlineDismiss)
             self.toolbarHeightConstraint.constant = showToolbar ? Constants.toolbarHeight : 0
             self.toolsToolbar.alpha = showToolbar ? 1 : 0
             self.updateAttachmentsStripLayout()
@@ -664,14 +680,11 @@ final class UnifiedToggleInputView: UIView {
 
     // MARK: - Private
 
-    /// Card trailing margin for the current state. Carves out room for the floating X in
-    /// the content container when the toggle is disabled at `.top`; otherwise the card
-    /// spans the full width to host the inline X.
+    /// Card trailing margin for the current state. The card spans the full width since the
+    /// inline X is hosted inside the card (in the toggle row when the toggle is shown, or in
+    /// the field row alongside the inline buttons when the toggle is hidden at `.top`).
     private var cardTrailingMargin: CGFloat {
-        let needsFloatingDismissCarveOut = isExpanded && cardPosition == .top && !isToggleEnabled
-        return needsFloatingDismissCarveOut
-            ? Constants.cardTrailingMarginWithFloatingDismiss
-            : Constants.cardHorizontalMargin
+        Constants.cardHorizontalMargin
     }
 
     private func updateToolbarVisibility(for mode: TextEntryMode, animated: Bool) {
@@ -713,11 +726,15 @@ private extension UnifiedToggleInputView {
     /// Updates layout and opacity so the toggle either reserves space for the inline dismiss
     /// button or expands to fill the card's top row. Safe to call outside of animation blocks.
     func refreshInlineDismissPresentation() {
-        let shouldShow = isExpanded && cardPosition == .top && isToggleEnabled
-        toggleTrailingConstraint.constant = shouldShow
+        let isAtTop = isExpanded && cardPosition == .top
+        let showToggleRowDismiss = isAtTop && isToggleEnabled
+        let showFieldRowDismiss = isAtTop && !isToggleEnabled
+        toggleTrailingConstraint.constant = isAtTop
             ? Constants.toggleTrailingWithInlineDismiss
             : -Constants.toggleHorizontalPadding
-        applyInlineDismissVisibility(shouldShow)
+        applyInlineDismissVerticalAnchor(useFieldRowAnchor: showFieldRowDismiss)
+        applyInlineDismissVisibility(showToggleRowDismiss || showFieldRowDismiss)
+        applyTextEntryViewTrailingInset(showFieldRowInlineDismiss: showFieldRowDismiss)
         layoutIfNeeded()
     }
 
@@ -729,6 +746,27 @@ private extension UnifiedToggleInputView {
         inlineDismissButton.alpha = visible ? 1 : 0
         inlineDismissButton.isUserInteractionEnabled = visible
         inlineDismissHeightConstraint.constant = visible ? Constants.inlineDismissSize : 0
+    }
+
+    /// Switches the inline dismiss button between the toggle-row anchor (top of card) and the
+    /// field-row anchor (vertically centered with `textEntryView`). The latter is used when
+    /// the toggle is hidden so the X visually shares a row with the inline trailing buttons.
+    func applyInlineDismissVerticalAnchor(useFieldRowAnchor: Bool) {
+        if useFieldRowAnchor {
+            inlineDismissTopConstraint.isActive = false
+            inlineDismissCenterYConstraint.isActive = true
+        } else {
+            inlineDismissCenterYConstraint.isActive = false
+            inlineDismissTopConstraint.isActive = true
+        }
+    }
+
+    /// Pulls the text entry field's trailing edge in to leave room for the inline dismiss
+    /// when it shares the field row, otherwise lets the field span the card's full width.
+    func applyTextEntryViewTrailingInset(showFieldRowInlineDismiss: Bool) {
+        textEntryViewTrailingConstraint.constant = showFieldRowInlineDismiss
+            ? Constants.textEntryViewTrailingWithInlineDismiss
+            : 0
     }
 
     @objc func handleInlineDismissTap() {
@@ -865,7 +903,10 @@ private extension UnifiedToggleInputView {
         toggleHeightConstraint = toggleView.heightAnchor.constraint(equalToConstant: 0)
         toggleTrailingConstraint = toggleView.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -Constants.toggleHorizontalPadding)
         inlineDismissHeightConstraint = inlineDismissButton.heightAnchor.constraint(equalToConstant: 0)
+        inlineDismissTopConstraint = inlineDismissButton.topAnchor.constraint(equalTo: cardView.topAnchor, constant: Constants.toggleTopPadding)
+        inlineDismissCenterYConstraint = inlineDismissButton.centerYAnchor.constraint(equalTo: textEntryView.centerYAnchor)
         inputTopConstraint = textEntryView.topAnchor.constraint(equalTo: toggleView.bottomAnchor, constant: 0)
+        textEntryViewTrailingConstraint = textEntryView.trailingAnchor.constraint(equalTo: cardView.trailingAnchor)
         toolbarBottomConstraint = toolsToolbar.bottomAnchor.constraint(equalTo: cardView.bottomAnchor)
         attachmentsStripHeightConstraint = attachmentsStrip.heightAnchor.constraint(equalToConstant: 0)
         toolbarHeightConstraint = toolsToolbar.heightAnchor.constraint(equalToConstant: 0)
@@ -881,14 +922,14 @@ private extension UnifiedToggleInputView {
             toggleTrailingConstraint,
             toggleHeightConstraint,
 
-            inlineDismissButton.topAnchor.constraint(equalTo: cardView.topAnchor, constant: Constants.toggleTopPadding),
+            inlineDismissTopConstraint,
             inlineDismissButton.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -Constants.inlineDismissTrailingPadding),
             inlineDismissButton.widthAnchor.constraint(equalToConstant: Constants.inlineDismissSize),
             inlineDismissHeightConstraint,
 
             inputTopConstraint,
             textEntryView.leadingAnchor.constraint(equalTo: cardView.leadingAnchor),
-            textEntryView.trailingAnchor.constraint(equalTo: cardView.trailingAnchor),
+            textEntryViewTrailingConstraint,
 
             attachmentsStrip.topAnchor.constraint(equalTo: textEntryView.bottomAnchor),
             attachmentsStrip.leadingAnchor.constraint(equalTo: cardView.leadingAnchor),

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -564,25 +564,27 @@ final class UnifiedToggleInputView: UIView {
         setExpanded(expanded, showToggle: false, animated: false)
     }
 
-    /// Top: slim card with toggle hidden. Bottom: collapsed bar.
+    /// Top + toggle-on: slim card with toggle hidden so the toggle can fade in alongside
+    /// the bar's grow animation. Top + toggle-off and bottom: collapsed bar — there's no
+    /// toggle-reveal transient to stage, so the show pose animates straight from collapsed
+    /// to expanded inside the surrounding `UIView.animate`.
     func prepareForOmnibarEditingShow() {
-        switch cardPosition {
-        case .top:
+        switch (cardPosition, isToggleEnabled) {
+        case (.top, true):
             setExpanded(false, animated: false)
             setExpandedWithToggleHidden(true)
-        case .bottom:
+        case (_, _):
             setExpanded(false, animated: false)
         }
     }
 
     /// Active editing pose. Call inside a UIView.animate block.
     func applyOmnibarEditingShowPose() {
-        switch cardPosition {
-        case .top:
-            guard isToggleEnabled else { return }
+        switch (cardPosition, isToggleEnabled) {
+        case (.top, true):
             applyToggleRevealChanges()
             layoutIfNeeded()
-        case .bottom:
+        case (_, _):
             setExpanded(true, animated: false)
         }
     }
@@ -591,20 +593,22 @@ final class UnifiedToggleInputView: UIView {
     /// Shadow swap is deferred to `finalizeOmnibarEditingDismiss` so the dominant expanded shadow
     /// stays visible during collapse instead of snapping off mid-animation.
     func applyOmnibarEditingDismissPose() {
-        switch cardPosition {
-        case .top:
-            guard isToggleEnabled else { return }
+        switch (cardPosition, isToggleEnabled) {
+        case (.top, true):
             applyToggleHideChanges()
             layoutIfNeeded()
-        case .bottom:
+        case (_, _):
             setExpanded(false, animated: false, updateShadow: false)
         }
     }
 
-    /// Snap the shadow to its collapsed-pose state. Only bottom needs this — top dismiss never
-    /// alters the shadow during animation. Call after the UTI is hidden.
+    /// Snap the shadow to its collapsed-pose state. Bottom and top + toggle-off both defer the
+    /// shadow swap during dismiss to keep the dominant expanded shadow visible across the
+    /// animation; this restores the collapsed shadow once the UTI is hidden. Top + toggle-on
+    /// never alters the shadow during animation, so it doesn't need finalizing here.
     func finalizeOmnibarEditingDismiss() {
-        guard cardPosition.isBottom else { return }
+        let needsShadowFinalize = cardPosition.isBottom || (cardPosition == .top && !isToggleEnabled)
+        guard needsShadowFinalize else { return }
         expandedShadowView.isHidden = true
         cardView.layer.shadowOpacity = 1.0
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -67,7 +67,7 @@ final class UnifiedToggleInputView: UIView {
         // Match the omnibar's small-top spacing so the dismiss snap lands on identical pill frames.
         static let collapsedCardTopMarginBottom: CGFloat = 10
         static let collapsedCardBottomMarginBottom: CGFloat = 6
-        static let cardCornerRadiusExpanded: CGFloat = 24
+        static let cardCornerRadiusExpanded: CGFloat = 28
         static let cardCornerRadiusCollapsed: CGFloat = 16
         static let toggleTopPadding: CGFloat = 8
         static let toggleBottomPadding: CGFloat = 4

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -36,6 +36,7 @@ protocol UnifiedToggleInputViewControllerDelegate: AnyObject {
     func unifiedToggleInputVCDidChangeAttachments(_ vc: UnifiedToggleInputViewController)
     func unifiedToggleInputVCDidChangeHeight(_ vc: UnifiedToggleInputViewController)
     func unifiedToggleInputVCDidTapInlineDismiss(_ vc: UnifiedToggleInputViewController)
+    func unifiedToggleInputVCDidTapAIChatShortcut(_ vc: UnifiedToggleInputViewController)
 }
 
 // MARK: - View Controller
@@ -327,6 +328,10 @@ final class UnifiedToggleInputViewController: UIViewController {
         barView.onInlineDismissTapped = { [weak self] in
             guard let self else { return }
             delegate?.unifiedToggleInputVCDidTapInlineDismiss(self)
+        }
+        barView.onAIChatShortcutTapped = { [weak self] in
+            guard let self else { return }
+            delegate?.unifiedToggleInputVCDidTapAIChatShortcut(self)
         }
         view = barView
     }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIRenderStateTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIRenderStateTests.swift
@@ -221,18 +221,18 @@ final class UTIRenderStateTests: XCTestCase {
         XCTAssertFalse(sut.computeRenderState().isInlineDismissActive)
     }
 
-    func test_inlineDismiss_hiddenWhenToggleDisabled() {
+    func test_inlineDismiss_activeWhenToggleDisabledAtTop() {
+        // With the toggle setting off, the inline X now lives in the field row alongside the
+        // mic / Duck.ai shortcut; the floating X is no longer used for this state.
         sut = UnifiedToggleInputCoordinator(isToggleEnabled: false)
         sut.activateFromOmnibar(cardPosition: .top)
-        XCTAssertFalse(sut.computeRenderState().isInlineDismissActive)
+        XCTAssertTrue(sut.computeRenderState().isInlineDismissActive)
     }
 
-    func test_floatingDismiss_visibleAtTopWhenToggleDisabled() {
-        // Regression: with the toggle setting off, the card has no top row for the inline X;
-        // the floating X must still appear so users can dismiss the omnibar session.
+    func test_floatingDismiss_hiddenAtTopWhenToggleDisabled() {
         sut = UnifiedToggleInputCoordinator(isToggleEnabled: false)
         sut.activateFromOmnibar(cardPosition: .top)
-        XCTAssertTrue(sut.computeRenderState().isFloatingDismissVisible)
+        XCTAssertFalse(sut.computeRenderState().isFloatingDismissVisible)
     }
 
     func test_inlineDismiss_hiddenWhenCollapsed() {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift
@@ -210,6 +210,7 @@ private final class SpyUnifiedToggleInputDelegate: UnifiedToggleInputDelegate {
     }
     func unifiedToggleInputDidSubmitQuery(_ query: String) {}
     func unifiedToggleInputDidRequestVoiceSearch() {}
+    func unifiedToggleInputDidRequestAIChat() {}
     func unifiedToggleInputDidChangeHeight() {}
     func unifiedToggleInputDidCommitMode(_ mode: TextEntryMode) {}
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -1408,6 +1408,24 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         XCTAssertTrue(sut.viewController.isToolbarAIVoiceChatActive)
     }
 
+    // MARK: - AI Chat Shortcut
+
+    func test_updateAIChatShortcutAvailability_propagatesToHandler() {
+        sut.updateAIChatShortcutAvailability(true)
+        XCTAssertTrue(sut.viewController.handler.isAIChatShortcutAvailable)
+
+        sut.updateAIChatShortcutAvailability(false)
+        XCTAssertFalse(sut.viewController.handler.isAIChatShortcutAvailable)
+    }
+
+    func test_unifiedToggleInputVCDidTapAIChatShortcut_invokesDelegate() {
+        XCTAssertEqual(mockDelegate.didRequestAIChatCount, 0)
+
+        sut.unifiedToggleInputVCDidTapAIChatShortcut(sut.viewController)
+
+        XCTAssertEqual(mockDelegate.didRequestAIChatCount, 1)
+    }
+
     // MARK: - Helpers
 
     private func makeModel(id: String, access: Bool, supportsImageUpload: Bool = false, supportedTools: [AIChatRAGTool] = []) -> AIChatModel {
@@ -1497,6 +1515,7 @@ private final class MockUnifiedToggleInputDelegate: UnifiedToggleInputDelegate {
     var submittedImages: [AIChatNativePrompt.NativePromptImage]?
     var submittedQuery: String?
     var committedMode: TextEntryMode?
+    var didRequestAIChatCount = 0
 
     func unifiedToggleInputDidSubmitPrompt(_ prompt: String, modelId: String?, tools: [AIChatRAGTool]?, reasoningEffort: AIChatReasoningEffort?, images: [AIChatNativePrompt.NativePromptImage]?) {
         submittedPrompt = prompt
@@ -1507,6 +1526,7 @@ private final class MockUnifiedToggleInputDelegate: UnifiedToggleInputDelegate {
     }
     func unifiedToggleInputDidSubmitQuery(_ query: String) { submittedQuery = query }
     func unifiedToggleInputDidRequestVoiceSearch() {}
+    func unifiedToggleInputDidRequestAIChat() { didRequestAIChatCount += 1 }
     func unifiedToggleInputDidChangeHeight() {}
     func unifiedToggleInputDidCommitMode(_ mode: TextEntryMode) {
         committedMode = mode

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputHandlerTests.swift
@@ -362,7 +362,7 @@ final class UnifiedToggleInputHandlerTests: XCTestCase {
         XCTAssertEqual(sut.buttonState, .noButtons)
     }
 
-    func test_toggleOff_searchMode_hasText_aiShortcutOn_showsClearOnly() {
+    func test_toggleOff_searchMode_hasText_aiShortcutOn_showsClearAndAIChatShortcut() {
         sut = UnifiedToggleInputHandler(
             isVoiceSearchEnabled: true,
             isToggleEnabled: false,
@@ -371,7 +371,7 @@ final class UnifiedToggleInputHandlerTests: XCTestCase {
         sut.setToggleState(.search)
         sut.updateCurrentText("hello")
 
-        XCTAssertEqual(sut.buttonState, .clearOnly)
+        XCTAssertEqual(sut.buttonState, .clearAndAIChatShortcut)
     }
 
     func test_toggleOn_searchMode_empty_aiShortcutAvailable_doesNotShowAIChatShortcut() {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputHandlerTests.swift
@@ -324,4 +324,87 @@ final class UnifiedToggleInputHandlerTests: XCTestCase {
         sut.stopGeneratingButtonTapped()
         waitForExpectations(timeout: 1)
     }
+
+    // MARK: - AI Chat Shortcut Button State
+
+    func test_toggleOff_searchMode_empty_voiceOn_aiShortcutOn_showsVoiceAndAIChatShortcut() {
+        sut = UnifiedToggleInputHandler(
+            isVoiceSearchEnabled: true,
+            isToggleEnabled: false,
+            isAIChatShortcutAvailable: true
+        )
+        sut.setToggleState(.search)
+
+        XCTAssertEqual(sut.buttonState, .voiceAndAIChatShortcut)
+    }
+
+    func test_toggleOff_searchMode_empty_voiceOff_aiShortcutOn_showsAIChatShortcutOnly() {
+        sut = UnifiedToggleInputHandler(
+            isVoiceSearchEnabled: false,
+            isToggleEnabled: false,
+            isAIChatShortcutAvailable: true
+        )
+        sut.setToggleState(.search)
+
+        XCTAssertEqual(sut.buttonState, .aiChatShortcutOnly)
+    }
+
+    func test_toggleOff_searchMode_empty_aiShortcutOff_fallsBackToVoiceOnlyOrNoButtons() {
+        sut = UnifiedToggleInputHandler(
+            isVoiceSearchEnabled: true,
+            isToggleEnabled: false,
+            isAIChatShortcutAvailable: false
+        )
+        sut.setToggleState(.search)
+        XCTAssertEqual(sut.buttonState, .voiceOnly)
+
+        sut.isVoiceSearchEnabled = false
+        XCTAssertEqual(sut.buttonState, .noButtons)
+    }
+
+    func test_toggleOff_searchMode_hasText_aiShortcutOn_showsClearOnly() {
+        sut = UnifiedToggleInputHandler(
+            isVoiceSearchEnabled: true,
+            isToggleEnabled: false,
+            isAIChatShortcutAvailable: true
+        )
+        sut.setToggleState(.search)
+        sut.updateCurrentText("hello")
+
+        XCTAssertEqual(sut.buttonState, .clearOnly)
+    }
+
+    func test_toggleOn_searchMode_empty_aiShortcutAvailable_doesNotShowAIChatShortcut() {
+        sut = UnifiedToggleInputHandler(
+            isVoiceSearchEnabled: true,
+            isToggleEnabled: true,
+            isAIChatShortcutAvailable: true
+        )
+        sut.setToggleState(.search)
+
+        XCTAssertEqual(sut.buttonState, .voiceOnly)
+    }
+
+    func test_toggleOff_aiChatMode_empty_aiShortcutAvailable_keepsVoiceAndSearchGoToBranch() {
+        sut = UnifiedToggleInputHandler(
+            isVoiceSearchEnabled: true,
+            isToggleEnabled: false,
+            isAIChatShortcutAvailable: true
+        )
+        // Default state is .aiChat; toggle-off + .aiChat hits the existing voice/searchGoTo branch.
+        XCTAssertEqual(sut.buttonState, .voiceAndSearchGoTo)
+    }
+
+    func test_isAIChatShortcutAvailable_setterRefreshesButtonState() {
+        sut = UnifiedToggleInputHandler(
+            isVoiceSearchEnabled: false,
+            isToggleEnabled: false,
+            isAIChatShortcutAvailable: false
+        )
+        sut.setToggleState(.search)
+        XCTAssertEqual(sut.buttonState, .noButtons)
+
+        sut.isAIChatShortcutAvailable = true
+        XCTAssertEqual(sut.buttonState, .aiChatShortcutOnly)
+    }
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputReasoningTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputReasoningTests.swift
@@ -265,6 +265,7 @@ private final class MockUnifiedToggleInputReasoningDelegate: UnifiedToggleInputD
 
     func unifiedToggleInputDidSubmitQuery(_ query: String) {}
     func unifiedToggleInputDidRequestVoiceSearch() {}
+    func unifiedToggleInputDidRequestAIChat() {}
     func unifiedToggleInputDidChangeHeight() {}
     func unifiedToggleInputDidCommitMode(_ mode: TextEntryMode) {}
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211767540372501/task/1214420693891551?focus=true

### Description

- Refines the unified input's UI when the Search/Duck.ai toggle is disabled by the user: card now sizes to 56pt with 8pt vertical padding around the inline buttons, and uses the larger 24pt expanded corner radius
- Hosts the inline dismiss (X) button inside the card's field row when the card is anchored at the top with the toggle disabled, replacing the previous floating-X-with-card-carve-out approach
- Adds the Duck.ai shortcut button to the toggle-off field row (alongside the mic), so users can still reach Duck.ai when the toggle is hidden, and keeps it visible while the user is typing (with a separator between the clear and Duck.ai shortcut buttons)
- Fixes the Duck.ai shortcut button not respecting live setting changes — toggling "Duck.ai in address bar" off (or disabling Duck.ai entirely) now hides it immediately instead of requiring an app restart
- Wires `UnifiedToggleInputDelegate.unifiedToggleInputDidRequestAIChat()` to `MainViewController.onAIChatPressed()` so the new shortcut button opens Duck.ai consistently with the legacy omnibar
- Adds unit tests covering the new button states, the inline-dismiss render-state changes, and the AI chat shortcut delegate plumbing

### Testing Steps

Prerequisites:
- Use a build with the `unifiedToggleInput` feature flag ON.
- In Settings → Duck.ai, ensure both "Duck.ai" and "Show Duck.ai in address bar" are enabled to start.

1. Disable the Search/Duck.ai toggle: Settings → Duck.ai → turn off "Duck.ai in search input" (the setting that hides the in-omnibar Search/Duck.ai pill toggle).
2. Tap the address bar to enter editing state at the **bottom** position.
   - Verify the card height is 56pt with comfortable vertical padding around the close (X), mic, and Duck.ai (`+`) buttons.
   - Verify the card uses the larger, rounder corner radius.
   - Verify the row order is: text field, mic, separator, Duck.ai, X.
3. Move the omnibar to the **top** position (Settings → Address bar → Top) and reactivate it.
   - Verify the same 56pt height and rounded corners as the bottom case.
   - Verify the X is now inside the card on the field row, not floating outside the card.
4. Type some text into the field.
   - Verify the Duck.ai (`+`) button stays visible alongside the clear (X) button, separated by the divider.
   - Clear the text and confirm the row returns to mic + separator + Duck.ai.
5. With the address bar still active, tap the Duck.ai (`+`) button → verify Duck.ai opens (same behaviour as the legacy `+` button).
6. Without killing the app, go to Settings → Duck.ai and turn off "Show Duck.ai in address bar".
   - Return to the browser and tap the address bar → verify the Duck.ai (`+`) button is gone.
7. Re-enable "Show Duck.ai in address bar" → verify the Duck.ai button reappears immediately.
8. Repeat step 6/7 by toggling Duck.ai globally off/on (the umbrella setting) → verify the same live behaviour.
9. Re-enable the Search/Duck.ai toggle and verify the toggle-on UI is unchanged (separator only between mic and Duck.ai shortcut where applicable, normal expanded card with the Search/Duck.ai pill row, etc.).
10. Turn the `unifiedToggleInput` feature flag OFF and confirm the legacy omnibar/SwitchBar UI is unchanged in all the same scenarios.

### Impact and Risks

**Impact Level: Low**

Scoped entirely to the unified-input feature flag's ON state. The toggle-disabled UX is a refinement of an in-development feature and does not affect the legacy omnibar/SwitchBar code path (verified in tests + the `unifiedToggleInput` flag check). User data, privacy, and core browser flows are unaffected. The new `SwitchBarButtonState` cases were added with full switch coverage, so the compiler enforces correctness for any other consumers of the enum.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state changes scoped to the `UnifiedToggleInput` path; main risk is regressions in input bar layout/visibility logic when the Search/Duck.ai toggle is disabled or settings change live.
> 
> **Overview**
> Adds an inline Duck.ai shortcut button to the unified input’s trailing controls when the Search/Duck.ai toggle is disabled, including new `SwitchBarButtonState` cases and tap plumbing from `SwitchBarTextEntryView` through `UnifiedToggleInputCoordinator` to `MainViewController.onAIChatPressed()`.
> 
> Refines toggle-off layout/behavior: the inline dismiss (X) is now always hosted inside the card when expanded at the top (no floating dismiss for that state), spacing/corner radius/padding rules are adjusted, and Duck.ai shortcut availability now updates live in response to settings changes. Unit tests are updated/added to cover the new render-state rules, shortcut propagation, and button-state matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 501789f9cf17ed5234e8821f7f653576a7d8d469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->