### PR TITLE
macOS: Remove duplicate channel parameter from m_mac_aichat_sidebar_resized

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/aichat_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_pixels.json5
@@ -97,7 +97,6 @@
         "parameters": [
             "appVersion",
             "pixelSource",
-            "channel",
             {
                 "key": "width",
                 "description": "The final sidebar width in points",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1199230911884351/task/1214471239491946?focus=true

### Description

PR #4718 added `"channel"` to `m_mac_aichat_sidebar_resized`'s `parameters` array, but PR #4648 had already added it earlier in the same file. The result was two `"channel"` entries on this pixel. Removed the duplicate so `channel` is declared exactly once, in the position that matches sibling AI Chat pixels with inline parameter objects (`m_mac_aichat_sidebar_closed`, `m_mac_aichat_is_enabled`).

### Testing Steps

1. From `macOS/PixelDefinitions/`, run `npm run validate-pixel-defs` — `aichat_pixels.json5` validates clean.

### Impact and Risks

Low. Schema-only change; no Swift code paths touched.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema-only change to analytics pixel definitions; it only removes a duplicate parameter entry and does not touch runtime code paths.
> 
> **Overview**
> Removes a duplicated `channel` entry from the `m_mac_aichat_sidebar_resized` pixel definition in `aichat_pixels.json5`, leaving `channel` declared exactly once alongside the inline `width` parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 256a9404e29856bd574e57f459c53494554916f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->