### PR TITLE
[macOS] [Hack] tab-selection observer for Freemium DBP banner impressions

### DIFF
--- a/macOS/DuckDuckGo/Freemium/DBP/FreemiumDBPPromotionViewCoordinator.swift
+++ b/macOS/DuckDuckGo/Freemium/DBP/FreemiumDBPPromotionViewCoordinator.swift
@@ -228,6 +228,10 @@ private extension FreemiumDBPPromotionViewCoordinator {
                 self?.onScanResultsUpdated?()
             }
             .store(in: &cancellables)
+
+        Task { @MainActor [weak self] in
+            self?.observeFreemiumDBPBannerImpressions()
+        }
     }
 
     /// Executes one of three possible actions based on the state of the user's first scan results.
@@ -254,4 +258,59 @@ private extension FreemiumDBPPromotionViewCoordinator {
         }
     }
 
+}
+
+// MARK: - Freemium DBP Promo Banner Impression Observation
+
+/// Observes per-window tab-selection changes to detect when the New Tab Page becomes the active tab,
+/// which is the moment the Freemium DBP promo banner (when visible) is presented to the user.
+/// Used to drive per-impression banner-view counting — `.newTabPageWebViewDidAppear` only fires on
+/// webview-to-window attach, not on tab activation back to an existing NTP, so it cannot.
+private extension FreemiumDBPPromotionViewCoordinator {
+
+    @MainActor
+    func observeFreemiumDBPBannerImpressions() {
+        let manager = Application.appDelegate.windowControllersManager
+
+        // Windows that already existed when this observer started: their @Published replay is
+        // ambient launch-time state, not a fresh impression event.
+        for windowController in manager.mainWindowControllers {
+            observeFreemiumDBPBannerImpressions(in: windowController, opened: false)
+        }
+
+        // Windows opened later (Cmd-N, deeplinks): the first emission is the user's fresh new tab.
+        manager.didRegisterWindowController
+            .sink { [weak self] windowController in
+                self?.observeFreemiumDBPBannerImpressions(in: windowController, opened: true)
+            }
+            .store(in: &cancellables)
+    }
+
+    @MainActor
+    func observeFreemiumDBPBannerImpressions(in windowController: MainWindowController, opened: Bool) {
+        let windowID = ObjectIdentifier(windowController)
+        let selectedTabPublisher = windowController.mainViewController.tabCollectionViewModel.$selectedTabViewModel
+            .compactMap { $0 }
+
+        // The first value @Published replays when we subscribe means very different things depending
+        // on when the window was registered:
+        //  - For windows that were already open at observer-setup time, the replay is the *current
+        //    ambient state* — the user has been looking at this tab; counting it as an impression
+        //    would conflate launch noise (e.g. placeholder→restored tab swaps) with real events.
+        //    Drop it, and rely on subsequent user-driven changes to fire.
+        //  - For just-opened windows, the first emission IS the impression — the user just opened
+        //    a new window and is seeing whatever tab landed in it (typically NTP). Keep it.
+        let pipeline: AnyPublisher<TabViewModel, Never> = opened
+            ? selectedTabPublisher.eraseToAnyPublisher()             // first emission counts
+            : selectedTabPublisher.dropFirst().eraseToAnyPublisher() // skip ambient replay
+
+        pipeline
+            .sink { [weak self] selectedTabViewModel in
+                guard let self else { return }
+                guard case .newtab = selectedTabViewModel.tab.content else { return }
+                let bannerVisible = self.viewModel != nil
+                print("🐶 [Freemium DBP][impression-c probe] NTP active — window=\(windowID) tab.uuid=\(selectedTabViewModel.tab.uuid) bannerVisible=\(bannerVisible)")
+            }
+            .store(in: &cancellables)
+    }
 }


### PR DESCRIPTION
## Summary

Hack exploring a per-window tab-selection observer as the firing signal for `dbp-free_newtab_scan_impression_c`. Prints a `🐶`-tagged log every time the NTP becomes the active tab in any window.

- Subscribes to each `TabCollectionViewModel.$selectedTabViewModel` via `WindowControllersManager` — covers existing windows at observer-setup time + future windows registered via `didRegisterWindowController`.
- For windows that were **already open** at observer-setup time, drops the `@Published` replay so launch-time ambient state (placeholder→restored tab swaps) doesn't count as an impression.
- For **just-opened** windows (Cmd-N, deeplinks, etc.), keeps the first emission since that IS the user's fresh new tab.
- Fires only when `selectedTab.content == .newtab`. Logs `bannerVisible` derived from `self.viewModel != nil`.

Why not `.newTabPageWebViewDidAppear`: empirically that notification only fires on webview-to-window attach (per NTP-tab-instance creation), not on tab activation back to an existing NTP — so it can't carry per-impression semantics.

Why not the coordinator-level fire site: `PromoService` short-circuits when an active session exists, so `delegate.show(...)` is bounded by app foregrounds + eligibility events, not user-visible renders.

## Test plan

- [ ] Cold launch app → 0 logs from already-open NTP windows (replay dropped)
- [ ] Cmd-N opens new window with NTP → 1 log
- [ ] Switch from NTP tab to non-NTP tab → 0 logs
- [ ] Switch back to NTP tab → 1 log
- [ ] Verify `bannerVisible=true` whenever the freemium banner is actually rendered, `false` otherwise
- [ ] Confirm the observer cleans up correctly when windows are closed (no zombie subscriptions / leaks)

## Status

Draft — `print` probe only. Next steps once the signal is validated:
1. Replace `print` with `pixelHandler.fire(.newTabScanImpressionCount)`
2. Add `_c` cases to `DataBrokerProtectionFreemiumPixels` and the `.standard` frequency in `DataBrokerProtectionFreemiumPixelHandler`
3. Add JSON5 definitions for `dbp-free_newtab_scan_impression_c`, `_click_c`, `_overflow_scan_c`
4. Wire click-side `_c` variants alongside the existing `_u` fire sites