### PR TITLE
Fix contributing style guide link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ We're always open to contributions from the community! There are different appro
 
 ### Style Guide
 
-We care about clean code. Refer to our [style guide](styleguide/STYLEGUIDE.md).
+We care about clean code. Refer to our [style guide](iOS/styleguide/STYLEGUIDE.md).
 
 ### Commit Messages
 


### PR DESCRIPTION
Task/Issue URL: N/A
Tech Design URL: N/A
CC:

### Description

Fixes a broken link in `CONTRIBUTING.md`.

The style guide link previously pointed to `styleguide/STYLEGUIDE.md`, but the actual file lives at `iOS/styleguide/STYLEGUIDE.md`.

### Testing Steps

1. Open `CONTRIBUTING.md`.
2. Click the style guide link.
3. Confirm it resolves to `iOS/styleguide/STYLEGUIDE.md`.

### Impact and Risks

None. This is a documentation-only change.

#### What could go wrong?

The only risk is the link pointing to the wrong file. I verified that `iOS/styleguide/STYLEGUIDE.md` exists.

### Quality Considerations

No app code was changed. No automated tests were run because this only updates documentation.

### Notes to Reviewer

Please confirm the updated relative link is correct for GitHub rendering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a relative link; no code paths or behavior are affected.
> 
> **Overview**
> Fixes a broken relative link in `CONTRIBUTING.md` by updating the Style Guide reference to point to `iOS/styleguide/STYLEGUIDE.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d8ffd196f1b6b112a80a78a2eef29145642ea38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->