### PR TITLE
macOS: Restores Tab Right Separators

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -247,7 +247,6 @@ final class TabBarItemCellView: NSView {
         return view
     }()
 
-    /// Deprecated: Always hidden when `tabAnimations` is enabled
     fileprivate let rightSeparatorView = ColorView(frame: .zero)
 
     /// Deprecated: Replaced by `TabBackgroundView`
@@ -603,6 +602,7 @@ extension TabBarItemCellView: ThemeUpdateListening {
         if displaysTabsAnimations {
             backgroundView.backgroundColor = colorsProvider.navigationBackgroundColor
             backgroundView.overlayColor = tabStyleProvider.hoverTabColor
+            rightSeparatorView.backgroundColor = tabStyleProvider.separatorColor
         } else {
             leftRampView.rampColor = colorsProvider.navigationBackgroundColor
             rightRampView.rampColor = colorsProvider.navigationBackgroundColor

--- a/macOS/DuckDuckGo/VisualRefresh/TabStyleProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/TabStyleProviding.swift
@@ -102,7 +102,7 @@ final class TabAnimationsStyleProvider: TabStyleProviding {
     let pinnedTabWidth: CGFloat = 38
     let pinnedTabHeight: CGFloat = 38
     let shouldShowSShapedTab = true
-    let shouldShowTabSeparators = false
+    let shouldShowTabSeparators = true
     let isRoundedBackgroundPresentOnHover = true
     let tabSpacing: CGFloat = 0
     let applyTabShadow: Bool = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1214138915723958
Tech Design URL:
CC:

### Description
This PR restores the Tab Separators on macOS.

### Testing Steps
1. Launch the browser
2. Add several New Tabs (so that the CollectionView overflows)

- [ ] Verify the Tab Dividers are displayed

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The Separators could be rendered incorrectly

### Quality Considerations
None

### Notes to Reviewer
Thank you!!


### Screenshots

Before | Now
-|-
<img width="400" alt="Before" src="https://github.com/user-attachments/assets/c6e47405-5f54-46c2-8ed4-1fb20fb9e233" /> | <img width="400" alt="Now" src="https://github.com/user-attachments/assets/9467afc2-785e-4ecd-8cb6-4dbc9bd28230" />


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change that re-enables tab separators and ensures they are themed correctly when `displaysTabsAnimations` is on; potential issues are limited to separator rendering/visibility.
> 
> **Overview**
> Restores the right-hand tab separators in the macOS tab bar by turning `shouldShowTabSeparators` back on for the animations tab style.
> 
> Also updates `TabBarItemCellView.applyThemeStyle` to set `rightSeparatorView`’s color in the tab-animations rendering path so separators are correctly themed when animations are enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c00b7837d19595d55ba062064e32eb4189d79aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->