### PR TITLE
Cache Classifier.Policy JSON to avoid per-keystroke encoding

### DIFF
--- a/SharedPackages/URLPredictor/Sources/URLPredictor/Classifier.swift
+++ b/SharedPackages/URLPredictor/Sources/URLPredictor/Classifier.swift
@@ -53,16 +53,22 @@ public enum Classifier {
     /// This struct describes the policy to be used when classifying the input.
     public struct Policy: Codable, Sendable {
         /// Treat any host-like strings as URLs (e.g. `package.json`) without consulting Public Suffix List.
-        public var allowIntranetMultiLabel: Bool
+        public let allowIntranetMultiLabel: Bool
 
         /// Whether to allow single-label domains (e.g. `test` or `dev`).
-        public var allowIntranetSingleLabel: Bool
+        public let allowIntranetSingleLabel: Bool
 
         /// When checking Public Suffix List, whether to consult private suffixes (e.g. `appspot.com` or `github.io`).
-        public var allowPrivateSuffix: Bool
+        public let allowPrivateSuffix: Bool
 
         /// Defines schemes recognized by the app/
-        public var allowedSchemes: Set<String>
+        public let allowedSchemes: Set<String>
+
+        /// JSON sent to the Rust classifier, computed once.
+        ///
+        /// `classify` runs per-keystroke in the address bar and re-encoding here
+        /// may pressure the heap enough to trip malloc on memory-tight machines.
+        fileprivate let encodedJSON: String
 
         public init(
             allowIntranetMultiLabel: Bool,
@@ -74,6 +80,43 @@ public enum Classifier {
             self.allowIntranetSingleLabel = allowIntranetSingleLabel
             self.allowPrivateSuffix = allowPrivateSuffix
             self.allowedSchemes = allowedSchemes
+
+            let encoder = JSONEncoder()
+            encoder.keyEncodingStrategy = .convertToSnakeCase
+            let shape = EncodableShape(
+                allowIntranetMultiLabel: allowIntranetMultiLabel,
+                allowIntranetSingleLabel: allowIntranetSingleLabel,
+                allowPrivateSuffix: allowPrivateSuffix,
+                allowedSchemes: allowedSchemes
+            )
+            // Encoding a struct of Bool/String/Set<String> with snake_case keys cannot fail at runtime.
+            // swiftlint:disable:next force_try
+            self.encodedJSON = String(data: try! encoder.encode(shape), encoding: .utf8)!
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.init(
+                allowIntranetMultiLabel: try container.decode(Bool.self, forKey: .allowIntranetMultiLabel),
+                allowIntranetSingleLabel: try container.decode(Bool.self, forKey: .allowIntranetSingleLabel),
+                allowPrivateSuffix: try container.decode(Bool.self, forKey: .allowPrivateSuffix),
+                allowedSchemes: try container.decode(Set<String>.self, forKey: .allowedSchemes)
+            )
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case allowIntranetMultiLabel
+            case allowIntranetSingleLabel
+            case allowPrivateSuffix
+            case allowedSchemes
+        }
+
+        /// Reflects the encodable Policy struct, to use with `encodedJSON` and `classify` calls.
+        private struct EncodableShape: Encodable {
+            let allowIntranetMultiLabel: Bool
+            let allowIntranetSingleLabel: Bool
+            let allowPrivateSuffix: Bool
+            let allowedSchemes: Set<String>
         }
 
 #if os(macOS)
@@ -156,14 +199,7 @@ public enum Classifier {
     // MARK: - Internal
 
     static func classifyRawJSON(input: String, policy: Policy?) throws -> String {
-        // Encode policy with snake_case to match Rust field names.
-        let encoder = JSONEncoder()
-        encoder.keyEncodingStrategy = .convertToSnakeCase
-        guard let policyData = try? encoder.encode(policy),
-              let policyJSON = String(data: policyData, encoding: .utf8)
-        else {
-            throw Error.policyEncodingFailed
-        }
+        let policyJSON = policy?.encodedJSON ?? "null"
 
         let jsonString: String = try input.withCString { inputPtr in
             try policyJSON.withCString { policyPtr in


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214294661819890/task/1214486588281411

### Description

Fix for Sentry crash `APPLE-MACOS-BMH` (`EXC_BREAKPOINT` in `Classifier.Policy.encode`).

`Classifier.classifyRawJSON` was running `JSONEncoder().encode(policy)` on every call. Because `classify` runs per-keystroke in the address bar, this was allocating and serialising a fresh `Policy` JSON on every character, which on memory-tight ARM64 machines pressured the heap enough to trip malloc and SIGTRAP.

The encoded JSON is now computed once at `Policy` construction and cached in a `fileprivate let encodedJSON: String`. `classifyRawJSON` reuses it, so address-bar typing no longer allocates per keystroke. `Policy` properties are now `let` (nothing mutated them), and a private `EncodableShape` carries the snake_case wire encoding so the cached field doesn't leak into `Codable` synthesis.

### Testing Steps
1. Smoke-test typing in the address bar.

### Impact and Risks
Low.

#### What could go wrong?

### Quality Considerations

### Notes to Reviewer

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `Classifier.Policy` from mutable to immutable and introduces cached JSON with `try!/!`, which could be source-breaking for callers that mutate policies and would crash if assumptions about encoding ever change.
> 
> **Overview**
> Avoids per-keystroke `JSONEncoder` work in `Classifier.classifyRawJSON` by pre-encoding `Classifier.Policy` once at initialization and reusing a cached `encodedJSON` string (sending `"null"` when policy is absent).
> 
> To support this cache, `Policy`’s public fields are now `let`, decoding is implemented manually to recompute the cache, and encoding uses a private `EncodableShape` with snake_case keys to match the Rust classifier wire format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03802950cbb351aab8bdf67ce40c176088573691. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->