### PR TITLE
Fix #4644 SwiftLint and test actor-isolation failures

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/DuckAIURLSuggestionsLoader.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/DuckAIURLSuggestionsLoader.swift
@@ -73,7 +73,7 @@ final class DuckAIURLSuggestionsLoader {
             return
         }
 
-        loader.getSuggestions(query: query, usingDataSource: dataSource) { [weak self] result, error in
+        loader.getSuggestions(query: query, usingDataSource: dataSource) { [weak self] result, _ in
             guard let self else { return }
             guard self.latestDispatchedQuery == query else { return }
             // Always settle, even on error — otherwise `hasSettled` stays false forever and Dax suppression never clears.

--- a/iOS/DuckDuckGo/AutocompleteView.swift
+++ b/iOS/DuckDuckGo/AutocompleteView.swift
@@ -341,4 +341,3 @@ private struct SuggestionListItem: View {
     }
 
 }
-

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/DuckAISuggestionsCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/DuckAISuggestionsCoordinatorTests.swift
@@ -20,6 +20,7 @@
 import XCTest
 @testable import DuckDuckGo
 
+@MainActor
 final class DuckAISuggestionsCoordinatorTests: XCTestCase {
 
     func test_hasSettled_returnsFalseWhenOnlyChatHasSettled() {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/DuckAIURLSuggestionsLoaderTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/DuckAIURLSuggestionsLoaderTests.swift
@@ -110,4 +110,3 @@ final class DuckAIURLSuggestionsLoaderTests: XCTestCase {
         cancellable.cancel()
     }
 }
-


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1214500809380358?focus=true

### Description

Fixes CI failures on `main` introduced by #4644:
- **SwiftLint** (`--strict`): 1× unused closure parameter, 2× extra trailing newline.
- **Unit Tests**: `DuckAISuggestionsCoordinatorTests` was missing `@MainActor`, so its 4 calls to `DuckAISuggestionsCoordinator.hasSettled` (a `@MainActor` static method) failed to compile.

### Testing Steps

1. CI on this branch goes green (`Shared - SwiftLint` + `iOS - PR Checks` Unit Tests).

### Impact and Risks

Low. Lint-only and test-only changes; no production-code behavior changed.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are lint/test fixes plus a closure parameter cleanup; no functional behavior changes beyond error parameter being ignored.
> 
> **Overview**
> Fixes CI failures by removing an unused closure parameter in `DuckAIURLSuggestionsLoader.fetch` and trimming extra trailing newlines that violated SwiftLint `--strict`.
> 
> Updates `DuckAISuggestionsCoordinatorTests` to run under `@MainActor` so calls to the `@MainActor` `hasSettled` API compile and pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e5710bb81a2231ad5b08831e6d6c53ec7133e03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->