### PR TITLE
Defer Duck.ai native storage DB open off main thread

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeDiskStorageHandler.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeDiskStorageHandler.swift
@@ -167,6 +167,10 @@ public final class DuckAiNativeDiskStorageHandler: DuckAiNativeStorageHandling {
         try settingsStore.set(data, for: \.migrationStatus)
     }
 
+    // MARK: - Lifecycle
+
+    public var setupSucceeded: Bool? { dataStore.setupSucceeded }
+
     // MARK: - Private helpers
 
     private func loadSettingsBlob() throws -> [String: Any] {

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageHandler.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageHandler.swift
@@ -59,14 +59,21 @@ public final class DuckAiNativeStorageHandler: DuckAiNativeStorageHandling {
                 let dataStore = try DuckAiNativeDataStore(
                     databaseURL: path.appendingPathComponent("chats.db"),
                     filesDirectoryURL: path.appendingPathComponent("files"),
-                    key: encryptionKey
+                    key: encryptionKey,
+                    setupCompletion: { result in
+                        switch result {
+                        case .success:
+                            pixelFiring.fire(.initSuccess)
+                        case .failure(let error):
+                            pixelFiring.fire(.initError(error))
+                        }
+                    }
                 )
                 self.backing = DuckAiNativeDiskStorageHandler(
                     settingsStore: settingsStore.throwingKeyedStoring(),
                     dataStore: dataStore
                 )
                 Logger.aiChat.debug("DuckAiNativeStorageHandler: disk store initialized at \(path.path)")
-                pixelFiring.fire(.initSuccess)
             } catch {
                 pixelFiring.fire(.initError(error))
                 throw error
@@ -103,4 +110,6 @@ public final class DuckAiNativeStorageHandler: DuckAiNativeStorageHandling {
     public func isMigrationDone() throws -> Bool { try backing.isMigrationDone() }
     public func isMigrationDone(key: String) throws -> Bool { try backing.isMigrationDone(key: key) }
     public func markMigrationDone(key: String) throws { try backing.markMigrationDone(key: key) }
+
+    public var setupSucceeded: Bool? { backing.setupSucceeded }
 }

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageHandling.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageHandling.swift
@@ -57,6 +57,20 @@ public protocol DuckAiNativeStorageHandling {
     func isMigrationDone(key: String) throws -> Bool
     /// Marks the migration for the given key as complete.
     func markMigrationDone(key: String) throws
+
+    // MARK: - Lifecycle
+
+    /// Non-blocking probe of any deferred initialization performed by the underlying
+    /// store. `nil` means setup is still in flight, `true` means it completed
+    /// successfully, `false` means it failed permanently. Bridge availability gates
+    /// should treat `nil` optimistically (assume available) so the launch path is
+    /// not blocked while the gate is evaluated, and only force the JS fallback once
+    /// a definitive failure is known.
+    var setupSucceeded: Bool? { get }
+}
+
+public extension DuckAiNativeStorageHandling {
+    var setupSucceeded: Bool? { true }
 }
 
 public enum DuckAiMigrationKey {

--- a/SharedPackages/BrowserServicesKit/Sources/DuckAiDataStore/DuckAiNativeDataStore.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DuckAiDataStore/DuckAiNativeDataStore.swift
@@ -24,9 +24,30 @@ import os.log
 
 public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
 
-    private let dbQueue: DatabaseQueue
+    /// Sentinel error stored in `setupResult` until the background setup task overwrites it.
+    /// Under normal init flow this is never observed — `init` enqueues the setup task on the
+    /// serial `setupQueue` before returning, so any later `sync` is FIFO-ordered behind it.
+    private struct SetupNotCompletedError: Error {}
+
     private let filesDirectoryURL: URL
     private let encryptionKey: SymmetricKey
+    private let setupQueue = DispatchQueue(label: "com.duckduckgo.duckai.nativedatastore.setup", qos: .userInitiated)
+    private var setupResult: Result<DatabaseQueue, Error> = .failure(SetupNotCompletedError())
+
+    // Non-blocking probe of background setup state. Read by `setupSucceeded` from
+    // any thread; written exactly once when the deferred work finishes.
+    private let setupStateLock = NSLock()
+    private var _setupSucceeded: Bool?
+
+    /// Non-blocking probe of background DB setup state.
+    /// - Returns: `nil` while setup is in flight, `true` if it completed successfully,
+    ///   `false` if it failed. Safe to call from any thread; never blocks on the
+    ///   setup queue and so is safe to evaluate on the main thread during launch.
+    public var setupSucceeded: Bool? {
+        setupStateLock.lock()
+        defer { setupStateLock.unlock() }
+        return _setupSucceeded
+    }
 
     /// Creates an encrypted data store backed by SQLCipher.
     ///
@@ -34,11 +55,25 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
     /// as an encrypted database. This handles the migration from the pre-encryption
     /// storage format.
     ///
+    /// The database open and migrations run asynchronously on a background queue;
+    /// errors surface at the first read/write call rather than from `init`. To observe
+    /// the async setup outcome (e.g. for telemetry) pass `setupCompletion`; it is
+    /// invoked exactly once on the setup queue when the DB is ready or has failed.
+    ///
     /// - Parameters:
     ///   - databaseURL: Path to the SQLite database file.
     ///   - filesDirectoryURL: Directory for storing file attachments on disk.
     ///   - key: 256-bit symmetric key used for SQLCipher encryption.
-    public init(databaseURL: URL, filesDirectoryURL: URL, key: Data) throws {
+    ///   - setupCompletion: Optional callback invoked once the background DB open
+    ///     and migrations finish. Called on the internal setup queue, which means
+    ///     the first DB read/write from any other thread queues behind it — the
+    ///     closure should be fast (e.g. fire a pixel) and must not block.
+    public init(
+        databaseURL: URL,
+        filesDirectoryURL: URL,
+        key: Data,
+        setupCompletion: ((Result<Void, Error>) -> Void)? = nil
+    ) throws {
         self.filesDirectoryURL = filesDirectoryURL
         self.encryptionKey = SymmetricKey(data: key)
 
@@ -52,13 +87,40 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
             throw DuckAiNativeDataStoreError.directoryCreationFailed(error)
         }
 
-        do {
-            dbQueue = try Self.openDatabase(at: databaseURL, key: key, filesDirectoryURL: filesDirectoryURL)
-        } catch {
-            throw DuckAiNativeDataStoreError.databaseError(error)
+        setupQueue.async { [filesDirectoryURL] in
+            let result: Result<DatabaseQueue, Error> = Result {
+                do {
+                    let queue = try Self.openDatabase(at: databaseURL, key: key, filesDirectoryURL: filesDirectoryURL)
+                    try Self.runMigrations(on: queue)
+                    return queue
+                } catch let error as DuckAiNativeDataStoreError {
+                    throw error
+                } catch {
+                    throw DuckAiNativeDataStoreError.databaseError(error)
+                }
+            }
+            self.setupResult = result
+            switch result {
+            case .success:
+                self.setupStateLock.lock()
+                self._setupSucceeded = true
+                self.setupStateLock.unlock()
+                setupCompletion?(.success(()))
+            case .failure(let error):
+                self.setupStateLock.lock()
+                self._setupSucceeded = false
+                self.setupStateLock.unlock()
+                setupCompletion?(.failure(error))
+            }
         }
+    }
 
-        try Self.runMigrations(on: dbQueue)
+    /// Blocks the caller until background setup completes, then returns the prepared
+    /// `DatabaseQueue` or rethrows the wrapped setup error.
+    private func dbQueue() throws -> DatabaseQueue {
+        try setupQueue.sync {
+            try self.setupResult.get()
+        }
     }
 
     /// Opens an encrypted database, recreating it if the existing file is unencrypted or corrupt.
@@ -135,9 +197,10 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
     // MARK: - Chats
 
     public func putChat(chatId: String, data: Data) throws {
+        let queue = try dbQueue()
         let record = ChatRecord(chatId: chatId, data: data)
         do {
-            try dbQueue.write { db in
+            try queue.write { db in
                 try record.save(db)
             }
         } catch {
@@ -146,8 +209,9 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
     }
 
     public func putChats(_ chats: [DuckAiChatRecord]) throws {
+        let queue = try dbQueue()
         do {
-            try dbQueue.write { db in
+            try queue.write { db in
                 for chat in chats where !chat.chatId.isEmpty {
                     let record = ChatRecord(chatId: chat.chatId, data: chat.data)
                     try record.save(db)
@@ -159,8 +223,9 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
     }
 
     public func getChat(chatId: String) throws -> DuckAiChatRecord? {
+        let queue = try dbQueue()
         do {
-            return try dbQueue.read { db in
+            return try queue.read { db in
                 guard let record = try ChatRecord.fetchOne(db, key: chatId) else { return nil }
                 return DuckAiChatRecord(chatId: record.chatId, data: record.data)
             }
@@ -170,8 +235,9 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
     }
 
     public func getAllChats() throws -> [DuckAiChatRecord] {
+        let queue = try dbQueue()
         do {
-            return try dbQueue.read { db in
+            return try queue.read { db in
                 let records = try ChatRecord.fetchAll(db)
                 return records.map { DuckAiChatRecord(chatId: $0.chatId, data: $0.data) }
             }
@@ -181,8 +247,9 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
     }
 
     public func deleteChat(chatId: String) throws {
+        let queue = try dbQueue()
         do {
-            try dbQueue.write { db in
+            try queue.write { db in
                 try db.execute(sql: "DELETE FROM duck_ai_chats WHERE chatId = ?", arguments: [chatId])
             }
         } catch {
@@ -191,8 +258,9 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
     }
 
     public func deleteAllChats() throws {
+        let queue = try dbQueue()
         do {
-            try dbQueue.write { db in
+            try queue.write { db in
                 try db.execute(sql: "DELETE FROM duck_ai_chats")
             }
         } catch {
@@ -211,6 +279,7 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
 
     public func putFile(uuid: String, chatId: String, data: Data) throws {
         let normalizedUUID = try validatedFileUUID(for: uuid)
+        let queue = try dbQueue()
         let fileURL = filesDirectoryURL.appendingPathComponent(normalizedUUID)
 
         do {
@@ -228,7 +297,7 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
         let fileName = fileURL.lastPathComponent
         let record = FileRecord(uuid: normalizedUUID, chatId: chatId, dataSize: data.count, filePath: fileName)
         do {
-            try dbQueue.write { db in
+            try queue.write { db in
                 try record.save(db)
             }
         } catch {
@@ -239,11 +308,12 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
 
     public func getFile(uuid: String) throws -> DuckAiFileContent? {
         let normalizedUUID = try validatedFileUUID(for: uuid)
+        let queue = try dbQueue()
         let fileURL = filesDirectoryURL.appendingPathComponent(normalizedUUID)
 
         let record: FileRecord?
         do {
-            record = try dbQueue.read { db in
+            record = try queue.read { db in
                 try FileRecord.fetchOne(db, key: normalizedUUID)
             }
         } catch {
@@ -268,8 +338,9 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
     }
 
     public func listFiles() throws -> [DuckAiFileMetadata] {
+        let queue = try dbQueue()
         do {
-            return try dbQueue.read { db in
+            return try queue.read { db in
                 let records = try FileRecord.fetchAll(db)
                 return records.map { DuckAiFileMetadata(uuid: $0.uuid, chatId: $0.chatId, dataSize: $0.dataSize) }
             }
@@ -280,11 +351,12 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
 
     public func deleteFile(uuid: String) throws {
         let normalizedUUID = try validatedFileUUID(for: uuid)
+        let queue = try dbQueue()
         let fileURL = filesDirectoryURL.appendingPathComponent(normalizedUUID)
         try? FileManager.default.removeItem(at: fileURL)
 
         do {
-            try dbQueue.write { db in
+            try queue.write { db in
                 try db.execute(sql: "DELETE FROM duck_ai_files WHERE uuid = ?", arguments: [normalizedUUID])
             }
         } catch {
@@ -293,9 +365,10 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
     }
 
     public func deleteFiles(chatId: String) throws {
+        let queue = try dbQueue()
         let fileNames: [String]
         do {
-            fileNames = try dbQueue.read { db in
+            fileNames = try queue.read { db in
                 try FileRecord
                     .filter(Column("chatId") == chatId)
                     .fetchAll(db)
@@ -311,7 +384,7 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
         }
 
         do {
-            try dbQueue.write { db in
+            try queue.write { db in
                 try db.execute(sql: "DELETE FROM duck_ai_files WHERE chatId = ?", arguments: [chatId])
             }
         } catch {
@@ -320,6 +393,7 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
     }
 
     public func deleteAllFiles() throws {
+        let queue = try dbQueue()
         let fileManager = FileManager.default
         if let contents = try? fileManager.contentsOfDirectory(at: filesDirectoryURL, includingPropertiesForKeys: nil) {
             for fileURL in contents {
@@ -328,7 +402,7 @@ public final class DuckAiNativeDataStore: DuckAiNativeDataStoring {
         }
 
         do {
-            try dbQueue.write { db in
+            try queue.write { db in
                 try db.execute(sql: "DELETE FROM duck_ai_files")
             }
         } catch {

--- a/SharedPackages/BrowserServicesKit/Sources/DuckAiDataStore/DuckAiNativeDataStoring.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DuckAiDataStore/DuckAiNativeDataStoring.swift
@@ -37,6 +37,17 @@ public protocol DuckAiNativeDataStoring {
     func deleteFile(uuid: String) throws
     func deleteFiles(chatId: String) throws
     func deleteAllFiles() throws
+
+    // MARK: - Lifecycle
+
+    /// Non-blocking probe of any deferred initialization. `nil` means setup is still
+    /// in flight, `true` means it succeeded, `false` means it failed permanently.
+    /// Implementations without deferred init may return `true` from the default.
+    var setupSucceeded: Bool? { get }
+}
+
+public extension DuckAiNativeDataStoring {
+    var setupSucceeded: Bool? { true }
 }
 
 public struct DuckAiChatRecord: Equatable {

--- a/SharedPackages/BrowserServicesKit/Tests/DuckAiDataStoreTests/DuckAiNativeDataStoreMigrationTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DuckAiDataStoreTests/DuckAiNativeDataStoreMigrationTests.swift
@@ -57,7 +57,8 @@ final class DuckAiNativeDataStoreMigrationTests: XCTestCase {
         let orphanedFile = filesDirectory.appendingPathComponent("orphaned-file.txt")
         try Data("plaintext data".utf8).write(to: orphanedFile)
 
-        _ = try DuckAiNativeDataStore(databaseURL: databaseURL, filesDirectoryURL: filesDirectory, key: key)
+        let store = try DuckAiNativeDataStore(databaseURL: databaseURL, filesDirectoryURL: filesDirectory, key: key)
+        _ = try store.getAllChats() // Force background setup (DB recreate + orphan cleanup) to complete.
 
         let contents = try FileManager.default.contentsOfDirectory(at: filesDirectory, includingPropertiesForKeys: nil)
         XCTAssertTrue(contents.isEmpty, "Orphaned files should be removed when database is recreated")
@@ -70,7 +71,8 @@ final class DuckAiNativeDataStoreMigrationTests: XCTestCase {
             try Data("data \(i)".utf8).write(to: file)
         }
 
-        _ = try DuckAiNativeDataStore(databaseURL: databaseURL, filesDirectoryURL: filesDirectory, key: key)
+        let store = try DuckAiNativeDataStore(databaseURL: databaseURL, filesDirectoryURL: filesDirectory, key: key)
+        _ = try store.getAllChats()
 
         let contents = try FileManager.default.contentsOfDirectory(at: filesDirectory, includingPropertiesForKeys: nil)
         XCTAssertTrue(contents.isEmpty)
@@ -85,14 +87,16 @@ final class DuckAiNativeDataStoreMigrationTests: XCTestCase {
         XCTAssertEqual(contentsBefore.count, 1)
 
         // Re-open with the same key — should NOT wipe files
-        _ = try DuckAiNativeDataStore(databaseURL: databaseURL, filesDirectoryURL: filesDirectory, key: key)
+        let reopened = try DuckAiNativeDataStore(databaseURL: databaseURL, filesDirectoryURL: filesDirectory, key: key)
+        _ = try reopened.getAllChats()
 
         let contentsAfter = try FileManager.default.contentsOfDirectory(at: filesDirectory, includingPropertiesForKeys: nil)
         XCTAssertEqual(contentsAfter.count, 1, "Files should be preserved when database opens normally")
     }
 
     func testWhenNoDbExistsThenEmptyFilesDirectoryStaysEmpty() throws {
-        _ = try DuckAiNativeDataStore(databaseURL: databaseURL, filesDirectoryURL: filesDirectory, key: key)
+        let store = try DuckAiNativeDataStore(databaseURL: databaseURL, filesDirectoryURL: filesDirectory, key: key)
+        _ = try store.getAllChats()
 
         let contents = try FileManager.default.contentsOfDirectory(at: filesDirectory, includingPropertiesForKeys: nil)
         XCTAssertTrue(contents.isEmpty)

--- a/iOS/DuckDuckGo/AIChat/FireModeNativeStorageController.swift
+++ b/iOS/DuckDuckGo/AIChat/FireModeNativeStorageController.swift
@@ -204,4 +204,6 @@ final class FireModeNativeStorageController: DuckAiNativeStorageHandling {
     func isMigrationDone() throws -> Bool { try inner.isMigrationDone() }
     func isMigrationDone(key: String) throws -> Bool { try inner.isMigrationDone(key: key) }
     func markMigrationDone(key: String) throws { try inner.markMigrationDone(key: key) }
+
+    var setupSucceeded: Bool? { inner.setupSucceeded }
 }

--- a/iOS/DuckDuckGo/UserScripts.swift
+++ b/iOS/DuckDuckGo/UserScripts.swift
@@ -100,7 +100,12 @@ final class UserScripts: UserScriptsProvider {
             webExtensionAvailability: sourceProvider.webExtensionAvailability
         )
 
-        let isNativeStorageBridgeAvailable = featureFlagger.isFeatureOn(.aiChatNativeStorage) && duckAiNativeStorageHandler != nil
+        // `setupSucceeded == nil` (setup still in flight) is treated as "available"
+        // so the launch path is not blocked. Only force the JS fallback when a
+        // permanent setup failure has been observed.
+        let isNativeStorageBridgeAvailable = featureFlagger.isFeatureOn(.aiChatNativeStorage)
+            && duckAiNativeStorageHandler != nil
+            && duckAiNativeStorageHandler?.setupSucceeded != false
         let experimentalManager: ExperimentalAIChatManager = .init(featureFlagger: featureFlagger)
         let aiChatSettings = AIChatSettings()
         let aiChatScriptHandler = AIChatUserScriptHandler(experimentalAIChatManager: experimentalManager,

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -75,7 +75,12 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
         clickToLoadScript = ClickToLoadUserScript()
         contentBlockerRulesScript = ContentBlockerRulesUserScript(configuration: sourceProvider.contentBlockerRulesConfig!)
         surrogatesScript = SurrogatesUserScript(configuration: sourceProvider.surrogatesConfig!)
-        let isNativeStorageBridgeAvailable = sourceProvider.featureFlagger.isFeatureOn(.aiChatNativeStorage) && duckAiNativeStorageHandler != nil
+        // `setupSucceeded == nil` (setup still in flight) is treated as "available"
+        // so the launch path is not blocked. Only force the JS fallback when a
+        // permanent setup failure has been observed.
+        let isNativeStorageBridgeAvailable = sourceProvider.featureFlagger.isFeatureOn(.aiChatNativeStorage)
+            && duckAiNativeStorageHandler != nil
+            && duckAiNativeStorageHandler?.setupSucceeded != false
         let aiChatMessageHandler = AIChatMessageHandler(
             featureFlagger: sourceProvider.featureFlagger,
             isNativeStorageBridgeAvailable: isNativeStorageBridgeAvailable


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214294661819890/task/1214486604186386?focus=true
Tech Design URL:
CC:

### Description
`DuckAiNativeDataStore.init` was opening the SQLCipher database synchronously during `Launching.init`, running 256k PBKDF2 iterations on the main thread and tripping the RunningBoard launch watchdog on slower devices (Sentry clusters DCCJ/DCMV/DCE0/DCVR). The DB open + migrations now run on a serial background queue; reads/writes block on it briefly until ready, so call sites are unchanged. Encryption parameters and the SQLITE_NOTADB recovery path are preserved verbatim, so no user data migration is needed.

### Testing Steps
1. Cold-launch the app on a slow device with the `aiChatNativeStorage` feature flag on; confirm the app launches without the RBSTerminate signal-9 crash.
2. Open Duck.ai, send a message, force-quit, relaunch, and confirm previous chats are still listed (existing encrypted DB opens with the same key).
3. Regular smoke test for duck.ai storage (create chats, images, etc and check if it's stored in the native storage)

### Impact and Risks
High — touches launch path and the DB open of a recently-rolled-out feature; mitigated by preserving every existing encryption and recovery branch and only changing thread placement.

#### What could go wrong?
A consistent async DB-open failure (e.g. disk-full / FS-permission) now surfaces at first DB op rather than from `init`, so the bridge stays "available" for the current `UserScripts` instance until the next rules-update regeneration picks up `setupSucceeded == false` and downgrades to the JS fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves SQLCipher DB open/migrations to an async setup path and changes launch-time bridge availability decisions, which could surface errors later (on first DB access) and alter when the JS fallback is used.
> 
> **Overview**
> Defers `DuckAiNativeDataStore` database open + migrations onto a dedicated background queue, and makes all read/write APIs synchronously wait for that setup to finish (surfacing failures at first use instead of during `init`).
> 
> Adds a `setupSucceeded: Bool?` lifecycle probe to `DuckAiNativeDataStoring`/`DuckAiNativeStorageHandling`, wires it through the disk handler/controller, and updates iOS/macOS `UserScripts` to treat the native storage bridge as available while setup is *in flight* (`nil`) but fall back once a permanent failure is observed (`false`).
> 
> Initialization telemetry is shifted to fire from the async setup completion callback (instead of immediately after handler construction), and migration tests are updated to force setup completion before asserting orphan-file cleanup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 577cb99722a3e018f0afe6960073527d3bda43cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->