### PR TITLE
Fix: Onboarding Duck.ai Toggle Race Condition

### DIFF
--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
@@ -112,6 +112,8 @@ final class OnboardingIntroViewModel: ObservableObject {
     private let tutorialSettings: TutorialSettings
     private let duckAIOnboardingResumeStepStore: any KeyedStoring<DuckAIOnboardingStoringKeys>
 
+    private var pendingOnboardingIntroActions: (() -> Void)?
+
     convenience init(pixelReporter: LinearOnboardingPixelReporting,
                      systemSettingsPiPTutorialManager: SystemSettingsPiPTutorialManaging,
                      daxDialogsManager: ContextualDaxDialogDisabling,
@@ -278,7 +280,9 @@ final class OnboardingIntroViewModel: ObservableObject {
     func restoreSyncAccountAction() {
         pixelReporter.measureAutoRestoreOnboardingRestoreCTAAction()
         restorePromptHandler.restoreSyncAccount()
-        contextualDaxDialogs.disableContextualDaxDialogs()
+        pendingOnboardingIntroActions = { [weak self] in
+            self?.contextualDaxDialogs.disableContextualDaxDialogs()
+        }
     }
 
     func restorePromptSkipAction() {
@@ -336,7 +340,7 @@ private extension OnboardingIntroViewModel {
         guard let currentStepIndex = introSteps.firstIndex(of: currentIntroStep) else {
             assertionFailure("Onboarding Step index not found.")
             DuckAIOnboardingResumeCheckpointStore.clearAll(in: duckAIOnboardingResumeStepStore)
-            onCompletingOnboardingIntro?()
+            completeOnboardingIntro()
             return
         }
 
@@ -348,7 +352,7 @@ private extension OnboardingIntroViewModel {
             if currentIntroStep != .duckAIQueryExperimentSelection {
                 DuckAIOnboardingResumeCheckpointStore.clearAll(in: duckAIOnboardingResumeStepStore)
             }
-            onCompletingOnboardingIntro?()
+            completeOnboardingIntro()
             return
         }
 
@@ -357,6 +361,16 @@ private extension OnboardingIntroViewModel {
         currentIntroStep = nextIntroStep
         persistPendingOnboardingStep(for: currentIntroStep)
         setViewState(introStep: currentIntroStep)
+    }
+
+    func completeOnboardingIntro() {
+        performPendingOnboardingIntroActions()
+        onCompletingOnboardingIntro?()
+    }
+
+    func performPendingOnboardingIntroActions() {
+        pendingOnboardingIntroActions?()
+        pendingOnboardingIntroActions = nil
     }
 
     func restorePendingOnboardingStepIfNeeded() {

--- a/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -115,7 +115,7 @@ final class OnboardingIntroViewModelTests: XCTestCase {
         XCTAssertEqual(result, .landing)
     }
 
-    func testWhenRestoreActionProvided_PerformRestoreInvokesAction() {
+    func testWhenRestoreActionProvided_PerformRestoreInvokesAction_AndDefersContextualDaxDialogsDismissal() {
         // GIVEN
         let restorePromptHandlerMock = MockRestorePromptHandler()
         let sut = makeSUT(
@@ -130,7 +130,38 @@ final class OnboardingIntroViewModelTests: XCTestCase {
 
         // THEN
         XCTAssertTrue(restorePromptHandlerMock.didCallRestoreSyncAccount)
+        XCTAssertFalse(contextualDaxDialogs.didCallDisableDaxDialogs)
+    }
+
+    func testWhenRestoreActionProvided_AndOnboardingCompletes_ThenDisablesContextualDaxDialogs() {
+        // GIVEN
+        let restorePromptHandlerMock = MockRestorePromptHandler()
+        onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedIPhoneSteps(isReturningUser: true)
+        let sut = makeSUT(
+            currentOnboardingStep: .addressBarPositionSelection,
+            restorePromptHandler: restorePromptHandlerMock
+        )
+        sut.restoreSyncAccountAction()
+        XCTAssertFalse(contextualDaxDialogs.didCallDisableDaxDialogs)
+
+        // WHEN
+        sut.selectAddressBarPositionAction()
+
+        // THEN
         XCTAssertTrue(contextualDaxDialogs.didCallDisableDaxDialogs)
+    }
+
+    func testWhenOnboardingCompletes_AndRestoreActionNotInvoked_ThenDoesNotDisableContextualDaxDialogs() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = OnboardingStepsHelper.expectedIPhoneSteps(isReturningUser: false)
+        let sut = makeSUT(currentOnboardingStep: .addressBarPositionSelection)
+        XCTAssertFalse(contextualDaxDialogs.didCallDisableDaxDialogs)
+
+        // WHEN
+        sut.selectAddressBarPositionAction()
+
+        // THEN
+        XCTAssertFalse(contextualDaxDialogs.didCallDisableDaxDialogs)
     }
 
     func testWhenReturningUserAndRestorePromptEligibilityIsTrueThenShowsRestorePrompt() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1214561883505111?focus=true
Tech Design URL:
CC:

### Description
This PR fixes a bug affecting the Onboarding's `Restore on App Reinstall` flow, in which the Duck.ai Toggle preference isn't correctly applied.

### Details:
1. OnboardingIntroViewModel.restoreSyncAccountAction invokes `disableContextualDaxDialogs` before the Toggle Selection occurs
2. This triggers a chain of events that results in `OnboardingSearchExperienceSelectionHandler.updateAIChatSettings` not actually persisting anything
3. After the user effectively selects their Toggle preferences, `OnboardingSearchExperienceSelectionHandler` never gets notified of the DAX Dialogue dismissal, and thus, the setting is never persisted.

### Testing

#### Scenario: Restore My Stuff
1. Fresh install the browser
5. Open `Settings > Sync & Backup`
6. Press on `Sync and Back Up this Device` and follow the flow
7. Make sure `Restore on App Reinstall` is **enabled**
8. **Reinstall**
9. Press on `Restore My Stuff`

- [ ] Verify that if you **Enable** the Duck.ai Toggle (Step 5), the setting is effectively applied
- [ ] Verify that if you reinstall, and instead **Disable** the Duck.ai Toggle, the setting is applied as well
- [ ] Verify the **Contextual Onboarding** doesn't start!

#### Scenario: I've been here Before
1. Open `Settings > Sync & Backup`
2. Press on `Turn Off Sync & Backup`
3. Reinstall
4. Press on `I've been here before`
5. Press on `Start Browsing`

- [ ] Verify the Duck.ai Toggle is Enabled

#### Scenario: Full Onboarding
1. Reinstall
2. Press on `Let's get Started`
3. Follow the Onboarding Flow, and enable the Duck.ai Toggle (during onboarding!)

- [ ] Verify the Duck.ai Toggle is effectively enabled once you complete Onboarding
- [ ] Verify that if you retry steps 1-3 **but instead** Disable Duck.ai Toggle, the setting is correctly applied

---

### Impact and Risks
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Worst case scenario, when running thru the `Restore my Stuff` Onboarding Flow, the contextual Onboarding is applied. It should not happen, though!

### Quality Considerations
Nothing in particular.

### Notes to Reviewer
Thank you!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small control-flow change in onboarding completion timing, covered by new unit tests; main risk is altering when `disableContextualDaxDialogs()` runs for restore flows.
> 
> **Overview**
> Fixes a race in the *Restore on App Reinstall* onboarding path by **deferring `contextualDaxDialogs.disableContextualDaxDialogs()`** until the onboarding intro actually completes, instead of running it immediately when `restoreSyncAccountAction()` is tapped.
> 
> Introduces a lightweight pending-action mechanism (`pendingOnboardingIntroActions`, `completeOnboardingIntro()`) and updates unit tests to assert the deferred dismissal behavior and that no dismissal occurs when restore isn’t invoked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8234bb2e265c4eed65fba86384e7a77fe3d2a2b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->