### PR TITLE
Fix image download in Duck.ai sidebar chat

### DIFF
--- a/macOS/DuckDuckGo/MainWindow/FireWindowSession.swift
+++ b/macOS/DuckDuckGo/MainWindow/FireWindowSession.swift
@@ -81,10 +81,8 @@ struct FireWindowSessionRef: Hashable {
     @MainActor
     init?(window: NSWindow?) {
         guard let window else { return nil }
-        guard let mainWindowController = window.windowController as? MainWindowController else {
-            assertionFailure("\(window) has no MainWindowController")
-            return nil
-        }
+        // Some windows (e.g. the detached AI Chat sidebar) don't use MainWindowController and aren't part of any fire session.
+        guard let mainWindowController = window.windowController as? MainWindowController else { return nil }
         guard let fireWindowSession = mainWindowController.fireWindowSession else { return nil }
         self.fireWindowSession = fireWindowSession
         self.identifier = ObjectIdentifier(fireWindowSession)

--- a/macOS/DuckDuckGo/Tab/TabExtensions/AIChatTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/AIChatTabExtension.swift
@@ -242,6 +242,11 @@ extension AIChatTabExtension: NavigationResponder {
             return .next
         }
 
+        // Downloads must stay in the sidebar webview: a redirect drops the download intent and blob: URLs are unresolvable elsewhere.
+        if navigationAction.shouldDownload {
+            return .next
+        }
+
         // Allow-list: also let certain hosts navigate inside the sidebar (e.g., duck.ai)
         if navigationAction.url.isStandaloneDuckAIURL {
             return .next


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1214393639832142

### Description

Image downloads from the Duck.ai chat sidebar on macOS produced a new tab with a 4xx error instead of saving the file. Both docked and detached/floating sidebar were affected.

`AIChatTabExtension.decidePolicy(for:NavigationAction)` (registered first in the responder chain at `Tab+Navigation.swift:34`) cancels every user-initiated, cross-document sidebar navigation that isn't `host == "duck.ai"` or `about:`, and re-opens it as a new main-window tab. Duck.ai's image download uses `<a download href="blob:…">`, which produces a navigation with `scheme=blob`, host nil, and `shouldDownload=true`. The cancel-and-redirect path drops the download intent and the blob URL is unresolvable in the new tab's webview process context, hence the 4xx-shaped error page.

Fix: short-circuit `decidePolicy` on `navigationAction.shouldDownload` before the cross-document redirect. The navigation now reaches `DownloadsTabExtension` (registered later in the responder chain) which converts it into a `WKDownload`. Verified via debug logging — pre-fix the action took the `.cancel + redirect` branch; post-fix it takes the new `.next (shouldDownload)` branch and the file saves normally.

### Testing Steps

1. Open the Duck.ai sidebar (docked).
2. Generate an image (e.g. "draw me a duck").
3. Click the Download button on the generated image — file should save via the standard download prompt; no new tab should open.
4. Detach the sidebar to a floating window and repeat — same result.
5. Re-dock and repeat — same result.

### Impact and Risks

Low. Scope is one early-return inside the sidebar's navigation responder, gated on `navigationAction.shouldDownload`.

#### What could go wrong?

The new branch only fires for `shouldDownload == true` actions, which WebKit sets exclusively for explicit download navigations (`<a download>`, Opt+Click, etc.). Non-download blob/data navigations are unaffected and continue to follow the existing redirect-to-main-window path. Worst case if `shouldDownload` is mis-classified upstream is that a navigation that would previously have been redirected stays in the sidebar — same outcome as the regular Duck.ai tab on the public site.

### Notes to Reviewer

The 7-line change includes a one-line comment because the responder ordering (this extension first, `downloads` later) makes the bug-class easy to reintroduce — the comment explains why downloads must short-circuit out before the cross-document redirect.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small guard/early-return changes to sidebar navigation policy and fire session lookup, affecting only download navigations and windows without `MainWindowController`. Potential regressions are limited to sidebar link handling and fire-session association for detached windows.
> 
> **Overview**
> Fixes Duck.ai sidebar downloads on macOS by short-circuiting `AIChatTabExtension.decidePolicy` when `navigationAction.shouldDownload` is true, preventing the existing cancel-and-open-in-new-tab redirect that broke `blob:`-backed downloads.
> 
> Separately, relaxes `FireWindowSessionRef.init(window:)` to return `nil` (instead of asserting) for windows that don’t use `MainWindowController` (e.g. detached AI Chat sidebar), avoiding treating them as part of a fire session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39a34c151451d3e72cdb18bdb899eaed856b8a50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->