### PR TITLE
[iOS] Submit AI chat input on Return key

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -298,7 +298,7 @@ class SwitchBarTextEntryView: UIView {
             disableAutoCorrectionAndSpellChecking()
         case .aiChat:
             textView.keyboardType = .default
-            textView.returnKeyType = .default
+            textView.returnKeyType = .go
             if handler.shouldDisableAutocorrectOnEmpty && textView.text.isEmpty {
                 disableAutoCorrectionAndSpellChecking()
             } else {
@@ -548,7 +548,7 @@ class SwitchBarTextEntryView: UIView {
             disableAutoCorrectionAndSpellChecking()
         } else {
             textView.keyboardType = currentMode == .aiChat ? .default : .webSearch
-            textView.returnKeyType = currentMode == .aiChat ? .default : .search
+            textView.returnKeyType = currentMode == .aiChat ? .go : .search
             enableAutoCorrectionAndSpellChecking()
         }
 
@@ -690,11 +690,6 @@ extension SwitchBarTextEntryView: UITextViewDelegate {
 
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         if text == "\n" {
-            // AI-chat mode allows multi-line input regardless of host. Search modes (omnibar
-            // toggle-off, omnibar search via toggle, AI-tab search) submit on Return.
-            if currentMode == .aiChat {
-                return true
-            }
             fireKeyboardGoPressedPixel()
             let currentText = textView.text ?? ""
             if !currentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1214392640638186?focus=true
Tech Design URL:
CC:

### Description
Switches the AI chat keyboard's return key to `.go` and submits the prompt on Return instead of inserting a newline. Brings AI chat in line with search-mode submission so users can send messages without tapping the dedicated submit button.

### Testing Steps
1. Open the unified input bar in AI chat mode and confirm the keyboard shows a "Go" return key.
2. Type a prompt and press Return — the message should submit instead of adding a newline.
3. Switch to search mode and confirm the search return key and behavior are unchanged.

### Impact and Risks
Low

#### What could go wrong?
Users who relied on Return to insert a newline in AI chat input will lose that affordance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX change limited to AI chat input handling; main impact is that Return no longer inserts newlines, which could surprise some users but shouldn’t affect data/security paths.
> 
> **Overview**
> AI chat input now uses a **“Go”** return key and treats the Return key as *submit* instead of inserting a newline.
> 
> This updates keyboard configuration (`returnKeyType = .go`) in AI chat mode (including the autocorrect toggling path) and changes `UITextViewDelegate.shouldChangeTextIn` to always submit on `"\n"` when the prompt is non-empty, keeping search-mode Return behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d7339a78e8c231190915b490f574f599f0f15ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->