### PR TITLE
Add optOutFormSubmittedDate to PIR native↔web contract

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/UIWeb/DBPUICommunicationModel.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/UIWeb/DBPUICommunicationModel.swift
@@ -247,6 +247,17 @@ public struct DBPUIBirthYear: Codable {
 /// Message object containing information related to a profile match on a data broker
 /// The message contains the data broker on which the profile was found and the names
 /// and addresses that were matched
+///
+/// There are three distinct moments in an opt-out's lifecycle that the contract surfaces:
+///   1. Form submitted — we successfully completed the form submission to the broker.
+///      This is `optOutFormSubmittedDate`.
+///   2. Opt-out submitted (broker-acknowledged) — for brokers that require email confirmation,
+///      the moment the broker confirmed receipt by email; for brokers that do not require email
+///      confirmation, this matches moment 1. This is `optOutSubmittedDate`.
+///   3. Removal confirmed — a follow-up scan finds the user's record gone. This is `removedDate`.
+///
+/// Web should read `optOutFormSubmittedDate ?? optOutSubmittedDate` so that older native clients
+/// (which do not yet emit `optOutFormSubmittedDate`) keep working.
 public struct DBPUIDataBrokerProfileMatch: Codable {
     public let id: Int64?
     public let dataBroker: DBPUIDataBroker
@@ -255,12 +266,31 @@ public struct DBPUIDataBrokerProfileMatch: Codable {
     public let alternativeNames: [String]
     public let relatives: [String]
     public let foundDate: Double
+    /// Moment 2 in the opt-out lifecycle. For brokers that require email confirmation this is the
+    /// instant the broker confirmed receipt by email; for brokers that do not, it matches
+    /// `optOutFormSubmittedDate`. Set once on first success; not overwritten on retries.
     public let optOutSubmittedDate: Double?
+    /// Moment 1 in the opt-out lifecycle: the instant our form-submission action against the
+    /// broker successfully completed. Set on every match regardless of broker type, including
+    /// child brokers (where it is propagated from the most recent opt-out on the parent broker).
+    /// Set once on first success; not overwritten on retries.
+    public let optOutFormSubmittedDate: Double?
     public let estimatedRemovalDate: Double?
     public let removedDate: Double?
     public let hasMatchingRecordOnParentBroker: Bool
 
-    public init(id: Int64?, dataBroker: DBPUIDataBroker, name: String, addresses: [DBPUIUserProfileAddress], alternativeNames: [String], relatives: [String], foundDate: Double, optOutSubmittedDate: Double? = nil, estimatedRemovalDate: Double? = nil, removedDate: Double? = nil, hasMatchingRecordOnParentBroker: Bool) {
+    public init(id: Int64?,
+                dataBroker: DBPUIDataBroker,
+                name: String,
+                addresses: [DBPUIUserProfileAddress],
+                alternativeNames: [String],
+                relatives: [String],
+                foundDate: Double,
+                optOutSubmittedDate: Double? = nil,
+                optOutFormSubmittedDate: Double? = nil,
+                estimatedRemovalDate: Double? = nil,
+                removedDate: Double? = nil,
+                hasMatchingRecordOnParentBroker: Bool) {
         self.id = id
         self.dataBroker = dataBroker
         self.name = name
@@ -269,6 +299,7 @@ public struct DBPUIDataBrokerProfileMatch: Codable {
         self.relatives = relatives
         self.foundDate = foundDate
         self.optOutSubmittedDate = optOutSubmittedDate
+        self.optOutFormSubmittedDate = optOutFormSubmittedDate
         self.estimatedRemovalDate = estimatedRemovalDate
         self.removedDate = removedDate
         self.hasMatchingRecordOnParentBroker = hasMatchingRecordOnParentBroker
@@ -313,6 +344,14 @@ extension DBPUIDataBrokerProfileMatch {
             extractedProfile.doesMatchExtractedProfile(parentOptOut.extractedProfile)
         } ?? false
 
+        // Derive the form-submission moment from the events already loaded on the read path.
+        // For child brokers (no own form submission), fall back to the most recent submission
+        // across any opt-out on the parent broker — see TD note: the structural parent↔child
+        // relationship is what matters, not strict profile matching, which rejects nearly every
+        // real-world child↔parent pairing because brokers scrape name granularity inconsistently.
+        let optOutFormSubmittedDate = Self.optOutFormSubmittedDate(in: optOutJobData.historyEvents)
+            ?? parentBrokerOptOutJobData.flatMap(Self.mostRecentOptOutFormSubmittedDate(across:))
+
         self.init(id: extractedProfile.id,
                   dataBroker: dataBroker,
                   name: extractedProfile.fullName ?? "No name",
@@ -321,9 +360,42 @@ extension DBPUIDataBrokerProfileMatch {
                   relatives: extractedProfile.relatives ?? [String](),
                   foundDate: foundDate.timeIntervalSince1970,
                   optOutSubmittedDate: optOutSubmittedDate?.timeIntervalSince1970,
+                  optOutFormSubmittedDate: optOutFormSubmittedDate?.timeIntervalSince1970,
                   estimatedRemovalDate: estimatedRemovalDate?.timeIntervalSince1970,
                   removedDate: extractedProfile.removedDate?.timeIntervalSince1970,
                   hasMatchingRecordOnParentBroker: hasFoundParentMatch)
+    }
+
+    /// Derives the moment our form-submission action against the broker successfully completed,
+    /// from the history events already loaded alongside the opt-out on the read path.
+    ///
+    /// For brokers that require email confirmation, the form-submission moment is the first
+    /// `.optOutSubmittedAndAwaitingEmailConfirmation` event — `.optOutRequested` is logged later,
+    /// after the broker confirms by email, which is moment 2 not moment 1.
+    ///
+    /// For brokers that do not require email confirmation, `.optOutRequested` is logged at
+    /// form-submission success, so it represents both moment 1 and moment 2.
+    ///
+    /// Returns the earliest matching event so the value is set once at the first successful
+    /// submission and not overwritten on retries.
+    static func optOutFormSubmittedDate(in historyEvents: [HistoryEvent]) -> Date? {
+        if let firstEmailConfirmationSubmitted = historyEvents
+            .filter({ $0.type == .optOutSubmittedAndAwaitingEmailConfirmation })
+            .min(by: { $0.date < $1.date }) {
+            return firstEmailConfirmationSubmitted.date
+        }
+        return historyEvents
+            .filter { $0.type == .optOutRequested }
+            .min(by: { $0.date < $1.date })?.date
+    }
+
+    /// The most recent `optOutFormSubmittedDate` derivation across the given opt-out jobs,
+    /// regardless of whether their extracted profiles match anything. Used for the child→parent
+    /// broker-level fallback.
+    static func mostRecentOptOutFormSubmittedDate(across jobs: [OptOutJobData]) -> Date? {
+        jobs.lazy
+            .compactMap { optOutFormSubmittedDate(in: $0.historyEvents) }
+            .max()
     }
 
     /// Generates an array of `DBPUIDataBrokerProfileMatch` objects from the provided query data.

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/DBPUICommunicationModelTests.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/DBPUICommunicationModelTests.swift
@@ -229,6 +229,258 @@ final class DBPUICommunicationModelTests: XCTestCase {
         XCTAssertTrue(profileMatch.hasMatchingRecordOnParentBroker)
     }
 
+    // MARK: - optOutFormSubmittedDate derivation
+
+    func testProfileMatchInit_whenNonEmailBrokerHasOptOutRequestedEvent_thenOptOutFormSubmittedDateIsThatEventDate() {
+
+        // Given — non-email-confirming broker: `.optOutRequested` is logged at form submission
+        // success, so it represents both moment 1 and moment 2.
+        let extractedProfile = ExtractedProfile.mockWithoutRemovedDate
+        let optOutRequestedDate = Calendar.current.date(byAdding: .day, value: -3, to: Date.now)!
+        let historyEvents = [
+            HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutRequested, date: optOutRequestedDate)
+        ]
+        let optOut = OptOutJobData.mock(with: extractedProfile,
+                                        historyEvents: historyEvents,
+                                        createdDate: Date.now,
+                                        submittedSuccessfullyDate: optOutRequestedDate)
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: optOut,
+                                                       dataBroker: makeUIBroker(),
+                                                       parentBrokerOptOutJobData: nil)
+
+        // Then
+        XCTAssertEqual(profileMatch.optOutFormSubmittedDate, optOutRequestedDate.timeIntervalSince1970)
+        XCTAssertEqual(profileMatch.optOutSubmittedDate, optOutRequestedDate.timeIntervalSince1970)
+    }
+
+    func testProfileMatchInit_whenEmailBrokerHasFormSubmittedAndConfirmationEvents_thenOptOutFormSubmittedDateIsTheFormSubmissionEventDate() {
+
+        // Given — email-confirming broker: `.optOutSubmittedAndAwaitingEmailConfirmation` is
+        // logged at form submission (moment 1), `.optOutRequested` is logged later, after the
+        // broker confirms by email (moment 2).
+        let extractedProfile = ExtractedProfile.mockWithoutRemovedDate
+        let formSubmittedAtDate = Calendar.current.date(byAdding: .day, value: -5, to: Date.now)!
+        let emailConfirmedDate = Calendar.current.date(byAdding: .day, value: -2, to: Date.now)!
+        let historyEvents = [
+            HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutSubmittedAndAwaitingEmailConfirmation, date: formSubmittedAtDate),
+            HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutRequested, date: emailConfirmedDate)
+        ]
+        let optOut = OptOutJobData.mock(with: extractedProfile,
+                                        historyEvents: historyEvents,
+                                        createdDate: Date.now,
+                                        submittedSuccessfullyDate: emailConfirmedDate)
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: optOut,
+                                                       dataBroker: makeUIBroker(),
+                                                       parentBrokerOptOutJobData: nil)
+
+        // Then
+        XCTAssertEqual(profileMatch.optOutFormSubmittedDate, formSubmittedAtDate.timeIntervalSince1970)
+        XCTAssertEqual(profileMatch.optOutSubmittedDate, emailConfirmedDate.timeIntervalSince1970)
+    }
+
+    func testProfileMatchInit_whenMultipleSubmissionEventsExist_thenOptOutFormSubmittedDateIsTheFirstOne() {
+
+        // Given — value should be set once at the first successful submission and not overwritten
+        // on retries.
+        let extractedProfile = ExtractedProfile.mockWithoutRemovedDate
+        let firstAttempt = Calendar.current.date(byAdding: .day, value: -10, to: Date.now)!
+        let secondAttempt = Calendar.current.date(byAdding: .day, value: -5, to: Date.now)!
+        let historyEvents = [
+            HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutRequested, date: secondAttempt),
+            HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutRequested, date: firstAttempt)
+        ]
+        let optOut = OptOutJobData.mock(with: extractedProfile,
+                                        historyEvents: historyEvents,
+                                        createdDate: Date.now,
+                                        submittedSuccessfullyDate: nil)
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: optOut,
+                                                       dataBroker: makeUIBroker(),
+                                                       parentBrokerOptOutJobData: nil)
+
+        // Then
+        XCTAssertEqual(profileMatch.optOutFormSubmittedDate, firstAttempt.timeIntervalSince1970)
+    }
+
+    func testProfileMatchInit_whenNoSubmissionEventsAndNoParent_thenOptOutFormSubmittedDateIsNil() {
+
+        // Given
+        let extractedProfile = ExtractedProfile.mockWithoutRemovedDate
+        let historyEvents = [
+            HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .matchesFound(count: 1), date: Date.now)
+        ]
+        let optOut = OptOutJobData.mock(with: extractedProfile,
+                                        historyEvents: historyEvents,
+                                        createdDate: Date.now,
+                                        submittedSuccessfullyDate: nil)
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: optOut,
+                                                       dataBroker: makeUIBroker(),
+                                                       parentBrokerOptOutJobData: nil)
+
+        // Then
+        XCTAssertNil(profileMatch.optOutFormSubmittedDate)
+    }
+
+    func testProfileMatchInit_whenChildBrokerHasNoOwnSubmissionEventsButParentDoes_thenOptOutFormSubmittedDateFallsBackToParent() {
+
+        // Given — child broker's opt-out is performed by its parent rather than directly, so the
+        // child has no submission events of its own; the parent ran the opt-out and has the
+        // submission event.
+        let extractedProfile = ExtractedProfile.mockWithName("Steve Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+        let parentProfile = ExtractedProfile.mockWithName("Steve Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+
+        let parentSubmissionDate = Calendar.current.date(byAdding: .day, value: -4, to: Date.now)!
+        let parentEvents = [
+            HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutRequested, date: parentSubmissionDate)
+        ]
+
+        let childOptOut = OptOutJobData.mock(with: extractedProfile, historyEvents: [])
+        let parentOptOut = OptOutJobData.mock(with: parentProfile, historyEvents: parentEvents)
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: childOptOut,
+                                                       dataBroker: makeUIBroker(parentURL: "parent.com"),
+                                                       parentBrokerOptOutJobData: [parentOptOut])
+
+        // Then
+        XCTAssertEqual(profileMatch.optOutFormSubmittedDate, parentSubmissionDate.timeIntervalSince1970)
+    }
+
+    func testProfileMatchInit_whenChildBrokerHasNoOwnSubmissionEventsAndParentMatchHasNone_thenOptOutFormSubmittedDateIsNil() {
+
+        // Given
+        let extractedProfile = ExtractedProfile.mockWithName("Steve Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+        let parentProfile = ExtractedProfile.mockWithName("Steve Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+
+        let childOptOut = OptOutJobData.mock(with: extractedProfile, historyEvents: [])
+        let parentOptOut = OptOutJobData.mock(with: parentProfile, historyEvents: [])
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: childOptOut,
+                                                       dataBroker: makeUIBroker(parentURL: "parent.com"),
+                                                       parentBrokerOptOutJobData: [parentOptOut])
+
+        // Then
+        XCTAssertNil(profileMatch.optOutFormSubmittedDate)
+    }
+
+    func testProfileMatchInit_whenChildHasOwnSubmissionEventAndParentAlsoHasOne_thenOptOutFormSubmittedDatePrefersChild() {
+
+        // Given — defensive: if a child somehow has its own submission event, the child's own
+        // value should win over the parent fallback.
+        let extractedProfile = ExtractedProfile.mockWithName("Steve Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+        let parentProfile = ExtractedProfile.mockWithName("Steve Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+
+        let childSubmission = Calendar.current.date(byAdding: .day, value: -2, to: Date.now)!
+        let parentSubmission = Calendar.current.date(byAdding: .day, value: -10, to: Date.now)!
+
+        let childOptOut = OptOutJobData.mock(
+            with: extractedProfile,
+            historyEvents: [HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutRequested, date: childSubmission)]
+        )
+        let parentOptOut = OptOutJobData.mock(
+            with: parentProfile,
+            historyEvents: [HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutRequested, date: parentSubmission)]
+        )
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: childOptOut,
+                                                       dataBroker: makeUIBroker(parentURL: "parent.com"),
+                                                       parentBrokerOptOutJobData: [parentOptOut])
+
+        // Then
+        XCTAssertEqual(profileMatch.optOutFormSubmittedDate, childSubmission.timeIntervalSince1970)
+    }
+
+    func testProfileMatchInit_whenChildHasNoSubmissionEventsAndParentMatchIsNotAnExactProfileMatch_thenOptOutFormSubmittedDateStillUsesParentSubmission() {
+
+        // Given — broker-level fallback: every child broker record is structurally downstream of
+        // the parent, so any parent submission is a removal request that may clear this record.
+        // The strict matcher (`doesMatchExtractedProfile`) is reserved for
+        // `hasMatchingRecordOnParentBroker`.
+        let extractedProfile = ExtractedProfile.mockWithName("Steve Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+        let parentProfileNonmatching = ExtractedProfile.mockWithName("Jamie Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+
+        let parentSubmission = Calendar.current.date(byAdding: .day, value: -4, to: Date.now)!
+        let childOptOut = OptOutJobData.mock(with: extractedProfile, historyEvents: [])
+        let parentOptOut = OptOutJobData.mock(
+            with: parentProfileNonmatching,
+            historyEvents: [HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutRequested, date: parentSubmission)]
+        )
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: childOptOut,
+                                                       dataBroker: makeUIBroker(parentURL: "parent.com"),
+                                                       parentBrokerOptOutJobData: [parentOptOut])
+
+        // Then
+        XCTAssertEqual(profileMatch.optOutFormSubmittedDate, parentSubmission.timeIntervalSince1970)
+        // Strict matcher still rejects, so the parent-broker-duplicate signal stays false.
+        XCTAssertFalse(profileMatch.hasMatchingRecordOnParentBroker)
+    }
+
+    func testProfileMatchInit_whenMultipleParentJobsHaveSubmissions_thenChildUsesMostRecent() {
+
+        // Given — three parent opt-outs, two with submissions on different dates, one without.
+        // The fallback should pick the most recent submission across all parent jobs.
+        let extractedProfile = ExtractedProfile.mockWithName("Steve Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+        let parentA = ExtractedProfile.mockWithName("Adam P Smith", age: "46", addresses: [AddressCityState(city: "San Diego", state: "CA")])
+        let parentB = ExtractedProfile.mockWithName("Adam M Smith", age: "48", addresses: [AddressCityState(city: "San Diego", state: "CA")])
+        let parentC = ExtractedProfile.mockWithName("Adam O Smith", age: "50", addresses: [AddressCityState(city: "San Diego", state: "CA")])
+
+        let oldSubmission = Calendar.current.date(byAdding: .day, value: -10, to: Date.now)!
+        let recentSubmission = Calendar.current.date(byAdding: .day, value: -2, to: Date.now)!
+
+        let childOptOut = OptOutJobData.mock(with: extractedProfile, historyEvents: [])
+        let parentOptOutA = OptOutJobData.mock(
+            with: parentA,
+            historyEvents: [HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutRequested, date: oldSubmission)]
+        )
+        let parentOptOutB = OptOutJobData.mock(
+            with: parentB,
+            historyEvents: [HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutSubmittedAndAwaitingEmailConfirmation, date: recentSubmission)]
+        )
+        let parentOptOutC = OptOutJobData.mock(with: parentC, historyEvents: [])
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: childOptOut,
+                                                       dataBroker: makeUIBroker(parentURL: "parent.com"),
+                                                       parentBrokerOptOutJobData: [parentOptOutA, parentOptOutB, parentOptOutC])
+
+        // Then
+        XCTAssertEqual(profileMatch.optOutFormSubmittedDate, recentSubmission.timeIntervalSince1970)
+    }
+
+    func testProfileMatchInit_whenAllParentJobsAreMissingSubmissionEvents_thenOptOutFormSubmittedDateIsNil() {
+
+        // Given — parent has opt-outs but none reached a submission event (e.g. only started, or
+        // failed). Broker-level fallback should resolve to nil rather than papering over the
+        // missing submission.
+        let extractedProfile = ExtractedProfile.mockWithName("Steve Jones", age: "20", addresses: [AddressCityState(city: "New York", state: "NY")])
+        let parentProfile = ExtractedProfile.mockWithName("Adam P Smith", age: "46", addresses: [AddressCityState(city: "San Diego", state: "CA")])
+
+        let childOptOut = OptOutJobData.mock(with: extractedProfile, historyEvents: [])
+        let parentOptOut = OptOutJobData.mock(
+            with: parentProfile,
+            historyEvents: [HistoryEvent(extractedProfileId: 0, brokerId: 0, profileQueryId: 0, type: .optOutStarted, date: Date.now)]
+        )
+
+        // When
+        let profileMatch = DBPUIDataBrokerProfileMatch(optOutJobData: childOptOut,
+                                                       dataBroker: makeUIBroker(parentURL: "parent.com"),
+                                                       parentBrokerOptOutJobData: [parentOptOut])
+
+        // Then
+        XCTAssertNil(profileMatch.optOutFormSubmittedDate)
+    }
+
     // MARK: - `profileMatches` Broker OptOut URL & Name tests
 
     func testProfileMatches_optOutUrlAndBrokerNameForChildBroker() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Task/Issue URL:
Tech Design URL:
CC:

### Description

Adds a nullable Unix-seconds `optOutFormSubmittedDate` field to `DBPUIDataBrokerProfileMatch` so the PIR web dashboard can count what we did (form submissions) rather than what the broker did (acknowledgements). The existing `optOutSubmittedDate` is unchanged.

The native↔web contract previously surfaced only one timestamp relevant to submission status, `optOutSubmittedDate`, which represents broker acknowledgement for ~50/61 email-confirming brokers and form-submission for the rest. With low confirmation rates the dashboard's "submitted" count effectively reflected broker acknowledgements rather than our actions.

There are three distinct moments in an opt-out's lifecycle:
1. **Form submitted** — we successfully completed the form submission to the broker → new `optOutFormSubmittedDate`
2. **Opt-out submitted (broker-acknowledged)** — for email-confirming brokers, the moment the broker confirmed receipt by email; for non-email brokers, identical to moment 1 → existing `optOutSubmittedDate`
3. **Removal confirmed** — a follow-up scan finds the user's record gone → existing `removedDate`

The new field is derived **at read time** from history events already loaded alongside each `OptOut`. No new persisted column, no backfill.

#### Derivation rules

- For brokers that require email confirmation, the form-submission moment is the first `.optOutSubmittedAndAwaitingEmailConfirmation` event. `.optOutRequested` is logged later, after the broker confirms by email, which is moment 2 not moment 1.
- For brokers that do not require email confirmation, `.optOutRequested` is logged at form-submission success, so it represents both moment 1 and moment 2.
- The earliest matching event wins, so the value is set once at the first successful submission and not overwritten on retries.

#### Child broker propagation

Child brokers (whose opt-out is performed by their parent) never run their own form submission. The convenience init falls back to the most recent `optOutFormSubmittedDate` across **any** opt-out on the parent broker — the structural parent↔child relationship is what matters, not strict profile matching. Strict matching (`doesMatchExtractedProfile`) is unchanged and still gates `hasMatchingRecordOnParentBroker`; using it for the timestamp fallback would reject nearly every real-world child↔parent pairing because brokers scrape name granularity inconsistently.

#### Backwards compatibility

Web reads `optOutFormSubmittedDate ?? optOutSubmittedDate`, so older native clients keep working. The new field is additive and nullable.

### Testing Steps

1. Run `DBPUICommunicationModelTests` in the `DataBrokerProtection-macOS` test target. The new `optOutFormSubmittedDate` test cases cover both broker types (email-confirming and non-email), the first-submission-wins semantics, and the parent-value derivation path for child brokers (including the strict-matcher mismatch case, the multi-parent most-recent case, and the all-parents-failed case).
2. Run the existing `DBPUICommunicationModelTests` cases to confirm `optOutSubmittedDate`, `foundDate`, and `hasMatchingRecordOnParentBroker` semantics are unchanged.

### Impact and Risks

Low. Additive, nullable field on the native↔web JSON payload. Other consumers of `optOutSubmittedDate` (broker info modal timeline, orphaned-record detection, "Waiting for confirmation" copy) are untouched.

#### What could go wrong?

- **Wrong derivation for email-confirming brokers**: covered by `testProfileMatchInit_whenEmailBrokerHasFormSubmittedAndConfirmationEvents_thenOptOutFormSubmittedDateIsTheFormSubmissionEventDate`. Asserts the form-submission timestamp comes from the email-confirmation-pending event, not the later `.optOutRequested` event.
- **Retry overwrites first-submission timestamp**: covered by `testProfileMatchInit_whenMultipleSubmissionEventsExist_thenOptOutFormSubmittedDateIsTheFirstOne`.
- **Child broker shows nil because strict matcher rejects parent**: covered by `testProfileMatchInit_whenChildHasNoSubmissionEventsAndParentMatchIsNotAnExactProfileMatch_thenOptOutFormSubmittedDateStillUsesParentSubmission`.
- **Child broker picks an old parent submission instead of the recent one**: covered by `testProfileMatchInit_whenMultipleParentJobsHaveSubmissions_thenChildUsesMostRecent`.

### Quality Considerations

- **Performance**: Derivation reads from `optOutJobData.historyEvents` and `parentBrokerOptOutJobData`, both of which the existing read paths already load. No extra query, no extra DB hit. The parent-broker derivation is a single linear scan over the per-parent opt-out array the existing code already builds.
- **Privacy**: No new user data is collected or persisted. The timestamp is already captured internally and only sent over the WebView contract — never persisted by the web client and never included in pixels.
- **Documentation**: Doc comments on `optOutSubmittedDate` and `optOutFormSubmittedDate` now spell out the moment-1 vs moment-2 distinction inline (the contract is documented in the source struct itself, not in a separate file).

### Notes to Reviewer

- The new derivation helpers (`optOutFormSubmittedDate(in:)` and `mostRecentOptOutFormSubmittedDate(across:)`) are static internal methods on `DBPUIDataBrokerProfileMatch`, kept colocated with the convenience init that uses them.
- A prototype existed in #4631; this PR ships a clean, production-quality version (final field name `optOutFormSubmittedDate` per the tech design, no unrelated rollback noise, doc comments updated to clarify the moment-1 vs moment-2 distinction, and a `DBPUIOptOutMatch`-side check confirmed unchanged because that struct only surfaces records that already have a `removedDate`).

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c19dbdc2-7c15-4df0-96c0-0ed3346c2b8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c19dbdc2-7c15-4df0-96c0-0ed3346c2b8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

