### PR TITLE
Fix failing pixels report

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -597,6 +597,11 @@
                 "key": "removed_at",
                 "description": "Timestamp, in milliseconds, when the broker was removed at (contained on the JSON)",
                 "type": "string"
+            },
+            {
+                "key": "keystoreField",
+                "description": "Present only when the underlying failure is a SecureVault keystore read error. Identifies the keychain account that failed to read (free-form string set by the secure storage layer).",
+                "type": "string"
             }
         ]
     },


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1214280322091000?focus=true
Tech Design URL:
CC: @samhouts 

### Description
Adds `keystoreField` to the parameters list of the `m_mac_dbp_update_databrokers_failure` pixel definition.

### Testing Steps
CI stays 🟢 

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
N/A

### Quality Considerations
N/A

### Notes to Reviewer
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change to the `PixelDefinitions` schema; it only expands allowed parameters for a single failure pixel and should not affect runtime behavior beyond reporting.
> 
> **Overview**
> Updates the `m_mac_dbp_update_databrokers_failure` pixel definition to accept a new optional `keystoreField` parameter, used to report which SecureVault/keychain account failed during keystore reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5218ba8682356201a9681b5d008cb8371f420ce2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->