### PR TITLE
[macOS] Re-check promo queue rules after external promo appears

### DIFF
--- a/macOS/DuckDuckGo/Promotions/PromoService.swift
+++ b/macOS/DuckDuckGo/Promotions/PromoService.swift
@@ -410,8 +410,24 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
             record.lastShown = currentDate
             historyStore.save(record)
             notifyRecordChanged(for: promoId, record: record)
+            // External visibility is not gated by checkRules; retract conflicting internal promos shown earlier.
+            hideInternalPromosConflictingWithCurrentVisibility()
         } else if externalVisiblePromoIds.remove(promoId) != nil {
             applyResult(delegate.resultWhenHidden, toRecordFor: promoId)
+        }
+    }
+
+    /// Retracts visible internal promos that would fail `checkRules` now that an external promo may be visible.
+    private func hideInternalPromosConflictingWithCurrentVisibility() {
+        dispatchPrecondition(condition: .onQueue(stateQueue))
+        let visiblePromos = Array(activeSessions.keys)
+        for promoID in visiblePromos {
+            guard activeSessions[promoID] != nil,
+                  let promo = promos.first(where: { $0.id == promoID }),
+                  promo.delegate is PromoDelegate else { continue }
+            if !checkRules(for: promo) {
+                recordResultAndCleanup(promoId: promoID, result: .noChange)
+            }
         }
     }
 

--- a/macOS/UnitTests/Promotions/PromoServiceTests.swift
+++ b/macOS/UnitTests/Promotions/PromoServiceTests.swift
@@ -1767,6 +1767,82 @@ final class PromoServiceTests: XCTestCase {
         XCTAssertFalse(internalRecord.actioned)
     }
 
+    func testWhenInternalPromoVisibleAndExternalBecomesVisible_ThenInternalIsRetractedWithNoChangeHistory() async {
+        let externalDelegate = MockExternalPromoDelegate(initialVisibility: false)
+        let internalDelegate = MockPromoDelegate(isEligible: true)
+        let externalPromo = PromoTestHelpers.makePromo(id: "external-promo", delegate: externalDelegate)
+        let internalPromo = PromoTestHelpers.makePromo(id: "internal-promo", delegate: internalDelegate)
+        let promoService = makeService(promos: [externalPromo, internalPromo])
+
+        let internalVisibleExpectation = XCTestExpectation(description: "internal promo visible")
+        let onlyExternalExpectation = XCTestExpectation(description: "only external visible after retraction")
+        var sawInternalVisible = false
+        promoService.visiblePromosPublisher
+            .sink { promos in
+                let ids = Set(promos.map(\.id))
+                if ids.contains(internalPromo.id) {
+                    sawInternalVisible = true
+                    internalVisibleExpectation.fulfill()
+                }
+                if sawInternalVisible, ids == Set([externalPromo.id]) {
+                    onlyExternalExpectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        promoService.applicationDidBecomeActive()
+        triggerSubject.send(.appLaunched)
+        await fulfillment(of: [internalVisibleExpectation], timeout: timeout)
+
+        externalDelegate.setVisible(true)
+        await fulfillment(of: [onlyExternalExpectation], timeout: timeout)
+
+        let externalRecord = historyStore.record(for: externalPromo.id)
+        XCTAssertNotNil(externalRecord.lastShown)
+        let internalRecord = historyStore.record(for: internalPromo.id)
+        XCTAssertEqual(internalRecord.timesDismissed, 0)
+        XCTAssertNil(internalRecord.lastShown)
+        XCTAssertFalse(internalRecord.actioned)
+    }
+
+    func testWhenInternalAndExternalMutuallyCoexist_AndExternalBecomesVisible_ThenInternalIsNotRetracted() async {
+        let externalDelegate = MockExternalPromoDelegate(initialVisibility: false)
+        let internalDelegate = MockPromoDelegate(isEligible: true)
+        let externalPromo = PromoTestHelpers.makePromo(id: "external-promo", coexistingPromoIDs: ["internal-promo"], delegate: externalDelegate)
+        let internalPromo = PromoTestHelpers.makePromo(id: "internal-promo", coexistingPromoIDs: ["external-promo"], delegate: internalDelegate)
+        let promoService = makeService(promos: [externalPromo, internalPromo])
+
+        let internalVisibleExpectation = XCTestExpectation(description: "internal promo visible")
+        let bothVisibleExpectation = XCTestExpectation(description: "internal and external both visible")
+        let onlyExternalExpectation = XCTestExpectation(description: "only external visible")
+        onlyExternalExpectation.isInverted = true // When external becomes visible, internal should remain visible
+        var sawInternalVisible = false
+        promoService.visiblePromosPublisher
+            .sink { promos in
+                let ids = Set(promos.map(\.id))
+                if ids.contains(internalPromo.id) {
+                    sawInternalVisible = true
+                    internalVisibleExpectation.fulfill()
+                }
+                if ids == Set([externalPromo.id, internalPromo.id]) {
+                    bothVisibleExpectation.fulfill()
+                }
+                if sawInternalVisible, ids == Set([externalPromo.id]) {
+                    onlyExternalExpectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        promoService.applicationDidBecomeActive()
+        triggerSubject.send(.appLaunched)
+        await fulfillment(of: [internalVisibleExpectation], timeout: timeout)
+
+        externalDelegate.setVisible(true)
+        await fulfillment(of: [bothVisibleExpectation, onlyExternalExpectation], timeout: timeout)
+
+        XCTAssertEqual(internalDelegate.hideCallCount, 0)
+    }
+
     func testWhenDismissExternalPromo_ThenRemovedFromVisibleAndResultApplied() async {
         let externalDelegate = MockExternalPromoDelegate(initialVisibility: true)
         let promo = PromoTestHelpers.makePromo(id: "external-dismiss-call", delegate: externalDelegate)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1214533668722876?focus=true
Tech Design URL:
CC:

### Description

We had a reported issue where an internal promo was shown in the promo queue, and then an external promo became visible at the same time. Because external promos aren't suppressed by the promo queue, they can be shown at any time.

This adds a fix for that scenario: When an external promo becomes visible, we re-evaluate the visible internal promos to retract any promos that are no longer allowed per the promo queue rules. Promos are retracted with `noChange`, making them eligible to be shown again when triggered.

### Testing Steps
<!-- Assume the reviewer is unfamiliar with this part of the app -->
1. Build and run the app.
2. Open a new tab page.
3. If the Next Steps cards are visible on the new tab page, dismiss all of them.
4. Go to Debug -> Promo Queue -> Fire Test Trigger.
5. Confirm "Test Promo A" appears. (internal promo)
6. Go to Debug -> New Tab Page -> Reset Next Steps.
7. Confirm the Next Steps cards appear (external promo) and Test Promo A is hidden.
8. Dismiss all Next Steps cards.
9. Go to Debug -> Promo Queue -> Fire Test Trigger.
10. Confirm "Test Promo A" appears again. (This promo is eligible immediately because it isn't affected by any global cooldown, since it's a user-initiated promo and Next Steps is app-initiated.)

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
11. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Medium: If the rules are misapplied, promos could be retracted/not shown when expected.

#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->
Rules could be applied incorrectly. To address this:
* Only already visible, internal promos are checked
* Same rules are applied as in the usual promo queue flow (using `checkRules(for:)`)
* A `noChange` result is applied so promo history is not changed for retracted promos
* Tests cover scenarios where visible promo should be hidden, and where visible promo remains eligible (mutual coexistence of the external/internal promos)
* Manual testing confirms the result works as expected (promo can be immediately re-triggered).

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches promo visibility/rule evaluation and can change which promos remain visible; incorrect rule re-evaluation could hide promos unexpectedly or fail to free slots as intended.
> 
> **Overview**
> When an *external* promo becomes visible, `PromoService` now re-checks `checkRules(for:)` against all currently visible *internal* promos and retracts any that are no longer allowed, recording the retraction as `.noChange` so they can be re-triggered later.
> 
> Adds unit tests covering the new behavior (internal promo is retracted when an external appears) and a coexistence case where both promos remain visible when mutually allowed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abaa8eb2786a61d4b45837f2dda2148210686b1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->