### PR TITLE
iOS: Bug - Activating UTI on Web Tab Shows Suggestions

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -435,6 +435,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         displayState = .aiTab(.expanded)
         setInitialInputMode(inputMode)
         isInputVisibleForKeyboard = true
+        viewController.handler.resetInteractionState()
 
         let renderState = computeRenderState()
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -493,6 +493,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         viewController.handler.hidesVoiceButton = false
         isInputVisibleForKeyboard = true
         hasSubmittedPrompt = false
+        viewController.handler.resetInteractionState()
         resetToolsSelection()
         updateModelChipVisibility()
         syncHasSubmittedPromptToHandler()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
@@ -18,6 +18,7 @@
 //
 
 import Combine
+import Core
 import Foundation
 
 /// Bridges `UnifiedToggleInput` state to `SwitchBarHandling` so `SwitchBarTextEntryView`
@@ -31,7 +32,6 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
     /// The fadeOutOnToggle experiment applies only to the OmniBar editing state, not here.
     let isUsingFadeOutAnimation: Bool = false
     let shouldDisableAutocorrectOnEmpty: Bool = true
-    let isCurrentTextValidURL: Bool = false
     let modeParameters: [String: String] = [:]
     var isFireTab: Bool
 
@@ -41,6 +41,7 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
     @Published private(set) var currentToggleState: TextEntryMode = .aiChat
     @Published private(set) var buttonState: SwitchBarButtonState = .noButtons
     @Published private(set) var hasUserInteractedWithText: Bool = false
+    @Published private(set) var isCurrentTextValidURL: Bool = false
     @Published var hasSubmittedPrompt: Bool = false
 
     var hasSubmittedPromptPublisher: AnyPublisher<Bool, Never> {
@@ -111,7 +112,7 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
     }
 
     var isCurrentTextValidURLPublisher: AnyPublisher<Bool, Never> {
-        Just(false).eraseToAnyPublisher()
+        $isCurrentTextValidURL.eraseToAnyPublisher()
     }
 
     var currentButtonStatePublisher: AnyPublisher<SwitchBarButtonState, Never> {
@@ -166,6 +167,7 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
     func updateCurrentText(_ text: String) {
         guard currentText != text else { return }
         currentText = text
+        isCurrentTextValidURL = URL.isValidAddressBarURLInput(text)
         updateButtonState()
     }
 
@@ -192,6 +194,10 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
     func markUserInteraction() {
         guard !hasUserInteractedWithText else { return }
         hasUserInteractedWithText = true
+    }
+
+    func resetInteractionState() {
+        hasUserInteractedWithText = false
     }
 
     func clearButtonTapped() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
@@ -197,6 +197,7 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
     }
 
     func resetInteractionState() {
+        guard hasUserInteractedWithText else { return }
         hasUserInteractedWithText = false
     }
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputHandlerTests.swift
@@ -114,6 +114,65 @@ final class UnifiedToggleInputHandlerTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
+    // MARK: - isCurrentTextValidURL
+
+    func test_updateCurrentText_withValidURL_setsIsCurrentTextValidURLTrue() {
+        sut.updateCurrentText("https://duckduckgo.com")
+        XCTAssertTrue(sut.isCurrentTextValidURL)
+    }
+
+    func test_updateCurrentText_withSearchTerm_setsIsCurrentTextValidURLFalse() {
+        sut.updateCurrentText("hello world")
+        XCTAssertFalse(sut.isCurrentTextValidURL)
+    }
+
+    func test_updateCurrentText_clearedFromURL_revertsIsCurrentTextValidURLToFalse() {
+        sut.updateCurrentText("https://duckduckgo.com")
+        sut.updateCurrentText("")
+        XCTAssertFalse(sut.isCurrentTextValidURL)
+    }
+
+    func test_updateCurrentText_withValidURL_publishesTrue() {
+        let expectation = expectation(description: "isCurrentTextValidURLPublisher emits true")
+        sut.isCurrentTextValidURLPublisher
+            .dropFirst()
+            .sink { isValid in
+                XCTAssertTrue(isValid)
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        sut.updateCurrentText("https://duckduckgo.com")
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - resetInteractionState
+
+    func test_resetInteractionState_clearsHasUserInteractedWithText() {
+        sut.markUserInteraction()
+        XCTAssertTrue(sut.hasUserInteractedWithText)
+
+        sut.resetInteractionState()
+
+        XCTAssertFalse(sut.hasUserInteractedWithText)
+    }
+
+    func test_resetInteractionState_publishesFalse() {
+        sut.markUserInteraction()
+
+        let expectation = expectation(description: "hasUserInteractedWithTextPublisher emits false after reset")
+        sut.hasUserInteractedWithTextPublisher
+            .dropFirst()
+            .sink { hasInteracted in
+                XCTAssertFalse(hasInteracted)
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        sut.resetInteractionState()
+        waitForExpectations(timeout: 1)
+    }
+
     // MARK: - clearText
 
     func test_clearText_emptiesCurrentText() {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputHandlerTests.swift
@@ -173,6 +173,20 @@ final class UnifiedToggleInputHandlerTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
+    func test_resetInteractionState_alreadyFalse_doesNotPublishChange() {
+        let expectation = expectation(description: "hasUserInteractedWithTextPublisher does not fire when already false")
+        expectation.isInverted = true
+        sut.hasUserInteractedWithTextPublisher
+            .dropFirst()
+            .sink { _ in
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        sut.resetInteractionState()
+        waitForExpectations(timeout: 1)
+    }
+
     // MARK: - clearText
 
     func test_clearText_emptiesCurrentText() {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ If you're an external contributor, please file an issue before working on a PR. Discussing your changes beforehand will help ensure they align with our roadmap and that your time is well spent.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214461042925175?focus=true
Tech Design URL:
CC:

### Description
Fixes an issue when `unifiedToggleInput` is ON, tapping the omnibar on a web tab showed autocomplete suggestions immediately instead of favorites/empty view. 

**Root cause**
`UnifiedToggleInputHandler` had two issues:

- `isCurrentTextValidURL` was hardcoded to `false`, bypassing the gate in `SuggestionTrayManager.shouldDisplaySuggestionTray` that hides autocomplete when a prefilled URL is present.
- The handler is long-lived (created once at app startup), unlike `SwitchBarHandler` which is recreated per omnibar session. `hasUserInteractedWithText` was set to `true` once and never reset, so every later activation behaved as if the user had already typed.

**Fix**
- Compute `isCurrentTextValidURL` dynamically in `updateCurrentText`, matching `SwitchBarHandler`.
- Add `resetInteractionState()` and call it from `activateFromOmnibar` so each activation starts fresh.


### Testing steps
**Setup:** 
- Enable `unifiedToggleInput`.
- Run scenarios A, B, C, D, E with favorites both present and absent.

#### Primary fix scenarios
**A. First activation on a web tab shows favorites (URL-detection fix)**
1. Have at least one website marked as favorite (or have none if you’re testing this case)
2. Open a web tab and load a page (e.g. `https://duckduckgo.com`).
3. Tap the omnibar.
4. **Expected:** the URL is prefilled; favorites are shown or Dax logo is displaed. Autocomplete suggestions must NOT appear.

**B. Typing transitions to autocomplete**
1. From scenario A, append a character to the input.
2. **Expected:** autocomplete suggestions appear immediately.

**C. Re-activation does not show stale autocomplete (persistent-state regression)**
1. From scenario B, tap the back button to dismiss UTI (back button within the UTI toggle)
2. Tap the omnibar again on the same tab.
3. **Expected:** favorites or Dax is shown. Autocomplete suggestions must NOT appear.
4. Switch to a different tab (or open a new web tab) and tap the omnibar.
5. **Expected:** favorites or Dax is shown — the user-interaction flag is reset across activations.

**D. Clearing the input shows favorites**
1. From scenario A, fully clear the prefilled URL.
2. **Expected:** favorites od Dax is shown for empty input.
3. Type some letters in the input
4. **Expected:** suggesstions are shown
5. Clear the input
6. **Expected:** favorites or Dax is shown for empty input.

**E. New Tab Page (no URL prefilled)**
1. Open a new tab. Tap the omnibar.
2. **Expected:** favorites are shown or Dax logo if there are no favorites
3. Type a character.
4. **Expected:** autocomplete suggestions appear.

**H. UTI feature flag OFF (legacy flow) — regression check**
- Disable the unifiedToggleInput flag, restart the app and re-run A, B, C.
- **Expected:** legacy omnibar flow unchanged. The fix only touches UTI-related code.

**I. Mid-edit dismissal**
- Tap the omnibar on a web tab, type a few characters, dismiss WITHOUT submitting (back button).
- Re-open the omnibar.
- **Expected:** the input is repopulated with the URL and favorites are shown — the typed text from the previous activation does not persist as an autocomplete 

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact and Risks
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low. Bug fix scoped to the UTI flow (gated by the `unifiedToggleInput` feature flag). No effect on data, privacy, or core navigation. Legacy flow is untouched.


#### What could go wrong?
<!-- Describe specific scenarios and how you've addressed them -->

### Quality Considerations
<!-- 
Focus on what matters for your changes:
- What edge cases exist?
- How does this affect performance?
- What monitoring have you added?
- What documentation needs updating?
- How does this impact privacy/security?
-->
- `isCurrentTextValidURLPublisher` now emits real transitions instead of always `false`. Any UTI subscriber not designed for changing values could react differently. The publisher contract matches `SwitchBarHandler`, and the only consumer (`SuggestionTrayManager`) already handles dynamic values from the legacy flow.
- `resetInteractionState()` clears `hasUserInteractedWithText` on each `activateFromOmnibar`. If a UTI flow expected the flag to persist across activations, it would now reset early. This matches the legacy lifecycle — `SwitchBarHandler` is recreated per session, achieving the same effect.

### Notes to Reviewer
<!-- Anything specific you want reviewers to focus on -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bug fix scoped to `UnifiedToggleInput` state/publishers; behavior changes may affect suggestion-tray visibility logic but adds focused unit coverage and doesn’t touch legacy omnibar flow.
> 
> **Overview**
> Fixes Unified Toggle Input showing autocomplete too early on web tabs by making `UnifiedToggleInputHandler.isCurrentTextValidURL` **dynamic** (computed in `updateCurrentText` and published via `isCurrentTextValidURLPublisher`) instead of hardcoded.
> 
> Resets long-lived handler session flags by adding `resetInteractionState()` (clears `hasUserInteractedWithText`) and invoking it on UTI activations (`activateFromOmnibar` and `showExpanded`) so each activation starts “fresh” and doesn’t leak prior interaction state.
> 
> Adds unit tests covering URL-validity detection/publishing and interaction-state reset behavior in `UnifiedToggleInputHandlerTests`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1703888a2458f0ca9cffcb35ab77b4025862d06a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->