### PR TITLE
Add ddg-github-pr skill

### DIFF
--- a/.claude/skills/ddg-github-pr/SKILL.md
+++ b/.claude/skills/ddg-github-pr/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: ddg-github-pr
+description: >
+  Creates GitHub pull requests for any DuckDuckGo team using the correct
+  platform-specific PR template. Use this skill whenever asked to open, draft,
+  or create a PR in a DuckDuckGo GitHub repository.
+---
+
+# DuckDuckGo GitHub PR Creation
+
+## Step 1 — Detect the platform team
+
+Determine which platform team owns the target repo:
+
+| Repo contains | Team |
+|---------------|------|
+| `apple-browsers` | Apple |
+| `windows-browser` | Windows |
+| `android` | Android |
+| Any other DDG repo | Use Apple template as default, note uncertainty |
+
+## Step 2 — Gather required fields
+
+Before creating the PR, collect:
+
+- **Task/Issue URL** — the Asana task URL (required). Ask the user if not provided.
+- **Tech Design URL** — link to a Tech Design doc if a design was created; leave blank otherwise.
+- **CC** — Mattermost handles of people to notify; leave blank if none.
+- **Description** — what changed and why.
+- **Testing steps** — how a reviewer can manually verify the change.
+- **Impact and risks** — what could go wrong; list rollback steps or mitigations.
+- **Quality considerations** — automated test coverage; new tests added; note if none needed and why.
+
+## Step 3 — Format by platform
+
+### Apple (`apple-browsers`)
+
+```
+Task/Issue URL: <url>
+Tech Design URL: <url or blank>
+CC: <handles or blank>
+
+### Description
+<what changed and why>
+
+### Testing Steps
+<numbered steps to manually verify>
+
+### Impact and Risks
+
+#### What could go wrong?
+<list risks and mitigations>
+
+### Quality Considerations
+<test coverage added; if no tests, explain why>
+
+---
+
+###### Internal references: [DoD](https://app.asana.com/0/1207634633537039) | [Eng Expectations](https://app.asana.com/0/199064865822552) | [Tech Design Template](https://app.asana.com/0/184709971311943)
+```
+
+### Windows (`windows-browser`)
+
+```
+Task/Issue URL: <url>
+Tech Design URL: <url or blank>
+Copy for release note: <user-facing release note sentence, or blank>
+CC: <handles or blank>
+
+Description
+
+---
+<what changed and why>
+
+Steps to test this PR
+
+---
+<numbered steps to manually verify>
+
+[PR Checklist](https://app.asana.com/0/1201007608267168)
+
+Automated tests
+
+---
+<list test method names and CI labels added; or "No new automated tests — <reason>">
+```
+
+### Android
+
+```
+Task/Issue URL: <url>
+
+### Description
+<what changed and why>
+
+### Steps to test this PR
+- [ ] <step>
+- [ ] <step>
+
+### UI changes
+| Before | After |
+|--------|-------|
+| <screenshot or N/A> | <screenshot or N/A> |
+```
+
+## Step 4 — Run `gh pr create`
+
+Use a HEREDOC to pass the body:
+
+```bash
+gh pr create \
+  --title "<short imperative title under 70 chars>" \
+  --body "$(cat <<'EOF'
+<filled template from Step 3>
+EOF
+)"
+```
+
+- Target branch: `main` unless the user specifies otherwise.
+- Add `--draft` if the PR is not ready for review.
+- Return the PR URL to the user when done.
+
+## Apple Definition of Done (checklist before marking ready for review)
+
+- [ ] PR description is complete with testing steps and risk assessment
+- [ ] Manually tested on a real device (or simulator if appropriate)
+- [ ] Happy path, error cases, and boundary conditions covered by automated tests
+- [ ] Pixel / analytics events have tests
+- [ ] No `// swiftlint:disable` added without justification
+- [ ] CI is passing (or failures are understood and unrelated)
+- [ ] User-visible strings are localized
+
+## Key Asana References
+
+| Document | GID |
+|----------|-----|
+| Apple Definition of Done | 1207634633537039 |
+| Software Engineering Expectations | 199064865822552 |
+| Technical Design Template | 184709971311943 |


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214137467353555/task/1214447047392520?focus=true
Tech Design URL:
CC:

### Description
Adds a Claude Code skill at `.claude/skills/ddg-github-pr/SKILL.md` that ensures Claude uses the correct platform-specific PR template when creating PRs in any DuckDuckGo GitHub repo.

Built by analysing the last 10 PRs across all DDG GitHub repos and cross-referencing PR guidelines in Asana (Apple DoD, Software Engineering Expectations, Technical Design Template). The skill detects the platform team from the repo name (Apple / Windows / Android) and fills the appropriate template before running `gh pr create`.

### Testing Steps
1. Check out this branch and open Claude Code in `apple-browsers`.
2. Ask Claude to create a PR — e.g. "create a PR pointing to `<asana-url>`".
3. Verify the `ddg-github-pr` skill is invoked and the resulting PR body matches the Apple template structure (Task/Issue URL · Tech Design URL · CC header · ### Description · ### Testing Steps · ### Impact and Risks · ### Quality Considerations · internal references footer).

### Impact and Risks

#### What could go wrong?
No production code changed — this is a Claude Code skill (configuration file only). No effect on the app, CI, or any shared system.

### Quality Considerations
No automated tests applicable. Skill files are Claude Code configuration; correctness is verified by manually invoking the skill as described in the testing steps above.

---

###### Internal references: [DoD](https://app.asana.com/0/1207634633537039) | [Eng Expectations](https://app.asana.com/0/199064865822552) | [Tech Design Template](https://app.asana.com/0/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a Claude Code skill/configuration file only; no production code or runtime behavior changes. Risk is limited to PR authoring quality if the template selection or fields are wrong.
> 
> **Overview**
> Adds a new Claude Code skill at `.claude/skills/ddg-github-pr/SKILL.md` that guides PR creation for DuckDuckGo repos by selecting an Apple/Windows/Android PR body template based on repo name and prompting for required fields.
> 
> Includes the exact platform-specific PR formats plus a `gh pr create` heredoc example and references/checklists to standardize PR descriptions across teams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5a4644c1f04202577f7ae4f98c30d1ee4226a9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->