### PR TITLE
New Duck AI Toggle Prompt Pixels

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1609,6 +1609,8 @@ extension Pixel {
         case aiChatNewAddressBarPickerDisplayed
         case aiChatNewAddressBarPickerConfirmed
         case aiChatNewAddressBarPickerNotNow
+        case aiChatNewAddressBarPickerV2Displayed
+        case aiChatNewAddressBarPickerV2Confirmed
         
         // MARK: Experimental Omnibar Metrics
         case aiChatExperimentalOmnibarShown
@@ -3304,6 +3306,8 @@ extension Pixel.Event {
         case .aiChatNewAddressBarPickerDisplayed: return "m_aichat_new_address_bar_picker_displayed"
         case .aiChatNewAddressBarPickerConfirmed: return "m_aichat_new_address_bar_picker_confirmed"
         case .aiChatNewAddressBarPickerNotNow: return "m_aichat_new_address_bar_picker_not_now"
+        case .aiChatNewAddressBarPickerV2Displayed: return "m_aichat_new_address_bar_picker_v2_displayed"
+        case .aiChatNewAddressBarPickerV2Confirmed: return "m_aichat_new_address_bar_picker_v2_confirmed"
         
         // MARK: Experimental Omnibar Metrics
         case .aiChatExperimentalOmnibarShown: return "m_aichat_experimental_omnibar_shown"

--- a/iOS/DuckDuckGo/AIChat/NewAddressBarPicker/NewAddressBarPickerViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/NewAddressBarPicker/NewAddressBarPickerViewController.swift
@@ -41,7 +41,7 @@ final class NewAddressBarPickerViewController: UIViewController {
         super.viewDidLoad()
         
         setupContentView()
-        DailyPixel.fireDailyAndCount(pixel: .aiChatNewAddressBarPickerDisplayed)
+        DailyPixel.fireDailyAndCount(pixel: .aiChatNewAddressBarPickerV2Displayed)
     }
     
     private func setupContentView() {

--- a/iOS/DuckDuckGo/AIChat/NewAddressBarPicker/NewAddressBarPickerViewModel.swift
+++ b/iOS/DuckDuckGo/AIChat/NewAddressBarPicker/NewAddressBarPickerViewModel.swift
@@ -51,7 +51,7 @@ private extension NewAddressBarPickerViewModel {
     func fireConfirmPixel() {
         let selectionValue = isDuckAISelected ? "search_and_ai" : "search_only"
         dailyPixelFiring.fireDailyAndCount(
-            .aiChatNewAddressBarPickerConfirmed,
+            .aiChatNewAddressBarPickerV2Confirmed,
             error: nil,
             withAdditionalParameters: [PixelParameters.selection: selectionValue]
         )

--- a/iOS/DuckDuckGoTests/AIChat/NewAddressBarPickerViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/NewAddressBarPickerViewModelTests.swift
@@ -58,7 +58,7 @@ final class NewAddressBarPickerViewModelTests: XCTestCase {
         sut.isDuckAISelected = true
         sut.confirm()
         XCTAssertEqual(aiChatSettings.lastEnableAIChatSearchInputValue, true)
-        XCTAssertEqual(pixelFiringMock.lastDailyPixelInfo?.pixelName, Pixel.Event.aiChatNewAddressBarPickerConfirmed.name)
+        XCTAssertEqual(pixelFiringMock.lastDailyPixelInfo?.pixelName, Pixel.Event.aiChatNewAddressBarPickerV2Confirmed.name)
         XCTAssertEqual(pixelFiringMock.lastDailyPixelInfo?.params?[PixelParameters.selection], "search_and_ai")
         XCTAssertEqual(dismissCallCount, 1)
     }
@@ -67,7 +67,7 @@ final class NewAddressBarPickerViewModelTests: XCTestCase {
         sut.isDuckAISelected = false
         sut.confirm()
         XCTAssertEqual(aiChatSettings.lastEnableAIChatSearchInputValue, false)
-        XCTAssertEqual(pixelFiringMock.lastDailyPixelInfo?.pixelName, Pixel.Event.aiChatNewAddressBarPickerConfirmed.name)
+        XCTAssertEqual(pixelFiringMock.lastDailyPixelInfo?.pixelName, Pixel.Event.aiChatNewAddressBarPickerV2Confirmed.name)
         XCTAssertEqual(pixelFiringMock.lastDailyPixelInfo?.params?[PixelParameters.selection], "search_only")
         XCTAssertEqual(dismissCallCount, 1)
     }

--- a/iOS/PixelDefinitions/pixels/definitions/new_address_bar_picker.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/new_address_bar_picker.json5
@@ -31,5 +31,28 @@
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_aichat_new_address_bar_picker_v2_displayed": {
+        "description": "Fires when the V2 (refreshed) New Address Bar Picker modal is displayed",
+        "owners": ["jleandroperez"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_aichat_new_address_bar_picker_v2_confirmed": {
+        "description": "Fires when user taps Confirm on the V2 (refreshed) New Address Bar Picker",
+        "owners": ["jleandroperez"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "selection",
+                "description": "Selected option",
+                "type": "string",
+                "enum": ["search_only", "search_and_ai"]
+            }
+        ]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1214407241452704?focus=true
Tech Design URL:
CC:

### Description

### Testing Steps
1. Open `Settings > Debug`
2. Press on `Show New AddressBar Modal`

- [ ] Verify we log this Pixel, as soon as the Popup appears: `m.aichat.new.address.bar.picker.v2.displayed.daily`
- [ ] Verify we log this Pixel after confirmation: `m.aichat.new.address.bar.picker.v2.confirmed.count`

### Impact and Risks
None: Internal tooling, documentation

#### What could go wrong?
Nothing really, this PR adds two new pixels

### Quality Considerations
None

### Notes to Reviewer
Thank you!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds new pixel definitions and switches the refreshed New Address Bar Picker flow to fire the new V2 pixels; no user-facing logic changes beyond analytics emission.
> 
> **Overview**
> Adds two new AI Chat pixels for the refreshed *New Address Bar Picker V2* (`..._v2_displayed` and `..._v2_confirmed`, including the existing `selection` parameter on confirm).
> 
> Updates the refreshed picker modal/view model to fire these V2 pixels instead of the original ones, and adjusts unit tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b761ed17a43c17624d0b3dea28a6f7c62e3a3ca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->