### PR TITLE
[macOS] Fix selected tab sizing in overflow mode

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabLazyLoader/TabLazyLoader.swift
+++ b/macOS/DuckDuckGo/Tab/TabLazyLoader/TabLazyLoader.swift
@@ -138,6 +138,7 @@ final class TabLazyLoader<DataSource: TabLazyLoaderDataSource> {
             .store(in: &cancellables)
 
         willReloadNextTab
+            .receive(on: RunLoop.main)
             .sink { [weak self] in
                 self?.findAndReloadNextTab()
             }

--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
@@ -453,11 +453,10 @@ final class TabCollectionViewModel: NSObject {
             }
         }
         let insertionIndex = tabCollection.tabs.indices.index(before: tabCollection.tabs.endIndex)
-        // Notify the delegate before updating selection — see `insert(_:at:selected:)`.
-        delegate?.tabCollectionViewModelDidAppend(self, selected: selected)
         if selected {
             selectUnpinnedTab(at: insertionIndex, forceChange: forceChange)
         }
+        delegate?.tabCollectionViewModelDidAppend(self, selected: selected)
         return insertionIndex
     }
 
@@ -478,13 +477,20 @@ final class TabCollectionViewModel: NSObject {
             return
         }
 
-        tabCollection.append(tabs: tabs)
-        // Notify the delegate before updating selection — see `insert(_:at:selected:)`.
-        delegate?.tabCollectionViewModelDidMultipleChanges(self)
+        // Materialize the to-be-selected last tab before insertion — see `insert(_:at:selected:)`.
+        var tabsToAppend = tabs
+        if shouldSelectLastTab,
+           let lastIndex = tabsToAppend.indices.last,
+           case .unloaded(let unloaded) = tabsToAppend[lastIndex] {
+            tabsToAppend[lastIndex] = .loaded(unloaded.materialize())
+        }
+
+        tabCollection.append(tabs: tabsToAppend)
         if shouldSelectLastTab {
             let newSelectionIndex = tabCollection.tabs.count - 1
             selectUnpinnedTab(at: newSelectionIndex)
         }
+        delegate?.tabCollectionViewModelDidMultipleChanges(self)
     }
 
     func append(tabs: [Tab], andSelect shouldSelectLastTab: Bool) {
@@ -514,16 +520,21 @@ final class TabCollectionViewModel: NSObject {
             return
         }
 
-        tabCollection.insert(tab, at: index.item)
-        // Notify the delegate before updating selection: setting `selectionIndex`
-        // publishes `selectedTabViewModel`, which can synchronously re-enter via
-        // `TabLazyLoader` → `materialize` → `replaceTab` → `didReplaceTabAt` and
-        // call `reloadItems` on the collection view while it still has the
-        // pre-insert item count, raising NSInternalInconsistencyException.
-        delegate?.tabCollectionViewModelDidInsert(self, at: index, selected: selected)
+        // Selection requires a loaded tab (see `AnyTab` doc-comment). Materialize
+        // before insertion so the materialize-on-select branch in
+        // `selectUnpinnedTab` is a no-op when `select(at:)` runs.
+        let tabToInsert: AnyTab = {
+            if selected, case .unloaded(let unloaded) = tab {
+                return .loaded(unloaded.materialize())
+            }
+            return tab
+        }()
+
+        tabCollection.insert(tabToInsert, at: index.item)
         if selected {
             select(at: index)
         }
+        delegate?.tabCollectionViewModelDidInsert(self, at: index, selected: selected)
     }
 
     func insert(_ tab: Tab, at index: TabIndex, selected: Bool = true) {

--- a/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests.swift
@@ -337,13 +337,14 @@ final class TabCollectionViewModelTests: XCTestCase {
         XCTAssert(tab === tabCollectionViewModel.tabViewModel(at: 2)?.tab)
     }
 
-    // Regression tests for APPLE-MACOS-BD7: setting `selectionIndex` from inside
-    // `insert`/`append` publishes `selectedTabViewModel`, which can synchronously
-    // re-enter and call `reloadItems` on the collection view. The delegate must
-    // be notified before that publication so the collection view's item count
-    // stays in sync with the data source.
+    // Selection is published BEFORE the delegate notification on insert/append
+    // paths, so cell sizing in the tab bar (which reads `selectionIndex`) sees
+    // the correct value when `sizeForItemAt` runs from `insertItems`. The
+    // materialize-on-select crash this used to guard against is now prevented
+    // structurally by pre-materializing at the API boundary, and the
+    // lazy-loader re-entry is prevented by deferring its sink.
     @MainActor
-    func testWhenInsertWithSelected_ThenDelegateIsNotifiedBeforeSelectionPublishes() {
+    func testWhenInsertWithSelected_ThenSelectionPublishesBeforeDelegate() {
         let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
         let delegate = TabCollectionViewModelDelegateMock()
         tabCollectionViewModel.delegate = delegate
@@ -358,12 +359,12 @@ final class TabCollectionViewModelTests: XCTestCase {
 
         tabCollectionViewModel.insert(Tab(), at: .unpinned(0), selected: true)
 
-        XCTAssertEqual(didInsertCalledWhenSelectionPublished, true)
+        XCTAssertEqual(didInsertCalledWhenSelectionPublished, false)
         cancellable.cancel()
     }
 
     @MainActor
-    func testWhenAppendWithSelected_ThenDelegateIsNotifiedBeforeSelectionPublishes() {
+    func testWhenAppendWithSelected_ThenSelectionPublishesBeforeDelegate() {
         let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
         let delegate = TabCollectionViewModelDelegateMock()
         tabCollectionViewModel.delegate = delegate
@@ -378,12 +379,12 @@ final class TabCollectionViewModelTests: XCTestCase {
 
         tabCollectionViewModel.append(tab: Tab(), selected: true)
 
-        XCTAssertEqual(didAppendCalledWhenSelectionPublished, true)
+        XCTAssertEqual(didAppendCalledWhenSelectionPublished, false)
         cancellable.cancel()
     }
 
     @MainActor
-    func testWhenAppendTabsWithSelectLast_ThenDelegateIsNotifiedBeforeSelectionPublishes() {
+    func testWhenAppendTabsWithSelectLast_ThenSelectionPublishesBeforeDelegate() {
         let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
         let delegate = TabCollectionViewModelDelegateMock()
         tabCollectionViewModel.delegate = delegate
@@ -398,7 +399,7 @@ final class TabCollectionViewModelTests: XCTestCase {
 
         tabCollectionViewModel.append(tabs: [.loaded(Tab()), .loaded(Tab())], andSelect: true)
 
-        XCTAssertEqual(didMultipleChangesCalledWhenSelectionPublished, true)
+        XCTAssertEqual(didMultipleChangesCalledWhenSelectionPublished, false)
         cancellable.cancel()
     }
 

--- a/macOS/UnitTests/TabBar/ViewModel/TabLazyLoaderTests.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabLazyLoaderTests.swift
@@ -385,6 +385,31 @@ class TabLazyLoaderTests: XCTestCase {
         XCTAssertEqual(materializedIndices, [0, 1, 2])
     }
 
+    // The lazy loader's reaction to a selection-driven `isSelectedTabLoading = false`
+    // must be asynchronous. If it fires synchronously, it can re-enter
+    // `tabCollection.replaceTab → didReplaceTabAt → reloadItems` while a tab insert
+    // is mid-flight on the collection view, raising NSInternalInconsistencyException
+    // (APPLE-MACOS-BD7).
+    @MainActor
+    func testWillReloadNextTab_DoesNotMaterializeSynchronously() {
+        var materializeCount = 0
+        let selected = TabMock(isUrl: false)
+        dataSource.selectedTab = selected
+        dataSource.totalTabCount = 1
+        dataSource.unloadedTabCount = 1
+        dataSource.isUnloadedHandler = { _ in true }
+        dataSource.materializeHandler = { _ in
+            materializeCount += 1
+            return TabMock()
+        }
+
+        let lazyLoader = TabLazyLoader(dataSource: dataSource)!
+        lazyLoader.scheduleLazyLoading()
+
+        dataSource.isSelectedTabLoadingSubject.send(false)
+        XCTAssertEqual(materializeCount, 0, "materialize must not fire synchronously")
+    }
+
     @MainActor
     func waitForLoadingDidFinishEvent<DataSource>(
         _ lazyLoader: TabLazyLoader<DataSource>,

--- a/macOS/UnitTests/TabBar/ViewModel/TabLazyLoaderTests.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabLazyLoaderTests.swift
@@ -336,6 +336,13 @@ class TabLazyLoaderTests: XCTestCase {
 
         await waitForLoadingDidFinishEvent(lazyLoader) {
             lazyLoader.scheduleLazyLoading()
+
+            // The lazy loader's reaction to selection is deferred to the next
+            // runloop turn, so spin until the first reload lands before asserting.
+            let deadline = Date(timeIntervalSinceNow: 1)
+            while reloadedTabsUrls.isEmpty && Date() < deadline {
+                RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+            }
             XCTAssertEqual(reloadedTabsUrls, [newTab.url])
 
             // unpause lazy loading here


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1214464381956469?focus=true

### Description

Fixes a visual glitch where a newly opened tab in the overflow tab bar appeared narrower than its neighbours despite being selected.

Background: the fix removes a defensive ordering introduced by PR #4583 to protect against a tab-bar crash, after first eliminating the lazy-loader re-entry that crash protection was guarding against. Step 10 of the testing plan inherently re-checks that the original crash stays fixed.

### Testing Steps

1. Open ~20 tabs to enter overflow mode.
2. Pin one of them to a page with a hyperlink.
3. On the pinned tab, right-click the link and choose Open Link in New Tab.
4. Verify the new tab appears at the full selected width.
5. Press Cmd-T.
6. Verify the new tab appears at the correct width without flicker.
7. Click the "+" button.
8. Verify the new tab appears at the correct width without flicker.
9. Open the Debug menu and choose Add N Debug Tabs.
10. Verify the last tab appears at the selected width and the app does not crash.
11. Right-click a link and choose Open in Background Tab.
12. Verify the previously selected tab keeps its width and the new tab is at the unselected width.
13. Right-click a bookmark folder and choose Open All in New Tabs.
14. Verify selection has not changed.
15. Click another tab.
16. Verify selection switches as before.
17. Use Cmd-Alt-←/→ to switch tabs.
18. Verify selection switches as before.
19. Close the selected tab.
20. Verify the adjacent tab takes selection at the correct width.
21. Relaunch with a saved many-tab session.
22. Verify the restored selected tab is at the correct width.

### Impact and Risks

Low. The change brings tab-bar insertion in line with patterns already used elsewhere in the same view-model. Independent selection paths (click, keyboard navigation, tab close) are not touched.

#### What could go wrong?

The lazy loader's reaction to selection is now async; tests that asserted state synchronously have been adjusted. Web-extension subscribers of `selectedTabViewModel` see the activation notification before the tab-bar callback fires; the model already contains the inserted tab at that moment, so a synchronous query inside the activation handler still observes it.

### Quality Considerations

Encodes an invariant the codebase already documents: selecting a tab requires a loaded tab. No measurable performance impact.

### Notes to Reviewer

Manual verification in overflow mode (≥20 open tabs) is the most useful check; the visual failure mode is purely about tab width.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)