### PR TITLE
[iOS] Add a definition file for the idle wide event

### DIFF
--- a/iOS/PixelDefinitions/wide_events/definitions/post-idle-session.json5
+++ b/iOS/PixelDefinitions/wide_events/definitions/post-idle-session.json5
@@ -1,0 +1,56 @@
+{
+    "ios-post-idle-session": {
+        "description": "Sent at the end of a post-idle session: the NTP or LUT (List of Used Tabs) shown after the After Inactivity threshold elapses, capturing what the user did on that surface and how the session ended.",
+        "owners": ["samsymons", "SabrinaTardio"],
+        "meta": {
+            "type": "ios-post-idle-session",
+            "version": "0.0"
+        },
+        "feature": {
+            "name": "post_idle_session",
+            "status": ["SUCCESS", "CANCELLED", "UNKNOWN"],
+            "data": {
+                "ext": {
+                    "surface": {
+                        "type": "string",
+                        "description": "Which post-idle surface was shown when the session started",
+                        "enum": ["ntp", "lut"]
+                    },
+                    "status_reason": {
+                        "type": "string",
+                        "description": "Terminal reason describing how the session ended. SUCCESS uses one of the user-action reasons; CANCELLED uses app_backgrounded; UNKNOWN uses app_terminated when an in-flight session is recovered after an app crash or termination.",
+                        "enum": [
+                            "bar_used",
+                            "return_to_page_tapped",
+                            "tab_switcher_selected",
+                            "app_backgrounded",
+                            "favorite_selected",
+                            "chat_selected",
+                            "app_terminated"
+                        ]
+                    },
+                    "session_duration_ms": {
+                        "type": "integer",
+                        "description": "Total time in milliseconds the post-idle surface was visible, from session start until the terminal action or background. Absent when the session was orphaned (UNKNOWN / app_terminated)."
+                    },
+                    "time_to_first_interaction_ms": {
+                        "type": "integer",
+                        "description": "Time in milliseconds from session start to the first user interaction with the post-idle surface (page engagement, toggle, back, or terminal action). Absent if the session ended without any interaction."
+                    },
+                    "page_engaged": {
+                        "type": "boolean",
+                        "description": "True if the user scrolled or activated an in-page link on the post-idle surface during the session"
+                    },
+                    "toggle_used": {
+                        "type": "boolean",
+                        "description": "True if the user toggled between Search and Duck.ai during the session"
+                    },
+                    "back_pressed": {
+                        "type": "boolean",
+                        "description": "True if the user pressed back / cancel from the post-idle surface during the session"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/iOS/PixelDefinitions/wide_events/generated_schemas/ios-post-idle-session-1.0.0.json
+++ b/iOS/PixelDefinitions/wide_events/generated_schemas/ios-post-idle-session-1.0.0.json
@@ -1,0 +1,108 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Sent at the end of a post-idle session: the NTP or LUT (List of Used Tabs) shown after the After Inactivity threshold elapses, capturing what the user did on that surface and how the session ended.",
+    "$comment": "{\"owners\":[\"samsymons\",\"SabrinaTardio\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "ios-post-idle-session" }, "version": { "const": "1.0.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application",
+                    "enum": ["DuckDuckGo", "DuckDuckGo-Alpha", "DuckDuckGo-Experimental", "PacketTunnelProvider"]
+                },
+                "version": { "type": "string", "description": "The version of the application", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+                "form_factor": { "type": "string", "description": "The form factor of the device", "enum": ["phone", "tablet"] }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["iOS"] },
+                "type": { "type": "string", "description": "The type of application", "enum": ["app"] },
+                "sample_rate": { "type": "number", "description": "Sample rate for this event", "minimum": 0, "maximum": 1 },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first occurrence of this event today. Only included when true."
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["post_idle_session"] },
+                "status": {
+                    "type": "string",
+                    "description": "The overall status of the operation",
+                    "enum": ["SUCCESS", "CANCELLED", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "surface": {
+                                    "type": "string",
+                                    "description": "Which post-idle surface was shown when the session started",
+                                    "enum": ["ntp", "lut"]
+                                },
+                                "status_reason": {
+                                    "type": "string",
+                                    "description": "Terminal reason describing how the session ended. SUCCESS uses one of the user-action reasons; CANCELLED uses app_backgrounded; UNKNOWN uses app_terminated when an in-flight session is recovered after an app crash or termination.",
+                                    "enum": [
+                                        "bar_used",
+                                        "return_to_page_tapped",
+                                        "tab_switcher_selected",
+                                        "app_backgrounded",
+                                        "favorite_selected",
+                                        "chat_selected",
+                                        "app_terminated"
+                                    ]
+                                },
+                                "session_duration_ms": {
+                                    "type": "integer",
+                                    "description": "Total time in milliseconds the post-idle surface was visible, from session start until the terminal action or background. Absent when the session was orphaned (UNKNOWN / app_terminated)."
+                                },
+                                "time_to_first_interaction_ms": {
+                                    "type": "integer",
+                                    "description": "Time in milliseconds from session start to the first user interaction with the post-idle surface (page engagement, toggle, back, or terminal action). Absent if the session ended without any interaction."
+                                },
+                                "page_engaged": {
+                                    "type": "boolean",
+                                    "description": "True if the user scrolled or activated an in-page link on the post-idle surface during the session"
+                                },
+                                "toggle_used": {
+                                    "type": "boolean",
+                                    "description": "True if the user toggled between Search and Duck.ai during the session"
+                                },
+                                "back_pressed": {
+                                    "type": "boolean",
+                                    "description": "True if the user pressed back / cancel from the post-idle surface during the session"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1214504428470257?focus=true
Tech Design URL:
CC:

### Description

This PR adds a definition file for the post-idle wide event.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Use the debug menu to set an idle threshold of something short, like 5 seconds
2. Background the app
3. Return after 5 seconds
4. Take some action, like submitting a Duck.ai prompt, and confirm that the event fires
5. In the terminal, run `./iOS/scripts/validate_wide_events.sh` - check that the event validates correctly

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
6. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only introduces new analytics schema/definition files and does not change app runtime logic.
> 
> **Overview**
> Defines a new wide event, `ios-post-idle-session`, to report how post-idle surfaces (NTP/LUT) are used and how the session terminates (success/cancel/unknown).
> 
> Adds the corresponding generated JSON schema (`ios-post-idle-session-1.0.0.json`) including the event fields for surface, terminal reason, durations, and basic interaction flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef2dad8e53f06af7908298254040a540cf18c4cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->