### PR TITLE
prevent tab preview crash

### DIFF
--- a/iOS/DuckDuckGo/TabViewCell.swift
+++ b/iOS/DuckDuckGo/TabViewCell.swift
@@ -183,7 +183,7 @@ class TabViewCell: UICollectionViewCell {
 
     private func updatePreviewToDisplay(image: UIImage) {
         let imageAspectRatio = image.size.width > 0 ? image.size.height / image.size.width : 1.0
-        let containerAspectRatio = (background.bounds.height - TabViewCell.Constants.cellHeaderHeight) / background.bounds.width
+        let containerAspectRatio = background.bounds.width > 0 ? (background.bounds.height - TabViewCell.Constants.cellHeaderHeight) / background.bounds.width : 1.0
 
         let strechContainerVerically = containerAspectRatio < imageAspectRatio
 

--- a/iOS/DuckDuckGo/TabViewCell.swift
+++ b/iOS/DuckDuckGo/TabViewCell.swift
@@ -182,7 +182,7 @@ class TabViewCell: UICollectionViewCell {
     }
 
     private func updatePreviewToDisplay(image: UIImage) {
-        let imageAspectRatio = image.size.height / image.size.width
+        let imageAspectRatio = image.size.width > 0 ? image.size.height / image.size.width : 1.0
         let containerAspectRatio = (background.bounds.height - TabViewCell.Constants.cellHeaderHeight) / background.bounds.width
 
         let strechContainerVerically = containerAspectRatio < imageAspectRatio


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1214310730947012?focus=true
Tech Design URL:
CC:

### Description
Fix crash by preventing NaN being passed to multiplier of constraint.

### Testing Steps
1. Open a few tabs and check the previews are working as per production.

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Could create some weird previews or not fix the crash (which is not reproducible).

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds simple guards to avoid division-by-zero/NaN when computing the preview aspect-ratio constraint multiplier; impact is limited to tab preview layout in edge cases.
> 
> **Overview**
> Prevents a crash in tab preview rendering by guarding aspect-ratio calculations in `TabViewCell.updatePreviewToDisplay(image:)` against zero-width images or containers.
> 
> When width is zero, the code now falls back to a `1.0` aspect ratio so a valid multiplier is always passed into the Auto Layout constraint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc817a58520a005019d65bc20c6046b21a2c7153. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->