### PR TITLE
Add auto-dismiss capability to Remote Messaging Framework

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/CoreData/RemoteMessageManagedObject.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/CoreData/RemoteMessageManagedObject.swift
@@ -30,6 +30,7 @@ public class RemoteMessageManagedObject: NSManagedObject {
         return NSEntityDescription.entity(forEntityName: "RemoteMessageManagedObject", in: context)!
     }
 
+    @NSManaged public var firstShownDate: Date?
     @NSManaged public var id: String?
     @NSManaged public var message: String?
     @NSManaged public var shown: Bool

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/CoreData/RemoteMessaging.xcdatamodeld/.xccurrentversion
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/CoreData/RemoteMessaging.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>RemoteMessaging 2.xcdatamodel</string>
+	<string>RemoteMessaging 3.xcdatamodel</string>
 </dict>
 </plist>

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/CoreData/RemoteMessaging.xcdatamodeld/RemoteMessaging 3.xcdatamodel/contents
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/CoreData/RemoteMessaging.xcdatamodeld/RemoteMessaging 3.xcdatamodel/contents
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24G222" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="RemoteMessageManagedObject" representedClassName="RemoteMessageManagedObject" syncable="YES">
+        <attribute name="firstShownDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="message" optional="YES" attributeType="String"/>
+        <attribute name="shown" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="status" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="surfaces" optional="YES" attributeType="Integer 16" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="RemoteMessagingConfigManagedObject" representedClassName="RemoteMessagingConfigManagedObject" syncable="YES">
+        <attribute name="evaluationTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="invalidate" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="version" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+</model>

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
@@ -126,7 +126,8 @@ struct JsonToRemoteMessageModelMapper {
                 content: content,
                 matchingRules: message.matchingRules ?? [],
                 exclusionRules: message.exclusionRules ?? [],
-                isMetricsEnabled: message.isMetricsEnabled
+                isMetricsEnabled: message.isMetricsEnabled,
+                dismissAfterDaysShown: message.dismissAfterDaysShown
             )
 
             if let translation = getTranslation(from: message.translations, for: Locale.current) {

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
@@ -120,6 +120,21 @@ struct JsonToRemoteMessageModelMapper {
                 return
             }
 
+            let displayConditions: DisplayConditions?
+            if let jsonConditions = message.displayConditions {
+                if let triggerString = jsonConditions.trigger {
+                    guard let trigger = MessageTrigger(rawValue: triggerString) else {
+                        Logger.remoteMessaging.debug("Unknown trigger '\(triggerString, privacy: .public)' for message \(message.id, privacy: .public), discarding")
+                        return
+                    }
+                    displayConditions = DisplayConditions(trigger: trigger, dismissAfterDaysShown: jsonConditions.dismissAfterDaysShown)
+                } else {
+                    displayConditions = DisplayConditions(trigger: nil, dismissAfterDaysShown: jsonConditions.dismissAfterDaysShown)
+                }
+            } else {
+                displayConditions = nil
+            }
+
             var remoteMessage = RemoteMessageModel(
                 id: message.id,
                 surfaces: surfaces,
@@ -127,7 +142,7 @@ struct JsonToRemoteMessageModelMapper {
                 matchingRules: message.matchingRules ?? [],
                 exclusionRules: message.exclusionRules ?? [],
                 isMetricsEnabled: message.isMetricsEnabled,
-                dismissAfterDaysShown: message.dismissAfterDaysShown
+                displayConditions: displayConditions
             )
 
             if let translation = getTranslation(from: message.translations, for: Locale.current) {

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Mappers/JsonToRemoteMessageModelMapper.swift
@@ -121,18 +121,11 @@ struct JsonToRemoteMessageModelMapper {
             }
 
             let displayConditions: DisplayConditions?
-            if let jsonConditions = message.displayConditions {
-                if let triggerString = jsonConditions.trigger {
-                    guard let trigger = MessageTrigger(rawValue: triggerString) else {
-                        Logger.remoteMessaging.debug("Unknown trigger '\(triggerString, privacy: .public)' for message \(message.id, privacy: .public), discarding")
-                        return
-                    }
-                    displayConditions = DisplayConditions(trigger: trigger, dismissAfterDaysShown: jsonConditions.dismissAfterDaysShown)
-                } else {
-                    displayConditions = DisplayConditions(trigger: nil, dismissAfterDaysShown: jsonConditions.dismissAfterDaysShown)
-                }
-            } else {
-                displayConditions = nil
+            do {
+                displayConditions = try mapToDisplayConditions(message: message)
+            } catch {
+                Logger.remoteMessaging.debug("Invalid display conditions for message \(message.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                return
             }
 
             var remoteMessage = RemoteMessageModel(
@@ -152,6 +145,15 @@ struct JsonToRemoteMessageModelMapper {
             remoteMessages.append(remoteMessage)
         }
         return remoteMessages
+    }
+
+    static func mapToDisplayConditions(message: RemoteMessageResponse.JsonRemoteMessage) throws -> DisplayConditions? {
+        try message.displayConditions.flatMap { conditions in
+            let validator = MappingValidator(root: conditions)
+            let trigger = try validator.mapEnumIfPresent(\.trigger, to: MessageTrigger.self)
+            let dismissAfterDaysShown = conditions.dismissAfterDaysShown.map { max($0, 1) }
+            return DisplayConditions(trigger: trigger, dismissAfterDaysShown: dismissAfterDaysShown)
+        }
     }
 
     static func mapToSurfaces(jsonSurfaces: [String]?, supportedSurfacesForMessage: RemoteMessageSurfaceType, messageId: String) -> RemoteMessageSurfaceType? {

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Mappers/MappingValidator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Mappers/MappingValidator.swift
@@ -72,6 +72,12 @@ struct MappingValidator<Root> {
         return result
     }
 
+    func mapEnumIfPresent<T, E: RawRepresentable>(_ keyPath: KeyPath<Root, T?>, to enumType: E.Type) throws(MappingError) -> E? where E.RawValue == T {
+        guard let value = root[keyPath: keyPath] else { return nil }
+        guard let result = E(rawValue: value) else { throw .invalidValue(keyPath) }
+        return result
+    }
+
     func mapRequired<T, U>(_ keyPath: KeyPath<Root, T?>, _ transform: (T) throws(MappingError) -> U?) throws(MappingError) -> U {
         let wrappedValue = try notNil(keyPath)
         guard let mappedValue = try transform(wrappedValue) else { throw .invalidValue(keyPath) }

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/JsonRemoteMessagingConfig.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/JsonRemoteMessagingConfig.swift
@@ -33,7 +33,7 @@ public enum RemoteMessageResponse {
         let translations: [String: JsonContentTranslation]?
         let matchingRules, exclusionRules: [Int]?
         let metrics: JsonMetrics?
-        let dismissAfterDaysShown: Int?
+        let displayConditions: JsonDisplayConditions?
 
         static func == (lhs: JsonRemoteMessage, rhs: JsonRemoteMessage) -> Bool {
             return lhs.id == rhs.id
@@ -42,6 +42,11 @@ public enum RemoteMessageResponse {
         var isMetricsEnabled: Bool {
             metrics?.state.flatMap(JsonMetrics.MetricsState.init) != .disabled
         }
+    }
+
+    struct JsonDisplayConditions: Decodable, Equatable {
+        let trigger: String?
+        let dismissAfterDaysShown: Int?
     }
 
     struct JsonMetrics: Decodable {

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/JsonRemoteMessagingConfig.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/JsonRemoteMessagingConfig.swift
@@ -33,6 +33,7 @@ public enum RemoteMessageResponse {
         let translations: [String: JsonContentTranslation]?
         let matchingRules, exclusionRules: [Int]?
         let metrics: JsonMetrics?
+        let dismissAfterDaysShown: Int?
 
         static func == (lhs: JsonRemoteMessage, rhs: JsonRemoteMessage) -> Bool {
             return lhs.id == rhs.id

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/RemoteMessageModel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/RemoteMessageModel.swift
@@ -27,14 +27,23 @@ public struct RemoteMessageModel: Equatable, Codable {
     public let matchingRules: [Int]
     public let exclusionRules: [Int]
     public let isMetricsEnabled: Bool
+    /// If set, the message will be automatically dismissed after being shown for this many days.
+    public let dismissAfterDaysShown: Int?
 
-    public init(id: String, surfaces: RemoteMessageSurfaceType, content: RemoteMessageModelType?, matchingRules: [Int], exclusionRules: [Int], isMetricsEnabled: Bool) {
+    public init(id: String,
+                surfaces: RemoteMessageSurfaceType,
+                content: RemoteMessageModelType?,
+                matchingRules: [Int],
+                exclusionRules: [Int],
+                isMetricsEnabled: Bool,
+                dismissAfterDaysShown: Int? = nil) {
         self.id = id
         self.surfaces = surfaces
         self.content = content
         self.matchingRules = matchingRules
         self.exclusionRules = exclusionRules
         self.isMetricsEnabled = isMetricsEnabled
+        self.dismissAfterDaysShown = dismissAfterDaysShown
     }
 
     enum CodingKeys: CodingKey {
@@ -44,6 +53,7 @@ public struct RemoteMessageModel: Equatable, Codable {
         case matchingRules
         case exclusionRules
         case isMetricsEnabled
+        case dismissAfterDaysShown
     }
 
     public init(from decoder: Decoder) throws {
@@ -54,6 +64,7 @@ public struct RemoteMessageModel: Equatable, Codable {
         self.matchingRules = try container.decode([Int].self, forKey: .matchingRules)
         self.exclusionRules = try container.decode([Int].self, forKey: .exclusionRules)
         self.isMetricsEnabled = try container.decodeIfPresent(Bool.self, forKey: .isMetricsEnabled) ?? true
+        self.dismissAfterDaysShown = try container.decodeIfPresent(Int.self, forKey: .dismissAfterDaysShown)
     }
 
     mutating func localizeContent(translation: RemoteMessageResponse.JsonContentTranslation) {

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/RemoteMessageModel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/Model/RemoteMessageModel.swift
@@ -18,6 +18,20 @@
 
 import Foundation
 
+public enum MessageTrigger: String, Codable {
+    case afterIdle = "after_idle"
+}
+
+public struct DisplayConditions: Codable, Equatable {
+    public let trigger: MessageTrigger?
+    public let dismissAfterDaysShown: Int?
+
+    public init(trigger: MessageTrigger? = nil, dismissAfterDaysShown: Int? = nil) {
+        self.trigger = trigger
+        self.dismissAfterDaysShown = dismissAfterDaysShown
+    }
+}
+
 public struct RemoteMessageModel: Equatable, Codable {
 
     public let id: String
@@ -27,8 +41,7 @@ public struct RemoteMessageModel: Equatable, Codable {
     public let matchingRules: [Int]
     public let exclusionRules: [Int]
     public let isMetricsEnabled: Bool
-    /// If set, the message will be automatically dismissed after being shown for this many days.
-    public let dismissAfterDaysShown: Int?
+    public let displayConditions: DisplayConditions?
 
     public init(id: String,
                 surfaces: RemoteMessageSurfaceType,
@@ -36,14 +49,14 @@ public struct RemoteMessageModel: Equatable, Codable {
                 matchingRules: [Int],
                 exclusionRules: [Int],
                 isMetricsEnabled: Bool,
-                dismissAfterDaysShown: Int? = nil) {
+                displayConditions: DisplayConditions? = nil) {
         self.id = id
         self.surfaces = surfaces
         self.content = content
         self.matchingRules = matchingRules
         self.exclusionRules = exclusionRules
         self.isMetricsEnabled = isMetricsEnabled
-        self.dismissAfterDaysShown = dismissAfterDaysShown
+        self.displayConditions = displayConditions
     }
 
     enum CodingKeys: CodingKey {
@@ -53,7 +66,7 @@ public struct RemoteMessageModel: Equatable, Codable {
         case matchingRules
         case exclusionRules
         case isMetricsEnabled
-        case dismissAfterDaysShown
+        case displayConditions
     }
 
     public init(from decoder: Decoder) throws {
@@ -64,7 +77,7 @@ public struct RemoteMessageModel: Equatable, Codable {
         self.matchingRules = try container.decode([Int].self, forKey: .matchingRules)
         self.exclusionRules = try container.decode([Int].self, forKey: .exclusionRules)
         self.isMetricsEnabled = try container.decodeIfPresent(Bool.self, forKey: .isMetricsEnabled) ?? true
-        self.dismissAfterDaysShown = try container.decodeIfPresent(Int.self, forKey: .dismissAfterDaysShown)
+        self.displayConditions = try container.decodeIfPresent(DisplayConditions.self, forKey: .displayConditions)
     }
 
     mutating func localizeContent(translation: RemoteMessageResponse.JsonContentTranslation) {

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/RemoteMessagingConfigMatcher.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/RemoteMessagingConfigMatcher.swift
@@ -195,7 +195,7 @@ extension RemoteMessageModel {
             matchingRules: self.matchingRules,
             exclusionRules: self.exclusionRules,
             isMetricsEnabled: self.isMetricsEnabled,
-            dismissAfterDaysShown: self.dismissAfterDaysShown
+            displayConditions: self.displayConditions
         )
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/RemoteMessagingConfigMatcher.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/RemoteMessagingConfigMatcher.swift
@@ -194,7 +194,8 @@ extension RemoteMessageModel {
             content: content?.withNewItems(items),
             matchingRules: self.matchingRules,
             exclusionRules: self.exclusionRules,
-            isMetricsEnabled: self.isMetricsEnabled
+            isMetricsEnabled: self.isMetricsEnabled,
+            dismissAfterDaysShown: self.dismissAfterDaysShown
         )
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/RemoteMessagingStore.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/RemoteMessagingStore.swift
@@ -213,7 +213,7 @@ extension RemoteMessagingStore {
 
 extension RemoteMessagingStore {
 
-    public func fetchScheduledRemoteMessage(surfaces: RemoteMessageSurfaceType) -> RemoteMessageModel? {
+    public func fetchScheduledRemoteMessage(surfaces: RemoteMessageSurfaceType, trigger: MessageTrigger? = nil) -> RemoteMessageModel? {
 
         func predicateForSurfaces(_ surfaces: RemoteMessageSurfaceType) -> NSPredicate {
             // Match any message whose surfaces bitmask overlaps with the requested surfaces
@@ -251,7 +251,7 @@ extension RemoteMessagingStore {
                     continue
                 }
 
-                if let dismissAfterDays = remoteMessage.dismissAfterDaysShown,
+                if let dismissAfterDays = remoteMessage.displayConditions?.dismissAfterDaysShown,
                    dismissAfterDays > 0,
                    let firstShown = remoteMessageManagedObject.firstShownDate,
                    let daysSinceFirstShown = Calendar.current.dateComponents([.day], from: firstShown, to: Date()).day,
@@ -262,13 +262,18 @@ extension RemoteMessagingStore {
                     continue
                 }
 
+                if let messageTrigger = remoteMessage.displayConditions?.trigger, messageTrigger != trigger {
+                    continue
+                }
+
                 scheduledRemoteMessage = RemoteMessageModel(
                     id: id,
                     surfaces: remoteMessageManagedObject.surfaces.flatMap { RemoteMessageSurfaceType(rawValue: $0.int16Value) } ?? .newTabPage,
                     content: remoteMessage.content,
                     matchingRules: [],
                     exclusionRules: [],
-                    isMetricsEnabled: remoteMessage.isMetricsEnabled
+                    isMetricsEnabled: remoteMessage.isMetricsEnabled,
+                    displayConditions: remoteMessage.displayConditions
                 )
                 break
             }

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/RemoteMessagingStore.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/RemoteMessagingStore.swift
@@ -462,10 +462,8 @@ extension RemoteMessagingStore {
     }
 
     private func dismissExpiredMessage(withID id: String) {
-        context.performAndWait {
-            updateRemoteMessage(withID: id, toStatus: .dismissed, in: context)
-            invalidateRemoteMessagingConfigs(in: context)
-            try? context.save()
+        Task {
+            await dismissRemoteMessage(withID: id)
         }
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/RemoteMessagingStore.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/RemoteMessagingStore.swift
@@ -251,6 +251,17 @@ extension RemoteMessagingStore {
                     continue
                 }
 
+                if let dismissAfterDays = remoteMessage.dismissAfterDaysShown,
+                   dismissAfterDays > 0,
+                   let firstShown = remoteMessageManagedObject.firstShownDate,
+                   let daysSinceFirstShown = Calendar.current.dateComponents([.day], from: firstShown, to: Date()).day,
+                   daysSinceFirstShown >= dismissAfterDays {
+                    remoteMessageManagedObject.status = NSNumber(value: RemoteMessageStatus.dismissed.rawValue)
+                    self.invalidateRemoteMessagingConfigs(in: context)
+                    try? context.save()
+                    continue
+                }
+
                 scheduledRemoteMessage = RemoteMessageModel(
                     id: id,
                     surfaces: remoteMessageManagedObject.surfaces.flatMap { RemoteMessageSurfaceType(rawValue: $0.int16Value) } ?? .newTabPage,
@@ -381,6 +392,9 @@ extension RemoteMessagingStore {
                         return
                     }
                     message.shown = shown
+                    if shown && message.firstShownDate == nil {
+                        message.firstShownDate = Date()
+                    }
                     try context.save()
                 } catch {
                     errorEvents?.fire(.updateMessageShownFailed, error: error)

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/RemoteMessagingStore.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/RemoteMessagingStore.swift
@@ -256,9 +256,7 @@ extension RemoteMessagingStore {
                    let firstShown = remoteMessageManagedObject.firstShownDate,
                    let daysSinceFirstShown = Calendar.current.dateComponents([.day], from: firstShown, to: Date()).day,
                    daysSinceFirstShown >= dismissAfterDays {
-                    remoteMessageManagedObject.status = NSNumber(value: RemoteMessageStatus.dismissed.rawValue)
-                    self.invalidateRemoteMessagingConfigs(in: context)
-                    try? context.save()
+                    self.dismissExpiredMessage(withID: id)
                     continue
                 }
 
@@ -460,6 +458,14 @@ extension RemoteMessagingStore {
                 remoteMessageManagedObject.id = remoteMessage.id
                 remoteMessageManagedObject.shown = false
             }
+        }
+    }
+
+    private func dismissExpiredMessage(withID id: String) {
+        context.performAndWait {
+            updateRemoteMessage(withID: id, toStatus: .dismissed, in: context)
+            invalidateRemoteMessagingConfigs(in: context)
+            try? context.save()
         }
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/RemoteMessagingStoring.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessaging/RemoteMessagingStoring.swift
@@ -26,11 +26,17 @@ public protocol RemoteMessagingStoring: RemoteMessagingStoringDebuggingSupport {
 
     func saveProcessedResult(_ processorResult: RemoteMessagingConfigProcessor.ProcessorResult) async
     func fetchRemoteMessagingConfig() -> RemoteMessagingConfig?
-    func fetchScheduledRemoteMessage(surfaces: RemoteMessageSurfaceType) -> RemoteMessageModel?
+    func fetchScheduledRemoteMessage(surfaces: RemoteMessageSurfaceType, trigger: MessageTrigger?) -> RemoteMessageModel?
     func hasShownRemoteMessage(withID id: String) -> Bool
     func fetchShownRemoteMessageIDs() -> [String]
     func dismissRemoteMessage(withID id: String) async
     func fetchDismissedRemoteMessageIDs() -> [String]
     func updateRemoteMessage(withID id: String, asShown shown: Bool) async
 
+}
+
+public extension RemoteMessagingStoring {
+    func fetchScheduledRemoteMessage(surfaces: RemoteMessageSurfaceType) -> RemoteMessageModel? {
+        fetchScheduledRemoteMessage(surfaces: surfaces, trigger: nil)
+    }
 }

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessagingTestsUtils/MockRemoteMessagingConfigFetcher.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessagingTestsUtils/MockRemoteMessagingConfigFetcher.swift
@@ -62,7 +62,8 @@ public extension RemoteMessageResponse.JsonRemoteMessagingConfig {
                 translations: nil,
                 matchingRules: nil,
                 exclusionRules: nil,
-                metrics: nil
+                metrics: nil,
+                dismissAfterDaysShown: nil
             )
         ],
         rules: []

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessagingTestsUtils/MockRemoteMessagingConfigFetcher.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessagingTestsUtils/MockRemoteMessagingConfigFetcher.swift
@@ -63,7 +63,7 @@ public extension RemoteMessageResponse.JsonRemoteMessagingConfig {
                 matchingRules: nil,
                 exclusionRules: nil,
                 metrics: nil,
-                dismissAfterDaysShown: nil
+                displayConditions: nil
             )
         ],
         rules: []

--- a/SharedPackages/BrowserServicesKit/Sources/RemoteMessagingTestsUtils/MockRemoteMessagingStore.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/RemoteMessagingTestsUtils/MockRemoteMessagingStore.swift
@@ -61,9 +61,12 @@ public class MockRemoteMessagingStore: RemoteMessagingStoring {
         return remoteMessagingConfig
     }
 
-    public func fetchScheduledRemoteMessage(surfaces: RemoteMessageSurfaceType) -> RemoteMessageModel? {
+    public var capturedTrigger: MessageTrigger?
+
+    public func fetchScheduledRemoteMessage(surfaces: RemoteMessageSurfaceType, trigger: MessageTrigger? = nil) -> RemoteMessageModel? {
         fetchScheduledRemoteMessageCalls += 1
         capturedSurfaces = surfaces
+        capturedTrigger = trigger
         return scheduledRemoteMessage
     }
 

--- a/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Mappers/JsonToRemoteMessageModelMapperTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Mappers/JsonToRemoteMessageModelMapperTests.swift
@@ -740,6 +740,36 @@ class JsonToRemoteMessageModelMapperTests: XCTestCase {
         XCTAssertNil(result.first?.displayConditions)
     }
 
+    func testWhenDismissAfterDaysShownIsZeroThenItIsClampedToOne() {
+        let jsonMessage = makeJsonMessage(
+            id: "msg-clamp",
+            displayConditions: RemoteMessageResponse.JsonDisplayConditions(trigger: nil, dismissAfterDaysShown: 0)
+        )
+
+        let result = JsonToRemoteMessageModelMapper.maps(
+            jsonRemoteMessages: [jsonMessage],
+            surveyActionMapper: MockSurveyActionMapper(),
+            supportedSurfacesForMessage: { _ in .newTabPage })
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.displayConditions?.dismissAfterDaysShown, 1)
+    }
+
+    func testWhenDismissAfterDaysShownIsNegativeThenItIsClampedToOne() {
+        let jsonMessage = makeJsonMessage(
+            id: "msg-negative",
+            displayConditions: RemoteMessageResponse.JsonDisplayConditions(trigger: nil, dismissAfterDaysShown: -5)
+        )
+
+        let result = JsonToRemoteMessageModelMapper.maps(
+            jsonRemoteMessages: [jsonMessage],
+            surveyActionMapper: MockSurveyActionMapper(),
+            supportedSurfacesForMessage: { _ in .newTabPage })
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.displayConditions?.dismissAfterDaysShown, 1)
+    }
+
     func testWhenMultipleMessagesAndOneHasUnknownTriggerThenOnlyThatOneIsDiscarded() {
         let validMessage = makeJsonMessage(
             id: "msg-valid",

--- a/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Mappers/JsonToRemoteMessageModelMapperTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Mappers/JsonToRemoteMessageModelMapperTests.swift
@@ -666,6 +666,136 @@ class JsonToRemoteMessageModelMapperTests: XCTestCase {
 
 }
 
+    // MARK: - DisplayConditions Mapping Tests
+
+    func testWhenMessageHasDisplayConditionsWithTriggerThenItIsMappedCorrectly() {
+        let jsonMessage = makeJsonMessage(
+            id: "msg-trigger",
+            displayConditions: RemoteMessageResponse.JsonDisplayConditions(trigger: "after_idle", dismissAfterDaysShown: nil)
+        )
+
+        let result = JsonToRemoteMessageModelMapper.maps(
+            jsonRemoteMessages: [jsonMessage],
+            surveyActionMapper: MockSurveyActionMapper(),
+            supportedSurfacesForMessage: { _ in .newTabPage })
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.displayConditions?.trigger, .afterIdle)
+        XCTAssertNil(result.first?.displayConditions?.dismissAfterDaysShown)
+    }
+
+    func testWhenMessageHasDisplayConditionsWithTriggerAndDismissThenBothAreMapped() {
+        let jsonMessage = makeJsonMessage(
+            id: "msg-both",
+            displayConditions: RemoteMessageResponse.JsonDisplayConditions(trigger: "after_idle", dismissAfterDaysShown: 5)
+        )
+
+        let result = JsonToRemoteMessageModelMapper.maps(
+            jsonRemoteMessages: [jsonMessage],
+            surveyActionMapper: MockSurveyActionMapper(),
+            supportedSurfacesForMessage: { _ in .newTabPage })
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.displayConditions?.trigger, .afterIdle)
+        XCTAssertEqual(result.first?.displayConditions?.dismissAfterDaysShown, 5)
+    }
+
+    func testWhenMessageHasDisplayConditionsWithDismissOnlyThenTriggerIsNil() {
+        let jsonMessage = makeJsonMessage(
+            id: "msg-dismiss-only",
+            displayConditions: RemoteMessageResponse.JsonDisplayConditions(trigger: nil, dismissAfterDaysShown: 3)
+        )
+
+        let result = JsonToRemoteMessageModelMapper.maps(
+            jsonRemoteMessages: [jsonMessage],
+            surveyActionMapper: MockSurveyActionMapper(),
+            supportedSurfacesForMessage: { _ in .newTabPage })
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertNil(result.first?.displayConditions?.trigger)
+        XCTAssertEqual(result.first?.displayConditions?.dismissAfterDaysShown, 3)
+    }
+
+    func testWhenMessageHasUnknownTriggerThenMessageIsDiscarded() {
+        let jsonMessage = makeJsonMessage(
+            id: "msg-unknown",
+            displayConditions: RemoteMessageResponse.JsonDisplayConditions(trigger: "some_future_trigger", dismissAfterDaysShown: nil)
+        )
+
+        let result = JsonToRemoteMessageModelMapper.maps(
+            jsonRemoteMessages: [jsonMessage],
+            surveyActionMapper: MockSurveyActionMapper(),
+            supportedSurfacesForMessage: { _ in .newTabPage })
+
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testWhenMessageHasNoDisplayConditionsThenDisplayConditionsIsNil() {
+        let jsonMessage = makeJsonMessage(id: "msg-no-conditions", displayConditions: nil)
+
+        let result = JsonToRemoteMessageModelMapper.maps(
+            jsonRemoteMessages: [jsonMessage],
+            surveyActionMapper: MockSurveyActionMapper(),
+            supportedSurfacesForMessage: { _ in .newTabPage })
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertNil(result.first?.displayConditions)
+    }
+
+    func testWhenMultipleMessagesAndOneHasUnknownTriggerThenOnlyThatOneIsDiscarded() {
+        let validMessage = makeJsonMessage(
+            id: "msg-valid",
+            displayConditions: RemoteMessageResponse.JsonDisplayConditions(trigger: "after_idle", dismissAfterDaysShown: nil)
+        )
+        let invalidMessage = makeJsonMessage(
+            id: "msg-invalid",
+            displayConditions: RemoteMessageResponse.JsonDisplayConditions(trigger: "unknown_trigger", dismissAfterDaysShown: nil)
+        )
+        let noConditionsMessage = makeJsonMessage(id: "msg-plain", displayConditions: nil)
+
+        let result = JsonToRemoteMessageModelMapper.maps(
+            jsonRemoteMessages: [validMessage, invalidMessage, noConditionsMessage],
+            surveyActionMapper: MockSurveyActionMapper(),
+            supportedSurfacesForMessage: { _ in .newTabPage })
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result.map(\.id), ["msg-valid", "msg-plain"])
+    }
+
+    // MARK: - Helpers
+
+    private func makeJsonMessage(id: String,
+                                 displayConditions: RemoteMessageResponse.JsonDisplayConditions?) -> RemoteMessageResponse.JsonRemoteMessage {
+        RemoteMessageResponse.JsonRemoteMessage(
+            id: id,
+            surfaces: nil,
+            content: .init(messageType: "small",
+                           titleText: "Title",
+                           descriptionText: "Description",
+                           listItems: nil,
+                           placeholder: nil,
+                           imageUrl: nil,
+                           actionText: nil,
+                           action: nil,
+                           primaryActionText: nil,
+                           primaryAction: nil,
+                           secondaryActionText: nil,
+                           secondaryAction: nil),
+            translations: nil,
+            matchingRules: [],
+            exclusionRules: [],
+            metrics: nil,
+            displayConditions: displayConditions
+        )
+    }
+}
+
+private struct MockSurveyActionMapper: RemoteMessagingSurveyActionMapping {
+    func add(parameters: [RemoteMessagingSurveyActionParameter], to url: URL) -> URL {
+        url
+    }
+}
+
 extension JsonToRemoteMessageModelMapperTests {
 
     func jsonTranslation(

--- a/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Mappers/JsonToRemoteMessageModelMapperTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Mappers/JsonToRemoteMessageModelMapperTests.swift
@@ -664,8 +664,6 @@ class JsonToRemoteMessageModelMapperTests: XCTestCase {
         XCTAssertEqual(resultItem.descriptionText, "Translated Description 1")
     }
 
-}
-
     // MARK: - DisplayConditions Mapping Tests
 
     func testWhenMessageHasDisplayConditionsWithTriggerThenItIsMappedCorrectly() {

--- a/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Mappers/MappingValidatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Mappers/MappingValidatorTests.swift
@@ -25,6 +25,7 @@ struct TestModel {
     let items: [String]
     let optionalItems: [String]?
     let status: String
+    let optionalStatus: String? = nil
 }
 
 enum TestStatus: String {
@@ -334,6 +335,44 @@ extension MappingValidatorTests {
 
             // THEN
             #expect(result == expectedStatus)
+        }
+    }
+
+}
+
+extension MappingValidatorTests {
+
+    @Suite("Map Enum If Present")
+    struct MapEnumIfPresentTests {
+
+        @Test("Check valid optional enum value maps successfully")
+        func checkValidOptionalEnumMaps() throws {
+            let model = TestModel(id: "1", name: nil, items: [], optionalItems: nil, status: "active", optionalStatus: "active")
+            let sut = MappingValidator(root: model)
+
+            let result = try sut.mapEnumIfPresent(\.optionalStatus, to: TestStatus.self)
+
+            #expect(result == .active)
+        }
+
+        @Test("Check nil optional enum returns nil")
+        func checkNilOptionalEnumReturnsNil() throws {
+            let model = TestModel(id: "1", name: nil, items: [], optionalItems: nil, status: "active")
+            let sut = MappingValidator(root: model)
+
+            let result = try sut.mapEnumIfPresent(\.optionalStatus, to: TestStatus.self)
+
+            #expect(result == nil)
+        }
+
+        @Test("Check invalid optional enum value throws invalidValue error")
+        func checkInvalidOptionalEnumThrows() {
+            let model = TestModel(id: "1", name: nil, items: [], optionalItems: nil, status: "active", optionalStatus: "unknown")
+            let sut = MappingValidator(root: model)
+
+            #expect(throws: MappingError.invalidValue(\TestModel.optionalStatus)) {
+                try sut.mapEnumIfPresent(\.optionalStatus, to: TestStatus.self)
+            }
         }
     }
 

--- a/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
@@ -570,6 +570,153 @@ class RemoteMessagingStoreTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    // MARK: - Auto-Dismiss Tests
+
+    func testWhenMessageExceedsDismissAfterDaysShownThenItIsNotReturned() async throws {
+        let context = store.context
+        try context.performAndWait {
+            let message = RemoteMessageManagedObject(context: context)
+            message.id = "auto-dismiss-1"
+            message.status = NSNumber(value: 0)
+            message.shown = true
+            message.firstShownDate = Calendar.current.date(byAdding: .day, value: -3, to: Date())
+            message.message = """
+              {"isMetricsEnabled":true,"content":{"small":{"titleText":"t","descriptionText":"d"}},"id":"auto-dismiss-1","exclusionRules":[],"matchingRules":[],"dismissAfterDaysShown":2}
+              """
+            context.insert(message)
+            try context.save()
+        }
+
+        let result = store.fetchScheduledRemoteMessage(surfaces: .allCases)
+        XCTAssertNil(result)
+    }
+
+    func testWhenMessageIsWithinDismissAfterDaysShownThenItIsReturned() async throws {
+        let context = store.context
+        try context.performAndWait {
+            let message = RemoteMessageManagedObject(context: context)
+            message.id = "auto-dismiss-2"
+            message.status = NSNumber(value: 0)
+            message.shown = true
+            message.firstShownDate = Calendar.current.date(byAdding: .day, value: -1, to: Date())
+            message.message = """
+              {"isMetricsEnabled":true,"content":{"small":{"titleText":"t","descriptionText":"d"}},"id":"auto-dismiss-2","exclusionRules":[],"matchingRules":[],"dismissAfterDaysShown":3}
+              """
+            context.insert(message)
+            try context.save()
+        }
+
+        let result = store.fetchScheduledRemoteMessage(surfaces: .allCases)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.id, "auto-dismiss-2")
+    }
+
+    func testWhenMessageHasNoDismissAfterDaysShownThenItIsAlwaysReturned() async throws {
+        let context = store.context
+        try context.performAndWait {
+            let message = RemoteMessageManagedObject(context: context)
+            message.id = "no-auto-dismiss"
+            message.status = NSNumber(value: 0)
+            message.shown = true
+            message.firstShownDate = Calendar.current.date(byAdding: .day, value: -100, to: Date())
+            message.message = """
+              {"isMetricsEnabled":true,"content":{"small":{"titleText":"t","descriptionText":"d"}},"id":"no-auto-dismiss","exclusionRules":[],"matchingRules":[]}
+              """
+            context.insert(message)
+            try context.save()
+        }
+
+        let result = store.fetchScheduledRemoteMessage(surfaces: .allCases)
+        XCTAssertNotNil(result)
+    }
+
+    func testWhenMessageExceedsDismissThresholdThenStatusIsSetToDismissed() async throws {
+        let context = store.context
+        try context.performAndWait {
+            let message = RemoteMessageManagedObject(context: context)
+            message.id = "auto-dismiss-status"
+            message.status = NSNumber(value: 0)
+            message.shown = true
+            message.firstShownDate = Calendar.current.date(byAdding: .day, value: -5, to: Date())
+            message.message = """
+              {"isMetricsEnabled":true,"content":{"small":{"titleText":"t","descriptionText":"d"}},"id":"auto-dismiss-status","exclusionRules":[],"matchingRules":[],"dismissAfterDaysShown":2}
+              """
+            context.insert(message)
+            try context.save()
+        }
+
+        _ = store.fetchScheduledRemoteMessage(surfaces: .allCases)
+
+        let dismissedIDs = store.fetchDismissedRemoteMessageIDs()
+        XCTAssertTrue(dismissedIDs.contains("auto-dismiss-status"))
+    }
+
+    func testWhenMessageHasNilFirstShownDateThenItIsReturned() async throws {
+        let context = store.context
+        try context.performAndWait {
+            let message = RemoteMessageManagedObject(context: context)
+            message.id = "nil-first-shown"
+            message.status = NSNumber(value: 0)
+            message.shown = false
+            message.firstShownDate = nil
+            message.message = """
+              {"isMetricsEnabled":true,"content":{"small":{"titleText":"t","descriptionText":"d"}},"id":"nil-first-shown","exclusionRules":[],"matchingRules":[],"dismissAfterDaysShown":1}
+              """
+            context.insert(message)
+            try context.save()
+        }
+
+        let result = store.fetchScheduledRemoteMessage(surfaces: .allCases)
+        XCTAssertNotNil(result)
+    }
+
+    func testWhenUpdateRemoteMessageAsShownThenFirstShownDateIsRecorded() async throws {
+        let remoteMessage = try await saveProcessedResultFetchRemoteMessage()
+        await store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
+
+        let context = store.context
+        context.performAndWait {
+            let fetchRequest: NSFetchRequest<RemoteMessageManagedObject> = RemoteMessageManagedObject.fetchRequest()
+            fetchRequest.predicate = NSPredicate(format: "id == %@", remoteMessage.id)
+            guard let result = try? context.fetch(fetchRequest).first else {
+                XCTFail("Message not found")
+                return
+            }
+            XCTAssertNotNil(result.firstShownDate)
+        }
+    }
+
+    func testWhenUpdateRemoteMessageAsShownTwiceThenFirstShownDateIsNotOverwritten() async throws {
+        let remoteMessage = try await saveProcessedResultFetchRemoteMessage()
+        await store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
+
+        let pastDate = Calendar.current.date(byAdding: .day, value: -10, to: Date())!
+        let context = store.context
+        try context.performAndWait {
+            let fetchRequest: NSFetchRequest<RemoteMessageManagedObject> = RemoteMessageManagedObject.fetchRequest()
+            fetchRequest.predicate = NSPredicate(format: "id == %@", remoteMessage.id)
+            guard let result = try? context.fetch(fetchRequest).first else {
+                XCTFail("Message not found")
+                return
+            }
+            result.firstShownDate = pastDate
+            try context.save()
+        }
+
+        await store.updateRemoteMessage(withID: remoteMessage.id, asShown: false)
+        await store.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
+
+        context.performAndWait {
+            let fetchRequest: NSFetchRequest<RemoteMessageManagedObject> = RemoteMessageManagedObject.fetchRequest()
+            fetchRequest.predicate = NSPredicate(format: "id == %@", remoteMessage.id)
+            guard let result = try? context.fetch(fetchRequest).first else {
+                XCTFail("Message not found")
+                return
+            }
+            XCTAssertEqual(result.firstShownDate, pastDate)
+        }
+    }
+
 }
 
 // MARK: - Helpers

--- a/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
@@ -630,7 +630,7 @@ class RemoteMessagingStoreTests: XCTestCase {
         XCTAssertNotNil(result)
     }
 
-    func testWhenMessageExceedsDismissThresholdThenStatusIsSetToDismissed() async throws {
+    func testWhenMessageExceedsDismissThresholdThenItIsNotReturned() async throws {
         let context = store.context
         try context.performAndWait {
             let message = RemoteMessageManagedObject(context: context)
@@ -645,10 +645,8 @@ class RemoteMessagingStoreTests: XCTestCase {
             try context.save()
         }
 
-        _ = store.fetchScheduledRemoteMessage(surfaces: .allCases)
-
-        let dismissedIDs = store.fetchDismissedRemoteMessageIDs()
-        XCTAssertTrue(dismissedIDs.contains("auto-dismiss-status"))
+        let result = store.fetchScheduledRemoteMessage(surfaces: .allCases)
+        XCTAssertNil(result)
     }
 
     func testWhenMessageHasNilFirstShownDateThenItIsReturned() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
@@ -581,7 +581,7 @@ class RemoteMessagingStoreTests: XCTestCase {
             message.shown = true
             message.firstShownDate = Calendar.current.date(byAdding: .day, value: -3, to: Date())
             message.message = """
-              {"isMetricsEnabled":true,"content":{"small":{"titleText":"t","descriptionText":"d"}},"id":"auto-dismiss-1","exclusionRules":[],"matchingRules":[],"dismissAfterDaysShown":2}
+              {"isMetricsEnabled":true,"content":{"small":{"titleText":"t","descriptionText":"d"}},"id":"auto-dismiss-1","exclusionRules":[],"matchingRules":[],"displayConditions":{"dismissAfterDaysShown":2}}
               """
             context.insert(message)
             try context.save()
@@ -600,7 +600,7 @@ class RemoteMessagingStoreTests: XCTestCase {
             message.shown = true
             message.firstShownDate = Calendar.current.date(byAdding: .day, value: -1, to: Date())
             message.message = """
-              {"isMetricsEnabled":true,"content":{"small":{"titleText":"t","descriptionText":"d"}},"id":"auto-dismiss-2","exclusionRules":[],"matchingRules":[],"dismissAfterDaysShown":3}
+              {"isMetricsEnabled":true,"content":{"small":{"titleText":"t","descriptionText":"d"}},"id":"auto-dismiss-2","exclusionRules":[],"matchingRules":[],"displayConditions":{"dismissAfterDaysShown":3}}
               """
             context.insert(message)
             try context.save()
@@ -639,7 +639,7 @@ class RemoteMessagingStoreTests: XCTestCase {
             message.shown = true
             message.firstShownDate = Calendar.current.date(byAdding: .day, value: -5, to: Date())
             message.message = """
-              {"isMetricsEnabled":true,"content":{"small":{"titleText":"t","descriptionText":"d"}},"id":"auto-dismiss-status","exclusionRules":[],"matchingRules":[],"dismissAfterDaysShown":2}
+              {"isMetricsEnabled":true,"content":{"small":{"titleText":"t","descriptionText":"d"}},"id":"auto-dismiss-status","exclusionRules":[],"matchingRules":[],"displayConditions":{"dismissAfterDaysShown":2}}
               """
             context.insert(message)
             try context.save()
@@ -660,7 +660,7 @@ class RemoteMessagingStoreTests: XCTestCase {
             message.shown = false
             message.firstShownDate = nil
             message.message = """
-              {"isMetricsEnabled":true,"content":{"small":{"titleText":"t","descriptionText":"d"}},"id":"nil-first-shown","exclusionRules":[],"matchingRules":[],"dismissAfterDaysShown":1}
+              {"isMetricsEnabled":true,"content":{"small":{"titleText":"t","descriptionText":"d"}},"id":"nil-first-shown","exclusionRules":[],"matchingRules":[],"displayConditions":{"dismissAfterDaysShown":1}}
               """
             context.insert(message)
             try context.save()
@@ -668,6 +668,100 @@ class RemoteMessagingStoreTests: XCTestCase {
 
         let result = store.fetchScheduledRemoteMessage(surfaces: .allCases)
         XCTAssertNotNil(result)
+    }
+
+    // MARK: - Trigger Matching Tests
+
+    func testWhenMessageHasTriggerAndCallerMatchesThenItIsReturned() async throws {
+        let context = store.context
+        try context.performAndWait {
+            let message = RemoteMessageManagedObject(context: context)
+            message.id = "trigger-match"
+            message.status = NSNumber(value: 0)
+            message.shown = false
+            message.message = """
+              {"isMetricsEnabled":true,"content":{"small":{"titleText":"t","descriptionText":"d"}},"id":"trigger-match","exclusionRules":[],"matchingRules":[],"displayConditions":{"trigger":"after_idle"}}
+              """
+            context.insert(message)
+            try context.save()
+        }
+
+        let result = store.fetchScheduledRemoteMessage(surfaces: .allCases, trigger: .afterIdle)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.id, "trigger-match")
+    }
+
+    func testWhenMessageHasTriggerAndCallerPassesNilThenItIsNotReturned() async throws {
+        let context = store.context
+        try context.performAndWait {
+            let message = RemoteMessageManagedObject(context: context)
+            message.id = "trigger-no-match"
+            message.status = NSNumber(value: 0)
+            message.shown = false
+            message.message = """
+              {"isMetricsEnabled":true,"content":{"small":{"titleText":"t","descriptionText":"d"}},"id":"trigger-no-match","exclusionRules":[],"matchingRules":[],"displayConditions":{"trigger":"after_idle"}}
+              """
+            context.insert(message)
+            try context.save()
+        }
+
+        let result = store.fetchScheduledRemoteMessage(surfaces: .allCases)
+        XCTAssertNil(result)
+    }
+
+    func testWhenMessageHasNoTriggerThenItIsReturnedRegardlessOfCallerTrigger() async throws {
+        let context = store.context
+        try context.performAndWait {
+            let message = RemoteMessageManagedObject(context: context)
+            message.id = "no-trigger"
+            message.status = NSNumber(value: 0)
+            message.shown = false
+            message.message = """
+              {"isMetricsEnabled":true,"content":{"small":{"titleText":"t","descriptionText":"d"}},"id":"no-trigger","exclusionRules":[],"matchingRules":[]}
+              """
+            context.insert(message)
+            try context.save()
+        }
+
+        let resultWithTrigger = store.fetchScheduledRemoteMessage(surfaces: .allCases, trigger: .afterIdle)
+        XCTAssertNotNil(resultWithTrigger)
+
+        // Reset status to scheduled for the second fetch
+        try context.performAndWait {
+            let fetchRequest: NSFetchRequest<RemoteMessageManagedObject> = RemoteMessageManagedObject.fetchRequest()
+            fetchRequest.predicate = NSPredicate(format: "id == %@", "no-trigger")
+            guard let result = try context.fetch(fetchRequest).first else {
+                XCTFail("Message not found")
+                return
+            }
+            result.status = NSNumber(value: 0)
+            try context.save()
+        }
+
+        let resultWithoutTrigger = store.fetchScheduledRemoteMessage(surfaces: .allCases)
+        XCTAssertNotNil(resultWithoutTrigger)
+    }
+
+    func testWhenMessageHasTriggerAndDismissAfterDaysShownAndBothConditionsMetThenItIsAutoDismissed() async throws {
+        let context = store.context
+        try context.performAndWait {
+            let message = RemoteMessageManagedObject(context: context)
+            message.id = "trigger-and-dismiss"
+            message.status = NSNumber(value: 0)
+            message.shown = true
+            message.firstShownDate = Calendar.current.date(byAdding: .day, value: -5, to: Date())
+            message.message = """
+              {"isMetricsEnabled":true,"content":{"small":{"titleText":"t","descriptionText":"d"}},"id":"trigger-and-dismiss","exclusionRules":[],"matchingRules":[],"displayConditions":{"trigger":"after_idle","dismissAfterDaysShown":3}}
+              """
+            context.insert(message)
+            try context.save()
+        }
+
+        let result = store.fetchScheduledRemoteMessage(surfaces: .allCases, trigger: .afterIdle)
+        XCTAssertNil(result)
+
+        let dismissedIDs = store.fetchDismissedRemoteMessageIDs()
+        XCTAssertTrue(dismissedIDs.contains("trigger-and-dismiss"))
     }
 
     func testWhenUpdateRemoteMessageAsShownThenFirstShownDateIsRecorded() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
@@ -757,9 +757,6 @@ class RemoteMessagingStoreTests: XCTestCase {
 
         let result = store.fetchScheduledRemoteMessage(surfaces: .allCases, trigger: .afterIdle)
         XCTAssertNil(result)
-
-        let dismissedIDs = store.fetchDismissedRemoteMessageIDs()
-        XCTAssertTrue(dismissedIDs.contains("trigger-and-dismiss"))
     }
 
     func testWhenUpdateRemoteMessageAsShownThenFirstShownDateIsRecorded() async throws {

--- a/iOS/DuckDuckGo/HomePageConfiguration.swift
+++ b/iOS/DuckDuckGo/HomePageConfiguration.swift
@@ -48,14 +48,14 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
         self.subscriptionDataReporter = subscriptionDataReporter
         self.fireModePromotionEligibility = fireModePromotionEligibility
         self.isStillOnboarding = isStillOnboarding
-        homeMessages = buildHomeMessages()
+        homeMessages = buildHomeMessages(openedAfterIdle: false)
     }
 
-    func refresh() {
-        homeMessages = buildHomeMessages()
+    func refresh(openedAfterIdle: Bool = false) {
+        homeMessages = buildHomeMessages(openedAfterIdle: openedAfterIdle)
     }
 
-    private func buildHomeMessages() -> [HomeMessage] {
+    private func buildHomeMessages(openedAfterIdle: Bool) -> [HomeMessage] {
         var messages = homeMessageStorage.messagesToBeShown
 
         if isStillOnboarding() {
@@ -67,7 +67,7 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
             return messages
         }
 
-        guard let remoteMessage = remoteMessageToShow() else {
+        guard let remoteMessage = remoteMessageToShow(openedAfterIdle: openedAfterIdle) else {
             return messages
         }
 
@@ -75,8 +75,9 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
         return messages
     }
 
-    private func remoteMessageToShow() -> HomeMessage? {
-        guard let remoteMessageToPresent = remoteMessagingStore.fetchScheduledRemoteMessage(surfaces: .newTabPage) else { return nil }
+    private func remoteMessageToShow(openedAfterIdle: Bool) -> HomeMessage? {
+        let trigger: MessageTrigger? = openedAfterIdle ? .afterIdle : nil
+        guard let remoteMessageToPresent = remoteMessagingStore.fetchScheduledRemoteMessage(surfaces: .newTabPage, trigger: trigger) else { return nil }
         Logger.remoteMessaging.info("Remote message to show: \(remoteMessageToPresent.id, privacy: .public)")
         return .remoteMessage(remoteMessage: remoteMessageToPresent)
     }

--- a/iOS/DuckDuckGo/HomePageMessagesConfiguration.swift
+++ b/iOS/DuckDuckGo/HomePageMessagesConfiguration.swift
@@ -22,8 +22,14 @@ import Foundation
 protocol HomePageMessagesConfiguration {
     var homeMessages: [HomeMessage] { get }
 
-    func refresh()
+    func refresh(openedAfterIdle: Bool)
     
     func dismissHomeMessage(_ homeMessage: HomeMessage) async
     func didAppear(_ homeMessage: HomeMessage)
+}
+
+extension HomePageMessagesConfiguration {
+    func refresh() {
+        refresh(openedAfterIdle: false)
+    }
 }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1516,7 +1516,9 @@ class MainViewController: UIViewController {
         
         currentTab?.dismiss()
         removeHomeScreen()
-        homePageConfiguration.refresh()
+
+        let hatch = buildEscapeHatch(openedAfterIdle: openedAfterIdle)
+        homePageConfiguration.refresh(openedAfterIdle: hatch != nil)
 
         // Access the tab model directly as we don't want to create a new tab controller here
         guard let tabModel = tabManager.currentTabsModel.currentTab else {
@@ -1549,6 +1551,7 @@ class MainViewController: UIViewController {
                                                   remoteMessagingImageLoader: remoteMessagingImageLoader,
                                                   remoteMessagingPixelReporter: remoteMessagingPixelReporter,
                                                   fireModePromotionEligibility: fireModePromotionEligibility,
+                                                  hasEscapeHatch: hatch != nil,
                                                   appSettings: appSettings,
                                                   faviconsCache: favicons,
                                                   subscriptionManager: subscriptionManager,
@@ -1561,7 +1564,6 @@ class MainViewController: UIViewController {
 
         newTabPageViewController = controller
 
-        let hatch = buildEscapeHatch(openedAfterIdle: openedAfterIdle)
         controller.setEscapeHatch(hatch)
         controller.setChromeLayoutContext(isBorderSuppressed: isInMinimalChromeLayout)
         currentNTPEscapeHatch = hatch

--- a/iOS/DuckDuckGo/NewTabPageMessagesModel.swift
+++ b/iOS/DuckDuckGo/NewTabPageMessagesModel.swift
@@ -36,6 +36,7 @@ final class NewTabPageMessagesModel: ObservableObject {
     private let imageLoader: RemoteMessagingImageLoading
     private let pixelReporter: RemoteMessagingPixelReporting?
     private let fireModePromotionEligibility: FireModePromotionCoordinating?
+    private let isOpenedAfterIdle: () -> Bool
 
     var onTryFireModeRequested: (() -> Void)?
 
@@ -46,7 +47,8 @@ final class NewTabPageMessagesModel: ObservableObject {
          messageActionHandler: RemoteMessagingActionHandling,
          imageLoader: RemoteMessagingImageLoading,
          pixelReporter: RemoteMessagingPixelReporting? = nil,
-         fireModePromotionEligibility: FireModePromotionCoordinating? = nil) {
+         fireModePromotionEligibility: FireModePromotionCoordinating? = nil,
+         isOpenedAfterIdle: @escaping () -> Bool = { false }) {
         self.homePageMessagesConfiguration = homePageMessagesConfiguration
         self.notificationCenter = notificationCenter
         self.pixelFiring = pixelFiring
@@ -55,6 +57,7 @@ final class NewTabPageMessagesModel: ObservableObject {
         self.imageLoader = imageLoader
         self.pixelReporter = pixelReporter
         self.fireModePromotionEligibility = fireModePromotionEligibility
+        self.isOpenedAfterIdle = isOpenedAfterIdle
     }
 
     func load() {
@@ -81,7 +84,7 @@ final class NewTabPageMessagesModel: ObservableObject {
     // MARK: - Private
 
     func refresh() {
-        homePageMessagesConfiguration.refresh()
+        homePageMessagesConfiguration.refresh(openedAfterIdle: isOpenedAfterIdle())
         updateHomeMessageViewModel()
     }
 

--- a/iOS/DuckDuckGo/NewTabPageMessagesModel.swift
+++ b/iOS/DuckDuckGo/NewTabPageMessagesModel.swift
@@ -36,7 +36,7 @@ final class NewTabPageMessagesModel: ObservableObject {
     private let imageLoader: RemoteMessagingImageLoading
     private let pixelReporter: RemoteMessagingPixelReporting?
     private let fireModePromotionEligibility: FireModePromotionCoordinating?
-    private let isOpenedAfterIdle: () -> Bool
+    private let isOpenedAfterIdle: Bool
 
     var onTryFireModeRequested: (() -> Void)?
 
@@ -48,7 +48,7 @@ final class NewTabPageMessagesModel: ObservableObject {
          imageLoader: RemoteMessagingImageLoading,
          pixelReporter: RemoteMessagingPixelReporting? = nil,
          fireModePromotionEligibility: FireModePromotionCoordinating? = nil,
-         isOpenedAfterIdle: @escaping () -> Bool = { false }) {
+         isOpenedAfterIdle: Bool = false) {
         self.homePageMessagesConfiguration = homePageMessagesConfiguration
         self.notificationCenter = notificationCenter
         self.pixelFiring = pixelFiring
@@ -84,7 +84,7 @@ final class NewTabPageMessagesModel: ObservableObject {
     // MARK: - Private
 
     func refresh() {
-        homePageMessagesConfiguration.refresh(openedAfterIdle: isOpenedAfterIdle())
+        homePageMessagesConfiguration.refresh(openedAfterIdle: isOpenedAfterIdle)
         updateHomeMessageViewModel()
     }
 

--- a/iOS/DuckDuckGo/NewTabPageView.swift
+++ b/iOS/DuckDuckGo/NewTabPageView.swift
@@ -324,7 +324,7 @@ private final class PreviewMessagesConfiguration: HomePageMessagesConfiguration 
         self.homeMessages = homeMessages
     }
 
-    func refresh() {
+    func refresh(openedAfterIdle: Bool) {
 
     }
 

--- a/iOS/DuckDuckGo/NewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewController.swift
@@ -97,7 +97,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
                                                 imageLoader: remoteMessagingImageLoader,
                                                 pixelReporter: remoteMessagingPixelReporter,
                                                 fireModePromotionEligibility: fireModePromotionEligibility,
-                                                isOpenedAfterIdle: { hasEscapeHatch })
+                                                isOpenedAfterIdle: hasEscapeHatch)
 
         super.init(rootView: NewTabPageView(isFocussedState: isFocussedState,
                                             narrowLayoutInLandscape: narrowLayoutInLandscape,

--- a/iOS/DuckDuckGo/NewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewController.swift
@@ -71,6 +71,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
          remoteMessagingImageLoader: RemoteMessagingImageLoading,
          remoteMessagingPixelReporter: RemoteMessagingPixelReporting? = nil,
          fireModePromotionEligibility: FireModePromotionCoordinating? = nil,
+         hasEscapeHatch: Bool = false,
          appSettings: AppSettings,
          faviconsCache: FavoritesFaviconCaching,
          subscriptionManager: any SubscriptionManager,
@@ -95,7 +96,8 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
                                                 messageActionHandler: remoteMessagingActionHandler,
                                                 imageLoader: remoteMessagingImageLoader,
                                                 pixelReporter: remoteMessagingPixelReporter,
-                                                fireModePromotionEligibility: fireModePromotionEligibility)
+                                                fireModePromotionEligibility: fireModePromotionEligibility,
+                                                isOpenedAfterIdle: { hasEscapeHatch })
 
         super.init(rootView: NewTabPageView(isFocussedState: isFocussedState,
                                             narrowLayoutInLandscape: narrowLayoutInLandscape,

--- a/iOS/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/iOS/DuckDuckGo/SuggestionTrayViewController.swift
@@ -379,6 +379,7 @@ class SuggestionTrayViewController: UIViewController {
             remoteMessagingImageLoader: dependencies.remoteMessagingImageLoader,
             remoteMessagingPixelReporter: dependencies.remoteMessagingPixelReporter,
             fireModePromotionEligibility: dependencies.fireModePromotionEligibility,
+            hasEscapeHatch: pendingEscapeHatchModel != nil,
             appSettings: dependencies.appSettings,
             faviconsCache: dependencies.faviconsCache,
             subscriptionManager: dependencies.subscriptionManager,

--- a/iOS/DuckDuckGoTests/HomePageConfigurationTests.swift
+++ b/iOS/DuckDuckGoTests/HomePageConfigurationTests.swift
@@ -47,4 +47,46 @@ struct HomePageConfigurationTests {
         #expect(storeMock.capturedSurfaces == .newTabPage)
     }
 
+    @Test("When refreshed with openedAfterIdle true, trigger is afterIdle")
+    func refreshWithOpenedAfterIdlePassesAfterIdleTrigger() {
+        // GIVEN
+        let storeMock = MockRemoteMessagingStore()
+        let sut = HomePageConfiguration(variantManager: nil, remoteMessagingStore: storeMock, subscriptionDataReporter: MockSubscriptionDataReporter(), isStillOnboarding: { false })
+        storeMock.capturedTrigger = nil
+
+        // WHEN
+        sut.refresh(openedAfterIdle: true)
+
+        // THEN
+        #expect(storeMock.capturedTrigger == .afterIdle)
+    }
+
+    @Test("When refreshed with openedAfterIdle false, trigger is nil")
+    func refreshWithOpenedAfterIdleFalsePassesNilTrigger() {
+        // GIVEN
+        let storeMock = MockRemoteMessagingStore()
+        let sut = HomePageConfiguration(variantManager: nil, remoteMessagingStore: storeMock, subscriptionDataReporter: MockSubscriptionDataReporter(), isStillOnboarding: { false })
+        storeMock.capturedTrigger = nil
+
+        // WHEN
+        sut.refresh(openedAfterIdle: false)
+
+        // THEN
+        #expect(storeMock.capturedTrigger == nil)
+    }
+
+    @Test("When refreshed without parameter, trigger is nil (backward compat)")
+    func refreshWithoutParameterPassesNilTrigger() {
+        // GIVEN
+        let storeMock = MockRemoteMessagingStore()
+        let sut = HomePageConfiguration(variantManager: nil, remoteMessagingStore: storeMock, subscriptionDataReporter: MockSubscriptionDataReporter(), isStillOnboarding: { false })
+        storeMock.capturedTrigger = nil
+
+        // WHEN
+        sut.refresh()
+
+        // THEN
+        #expect(storeMock.capturedTrigger == nil)
+    }
+
 }

--- a/iOS/DuckDuckGoTests/HomePageConfigurationTests.swift
+++ b/iOS/DuckDuckGoTests/HomePageConfigurationTests.swift
@@ -47,7 +47,8 @@ struct HomePageConfigurationTests {
         #expect(storeMock.capturedSurfaces == .newTabPage)
     }
 
-    @Test("When refreshed with openedAfterIdle true, trigger is afterIdle")
+    @available(iOS 16, *)
+    @Test("When refreshed with openedAfterIdle true, trigger is afterIdle", .timeLimit(.minutes(1)))
     func refreshWithOpenedAfterIdlePassesAfterIdleTrigger() {
         // GIVEN
         let storeMock = MockRemoteMessagingStore()
@@ -61,7 +62,8 @@ struct HomePageConfigurationTests {
         #expect(storeMock.capturedTrigger == .afterIdle)
     }
 
-    @Test("When refreshed with openedAfterIdle false, trigger is nil")
+    @available(iOS 16, *)
+    @Test("When refreshed with openedAfterIdle false, trigger is nil", .timeLimit(.minutes(1)))
     func refreshWithOpenedAfterIdleFalsePassesNilTrigger() {
         // GIVEN
         let storeMock = MockRemoteMessagingStore()
@@ -75,7 +77,8 @@ struct HomePageConfigurationTests {
         #expect(storeMock.capturedTrigger == nil)
     }
 
-    @Test("When refreshed without parameter, trigger is nil (backward compat)")
+    @available(iOS 16, *)
+    @Test("When refreshed without parameter, trigger is nil (backward compat)", .timeLimit(.minutes(1)))
     func refreshWithoutParameterPassesNilTrigger() {
         // GIVEN
         let storeMock = MockRemoteMessagingStore()

--- a/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
+++ b/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
@@ -293,7 +293,7 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         sut.load()
 
         XCTAssertTrue(messagesConfiguration.didRefresh)
-        XCTAssertTrue(messagesConfiguration.lastRefreshOpenedAfterIdle)
+        XCTAssertEqual(messagesConfiguration.lastRefreshOpenedAfterIdle, true)
     }
 
     func testWhenOpenedAfterIdleIsFalseThenRefreshPassesOpenedAfterIdleFalse() {
@@ -302,7 +302,7 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         sut.load()
 
         XCTAssertTrue(messagesConfiguration.didRefresh)
-        XCTAssertFalse(messagesConfiguration.lastRefreshOpenedAfterIdle)
+        XCTAssertEqual(messagesConfiguration.lastRefreshOpenedAfterIdle, false)
     }
 
     func testWhenDefaultOpenedAfterIdleThenRefreshPassesFalse() {
@@ -311,7 +311,7 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         sut.load()
 
         XCTAssertTrue(messagesConfiguration.didRefresh)
-        XCTAssertFalse(messagesConfiguration.lastRefreshOpenedAfterIdle)
+        XCTAssertEqual(messagesConfiguration.lastRefreshOpenedAfterIdle, false)
     }
 
     // MARK: - Helpers

--- a/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
+++ b/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
@@ -288,7 +288,7 @@ final class NewTabPageMessagesModelTests: XCTestCase {
     // MARK: - openedAfterIdle
 
     func testWhenOpenedAfterIdleIsTrueThenRefreshPassesOpenedAfterIdleTrue() {
-        let sut = createSUT(isOpenedAfterIdle: { true })
+        let sut = createSUT(isOpenedAfterIdle: true)
 
         sut.load()
 
@@ -297,7 +297,7 @@ final class NewTabPageMessagesModelTests: XCTestCase {
     }
 
     func testWhenOpenedAfterIdleIsFalseThenRefreshPassesOpenedAfterIdleFalse() {
-        let sut = createSUT(isOpenedAfterIdle: { false })
+        let sut = createSUT(isOpenedAfterIdle: false)
 
         sut.load()
 
@@ -316,7 +316,7 @@ final class NewTabPageMessagesModelTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func createSUT(isOpenedAfterIdle: @escaping () -> Bool = { false }) -> NewTabPageMessagesModel {
+    private func createSUT(isOpenedAfterIdle: Bool = false) -> NewTabPageMessagesModel {
         let remoteMessageActionHandler = RemoteMessagingActionHandler(lastSearchStateRefresher: RemoteMessagingSurveyLastSearchStateRefresher())
         remoteMessageActionHandler.messageNavigator = DefaultMessageNavigator(delegate: self)
 

--- a/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
+++ b/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
@@ -285,7 +285,38 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         XCTAssertNil(PixelFiringMock.lastParams)
     }
 
-    private func createSUT() -> NewTabPageMessagesModel {
+    // MARK: - openedAfterIdle
+
+    func testWhenOpenedAfterIdleIsTrueThenRefreshPassesOpenedAfterIdleTrue() {
+        let sut = createSUT(isOpenedAfterIdle: { true })
+
+        sut.load()
+
+        XCTAssertTrue(messagesConfiguration.didRefresh)
+        XCTAssertEqual(messagesConfiguration.lastRefreshOpenedAfterIdle, true)
+    }
+
+    func testWhenOpenedAfterIdleIsFalseThenRefreshPassesOpenedAfterIdleFalse() {
+        let sut = createSUT(isOpenedAfterIdle: { false })
+
+        sut.load()
+
+        XCTAssertTrue(messagesConfiguration.didRefresh)
+        XCTAssertEqual(messagesConfiguration.lastRefreshOpenedAfterIdle, false)
+    }
+
+    func testWhenDefaultOpenedAfterIdleThenRefreshPassesFalse() {
+        let sut = createSUT()
+
+        sut.load()
+
+        XCTAssertTrue(messagesConfiguration.didRefresh)
+        XCTAssertEqual(messagesConfiguration.lastRefreshOpenedAfterIdle, false)
+    }
+
+    // MARK: - Helpers
+
+    private func createSUT(isOpenedAfterIdle: @escaping () -> Bool = { false }) -> NewTabPageMessagesModel {
         let remoteMessageActionHandler = RemoteMessagingActionHandler(lastSearchStateRefresher: RemoteMessagingSurveyLastSearchStateRefresher())
         remoteMessageActionHandler.messageNavigator = DefaultMessageNavigator(delegate: self)
 
@@ -293,7 +324,8 @@ final class NewTabPageMessagesModelTests: XCTestCase {
                                 notificationCenter: notificationCenter,
                                 pixelFiring: PixelFiringMock.self,
                                 messageActionHandler: remoteMessageActionHandler,
-                                imageLoader: MockRemoteMessagingImageLoader())
+                                imageLoader: MockRemoteMessagingImageLoader(),
+                                isOpenedAfterIdle: isOpenedAfterIdle)
     }
 }
 

--- a/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
+++ b/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
@@ -293,7 +293,7 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         sut.load()
 
         XCTAssertTrue(messagesConfiguration.didRefresh)
-        XCTAssertEqual(messagesConfiguration.lastRefreshOpenedAfterIdle, true)
+        XCTAssertTrue(messagesConfiguration.lastRefreshOpenedAfterIdle)
     }
 
     func testWhenOpenedAfterIdleIsFalseThenRefreshPassesOpenedAfterIdleFalse() {
@@ -302,7 +302,7 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         sut.load()
 
         XCTAssertTrue(messagesConfiguration.didRefresh)
-        XCTAssertEqual(messagesConfiguration.lastRefreshOpenedAfterIdle, false)
+        XCTAssertFalse(messagesConfiguration.lastRefreshOpenedAfterIdle)
     }
 
     func testWhenDefaultOpenedAfterIdleThenRefreshPassesFalse() {
@@ -311,7 +311,7 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         sut.load()
 
         XCTAssertTrue(messagesConfiguration.didRefresh)
-        XCTAssertEqual(messagesConfiguration.lastRefreshOpenedAfterIdle, false)
+        XCTAssertFalse(messagesConfiguration.lastRefreshOpenedAfterIdle)
     }
 
     // MARK: - Helpers

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/NewTabPage/HomePageMessagesConfigurationMock.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/NewTabPage/HomePageMessagesConfigurationMock.swift
@@ -41,7 +41,9 @@ class HomePageMessagesConfigurationMock: HomePageMessagesConfiguration {
     }
 
     private(set) var didRefresh: Bool = false
-    func refresh() {
+    private(set) var lastRefreshOpenedAfterIdle: Bool?
+    func refresh(openedAfterIdle: Bool) {
         didRefresh = true
+        lastRefreshOpenedAfterIdle = openedAfterIdle
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214525802264426
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1214488238400075
CC: N/A

### Description
- Add `displayConditions` wrapper object to RMF message JSON config, nesting `dismissAfterDaysShown` and a new `trigger` field
- Add `MessageTrigger` enum and `DisplayConditions` struct to the domain model; messages with unknown triggers are silently discarded for forward compatibility
- Extend `fetchScheduledRemoteMessage` with an optional `trigger` parameter for filtering messages by their trigger context
- Thread idle-return context through iOS: `HomePageConfiguration.refresh(openedAfterIdle:)` passes `trigger: .afterIdle` when the user returns from idle, and `NewTabPageMessagesModel` forwards this via an `isOpenedAfterIdle` closure
- After-idle messages now appear in both the main NTP and the focussed NTP (suggestion tray), by passing `hasEscapeHatch` to the focussed NTP in `SuggestionTrayViewController`
- Auto-dismiss via `dismissAfterDaysShown` continues to work as before, now nested under `displayConditions`

### Testing Steps

**Test 1 -- Regular message (no trigger, no auto-dismiss):**
1. Apply config from https://pastebin.com/raw/zTS5cAE1 via Debug > Remote Messages > Set source URL, then reset messages and reload
2. Verify the "Regular Message" appears on the NTP on normal launch
3. Dismiss it and verify it stays dismissed

**Test 2 -- After-idle trigger only:**
1. Apply config from https://pastebin.com/raw/MmpU87dY via Debug > Remote Messages > Set source URL, then reset messages and reload
2. Kill and relaunch the app normally -- the message should **not** appear
3. Trigger idle return (background app, wait for threshold, return) -- the "Welcome Back!" message should appear on the main NTP
4. Tap the address bar -- the message should also appear in the focussed NTP
5. Dismiss the escape hatch, open a new tab -- the message should not appear (no idle context)

**Test 3 -- Normal app usage after idle return:**
1. After idle return, verify the message appears
2. Navigate to a URL, then open a new tab -- the message should not appear (no idle context)

**Test 4 -- After-idle + auto-dismiss combo:**
1. Apply config from https://pastebin.com/raw/azMhR7mc
2. Trigger idle return -- "Time-limited idle message" should appear
3. Move the device date forward by 2+ days, trigger idle return again -- the message should no longer appear (auto-dismissed)

**Test 5 -- Unknown trigger (forward compatibility):**
1. Apply config from https://pastebin.com/raw/RhCG3Kaj
2. The message should **never** appear -- the unknown trigger causes it to be discarded during mapping

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- If the escape hatch state is not set before the focussed NTP's `onAppear` fires, the after-idle message may not show in focussed mode. Mitigated by the fact that `setEscapeHatch` is called before the view is installed in the hierarchy
- Messages with unknown triggers are silently dropped, which is the intended forward-compatibility behavior but could cause confusion if a trigger name is misspelled in the server config

### Quality Considerations
- `displayConditions` is fully backward compatible; messages without it behave identically to before
- Unknown triggers are discarded at the mapping layer to avoid showing messages at wrong times
- Unit tests cover: trigger mapping, unknown trigger discard, backward compat, store trigger filtering, auto-dismiss with trigger combo, iOS wiring (HomePageConfiguration and NewTabPageMessagesModel)

### Notes to Reviewer
- The `displayConditions` wrapper replaces the top-level `dismissAfterDaysShown` field in the JSON schema. The domain model groups both fields under `DisplayConditions`
- The focussed NTP fix was a one-line addition in `SuggestionTrayViewController` to forward the escape hatch state

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a Core Data schema migration plus new message filtering logic (trigger matching and time-based auto-dismiss), which can affect which remote messages are shown/dismissed and requires correct persistence/migration behavior.
> 
> **Overview**
> Introduces a new `displayConditions` block in remote message JSON and domain models, adding support for a `trigger` (e.g. `after_idle`) and nesting `dismissAfterDaysShown`; messages with unknown triggers are now dropped during mapping.
> 
> Updates storage and scheduling to support these conditions: Core Data model bumps to v3 with a new `firstShownDate` field, `fetchScheduledRemoteMessage` gains an optional `trigger` filter, and scheduled messages can be automatically dismissed once the `dismissAfterDaysShown` threshold is exceeded (recording `firstShownDate` on first show).
> 
> Threads the idle-return context through iOS NTP code (`HomePageConfiguration`, `NewTabPageMessagesModel`, focussed NTP via `hasEscapeHatch`) so after-idle messages only appear in the appropriate context, with new unit tests covering mapping, trigger filtering, and auto-dismiss behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 739f75026aa3747c0002dcdaf72b97f9764531bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->