### PR TITLE
[macOS] Set correct colors to vpn toolbar button

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBarViewController.swift
@@ -1079,7 +1079,8 @@ final class NavigationBarViewController: NSViewController {
     private func setupNavigationButtonColors() {
         let allButtons: [MouseOverButton] = [
             goBackButton, goForwardButton, refreshOrStopButton, homeButton,
-            downloadsButton, shareButton, passwordManagementButton, bookmarkListButton, optionsButton
+            downloadsButton, shareButton, passwordManagementButton, bookmarkListButton, optionsButton,
+            networkProtectionButton
         ]
 
         let colorsProvider = theme.colorsProvider


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1212913445614621?focus=true
Tech Design URL:
CC:

### Description
Fixes the VPN toolbar icon colors

### Testing Steps
1. Run the macOS application
2. Set a subscription, right-tap the toolbar, select to show the VPN toolbar shortcut
3. Check the VPN toolbar icon color is correct

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Nothing specific.

### Quality Considerations
Nothing specific.

### Notes to Reviewer
Nothing specific.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that extends existing theming to the VPN toolbar button; main potential issue is unintended tint/hover color differences if the button expects custom styling.
> 
> **Overview**
> Ensures the VPN (`networkProtectionButton`) toolbar icon uses the same theme-driven `normalTintColor` and hover color as the other navigation bar buttons by including it in `setupNavigationButtonColors()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90a93faaaa087941c62372f17aecfe457ffae257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->