### PR TITLE
Add new sync setup pixels, and new callsites for existing pixels

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1355,6 +1355,10 @@ extension Pixel {
         case settingsEmailProtectionEnable
         case settingsGeneralOpen
         case settingsSyncOpen
+        case settingsSyncBackUpThisDeviceTapped
+        case settingsSyncRecoverSyncedDataTapped
+        case settingsSyncSignupConfirmedTapped
+        case settingsSyncRecoveryConfirmedTapped
         case settingsAppearanceOpen
         case settingsThemeSelectorPressed
         case settingsAddressBarTopSelected
@@ -1934,6 +1938,10 @@ extension Pixel.Event {
         case .settingsEmailProtectionEnable: return "m_settings_email_protection_enable"
         case .settingsGeneralOpen: return "m_settings_general_open"
         case .settingsSyncOpen: return "m_settings_sync_open"
+        case .settingsSyncBackUpThisDeviceTapped: return "m_settings_sync_back_up_this_device_tapped"
+        case .settingsSyncRecoverSyncedDataTapped: return "m_settings_sync_recover_synced_data_tapped"
+        case .settingsSyncSignupConfirmedTapped: return "m_settings_sync_signup_confirmed_tapped"
+        case .settingsSyncRecoveryConfirmedTapped: return "m_settings_sync_recovery_confirmed_tapped"
         case .settingsAppearanceOpen: return "m_settings_appearance_open"
         case .settingsThemeSelectorPressed: return "m_settings_theme_selector_pressed"
         case .settingsAddressBarTopSelected: return "m_settings_address_bar_top_selected"

--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -180,6 +180,9 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                     let additionalParameters = self.source.map { ["source": $0] } ?? [:]
                     try await Pixel.fire(pixel: .syncSignupDirect, withAdditionalParameters: additionalParameters, includedParameters: [.appVersion])
                     self.syncSetupExperimentPixels.fireSignupDirect()
+                    try await Pixel.fire(pixel: .syncSetupEndedSuccessful,
+                                         withAdditionalParameters: [PixelParameters.source: "signup"],
+                                         includedParameters: [.appVersion])
                     self.syncSetupExperimentPixels.fireSetupEndedSuccessful()
                     AutofillOnboardingExperimentPixelReporter().fireSyncEnabled(true)
                     self.viewModel.syncEnabled(recoveryCode: self.recoveryCode)
@@ -203,6 +206,9 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                 let additionalParameters = self.source.map { ["source": $0] } ?? [:]
                 try await Pixel.fire(pixel: .syncSignupDirect, withAdditionalParameters: additionalParameters, includedParameters: [.appVersion])
                 self.syncSetupExperimentPixels.fireSignupDirect()
+                try await Pixel.fire(pixel: .syncSetupEndedSuccessful,
+                                     withAdditionalParameters: [PixelParameters.source: "signup"],
+                                     includedParameters: [.appVersion])
                 self.syncSetupExperimentPixels.fireSetupEndedSuccessful()
                 AutofillOnboardingExperimentPixelReporter().fireSyncEnabled(true)
                 optionsViewModel.syncEnabled(recoveryCode: self.recoveryCode)
@@ -448,6 +454,24 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
             Pixel.fire(pixel: .syncAutoRestoreSettingsRestoreTapped, withAdditionalParameters: autoRestorePromptSourceParameters)
         case .readySkipRestoreTapped:
             Pixel.fire(pixel: .syncAutoRestoreSettingsSkipRestoreTapped, withAdditionalParameters: autoRestorePromptSourceParameters)
+        }
+    }
+
+    func fireSyncSetupPixel(event: SyncSettingsViewModel.SyncSetupPixelEvent) {
+        switch event {
+        case .backUpThisDeviceTapped:
+            Pixel.fire(pixel: .settingsSyncBackUpThisDeviceTapped, includedParameters: [.appVersion])
+        case .signupConfirmedTapped:
+            Pixel.fire(pixel: .settingsSyncSignupConfirmedTapped, includedParameters: [.appVersion])
+        case .signupAbandoned:
+            Pixel.fire(pixel: .syncSetupEndedAbandoned,
+                       withAdditionalParameters: [PixelParameters.source: "signup"],
+                       includedParameters: [.appVersion])
+            syncSetupExperimentPixels.fireSetupEndedAbandoned()
+        case .recoverSyncedDataTapped:
+            Pixel.fire(pixel: .settingsSyncRecoverSyncedDataTapped, includedParameters: [.appVersion])
+        case .recoveryConfirmedTapped:
+            Pixel.fire(pixel: .settingsSyncRecoveryConfirmedTapped, includedParameters: [.appVersion])
         }
     }
 

--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -180,9 +180,10 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                     let additionalParameters = self.source.map { ["source": $0] } ?? [:]
                     try await Pixel.fire(pixel: .syncSignupDirect, withAdditionalParameters: additionalParameters, includedParameters: [.appVersion])
                     self.syncSetupExperimentPixels.fireSignupDirect()
-                    try await Pixel.fire(pixel: .syncSetupEndedSuccessful,
-                                         withAdditionalParameters: [PixelParameters.source: "signup"],
-                                         includedParameters: [.appVersion])
+                    Pixel.fire(pixel: .syncSetupEndedSuccessful,
+                               withAdditionalParameters: [PixelParameters.source: "signup"],
+                               includedParameters: [.appVersion],
+                               onComplete: { _ in })
                     self.syncSetupExperimentPixels.fireSetupEndedSuccessful()
                     AutofillOnboardingExperimentPixelReporter().fireSyncEnabled(true)
                     self.viewModel.syncEnabled(recoveryCode: self.recoveryCode)
@@ -206,9 +207,10 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                 let additionalParameters = self.source.map { ["source": $0] } ?? [:]
                 try await Pixel.fire(pixel: .syncSignupDirect, withAdditionalParameters: additionalParameters, includedParameters: [.appVersion])
                 self.syncSetupExperimentPixels.fireSignupDirect()
-                try await Pixel.fire(pixel: .syncSetupEndedSuccessful,
-                                     withAdditionalParameters: [PixelParameters.source: "signup"],
-                                     includedParameters: [.appVersion])
+                Pixel.fire(pixel: .syncSetupEndedSuccessful,
+                           withAdditionalParameters: [PixelParameters.source: "signup"],
+                           includedParameters: [.appVersion],
+                           onComplete: { _ in })
                 self.syncSetupExperimentPixels.fireSetupEndedSuccessful()
                 AutofillOnboardingExperimentPixelReporter().fireSyncEnabled(true)
                 optionsViewModel.syncEnabled(recoveryCode: self.recoveryCode)

--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -565,7 +565,7 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
     private func continueSyncSetupFlow(entryPoint: SyncSettingsViewModel.SyncSetupEntryPoint) {
         switch entryPoint {
         case .backup:
-            viewModel.isSyncWithSetUpSheetVisible = true
+            viewModel.showSyncWithSetUpSheet()
         case .pairing:
             showSyncWithAnotherDevice()
         case .simplifiedToggle:
@@ -646,7 +646,7 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                 stringForQRCode = recoveryCode
                 codeForDisplayOrPasting = recoveryCode
                 onPresentPixelInfo = nil
-                source = .exchange
+                source = showQRCode ? .exchange : .recovery
             } else {
                 do {
                     let pairingInfo = try await connectionController.startConnectMode()

--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -605,7 +605,7 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
         }
         Task { @MainActor in
             let pairingInfo: PairingInfo
-            let source: SyncSetupSource
+            var source: SyncSetupSource
             if shouldUsePreservedAccountForConnectionFlow {
                 do {
                     pairingInfo = try await connectionController.startExchangeMode()
@@ -623,8 +623,16 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                     return
                 }
             }
+            if !showQRCode {
+                source = .recovery
+            }
             let stringForQRCode = featureFlagger.isFeatureOn(.syncSetupBarcodeIsUrlBased) ? pairingInfo.url.absoluteString : pairingInfo.base64Code
-            presentScanOrPasteCodeView(codeForDisplayOrPasting: pairingInfo.base64Code, stringForQRCode: stringForQRCode, showQRCode: showQRCode, onPresentPixelInfo: .init(pixel: .syncSetupBarcodeScreenShown, source: source))
+            presentScanOrPasteCodeView(
+                codeForDisplayOrPasting: pairingInfo.base64Code,
+                stringForQRCode: stringForQRCode,
+                showQRCode: showQRCode,
+                source: source,
+                onPresentPixelInfo: .init(pixel: .syncSetupBarcodeScreenShown, source: source))
         }
     }
 
@@ -633,27 +641,42 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
             let stringForQRCode: String
             let codeForDisplayOrPasting: String
             let onPresentPixelInfo: SyncSetupPixelInfo?
+            let source: SyncSetupSource
             if shouldUsePreservedAccountForConnectionFlow {
                 stringForQRCode = recoveryCode
                 codeForDisplayOrPasting = recoveryCode
                 onPresentPixelInfo = nil
+                source = .exchange
             } else {
                 do {
                     let pairingInfo = try await connectionController.startConnectMode()
                     stringForQRCode = featureFlagger.isFeatureOn(.syncSetupBarcodeIsUrlBased) ? pairingInfo.url.absoluteString : pairingInfo.base64Code
                     codeForDisplayOrPasting = pairingInfo.base64Code
-                    onPresentPixelInfo = .init(pixel: .syncSetupBarcodeScreenShown, source: .connect)
+                    source = showQRCode ? .connect : .recovery
+                    onPresentPixelInfo = .init(pixel: .syncSetupBarcodeScreenShown, source: source)
                 } catch {
                     await handleError(SyncErrorMessage.unableToSyncToServer, error: error, event: .syncLoginError)
                     return
                 }
             }
-            presentScanOrPasteCodeView(codeForDisplayOrPasting: codeForDisplayOrPasting, stringForQRCode: stringForQRCode, showQRCode: showQRCode, onPresentPixelInfo: onPresentPixelInfo)
+            presentScanOrPasteCodeView(
+                codeForDisplayOrPasting: codeForDisplayOrPasting,
+                stringForQRCode: stringForQRCode,
+                showQRCode: showQRCode,
+                source: source,
+                onPresentPixelInfo: onPresentPixelInfo)
         }
     }
 
-    private func presentScanOrPasteCodeView(codeForDisplayOrPasting: String, stringForQRCode: String, showQRCode: Bool, onPresentPixelInfo: SyncSetupPixelInfo?) {
-        let model = ScanOrPasteCodeViewModel(codeForDisplayOrPasting: codeForDisplayOrPasting, qrCodeString: stringForQRCode)
+    private func presentScanOrPasteCodeView(codeForDisplayOrPasting: String,
+                                            stringForQRCode: String,
+                                            showQRCode: Bool,
+                                            source: SyncSetupSource,
+                                            onPresentPixelInfo: SyncSetupPixelInfo?) {
+        let model = ScanOrPasteCodeViewModel(
+            codeForDisplayOrPasting: codeForDisplayOrPasting,
+            qrCodeString: stringForQRCode,
+            source: CodeCollectionSource(syncSetupSource: source))
         model.delegate = self
         
         var controller: UIHostingController<AnyView>
@@ -938,6 +961,20 @@ private class PortraitNavigationController: UINavigationController {
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         [.portrait, .portraitUpsideDown]
+    }
+}
+
+private extension CodeCollectionSource {
+
+    init(syncSetupSource: SyncSetupSource) {
+        switch syncSetupSource {
+        case .exchange:
+            self = .exchange
+        case .recovery:
+            self = .recovery
+        case .connect, .unknown:
+            self = .connect
+        }
     }
 }
 

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -540,7 +540,9 @@ extension SyncSettingsViewController: ScanOrPasteCodeViewModelDelegate {
         needsPreservedAccountCleanupBeforeServerOperation = false
         autoRestorePromptSource = nil
         dismissPresentedViewController()
-        Pixel.fire(pixel: .syncSetupEndedAbandoned)
+        Pixel.fire(pixel: .syncSetupEndedAbandoned,
+                   withAdditionalParameters: [PixelParameters.source: SyncSetupSource.connect.rawValue],
+                   includedParameters: [.appVersion])
         syncSetupExperimentPixels.fireSetupEndedAbandoned()
     }
 
@@ -599,6 +601,9 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
     }
     
     func controllerDidFinishTransmittingRecoveryKey() {
+        Pixel.fire(pixel: .syncSetupEndedSuccessful,
+                   withAdditionalParameters: [PixelParameters.source: SyncSetupSource.exchange.rawValue],
+                   includedParameters: [.appVersion])
         dismissPresentedViewController()
     }
     
@@ -633,6 +638,10 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         AutofillOnboardingExperimentPixelReporter().fireSyncEnabled(true)
         presentSyncCompletionAfterDelay()
         guard case .receiver(let syncSetupSource, let syncCodeSource) = setupRole else {
+            // .sharer reaches here only via the connect flow (exchange-sharer terminates in controllerDidFinishTransmittingRecoveryKey).
+            Pixel.fire(pixel: .syncSetupEndedSuccessful,
+                       withAdditionalParameters: [PixelParameters.source: SyncSetupSource.connect.rawValue],
+                       includedParameters: [.appVersion])
             return
         }
 
@@ -670,7 +679,7 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
     }
 
     private func sendCodeRecognisedPixel(setupSource: SyncSetupSource, codeSource: SyncCodeSource) {
-        guard setupSource != .recovery, setupSource != .unknown else { return }
+        guard setupSource != .unknown else { return }
         let parameters = source.map { [PixelParameters.source: $0] } ?? [PixelParameters.source: setupSource.rawValue]
         switch codeSource {
         case .qrCode:
@@ -702,7 +711,7 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
     }
 
     private func sendSetupEndedSuccessfullyPixel(setupSource: SyncSetupSource, codeSource: SyncCodeSource) {
-        guard setupSource != .recovery, setupSource != .unknown else { return }
+        guard setupSource != .unknown else { return }
         let parameters = source.map { [PixelParameters.source: $0] } ?? [PixelParameters.source: setupSource.rawValue]
         switch codeSource {
         case .pastedCode, .qrCode:

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -346,7 +346,7 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
     }
 
     func dismissPresentedViewController(completion: (() -> Void)? = nil) {
-        viewModel.isSyncWithSetUpSheetVisible = false
+        viewModel.dismissSyncWithSetUpSheet()
         viewModel.isRecoverSyncedDataSheetVisible = false
         guard let presentedViewController = navigationController?.presentedViewController,
               !(presentedViewController is SyncSettingsViewController) else {

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -535,13 +535,13 @@ extension SyncSettingsViewController: ScanOrPasteCodeViewModelDelegate {
         refreshAutoRestoreDecisionState()
     }
 
-    func codeCollectionCancelled() {
+    func codeCollectionCancelled(source: CodeCollectionSource) {
         assert(navigationController?.visibleViewController is UIHostingController<AnyView>)
         needsPreservedAccountCleanupBeforeServerOperation = false
         autoRestorePromptSource = nil
         dismissPresentedViewController()
         Pixel.fire(pixel: .syncSetupEndedAbandoned,
-                   withAdditionalParameters: [PixelParameters.source: SyncSetupSource.connect.rawValue],
+                   withAdditionalParameters: [PixelParameters.source: source.rawValue],
                    includedParameters: [.appVersion])
         syncSetupExperimentPixels.fireSetupEndedAbandoned()
     }

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/ScanOrPasteCodeViewModel.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/ScanOrPasteCodeViewModel.swift
@@ -25,6 +25,12 @@ public enum CodeEntrySource: String {
     case pastedCode
 }
 
+public enum CodeCollectionSource: String {
+    case connect
+    case exchange
+    case recovery
+}
+
 public protocol ScanOrPasteCodeViewModelDelegate: AnyObject {
 
     var pasteboardString: String? { get }
@@ -34,7 +40,7 @@ public protocol ScanOrPasteCodeViewModelDelegate: AnyObject {
     /// Returns true if we were able to use the code. Either way, stop validating.
     func syncCodeEntered(code: String, source: CodeEntrySource) async -> Bool
 
-    func codeCollectionCancelled()
+    func codeCollectionCancelled(source: CodeCollectionSource)
     func gotoSettings()
     func shareCode(_ code: String)
 
@@ -71,9 +77,11 @@ public class ScanOrPasteCodeViewModel: ObservableObject {
     public weak var delegate: ScanOrPasteCodeViewModelDelegate?
 
     var showQRCodeModel: ShowQRCodeViewModel
+    private let source: CodeCollectionSource
 
-    public init(codeForDisplayOrPasting: String, qrCodeString: String) {
+    public init(codeForDisplayOrPasting: String, qrCodeString: String, source: CodeCollectionSource) {
         showQRCodeModel = ShowQRCodeViewModel(codeForDisplayOrPasting: codeForDisplayOrPasting, qrCodeString: qrCodeString)
+        self.source = source
     }
 
     func codeScanned(_ code: String) async -> Bool {
@@ -119,7 +127,7 @@ public class ScanOrPasteCodeViewModel: ObservableObject {
     }
 
     func cancel() {
-        delegate?.codeCollectionCancelled()
+        delegate?.codeCollectionCancelled(source: source)
     }
 
     func showShareCodeSheet() {

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/SyncSettingsViewModel.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/SyncSettingsViewModel.swift
@@ -46,6 +46,7 @@ public protocol SyncManagementViewModelDelegate: AnyObject {
     func showOtherPlatformLinks()
     func fireOtherPlatformLinksPixel(event: SyncSettingsViewModel.PlatformLinksPixelEvent, with source: SyncSettingsViewModel.PlatformLinksPixelSource)
     func fireAutoRestorePixel(event: SyncSettingsViewModel.AutoRestorePixelEvent)
+    func fireSyncSetupPixel(event: SyncSettingsViewModel.SyncSetupPixelEvent)
     func shareLink(for url: URL, with message: String, from rect: CGRect)
 
     // Simplified sync setup experiment
@@ -118,6 +119,14 @@ public class SyncSettingsViewModel: ObservableObject {
         case manualRecoveryShown
         case readyRestoreTapped
         case readySkipRestoreTapped
+    }
+
+    public enum SyncSetupPixelEvent {
+        case backUpThisDeviceTapped
+        case signupConfirmedTapped
+        case signupAbandoned
+        case recoverSyncedDataTapped
+        case recoveryConfirmedTapped
     }
 
     public enum SyncSetupEntryPoint: Equatable {
@@ -539,6 +548,7 @@ public class SyncSettingsViewModel: ObservableObject {
 
 public extension SyncManagementViewModelDelegate {
     func fireAutoRestorePixel(event _: SyncSettingsViewModel.AutoRestorePixelEvent) {}
+    func fireSyncSetupPixel(event _: SyncSettingsViewModel.SyncSetupPixelEvent) {}
     func simplifiedCopyRecoveryCode() {}
     func showSimplifiedSyncEnabledToast() {}
 }

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/SyncSettingsViewModel.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/SyncSettingsViewModel.swift
@@ -188,6 +188,7 @@ public class SyncSettingsViewModel: ObservableObject {
     private(set) var switchToProdEnvironment: () -> Void = {}
     private var cancellables = Set<AnyCancellable>()
     private var pendingPreservedAccountContinuation: PreservedAccountContinuation?
+    private var shouldFireSignupAbandonedOnSheetDismissal = false
     private var shouldShowSyncEnabledToastAfterSyncWithAnotherDevicePromptDismissal = false
 
     private let autoRestoreProvider: SyncAutoRestoreProviding
@@ -344,7 +345,7 @@ public class SyncSettingsViewModel: ObservableObject {
         case .setup(let entryPoint):
             switch entryPoint {
             case .backup:
-                isSyncWithSetUpSheetVisible = true
+                showSyncWithSetUpSheet()
             case .pairing:
                 delegate?.showSyncWithAnotherDevice()
             case .simplifiedToggle:
@@ -373,7 +374,24 @@ public class SyncSettingsViewModel: ObservableObject {
         self.recoveryCode = recoveryCode
     }
 
+    public func showSyncWithSetUpSheet() {
+        shouldFireSignupAbandonedOnSheetDismissal = true
+        isSyncWithSetUpSheetVisible = true
+    }
+
+    public func dismissSyncWithSetUpSheet() {
+        isSyncWithSetUpSheetVisible = false
+    }
+
+    public func syncWithSetUpSheetDidDismiss() {
+        guard shouldFireSignupAbandonedOnSheetDismissal else { return }
+
+        shouldFireSignupAbandonedOnSheetDismissal = false
+        delegate?.fireSyncSetupPixel(event: .signupAbandoned)
+    }
+
     public func startSyncPressed() {
+        shouldFireSignupAbandonedOnSheetDismissal = false
         isBusy = true
         delegate?.createAccountAndStartSyncing(optionsViewModel: self)
     }

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/RecoverSyncedDataView.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/RecoverSyncedDataView.swift
@@ -58,6 +58,7 @@ public struct RecoverSyncedDataView: View {
             .foregroundStyle(Color(designSystemColor: .textPrimary))
         } foregroundContent: {
             Button {
+                model.delegate?.fireSyncSetupPixel(event: .recoveryConfirmedTapped)
                 model.continueRecoverFlow()
             } label: {
                 Text(UserText.recoverSyncedDataButton)

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SimplifiedSyncSettingsView.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SimplifiedSyncSettingsView.swift
@@ -206,6 +206,7 @@ extension SimplifiedSyncSettingsView {
                     get: { model.isSyncEnabled },
                     set: { newValue in
                         if newValue {
+                            model.delegate?.fireSyncSetupPixel(event: .backUpThisDeviceTapped)
                             model.enableSyncToggleTapped()
                         } else {
                             model.disableSyncToggleTapped()
@@ -238,6 +239,7 @@ extension SimplifiedSyncSettingsView {
             .disabled(!model.isAccountCreationAvailable)
 
             Button {
+                model.delegate?.fireSyncSetupPixel(event: .recoverSyncedDataTapped)
                 model.beginRecoverFlow()
             } label: {
                 HStack(spacing: 8) {

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncSettingsViewExtension.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncSettingsViewExtension.swift
@@ -76,6 +76,7 @@ extension SyncSettingsView {
     func otherOptions() -> some View {
         Section {
             Button {
+                model.delegate?.fireSyncSetupPixel(event: .backUpThisDeviceTapped)
                 model.beginBackupFlow()
             } label: {
                 Text(UserText.syncAndBackUpThisDeviceLink)
@@ -83,12 +84,14 @@ extension SyncSettingsView {
             }
             .sheet(isPresented: $model.isSyncWithSetUpSheetVisible, content: {
                 SyncWithServerView(model: model, onCancel: {
+                    model.delegate?.fireSyncSetupPixel(event: .signupAbandoned)
                     model.isSyncWithSetUpSheetVisible = false
                 })
             })
             .disabled(!model.isAccountCreationAvailable)
 
             Button {
+                model.delegate?.fireSyncSetupPixel(event: .recoverSyncedDataTapped)
                 model.beginRecoverFlow()
             } label: {
                 Text(UserText.recoverSyncedDataLink)

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncSettingsViewExtension.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncSettingsViewExtension.swift
@@ -82,12 +82,9 @@ extension SyncSettingsView {
                 Text(UserText.syncAndBackUpThisDeviceLink)
                     .foregroundColor(Color(designSystemColor: .accent))
             }
-            .sheet(isPresented: $model.isSyncWithSetUpSheetVisible, onDismiss: {
-                guard !model.isBusy else { return }
-                model.delegate?.fireSyncSetupPixel(event: .signupAbandoned)
-            }, content: {
+            .sheet(isPresented: $model.isSyncWithSetUpSheetVisible, onDismiss: model.syncWithSetUpSheetDidDismiss, content: {
                 SyncWithServerView(model: model, onCancel: {
-                    model.isSyncWithSetUpSheetVisible = false
+                    model.dismissSyncWithSetUpSheet()
                 })
             })
             .disabled(!model.isAccountCreationAvailable)

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncSettingsViewExtension.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncSettingsViewExtension.swift
@@ -82,9 +82,11 @@ extension SyncSettingsView {
                 Text(UserText.syncAndBackUpThisDeviceLink)
                     .foregroundColor(Color(designSystemColor: .accent))
             }
-            .sheet(isPresented: $model.isSyncWithSetUpSheetVisible, content: {
+            .sheet(isPresented: $model.isSyncWithSetUpSheetVisible, onDismiss: {
+                guard !model.isBusy else { return }
+                model.delegate?.fireSyncSetupPixel(event: .signupAbandoned)
+            }, content: {
                 SyncWithServerView(model: model, onCancel: {
-                    model.delegate?.fireSyncSetupPixel(event: .signupAbandoned)
                     model.isSyncWithSetUpSheetVisible = false
                 })
             })

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncWithServerView.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncWithServerView.swift
@@ -63,6 +63,7 @@ public struct SyncWithServerView: View {
         } foregroundContent: {
             VStack(spacing: 8) {
                 Button {
+                    model.delegate?.fireSyncSetupPixel(event: .signupConfirmedTapped)
                     model.startSyncPressed()
                 } label: {
                     Text(UserText.connectWithServerSheetButton)

--- a/iOS/PixelDefinitions/pixels/definitions/settings_sync.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/settings_sync.json5
@@ -1,0 +1,30 @@
+{
+    "m_settings_sync_back_up_this_device_tapped": {
+        "description": "Fired when the user taps the 'Sync And Back Up This Device' action from the sync settings screen.",
+        "owners": ["frosty"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_settings_sync_recover_synced_data_tapped": {
+        "description": "Fired when the user taps the entry point to the Recover Synced Data flow from the sync settings screen.",
+        "owners": ["frosty"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_settings_sync_signup_confirmed_tapped": {
+        "description": "Fired when the user taps the primary 'Turn On Sync and Backup' button on the Sync With Server confirmation sheet (SyncWithServerView), confirming intent to set up sync on this device.",
+        "owners": ["frosty"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_settings_sync_recovery_confirmed_tapped": {
+        "description": "Fired when the user taps the primary 'Recover Synced Data' button on the Recover Synced Data sheet (RecoverSyncedDataView), confirming intent to begin recovery.",
+        "owners": ["frosty"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211264967278501/task/1213215665913759?focus=true
Tech Design URL:
CC:

### Description

This PR adds the new pixels needed for iOS Sync & Backup setup dashboards, complementing the experiment-pixel work in #4575. As well as some new pixels, it fills some gaps for existing regular pixels that our new experiment pixels have already covered.

**New pixels**

| Pixel | Where it fires |
|---|---|
| `m_settings_sync_back_up_this_device_tapped` | Sync settings → "Sync And Back Up This Device" **or** sync toggle ON (simplified sync experiment) |
| `m_settings_sync_signup_confirmed_tapped` | Primary "Turn On Sync and Backup” CTA button in `SyncWithServerView` |
| `m_settings_sync_recover_synced_data_tapped` | Sync settings → "Recover Synced Data" (control) **or** "Use Recovery Code" button (simplified sync experiment) |
| `m_settings_sync_recovery_confirmed_tapped` | Primary CTA button in `RecoverSyncedDataView` |

Pixels are fired through a new `SyncManagementViewModelDelegate.fireSyncSetupPixel(event:)` so the `SyncUI-iOS` package can trigger pixel firing without importing `Pixel`.

**Existing pixels: `source` parameter changes**:

- `m_sync_setup_ended_abandoned`, was firing without a `source` parameter from `codeCollectionCancelled`. Now:
  - `source=connect`: kept on `codeCollectionCancelled` (this is the login/connect flow's abandonment)
  - `source=signup`: **new fire site** from `SyncWithServerView` `onCancel`. Closes the "🆕 Sync Setup Abandoned (Signup)" item.
- Removed the `setupSource != .recovery` guard from `sendCodeRecognisedPixel` and `sendSetupEndedSuccessfullyPixel`. The recovery flow now produces its previously-suppressed `m_sync_setup_barcode_scanner_success` / `m_sync_setup_manual_code_entered_success` / `m_sync_setup_ended_successful` pixels with `source=recovery`. Closes the "🆕 Recovery Barcode Scanned" and "🆕 Recovery Complete" items.

**Existing pixel: new `m_sync_setup_ended_successful` fire sites** (mirrors the experiment pixel coverage from #4575):

- After `m_sync_signup_direct` in both `createAccountAndStartSyncing` and `simplifiedCreateAccountAndStartSyncing` with `source=signup`.
- `controllerDidFinishTransmittingRecoveryKey` with `source=exchange` (sharer-completion in exchange flow).
- `controllerDidCompleteLogin` `.sharer` fallthrough with `source=connect` (sharer-completion in connect flow).

### Testing Steps

- Build and run the iOS app.
- You can test with the simplified sync setup experiment both disabled and enabled.
- Filter your Xcode console for ‘pixel’, and watch the pixels fired in each of the following scenarios:

#### Scan-flow scenarios (use two devices/simulators — one must be a real device for QR scanning)

**Scenario 1: Both signed out (connect flow)**

- Setup: A signed out, B signed out.
- Action: B scans A's QR.
- Result: B creates a new sync account; A joins **B's** account.

| Device | Pixels fired |
|---|---|
| A | `m_settings_sync_open` (`is_enabled=0`), `m_sync_setup_barcode_screen_shown`, `m_sync_login`, `m_sync_setup_ended_successful` (`source=connect`) ⬅ *new* |
| B | `m_settings_sync_open`, `m_sync_setup_barcode_scanner_success` (`source=connect`), `m_sync_signup_connect`, `m_sync_setup_ended_successful` (`source=connect`) |

**Scenario 2: A signed out, B signed in (connect flow)**

- Setup: A signed out, B signed in.
- Action: B scans A's QR.
- Result: A joins B's existing account.

| Device | Pixels fired |
|---|---|
| A | `m_settings_sync_open`, `m_sync_setup_barcode_screen_shown`, `m_sync_login`, `m_sync_setup_ended_successful` (`source=connect`) ⬅ *new* |
| B | `m_sync_setup_barcode_scanner_success` (`source=connect`), `m_sync_setup_ended_successful` (`source=connect`) |

**Scenario 3: A signed in, B signed out (exchange flow)**

- Setup: A signed in, B signed out.
- Action: B scans A's QR.
- Result: B joins **A's** account.

| Device | Pixels fired |
|---|---|
| A | `m_settings_sync_open` (`is_enabled=1`), `m_sync_setup_barcode_screen_shown` (`source=exchange`), `m_sync_setup_ended_successful` (`source=exchange`) ⬅ *new — sharer-completion* |
| B | `m_settings_sync_open`, `m_sync_setup_barcode_scanner_success` (`source=exchange`), `m_sync_login`, `m_sync_setup_ended_successful` (`source=exchange`) |

#### New pixels (4)

| # | Pixel | How to fire it |
|---|---|---|
| 1 | `m_settings_sync_back_up_this_device_tapped` | **Control flow**: Settings → Sync & Backup → tap "Sync And Back Up This Device" link. **Experiment flow**: Settings → Sync & Backup → flip the sync toggle on. |
| 2 | `m_settings_sync_signup_confirmed_tapped` | After tapping #1 (control) or arriving from an external entry like data-import promotion, tap "Turn On Sync and Backup" on the resulting modal. |
| 3 | `m_settings_sync_recover_synced_data_tapped` | **Control flow**: Settings → Sync & Backup → tap "Recover Synced Data" link. **Treatment flow**: Settings → Sync & Backup → tap "Use Recovery Code" button. |
| 4 | `m_settings_sync_recovery_confirmed_tapped` | After tapping #3, tap the primary "Recover Synced Data" button on the resulting sheet. |

#### Abandonment: `m_sync_setup_ended_abandoned` source attribution

| Test | Action | Pixel |
|---|---|---|
| Login abandoned | Tap "Sync With Another Device", then dismiss the scan/paste code view without completing. | `source=connect` |
| Signup abandoned ⬅ *new fire site* | Tap "Sync And Back Up This Device" (control), then dismiss `SyncWithServerView` without confirming. | `source=signup` |

> Simplified signup doesn’t have a confirmation modal, so it has no equivalent abandonment moment.

#### Recovery flow: previously suppressed pixels now fire

Paste a valid recovery code on a signed-out device.

| Pixel | When |
|---|---|
| `m_sync_setup_barcode_scanner_success` (`source=recovery`) | Recovery code successfully scanned via QR |
| `m_sync_setup_manual_code_entered_success` (`source=recovery`) | Recovery code successfully pasted |
| `m_sync_setup_ended_successful` (`source=recovery`) | Recovery completes successfully |

### Impact and Risks

None: Internal tooling, documentation

#### What could go wrong?

No risks to users, but risks to the integrity of our pixel data if events are fired incorrectly.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Analytics-only changes but touch multiple sync setup/recovery entry points and delegate interfaces; incorrect wiring could skew telemetry for critical onboarding flows.
> 
> **Overview**
> Adds four new settings-level sync pixels (backup-this-device, recover-synced-data entry, signup confirm, recovery confirm) and routes them through a new `SyncManagementViewModelDelegate.fireSyncSetupPixel` so `SyncUI-iOS` can trigger tracking without importing `Pixel`.
> 
> Refines existing sync setup pixels by **adding/adjusting `source` parameters** for abandonment and success across signup/connect/exchange/recovery, including firing `m_sync_setup_ended_successful` for signup completion and sharer-completion, and ensuring recovery flows are no longer suppressed.
> 
> Updates code-collection cancellation to carry a `CodeCollectionSource`, and adds sheet dismissal handling to emit a signup-abandoned event when the signup confirmation sheet is dismissed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cb0a774fd5aaf724ab1255902940eb87aa88adc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->