### PR TITLE
macOS: Allow channel parameter on AI Chat sidebar/tabbar pixels

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/aichat_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_pixels.json5
@@ -96,6 +96,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "channel",
             {
                 "key": "width",
                 "description": "The final sidebar width in points",
@@ -115,35 +116,35 @@
         "owners": ["jaceklyp"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_sidebar_attached": {
         "description": "Fired when user re-docks the floating AI Chat window via the attach button",
         "owners": ["jaceklyp"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_sidebar_floating_closed": {
         "description": "Fired when user closes the floating AI Chat window via the close button",
         "owners": ["jaceklyp"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_sidebar_floating_tab_activated": {
         "description": "Fired when user clicks the floating title button to activate the associated tab",
         "owners": ["jaceklyp"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_tabbar_button_clicked": {
         "description": "Fired when user clicks the Duck.ai button in the tab bar to open a new chat tab",
         "owners": ["jaceklyp"],
         "triggers": ["other"],
         "suffixes": ["daily_standard"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_sidebar_closed": {
         "description": "Fired when the AI Chat sidebar is closed",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214471239491946

### Description

Six AI Chat pixels failed live validation with `must NOT have additional properties. Found extra property 'channel'`. PixelKit auto-injects a `channel` parameter on canary/dev builds (`PixelKit.swift:292`), but these six pixels didn't declare it in their schemas.

This adds `"channel"` to the `parameters` array of:

- `m_mac_aichat_sidebar_resized`
- `m_mac_aichat_sidebar_detached`
- `m_mac_aichat_sidebar_attached`
- `m_mac_aichat_sidebar_floating_closed`
- `m_mac_aichat_sidebar_floating_tab_activated`
- `m_mac_aichat_tabbar_button_clicked`

The new entries reference the shared `channel` definition in `params_dictionary.json5` (`enum: ["canary", "dev"]`), matching the convention already used by `m_mac_aichat_start_new_conversation` and `m_mac_aichat_sent_prompt_ongoing_chat`.

### Testing Steps

1. From `macOS/PixelDefinitions/`, run `npm run validate-pixel-defs` — `aichat_pixels.json5` validates clean.

### Impact and Risks

Low. Schema-only change; no Swift code paths touched. Stops these six pixels from being rejected by live validation on canary/dev builds.

### Notes to Reviewer

The same gap likely exists in this file for AI Chat pixels owned by other devs (`miasma13`, `rachelmcr`, `tomasstrba`, `Bunn`) — out of scope here, but worth a heads-up so they aren't surprised by their own validation reports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema-only change that broadens accepted parameters for a handful of analytics pixels; main risk is mismatched pixel schema expectations in downstream validation/processing.
> 
> **Overview**
> Updates macOS AI Chat pixel schemas to **accept the auto-injected `channel` parameter** for several sidebar/tabbar interaction pixels in `aichat_pixels.json5`.
> 
> This prevents live validation failures on canary/dev builds by aligning these pixel definitions with existing `channel` usage elsewhere in the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a05e4dcc5575037e88a1707ab5cec9fcfea3a02c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->