### PR TITLE
[macOS] Add pixel definitions for ContextualOnboardingPixel

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/onboarding_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/onboarding_pixels.json5
@@ -176,5 +176,83 @@
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "parameters": ["appVersion", "onboardingEventType", "onboardingClickedValue", "onboardingInstallType", "onboardingDaysSinceInstall"]
+    },
+    "m_mac_onboarding_search_custom_u": {
+        "description": "Fired when the user types into the address bar when the search suggestions dialog is shown during the contextual onboarding",
+        "owners": ["SabrinaTardio", "rachelmcr"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_onboarding_visit_site_custom_u": {
+        "description": "Fired when the user types into the address bar when the site suggestions dialog  is shown during the contextual onboarding",
+        "owners": ["SabrinaTardio", "rachelmcr"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_onboarding_fire_button_try_it_pressed_u": {
+        "description": "Fired when the “skip” button is clicked on the Fire Button dialog during the contextual onboarding",
+        "owners": ["SabrinaTardio", "rachelmcr"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_onboarding_finished_u": {
+        "description": "Fired when the final onboarding dialog is displayed during the contextual onboarding",
+        "owners": ["SabrinaTardio", "rachelmcr"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_onboarding_fire_button_pressed_u": {
+        "description": "Fired when the Fire button is clicked from the Fire Button dialog during the contextual onboarding",
+        "owners": ["SabrinaTardio", "rachelmcr"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_onboarding_privacy_dashboard_opened_u": {
+        "description": "Fired when the privacy dashboard is opened from the Trackers dialog during the contextual onboarding",
+        "owners": ["SabrinaTardio", "rachelmcr"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_second_site_visit_u": {
+        "description": "Fired on didFinishLoading on Tab only if it's not a search; the OnboardingPixelProvider sends it only the second time",
+        "owners": ["SabrinaTardio", "rachelmcr"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_onboarding_try_search_dialog_dismiss_button_tapped_u": {
+        "description": "Fired when the try search dialog in the contextual onboarding is dismissed",
+        "owners": ["SabrinaTardio", "rachelmcr"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_onboarding_search-result-dialog_dismiss-button-tapped_u": {
+        "description": "Fired when the search result dialog in the contextual onboarding is dismissed",
+        "owners": ["SabrinaTardio", "rachelmcr"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_onboarding_try_visit_site_dialog_dismiss_button_tapped_u": {
+        "description": "Fired when the try visit site dialog in the contextual onboarding is dismissed",
+        "owners": ["SabrinaTardio", "rachelmcr"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_onboarding_trackers_dialog_dismiss_button_tapped_u": {
+        "description": "Fired when the trackers blocked dialog in the contextual onboarding is dismissed",
+        "owners": ["SabrinaTardio", "rachelmcr"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_onboarding_fire_dialog_dismiss_button_tapped_u": {
+        "description": "Fired when the try fire button dialog in the contextual onboarding is dismissed",
+        "owners": ["SabrinaTardio", "rachelmcr"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "m_mac_onboarding_end_dialog_dismiss_button_tapped_u": {
+        "description": "Fired when the final dialog in the contextual onboarding is dismissed",
+        "owners": ["SabrinaTardio", "rachelmcr"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource"]
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1214528167797315?focus=true
Tech Design URL:
CC:

### Description

There are some failing pixels being reported because some of the new onboarding pixel names (e.g. `m_mac_onboarding_search`) are similar to existing pixels (e.g. `m_mac_onboarding_search_custom_u`), which causes a "Found extra suffix" error.

This adds pixel definitions for the existing contextual onboarding pixels (`ContextualOnboardingPixel`) to resolve those errors. I added two owners to cover the initial implementation plus more recent pixel changes.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
No functional changes; can confirm the pixel definitions match actual pixels fired by going through onboarding:
1. Build and run the app.
2. Debug -> Reset Data -> Reset Contextual Onboarding
3. Restart the app.
4. Trigger each pixel as described and confirm the name and parameters match.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
5. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling, documentation

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
If there are any errors in the pixel definitions, there could be failing pixels reported.

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds analytics pixel metadata and does not change runtime behavior; the main risk is typos/mismatched names or parameters causing pixels to still fail validation.
> 
> **Overview**
> Adds missing pixel definitions in `onboarding_pixels.json5` for *contextual onboarding* events (e.g. custom search/site entry, fire/finish actions, privacy dashboard open, second site visit, and various dialog dismiss actions).
> 
> These new definitions include descriptions, owners, and expected parameters (primarily `appVersion` and `pixelSource`) to prevent pixel validation errors caused by similar pixel names/suffix handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b26cc12e9396503f9e8e23424c0c5b1517bca88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->