### PR TITLE
Keep UTI expanded when hardware keyboard hides software keyboard

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/iOS/Views/ContextChip/AIChatContextChipView.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/iOS/Views/ContextChip/AIChatContextChipView.swift
@@ -249,6 +249,19 @@ private extension AIChatContextChipView {
     }
 
     func setupConstraints() {
+        // The chip's host can collapse it via an external `height == 0` constraint while it's
+        // hidden. Internal top/bottom padding around the 24pt favicon/remove button would otherwise
+        // demand >= 44pt, so make them break gracefully when the host pins height to 0.
+        let faviconTop = faviconView.topAnchor.constraint(equalTo: chipContentView.topAnchor, constant: Constants.faviconVerticalPadding)
+        faviconTop.priority = .defaultHigh
+        let faviconBottom = faviconView.bottomAnchor.constraint(equalTo: chipContentView.bottomAnchor, constant: -Constants.faviconVerticalPadding)
+        faviconBottom.priority = .defaultHigh
+
+        let removeTop = removeButton.topAnchor.constraint(equalTo: chipContentView.topAnchor, constant: Constants.removeButtonVerticalPadding)
+        removeTop.priority = .defaultHigh
+        let removeBottom = removeButton.bottomAnchor.constraint(equalTo: chipContentView.bottomAnchor, constant: -Constants.removeButtonVerticalPadding)
+        removeBottom.priority = .defaultHigh
+
         NSLayoutConstraint.activate([
             widthAnchor.constraint(equalToConstant: Constants.chipWidth),
 
@@ -258,8 +271,8 @@ private extension AIChatContextChipView {
             mainStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
 
             faviconView.leadingAnchor.constraint(equalTo: chipContentView.leadingAnchor, constant: Constants.faviconLeading),
-            faviconView.topAnchor.constraint(equalTo: chipContentView.topAnchor, constant: Constants.faviconVerticalPadding),
-            faviconView.bottomAnchor.constraint(equalTo: chipContentView.bottomAnchor, constant: -Constants.faviconVerticalPadding),
+            faviconTop,
+            faviconBottom,
             faviconView.widthAnchor.constraint(equalToConstant: Constants.faviconSize),
             faviconView.heightAnchor.constraint(equalToConstant: Constants.faviconSize),
 
@@ -268,8 +281,8 @@ private extension AIChatContextChipView {
             titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: removeButton.leadingAnchor, constant: -Constants.contentSpacing),
 
             removeButton.trailingAnchor.constraint(equalTo: chipContentView.trailingAnchor, constant: -Constants.removeButtonTrailing),
-            removeButton.topAnchor.constraint(equalTo: chipContentView.topAnchor, constant: Constants.removeButtonVerticalPadding),
-            removeButton.bottomAnchor.constraint(equalTo: chipContentView.bottomAnchor, constant: -Constants.removeButtonVerticalPadding),
+            removeTop,
+            removeBottom,
             removeButton.widthAnchor.constraint(equalToConstant: Constants.removeButtonSize),
             removeButton.heightAnchor.constraint(equalToConstant: Constants.removeButtonSize),
         ])

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -984,6 +984,13 @@ class MainViewController: UIViewController {
               let coordinator = unifiedToggleInputCoordinator,
               coordinator.shouldCollapseOnKeyboardDismiss,
               currentTab?.aiChatContextualSheetCoordinator.isSheetPresented != true else { return }
+        // With a hardware keyboard connected, iOS fires keyboardWillHide even though the
+        // text field is still the first responder. Treat that as "still editing" and skip
+        // the collapse — otherwise the expanded bar collapses on every focus, making it
+        // impossible to type.
+        if coordinator.viewController.isInputFirstResponder {
+            return
+        }
         coordinator.showCollapsed()
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -655,6 +655,11 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         switch (displayState, isInputVisible) {
         case (.omnibar(.active), false) where isAwaitingTopOmnibarKeyboardPresentation:
             return
+        case (.omnibar(.active), false) where viewController.isInputFirstResponder:
+            // A hardware keyboard is connected (or the keyboard frame went off-screen)
+            // while the user is still actively editing. Treat the input as in-use and
+            // skip the dismissal — otherwise the bar collapses on every keystroke.
+            cancelTopOmnibarKeyboardPresentationFallback()
         case (.omnibar(.active), false):
             cancelTopOmnibarKeyboardPresentationFallback()
             transitionOmnibarToInactive()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214545615232720?focus=true
Tech Design URL:
CC:

### Description
With a hardware keyboard connected, iOS fires `keyboardWillHide` while the text field is still first responder, collapsing the expanded unified toggle input on every focus. The AI-tab dismiss path and the omnibar inactive transition now skip the collapse when the input is still first responder. Also lowers the priority of the context chip's vertical padding so the host's `height == 0` collapse no longer conflicts with internal layout.

### Testing Steps
1. Pair a hardware keyboard with the simulator/device (Simulator → I/O → Keyboard → Connect Hardware Keyboard).
2. On an AI tab, tap the unified toggle input to expand it and start typing — the bar should remain expanded across keystrokes and focus changes.
3. On a regular tab with the omnibar active, type with the hardware keyboard — the omnibar should not transition to inactive while you're still editing.
4. Smoke test steps with the software keyboard as well

### Impact and Risks
Low

#### What could go wrong?
The new first-responder guard could keep the bar expanded in an edge case where the input legitimately needs to collapse without resigning first responder.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX behavior tweaks around keyboard visibility; main risk is leaving the unified toggle input expanded in edge cases where the input remains first responder but should collapse.
> 
> **Overview**
> Prevents the unified toggle input from collapsing when iOS sends `keyboardWillHide`/input-hidden signals while a hardware keyboard is connected and the text field is still first responder (both for the AI-tab collapse path and the omnibar active→inactive transition).
> 
> Also lowers the priority of `AIChatContextChipView` top/bottom padding constraints for the favicon/remove button so an external `height == 0` collapse can succeed without Auto Layout conflicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11245f3405003da4a51ba6b9ae74e34cade13a8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->