### PR TITLE
macOS: Fix UP/DOWN arrow keys with multiline text in Duck.ai address bar

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
@@ -489,6 +489,10 @@ extension AIChatOmnibarTextContainerViewController: FocusableTextViewNavigationD
         return viewModel.selectPrevious()
     }
 
+    func isSuggestionSelected() -> Bool {
+        omnibarController.suggestionsViewModel.selectedIndex != nil
+    }
+
     func textViewDidRequestSelectCurrentSuggestion() -> Bool {
         if omnibarController.suggestionsViewModel.isViewAllChatsSelected {
             return omnibarController.submitSelectedSuggestion()
@@ -524,6 +528,8 @@ protocol FocusableTextViewNavigationDelegate: AnyObject {
     /// Called when user presses up arrow on the first line (when suggestions are selected)
     /// - Returns: `true` if navigation was handled, `false` otherwise
     func textViewDidRequestMoveFromSuggestions() -> Bool
+    /// Whether a suggestion is currently selected in the suggestions list.
+    func isSuggestionSelected() -> Bool
     /// Called when user presses Enter while a suggestion is selected
     /// - Returns: `true` if a suggestion was selected, `false` otherwise
     func textViewDidRequestSelectCurrentSuggestion() -> Bool
@@ -640,7 +646,8 @@ private final class FocusableTextView: NSTextView {
     }
 
     override func moveDown(_ sender: Any?) {
-        if isCursorOnLastLine() {
+        let suggestionSelected = navigationDelegate?.isSuggestionSelected() ?? false
+        if suggestionSelected || isCursorOnLastLine() {
             if navigationDelegate?.textViewDidRequestMoveToSuggestions() == true {
                 return
             }
@@ -649,9 +656,11 @@ private final class FocusableTextView: NSTextView {
     }
 
     override func moveUp(_ sender: Any?) {
-        // First check if we should navigate in suggestions
-        if navigationDelegate?.textViewDidRequestMoveFromSuggestions() == true {
-            return
+        let suggestionSelected = navigationDelegate?.isSuggestionSelected() ?? false
+        if suggestionSelected || isCursorOnFirstLine() {
+            if navigationDelegate?.textViewDidRequestMoveFromSuggestions() == true {
+                return
+            }
         }
         super.moveUp(sender)
     }
@@ -674,5 +683,20 @@ private final class FocusableTextView: NSTextView {
         layoutManager.lineFragmentRect(forGlyphAt: lastGlyphIndex, effectiveRange: &lastLineRange)
 
         return NSMaxRange(lineRange) >= NSMaxRange(lastLineRange)
+    }
+
+    /// Checks if the cursor is on the first line of the text view
+    private func isCursorOnFirstLine() -> Bool {
+        guard let layoutManager = layoutManager else {
+            return true
+        }
+
+        let selectedRange = selectedRange()
+        let glyphRange = layoutManager.glyphRange(forCharacterRange: selectedRange, actualCharacterRange: nil)
+
+        var lineRange = NSRange()
+        layoutManager.lineFragmentRect(forGlyphAt: glyphRange.location, effectiveRange: &lineRange)
+
+        return lineRange.location == 0
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1214279321176716

### Description

In Duck.ai address bar mode, UP/DOWN arrow keys always navigated the suggestions list and never moved the cursor between lines of multi-line input.

`FocusableTextView.moveUp` always delegated to suggestion navigation; `selectPrevious()` always returns `true` when suggestions exist, so `super.moveUp` was never reached. This change gates suggestion navigation in both `moveUp` and `moveDown` on either an active suggestion selection or the cursor being at the first/last line — otherwise the cursor moves within the text.

### Testing Steps

1. Open Duck.ai mode in the address bar with recent chats / suggestions visible.
2. Type a multi-line prompt (Shift+Option+Enter to insert newlines).
3. UP/DOWN move the cursor between lines; reaching the first/last line and pressing UP/DOWN selects the last/first suggestion.
4. With a suggestion selected, UP/DOWN continues to navigate suggestions.
5. Enter still submits a selected suggestion or the prompt as before.

### Impact and Risks

Low — scoped to two overrides on the Duck.ai-only `FocusableTextView`. Existing suggestion-navigation paths are preserved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped to keyboard navigation gating in `FocusableTextView` and a small delegate API addition; suggestion-selection behavior is preserved but arrow-key handling changes could affect edge-case navigation.
> 
> **Overview**
> Fixes UP/DOWN arrow behavior in the Duck.ai omnibar when the prompt is multiline by only handing arrow keys to the suggestions list when a suggestion is already selected or the caret is on the first/last line.
> 
> This adds `isSuggestionSelected()` to `FocusableTextViewNavigationDelegate`, implements it in `AIChatOmnibarTextContainerViewController`, and introduces `isCursorOnFirstLine()` to mirror the existing last-line check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd34163dd943230636eab308b2bee1beb92f26c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->